### PR TITLE
Add credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Infection - Mutation Testing framework
 Please read documentation here: http://infection.github.io
 
 Twitter: http://twitter.com/infection_php
+
+### Credits
+
+This project is originally a fork of Pádraic Brady ([@padraic](https://github.com/padraic))'s [Humbug library](https://github.com/humbug/humbug). Humbug has since then been discountinued in favour of this project.

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Twitter: http://twitter.com/infection_php
 
 ### Credits
 
-This project is heavily inspired from Pádraic Brady ([@padraic](https://github.com/padraic))'s [Humbug library](https://github.com/humbug/humbug). Humbug has since then been discountinued in favour of this project.
+This project is highly inspired from Pádraic Brady ([@padraic](https://github.com/padraic))'s [Humbug library](https://github.com/humbug/humbug). Humbug has since then been discountinued in favour of this project.

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Twitter: http://twitter.com/infection_php
 
 ### Credits
 
-This project is originally a fork of Pádraic Brady ([@padraic](https://github.com/padraic))'s [Humbug library](https://github.com/humbug/humbug). Humbug has since then been discountinued in favour of this project.
+This project is heavily inspired from Pádraic Brady ([@padraic](https://github.com/padraic))'s [Humbug library](https://github.com/humbug/humbug). Humbug has since then been discountinued in favour of this project.


### PR DESCRIPTION
Add credits for Padraic.

I also updated Humbug to mention the library is no longer maintained as well as abandoned the package on Packagist with Infection as a replacement.

Hope hope that will pull out a few Humbug users here. It could be good to provide a migration path as well which I believe should be relatively easy. Maybe even better, IIRC the base config of Humbug  is working fine so we could support the humbug config file and just provide a deprecation notice recommending to rename the file. That way one wouldn't have to change anything but the package as a first step, can't get a smoother migration.