### PR TITLE
Fix phpdbg issue caused by xdebug disabling feature

### DIFF
--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -41,11 +41,13 @@ final class ProcessBuilder
      */
     public function getProcessForInitialTestRun(string $testFrameworkExtraOptions = ''): Process
     {
+        $includeArgs = PHP_SAPI === 'phpdbg';
+
         return new Process(
             $this->testFrameworkAdapter->getExecutableCommandLine(
                 $this->testFrameworkAdapter->buildInitialConfigFile(),
                 $testFrameworkExtraOptions,
-                false
+                $includeArgs
             ),
             null,
             [],


### PR DESCRIPTION
This PR fixes https://github.com/infection/infection/issues/106 issue which was caused by switching `$includeArgs` variable from `true` to `false`. But I totally forgot that to run `phpdbg` we need to add  `-qrr` argument.

And that is why we have an issue when this parameter is equal to `false` then `-qrr` argument will be ignored.
proof: https://github.com/symfony/process/blob/3.4/PhpExecutableFinder.php#L39

p.s. I didn't find more elegant case how to avoid it. Any suggestions are welcome.