### PR TITLE
Add possibility to set custom PHPUnit executable path

### DIFF
--- a/app/container.php
+++ b/app/container.php
@@ -66,7 +66,7 @@ $c['path.replacer'] = function(Container $c) : PathReplacer {
 };
 
 $c['test.framework.factory'] = function (Container $c) : Factory {
-    return new Factory($c['temp.dir'], $c['project.dir'], $c['testframework.config.locator'], $c['path.replacer'], $c['phpunit.junit.file.path']);
+    return new Factory($c['temp.dir'], $c['project.dir'], $c['testframework.config.locator'], $c['path.replacer'], $c['phpunit.junit.file.path'], $c['infection.config']);
 };
 
 $c['mutant.creator'] = function (Container $c) : MutantCreator {

--- a/src/Config/ConsoleHelper.php
+++ b/src/Config/ConsoleHelper.php
@@ -33,7 +33,7 @@ class ConsoleHelper
         ]);
     }
 
-    public function getQuestion($question, $default, $sep = ':')
+    public function getQuestion($question, $default = null, $sep = ':')
     {
         return $default
             ? sprintf('<info>%s</info> [<comment>%s</comment>]%s ', $question, $default, $sep)

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -36,6 +36,11 @@ class InfectionConfig
         return getcwd();
     }
 
+    public function getPhpUnitCustomPath()
+    {
+        return $this->config->phpUnit->customPath ?? null;
+    }
+
     public function getProcessTimeout(): int
     {
         return $this->config->timeout ?? self::PROCESS_TIMEOUT_SECONDS;

--- a/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
+++ b/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
@@ -44,6 +44,8 @@ class PhpUnitCustomExecutablePathProvider
         try{
             $this->phpUnitExecutableFinder->find();
         } catch (TestFrameworkExecutableFinderNotFound $e) {
+            $output->writeln(['']);
+
             $questionText = $this->consoleHelper->getQuestion(
                 'We did not find phpunit executable. Please provide custom absolute path'
             );
@@ -64,13 +66,9 @@ class PhpUnitCustomExecutablePathProvider
     private function getValidator(): \Closure
     {
         return function ($answerPath) {
-            if (!$answerPath) {
-                return $answerPath;
-            }
+            $answerPath = $answerPath ? trim($answerPath) : $answerPath;
 
-            $answerPath = trim($answerPath);
-
-            if (!file_exists($answerPath)) {
+            if (!$answerPath || !file_exists($answerPath)) {
                 throw new \RuntimeException(sprintf('Custom path "%s" is incorrect.', $answerPath));
             }
 

--- a/src/Config/ValueProvider/PhpUnitPathProvider.php
+++ b/src/Config/ValueProvider/PhpUnitPathProvider.php
@@ -106,5 +106,4 @@ class PhpUnitPathProvider
             return $answerDir;
         };
     }
-
 }

--- a/src/Finder/Exception/TestFrameworkExecutableFinderNotFound.php
+++ b/src/Finder/Exception/TestFrameworkExecutableFinderNotFound.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Finder\Exception;
+
+class TestFrameworkExecutableFinderNotFound extends \RuntimeException
+{
+
+}

--- a/src/Finder/TestFrameworkExecutableFinder.php
+++ b/src/Finder/TestFrameworkExecutableFinder.php
@@ -44,7 +44,7 @@ class TestFrameworkExecutableFinder extends AbstractExecutableFinder
     {
         if ($this->cachedExecutable === null) {
             $this->addVendorFolderToPath();
-            $this->cachedExecutable = $this->findPhpunit();
+            $this->cachedExecutable = $this->findExecutable();
         }
 
         return $this->cachedExecutable;
@@ -87,7 +87,7 @@ class TestFrameworkExecutableFinder extends AbstractExecutableFinder
      * @return string
      * @throws TestFrameworkExecutableFinderNotFound
      */
-    private function findPhpunit()
+    private function findExecutable()
     {
         if ($this->customPath && file_exists($this->customPath)) {
             return $this->makeExecutable($this->customPath);

--- a/src/Finder/TestFrameworkExecutableFinder.php
+++ b/src/Finder/TestFrameworkExecutableFinder.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Finder;
 
+use Infection\Finder\Exception\TestFrameworkExecutableFinderNotFound;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
@@ -25,9 +26,15 @@ class TestFrameworkExecutableFinder extends AbstractExecutableFinder
      */
     private $testFrameworkName;
 
-    public function __construct($testFrameworkName)
+    /**
+     * @var string
+     */
+    private $customPath;
+
+    public function __construct(string $testFrameworkName, string $customPath = null)
     {
         $this->testFrameworkName = $testFrameworkName;
+        $this->customPath = $customPath;
     }
 
     /**
@@ -78,9 +85,14 @@ class TestFrameworkExecutableFinder extends AbstractExecutableFinder
 
     /**
      * @return string
+     * @throws TestFrameworkExecutableFinderNotFound
      */
     private function findPhpunit()
     {
+        if ($this->customPath && file_exists($this->customPath)) {
+            return $this->makeExecutable($this->customPath);
+        }
+
         $candidates = [$this->testFrameworkName, $this->testFrameworkName . '.phar'];
         $finder = new ExecutableFinder();
 
@@ -96,7 +108,7 @@ class TestFrameworkExecutableFinder extends AbstractExecutableFinder
             return $result;
         }
 
-        throw new \RuntimeException(
+        throw new TestFrameworkExecutableFinderNotFound(
             sprintf(
                 'Unable to locate a %s executable on local system. Ensure that %s is installed and available.',
                 $this->testFrameworkName,

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -79,7 +79,7 @@ class Factory
             $phpSpecConfigPath = $this->configLocator->locate(PhpSpecAdapter::NAME);
 
             return new PhpSpecAdapter(
-                new TestFrameworkExecutableFinder(PhpSpecAdapter::NAME, $this->infectionConfig->getPhpSpecCustomPath()),
+                new TestFrameworkExecutableFinder(PhpSpecAdapter::NAME),
                 new PhpSpecInitialConfigBuilder($this->tempDir, $phpSpecConfigPath),
                 new PhpSpecMutationConfigBuilder($this->tempDir, $phpSpecConfigPath, $this->projectDir),
                 new PhpSpecArgumentsAndOptionsBuilder()

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework;
 
+use Infection\Config\InfectionConfig;
 use Infection\Finder\TestFrameworkExecutableFinder;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapter;
@@ -46,14 +47,19 @@ class Factory
      * @var string
      */
     private $jUnitFilePath;
+    /**
+     * @var InfectionConfig
+     */
+    private $infectionConfig;
 
-    public function __construct(string $tempDir, string $projectDir, TestFrameworkConfigLocator $configLocator, PathReplacer $pathReplacer, string $jUnitFilePath)
+    public function __construct(string $tempDir, string $projectDir, TestFrameworkConfigLocator $configLocator, PathReplacer $pathReplacer, string $jUnitFilePath, InfectionConfig $infectionConfig)
     {
         $this->tempDir = $tempDir;
         $this->configLocator = $configLocator;
         $this->pathReplacer = $pathReplacer;
         $this->projectDir = $projectDir;
         $this->jUnitFilePath = $jUnitFilePath;
+        $this->infectionConfig = $infectionConfig;
     }
 
     public function create($adapterName) : AbstractTestFrameworkAdapter
@@ -62,7 +68,7 @@ class Factory
             $phpUnitConfigPath = $this->configLocator->locate(PhpUnitAdapter::NAME);
 
             return new PhpUnitAdapter(
-                new TestFrameworkExecutableFinder(PhpUnitAdapter::NAME),
+                new TestFrameworkExecutableFinder(PhpUnitAdapter::NAME, $this->infectionConfig->getPhpUnitCustomPath()),
                 new InitialConfigBuilder($this->tempDir, $phpUnitConfigPath, $this->pathReplacer, $this->jUnitFilePath),
                 new MutationConfigBuilder($this->tempDir, $phpUnitConfigPath, $this->pathReplacer, $this->projectDir),
                 new ArgumentsAndOptionsBuilder()
@@ -73,7 +79,7 @@ class Factory
             $phpSpecConfigPath = $this->configLocator->locate(PhpSpecAdapter::NAME);
 
             return new PhpSpecAdapter(
-                new TestFrameworkExecutableFinder(PhpSpecAdapter::NAME),
+                new TestFrameworkExecutableFinder(PhpSpecAdapter::NAME, $this->infectionConfig->getPhpSpecCustomPath()),
                 new PhpSpecInitialConfigBuilder($this->tempDir, $phpSpecConfigPath),
                 new PhpSpecMutationConfigBuilder($this->tempDir, $phpSpecConfigPath, $this->projectDir),
                 new PhpSpecArgumentsAndOptionsBuilder()

--- a/tests/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
+++ b/tests/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Config\ValueProvider;
+
+use Infection\Config\ConsoleHelper;
+use Infection\Config\ValueProvider\PhpUnitCustomExecutablePathProvider;
+use Infection\Finder\Exception\TestFrameworkExecutableFinderNotFound;
+use Infection\Finder\TestFrameworkExecutableFinder;
+use Mockery;
+
+class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProviderTest
+{
+    public function test_it_returns_null_if_executable_is_found()
+    {
+        $finderMock = Mockery::mock(TestFrameworkExecutableFinder::class);
+
+        $finderMock->shouldReceive('find')->once();
+
+        $consoleMock = $this->getMockBuilder(ConsoleHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $provider = new PhpUnitCustomExecutablePathProvider($finderMock, $consoleMock, $this->getQuestionHelper());
+
+        $result = $provider->get($this->createStreamableInputInterfaceMock(), $this->createOutputInterface());
+
+        $this->assertNull($result);
+    }
+
+    public function test_it_asks_question_if_no_config_is_found_in_current_dir()
+    {
+        $finderMock = Mockery::mock(TestFrameworkExecutableFinder::class);
+
+        $finderMock->shouldReceive('find')->once()->andThrow(new TestFrameworkExecutableFinderNotFound());
+
+        $consoleMock = $this->getMockBuilder(ConsoleHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $consoleMock->expects($this->once())->method('getQuestion');
+        $dialog = $this->getQuestionHelper();
+
+        $provider = new PhpUnitCustomExecutablePathProvider($finderMock, $consoleMock, $dialog);
+        $customExecutable = realpath(__DIR__ . '/../../Files/phpunit/phpunit.phar');
+
+        $path = $provider->get(
+            $this->createStreamableInputInterfaceMock($this->getInputStream("{$customExecutable}\n")),
+            $this->createOutputInterface()
+        );
+
+        $this->assertSame($customExecutable, $path);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
+     */
+    public function test_validates_incorrect_dir()
+    {
+        if (!$this->hasSttyAvailable()) {
+            $this->markTestSkipped('Stty is not available');
+        }
+
+        $finderMock = Mockery::mock(TestFrameworkExecutableFinder::class);
+
+        $finderMock->shouldReceive('find')->once()->andThrow(new TestFrameworkExecutableFinderNotFound());
+
+        $consoleMock = $this->getMockBuilder(ConsoleHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $consoleMock->expects($this->once())->method('getQuestion');
+        $dialog = $this->getQuestionHelper();
+
+        $provider = new PhpUnitCustomExecutablePathProvider($finderMock, $consoleMock, $dialog);
+
+        $provider->get(
+            $this->createStreamableInputInterfaceMock($this->getInputStream("abc\n")),
+            $this->createOutputInterface()
+        );
+    }
+}


### PR DESCRIPTION
Add custom PHPUnit executable path to the config

How to use:

```json
# infection.json.dist
{
    ...
    "phpUnit": {
        "customPath": "\/path\/to\/phpunit-6.1.phar"
    }
    ...
}
```

Closes #4 