### PR TITLE
PHPSPEC -  If you had a custom bootstrap file in the phpspec.yml it would generate the autoload without the semicolon.

### DIFF
--- a/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
@@ -69,7 +69,7 @@ class MutationConfigBuilder extends ConfigBuilder
         $mutatedFilePath = $mutant->getMutatedFilePath();
 
         $originalBootstrap = $this->getOriginalBootstrapFilePath($parsedYaml);
-        $autoloadPlaceholder = $originalBootstrap ? "require_once '{$originalBootstrap}'" : '';
+        $autoloadPlaceholder = $originalBootstrap ? "require_once '{$originalBootstrap}';" : '';
         $interceptorPath = dirname(__DIR__, 4) . '/StreamWrapper/IncludeInterceptor.php';
 
         $customAutoload = <<<AUTOLOAD


### PR DESCRIPTION
Fixed:
  - src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php

Cause:
  - If you had a custom bootstrap file in the phpspec.yml it would generate the autoload without the semicolon.

