### PR TITLE
Add Filesystem and add Directory Check for logs path.

### DIFF
--- a/app/container.php
+++ b/app/container.php
@@ -15,6 +15,7 @@ use Infection\Mutant\MutantCreator;
 use Infection\Command\InfectionCommand;
 use Infection\Process\Runner\Parallel\ParallelProcessRunner;
 use Infection\EventDispatcher\EventDispatcher;
+use Infection\Filesystem\Filesystem;
 use Infection\Finder\Locator;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
@@ -44,6 +45,10 @@ $c['phpunit.config.dir'] = function (Container $c): string {
 
 $c['temp.dir'] = function (Container $c): string {
     return $c['temp.dir.creator']->createAndGet();
+};
+
+$c['filesystem'] = function (Container $c): Filesystem {
+    return new Filesystem();
 };
 
 $c['temp.dir.creator'] = function (): TempDirectoryCreator {

--- a/src/Filesystem/Exception/IOException.php
+++ b/src/Filesystem/Exception/IOException.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Filesystem\Exception;
+
+class IOException extends \RuntimeException
+{
+    /**
+     * @var null|string
+     */
+    private $path;
+
+    public function __construct($message, $code = 0, \Exception $previous = null, $path = null)
+    {
+        $this->path = $path;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+}

--- a/src/Filesystem/Exception/IOExceptionInterface.php
+++ b/src/Filesystem/Exception/IOExceptionInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+namespace Infection\Filesystem\Exception;
+
+interface IOExceptionInterface
+{
+    /**
+     * Returns the associated path for the exception.
+     *
+     * @return string The path
+     */
+    public function getPath();
+}

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -18,7 +18,7 @@ class Filesystem
      * @param string $path The directory path
      * @param int $mode The directory mode
      *
-     * @throws \RuntimeException On any directory creation failure
+     * @throws IOException On any directory creation failure
      */
     public function mkdir($path, int $mode = 0755)
     {

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Filesystem;
+
+use Infection\Filesystem\Exception\IOException;
+
+class Filesystem
+{
+    /**
+     * Create a directory recursively.
+     *
+     * @param string $path The directory path
+     * @param int $mode The directory mode
+     *
+     * @throws \RuntimeException On any directory creation failure
+     */
+    public function mkdir($path, int $mode = 0755)
+    {
+        if (\is_dir($path)) {
+            return;
+        }
+
+        if (true !== @\mkdir($path, $mode, true)) {
+            $error = \error_get_last();
+
+            if ($error) {
+                throw new IOException(\sprintf('Failed to create "%s": %s', $path, $error['message']), 0, null, $path);
+            }
+
+            throw new IOException(\sprintf('Failed to create "%s"', $path), 0, null, $path);
+        }
+    }
+}

--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -161,7 +161,7 @@ class InfectionApplication
         $eventDispatcher->addSubscriber(new MutationGeneratingConsoleLoggerSubscriber($this->output, $mutationGeneratingProgressBar));
         $eventDispatcher->addSubscriber(new MutantCreatingConsoleLoggerSubscriber($this->output, $mutantCreatingProgressBar));
         $eventDispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber($this->output, $this->getOutputFormatter(), $metricsCalculator, $this->get('diff.colorizer'), $this->input->getOption('show-mutations')));
-        $eventDispatcher->addSubscriber(new TextFileLoggerSubscriber($this->get('infection.config'), $metricsCalculator));
+        $eventDispatcher->addSubscriber(new TextFileLoggerSubscriber($this->get('infection.config'), $metricsCalculator, $this->get('filesystem')));
     }
 
     private function getCodeCoverageData(string $testFrameworkKey): CodeCoverageData

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -108,10 +108,13 @@ class IncludeInterceptor
     public function mkdir($path, $mode, $options)
     {
         self::disable();
+
+        $isRecursive = (bool) ($options & STREAM_MKDIR_RECURSIVE);
+
         if (isset($this->context)) {
-            $return = mkdir($path, $mode, $options, $this->context);
+            $return = mkdir($path, $mode, $isRecursive, $this->context);
         } else {
-            $return = mkdir($path, $mode, $options);
+            $return = mkdir($path, $mode, $isRecursive);
         }
         self::enable();
 

--- a/src/Utils/TempDirectoryCreator.php
+++ b/src/Utils/TempDirectoryCreator.php
@@ -15,11 +15,19 @@ class TempDirectoryCreator
      */
     private $tempDirectory;
 
-    public function createAndGet($dirName = null): string
+    /**
+     * @param string|null $dir
+     *
+     * @return string
+     */
+    public function createAndGet(string $dirName = null): string
     {
         if ($this->tempDirectory === null) {
-            $root = sys_get_temp_dir();
-            $path = $root . sprintf('/%s', $dirName ?: 'infection');
+            $path =  sprintf(
+                '%s/%s',
+                sys_get_temp_dir(),
+                $dirName ?: 'infection'
+            );
 
             if (!@mkdir($path, 0777, true) && !is_dir($path)) {
                 throw new \RuntimeException('Can not create temp dir');

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -76,12 +76,12 @@ class FilesystemTest extends TestCase
 
     public function test_mkdir_passes_path_to_io_exceptino()
     {
+        $basePath = $this->workspace.DIRECTORY_SEPARATOR;
+        $dir = $basePath.'2';
+
+        \file_put_contents($dir, '');
+
         try {
-            $basePath = $this->workspace.DIRECTORY_SEPARATOR;
-            $dir = $basePath.'2';
-
-            \file_put_contents($dir, '');
-
             $this->filesystem->mkdir($dir);
         } catch (IOException $e) {
             $this->assertSame($dir, $e->getPath());

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Filesystem;
 
+use Infection\Filesystem\Exception\IOException;
 use Infection\Filesystem\Filesystem;
 use PHPUnit\Framework\TestCase;
 
@@ -61,6 +62,7 @@ class FilesystemTest extends TestCase
 
     /**
      * @expectedException \Infection\Filesystem\Exception\IOException
+     * @expectedExceptionCode 0
      */
     public function test_mkdir_creates_directory_fails()
     {
@@ -70,5 +72,29 @@ class FilesystemTest extends TestCase
         \file_put_contents($dir, '');
 
         $this->filesystem->mkdir($dir);
+    }
+
+    public function test_mkdir_passes_path_to_io_exceptino()
+    {
+        try {
+            $basePath = $this->workspace.DIRECTORY_SEPARATOR;
+            $dir = $basePath.'2';
+
+            \file_put_contents($dir, '');
+
+            $this->filesystem->mkdir($dir);
+        } catch (IOException $e) {
+            $this->assertSame($dir, $e->getPath());
+        }
+    }
+
+    public function test_mkdir_does_not_fail_when_dir_already_exists()
+    {
+        $dir = $this->workspace . DIRECTORY_SEPARATOR . 'test' . DIRECTORY_SEPARATOR;
+
+        $this->filesystem->mkdir($dir);
+        $this->filesystem->mkdir($dir);
+
+        $this->assertTrue(\is_dir($dir));
     }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests\Filesystem;
+
+use Infection\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
+
+class FilesystemTest extends TestCase
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string
+     */
+    private $workspace;
+
+    private $umask;
+
+    protected function setUp()
+    {
+        $this->umask = \umask(0);
+        $this->filesystem = new Filesystem();
+        $this->workspace = \sys_get_temp_dir() . '/' . \microtime(true) . \random_int(100, 999);
+        \mkdir($this->workspace, 0777, true);
+    }
+
+    protected function tearDown()
+    {
+        @\unlink($this->workspace);
+        \umask($this->umask);
+    }
+
+    public function test_mkdir_creates_directory()
+    {
+        $dir = $this->workspace . DIRECTORY_SEPARATOR . 'test' . DIRECTORY_SEPARATOR;
+
+        $this->filesystem->mkdir($dir);
+
+        $this->assertTrue(\is_dir($dir));
+    }
+
+    public function test_mkdir_creates_directory_recursively()
+    {
+        $dir = $this->workspace
+            . DIRECTORY_SEPARATOR . 'test'
+            . DIRECTORY_SEPARATOR . 'sub_directory';
+
+        $this->filesystem->mkdir($dir);
+
+        $this->assertTrue(\is_dir($dir));
+    }
+
+    /**
+     * @expectedException \Infection\Filesystem\Exception\IOException
+     */
+    public function test_mkdir_creates_directory_fails()
+    {
+        $basePath = $this->workspace.DIRECTORY_SEPARATOR;
+        $dir = $basePath.'2';
+
+        \file_put_contents($dir, '');
+
+        $this->filesystem->mkdir($dir);
+    }
+}


### PR DESCRIPTION
Implemented Filesystem class.

For example to prevent cases when user wants to put his logs into `./my-test/folder/infection-log.txt`.
I've implemented `mkdir` method only.