### PR TITLE
Fix issue when custom path for test framework exists

### DIFF
--- a/src/Finder/TestFrameworkExecutableFinder.php
+++ b/src/Finder/TestFrameworkExecutableFinder.php
@@ -83,7 +83,7 @@ class TestFrameworkExecutableFinder extends AbstractExecutableFinder
     private function findExecutable(bool $includeArgs = true): string
     {
         if ($this->doesCustomPathExist()) {
-            return $this->makeExecutable($this->customPath);
+            return $this->makeExecutable($this->customPath, $includeArgs);
         }
 
         $candidates = [$this->testFrameworkName, $this->testFrameworkName . '.phar'];


### PR DESCRIPTION
Quick fix for case when `customPath` exists in the config file.

Issue added by my previous PR: https://github.com/infection/infection/pull/85