### PR TITLE
Handle situation when PHPUnit <testsuite /> node is placed directly inside the root node

### DIFF
--- a/tests/Files/phpunit/phpunit_root_test_suite.xml
+++ b/tests/Files/phpunit/phpunit_root_test_suite.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2017 Maks Rafalko
+  ~
+  ~ License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+  -->
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="app/autoload2.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         syntaxCheck="false"
+>
+        <testsuite name="Application Test Suite">
+            <directory>./*Bundle</directory>
+        </testsuite>
+
+    <filter>
+        <whitelist>
+            <directory>src/</directory>
+            <!--<exclude>-->
+                <!--<directory>src/*Bundle/Resources</directory>-->
+                <!--<directory>src/*/*Bundle/Resources</directory>-->
+                <!--<directory>src/*/Bundle/*Bundle/Resources</directory>-->
+            <!--</exclude>-->
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-html" target="/path/to/tmp"/>
+    </logging>
+</phpunit>

--- a/tests/TestFramework/PhpUnit/Config/MutationXmlConfigurationTest.php
+++ b/tests/TestFramework/PhpUnit/Config/MutationXmlConfigurationTest.php
@@ -77,6 +77,27 @@ class MutationXmlConfigurationTest extends AbstractXmlConfiguration
         $this->assertSame($expectedFiles, $files);
     }
 
+    public function test_it_handles_root_test_suite()
+    {
+        $phpunitXmlPath = __DIR__ . '/../../../Files/phpunit/phpunit_root_test_suite.xml';
+
+        $replacer = new PathReplacer(new Locator($this->pathToProject));
+
+        $configuration = new MutationXmlConfiguration(
+            $this->tempDir,
+            $phpunitXmlPath,
+            $replacer,
+            $this->customAutoloadConfigPath,
+            []
+        );
+
+        $xml = $configuration->getXml();
+
+        echo $xml;
+
+        $this->assertEquals(1, $this->queryXpath($xml, '/phpunit/testsuite')->length);
+    }
+
     public function coverageTestsProvider()
     {
         return [

--- a/tests/TestFramework/PhpUnit/Config/MutationXmlConfigurationTest.php
+++ b/tests/TestFramework/PhpUnit/Config/MutationXmlConfigurationTest.php
@@ -93,8 +93,6 @@ class MutationXmlConfigurationTest extends AbstractXmlConfiguration
 
         $xml = $configuration->getXml();
 
-        echo $xml;
-
         $this->assertEquals(1, $this->queryXpath($xml, '/phpunit/testsuite')->length);
     }
 


### PR DESCRIPTION
Handle situation when PHPUnit <testsuite /> node is placed directly inside the root node