### PR TITLE
Add Log verbosity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - composer analyze
-  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=58 --min-covered-msi=91; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=59 --min-covered-msi=91; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Infection\Command;
 
-use Infection\Console\LogVerbosityInterface;
+use Infection\Console\LogVerbosity;
 use Infection\InfectionApplication;
 use Infection\Config\InfectionConfig;
 use Pimple\Container;
@@ -112,7 +112,7 @@ class InfectionCommand extends Command
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Log verbosity level. 1 - full logs format, 2 - short logs format.',
-                LogVerbosityInterface::DEBUG
+                LogVerbosity::DEBUG
             )
         ;
     }

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Infection\Command;
 
+use Infection\Console\LogVerbosityInterface;
 use Infection\InfectionApplication;
 use Infection\Config\InfectionConfig;
 use Pimple\Container;
@@ -105,6 +106,13 @@ class InfectionCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Minimum Covered Code Mutation Score Indicator (MSI) percentage value. Should be used in CI server.'
+            )
+            ->addOption(
+                'log-verbosity',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Log verbosity level. 1 - full logs format, 2 - short logs format.',
+                LogVerbosityInterface::DEBUG
             )
         ;
     }

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -196,6 +196,9 @@ class InfectionConfig
         return self::DEFAULT_EXCLUDE_DIRS;
     }
 
+    /**
+     * @return string|null
+     */
     public function getTextFileLogPath()
     {
         return $this->config->logs->text ?? null;

--- a/src/Console/LogVerbosity.php
+++ b/src/Console/LogVerbosity.php
@@ -7,7 +7,7 @@
 
 namespace Infection\Console;
 
-interface LogVerbosityInterface
+final class LogVerbosity
 {
     const DEBUG = 1;
     const NORMAL = 2;

--- a/src/Console/LogVerbosityInterface.php
+++ b/src/Console/LogVerbosityInterface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+namespace Infection\Console;
+
+interface LogVerbosityInterface
+{
+    const DEBUG = 1;
+    const NORMAL = 2;
+}

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -36,4 +36,29 @@ class Filesystem
             throw new IOException(\sprintf('Failed to create "%s"', $path), 0, null, $path);
         }
     }
+
+    /**
+     * Atomically dumps content into a file.
+     *
+     * @param string $filename The file to be written to
+     * @param string $content  The data to write into the file
+     *
+     * @throws IOException If the file cannot be written to
+     */
+    public function dumpFile(string $filename, string $content)
+    {
+        $dir = dirname($filename);
+
+        if (!is_dir($dir)) {
+            $this->mkdir($dir);
+        }
+
+        if (!is_writable($dir)) {
+            throw new IOException(sprintf('Unable to write to the "%s" directory.', $dir), 0, null, $dir);
+        }
+
+        if (false === @file_put_contents($filename, $content)) {
+            throw new IOException(sprintf('Failed to write file "%s".', $filename), 0, null, $filename);
+        }
+    }
 }

--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -178,7 +178,7 @@ class InfectionApplication
         $eventDispatcher->addSubscriber(new MutationGeneratingConsoleLoggerSubscriber($this->output, $mutationGeneratingProgressBar));
         $eventDispatcher->addSubscriber(new MutantCreatingConsoleLoggerSubscriber($this->output, $mutantCreatingProgressBar));
         $eventDispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber($this->output, $this->getOutputFormatter(), $metricsCalculator, $this->get('diff.colorizer'), $this->input->getOption('show-mutations')));
-        $eventDispatcher->addSubscriber(new TextFileLoggerSubscriber($this->get('infection.config'), $metricsCalculator, $this->get('filesystem')));
+        $eventDispatcher->addSubscriber(new TextFileLoggerSubscriber($this->get('infection.config'), $metricsCalculator, $this->get('filesystem'), (int) $this->input->getOption('log-verbosity')));
     }
 
     private function getCodeCoverageData(string $testFrameworkKey): CodeCoverageData

--- a/src/Process/Listener/TextFileLoggerSubscriber.php
+++ b/src/Process/Listener/TextFileLoggerSubscriber.php
@@ -62,10 +62,7 @@ class TextFileLoggerSubscriber implements EventSubscriberInterface
         $logFilePath = $this->infectionConfig->getTextFileLogPath();
 
         if ($logFilePath) {
-            $this->fs->mkdir(dirname($logFilePath));
-
             $logs[] = $this->getLogParts($this->metricsCalculator->getEscapedMutantProcesses(), 'Escaped');
-
             $logs[] = $this->getLogParts($this->metricsCalculator->getTimedOutProcesses(), 'Timeout');
 
             if ($this->isDebugMode) {
@@ -74,7 +71,7 @@ class TextFileLoggerSubscriber implements EventSubscriberInterface
 
             $logs[] = $this->getLogParts($this->metricsCalculator->getNotCoveredMutantProcesses(), 'Not covered');
 
-            file_put_contents(
+            $this->fs->dumpFile(
                 $logFilePath,
                 implode(
                     array_merge(...$logs),

--- a/src/Process/Listener/TextFileLoggerSubscriber.php
+++ b/src/Process/Listener/TextFileLoggerSubscriber.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Infection\Process\Listener;
 
 use Infection\Config\InfectionConfig;
-use Infection\Console\LogVerbosityInterface;
+use Infection\Console\LogVerbosity;
 use Infection\EventDispatcher\EventSubscriberInterface;
 use Infection\Events\MutationTestingFinished;
 use Infection\Filesystem\Filesystem;
@@ -42,12 +42,12 @@ class TextFileLoggerSubscriber implements EventSubscriberInterface
         InfectionConfig $infectionConfig,
         MetricsCalculator $metricsCalculator,
         Filesystem $fs,
-        int $logVerbosity = LogVerbosityInterface::DEBUG
+        int $logVerbosity = LogVerbosity::DEBUG
     ) {
         $this->infectionConfig = $infectionConfig;
         $this->metricsCalculator = $metricsCalculator;
         $this->fs = $fs;
-        $this->isDebugMode = ($logVerbosity === LogVerbosityInterface::DEBUG);
+        $this->isDebugMode = ($logVerbosity === LogVerbosity::DEBUG);
     }
 
     public function getSubscribedEvents()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -28,16 +28,16 @@ class FilesystemTest extends TestCase
 
     protected function setUp()
     {
-        $this->umask = \umask(0);
+        $this->umask = umask(0);
         $this->filesystem = new Filesystem();
-        $this->workspace = \sys_get_temp_dir() . '/' . \microtime(true) . \random_int(100, 999);
-        \mkdir($this->workspace, 0777, true);
+        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . microtime(true) . random_int(100, 999);
+        mkdir($this->workspace, 0777, true);
     }
 
     protected function tearDown()
     {
-        @\unlink($this->workspace);
-        \umask($this->umask);
+        @unlink($this->workspace);
+        umask($this->umask);
     }
 
     public function test_mkdir_creates_directory()
@@ -46,7 +46,7 @@ class FilesystemTest extends TestCase
 
         $this->filesystem->mkdir($dir);
 
-        $this->assertTrue(\is_dir($dir));
+        $this->assertTrue(is_dir($dir));
     }
 
     public function test_mkdir_creates_directory_recursively()
@@ -57,7 +57,7 @@ class FilesystemTest extends TestCase
 
         $this->filesystem->mkdir($dir);
 
-        $this->assertTrue(\is_dir($dir));
+        $this->assertTrue(is_dir($dir));
     }
 
     /**
@@ -69,7 +69,7 @@ class FilesystemTest extends TestCase
         $basePath = $this->workspace.DIRECTORY_SEPARATOR;
         $dir = $basePath.'2';
 
-        \file_put_contents($dir, '');
+        file_put_contents($dir, '');
 
         $this->filesystem->mkdir($dir);
     }
@@ -79,7 +79,7 @@ class FilesystemTest extends TestCase
         $basePath = $this->workspace.DIRECTORY_SEPARATOR;
         $dir = $basePath.'2';
 
-        \file_put_contents($dir, '');
+        file_put_contents($dir, '');
 
         try {
             $this->filesystem->mkdir($dir);
@@ -95,6 +95,26 @@ class FilesystemTest extends TestCase
         $this->filesystem->mkdir($dir);
         $this->filesystem->mkdir($dir);
 
-        $this->assertTrue(\is_dir($dir));
+        $this->assertTrue(is_dir($dir));
+    }
+
+    public function test_dump_file_creates_file_with_content()
+    {
+        $filename = $this->workspace . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR . 'baz.txt';
+
+        $this->filesystem->dumpFile($filename, 'bar');
+        $this->assertFileExists($filename);
+        $this->assertSame('bar', file_get_contents($filename));
+    }
+
+    public function test_dump_file_overwrites_an_existing_file()
+    {
+        $filename = $this->workspace . DIRECTORY_SEPARATOR . 'foo.txt';
+        file_put_contents($filename, 'FOO BAR');
+
+        $this->filesystem->dumpFile($filename, 'bar');
+
+        $this->assertFileExists($filename);
+        $this->assertSame('bar', file_get_contents($filename));
     }
 }

--- a/tests/Process/Listener/TextFileLoggerSubscriberTest.php
+++ b/tests/Process/Listener/TextFileLoggerSubscriberTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests\Process\Listener;
+
+use Infection\Config\InfectionConfig;
+use Infection\Console\LogVerbosity;
+use Infection\EventDispatcher\EventDispatcher;
+use Infection\Events\MutationTestingFinished;
+use Infection\Filesystem\Filesystem;
+use Infection\Mutant\MetricsCalculator;
+use Infection\Process\Listener\TextFileLoggerSubscriber;
+use PHPUnit\Framework\TestCase;
+
+class TextFileLoggerSubscriberTest extends TestCase
+{
+    /**
+     * @var InfectionConfig|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $infectionConfig;
+
+    /**
+     * @var Filesystem|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $filesystem;
+
+    /**
+     * @var MetricsCalculator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $metricsCalculator;
+
+    protected function setUp()
+    {
+        $this->infectionConfig = $this->getMockBuilder(InfectionConfig::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->metricsCalculator = $this->getMockBuilder(MetricsCalculator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->filesystem = $this->getMockBuilder(Filesystem::class)
+            ->getMock();
+    }
+
+    public function test_it_do_nothing_when_file_log_path_is_not_defined()
+    {
+        $this->metricsCalculator->expects($this->never())
+            ->method('getEscapedMutantProcesses');
+
+        $this->metricsCalculator->expects($this->never())
+            ->method('getTimedOutProcesses');
+
+        $this->metricsCalculator->expects($this->never())
+            ->method('getNotCoveredMutantProcesses');
+
+        $this->infectionConfig->expects($this->any())
+            ->method('getTextFileLogPath')
+            ->willReturn(null);
+
+        $this->filesystem->expects($this->never())
+            ->method('dumpFile');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new TextFileLoggerSubscriber(
+            $this->infectionConfig,
+            $this->metricsCalculator,
+            $this->filesystem
+        ));
+
+        $dispatcher->dispatch(new MutationTestingFinished());
+    }
+
+    public function test_it_reacts_on_mutation_testing_finished()
+    {
+        $this->infectionConfig->expects($this->once())
+            ->method('getTextFileLogPath')
+            ->willReturn(sys_get_temp_dir() . '/infection-log.txt');
+
+        $this->metricsCalculator->expects($this->once())
+            ->method('getEscapedMutantProcesses')
+            ->willReturn([]);
+
+        $this->metricsCalculator->expects($this->once())
+            ->method('getTimedOutProcesses')
+            ->willReturn([]);
+
+        $this->metricsCalculator->expects($this->once())
+            ->method('getKilledMutantProcesses')
+            ->willReturn([]);
+
+        $this->metricsCalculator->expects($this->once())
+            ->method('getNotCoveredMutantProcesses')
+            ->willReturn([]);
+
+        $this->filesystem->expects($this->once())
+            ->method('dumpFile');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new TextFileLoggerSubscriber(
+            $this->infectionConfig,
+            $this->metricsCalculator,
+            $this->filesystem
+        ));
+
+        $dispatcher->dispatch(new MutationTestingFinished());
+    }
+
+    public function test_it_reacts_on_mutation_testing_finished_and_debug_mode_off()
+    {
+        $this->infectionConfig->expects($this->once())
+            ->method('getTextFileLogPath')
+            ->willReturn(sys_get_temp_dir() . '/infection-log.txt');
+
+        $this->metricsCalculator->expects($this->once())
+            ->method('getEscapedMutantProcesses')
+            ->willReturn([]);
+
+        $this->metricsCalculator->expects($this->once())
+            ->method('getTimedOutProcesses')
+            ->willReturn([]);
+
+        $this->metricsCalculator->expects($this->never())
+            ->method('getKilledMutantProcesses');
+
+        $this->metricsCalculator->expects($this->once())
+            ->method('getNotCoveredMutantProcesses')
+            ->willReturn([]);
+
+        $this->filesystem->expects($this->once())
+            ->method('dumpFile');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new TextFileLoggerSubscriber(
+            $this->infectionConfig,
+            $this->metricsCalculator,
+            $this->filesystem,
+            LogVerbosity::NORMAL
+        ));
+
+        $dispatcher->dispatch(new MutationTestingFinished());
+    }
+}


### PR DESCRIPTION
Added 2 levels:
1 - debug/full mode (as it works now)
2 - short mode will show short log format (https://github.com/infection/infection/issues/54#issuecomment-338206510). Like:
```
1) /var/www/infection/src/Utils/TempDirectoryCreator.php:32    [M] TrueValue

--- Original
+++ New
@@ @@
             $path = sprintf('%s/%s', sys_get_temp_dir(), $dirName ?: 'infection');
-            if (!@mkdir($path, 0777, true) && !is_dir($path)) {
+            if (!@mkdir($path, 0777, false) && !is_dir($path)) {
                 throw new \RuntimeException('Can not create temp dir');
             }
             $this->tempDirectory = $path;
         }
         return $this->tempDirectory;
     }
```

- I left old diff format. It looks fine with PublicVisibility mutator but looks weird with Break/Continue for example:
```
- break;
+ continue;
```
- all levels will show line number and mutation name