### PR TITLE
Auto add coverage filter whitelist for phpunit.xml.dist to make it possible to analyze coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection --allow-risky=yes
   - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
-  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=49 --min-covered-msi=89; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=50 --min-covered-msi=89; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -68,7 +68,7 @@ class Factory
 
             return new PhpUnitAdapter(
                 new TestFrameworkExecutableFinder(PhpUnitAdapter::NAME, $this->infectionConfig->getPhpUnitCustomPath()),
-                new InitialConfigBuilder($this->tempDir, $phpUnitConfigPath, $this->pathReplacer, $this->jUnitFilePath),
+                new InitialConfigBuilder($this->tempDir, $phpUnitConfigPath, $this->pathReplacer, $this->jUnitFilePath, $this->infectionConfig->getSourceDirs()),
                 new MutationConfigBuilder($this->tempDir, $phpUnitConfigPath, $this->pathReplacer, $this->projectDir),
                 new ArgumentsAndOptionsBuilder()
             );

--- a/src/TestFramework/PhpUnit/Config/AbstractXmlConfiguration.php
+++ b/src/TestFramework/PhpUnit/Config/AbstractXmlConfiguration.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpUnit\Config;
 
-use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 
 abstract class AbstractXmlConfiguration
@@ -60,25 +59,6 @@ abstract class AbstractXmlConfiguration
         foreach ($nodes as $node) {
             $dom->documentElement->removeChild($node);
         }
-    }
-
-    protected function addCodeCoverageLogger(\DOMDocument $dom, \DOMXPath $xPath)
-    {
-        $loggingList = $xPath->query('/phpunit/logging');
-
-        // TODO reuse
-        if ($loggingList->length) {
-            $logging = $loggingList->item(0);
-        } else {
-            $logging = $dom->createElement('logging');
-            $dom->documentElement->appendChild($logging);
-        }
-
-        $coverageXmlLog = $dom->createElement('log');
-        $coverageXmlLog->setAttribute('type', 'coverage-xml');
-        $coverageXmlLog->setAttribute('target', $this->tempDirectory . '/' . CodeCoverageData::PHP_UNIT_COVERAGE_DIR);
-
-        $logging->appendChild($coverageXmlLog);
     }
 
     protected function setStopOnFailure(\DOMXPath $xPath)

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -32,12 +32,18 @@ class InitialConfigBuilder implements ConfigBuilder
      */
     private $jUnitFilePath;
 
-    public function __construct(string $tempDirectory, string $originalXmlConfigPath, PathReplacer $pathReplacer, string $jUnitFilePath)
+    /**
+     * @var array
+     */
+    private $srcDirs = [];
+
+    public function __construct(string $tempDirectory, string $originalXmlConfigPath, PathReplacer $pathReplacer, string $jUnitFilePath, array $srcDirs)
     {
         $this->tempDirectory = $tempDirectory;
         $this->originalXmlConfigPath = $originalXmlConfigPath;
         $this->pathReplacer = $pathReplacer;
         $this->jUnitFilePath = $jUnitFilePath;
+        $this->srcDirs = $srcDirs;
     }
 
     public function build(): string
@@ -48,7 +54,8 @@ class InitialConfigBuilder implements ConfigBuilder
             $this->tempDirectory,
             $this->originalXmlConfigPath,
             $this->pathReplacer,
-            $this->jUnitFilePath
+            $this->jUnitFilePath,
+            $this->srcDirs
         );
 
         file_put_contents($path, $xmlConfigurationFile->getXml());

--- a/src/TestFramework/PhpUnit/Config/InitialXmlConfiguration.php
+++ b/src/TestFramework/PhpUnit/Config/InitialXmlConfiguration.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpUnit\Config;
 
+use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 
 class InitialXmlConfiguration extends AbstractXmlConfiguration
@@ -17,11 +18,17 @@ class InitialXmlConfiguration extends AbstractXmlConfiguration
      */
     private $jUnitFilePath;
 
-    public function __construct($tempDirectory, $originalXmlConfigPath, PathReplacer $pathReplacer, string $jUnitFilePath)
+    /**
+     * @var array
+     */
+    private $srcDirs = [];
+
+    public function __construct(string $tempDirectory, string $originalXmlConfigPath, PathReplacer $pathReplacer, string $jUnitFilePath, array $srcDirs)
     {
         parent::__construct($tempDirectory, $originalXmlConfigPath, $pathReplacer);
 
         $this->jUnitFilePath = $jUnitFilePath;
+        $this->srcDirs = $srcDirs;
     }
 
     public function getXml(): string
@@ -35,6 +42,7 @@ class InitialXmlConfiguration extends AbstractXmlConfiguration
 
         $xPath = new \DOMXPath($dom);
 
+        $this->addCoverageFilterWhitelistIfDoesNotExist($dom, $xPath);
         $this->replaceWithAbsolutePaths($xPath);
         $this->setStopOnFailure($xPath);
         $this->deactivateColours($xPath);
@@ -47,19 +55,75 @@ class InitialXmlConfiguration extends AbstractXmlConfiguration
 
     private function addJUnitLogger(\DOMDocument $dom, \DOMXPath $xPath)
     {
-        $loggingList = $xPath->query('/phpunit/logging');
-
-        if ($loggingList->length) {
-            $logging = $loggingList->item(0);
-        } else {
-            $logging = $dom->createElement('logging');
-            $dom->documentElement->appendChild($logging);
-        }
+        $logging = $this->getOrCreateNode($dom, $xPath, 'logging');
 
         $junitLog = $dom->createElement('log');
         $junitLog->setAttribute('type', 'junit');
         $junitLog->setAttribute('target', $this->jUnitFilePath);
 
         $logging->appendChild($junitLog);
+    }
+
+    private function addCodeCoverageLogger(\DOMDocument $dom, \DOMXPath $xPath)
+    {
+        $logging = $this->getOrCreateNode($dom, $xPath, 'logging');
+
+        $coverageXmlLog = $dom->createElement('log');
+        $coverageXmlLog->setAttribute('type', 'coverage-xml');
+        $coverageXmlLog->setAttribute('target', $this->tempDirectory . '/' . CodeCoverageData::PHP_UNIT_COVERAGE_DIR);
+
+        $logging->appendChild($coverageXmlLog);
+    }
+
+    private function addCoverageFilterWhitelistIfDoesNotExist(\DOMDocument $dom, \DOMXPath $xPath)
+    {
+        $filterNode = $this->getNode($dom, $xPath, 'filter');
+
+        if ($filterNode === null) {
+            $filterNode = $this->createNode($dom, 'filter');
+
+            $whiteListNode = $dom->createElement('whitelist');
+
+            foreach ($this->srcDirs as $srcDir) {
+                $directoryNode = $dom->createElement(
+                    'directory',
+                        $srcDir
+                );
+
+                $whiteListNode->appendChild($directoryNode);
+            }
+
+            $filterNode->appendChild($whiteListNode);
+        }
+    }
+
+    private function getOrCreateNode(\DOMDocument $dom, \DOMXPath $xPath, string $nodeName): \DOMElement
+    {
+        $node = $this->getNode($dom, $xPath, $nodeName);
+
+        if ($node === null) {
+            $node = $this->createNode($dom, $nodeName);
+        }
+
+        return $node;
+    }
+
+    private function getNode(\DOMDocument $dom, \DOMXPath $xPath, string $nodeName)
+    {
+        $nodeList = $xPath->query(sprintf('/phpunit/%s', $nodeName));
+
+        if ($nodeList->length) {
+            return $nodeList->item(0);
+        }
+
+        return null;
+    }
+
+    private function createNode(\DOMDocument $dom, string $nodeName): \DOMElement
+    {
+        $node = $dom->createElement($nodeName);
+        $dom->documentElement->appendChild($node);
+
+        return $node;
     }
 }

--- a/tests/Files/phpunit/phpunit_root_test_suite.xml
+++ b/tests/Files/phpunit/phpunit_root_test_suite.xml
@@ -15,9 +15,9 @@
          processIsolation="false"
          syntaxCheck="false"
 >
-        <testsuite name="Application Test Suite">
-            <directory>./*Bundle</directory>
-        </testsuite>
+    <testsuite name="Application Test Suite">
+        <directory>./*Bundle</directory>
+    </testsuite>
 
     <filter>
         <whitelist>

--- a/tests/Files/phpunit/phpunit_without_coverage_whitelist.xml
+++ b/tests/Files/phpunit/phpunit_without_coverage_whitelist.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="app/autoload2.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>./*Bundle</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/TestFramework/PhpUnit/Config/AbstractXmlConfiguration.php
+++ b/tests/TestFramework/PhpUnit/Config/AbstractXmlConfiguration.php
@@ -34,9 +34,11 @@ abstract class AbstractXmlConfiguration extends TestCase
     protected $tempDir = '/path/to/tmp';
 
     /**
+     * @param string|null $phpunitXmlPath
+     * @param array $coverageTests
      * @return InitialXmlConfiguration|MutationXmlConfiguration
      */
-    abstract protected function getConfigurationObject();
+    abstract protected function getConfigurationObject(string $phpunitXmlPath = null, array $coverageTests = []);
 
     protected function setUp()
     {

--- a/tests/TestFramework/PhpUnit/Config/InitialXmlConfigurationTest.php
+++ b/tests/TestFramework/PhpUnit/Config/InitialXmlConfigurationTest.php
@@ -73,4 +73,16 @@ class InitialXmlConfigurationTest extends AbstractXmlConfiguration
 
         $this->assertSame(2, $filterNodes->length);
     }
+
+    public function test_it_does_not_create_coverage_filter_whitelist_node_if_already_exist()
+    {
+        $configuration = $this->getConfigurationObject();
+
+        $xml = $configuration->getXml();
+
+        /** @var \DOMNodeList $filterNodes */
+        $filterNodes = $this->queryXpath($xml, '/phpunit/filter/whitelist/directory');
+
+        $this->assertSame(1, $filterNodes->length);
+    }
 }

--- a/tests/TestFramework/PhpUnit/Config/InitialXmlConfigurationTest.php
+++ b/tests/TestFramework/PhpUnit/Config/InitialXmlConfigurationTest.php
@@ -16,14 +16,15 @@ use function Infection\Tests\normalizePath as p;
 
 class InitialXmlConfigurationTest extends AbstractXmlConfiguration
 {
-    protected function getConfigurationObject()
+    protected function getConfigurationObject(string $phpunitXmlPath = null, array $coverageTests = [])
     {
-        $phpunitXmlPath = __DIR__ . '/../../../Files/phpunit/phpunit.xml';
-        $jUnitFilePath = '/path/to/jsunit.xml';
+        $resultPhpunitXmlPath = $phpunitXmlPath ?: __DIR__ . '/../../../Files/phpunit/phpunit.xml';
+        $jUnitFilePath = '/path/to/junit.xml';
+        $srcDirs = ['src', 'app'];
 
         $replacer = new PathReplacer(new Locator($this->pathToProject));
 
-        return new InitialXmlConfiguration($this->tempDir, $phpunitXmlPath, $replacer, $jUnitFilePath);
+        return new InitialXmlConfiguration($this->tempDir, $resultPhpunitXmlPath, $replacer, $jUnitFilePath, $srcDirs);
     }
 
     public function test_it_replaces_test_suite_directory_wildcard()
@@ -47,7 +48,7 @@ class InitialXmlConfigurationTest extends AbstractXmlConfiguration
         $this->assertSame($this->pathToProject . '/app/autoload2.php', $value);
     }
 
-    public function test_it_adds_php_logger()
+    public function test_it_adds_needed_loggers()
     {
         $xml = $this->configuration->getXml();
 
@@ -58,5 +59,18 @@ class InitialXmlConfigurationTest extends AbstractXmlConfiguration
         $this->assertSame($this->tempDir . '/coverage-xml', $logEntries[0]->getAttribute('target'));
         $this->assertSame('coverage-xml', $logEntries[0]->getAttribute('type'));
         $this->assertSame('junit', $logEntries[1]->getAttribute('type'));
+    }
+
+    public function test_it_creates_coverage_filter_whitelist_node_if_does_not_exist()
+    {
+        $phpunitXmlPath = __DIR__ . '/../../../Files/phpunit/phpunit_without_coverage_whitelist.xml';
+        $configuration = $this->getConfigurationObject($phpunitXmlPath);
+
+        $xml = $configuration->getXml();
+
+        /** @var \DOMNodeList $filterNodes */
+        $filterNodes = $this->queryXpath($xml, '/phpunit/filter/whitelist/directory');
+
+        $this->assertSame(2, $filterNodes->length);
     }
 }

--- a/tests/TestFramework/PhpUnit/Config/MutationXmlConfigurationTest.php
+++ b/tests/TestFramework/PhpUnit/Config/MutationXmlConfigurationTest.php
@@ -17,7 +17,7 @@ class MutationXmlConfigurationTest extends AbstractXmlConfiguration
 {
     private $customAutoloadConfigPath = '/custom/path/autoload.php';
 
-    protected function getConfigurationObject(array $coverageTests = [])
+    protected function getConfigurationObject(string $phpunitXmlPath = null, array $coverageTests = [])
     {
         $phpunitXmlPath = __DIR__ . '/../../../Files/phpunit/phpunit.xml';
 
@@ -64,7 +64,7 @@ class MutationXmlConfigurationTest extends AbstractXmlConfiguration
      */
     public function test_it_sets_sorted_list_of_test_files(array $coverageTests, array $expectedFiles)
     {
-        $configuration = $this->getConfigurationObject($coverageTests);
+        $configuration = $this->getConfigurationObject(null, $coverageTests);
         $xml = $configuration->getXml();
 
         $files = [];


### PR DESCRIPTION
It's possible when project's `phpunit.xml.dist` file does not have `<filter>` node that whitelists source code for code coverage.

This prevents Infection from anayling code because no coverage is created.

If this is the case, Infection now adds `filter->whitelist->all source dirs` nodes by default

```xml
<filter>
    <whitelist>
        <directory>src/</directory>
        <directory>other-source-dir/</directory>
    </whitelist>
</filter>
```