### PR TITLE
Add option to pass test framework extra options

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -44,6 +44,12 @@ class InfectionCommand extends Command
                 'phpunit'
             )
             ->addOption(
+                'test-framework-options',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Options to be passed to the test framework'
+            )
+            ->addOption(
                 'threads',
                 null,
                 InputOption::VALUE_REQUIRED,

--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -32,11 +32,11 @@ class ProcessBuilder
         $this->timeout = $timeout;
     }
 
-    public function getProcessForInitialTestRun(): Process
+    public function getProcessForInitialTestRun(string $testFrameworkExtraOptions = ''): Process
     {
         $configPath = $this->testFrameworkAdapter->buildInitialConfigFile();
 
-        return $this->getProcess($configPath);
+        return $this->getProcess($configPath, $testFrameworkExtraOptions);
 
         // TODO debug why processBuilder does not work with env
         // TODO read and add -vvv
@@ -53,22 +53,23 @@ class ProcessBuilder
      * @throws RuntimeException
      *
      * @param Mutant $mutant
+     * @param string|null $testFrameworkExtraOptions
      *
      * @return MutantProcess
      */
-    public function getProcessForMutant(Mutant $mutant): MutantProcess
+    public function getProcessForMutant(Mutant $mutant, string $testFrameworkExtraOptions = ''): MutantProcess
     {
         $configPath = $this->testFrameworkAdapter->buildMutationConfigFile($mutant);
 
-        $symfonyProcess = $this->getProcess($configPath, $this->timeout);
+        $symfonyProcess = $this->getProcess($configPath, $testFrameworkExtraOptions, $this->timeout);
 
         return new MutantProcess($symfonyProcess, $mutant, $this->testFrameworkAdapter);
     }
 
-    private function getProcess(string $configPath, int $timeout = null): Process
+    private function getProcess(string $configPath, string $testFrameworkExtraOptions, int $timeout = null): Process
     {
         return new Process(
-            $this->testFrameworkAdapter->getExecutableCommandLine($configPath),
+            $this->testFrameworkAdapter->getExecutableCommandLine($configPath, $testFrameworkExtraOptions),
             null,
             array_replace($_ENV, $_SERVER),
             null,

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -39,9 +39,9 @@ class InitialTestsRunner
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    public function run(): Process
+    public function run(string $testFrameworkExtraOptions): Process
     {
-        $process = $this->processBuilder->getProcessForInitialTestRun();
+        $process = $this->processBuilder->getProcessForInitialTestRun($testFrameworkExtraOptions);
 
         $this->eventDispatcher->dispatch(new InitialTestSuiteStarted());
 

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -54,17 +54,17 @@ class MutationTestingRunner
         $this->mutations = $mutations;
     }
 
-    public function run(int $threadCount, CodeCoverageData $codeCoverageData)
+    public function run(int $threadCount, CodeCoverageData $codeCoverageData, string $testFrameworkExtraOptions)
     {
         $mutantCount = count($this->mutations);
 
         $this->eventDispatcher->dispatch(new MutantsCreatingStarted($mutantCount));
 
         $processes = array_map(
-            function (Mutation $mutation) use ($codeCoverageData): MutantProcess {
+            function (Mutation $mutation) use ($codeCoverageData, $testFrameworkExtraOptions): MutantProcess {
                 $mutant = $this->mutantCreator->create($mutation, $codeCoverageData);
 
-                $process = $this->processBuilder->getProcessForMutant($mutant);
+                $process = $this->processBuilder->getProcessForMutant($mutant, $testFrameworkExtraOptions);
 
                 $this->eventDispatcher->dispatch(new MutantCreated());
 

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -67,15 +67,16 @@ abstract class AbstractTestFrameworkAdapter
      *     vendor/phpunit/phpunit/phpunit
      *
      * @param string $configPath
+     * @param string $extraOptions
      *
      * @return string
      */
-    public function getExecutableCommandLine(string $configPath): string
+    public function getExecutableCommandLine(string $configPath, string $extraOptions): string
     {
         return sprintf(
             '%s %s',
             $this->executableFinder->find(),
-            $this->argumentsAndOptionsBuilder->build($configPath)
+            $this->argumentsAndOptionsBuilder->build($configPath, $extraOptions)
         );
     }
 

--- a/src/TestFramework/CommandLineArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/CommandLineArgumentsAndOptionsBuilder.php
@@ -10,5 +10,5 @@ namespace Infection\TestFramework;
 
 interface CommandLineArgumentsAndOptionsBuilder
 {
-    public function build(string $configPath): string;
+    public function build(string $configPath, string $extraOptions): string;
 }

--- a/src/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -12,7 +12,7 @@ use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 
 class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilder
 {
-    public function build(string $configPath): string
+    public function build(string $configPath, string $extraOptions): string
     {
         $options = ['run'];
 
@@ -20,6 +20,8 @@ class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilde
         $options[] = '--no-ansi';
         $options[] = '--format=tap';
         $options[] = '--stop-on-failure';
+
+        $options[] = $extraOptions;
 
         return implode(' ', $options);
     }

--- a/src/TestFramework/PhpSpec/PhpSpecExtraOptions.php
+++ b/src/TestFramework/PhpSpec/PhpSpecExtraOptions.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\TestFramework\PhpSpec;
+
+use Infection\TestFramework\TestFrameworkExtraOptions;
+
+class PhpSpecExtraOptions extends TestFrameworkExtraOptions
+{
+    protected function getInitialRunOnlyOptions(): array
+    {
+        return [];
+    }
+}

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -12,12 +12,14 @@ use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 
 class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilder
 {
-    public function build(string $configPath): string
+    public function build(string $configPath, string $extraOptions): string
     {
         $options = [];
 
         $options[] = sprintf('--configuration %s', $configPath);
         $options[] = '--stop-on-failure';
+
+        $options[] = $extraOptions;
 
         return implode(' ', $options);
     }

--- a/src/TestFramework/PhpUnit/PhpUnitExtraOptions.php
+++ b/src/TestFramework/PhpUnit/PhpUnitExtraOptions.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\TestFramework\PhpUnit;
+
+use Infection\TestFramework\TestFrameworkExtraOptions;
+
+class PhpUnitExtraOptions extends TestFrameworkExtraOptions
+{
+    protected function getInitialRunOnlyOptions(): array
+    {
+        return ['--filter'];
+    }
+}

--- a/src/TestFramework/TestFrameworkExtraOptions.php
+++ b/src/TestFramework/TestFrameworkExtraOptions.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\TestFramework;
+
+abstract class TestFrameworkExtraOptions
+{
+    /**
+     * @var string
+     */
+    private $extraOptions;
+
+    abstract protected function getInitialRunOnlyOptions(): array;
+
+    public function __construct(string $extraOptions = null)
+    {
+        $this->extraOptions = $extraOptions ?: '';
+    }
+
+    public function getForInitialProcess(): string
+    {
+        return $this->extraOptions;
+    }
+
+    public function getForMutantProcess(): string
+    {
+        $extraOptions = $this->extraOptions;
+
+        foreach ($this->getInitialRunOnlyOptions() as $initialRunOnlyOption) {
+            $extraOptions = preg_replace(sprintf('/%s[\=| ]([^ ]+)/', $initialRunOnlyOption), '', $extraOptions);
+        }
+
+        return preg_replace('/\s+/', ' ', trim($extraOptions));
+    }
+}

--- a/tests/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -7,11 +7,9 @@
 
 declare(strict_types=1);
 
+namespace Infection\Tests\TestFramework\PhpUnit\CommandLine;
 
-namespace Infection\Tests\TestFramework\PhpSpec\CommandLine;
-
-
-use Infection\TestFramework\PhpSpec\CommandLine\ArgumentsAndOptionsBuilder;
+use Infection\TestFramework\PhpUnit\CommandLine\ArgumentsAndOptionsBuilder;
 use PHPUnit\Framework\TestCase;
 
 class ArgumentsAndOptionsBuilderTest extends TestCase
@@ -23,11 +21,8 @@ class ArgumentsAndOptionsBuilderTest extends TestCase
 
         $command = $builder->build($configPath, '--verbose');
 
-        $this->assertContains('run', $command);
-        $this->assertContains('--no-ansi', $command);
-        $this->assertContains('--format=tap', $command);
         $this->assertContains('--stop-on-failure', $command);
         $this->assertContains('--verbose', $command);
-        $this->assertContains(sprintf('--config=%s', $configPath), $command);
+        $this->assertContains(sprintf('--configuration %s', $configPath), $command);
     }
 }

--- a/tests/TestFramework/PhpUnit/PhpUnitExtraOptionsTest.php
+++ b/tests/TestFramework/PhpUnit/PhpUnitExtraOptionsTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests\TestFramework\PhpUnit;
+
+use Infection\TestFramework\PhpUnit\PhpUnitExtraOptions;
+use PHPUnit\Framework\TestCase;
+
+class PhpUnitExtraOptionsTest extends TestCase
+{
+    /**
+     * @dataProvider mutantProcessProvider
+     */
+    public function test_it_skips_filter_for_mutant_process(string $sourceExtraOptions, string $expectedExtraOptions)
+    {
+        $phpUnitOptions = new PhpUnitExtraOptions($sourceExtraOptions);
+
+        $this->assertSame($expectedExtraOptions, $phpUnitOptions->getForMutantProcess());
+    }
+
+    public function test_it_returns_empty_string_when_source_options_are_null()
+    {
+        $phpUnitOptions = new PhpUnitExtraOptions(null);
+
+        $this->assertSame('', $phpUnitOptions->getForInitialProcess());
+        $this->assertSame('', $phpUnitOptions->getForMutantProcess());
+    }
+
+    public function mutantProcessProvider()
+    {
+        return [
+            ['--filter=someTest#2 --a --b=value', '--a --b=value'],
+            ['--a --filter=someTest#2 --b=value', '--a --b=value'],
+            ['--a --filter someTest#2 --b=value', '--a --b=value'],
+        ];
+    }
+}


### PR DESCRIPTION
This feature allows to pass additional options to the testing framework.

Use case: when you want to run only particular tests, you can run

```bash
infection.phar --test-framework-options="--filter=just/unit/tests"
```

`--filter` options for PHPUnit is a special one, because we can add it to executable command only for *initial* test run. For each mutation process, it can't be used because we already have filtered out list of executed tests which should not be overridden by this option.