### PR TITLE
Update gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary
+
+#Files we do not want to distribute
+/tests export-ignore


### PR DESCRIPTION
This causes these files to not be exported when tagging a release on github.