### PR TITLE
Reuse Parser, Lexer, PrettyPrinter

### DIFF
--- a/app/container.php
+++ b/app/container.php
@@ -29,6 +29,10 @@ use Infection\Utils\VersionParser;
 use Infection\TestFramework\Coverage\CachedTestFileDataProvider;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use SebastianBergmann\Diff\Differ as BaseDiffer;
+use PhpParser\Lexer;
+use PhpParser\ParserFactory;
+use PhpParser\Parser;
+use PhpParser\PrettyPrinter\Standard;
 
 $c = new Container();
 
@@ -83,7 +87,7 @@ $c['xml.configuration.helper'] = function (Container $c): XmlConfigurationHelper
 };
 
 $c['mutant.creator'] = function (Container $c): MutantCreator {
-    return new MutantCreator($c['temp.dir'], $c['differ']);
+    return new MutantCreator($c['temp.dir'], $c['differ'], $c['parser'], $c['pretty.printer']);
 };
 
 $c['differ'] = function (): Differ {
@@ -120,6 +124,22 @@ $c['test.file.data.provider.phpunit'] = function (Container $c): TestFileDataPro
 
 $c['version.parser'] = function (): VersionParser {
     return new VersionParser();
+};
+
+$c['lexer'] = function (): Lexer {
+    return new Lexer([
+        'usedAttributes' => [
+            'comments', 'startLine', 'endLine', 'startTokenPos', 'endTokenPos', 'startFilePos', 'endFilePos',
+        ],
+    ]);
+};
+
+$c['parser'] = function ($c): Parser {
+    return (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $c['lexer']);
+};
+
+$c['pretty.printer'] = function ($c): Standard {
+    return new Standard();
 };
 
 function registerMutators(array $mutators, Container $container)

--- a/src/InfectionApplication.php
+++ b/src/InfectionApplication.php
@@ -100,7 +100,8 @@ class InfectionApplication
                 $codeCoverageData,
                 $this->getDefaultMutators(),
                 $this->parseMutators($this->input->getOption('mutators')),
-                $eventDispatcher
+                $eventDispatcher,
+                $this->get('parser')
             );
             $mutations = $mutationsGenerator->generate($this->input->getOption('only-covered'), $this->input->getOption('filter'));
 

--- a/tests/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/Mutant/Generator/MutationsGeneratorTest.php
@@ -15,6 +15,9 @@ use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use \Mockery;
+use PhpParser\Lexer;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
 use Pimple\Container;
 
 class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
@@ -139,7 +142,19 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             $codeCoverageDataMock,
             $defaultMutators,
             $whitelistedMutatorNames,
-            $eventDispatcherMock
+            $eventDispatcherMock,
+            $this->getParser()
         );
+    }
+
+    private function getParser(): Parser
+    {
+        $lexer = new Lexer([
+            'usedAttributes' => [
+                'comments', 'startLine', 'endLine', 'startTokenPos', 'endTokenPos', 'startFilePos', 'endFilePos',
+            ],
+        ]);
+
+        return (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);
     }
 }


### PR DESCRIPTION
* Reuse Parser, Lexer, PrettyPrinter since their instantiation is quite an expensive thing according to Nikic article. 
* Do not pretty print the same file more than once: added cache.

Idea from https://github.com/nikic/PHP-Parser/blob/73be076/doc/component/Performance.markdown#object-reuse

