### PR TITLE
Show correct type of error message for CI flags

### DIFF
--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -114,6 +114,12 @@ class InfectionApplication
                 return 1;
             }
 
+            if ($this->hasBadCoveredMsi($metricsCalculator)) {
+                $io->error($this->getBadCoveredMsiErrorMessage($metricsCalculator));
+
+                return 1;
+            }
+
             return 0;
         } catch (InfectionException $e) {
             $io->error($e->getMessage());
@@ -226,6 +232,11 @@ class InfectionApplication
             }
         }
 
+        return false;
+    }
+
+    private function hasBadCoveredMsi(MetricsCalculator $metricsCalculator): bool
+    {
         if ($minCoveredMsi = (float) $this->input->getOption('min-covered-msi')) {
             if ($metricsCalculator->getCoveredCodeMutationScoreIndicator() < $minCoveredMsi) {
                 return true;
@@ -247,6 +258,13 @@ class InfectionApplication
                 $metricsCalculator->getMutationScoreIndicator()
             );
         }
+
+        throw new \LogicException('Seems like something is wrong with calculations and min-msi options.');
+    }
+
+    private function getBadCoveredMsiErrorMessage(MetricsCalculator $metricsCalculator): string
+    {
+        $baseMessage = 'The minimum required %s percentage should be %s%%, but actual is %s%%. Improve your tests!';
 
         if ($minCoveredMsi = (float) $this->input->getOption('min-covered-msi')) {
             return sprintf(

--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -15,6 +15,7 @@ use Infection\Console\OutputFormatter\DotFormatter;
 use Infection\Console\OutputFormatter\OutputFormatter;
 use Infection\Console\OutputFormatter\ProgressFormatter;
 use Infection\EventDispatcher\EventDispatcher;
+use Infection\Mutant\Exception\MsiCalculationException;
 use Infection\Mutant\Generator\MutationsGenerator;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutator\Mutator;
@@ -42,6 +43,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class InfectionApplication
 {
+    const CI_FLAG_ERROR = 'The minimum required %s percentage should be %s%%, but actual is %s%%. Improve your tests!';
+
     /**
      * @var Container
      */
@@ -248,34 +251,30 @@ class InfectionApplication
 
     private function getBadMsiErrorMessage(MetricsCalculator $metricsCalculator): string
     {
-        $baseMessage = 'The minimum required %s percentage should be %s%%, but actual is %s%%. Improve your tests!';
-
         if ($minMsi = (float) $this->input->getOption('min-msi')) {
             return sprintf(
-                $baseMessage,
+                self::CI_FLAG_ERROR,
                 'MSI',
                 $minMsi,
                 $metricsCalculator->getMutationScoreIndicator()
             );
         }
 
-        throw new \LogicException('Seems like something is wrong with calculations and min-msi options.');
+        throw MsiCalculationException::create('min-msi');
     }
 
     private function getBadCoveredMsiErrorMessage(MetricsCalculator $metricsCalculator): string
     {
-        $baseMessage = 'The minimum required %s percentage should be %s%%, but actual is %s%%. Improve your tests!';
-
         if ($minCoveredMsi = (float) $this->input->getOption('min-covered-msi')) {
             return sprintf(
-                $baseMessage,
+                self::CI_FLAG_ERROR,
                 'Covered Code MSI',
                 $minCoveredMsi,
                 $metricsCalculator->getCoveredCodeMutationScoreIndicator()
             );
         }
 
-        throw new \LogicException('Seems like something is wrong with calculations and min-msi options.');
+        throw MsiCalculationException::create('min-covered-msi');
     }
 
     private function parseMutators(string $mutators = null): array

--- a/src/Mutant/Exception/MsiCalculationException.php
+++ b/src/Mutant/Exception/MsiCalculationException.php
@@ -10,7 +10,7 @@ namespace Infection\Mutant\Exception;
 
 class MsiCalculationException extends \LogicException
 {
-    public static function create(string $type): MsiCalculationException
+    public static function create(string $type): self
     {
         return new self(sprintf(
             'Seems like something is wrong with calculations and %s options.', $type

--- a/src/Mutant/Exception/MsiCalculationException.php
+++ b/src/Mutant/Exception/MsiCalculationException.php
@@ -12,7 +12,7 @@ class MsiCalculationException extends \LogicException
 {
     public static function create(string $type): MsiCalculationException
     {
-        return new MsiCalculationException(sprintf(
+        return new self(sprintf(
             'Seems like something is wrong with calculations and %s options.', $type
         ));
     }

--- a/src/Mutant/Exception/MsiCalculationException.php
+++ b/src/Mutant/Exception/MsiCalculationException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Mutant\Exception;
+
+class MsiCalculationException extends \LogicException
+{
+    public static function create(string $type): MsiCalculationException
+    {
+        return new MsiCalculationException(sprintf(
+            'Seems like something is wrong with calculations and %s options.', $type
+        ));
+    }
+}


### PR DESCRIPTION
Hi there!

First of all, thank you very much for the great tool!

When using both CI flags, --min-msi and --min-covered-msi together and only min-covered-msi fails, it shows a message that the minimum required min-msi percentage is not reached which is wrong.

This pull request checks boths values individually and shows the corresponding error message.

Please tell me if I need to improve something in this pull request.