### PR TITLE
Add comma separated files filter

### DIFF
--- a/src/Finder/SourceFilesFinder.php
+++ b/src/Finder/SourceFilesFinder.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Finder;
+
+use Symfony\Component\Finder\Finder;
+
+class SourceFilesFinder
+{
+    private $sourceDirectories;
+    private $excludeDirectories;
+
+    /**
+     * @param string[] $sourceDirectories
+     * @param string[] $excludeDirectories
+     */
+    public function __construct(array $sourceDirectories, array $excludeDirectories)
+    {
+        $this->sourceDirectories = $sourceDirectories;
+        $this->excludeDirectories = $excludeDirectories;
+    }
+
+    public function getSourceFiles(string $filter = ''): Finder
+    {
+        $finder = new Finder();
+
+        array_walk($this->excludeDirectories, function ($excludePath) use ($finder) {
+            $finder->notPath($excludePath);
+        });
+
+        if ('' === $filter) {
+            $finder->in($this->sourceDirectories)->files();
+
+            return $finder;
+        }
+
+        $finder->in('.')->files();
+
+        $filters = explode(',', $filter);
+        array_walk($filters, function ($fileFilter) use ($finder) {
+            $finder->path($fileFilter);
+        });
+
+        return $finder;
+    }
+}

--- a/tests/Files/Finder/FirstFile.php
+++ b/tests/Files/Finder/FirstFile.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests\Files\Finder;
+
+class FirstFile
+{
+}

--- a/tests/Files/Finder/SecondFile.php
+++ b/tests/Files/Finder/SecondFile.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests\Files\Finder;
+
+class SecondFile
+{
+}

--- a/tests/Finder/SourceFilesFinderTest.php
+++ b/tests/Finder/SourceFilesFinderTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Finder;
+
+use Infection\Finder\SourceFilesFinder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder;
+
+class SourceFilesFinderTest extends TestCase
+{
+    public function test_it_lists_all_files_without_a_filter()
+    {
+        $sourceFilesFinder = new SourceFilesFinder(['tests/Files/Finder'], []);
+
+        $files = $sourceFilesFinder->getSourceFiles();
+
+        $this->assertInstanceOf(Finder::class, $files);
+        $this->assertSame(2, $files->count());
+    }
+
+    public function test_it_can_filter_one_file_by_a_relative_path()
+    {
+        $sourceFilesFinder = new SourceFilesFinder(['tests/Files/Finder'], []);
+
+        $filter = 'tests/Files/Finder/FirstFile.php';
+        $files = $sourceFilesFinder->getSourceFiles($filter);
+
+        $iterator = $files->getIterator();
+        $iterator->rewind();
+        $firstFile = $iterator->current();
+
+        $this->assertInstanceOf(Finder::class, $files);
+        $this->assertSame(1, $files->count());
+        $this->assertSame('FirstFile.php', $firstFile->getFilename());
+    }
+
+    public function test_it_can_filter_one_file_by_filename()
+    {
+        $sourceFilesFinder = new SourceFilesFinder(['tests/Files/Finder'], []);
+
+        $filter = 'FirstFile.php';
+        $files = $sourceFilesFinder->getSourceFiles($filter);
+
+        $iterator = $files->getIterator();
+        $iterator->rewind();
+        $firstFile = $iterator->current();
+
+        $this->assertInstanceOf(Finder::class, $files);
+        $this->assertSame(1, $files->count());
+        $this->assertSame('FirstFile.php', $firstFile->getFilename());
+    }
+
+    public function test_it_can_filter_a_list_of_files_by_relative_paths()
+    {
+        $sourceFilesFinder = new SourceFilesFinder(['tests/Files/Finder'], []);
+
+        $filter = 'tests/Files/Finder/FirstFile.php,tests/Files/Finder/SecondFile.php';
+        $files = $sourceFilesFinder->getSourceFiles($filter);
+
+        $iterator = $files->getIterator();
+        $iterator->rewind();
+        $firstFile = $iterator->current();
+        $iterator->next();
+        $secondFile = $iterator->current();
+
+        $this->assertInstanceOf(Finder::class, $files);
+        $this->assertSame(2, $files->count());
+        $this->assertSame('FirstFile.php', $firstFile->getFilename());
+        $this->assertSame('SecondFile.php', $secondFile->getFilename());
+    }
+
+    public function test_it_can_filter_a_list_of_files_by_filename()
+    {
+        $sourceFilesFinder = new SourceFilesFinder(['tests/Files/Finder'], []);
+
+        $filter = 'FirstFile.php,SecondFile.php';
+        $files = $sourceFilesFinder->getSourceFiles($filter);
+
+        $iterator = $files->getIterator();
+        $iterator->rewind();
+        $firstFile = $iterator->current();
+        $iterator->next();
+        $secondFile = $iterator->current();
+
+        $this->assertInstanceOf(Finder::class, $files);
+        $this->assertSame(2, $files->count());
+        $this->assertSame('FirstFile.php', $firstFile->getFilename());
+        $this->assertSame('SecondFile.php', $secondFile->getFilename());
+    }
+
+    public function test_it_can_filter_to_an_empty_result()
+    {
+        $sourceFilesFinder = new SourceFilesFinder(['tests/Files/Finder'], []);
+
+        $filter = 'ThisFileDoesNotExist.php';
+        $files = $sourceFilesFinder->getSourceFiles($filter);
+
+        $this->assertInstanceOf(Finder::class, $files);
+        $this->assertSame(0, $files->count());
+    }
+}


### PR DESCRIPTION
It's currently not possible to have a comma separated file list with relative paths as a _filter_ argument.

For example: `$ bin/infection --filter=src/AppBundle/Entity/A.php,src/AppBundle/Service/B.php,src/AppBundle/Service/C.php`.

This PR adds this feature.