### PR TITLE
Fix PHPSpec initial yaml config generate logic

### DIFF
--- a/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
@@ -42,11 +42,9 @@ abstract class AbstractYamlConfiguration
                 continue;
             }
 
-            $options = [
-                'format' => ['xml'],
-                'output' => [
-                    'xml' => $this->tempDirectory . '/' . CodeCoverageData::PHP_SPEC_COVERAGE_DIR,
-                ],
+            $options['format'] = ['xml'];
+            $options['output'] = [
+                'xml' => $this->tempDirectory . '/' . CodeCoverageData::PHP_SPEC_COVERAGE_DIR,
             ];
         }
         unset($options);

--- a/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
+++ b/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
@@ -26,6 +26,7 @@ class InitialYamlConfigurationTest extends TestCase
                 'output' => [
                     'xml' => '/path'
                 ],
+                'whitelist' => ['.'],
             ],
         ],
         'bootstrap' => '/path/to/adc',
@@ -54,5 +55,14 @@ class InitialYamlConfigurationTest extends TestCase
         $expectedPath = $this->tempDir . '/' . CodeCoverageData::PHP_SPEC_COVERAGE_DIR;
 
         $this->assertSame($expectedPath, $parsedYaml['extensions']['PhpSpecCodeCoverageExtension']['output']['xml']);
+    }
+
+    public function test_it_preserves_options_form_coverage_extension()
+    {
+        $configuration = $this->getConfigurationObject();
+
+        $parsedYaml = Yaml::parse($configuration->getYaml());
+
+        $this->assertSame(['.'], $parsedYaml['extensions']['PhpSpecCodeCoverageExtension']['whitelist']);
     }
 }


### PR DESCRIPTION
Update just 'path' and 'output' keys for PHPSpec config instead of overriding the whole container. Fixes #57