### PR TITLE
Do not return path of config file when dir is expected. 

### DIFF
--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -40,7 +40,7 @@ class TestFrameworkConfigPathProvider
         $this->questionHelper = $questionHelper;
     }
 
-    public function get(InputInterface $input, OutputInterface $output, array $dirsInCurrentDir, string $testFramework): ?string
+    public function get(InputInterface $input, OutputInterface $output, array $dirsInCurrentDir, string $testFramework)
     {
         try {
             $this->testFrameworkConfigLocator->locate($testFramework);

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -44,6 +44,7 @@ class TestFrameworkConfigPathProvider
     {
         try {
             $this->testFrameworkConfigLocator->locate($testFramework);
+
             return null;
         } catch (\Exception $e) {
             if ($testFramework !== TestFrameworkTypes::PHPUNIT) {

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -40,10 +40,11 @@ class TestFrameworkConfigPathProvider
         $this->questionHelper = $questionHelper;
     }
 
-    public function get(InputInterface $input, OutputInterface $output, array $dirsInCurrentDir, string $testFramework): string
+    public function get(InputInterface $input, OutputInterface $output, array $dirsInCurrentDir, string $testFramework): ?string
     {
         try {
-            return $this->testFrameworkConfigLocator->locate($testFramework);
+            $this->testFrameworkConfigLocator->locate($testFramework);
+            return null;
         } catch (\Exception $e) {
             if ($testFramework !== TestFrameworkTypes::PHPUNIT) {
                 return $this->askTestFrameworkConfigLocation($input, $output, $dirsInCurrentDir, $testFramework, null);

--- a/tests/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -32,7 +32,9 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
 
         $provider = new TestFrameworkConfigPathProvider($locatorMock, $consoleMock, $this->getQuestionHelper());
 
-        $provider->get($this->createStreamableInputInterfaceMock(), $this->createOutputInterface(), [], 'phpunit');
+        $result = $provider->get($this->createStreamableInputInterfaceMock(), $this->createOutputInterface(), [], 'phpunit');
+
+        $this->assertNull($result);
     }
 
     public function test_it_asks_question_if_no_config_is_found_in_current_dir()
@@ -61,6 +63,7 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
         );
 
         $this->assertSame($inputPhpUnitPath, $path);
+        $this->assertDirectoryExists($path);
     }
 
     public function test_it_automatically_guesses_path()


### PR DESCRIPTION
When config is located in ".", we should not save the path.

Unfortunately, tag 0.6.1 introduced a bug, when `phpunit.xml.dist` is located in current root folder, `TestFrameworkConfigPathProvider` returned the `realpath()` for this file. It led to saving incorrect value to `infection.json.dist`:

```json
{
    "phpUnit": {
        "configDir": "/path/to/phpunit.xml.dist"
     }
}
```

Instead of just skipping this setting, the path to *file* was saved while path to *folder* was expected.

After this update, it returns `null` by default which means `phpunit.xml.dist` is located in the root dir.

Will have to release 0.6.2.