### PR TITLE
Show fatal errors in the console and file logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - composer analyze
-  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=59 --min-covered-msi=91; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=60 --min-covered-msi=91; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,9 @@
             "wget -nc http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar",
             "chmod a+x php-cs-fixer-v2.phar",
             "./php-cs-fixer-v2.phar fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --allow-risky=yes"
+        ],
+        "php-cs-fixer:fix": [
+            "./php-cs-fixer-v2.phar fix --config=.php_cs.dist -v --allow-risky=yes"
         ]
     }
 }

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -185,7 +185,7 @@ class InfectionCommand extends Command
 
     private function setOutputFormatterStyles(OutputInterface $output)
     {
-        $output->getFormatter()->setStyle('with-error', new OutputFormatterStyle('red'));
+        $output->getFormatter()->setStyle('with-error', new OutputFormatterStyle('green'));
         $output->getFormatter()->setStyle('uncovered', new OutputFormatterStyle('blue', null, ['bold']));
         $output->getFormatter()->setStyle('timeout', new OutputFormatterStyle('yellow'));
         $output->getFormatter()->setStyle('escaped', new OutputFormatterStyle('red', null, ['bold']));

--- a/src/Console/OutputFormatter/DotFormatter.php
+++ b/src/Console/OutputFormatter/DotFormatter.php
@@ -57,6 +57,9 @@ class DotFormatter extends AbstractOutputFormatter
             case MutantProcess::CODE_TIMED_OUT:
                 $this->output->write('<timeout>T</timeout>');
                 break;
+            case MutantProcess::CODE_ERROR:
+                $this->output->write('<with-error>E</with-error>');
+                break;
         }
 
         $remainder = $this->callsCount % self::DOTS_PER_ROW;

--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -74,7 +74,7 @@ class InfectionApplication
             $testFrameworkKey = $this->input->getOption('test-framework');
             $adapter = $this->get('test.framework.factory')->create($testFrameworkKey);
 
-            $metricsCalculator = new MetricsCalculator($adapter);
+            $metricsCalculator = new MetricsCalculator();
 
             $this->addSubscribers($eventDispatcher, $metricsCalculator, $adapter);
 

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -26,6 +26,16 @@ class MetricsCalculator
     /**
      * @var int
      */
+    private $errorCount = 0;
+
+    /**
+     * @var MutantProcess[]
+     */
+    private $errorProcesses = [];
+
+    /**
+     * @var int
+     */
     private $escapedCount = 0;
 
     /**
@@ -58,21 +68,6 @@ class MetricsCalculator
      */
     private $totalMutantsCount = 0;
 
-    /**
-     * @var AbstractTestFrameworkAdapter
-     */
-    private $testFrameworkAdapter;
-
-    /**
-     * MetricsCalculator constructor.
-     *
-     * @param AbstractTestFrameworkAdapter $testFrameworkAdapter
-     */
-    public function __construct(AbstractTestFrameworkAdapter $testFrameworkAdapter)
-    {
-        $this->testFrameworkAdapter = $testFrameworkAdapter;
-    }
-
     public function collect(MutantProcess $mutantProcess)
     {
         ++$this->totalMutantsCount;
@@ -94,6 +89,10 @@ class MetricsCalculator
                 $this->timedOutCount++;
                 $this->timedOutProcesses[] = $mutantProcess;
                 break;
+            case MutantProcess::CODE_ERROR:
+                $this->errorCount++;
+                $this->errorProcesses[] = $mutantProcess;
+                break;
         }
     }
 
@@ -105,7 +104,7 @@ class MetricsCalculator
     public function getMutationScoreIndicator(): float
     {
         $detectionRateAll = 0;
-        $defeatedTotal = $this->killedCount + $this->timedOutCount/* + $errorCount*/;
+        $defeatedTotal = $this->killedCount + $this->timedOutCount + $this->errorCount;
 
         if ($this->totalMutantsCount) {
             $detectionRateAll = round(100 * ($defeatedTotal / $this->totalMutantsCount));
@@ -135,7 +134,7 @@ class MetricsCalculator
     {
         $detectionRateTested = 0;
         $coveredByTestsTotal = $this->totalMutantsCount - $this->notCoveredByTestsCount;
-        $defeatedTotal = $this->killedCount + $this->timedOutCount/* + $errorCount*/;
+        $defeatedTotal = $this->killedCount + $this->timedOutCount + $this->errorCount;
 
         if ($coveredByTestsTotal) {
             $detectionRateTested = round(100 * ($defeatedTotal / $coveredByTestsTotal));
@@ -214,5 +213,18 @@ class MetricsCalculator
     public function getNotCoveredMutantProcesses(): array
     {
         return $this->notCoveredMutantProcesses;
+    }
+
+    public function getErrorCount(): int
+    {
+        return $this->errorCount;
+    }
+
+    /**
+     * @return MutantProcess[]
+     */
+    public function getErrorProcesses(): array
+    {
+        return $this->errorProcesses;
     }
 }

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Infection\Mutant;
 
 use Infection\Process\MutantProcess;
-use Infection\TestFramework\AbstractTestFrameworkAdapter;
 
 class MetricsCalculator
 {

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -135,7 +135,7 @@ class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
         $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getKilledCount()) . '</options=bold> mutants were killed');
         $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getNotCoveredByTestsCount()) . '</options=bold> mutants were not covered by tests');
         $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getEscapedCount()) . '</options=bold> covered mutants were not detected');
-        //        $this->output->writeln($this->getPadded($errorCount) . ' fatal errors were encountered'); // TODO
+        $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getErrorCount()) . '</options=bold> errors were encountered');
         $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getTimedOutCount()) . '</options=bold> time outs were encountered');
 
         $msiTag = $this->getPercentageTag($this->metricsCalculator->getMutationScoreIndicator());

--- a/src/Process/Listener/TextFileLoggerSubscriber.php
+++ b/src/Process/Listener/TextFileLoggerSubscriber.php
@@ -67,6 +67,7 @@ class TextFileLoggerSubscriber implements EventSubscriberInterface
 
             if ($this->isDebugMode) {
                 $logs[] = $this->getLogParts($this->metricsCalculator->getKilledMutantProcesses(), 'Killed');
+                $logs[] = $this->getLogParts($this->metricsCalculator->getErrorProcesses(), 'Errors');
             }
 
             $logs[] = $this->getLogParts($this->metricsCalculator->getNotCoveredMutantProcesses(), 'Not covered');
@@ -120,12 +121,14 @@ class TextFileLoggerSubscriber implements EventSubscriberInterface
 
     private function getMutatorFirstLine(int $index, MutantProcess $mutantProcess): string
     {
+        $mutation = $mutantProcess->getMutant()->getMutation();
+
         return sprintf(
             '%d) %s:%d    [M] %s',
             $index + 1,
-            $mutantProcess->getMutant()->getMutation()->getOriginalFilePath(),
-            (int) $mutantProcess->getMutant()->getMutation()->getAttributes()['startLine'],
-            $mutantProcess->getMutant()->getMutation()->getMutator()->getName()
+            $mutation->getOriginalFilePath(),
+            (int) $mutation->getAttributes()['startLine'],
+            $mutation->getMutator()->getName()
         );
     }
 }

--- a/tests/Mutant/MetricsCalculatorTest.php
+++ b/tests/Mutant/MetricsCalculatorTest.php
@@ -21,17 +21,17 @@ class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 {
     public function test_it_shows_zero_values_by_default()
     {
-        $adapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
-
-        $calculator = new MetricsCalculator($adapter);
+        $calculator = new MetricsCalculator();
 
         $this->assertSame(0, $calculator->getEscapedCount());
         $this->assertSame(0, $calculator->getKilledCount());
+        $this->assertSame(0, $calculator->getErrorCount());
         $this->assertSame(0, $calculator->getTimedOutCount());
         $this->assertSame(0, $calculator->getNotCoveredByTestsCount());
         $this->assertSame(0, $calculator->getTotalMutantsCount());
         $this->assertSame([], $calculator->getEscapedMutantProcesses());
         $this->assertSame([], $calculator->getKilledMutantProcesses());
+        $this->assertSame([], $calculator->getErrorProcesses());
         $this->assertSame([], $calculator->getTimedOutProcesses());
         $this->assertSame([], $calculator->getNotCoveredMutantProcesses());
 
@@ -42,8 +42,6 @@ class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     public function test_it_collects_all_values()
     {
-        $adapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
-
         $process = Mockery::mock(Process::class);
         $process->shouldReceive('stop');
 
@@ -59,20 +57,25 @@ class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $killedMutantProcess = Mockery::mock(MutantProcess::class);
         $killedMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_KILLED);
 
-        $calculator = new MetricsCalculator($adapter);
+        $errorMutantProcess = Mockery::mock(MutantProcess::class);
+        $errorMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_ERROR);
+
+        $calculator = new MetricsCalculator();
 
         $calculator->collect($notCoveredMutantProcess);
         $calculator->collect($passMutantProcess);
         $calculator->collect($timedOutMutantProcess);
         $calculator->collect($killedMutantProcess);
+        $calculator->collect($errorMutantProcess);
 
         $this->assertSame(1, $calculator->getNotCoveredByTestsCount());
         $this->assertSame(1, $calculator->getEscapedCount());
         $this->assertSame(1, $calculator->getTimedOutCount());
         $this->assertSame(1, $calculator->getKilledCount());
+        $this->assertSame(1, $calculator->getErrorCount());
 
-        $this->assertSame(50.0, $calculator->getMutationScoreIndicator());
-        $this->assertSame(75.0, $calculator->getCoverageRate());
-        $this->assertSame(67.0, $calculator->getCoveredCodeMutationScoreIndicator());
+        $this->assertSame(60.0, $calculator->getMutationScoreIndicator());
+        $this->assertSame(80.0, $calculator->getCoverageRate());
+        $this->assertSame(75.0, $calculator->getCoveredCodeMutationScoreIndicator());
     }
 }

--- a/tests/Process/Listener/TextFileLoggerSubscriberTest.php
+++ b/tests/Process/Listener/TextFileLoggerSubscriberTest.php
@@ -95,6 +95,10 @@ class TextFileLoggerSubscriberTest extends TestCase
             ->willReturn([]);
 
         $this->metricsCalculator->expects($this->once())
+            ->method('getErrorProcesses')
+            ->willReturn([]);
+
+        $this->metricsCalculator->expects($this->once())
             ->method('getNotCoveredMutantProcesses')
             ->willReturn([]);
 
@@ -127,6 +131,9 @@ class TextFileLoggerSubscriberTest extends TestCase
 
         $this->metricsCalculator->expects($this->never())
             ->method('getKilledMutantProcesses');
+
+        $this->metricsCalculator->expects($this->never())
+            ->method('getErrorProcesses');
 
         $this->metricsCalculator->expects($this->once())
             ->method('getNotCoveredMutantProcesses')

--- a/tests/Process/MutantProcessTest.php
+++ b/tests/Process/MutantProcessTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Process;
+namespace Infection\Tests\Process;
 
 use Infection\Mutant\Mutant;
 use Infection\Process\MutantProcess;

--- a/tests/Process/MutantProcessTest.php
+++ b/tests/Process/MutantProcessTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Process;
+
+use Infection\Mutant\Mutant;
+use Infection\Process\MutantProcess;
+use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Symfony\Component\Process\Process;
+
+class MutantProcessTest extends MockeryTestCase
+{
+    public function test_it_handles_not_covered_mutant()
+    {
+        $process = Mockery::mock(Process::class);
+        $mutant = Mockery::mock(Mutant::class);
+        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(false);
+        $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
+
+        $mutantProcess = new MutantProcess($process, $mutant, $testFrameworkAdapter);
+
+        $this->assertSame(MutantProcess::CODE_NOT_COVERED, $mutantProcess->getResultCode());
+    }
+
+    public function test_it_handles_timeout()
+    {
+        $process = Mockery::mock(Process::class);
+        $mutant = Mockery::mock(Mutant::class);
+        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
+        $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
+
+        $mutantProcess = new MutantProcess($process, $mutant, $testFrameworkAdapter);
+        $mutantProcess->markTimeout();
+
+        $this->assertSame(MutantProcess::CODE_TIMED_OUT, $mutantProcess->getResultCode());
+    }
+
+    public function test_it_handles_error()
+    {
+        $process = Mockery::mock(Process::class);
+        $process->shouldReceive('getExitCode')->once()->andReturn(126);
+        $mutant = Mockery::mock(Mutant::class);
+        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
+        $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
+
+        $mutantProcess = new MutantProcess($process, $mutant, $testFrameworkAdapter);
+
+        $this->assertSame(MutantProcess::CODE_ERROR, $mutantProcess->getResultCode());
+    }
+
+    public function test_it_handles_escaped_mutant()
+    {
+        $process = Mockery::mock(Process::class);
+        $process->shouldReceive('getExitCode')->once()->andReturn(0);
+        $process->shouldReceive('getOutput')->once()->andReturn('...');
+
+        $mutant = Mockery::mock(Mutant::class);
+        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
+
+        $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
+        $testFrameworkAdapter->shouldReceive('testsPass')->once()->andReturn(true);
+
+        $mutantProcess = new MutantProcess($process, $mutant, $testFrameworkAdapter);
+
+        $this->assertSame(MutantProcess::CODE_ESCAPED, $mutantProcess->getResultCode());
+    }
+
+    public function test_it_handles_killed_mutant()
+    {
+        $process = Mockery::mock(Process::class);
+        $process->shouldReceive('getExitCode')->once()->andReturn(0);
+        $process->shouldReceive('getOutput')->once()->andReturn('...');
+
+        $mutant = Mockery::mock(Mutant::class);
+        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
+
+        $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
+        $testFrameworkAdapter->shouldReceive('testsPass')->once()->andReturn(false);
+
+        $mutantProcess = new MutantProcess($process, $mutant, $testFrameworkAdapter);
+
+        $this->assertSame(MutantProcess::CODE_KILLED, $mutantProcess->getResultCode());
+        $this->assertSame($mutant, $mutantProcess->getMutant());
+    }
+}

--- a/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
+++ b/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
@@ -9,7 +9,6 @@ namespace Infection\Tests\TestFramework\Coverage;
 
 use Infection\TestFramework\Coverage\CachedTestFileDataProvider;
 use Infection\TestFramework\Coverage\TestFileDataProvider;
-use PHPUnit\Framework\TestCase;
 use Mockery;
 
 class CachedTestFileDataProviderTest extends Mockery\Adapter\Phpunit\MockeryTestCase


### PR DESCRIPTION
There was a missing feature to show [fatal] errors in the logs when PHPUnit process fails with the exit code not in [0, 1, 2].

Before:

```bash
.: killed, M: escaped, S: uncovered, E: fatal error, T: timed out

...M........T..........S....M....................S   (50 / 50)
```

After:

```bash
.: killed, M: escaped, S: uncovered, E: fatal error, T: timed out

...ME.....E.T..........S....ME.EEE.E.....E..E.E.ES   (50 / 50)
```

Mutant with [fatal] error is a killed mutant, that's why `E` has green (positive) color.

http://tldp.org/LDP/abs/html/exitcodes.html