### PR TITLE
Fix performance bottleneck by introducing a simple instance-level object cache

### DIFF
--- a/app/container.php
+++ b/app/container.php
@@ -26,6 +26,7 @@ use Infection\Differ\DiffColorizer;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
 use Infection\Config\InfectionConfig;
 use Infection\Utils\VersionParser;
+use Infection\TestFramework\Coverage\CachedTestFileDataProvider;
 
 $c = new Container();
 
@@ -104,7 +105,9 @@ $c['phpunit.junit.file.path'] = function (Container $c): string {
 };
 
 $c['test.file.data.provider.phpunit'] = function (Container $c): TestFileDataProvider {
-    return new PhpUnitTestFileDataProvider($c['phpunit.junit.file.path']);
+    return new CachedTestFileDataProvider(
+        new PhpUnitTestFileDataProvider($c['phpunit.junit.file.path'])
+    );
 };
 
 $c['version.parser'] = function (): VersionParser {

--- a/src/TestFramework/Coverage/CachedTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/CachedTestFileDataProvider.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\TestFramework\Coverage;
+
+class CachedTestFileDataProvider implements TestFileDataProvider
+{
+    /**
+     * @var TestFileDataProvider
+     */
+    private $testFileDataProvider;
+
+    /**
+     * @var array
+     */
+    private $testFileInfoCache = [];
+
+    public function __construct(TestFileDataProvider $testFileDataProvider)
+    {
+        $this->testFileDataProvider = $testFileDataProvider;
+    }
+
+    public function getTestFileInfo(string $fullyQualifiedClassName): array
+    {
+        if (array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
+            return $this->testFileInfoCache[$fullyQualifiedClassName];
+        }
+
+        return $this->testFileInfoCache[$fullyQualifiedClassName] = $this->testFileDataProvider->getTestFileInfo(
+            $fullyQualifiedClassName
+        );
+    }
+}

--- a/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
+++ b/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
@@ -23,11 +23,6 @@ class PhpUnitTestFileDataProvider implements TestFileDataProvider
      */
     private $xPath;
 
-    /**
-     * @var array
-     */
-    private $testFileInfoCache = [];
-
     public function __construct(string $jUnitFilePath)
     {
         $this->jUnitFilePath = $jUnitFilePath;
@@ -35,10 +30,6 @@ class PhpUnitTestFileDataProvider implements TestFileDataProvider
 
     public function getTestFileInfo(string $fullyQualifiedClassName): array
     {
-        if (array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
-            return $this->testFileInfoCache[$fullyQualifiedClassName];
-        }
-
         $xPath = $this->getXPath();
 
         $nodes = $xPath->query(sprintf('//testsuite[@name="%s"]', $fullyQualifiedClassName));
@@ -47,7 +38,7 @@ class PhpUnitTestFileDataProvider implements TestFileDataProvider
             throw new TestFileNameNotFoundException(sprintf('For FQCN: %s', $fullyQualifiedClassName));
         }
 
-        return $this->testFileInfoCache[$fullyQualifiedClassName] = [
+        return [
             'path' => $nodes[0]->getAttribute('file'),
             'time' => (float) $nodes[0]->getAttribute('time'),
         ];

--- a/tests/Files/phpunit/junit.xml
+++ b/tests/Files/phpunit/junit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<testsuites>
+  <testsuite name="Application Test Suite" tests="118" assertions="155" errors="0" failures="1" skipped="0" time="0.767565">
+    <testsuite name="Infection\Tests\Config\InfectionConfigTest" file="/project/tests/Config/InfectionConfigTest.php" tests="11" assertions="11" errors="0" failures="0" skipped="0" time="0.021983">
+      <testcase name="test_it_returns_default_timeout_with_no_config" class="Infection\Tests\Config\InfectionConfigTest" classname="Infection.Tests.Config.InfectionConfigTest" file="/project/tests/Config/InfectionConfigTest.php" line="14" assertions="1" time="0.017883"/>
+      <testcase name="test_it_returns_timeout_from_config" class="Infection\Tests\Config\InfectionConfigTest" classname="Infection.Tests.Config.InfectionConfigTest" file="/project/tests/Config/InfectionConfigTest.php" line="21" assertions="1" time="0.000353"/>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
+++ b/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+namespace Infection\Tests\TestFramework\Coverage;
+
+use Infection\TestFramework\Coverage\CachedTestFileDataProvider;
+use Infection\TestFramework\Coverage\TestFileDataProvider;
+use PHPUnit\Framework\TestCase;
+use \Mockery;
+
+class CachedTestFileDataProviderTest extends TestCase
+{
+    public function test_the_second_call_returns_cached_result()
+    {
+        $class = 'Test\Class';
+        $providerMock = Mockery::mock(TestFileDataProvider::class);
+        $providerMock->shouldReceive('getTestFileInfo')
+            ->with($class)
+            ->once()
+            ->andReturn(['data']);
+
+        $infoProvider = new CachedTestFileDataProvider($providerMock);
+
+        $info1 = $infoProvider->getTestFileInfo($class);
+        $info2 = $infoProvider->getTestFileInfo($class);
+
+        $this->assertSame($info1, $info2);
+    }
+
+    protected function tearDown()
+    {
+        if ($container = Mockery::getContainer()) {
+            $this->addToAssertionCount($container->mockery_getExpectationCount());
+        }
+
+        Mockery::close();
+    }
+}

--- a/tests/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProviderTest.php
+++ b/tests/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProviderTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+namespace Infection\Tests\TestFramework\PhpUnit\Coverage;
+
+use Infection\TestFramework\PhpUnit\Coverage\PhpUnitTestFileDataProvider;
+use PHPUnit\Framework\TestCase;
+
+class PhpUnitTestFileDataProviderTest extends TestCase
+{
+    /**
+     * @var PhpUnitTestFileDataProvider
+     */
+    private $infoProvider;
+
+    protected function setUp()
+    {
+        $this->infoProvider = new PhpUnitTestFileDataProvider(
+            __DIR__ . '/../../../Files/phpunit/junit.xml'
+        );
+    }
+
+    /**
+     * @expectedException \Infection\TestFramework\Coverage\TestFileNameNotFoundException
+     */
+    public function test_it_throws_an_exception_if_class_is_not_found()
+    {
+        $this->infoProvider->getTestFileInfo('abc');
+    }
+
+    public function test_it_returns_time_and_path()
+    {
+        $info = $this->infoProvider->getTestFileInfo('Infection\Tests\Config\InfectionConfigTest');
+
+        $this->assertSame('/project/tests/Config/InfectionConfigTest.php', $info['path']);
+        $this->assertSame(0.021983, $info['time']);
+    }
+
+    public function test_consecutive_calls_with_the_same_class_return_the_same_result()
+    {
+        $info1 = $this->infoProvider->getTestFileInfo('Infection\Tests\Config\InfectionConfigTest');
+        $info2 = $this->infoProvider->getTestFileInfo('Infection\Tests\Config\InfectionConfigTest');
+
+        $this->assertSame($info1, $info2);
+    }
+}


### PR DESCRIPTION
There was a performance issue with opening and parsings (XPath) `junit.xml` thousands of times instead of caching the results.

This update eliminates the issue.

Blackfire comparison before/after: https://blackfire.io/profiles/compare/a6ef3b53-93c5-44b4-bf16-9c2510b44e61/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()

On infection itself, the number of `DomDocument::loadXML` calls reduced by almost 8k times.

![blackfire](https://user-images.githubusercontent.com/3725595/30845131-ab333ad4-a29a-11e7-9780-c5c783ca48f1.png)
