### PR TITLE
Fix autoload section from composer.json and allow to use multiple paths

### DIFF
--- a/src/Config/ValueProvider/SourceDirsProvider.php
+++ b/src/Config/ValueProvider/SourceDirsProvider.php
@@ -40,9 +40,13 @@ class SourceDirsProvider
         $guessedSourceDirs = null;
 
         if (file_exists('composer.json')) {
-            $sourceDirGuesser = new SourceDirGuesser(
-                json_decode(file_get_contents('composer.json'))
-            );
+            $content = json_decode(file_get_contents('composer.json'));
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \LogicException('composer.json does not contain valid JSON');
+            }
+
+            $sourceDirGuesser = new SourceDirGuesser($content);
             $guessedSourceDirs = $sourceDirGuesser->guess();
         }
 

--- a/tests/Config/Guesser/PhpUnitPathGuesserTest.php
+++ b/tests/Config/Guesser/PhpUnitPathGuesserTest.php
@@ -7,8 +7,7 @@
 
 declare(strict_types=1);
 
-
-namespace Infection\Tests\Guesser;
+namespace Infection\Tests\Config\Guesser;
 
 use Infection\Config\Guesser\PhpUnitPathGuesser;
 use PHPUnit\Framework\TestCase;

--- a/tests/Config/Guesser/SourceDirGuesserTest.php
+++ b/tests/Config/Guesser/SourceDirGuesserTest.php
@@ -7,8 +7,7 @@
 
 declare(strict_types=1);
 
-
-namespace Infection\Tests\Guesser;
+namespace Infection\Tests\Config\Guesser;
 
 use Infection\Config\Guesser\SourceDirGuesser;
 use PHPUnit\Framework\TestCase;
@@ -63,5 +62,43 @@ CODE;
         $guesser = new SourceDirGuesser(json_decode($composerJson));
 
         $this->assertSame(['src'], $guesser->guess());
+    }
+
+    public function test_it_returns_null_when_does_not_have_autoload()
+    {
+        $guesser = new SourceDirGuesser(json_decode('{}'));
+
+        $this->assertNull($guesser->guess());
+    }
+
+    public function test_it_returns_only_src_if_contains_array_of_paths()
+    {
+        $guesser = new SourceDirGuesser(
+            json_decode('{"autoload":{"psr-0": {"": ["src/", "libs"]}}}')
+        );
+
+        $this->assertSame(['src'], $guesser->guess());
+    }
+
+    public function test_it_returns_list_if_contains_array_of_paths_without_src()
+    {
+        $guesser = new SourceDirGuesser(
+            json_decode('{"autoload":{"psr-4": {"NameSpace\\//": ["sources/", "libs"]}}}')
+        );
+
+        $this->assertSame(['sources', 'libs'], $guesser->guess());
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage autoload section does not match the expected JSON schema
+     */
+    public function test_it_throw_invalid_autoload_exception()
+    {
+        $guesser = new SourceDirGuesser(
+            json_decode('{"autoload":{"psr-4": [{"NameSpace\\//": ["sources/", "libs"]}]}}')
+        );
+
+        $guesser->guess();
     }
 }


### PR DESCRIPTION
Fix for https://github.com/infection/infection/issues/23 issue.

I've added some rules + few exceptions.
Didn't find any valid way to parse composer.json without including JsonLint library. I think it'll be overhead.