### PR TITLE
Fixed bootstrap.php for case with install by Composer as dependency and run from vendor/bin

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -4,6 +4,32 @@
  *
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
-require __DIR__ . '/../vendor/autoload.php';
+
+$files = [
+    __DIR__ . '/../../../autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/vendor/autoload.php'
+];
+
+foreach ($files as $file) {
+    if (file_exists($file)) {
+        define('INFECTION_COMPOSER_INSTALL', $file);
+
+        break;
+    }
+}
+unset($file);
+
+if (!defined('INFECTION_COMPOSER_INSTALL')) {
+    fwrite(STDERR,
+        'You need to set up the project dependencies using Composer:' . PHP_EOL . PHP_EOL .
+        '    composer install' . PHP_EOL . PHP_EOL .
+        'You can learn all about Composer on https://getcomposer.org/.' . PHP_EOL
+    );
+
+    die(1);
+}
+
+require INFECTION_COMPOSER_INSTALL;
 
 $container = require __DIR__ . '/container.php';

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -18,7 +18,6 @@ foreach ($files as $file) {
         break;
     }
 }
-unset($file);
 
 if (!defined('INFECTION_COMPOSER_INSTALL')) {
     fwrite(STDERR,


### PR DESCRIPTION
Fixed `bootstrap.php` for case with install by Composer as dependency and run from `vendor/bin` (`./vendor/bin/infection`).