### PR TITLE
Add composer script for static analyzing tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,13 @@ cache:
 
 before_install:
   - composer selfupdate
-  - composer global require friendsofphp/php-cs-fixer
-  - composer global require --dev 'phpstan/phpstan:^0.8'
 
 install:
   - composer install
 
 script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
-  - /home/travis/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --allow-risky=yes
-  - /home/travis/.composer/vendor/bin/phpstan analyse src tests --level=1 --no-interaction --no-progress
+  - composer analyze
   - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=57 --min-covered-msi=91; fi
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,21 @@
         "phpunit/phpunit": "^6.1",
         "mockery/mockery": "^0.9.9"
     },
-    "bin": ["bin/infection"]
+    "bin": ["bin/infection"],
+    "scripts": {
+        "analyze": [
+            "@php-cs-fixer",
+            "@phpstan"
+        ],
+        "phpstan": [
+            "wget -nc https://github.com/phpstan/phpstan/releases/download/0.8.4/phpstan.phar",
+            "chmod a+x phpstan.phar",
+            "./phpstan.phar analyse src tests --level=1 --no-interaction --no-progress"
+        ],
+        "php-cs-fixer": [
+            "wget -nc http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar",
+            "chmod a+x php-cs-fixer-v2.phar",
+            "./php-cs-fixer-v2.phar fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --allow-risky=yes"
+        ]
+    }
 }


### PR DESCRIPTION
This will simplify the process of running all static analyzing tools locally during development.

Just

```bash
composer analyze
```

It will download (if not yet exists) phars and run analyzing.