### PR TITLE
Add --min-msi and --min-covered-msi options to control MSI in CI and fail builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection --allow-risky=yes
   - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
-  - if [[ $INFECTION == 1 ]]; then infection.phar --threads=4 --min-covered-msi=76; fi
+  - if [[ $INFECTION == 1 ]]; then ./infection.phar --threads=4 --min-covered-msi=76; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection --allow-risky=yes
   - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
-  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-covered-msi=76 -s; fi
+  # add --threads=4
+  - if [[ $INFECTION == 1 ]]; then bin/infection --min-covered-msi=76 -s; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - php: 7.0
       env: INFECTION=1
     - php: 7.1
+      env: INFECTION=1
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ php:
 matrix:
   include:
     - php: 7.0
-    - php: 7.1
       env: INFECTION=1
+    - php: 7.1
 
 cache:
   directories:
@@ -20,9 +20,6 @@ before_install:
   - composer selfupdate
   - composer global require friendsofphp/php-cs-fixer
   - composer global require --dev 'phpstan/phpstan:^0.8'
-  - if [[ $INFECTION == 1 ]]; then wget https://github.com/infection/infection/releases/download/0.3.0/infection.phar; fi
-  - if [[ $INFECTION == 1 ]]; then wget https://github.com/infection/infection/releases/download/0.3.0/infection.phar.pubkey; fi
-  - if [[ $INFECTION == 1 ]]; then chmod +x infection.phar; fi
 
 install:
   - composer install
@@ -31,7 +28,7 @@ script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection --allow-risky=yes
   - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
-  - if [[ $INFECTION == 1 ]]; then ./infection.phar --threads=4 --min-covered-msi=76; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-covered-msi=76; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ php:
   - 7.0
   - 7.1
 
+matrix:
+  include:
+    - php: 7.0
+      env: INFECTION=1
+    - php: 7.1
+
 cache:
   directories:
   - $HOME/.composer/cache
@@ -14,6 +20,9 @@ before_install:
   - composer selfupdate
   - composer global require friendsofphp/php-cs-fixer
   - composer global require --dev 'phpstan/phpstan:^0.8'
+  - if [[ $INFECTION == 1 ]]; then wget https://github.com/infection/infection/releases/download/0.3.0/infection.phar; fi
+  - if [[ $INFECTION == 1 ]]; then wget https://github.com/infection/infection/releases/download/0.3.0/infection.phar.pubkey; fi
+  - if [[ $INFECTION == 1 ]]; then chmod +x infection.phar; fi
 
 install:
   - composer install
@@ -22,6 +31,7 @@ script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection --allow-risky=yes
   - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
+  - if [[ $INFECTION == 1 ]]; then infection.phar --threads=4 --min-covered-msi=76; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection --allow-risky=yes
   - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
-  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-covered-msi=76; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-covered-msi=76 -s; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection --allow-risky=yes
   - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
-  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-covered-msi=76; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=34 --min-covered-msi=76; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection --allow-risky=yes
   - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
   # add --threads=4
-  - if [[ $INFECTION == 1 ]]; then bin/infection --min-covered-msi=76 -s; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --min-covered-msi=80 -s; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ php:
 matrix:
   include:
     - php: 7.0
-      env: INFECTION=1
     - php: 7.1
+      env: INFECTION=1
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection --allow-risky=yes
   - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
-  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-covered-msi=80; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-covered-msi=76; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection --allow-risky=yes
   - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
-  # add --threads=4
-  - if [[ $INFECTION == 1 ]]; then bin/infection --min-covered-msi=80 -s; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-covered-msi=80; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -154,5 +154,9 @@ class InfectionCommand extends Command
 
         $output->getFormatter()->setStyle('diff-add', new OutputFormatterStyle('green'));
         $output->getFormatter()->setStyle('diff-del', new OutputFormatterStyle('red'));
+
+        $output->getFormatter()->setStyle('low', new OutputFormatterStyle('red', null, ['bold']));
+        $output->getFormatter()->setStyle('medium', new OutputFormatterStyle('yellow', null, ['bold']));
+        $output->getFormatter()->setStyle('high', new OutputFormatterStyle('green', null, ['bold']));
     }
 }

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -76,6 +76,18 @@ class InfectionCommand extends Command
                 'Output formatter. Possible values: dot, progress',
                 'dot'
             )
+            ->addOption(
+                'min-msi',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Minimum Mutation Score Indicator (MSI) percentage value. Should be used in CI server.'
+            )
+            ->addOption(
+                'min-covered-msi',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Minimum Covered Code Mutation Score Indicator (MSI) percentage value. Should be used in CI server.'
+            )
         ;
     }
 

--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -95,10 +95,7 @@ class InfectionApplication
 
         // todo read in phpstan hot to skip set of errors
         // todo create doc PR
-        // todo add infection to infection CI ;)
         // todo colorize percentage (red, yellow, green). Add tweet with the image
-        // todo informative error message about msi? google how to do that with return codes. Exceptions?
-        // todo the same settings in config?
 
         if ($this->hasBadMsi($metricsCalculator)) {
             $io->error($this->getBadMsiErrorMessage($metricsCalculator));

--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class InfectionApplication
 {
@@ -55,6 +56,7 @@ class InfectionApplication
 
     public function run()
     {
+        $io = new SymfonyStyle($this->input, $this->output);
         /** @var EventDispatcher $eventDispatcher */
         $eventDispatcher = $this->get('dispatcher');
         $testFrameworkKey = $this->input->getOption('test-framework');
@@ -98,7 +100,13 @@ class InfectionApplication
         // todo informative error message about msi? google how to do that with return codes. Exceptions?
         // todo the same settings in config?
 
-        return $this->hasBadMsi($metricsCalculator) ? 1 : 0;
+        if ($this->hasBadMsi($metricsCalculator)) {
+            $io->error($this->getBadMsiErrorMessage($metricsCalculator));
+
+            return 1;
+        };
+
+        return 0;
     }
 
     /**
@@ -181,5 +189,30 @@ class InfectionApplication
         }
 
         return false;
+    }
+
+    private function getBadMsiErrorMessage(MetricsCalculator $metricsCalculator): string
+    {
+        $baseMessage = 'The minimum required %s percentage should be %s%%, but actual is %s%%. Improve your tests!';
+
+        if ($minMsi = (float) $this->input->getOption('min-msi')) {
+            return sprintf(
+                $baseMessage,
+                'MSI',
+                $minMsi,
+                $metricsCalculator->getMutationScoreIndicator()
+            );
+        }
+
+        if ($minCoveredMsi = (float) $this->input->getOption('min-covered-msi')) {
+            return sprintf(
+                $baseMessage,
+                'Covered Code MSI',
+                $minCoveredMsi,
+                $metricsCalculator->getMutationScoreIndicator()
+            );
+        }
+
+        throw new \LogicException('Seems like something is wrong with calculations and min-msi options.');
     }
 }

--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -209,7 +209,7 @@ class InfectionApplication
                 $baseMessage,
                 'Covered Code MSI',
                 $minCoveredMsi,
-                $metricsCalculator->getMutationScoreIndicator()
+                $metricsCalculator->getCoveredCodeMutationScoreIndicator()
             );
         }
 

--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -93,10 +93,6 @@ class InfectionApplication
         $mutationTestingRunner = new MutationTestingRunner($processBuilder, $parallelProcessManager, $mutantCreator, $eventDispatcher, $mutations);
         $mutationTestingRunner->run($threadCount, $codeCoverageData);
 
-        // todo read in phpstan hot to skip set of errors
-        // todo create doc PR
-        // todo colorize percentage (red, yellow, green). Add tweet with the image
-
         if ($this->hasBadMsi($metricsCalculator)) {
             $io->error($this->getBadMsiErrorMessage($metricsCalculator));
 

--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -91,7 +91,14 @@ class InfectionApplication
         $mutationTestingRunner = new MutationTestingRunner($processBuilder, $parallelProcessManager, $mutantCreator, $eventDispatcher, $mutations);
         $mutationTestingRunner->run($threadCount, $codeCoverageData);
 
-        return 0;
+        // todo read in phpstan hot to skip set of errors
+        // todo create doc PR
+        // todo add infection to infection CI ;)
+        // todo colorize percentage (red, yellow, green). Add tweet with the image
+        // todo informative error message about msi? google how to do that with return codes. Exceptions?
+        // todo the same settings in config?
+
+        return $this->hasBadMsi($metricsCalculator) ? 1 : 0;
     }
 
     /**
@@ -157,5 +164,22 @@ class InfectionApplication
                 $initialTestSuitProcess->getErrorOutput()
             )
         );
+    }
+
+    private function hasBadMsi(MetricsCalculator $metricsCalculator): bool
+    {
+        if ($minMsi = (float) $this->input->getOption('min-msi')) {
+            if ($metricsCalculator->getMutationScoreIndicator() < $minMsi) {
+                return true;
+            }
+        }
+
+        if ($minCoveredMsi = (float) $this->input->getOption('min-covered-msi')) {
+            if ($metricsCalculator->getCoveredCodeMutationScoreIndicator() < $minCoveredMsi) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Process/Listener/MutationConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationConsoleLoggerSubscriber.php
@@ -108,40 +108,14 @@ class MutationConsoleLoggerSubscriber implements EventSubscriberInterface
     {
         $this->output->writeln('');
 
-        $logParts = [];
-
-        $logParts = array_merge(
-            $logParts,
-            $this->getLogParts($this->metricsCalculator->getKilledMutantProcesses(), 'Killed')
-        );
-
-        $logParts = array_merge(
-            $logParts,
-            $this->getLogParts($this->metricsCalculator->getEscapedMutantProcesses(), 'Escaped')
-        );
-
-        $logParts = array_merge(
-            $logParts,
-            $this->getLogParts($this->metricsCalculator->getTimedOutProcesses(), 'Timeout')
-        );
-
-        $this->output->writeln(implode($logParts, "\n"));
-    }
-
-    private function getLogParts(array $processes, string $headlinePrefix): array
-    {
-        $logParts = [sprintf('%s mutants:', $headlinePrefix), ''];
-
         foreach ($processes as $index => $mutantProcess) {
-            $logParts[] = '';
-            $logParts[] = sprintf('%d) %s', $index + 1, get_class($mutantProcess->getMutant()->getMutation()->getMutator()));
-            $logParts[] = $mutantProcess->getMutant()->getMutation()->getOriginalFilePath();
-            $logParts[] = $mutantProcess->getProcess()->getCommandLine();
-            $logParts[] = $mutantProcess->getMutant()->getDiff();
-            $logParts[] = $mutantProcess->getProcess()->getOutput();
+            $this->output->writeln([
+                '',
+                sprintf('%d) %s', $index + 1, get_class($mutantProcess->getMutant()->getMutation()->getMutator())),
+            ]);
+            $this->output->writeln($mutantProcess->getMutant()->getMutation()->getOriginalFilePath());
+            $this->output->writeln($this->diffColorizer->colorize($mutantProcess->getMutant()->getDiff()));
         }
-
-        return $logParts;
     }
 
     private function showMetrics()

--- a/src/Process/Listener/MutationConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationConsoleLoggerSubscriber.php
@@ -128,10 +128,21 @@ class MutationConsoleLoggerSubscriber implements EventSubscriberInterface
         //        $this->output->writeln($this->getPadded($errorCount) . ' fatal errors were encountered'); // TODO
         $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getTimedOutCount()) . '</options=bold> time outs were encountered');
 
+        $msiTag = $this->getPercentageTag($this->metricsCalculator->getMutationScoreIndicator());
+        $mutationCoverageTag = $this->getPercentageTag($this->metricsCalculator->getCoverageRate());
+        $coveredMsiTag = $this->getPercentageTag($this->metricsCalculator->getCoveredCodeMutationScoreIndicator());
+
+
         $this->output->writeln(['', 'Metrics:']);
-        $this->output->writeln($this->addIndentation('Mutation Score Indicator (MSI): <options=bold>' . $this->metricsCalculator->getMutationScoreIndicator() . '%</options=bold>'));
-        $this->output->writeln($this->addIndentation('Mutation Code Coverage: <options=bold>' . $this->metricsCalculator->getCoverageRate() . '%</options=bold>'));
-        $this->output->writeln($this->addIndentation('Covered Code MSI: <options=bold>' . $this->metricsCalculator->getCoveredCodeMutationScoreIndicator() . '%</options=bold>'));
+        $this->output->writeln(
+            $this->addIndentation("Mutation Score Indicator (MSI): <{$msiTag}>{$this->metricsCalculator->getMutationScoreIndicator()}%</{$msiTag}>")
+        );
+        $this->output->writeln(
+            $this->addIndentation("Mutation Code Coverage: <{$mutationCoverageTag}>{$this->metricsCalculator->getCoverageRate()}%</{$mutationCoverageTag}>")
+        );
+        $this->output->writeln(
+            $this->addIndentation("Covered Code MSI: <{$coveredMsiTag}>{$this->metricsCalculator->getCoveredCodeMutationScoreIndicator()}%</{$coveredMsiTag}>")
+        );
 
         $this->output->writeln('');
         $this->output->writeln('Please note that some mutants will inevitably be harmless (i.e. false positives).');
@@ -145,5 +156,18 @@ class MutationConsoleLoggerSubscriber implements EventSubscriberInterface
     private function addIndentation(string $string): string
     {
         return str_repeat(' ', self::PAD_LENGTH + 1) . $string;
+    }
+
+    private function getPercentageTag(float $percentage)
+    {
+        if ($percentage >= 0 && $percentage < 50) {
+            return 'low';
+        }
+
+        if ($percentage >= 50 && $percentage < 90) {
+            return 'medium';
+        }
+
+        return 'high';
     }
 }

--- a/src/Process/Listener/MutationConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationConsoleLoggerSubscriber.php
@@ -108,14 +108,40 @@ class MutationConsoleLoggerSubscriber implements EventSubscriberInterface
     {
         $this->output->writeln('');
 
+        $logParts = [];
+
+        $logParts = array_merge(
+            $logParts,
+            $this->getLogParts($this->metricsCalculator->getKilledMutantProcesses(), 'Killed')
+        );
+
+        $logParts = array_merge(
+            $logParts,
+            $this->getLogParts($this->metricsCalculator->getEscapedMutantProcesses(), 'Escaped')
+        );
+
+        $logParts = array_merge(
+            $logParts,
+            $this->getLogParts($this->metricsCalculator->getTimedOutProcesses(), 'Timeout')
+        );
+
+        $this->output->writeln(implode($logParts, "\n"));
+    }
+
+    private function getLogParts(array $processes, string $headlinePrefix): array
+    {
+        $logParts = [sprintf('%s mutants:', $headlinePrefix), ''];
+
         foreach ($processes as $index => $mutantProcess) {
-            $this->output->writeln([
-                '',
-                sprintf('%d) %s', $index + 1, get_class($mutantProcess->getMutant()->getMutation()->getMutator())),
-            ]);
-            $this->output->writeln($mutantProcess->getMutant()->getMutation()->getOriginalFilePath());
-            $this->output->writeln($this->diffColorizer->colorize($mutantProcess->getMutant()->getDiff()));
+            $logParts[] = '';
+            $logParts[] = sprintf('%d) %s', $index + 1, get_class($mutantProcess->getMutant()->getMutation()->getMutator()));
+            $logParts[] = $mutantProcess->getMutant()->getMutation()->getOriginalFilePath();
+            $logParts[] = $mutantProcess->getProcess()->getCommandLine();
+            $logParts[] = $mutantProcess->getMutant()->getDiff();
+            $logParts[] = $mutantProcess->getProcess()->getOutput();
         }
+
+        return $logParts;
     }
 
     private function showMetrics()

--- a/tests/Mutator/ConditionalBoundary/GreaterThanOrEqualToTest.php
+++ b/tests/Mutator/ConditionalBoundary/GreaterThanOrEqualToTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\ConditionalBoundary;
+
+use Infection\Mutator\ConditionalBoundary\GreaterThanOrEqualTo;
+use Infection\Mutator\Mutator;
+use Infection\Tests\Mutator\AbstractMutator;
+
+class GreaterThanOrEqualToTest extends AbstractMutator
+{
+    public function test_replaces_greater_sign()
+    {
+        $code = '<?php 1 >= 2;';
+        $mutatedCode = $this->mutate($code);
+
+        $expectedMutatedCode = <<<'CODE'
+<?php
+
+1 > 2;
+CODE;
+
+        $this->assertSame($expectedMutatedCode, $mutatedCode);
+    }
+
+    protected function getMutator(): Mutator
+    {
+        return new GreaterThanOrEqualTo();
+    }
+}

--- a/tests/Mutator/ConditionalBoundary/GreaterThanTest.php
+++ b/tests/Mutator/ConditionalBoundary/GreaterThanTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\ConditionalBoundary;
+
+use Infection\Mutator\ConditionalBoundary\GreaterThan;
+use Infection\Mutator\Mutator;
+use Infection\Tests\Mutator\AbstractMutator;
+
+class GreaterThanTest extends AbstractMutator
+{
+    public function test_replaces_greater_sign()
+    {
+        $code = '<?php 1 > 2;';
+        $mutatedCode = $this->mutate($code);
+
+        $expectedMutatedCode = <<<'CODE'
+<?php
+
+1 >= 2;
+CODE;
+
+        $this->assertSame($expectedMutatedCode, $mutatedCode);
+    }
+
+    protected function getMutator(): Mutator
+    {
+        return new GreaterThan();
+    }
+}

--- a/tests/Mutator/ConditionalBoundary/LessThanOrEqualToTest.php
+++ b/tests/Mutator/ConditionalBoundary/LessThanOrEqualToTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\ConditionalBoundary;
+
+use Infection\Mutator\ConditionalBoundary\LessThanOrEqualTo;
+use Infection\Mutator\Mutator;
+use Infection\Tests\Mutator\AbstractMutator;
+
+class LessThanOrEqualToTest extends AbstractMutator
+{
+    public function test_replaces_greater_sign()
+    {
+        $code = '<?php 1 <= 2;';
+        $mutatedCode = $this->mutate($code);
+
+        $expectedMutatedCode = <<<'CODE'
+<?php
+
+1 < 2;
+CODE;
+
+        $this->assertSame($expectedMutatedCode, $mutatedCode);
+    }
+
+    protected function getMutator(): Mutator
+    {
+        return new LessThanOrEqualTo();
+    }
+}

--- a/tests/Mutator/ConditionalBoundary/LessThanTest.php
+++ b/tests/Mutator/ConditionalBoundary/LessThanTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\ConditionalBoundary;
+
+use Infection\Mutator\ConditionalBoundary\LessThan;
+use Infection\Mutator\Mutator;
+use Infection\Tests\Mutator\AbstractMutator;
+
+class LessThanTest extends AbstractMutator
+{
+    public function test_replaces_greater_sign()
+    {
+        $code = '<?php 1 < 2;';
+        $mutatedCode = $this->mutate($code);
+
+        $expectedMutatedCode = <<<'CODE'
+<?php
+
+1 <= 2;
+CODE;
+
+        $this->assertSame($expectedMutatedCode, $mutatedCode);
+    }
+
+    protected function getMutator(): Mutator
+    {
+        return new LessThan();
+    }
+}

--- a/tests/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpUnit\Config\Path;
 
 use Infection\Finder\Locator;
-use Infection\TestFramework\PhPunit\Config\Path\PathReplacer;
+use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use PHPUnit\Framework\TestCase;
 use function Infection\Tests\normalizePath as p;
 


### PR DESCRIPTION
Add `--min-msi` and `--min-covered-msi` options to control MSI in CI and fail builds

This update allows to run Infection with your CI server. Builds, that have MSI percentage less than provided by options above will be failed.

So now we can control effectiveness of your tests on CI.

- [x] Implement --min-msi
- [x] Implement --min-covered-msi
- [x] Documentation PR
- [x] Add tests to increase coverage