### PR TITLE
Parse only PHP files by default

### DIFF
--- a/src/Finder/SourceFilesFinder.php
+++ b/src/Finder/SourceFilesFinder.php
@@ -34,7 +34,7 @@ class SourceFilesFinder
         });
 
         if ('' === $filter) {
-            $finder->in($this->sourceDirectories)->files();
+            $finder->in($this->sourceDirectories)->files()->name('*.php');
 
             return $finder;
         }

--- a/tests/Finder/SourceFilesFinderTest.php
+++ b/tests/Finder/SourceFilesFinderTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Finder\Finder;
 
 class SourceFilesFinderTest extends TestCase
 {
-    public function test_it_lists_all_files_without_a_filter()
+    public function test_it_lists_all_php_files_without_a_filter()
     {
         $sourceFilesFinder = new SourceFilesFinder(['tests/Files/Finder'], []);
 


### PR DESCRIPTION
Fixes #104 bug [introduced earlier](https://github.com/infection/infection/commit/7d738bf15995d44fe2f930d61cc4b33cfdddd1fe#diff-c9fd62c42ae1c11f8c039f4dfd29a119L125). We should parse only PHP files as it was before if no `--filter` option is set.