### PR TITLE
Disable xdebug for all php processes except code coverage generator

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,6 +14,7 @@ return \PhpCsFixer\Config::create()
        'phpdoc_summary' => false,
        'phpdoc_align' => false,
        'yoda_style' => false,
+       'is_null' => true,
    ])
    ->setFinder($finder)
 ;

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -4,6 +4,9 @@
  *
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
+use Infection\Php\XdebugHandler;
+use Infection\Php\ConfigBuilder;
+
 $files = [
     __DIR__ . '/../../../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
@@ -18,8 +21,11 @@ foreach ($files as $file) {
     }
 }
 
+unset($files);
+
 if (!defined('INFECTION_COMPOSER_INSTALL')) {
-    fwrite(STDERR,
+    fwrite(
+        STDERR,
         'You need to set up the project dependencies using Composer:' . PHP_EOL . PHP_EOL .
         '    composer install' . PHP_EOL . PHP_EOL .
         'You can learn all about Composer on https://getcomposer.org/.' . PHP_EOL
@@ -29,5 +35,20 @@ if (!defined('INFECTION_COMPOSER_INSTALL')) {
 }
 
 require INFECTION_COMPOSER_INSTALL;
+
+$isDebuggerDisabled = empty((string) getenv(XdebugHandler::ENV_DISABLE_XDEBUG));
+
+$xdebug = new XdebugHandler(new ConfigBuilder(sys_get_temp_dir()));
+$xdebug->check();
+unset($xdebug);
+
+if (PHP_SAPI !== 'phpdbg' && $isDebuggerDisabled && !extension_loaded('xdebug')) {
+    fwrite(
+        STDERR,
+        'You need to use phpdbg or install and enable xdebug in order to allow for code coverage generation.' . PHP_EOL
+    );
+
+    die(1);
+}
 
 $container = require __DIR__ . '/container.php';

--- a/app/container.php
+++ b/app/container.php
@@ -12,7 +12,6 @@ use Infection\Utils\TempDirectoryCreator;
 use Infection\TestFramework\Factory;
 use Infection\Differ\Differ;
 use Infection\Mutant\MutantCreator;
-use Infection\Command\InfectionCommand;
 use Infection\Process\Runner\Parallel\ParallelProcessRunner;
 use Infection\EventDispatcher\EventDispatcher;
 use Infection\Filesystem\Filesystem;
@@ -26,6 +25,7 @@ use Infection\Differ\DiffColorizer;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
 use Infection\Config\InfectionConfig;
 use Infection\Utils\VersionParser;
+use Infection\Command;
 use Infection\TestFramework\Coverage\CachedTestFileDataProvider;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use SebastianBergmann\Diff\Differ as BaseDiffer;
@@ -54,7 +54,7 @@ $c['temp.dir'] = function (Container $c): string {
     return $c['temp.dir.creator']->createAndGet();
 };
 
-$c['filesystem'] = function (Container $c): Filesystem {
+$c['filesystem'] = function (): Filesystem {
     return new Filesystem();
 };
 
@@ -138,14 +138,14 @@ $c['parser'] = function ($c): Parser {
     return (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $c['lexer']);
 };
 
-$c['pretty.printer'] = function ($c): Standard {
+$c['pretty.printer'] = function (): Standard {
     return new Standard();
 };
 
 function registerMutators(array $mutators, Container $container)
 {
     foreach ($mutators as $mutator) {
-        $container[$mutator] = function (Container $c) use ($mutator) {
+        $container[$mutator] = function () use ($mutator) {
             return new $mutator();
         };
     }
@@ -158,11 +158,10 @@ $c['application'] = function (Container $container): Application {
         'Infection - PHP Mutation Testing Framework',
         '@package_version@'
     );
-    $infectionCommand = new InfectionCommand($container);
 
-    $application->add(new \Infection\Command\ConfigureCommand());
-    $application->add(new \Infection\Command\SelfUpdateCommand());
-    $application->add($infectionCommand);
+    $application->add(new Command\ConfigureCommand());
+    $application->add(new Command\SelfUpdateCommand());
+    $application->add(new Command\InfectionCommand($container));
 
     return $application;
 };

--- a/composer.lock
+++ b/composer.lock
@@ -546,25 +546,25 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.2.7",
+            "version": "v3.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "57fdaa55827ae14d617550ebe71a820f0a5e2282"
+                "reference": "a56a3989fb762d7b19a0cf8e7693ee99a6ffb78d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/57fdaa55827ae14d617550ebe71a820f0a5e2282",
-                "reference": "57fdaa55827ae14d617550ebe71a820f0a5e2282",
+                "url": "https://api.github.com/repos/symfony/process/zipball/a56a3989fb762d7b19a0cf8e7693ee99a6ffb78d",
+                "reference": "a56a3989fb762d7b19a0cf8e7693ee99a6ffb78d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -591,7 +591,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-27T18:07:02+00:00"
+            "time": "2017-11-13T15:31:11+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -177,10 +177,6 @@ class InfectionCommand extends Command
                 throw new \Exception('Configuration aborted');
             }
         }
-
-        if (PHP_SAPI !== 'phpdbg' && !defined('HHVM_VERSION') && !extension_loaded('xdebug')) {
-            throw new \Exception('You need to use phpdbg or install and enable xDebug in order to allow for code coverage generation.');
-        }
     }
 
     private function setOutputFormatterStyles(OutputInterface $output)

--- a/src/Finder/AbstractExecutableFinder.php
+++ b/src/Finder/AbstractExecutableFinder.php
@@ -8,46 +8,42 @@ declare(strict_types=1);
 
 namespace Infection\Finder;
 
-use Symfony\Component\Process\PhpExecutableFinder;
+use Infection\Process\ExecutableFinder\PhpExecutableFinder;
 
 abstract class AbstractExecutableFinder
 {
-    /**
-     * @return string
-     */
-    abstract public function find();
+    abstract public function find(bool $includeArgs = true): string;
 
     /**
      * @param array $probableNames
      * @param array $extraDirectories
+     * @param bool $includeArgs
      *
      * @return string|null
      */
-    protected function searchNonExecutables(array $probableNames, array $extraDirectories = [])
+    protected function searchNonExecutables(array $probableNames, array $extraDirectories = [], bool $includeArgs = true)
     {
         $dirs = array_merge(
             explode(PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
             $extraDirectories
         );
+
         foreach ($dirs as $dir) {
             foreach ($probableNames as $name) {
                 $path = sprintf('%s/%s', $dir, $name);
                 if (file_exists($path)) {
-                    return $this->makeExecutable($path);
+                    return $this->makeExecutable($path, $includeArgs);
                 }
             }
         }
     }
 
-    /**
-     * @param string $path
-     *
-     * @return string
-     */
-    protected function makeExecutable($path)
+    protected function makeExecutable(string $path, bool $includeArgs = true): string
     {
-        $phpFinder = new PhpExecutableFinder();
-
-        return sprintf('%s %s', $phpFinder->find(), $path);
+        return sprintf(
+            '%s %s',
+            (new PhpExecutableFinder())->find($includeArgs),
+            $path
+        );
     }
 }

--- a/src/Finder/ComposerExecutableFinder.php
+++ b/src/Finder/ComposerExecutableFinder.php
@@ -10,14 +10,9 @@ namespace Infection\Finder;
 
 use Symfony\Component\Process\ExecutableFinder;
 
-class ComposerExecutableFinder extends AbstractExecutableFinder
+final class ComposerExecutableFinder extends AbstractExecutableFinder
 {
-    /**
-     * @return string
-     *
-     * @throws \Exception
-     */
-    public function find()
+    public function find(bool $includeArgs = true): string
     {
         $probable = ['composer', 'composer.phar'];
         $finder = new ExecutableFinder();
@@ -33,9 +28,9 @@ class ComposerExecutableFinder extends AbstractExecutableFinder
          * Check for options without execute permissions and prefix the PHP
          * executable instead.
          */
-        $result = $this->searchNonExecutables($probable, $immediatePaths);
+        $result = $this->searchNonExecutables($probable, $immediatePaths, $includeArgs);
 
-        if (!is_null($result)) {
+        if (null !== $result) {
             return $result;
         }
 

--- a/src/Php/ConfigBuilder.php
+++ b/src/Php/ConfigBuilder.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Php;
+
+use Infection\Filesystem\Exception\IOException;
+
+final class ConfigBuilder
+{
+    const ENV_TEMP_PHP_CONFIG_PATH = 'INFECTION_TEMP_PHP_CONFIG_PATH';
+    const ENV_PHP_INI_SCAN_DIR = 'PHP_INI_SCAN_DIR';
+
+    /**
+     * @var string
+     */
+    private $tempDir;
+
+    /**
+     * @var string
+     */
+    private $tmpIniPath;
+
+    public function __construct(string $tempDir)
+    {
+        $this->tempDir = $tempDir;
+    }
+
+    /**
+     * @return string|null config path
+     *
+     * @throws \Exception
+     */
+    public function build()
+    {
+        $tmpIniPath = (string) getenv(self::ENV_TEMP_PHP_CONFIG_PATH);
+
+        if (!empty($tmpIniPath) && file_exists($tmpIniPath)) {
+            return $tmpIniPath;
+        }
+
+        $iniPaths = PhpIniHelper::get();
+
+        if ($this->writeTempIni($iniPaths)) {
+            $additional = count($iniPaths) > 1;
+
+            $this->setEnvironment($additional);
+
+            return $this->tmpIniPath;
+        }
+
+        throw new IOException('Can not create temporary php config with disabled xdebug.');
+    }
+
+    /**
+     * @param string[] $originalIniPaths
+     *
+     * @return bool
+     */
+    private function writeTempIni(array $originalIniPaths): bool
+    {
+        if (!($this->tmpIniPath = tempnam($this->tempDir, 'infection'))) {
+            return false;
+        }
+
+        // $originalIniPaths is either empty or has at least one element
+        if (empty($originalIniPaths[0])) {
+            array_shift($originalIniPaths);
+        }
+
+        $content = '';
+        $regex = '/^\s*(zend_extension\s*=.*xdebug.*)$/mi';
+
+        foreach ($originalIniPaths as $iniPath) {
+            $content .= preg_replace($regex, ';$1', file_get_contents($iniPath)) . PHP_EOL;
+        }
+
+        return (bool) @file_put_contents($this->tmpIniPath, $content);
+    }
+
+    private function setEnvironment(bool $additional): bool
+    {
+        if ($additional && !putenv(self::ENV_PHP_INI_SCAN_DIR . '=')) {
+            return false;
+        }
+
+        return putenv(self::ENV_TEMP_PHP_CONFIG_PATH . '=' . $this->tmpIniPath);
+    }
+}

--- a/src/Php/PhpIniHelper.php
+++ b/src/Php/PhpIniHelper.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Php;
+
+final class PhpIniHelper
+{
+    const ENV_ORIGINALS_PHP_INIS = 'INFECTION_ORIGINAL_INIS';
+
+    /**
+     * @return string[] List of php.ini locations
+     */
+    public static function get(): array
+    {
+        if ($env = (string) getenv(self::ENV_ORIGINALS_PHP_INIS)) {
+            return explode(PATH_SEPARATOR, $env);
+        }
+
+        $paths = [(string) php_ini_loaded_file()];
+
+        if ($scanned = php_ini_scanned_files()) {
+            $paths = array_merge($paths, array_map('trim', explode(',', $scanned)));
+        }
+
+        putenv(self::ENV_ORIGINALS_PHP_INIS . '=' . implode(PATH_SEPARATOR, $paths));
+
+        return $paths;
+    }
+}

--- a/src/Php/XdebugHandler.php
+++ b/src/Php/XdebugHandler.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Php;
+
+class XdebugHandler
+{
+    const ENV_DISABLE_XDEBUG = 'INFECTION_DISABLE_XDEBUG';
+
+    const RESTART_HANDLE = 'internal';
+
+    /**
+     * @var ConfigBuilder
+     */
+    private $configBuilder;
+
+    /**
+     * @var bool
+     */
+    private $isLoaded;
+
+    /**
+     * @var string
+     */
+    private $envScanDir;
+
+    /**
+     * @var string
+     */
+    private $tmpIniPath;
+
+    public function __construct(ConfigBuilder $configBuilder)
+    {
+        $this->configBuilder = $configBuilder;
+
+        $this->isLoaded = extension_loaded('xdebug');
+        $this->envScanDir = (string) getenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR);
+    }
+
+    public function check()
+    {
+        $args = explode('|', (string) getenv(self::ENV_DISABLE_XDEBUG));
+
+        if ($this->needsRestart($args[0])) {
+            if ($this->prepareRestart()) {
+                $this->restart($this->getCommand());
+            }
+        }
+
+        if (self::RESTART_HANDLE === $args[0]) {
+            putenv(self::ENV_DISABLE_XDEBUG);
+
+            if (false !== $this->envScanDir) {
+                // $args[1] contains the original value
+                if (isset($args[1])) {
+                    putenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR . '=' . $args[1]);
+                } else {
+                    putenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR);
+                }
+            }
+        }
+    }
+
+    private function needsRestart(string $allow): bool
+    {
+        if (PHP_SAPI !== 'cli' || !\defined('PHP_BINARY')) {
+            return false;
+        }
+
+        return $this->isLoaded && '' === $allow;
+    }
+
+    private function prepareRestart(): bool
+    {
+        if ($this->tmpIniPath = $this->configBuilder->build()) {
+            return $this->setEnvironment();
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the restart environment variables were set
+     *
+     * @return bool
+     */
+    private function setEnvironment(): bool
+    {
+        return putenv(self::ENV_DISABLE_XDEBUG . '=' . self::RESTART_HANDLE);
+    }
+
+    /**
+     * Returns the restart command line
+     *
+     * @return string
+     */
+    private function getCommand(): string
+    {
+        $params = array_merge(
+            [PHP_BINARY, '-c', $this->tmpIniPath],
+            $this->getScriptArgs($_SERVER['argv'])
+        );
+
+        return implode(' ', array_map([$this, 'escape'], $params));
+    }
+
+    /**
+     * Returns the restart script arguments, adding --ansi if required
+     *
+     * If we are a terminal with color support we must ensure that the --ansi
+     * option is set, because the restarted output is piped.
+     *
+     * @param array $args The argv array
+     *
+     * @return array
+     */
+    private function getScriptArgs(array $args): array
+    {
+        if (\in_array(['--no-ansi', '--ansi'], $args, true)) {
+            return $args;
+        }
+
+        $offset = \count($args) > 1 ? 2 : 1;
+        array_splice($args, $offset, 0, '--ansi');
+
+        return $args;
+    }
+
+    /**
+     * Escapes a string to be used as a shell argument.
+     *
+     * From https://github.com/johnstevenson/winbox-args
+     * MIT Licensed (c) John Stevenson <john-stevenson@blueyonder.co.uk>
+     *
+     * @param string $arg  The argument to be escaped
+     * @param bool   $meta Additionally escape cmd.exe meta characters
+     *
+     * @return string The escaped argument
+     */
+    private function escape(string $arg, bool $meta = true): string
+    {
+        if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
+            return escapeshellarg($arg);
+        }
+
+        $quote = strpbrk($arg, " \t") !== false || $arg === '';
+        $arg = preg_replace('/(\\\\*)"/', '$1$1\\"', $arg, -1, $quotesCount);
+
+        if ($meta) {
+            $meta = $quotesCount || preg_match('/%[^%]+%/', $arg);
+
+            if (!$meta && !$quote) {
+                $quote = strpbrk($arg, '^&|<>()') !== false;
+            }
+        }
+
+        if ($quote) {
+            $arg = preg_replace('/(\\\\*)$/', '$1$1', $arg);
+            $arg = '"' . $arg . '"';
+        }
+
+        if ($meta) {
+            $arg = preg_replace('/(["^&|<>()%])/', '^$1', $arg);
+        }
+
+        return $arg;
+    }
+
+    /**
+     * Executes the restarted command then deletes the tmp ini
+     *
+     * @param string $command
+     */
+    protected function restart(string $command)
+    {
+        passthru($command, $exitCode);
+
+        exit($exitCode);
+    }
+}

--- a/src/Process/ExecutableFinder/PhpExecutableFinder.php
+++ b/src/Process/ExecutableFinder/PhpExecutableFinder.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Process\ExecutableFinder;
+
+use Infection\Php\ConfigBuilder;
+use Symfony\Component\Process\PhpExecutableFinder as BasePhpExecutableFinder;
+
+final class PhpExecutableFinder extends BasePhpExecutableFinder
+{
+    public function findArguments()
+    {
+        $arguments = [];
+
+        $tempConfigPath = (string) getenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
+
+        if (!empty($tempConfigPath) && file_exists($tempConfigPath)) {
+            $arguments[] = '-c';
+            $arguments[] = $tempConfigPath;
+        } elseif ('phpdbg' === PHP_SAPI) {
+            $arguments[] = '-qrr';
+        }
+
+        return $arguments;
+    }
+}

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -20,7 +20,8 @@ abstract class AbstractTestFrameworkAdapter
     /**
      * @var AbstractExecutableFinder
      */
-    private $executableFinder;
+    private $phpExecutableFinder;
+
     /**
      * @var CommandLineArgumentsAndOptionsBuilder
      */
@@ -42,13 +43,13 @@ abstract class AbstractTestFrameworkAdapter
     private $versionParser;
 
     public function __construct(
-        AbstractExecutableFinder $executableFinder,
+        AbstractExecutableFinder $phpExecutableFinder,
         InitialConfigBuilder $initialConfigBuilder,
         MutationConfigBuilder $mutationConfigBuilder,
         CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder,
         VersionParser $versionParser
     ) {
-        $this->executableFinder = $executableFinder;
+        $this->phpExecutableFinder = $phpExecutableFinder;
         $this->initialConfigBuilder = $initialConfigBuilder;
         $this->mutationConfigBuilder = $mutationConfigBuilder;
         $this->argumentsAndOptionsBuilder = $argumentsAndOptionsBuilder;
@@ -68,14 +69,15 @@ abstract class AbstractTestFrameworkAdapter
      *
      * @param string $configPath
      * @param string $extraOptions
+     * @param bool $includePhpArgs
      *
      * @return string
      */
-    public function getExecutableCommandLine(string $configPath, string $extraOptions): string
+    public function getExecutableCommandLine(string $configPath, string $extraOptions, bool $includePhpArgs = true): string
     {
         return sprintf(
             '%s %s',
-            $this->executableFinder->find(),
+            $this->phpExecutableFinder->find($includePhpArgs),
             $this->argumentsAndOptionsBuilder->build($configPath, $extraOptions)
         );
     }
@@ -95,7 +97,7 @@ abstract class AbstractTestFrameworkAdapter
         $process = new Process(
             sprintf(
                 '%s %s',
-                $this->executableFinder->find(),
+                $this->phpExecutableFinder->find(),
                 '--version'
             )
         );

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -22,7 +22,7 @@ use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use Infection\Utils\VersionParser;
 
-class Factory
+final class Factory
 {
     /**
      * @var string
@@ -77,7 +77,7 @@ class Factory
         $this->versionParser = $versionParser;
     }
 
-    public function create($adapterName): AbstractTestFrameworkAdapter
+    public function create(string $adapterName): AbstractTestFrameworkAdapter
     {
         if ($adapterName === TestFrameworkTypes::PHPUNIT) {
             $phpUnitConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPUNIT);

--- a/tests/Php/ConfigBuilderTest.php
+++ b/tests/Php/ConfigBuilderTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests\Php;
+
+use Infection\Php\ConfigBuilder;
+use PHPUnit\Framework\TestCase;
+
+class ConfigBuilderTest extends TestCase
+{
+    public static $envOriginal;
+
+    /**
+     * @var string
+     */
+    private $workspace;
+
+    public static function setUpBeforeClass()
+    {
+        // Save current state
+        self::$envOriginal = getenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        // Restore original state
+        if (false !== self::$envOriginal) {
+            putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH . '=' . self::$envOriginal);
+        } else {
+            putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
+        }
+    }
+
+    protected function setUp()
+    {
+        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . microtime(true) . random_int(100, 999);
+        mkdir($this->workspace, 0777, true);
+    }
+
+    protected function tearDown()
+    {
+        @unlink($this->workspace);
+    }
+
+    public function test_it_builds_return_existing_path()
+    {
+        $builder = new ConfigBuilder(sys_get_temp_dir());
+
+        $file = $this->workspace . DIRECTORY_SEPARATOR . 'infectionTest';
+
+        touch($file);
+
+        $this->setEnv($file);
+
+        $this->assertSame($file, $builder->build());
+    }
+
+    private function setEnv(string $path)
+    {
+        putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH . '=' . $path);
+    }
+}

--- a/tests/Php/Mock/XdebugHandlerMock.php
+++ b/tests/Php/Mock/XdebugHandlerMock.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests\Php\Mock;
+
+use Infection\Php\ConfigBuilder;
+use Infection\Php\XdebugHandler;
+
+class XdebugHandlerMock extends XdebugHandler
+{
+    public $restarted;
+
+    public function __construct($isLoaded = null)
+    {
+        parent::__construct(new ConfigBuilder(sys_get_temp_dir()));
+
+        $isLoaded = null === $isLoaded ? true : $isLoaded;
+        $class = new \ReflectionClass(get_parent_class($this));
+
+        $prop = $class->getProperty('isLoaded');
+        $prop->setAccessible(true);
+        $prop->setValue($this, $isLoaded);
+
+        $this->restarted = false;
+    }
+
+    protected function restart(string $command)
+    {
+        $this->restarted = true;
+    }
+}

--- a/tests/Php/PhpIniHelperTest.php
+++ b/tests/Php/PhpIniHelperTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests\Php;
+
+use Infection\Php\PhpIniHelper;
+use PHPUnit\Framework\TestCase;
+
+class PhpIniHelperTest extends TestCase
+{
+    public static $envOriginal;
+
+    public static function setUpBeforeClass()
+    {
+        // Save current state
+        self::$envOriginal = getenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        // Restore original state
+        if (false !== self::$envOriginal) {
+            putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS . '=' . self::$envOriginal);
+        } else {
+            putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS);
+        }
+    }
+
+    public function test_it_works_with_loaded_ini()
+    {
+        $paths = [
+            'test.ini',
+        ];
+
+        $this->setEnv($paths);
+        $this->assertSame($paths, PhpIniHelper::get());
+    }
+
+    public function test_it_works_without_loaded_ini()
+    {
+        $paths = [
+            '',
+            'one.ini',
+            'two.ini',
+        ];
+
+        $this->setEnv($paths);
+        $this->assertSame($paths, PhpIniHelper::get());
+    }
+
+    private function setEnv(array $paths)
+    {
+        putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS . '=' . implode(PATH_SEPARATOR, $paths));
+    }
+}

--- a/tests/Php/XdebugHandlerTest.php
+++ b/tests/Php/XdebugHandlerTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests\Php;
+
+use Infection\Php\PhpIniHelper;
+use Infection\Tests\Php\Mock\XdebugHandlerMock;
+use PHPUnit\Framework\TestCase;
+
+class XdebugHandlerTest extends TestCase
+{
+    private static $env = [];
+
+    public static function setUpBeforeClass()
+    {
+        // Save current state
+        $names = [
+            XdebugHandlerMock::ENV_DISABLE_XDEBUG,
+            'PHP_INI_SCAN_DIR',
+            PhpIniHelper::ENV_ORIGINALS_PHP_INIS,
+        ];
+
+        foreach ($names as $name) {
+            self::$env[$name] = getenv($name);
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        // Restore original state
+        foreach (self::$env as $name => $value) {
+            if (false !== $value) {
+                putenv($name.'='.$value);
+            } else {
+                putenv($name);
+            }
+        }
+    }
+
+    protected function setUp()
+    {
+        putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS);
+        putenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG);
+    }
+
+    public function test_it_restart_when_loaded()
+    {
+        $loaded = true;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertTrue($xdebug->restarted);
+        $this->assertInternalType('string', getenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS));
+    }
+
+    public function test_it_not_restart_when_loaded()
+    {
+        $loaded = false;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertFalse($xdebug->restarted);
+        $this->assertFalse(getenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS));
+    }
+
+    public function test_it_not_restart_when_loaded_and_allowed()
+    {
+        $loaded = true;
+        putenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG.'=1');
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertFalse($xdebug->restarted);
+    }
+
+    public function test_env_allow()
+    {
+        $loaded = true;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $expected = XdebugHandlerMock::RESTART_HANDLE;
+        $this->assertEquals($expected, getenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG));
+
+        // Mimic restart
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertFalse($xdebug->restarted);
+        $this->assertFalse(getenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG));
+    }
+}

--- a/tests/Process/Builder/ProcessBuilderTest.php
+++ b/tests/Process/Builder/ProcessBuilderTest.php
@@ -1,4 +1,10 @@
-<?php declare(strict_types=1);
+<?php
+/**
+ * Copyright © 2017 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
 
 namespace Infection\Tests\Process\Builder;
 
@@ -6,7 +12,6 @@ use Infection\Mutant\Mutant;
 use Infection\Process\Builder\ProcessBuilder;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Mockery;
-
 
 class ProcessBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 {

--- a/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
+++ b/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Process\ExecutableFinder;
+
+use Infection\Php\ConfigBuilder;
+use Infection\Process\ExecutableFinder\PhpExecutableFinder;
+use PHPUnit\Framework\TestCase;
+
+class PhpExecutableFinderTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private $workspace;
+
+    public function setUp()
+    {
+        putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
+
+        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . microtime(true) . random_int(100, 999);
+        mkdir($this->workspace, 0777, true);
+    }
+
+    public function test_it_find_temp_php_config()
+    {
+        $finder = new PhpExecutableFinder();
+
+        $tempConfig = $this->workspace . DIRECTORY_SEPARATOR . 'php.ini';
+
+        touch($tempConfig);
+
+        putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH . '=' . $tempConfig);
+
+        $this->assertSame(['-c', $tempConfig], $finder->findArguments());
+    }
+
+    public function tearDown()
+    {
+        @unlink($this->workspace);
+    }
+}


### PR DESCRIPTION
**What I did:**

So I've checked how guys from composer did the same feature and I've done it almost in the same way.

Left condition when we check is xdebug loaded or not. We still need to have this check as we can't determine is xdebug installed or it is just disabled. So I decided to left condition and user still should have xdebug enabled.

Also symfony/process was updated to the latest stable version.

suggestions are welcome.

**What I didn't do:**
We will need to do the same for the native phpdbg. I think it should be separate PR.

p.s. @borNfreee if you don't mind could you please check execution time before and after this enhancement.