### PR TITLE
Remove tests/test folders when infection is run for root directory. W…

### DIFF
--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -17,6 +17,8 @@ use Symfony\Component\Console\Question\Question;
 
 class ExcludeDirsProvider
 {
+    const EXCLUDED_ROOT_DIRS = ['vendor', 'tests', 'test'];
+
     /**
      * @var ConsoleHelper
      */
@@ -40,6 +42,7 @@ class ExcludeDirsProvider
             'There can be situations when you want to exclude some folders from generating mutants.',
             'You can use glob pattern (<comment>*Bundle/**/*/Tests</comment>) for them or just regular dir path.',
             'It should be <comment>relative</comment> to the source directory.',
+            '<comment>You should not mutate test suite files.</comment>',
             'Press <comment><return></comment> to stop/skip adding dirs.',
             '',
         ]);
@@ -52,8 +55,10 @@ class ExcludeDirsProvider
         $excludedDirs = [];
 
         if ($sourceDirs === ['.']) {
-            if (is_dir('vendor')) {
-                $excludedDirs[] = 'vendor';
+            foreach (self::EXCLUDED_ROOT_DIRS as $dir) {
+                if (in_array($dir, $dirsInCurrentDir, true)) {
+                    $excludedDirs[] = $dir;
+                }
             }
 
             $autocompleteValues = $dirsInCurrentDir;

--- a/tests/Config/ValueProvider/ExcludeDirsProviderTest.php
+++ b/tests/Config/ValueProvider/ExcludeDirsProviderTest.php
@@ -36,7 +36,10 @@ class ExcludeDirsProviderTest extends AbstractBaseProviderTest
         \umask($this->umask);
     }
 
-    public function test_it_contains_vendors_when_sources_contains_current_dir()
+    /**
+     * @dataProvider excludeDirsProvider
+     */
+    public function test_it_contains_vendors_when_sources_contains_current_dir(string $excludedRootDir, array $dirsInCurrentFolder)
     {
         $consoleMock = Mockery::mock(ConsoleHelper::class);
         $consoleMock->shouldReceive('getQuestion')->once()->andReturn('?');
@@ -45,14 +48,14 @@ class ExcludeDirsProviderTest extends AbstractBaseProviderTest
 
         $provider = new ExcludeDirsProvider($consoleMock, $dialog);
 
-        $excludeDirs = $provider->get(
+        $excludedDirs = $provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("\n")),
             $this->createOutputInterface(),
-            ['src'],
+            $dirsInCurrentFolder,
             ['.']
         );
 
-        $this->assertContains('vendor', $excludeDirs);
+        $this->assertContains($excludedRootDir, $excludedDirs);
     }
 
     public function test_it_validates_dirs()
@@ -105,5 +108,15 @@ class ExcludeDirsProviderTest extends AbstractBaseProviderTest
         );
 
         $this->assertContains('foo', $excludeDirs);
+    }
+
+    public function excludeDirsProvider()
+    {
+        return array_map(
+            function (string $excludedRootDir) {
+                return [$excludedRootDir, [$excludedRootDir, 'src']];
+            },
+            ExcludeDirsProvider::EXCLUDED_ROOT_DIRS
+        );
     }
 }


### PR DESCRIPTION
* Remove tests/test folders when infection is run for root directory.
* Warn users about excluding test suite from mutating
* Update documentation https://github.com/infection/site/pull/14

Fixes #115