### PR TITLE
Console logger output format to be compatible with TextFile logger format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - composer analyze
-  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=60 --min-covered-msi=91; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=61 --min-covered-msi=91; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 script:
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - composer analyze
-  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=61 --min-covered-msi=91; fi
+  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=61 --min-covered-msi=89; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -139,7 +139,7 @@ class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
                     $mutation->getOriginalFilePath(),
                     (int) $mutation->getAttributes()['startLine'],
                     $mutation->getMutator()->getName()
-                )
+                ),
             ]);
 
             $this->output->writeln($this->diffColorizer->colorize($mutantProcess->getMutant()->getDiff()));

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -46,6 +46,7 @@ class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
      * @var bool
      */
     private $showMutations;
+
     /**
      * @var DiffColorizer
      */
@@ -56,8 +57,13 @@ class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
      */
     private $mutationCount = 0;
 
-    public function __construct(OutputInterface $output, OutputFormatter $outputFormatter, MetricsCalculator $metricsCalculator, DiffColorizer $diffColorizer, bool $showMutations)
-    {
+    public function __construct(
+        OutputInterface $output,
+        OutputFormatter $outputFormatter,
+        MetricsCalculator $metricsCalculator,
+        DiffColorizer $diffColorizer,
+        bool $showMutations
+    ) {
         $this->output = $output;
         $this->outputFormatter = $outputFormatter;
         $this->metricsCalculator = $metricsCalculator;
@@ -107,6 +113,10 @@ class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
         $this->showMetrics();
     }
 
+    /**
+     * @param MutantProcess[] $processes
+     * @param string $headlinePrefix
+     */
     private function showMutations(array $processes, string $headlinePrefix)
     {
         $headline = sprintf('%s mutants:', $headlinePrefix);
@@ -119,11 +129,19 @@ class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
         ]);
 
         foreach ($processes as $index => $mutantProcess) {
+            $mutation = $mutantProcess->getMutant()->getMutation();
+
             $this->output->writeln([
                 '',
-                sprintf('%d) %s', $index + 1, get_class($mutantProcess->getMutant()->getMutation()->getMutator())),
+                sprintf(
+                    '%d) %s:%d    [M] %s',
+                    $index + 1,
+                    $mutation->getOriginalFilePath(),
+                    (int) $mutation->getAttributes()['startLine'],
+                    $mutation->getMutator()->getName()
+                )
             ]);
-            $this->output->writeln($mutantProcess->getMutant()->getMutation()->getOriginalFilePath());
+
             $this->output->writeln($this->diffColorizer->colorize($mutantProcess->getMutant()->getDiff()));
         }
     }

--- a/tests/Process/Listener/MutationTestingConsoleLoggerSubscriberTest.php
+++ b/tests/Process/Listener/MutationTestingConsoleLoggerSubscriberTest.php
@@ -110,4 +110,25 @@ class MutationTestingConsoleLoggerSubscriberTest extends TestCase
 
         $dispatcher->dispatch(new MutationTestingFinished());
     }
+
+    public function test_it_reacts_on_mutation_testing_finished_and_show_mutations_on()
+    {
+        $this->output->expects($this->once())
+            ->method('getVerbosity');
+
+        $this->outputFormatter
+            ->expects($this->once())
+            ->method('finish');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
+            $this->output,
+            $this->outputFormatter,
+            $this->metricsCalculator,
+            $this->diffColorizer,
+            true
+        ));
+
+        $dispatcher->dispatch(new MutationTestingFinished());
+    }
 }

--- a/tests/Process/Listener/MutationTestingConsoleLoggerSubscriberTest.php
+++ b/tests/Process/Listener/MutationTestingConsoleLoggerSubscriberTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests\Process\Listener;
+
+use Infection\Console\OutputFormatter\OutputFormatter;
+use Infection\Differ\DiffColorizer;
+use Infection\EventDispatcher\EventDispatcher;
+use Infection\Events\MutantProcessFinished;
+use Infection\Events\MutationTestingFinished;
+use Infection\Events\MutationTestingStarted;
+use Infection\Mutant\MetricsCalculator;
+use Infection\Process\Listener\MutationTestingConsoleLoggerSubscriber;
+use Infection\Process\MutantProcess;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MutationTestingConsoleLoggerSubscriberTest extends TestCase
+{
+    /**
+     * @var OutputInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $output;
+
+    /**
+     * @var OutputFormatter|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $outputFormatter;
+
+    /**
+     * @var MetricsCalculator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $metricsCalculator;
+
+    /**
+     * @var DiffColorizer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $diffColorizer;
+
+    protected function setUp()
+    {
+        $this->output = $this->createMock(OutputInterface::class);
+        $this->outputFormatter = $this->createMock(OutputFormatter::class);
+        $this->metricsCalculator = $this->getMockBuilder(MetricsCalculator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->diffColorizer = $this->createMock(DiffColorizer::class);
+    }
+
+    public function test_it_reacts_on_mutation_testing_started()
+    {
+        $this->outputFormatter
+            ->expects($this->once())
+            ->method('start');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
+            $this->output,
+            $this->outputFormatter,
+            $this->metricsCalculator,
+            $this->diffColorizer,
+            false
+        ));
+
+        $dispatcher->dispatch(new MutationTestingStarted(1));
+    }
+
+    public function test_it_reacts_on_mutation_process_finished()
+    {
+        $this->metricsCalculator
+            ->expects($this->once())
+            ->method('collect');
+
+        $this->outputFormatter
+            ->expects($this->once())
+            ->method('advance');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
+            $this->output,
+            $this->outputFormatter,
+            $this->metricsCalculator,
+            $this->diffColorizer,
+            false
+        ));
+
+        $dispatcher->dispatch(new MutantProcessFinished($this->createMock(MutantProcess::class)));
+    }
+
+    public function test_it_reacts_on_mutation_testing_finished()
+    {
+        $this->outputFormatter
+            ->expects($this->once())
+            ->method('finish');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
+            $this->output,
+            $this->outputFormatter,
+            $this->metricsCalculator,
+            $this->diffColorizer,
+            false
+        ));
+
+        $dispatcher->dispatch(new MutationTestingFinished());
+    }
+}


### PR DESCRIPTION
When we did changes for text logger output format seems like we forgot to change console output format as well to be compatible with new structure:
- Filename (preferably the relative path)
- Line number
- Mutation type
- Mutation


This PR fixes it. So we will have the same format for both Console and Text File loggers.

```
1) /var/www/infection/src/Filesystem/Filesystem.php:60    [M] FalseValue

--- Original
+++ New
@@ @@
         }
-        if (false === @file_put_contents($filename, $content)) {
+        if (true === @file_put_contents($filename, $content)) {
             throw new IOException(sprintf('Failed to write file "%s".', $filename), 0, null, $filename);
         }
     }
 }

```