### PR TITLE
Filter mutations to only cover php classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,10 @@
         "psr-4": {
             "Infection\\Tests\\": "tests/"
         },
-        "files": ["tests/Helpers.php"]
+        "files": [
+            "tests/Helpers.php",
+            "tests/Files/Finder/test_functions.php"
+        ]
     },
     "config": {
         "platform": {

--- a/src/Finder/SourceFilesFinder.php
+++ b/src/Finder/SourceFilesFinder.php
@@ -34,12 +34,12 @@ class SourceFilesFinder
         });
 
         if ('' === $filter) {
-            $finder->in($this->sourceDirectories)->files()->name('*.php');
+            $finder->in($this->sourceDirectories)->files()->name('*.php')->contains('class ');
 
             return $finder;
         }
 
-        $finder->in('.')->files();
+        $finder->in('.')->files()->contains('class ');
 
         $filters = explode(',', $filter);
         array_walk($filters, function ($fileFilter) use ($finder) {

--- a/tests/Files/Finder/test_functions.php
+++ b/tests/Files/Finder/test_functions.php
@@ -1,0 +1,8 @@
+<?php
+
+if(!function_exists('hello_function')) {
+
+    function hello_function(){
+        return 1;
+    }
+}

--- a/tests/Finder/SourceFilesFinderTest.php
+++ b/tests/Finder/SourceFilesFinderTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Finder\Finder;
 
 class SourceFilesFinderTest extends TestCase
 {
-    public function test_it_lists_all_php_files_without_a_filter()
+    public function test_it_lists_all_php_files_that_are_classes_without_a_filter()
     {
         $sourceFilesFinder = new SourceFilesFinder(['tests/Files/Finder'], []);
 


### PR DESCRIPTION
This filters out files that don't have 'class ' in them.

Related to: #97 

I'm not 100% sure this is the best way to handle this, so i'm open for suggestions.