### PR TITLE
Add whitelist for executed mutators. New option --mutators=X,Yy,Zzz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection --allow-risky=yes
   - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
-  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=46 --min-covered-msi=86; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=46 --min-covered-msi=88; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/app/container.php
+++ b/app/container.php
@@ -23,6 +23,7 @@ use Infection\TestFramework\Coverage\TestFileDataProvider;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\Differ\DiffColorizer;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
+use Infection\Config\InfectionConfig;
 
 $c = new Container();
 
@@ -99,6 +100,16 @@ $c['phpunit.junit.file.path'] = function (Container $c): string {
 $c['test.file.data.provider.phpunit'] = function (Container $c): TestFileDataProvider {
     return new PhpUnitTestFileDataProvider($c['phpunit.junit.file.path']);
 };
+
+function registerMutators(array $mutators, Container $container) {
+    foreach ($mutators as $mutator) {
+        $container[$mutator] = function (Container $c) use ($mutator) {
+            return new $mutator();
+        };
+    }
+}
+
+registerMutators(InfectionConfig::DEFAULT_MUTATORS, $c);
 
 $c['application'] = function (Container $container): Application {
     $application = new Application(

--- a/bin/infection
+++ b/bin/infection
@@ -21,7 +21,7 @@ function prepareArgv()
     }
 
     if (!$found) {
-        $argv[] = 'run';
+        array_splice($argv, 1, 0,'run');
     }
 
     return $argv;

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -63,6 +63,12 @@ class InfectionCommand extends Command
                 'Show mutations to the console'
             )
             ->addOption(
+                'mutators',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Specify particular mutators. Example: --mutators=Plus,PublicVisibility'
+            )
+            ->addOption(
                 'filter',
                 null,
                 InputOption::VALUE_REQUIRED,

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -8,12 +8,125 @@ declare(strict_types=1);
 
 namespace Infection\Config;
 
+use Infection\Mutator\Arithmetic\BitwiseAnd;
+use Infection\Mutator\Arithmetic\BitwiseNot;
+use Infection\Mutator\Arithmetic\BitwiseOr;
+use Infection\Mutator\Arithmetic\BitwiseXor;
+use Infection\Mutator\Arithmetic\Decrement;
+use Infection\Mutator\Arithmetic\DivEqual;
+use Infection\Mutator\Arithmetic\Division;
+use Infection\Mutator\Arithmetic\Exponentiation;
+use Infection\Mutator\Arithmetic\Increment;
+use Infection\Mutator\Arithmetic\Minus;
+use Infection\Mutator\Arithmetic\MinusEqual;
+use Infection\Mutator\Arithmetic\ModEqual;
+use Infection\Mutator\Arithmetic\Modulus;
+use Infection\Mutator\Arithmetic\MulEqual;
+use Infection\Mutator\Arithmetic\Multiplication;
+use Infection\Mutator\Arithmetic\Plus;
+use Infection\Mutator\Arithmetic\PlusEqual;
+use Infection\Mutator\Arithmetic\PowEqual;
+use Infection\Mutator\Arithmetic\ShiftLeft;
+use Infection\Mutator\Arithmetic\ShiftRight;
+use Infection\Mutator\Boolean\FalseValue;
+use Infection\Mutator\Boolean\LogicalAnd;
+use Infection\Mutator\Boolean\LogicalLowerAnd;
+use Infection\Mutator\Boolean\LogicalLowerOr;
+use Infection\Mutator\Boolean\LogicalNot;
+use Infection\Mutator\Boolean\LogicalOr;
+use Infection\Mutator\Boolean\TrueValue;
+use Infection\Mutator\ConditionalBoundary\GreaterThanOrEqualTo;
+use Infection\Mutator\ConditionalBoundary\GreaterThan;
+use Infection\Mutator\ConditionalBoundary\LessThan;
+use Infection\Mutator\ConditionalBoundary\LessThanOrEqualTo;
+use Infection\Mutator\ConditionalNegotiation\Equal;
+use Infection\Mutator\ConditionalNegotiation\GreaterThan as GreaterThanNegotiation;
+use Infection\Mutator\ConditionalNegotiation\GreaterThanOrEqualTo as GreaterThanOrEqualToNegotiation;
+use Infection\Mutator\ConditionalNegotiation\Identical;
+use Infection\Mutator\ConditionalNegotiation\LessThanNegotiation;
+use Infection\Mutator\ConditionalNegotiation\LessThanOrEqualToNegotiation;
+use Infection\Mutator\ConditionalNegotiation\NotEqual;
+use Infection\Mutator\ConditionalNegotiation\NotIdentical;
+use Infection\Mutator\FunctionSignature\ProtectedVisibility;
+use Infection\Mutator\FunctionSignature\PublicVisibility;
+use Infection\Mutator\Number\OneZeroFloat;
+use Infection\Mutator\Number\OneZeroInteger;
+use Infection\Mutator\ReturnValue\FloatNegation;
+use Infection\Mutator\ReturnValue\FunctionCall;
+use Infection\Mutator\ReturnValue\IntegerNegation;
+use Infection\Mutator\ReturnValue\NewObject;
+use Infection\Mutator\ReturnValue\This;
+
 class InfectionConfig
 {
     const PROCESS_TIMEOUT_SECONDS = 10;
     const DEFAULT_SOURCE_DIRS = ['.'];
     const DEFAULT_EXCLUDE_DIRS = ['vendor'];
     const CONFIG_FILE_NAME = 'infection.json';
+
+    const DEFAULT_MUTATORS = [
+        // Arithmetic
+        BitwiseAnd::class,
+        BitwiseNot::class,
+        BitwiseOr::class,
+        BitwiseXor::class,
+        Decrement::class,
+        DivEqual::class,
+        Division::class,
+        Exponentiation::class,
+        Increment::class,
+        Minus::class,
+        MinusEqual::class,
+        ModEqual::class,
+        Modulus::class,
+        MulEqual::class,
+        Multiplication::class,
+        Plus::class,
+        PlusEqual::class,
+        PowEqual::class,
+        ShiftLeft::class,
+        ShiftRight::class,
+
+        // Boolean
+        FalseValue::class,
+        LogicalAnd::class,
+        LogicalLowerAnd::class,
+        LogicalLowerOr::class,
+        LogicalNot::class,
+        LogicalOr::class,
+        TrueValue::class,
+
+        // Conditional Boundary
+        GreaterThan::class,
+        GreaterThanOrEqualTo::class,
+        LessThan::class,
+        LessThanOrEqualTo::class,
+
+        // Conditional Negotiation
+        Equal::class,
+        GreaterThanNegotiation::class,
+        GreaterThanOrEqualToNegotiation::class,
+        Identical::class,
+        LessThanNegotiation::class,
+        LessThanOrEqualToNegotiation::class,
+        NotEqual::class,
+        NotIdentical::class,
+
+        // Number
+        OneZeroInteger::class,
+        OneZeroFloat::class,
+
+        // Return Value
+        FloatNegation::class,
+        FunctionCall::class,
+        IntegerNegation::class,
+        NewObject::class,
+        This::class,
+
+        // Function Signature
+        PublicVisibility::class,
+        ProtectedVisibility::class,
+    ];
 
     /**
      * @var \stdClass

--- a/src/Console/Exception/InvalidOptionException.php
+++ b/src/Console/Exception/InvalidOptionException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Console\Exception;
+
+class InvalidOptionException extends \Exception
+{
+    public static function withMessage(string $message)
+    {
+        return new self($message);
+    }
+}

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -38,11 +38,6 @@ class MutationsGenerator
     private $excludeDirsOrFiles;
 
     /**
-     * @var Container
-     */
-    private $container;
-
-    /**
      * @var array
      */
     private $whitelistedMutatorNames;

--- a/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
@@ -11,7 +11,7 @@ namespace Infection\Mutator\ConditionalNegotiation;
 use Infection\Mutator\FunctionBodyMutator;
 use PhpParser\Node;
 
-class LessThan extends FunctionBodyMutator
+class LessThanNegotiation extends FunctionBodyMutator
 {
     /**
      * Replaces "<" with ">="

--- a/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
@@ -11,7 +11,7 @@ namespace Infection\Mutator\ConditionalNegotiation;
 use Infection\Mutator\FunctionBodyMutator;
 use PhpParser\Node;
 
-class LessThanOrEqualTo extends FunctionBodyMutator
+class LessThanOrEqualToNegotiation extends FunctionBodyMutator
 {
     /**
      * Replaces "<=" with ">"

--- a/src/Mutator/FunctionBodyMutator.php
+++ b/src/Mutator/FunctionBodyMutator.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator;
 
-abstract class FunctionBodyMutator implements Mutator
+abstract class FunctionBodyMutator extends Mutator
 {
     public function isFunctionBodyMutator(): bool
     {

--- a/src/Mutator/FunctionSignatureMutator.php
+++ b/src/Mutator/FunctionSignatureMutator.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator;
 
-abstract class FunctionSignatureMutator implements Mutator
+abstract class FunctionSignatureMutator extends Mutator
 {
     public function isFunctionBodyMutator(): bool
     {

--- a/src/Mutator/Mutator.php
+++ b/src/Mutator/Mutator.php
@@ -10,13 +10,20 @@ namespace Infection\Mutator;
 
 use PhpParser\Node;
 
-interface Mutator
+abstract class Mutator
 {
-    public function mutate(Node $node);
+    abstract public function mutate(Node $node);
 
-    public function shouldMutate(Node $node): bool;
+    abstract public function shouldMutate(Node $node): bool;
 
-    public function isFunctionBodyMutator(): bool;
+    abstract public function isFunctionBodyMutator(): bool;
 
-    public function isFunctionSignatureMutator(): bool;
+    abstract public function isFunctionSignatureMutator(): bool;
+
+    public function getName(): string
+    {
+        $parts = explode('\\', static::class);
+
+        return $parts[count($parts) - 1];
+    }
 }

--- a/tests/EventDispatcher/EventDispatcherTest.php
+++ b/tests/EventDispatcher/EventDispatcherTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Infection\Tests\EventDispatcher;
+
+use Infection\EventDispatcher\EventDispatcher;
+use Infection\Tests\Fixtures\UserEventSubscriber;
+use Infection\Tests\Fixtures\UserWasCreated;
+use PHPUnit\Framework\TestCase;
+
+class EventDispatcherTest extends TestCase
+{
+    /**
+     * @var EventDispatcher
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var string
+     */
+    private $eventName;
+
+    /**
+     * @var callable
+     */
+    private $listener;
+
+    /**
+     * @var int
+     */
+    private $listenerCallsCount = 0;
+
+    public function setUp()
+    {
+        $this->eventName = UserWasCreated::class;
+
+        $this->listener = function () {
+            $this->listenerCallsCount++;
+        };
+
+        $this->eventDispatcher = new EventDispatcher();
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_event_listeners()
+    {
+        $this->eventDispatcher->addListener($this->eventName, $this->listener);
+
+        $this->assertTrue($this->eventDispatcher->hasListeners($this->eventName));
+        $this->assertEquals($this->listener, $this->eventDispatcher->getListeners($this->eventName)[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_return_empty_array_when_event_does_not_have_listeners()
+    {
+        $this->assertEquals([], $this->eventDispatcher->getListeners('test'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_calls_all_listeners_during_dispatch()
+    {
+        $this->eventDispatcher->addListener($this->eventName, $this->listener);
+        $this->eventDispatcher->addListener($this->eventName, $this->listener);
+
+        $this->eventDispatcher->dispatch(new UserWasCreated());
+
+        $this->assertEquals(2, $this->listenerCallsCount);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_event_listeners_from_subscriber()
+    {
+        $this->eventDispatcher->addSubscriber(new UserEventSubscriber());
+
+        $this->assertTrue($this->eventDispatcher->hasListeners($this->eventName));
+    }
+}

--- a/tests/Fixtures/CreateUserCommand.php
+++ b/tests/Fixtures/CreateUserCommand.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+namespace Infection\Tests\Fixtures;
+
+
+class CreateUserCommand
+{
+
+}

--- a/tests/Fixtures/UserEventSubscriber.php
+++ b/tests/Fixtures/UserEventSubscriber.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+namespace Infection\Tests\Fixtures;
+
+use Infection\EventDispatcher\EventSubscriberInterface;
+
+class UserEventSubscriber implements EventSubscriberInterface
+{
+    public function getSubscribedEvents()
+    {
+        return [
+            UserWasCreated::class => [$this, '__invoke'],
+        ];
+    }
+
+    public function __invoke()
+    {
+    }
+}

--- a/tests/Fixtures/UserWasCreated.php
+++ b/tests/Fixtures/UserWasCreated.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+namespace Infection\Tests\Fixtures;
+
+class UserWasCreated
+{
+}


### PR DESCRIPTION
Allow to whitelist mutators - run only particular set of mutators instead of all by default.

Example:

```bash
./infection.phar --mutators=PublicVisibility,Plus,Decrement
```