### PR TITLE
Add exceptions handling with printing trace for verbose level.

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,5 +1,5 @@
 {
-    "timeout": 20,
+    "timeout": 25,
     "source": {
         "directories": [
             "src"

--- a/src/Console/Exception/InfectionException.php
+++ b/src/Console/Exception/InfectionException.php
@@ -6,12 +6,10 @@
  */
 declare(strict_types=1);
 
+
 namespace Infection\Console\Exception;
 
-class InvalidOptionException extends InfectionException
+
+class InfectionException extends \Exception
 {
-    public static function withMessage(string $message)
-    {
-        return new self($message);
-    }
 }

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -83,7 +83,7 @@ class Mutation
             $attrs['startTokenPos'],
             $attrs['endTokenPos'],
             $attrs['startFilePos'],
-            $attrs['startFilePos'],
+            $attrs['endFilePos'],
         ];
 
         $hashKeys = array_merge([$this->getOriginalFilePath(), $mutatorClass], $attributeValues);

--- a/src/TestFramework/Coverage/CoverageDoesNotExistException.php
+++ b/src/TestFramework/Coverage/CoverageDoesNotExistException.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\TestFramework\Coverage;
+
+use Infection\Console\Exception\InfectionException;
+
+class CoverageDoesNotExistException extends InfectionException
+{
+    public static function with(string $coverageIndexFilePath, string $testFrameworkKey, string $tempDir): self
+    {
+        return new self(
+            sprintf(
+                'Code Coverage does not exist. File %s is not found. Check %s version Infection was run with and generated config files inside %s.',
+                $coverageIndexFilePath,
+                $testFrameworkKey,
+                $tempDir
+            )
+        );
+    }
+}

--- a/tests/MutationTest.php
+++ b/tests/MutationTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests;
+
+use Infection\Mutation;
+use Infection\Mutator\Arithmetic\Plus;
+use PHPUnit\Framework\TestCase;
+
+class MutationTest extends TestCase
+{
+    public function test_it_correctly_generates_hash()
+    {
+        $mutator = new Plus();
+        $attributes = [
+            'startLine' => 3,
+            'endLine' => 5,
+            'startTokenPos' => 21,
+            'endTokenPos' => 31,
+            'startFilePos' => 43,
+            'endFilePos' => 53,
+        ];
+
+        $mutation = new Mutation(
+            '/abc.php',
+            $mutator,
+            $attributes,
+            'Interface_'
+        );
+
+        $this->assertSame('5f52c44bcebde86a7ee79d0080c0e12a', $mutation->getHash());
+    }
+}

--- a/tests/TestFramework/Coverage/CodeCoverageDataTest.php
+++ b/tests/TestFramework/Coverage/CodeCoverageDataTest.php
@@ -15,6 +15,7 @@ use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
+use Infection\TestFramework\TestFrameworkTypes;
 use PHPUnit\Framework\TestCase;
 use Mockery;
 
@@ -158,6 +159,18 @@ class CodeCoverageDataTest extends TestCase
         $this->assertCount(6, $codeCoverageData->getAllTestsFor($mutation));
     }
 
+    /**
+     * @expectedException \Infection\TestFramework\Coverage\CoverageDoesNotExistException
+     */
+    public function test_it_throws_an_exception_when_no_coverage_found()
+    {
+        $coverageXmlParserMock = Mockery::mock(CoverageXmlParser::class);
+
+        $coverage = new CodeCoverageData('/abc', $coverageXmlParserMock, TestFrameworkTypes::PHPUNIT);
+
+        $coverage->hasTests('/abc/def.php');
+    }
+
     private function getParsedCodeCoverageData(): array
     {
         return [
@@ -215,6 +228,6 @@ class CodeCoverageDataTest extends TestCase
         $coverageXmlParserMock = Mockery::mock(CoverageXmlParser::class);
         $coverageXmlParserMock->shouldReceive('parse')->once()->andReturn($this->getParsedCodeCoverageData());
 
-        return new CodeCoverageData($this->coverageDir, $coverageXmlParserMock);
+        return new CodeCoverageData($this->coverageDir, $coverageXmlParserMock, TestFrameworkTypes::PHPUNIT);
     }
 }


### PR DESCRIPTION
Add exceptions handling with printing trace for a verbose level.

Throw exception with friendly details when Code Coverage not found. This will help developers to understand issues quicker.

Fixes #29