### PR TITLE
Add \Phar::loadPhar() in custom autoloader with Stream Interceptor

### DIFF
--- a/src/TestFramework/Config/MutationConfigBuilder.php
+++ b/src/TestFramework/Config/MutationConfigBuilder.php
@@ -12,7 +12,30 @@ namespace Infection\TestFramework\Config;
 use Infection\Mutant\Mutant;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 
-interface MutationConfigBuilder
+abstract class MutationConfigBuilder
 {
-    public function build(Mutant $mutant) : string;
+    abstract public function build(Mutant $mutant) : string;
+
+    protected function getInterceptorFileContent(string $interceptorPath, string $originalFilePath, string $mutatedFilePath)
+    {
+        $infectionPhar = '';
+
+        if (0 === strpos(__FILE__, 'phar:')) {
+            $infectionPhar = sprintf(
+                '\Phar::loadPhar("%s", "%s");',
+                str_replace('phar://', '', \Phar::running()),
+                'infection.phar'
+            );
+        }
+
+        return <<<CONTENT
+{$infectionPhar}
+require_once '{$interceptorPath}';
+
+use Infection\StreamWrapper\IncludeInterceptor;
+
+IncludeInterceptor::intercept('{$originalFilePath}', '{$mutatedFilePath}');
+IncludeInterceptor::enable();
+CONTENT;
+    }
 }

--- a/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
@@ -15,7 +15,7 @@ use Infection\TestFramework\PhpSpec\Config\MutationYamlConfiguration;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Symfony\Component\Yaml\Yaml;
 
-class MutationConfigBuilder implements ConfigBuilder
+class MutationConfigBuilder extends ConfigBuilder
 {
     /**
      * @var string
@@ -78,16 +78,15 @@ class MutationConfigBuilder implements ConfigBuilder
 <?php
 
 %s
-require_once '{$interceptorPath}';
-
-use Infection\StreamWrapper\IncludeInterceptor;
-
-IncludeInterceptor::intercept('{$originalFilePath}', '{$mutatedFilePath}');
-IncludeInterceptor::enable();
+%s
 
 AUTOLOAD;
 
-        return sprintf($customAutoload, $autoloadPlaceholder);
+        return sprintf(
+            $customAutoload,
+            $autoloadPlaceholder,
+            $this->getInterceptorFileContent($interceptorPath, $originalFilePath, $mutatedFilePath)
+        );
     }
 
     private function buildPath(Mutant $mutant): string

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -14,7 +14,7 @@ use Infection\TestFramework\Config\MutationConfigBuilder as ConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\MutationXmlConfiguration;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 
-class MutationConfigBuilder implements ConfigBuilder
+class MutationConfigBuilder extends ConfigBuilder
 {
     /**
      * @var string
@@ -82,16 +82,11 @@ class MutationConfigBuilder implements ConfigBuilder
 <?php
 
 require_once '{$autoload}';
-require_once '{$interceptorPath}';
-
-use Infection\StreamWrapper\IncludeInterceptor;
-
-IncludeInterceptor::intercept('{$originalFilePath}', '{$mutatedFilePath}');
-IncludeInterceptor::enable();
+%s
 
 AUTOLOAD;
 
-        return $customAutoload;
+        return sprintf($customAutoload, $this->getInterceptorFileContent($interceptorPath, $originalFilePath, $mutatedFilePath));
     }
 
     private function buildPath(Mutant $mutant): string


### PR DESCRIPTION
Load infection.phar in custom autoloader with Stream Interceptor because
for some reason requiring interceptor file from renamed (interceptor.phar
-> interceptor) phar does not work.

After adding `\Phar.loadPhar('/path/to/renamed/phar')` everything works
as expected