### PR TITLE
Allow to exclude files, not only dirs in the `infection.json` config file

### DIFF
--- a/app/container.php
+++ b/app/container.php
@@ -30,8 +30,8 @@ $c['src.dirs'] = function (Container $c): array {
     return $c['infection.config']->getSourceDirs();
 };
 
-$c['exclude.dirs'] = function (Container $c): array {
-    return $c['infection.config']->getSourceExcludeDirs();
+$c['exclude.paths'] = function (Container $c): array {
+    return $c['infection.config']->getSourceExcludePaths();
 };
 
 $c['project.dir'] = getcwd();

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -49,24 +49,24 @@ class InfectionConfig
         return $this->config->source->directories ?? self::DEFAULT_SOURCE_DIRS;
     }
 
-    public function getSourceExcludeDirs(): array
+    public function getSourceExcludePaths(): array
     {
         if (isset($this->config->source->exclude) && is_array($this->config->source->exclude)) {
-            $originalExcludedDirs = $this->config->source->exclude;
-            $excludedDirs = [];
+            $originalExcludedPaths = $this->config->source->exclude;
+            $excludedPaths = [];
 
-            foreach ($originalExcludedDirs as $originalExcludedDir) {
-                if (strpos($originalExcludedDir, '*') === false) {
-                    $excludedDirs[] = $originalExcludedDir;
+            foreach ($originalExcludedPaths as $originalExcludedPath) {
+                if (strpos($originalExcludedPath, '*') === false) {
+                    $excludedPaths[] = $originalExcludedPath;
                 } else {
-                    $excludedDirs = array_merge(
-                        $excludedDirs,
-                        $this->getExcludedDirsByPattern($originalExcludedDir)
+                    $excludedPaths = array_merge(
+                        $excludedPaths,
+                        $this->getExcludedDirsByPattern($originalExcludedPath)
                     );
                 }
             }
 
-            return $excludedDirs;
+            return $excludedPaths;
         }
 
         return self::DEFAULT_EXCLUDE_DIRS;

--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -81,7 +81,7 @@ class InfectionApplication
         $this->output->writeln(['', 'Generate mutants...', '']);
 
         $codeCoverageData = $this->getCodeCoverageData($testFrameworkKey);
-        $mutationsGenerator = new MutationsGenerator($this->get('src.dirs'), $this->get('exclude.dirs'), $codeCoverageData);
+        $mutationsGenerator = new MutationsGenerator($this->get('src.dirs'), $this->get('exclude.paths'), $codeCoverageData);
         $mutations = $mutationsGenerator->generate($this->input->getOption('only-covered'), $this->input->getOption('filter'));
 
         $parallelProcessManager = $this->get('parallel.process.runner');

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -77,13 +77,13 @@ class MutationsGenerator
     /**
      * @var array
      */
-    private $excludeDirs;
+    private $excludeDirsOrFiles;
 
-    public function __construct(array $srcDirs, array $excludeDirs, CodeCoverageData $codeCoverageData)
+    public function __construct(array $srcDirs, array $excludeDirsOrFiles, CodeCoverageData $codeCoverageData)
     {
         $this->srcDirs = $srcDirs;
         $this->codeCoverageData = $codeCoverageData;
-        $this->excludeDirs = $excludeDirs;
+        $this->excludeDirsOrFiles = $excludeDirsOrFiles;
     }
 
     /**
@@ -117,9 +117,12 @@ class MutationsGenerator
     {
         $finder = new Finder();
         $finder->files()->in($this->srcDirs);
-        $finder->exclude($this->excludeDirs);
 
         $finder->files()->name($filter ?: '*.php');
+
+        foreach ($this->excludeDirsOrFiles as $excludePath) {
+            $finder->notPath($excludePath);
+        }
 
         return $finder;
     }

--- a/tests/Config/InfectionConfigTest.php
+++ b/tests/Config/InfectionConfigTest.php
@@ -71,7 +71,7 @@ class InfectionConfigTest extends TestCase
     {
         $config = new InfectionConfig(new \stdClass());
 
-        $this->assertSame(InfectionConfig::DEFAULT_EXCLUDE_DIRS, $config->getSourceExcludeDirs());
+        $this->assertSame(InfectionConfig::DEFAULT_EXCLUDE_DIRS, $config->getSourceExcludePaths());
     }
 
     public function test_it_returns_exclude_dirs_from_config()
@@ -79,7 +79,7 @@ class InfectionConfigTest extends TestCase
         $json = '{"source": {"exclude":["subfolder/excluded-folder"], "directories": ["source"]}}';
         $config = new InfectionConfig(json_decode($json));
 
-        $this->assertSame(['subfolder/excluded-folder'], $config->getSourceExcludeDirs());
+        $this->assertSame(['subfolder/excluded-folder'], $config->getSourceExcludePaths());
     }
 
     public function test_it_excludes_by_glob_patterns()
@@ -89,7 +89,7 @@ class InfectionConfigTest extends TestCase
 
         $config = new InfectionConfig(json_decode($json));
 
-        $excludedDirs = $config->getSourceExcludeDirs();
+        $excludedDirs = $config->getSourceExcludePaths();
 
         $this->assertCount(2, $excludedDirs);
     }


### PR DESCRIPTION
Example with excluding dir and file

```json
{
    "timeout": 10,
    "source": {
        "directories": [
            "src"
        ],
        "exclude": [
            "relative/path/to/dir",
            "relative/path/to/File.php"
        ]
    },
    "logs": {
        "text": "infection-log.txt"
    }
}
```