### PR TITLE
Make Humbug's config to be compatible with Infection

### DIFF
--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -175,22 +175,31 @@ class InfectionConfig
 
     public function getSourceExcludePaths(): array
     {
-        if (isset($this->config->source->exclude) && is_array($this->config->source->exclude)) {
-            $originalExcludedPaths = $this->config->source->exclude;
-            $excludedPaths = [];
+        $originalExcludedPaths = $this->getExcludes();
+        $excludedPaths = [];
 
-            foreach ($originalExcludedPaths as $originalExcludedPath) {
-                if (strpos($originalExcludedPath, '*') === false) {
-                    $excludedPaths[] = $originalExcludedPath;
-                } else {
-                    $excludedPaths = array_merge(
-                        $excludedPaths,
-                        $this->getExcludedDirsByPattern($originalExcludedPath)
-                    );
-                }
+        foreach ($originalExcludedPaths as $originalExcludedPath) {
+            if (strpos($originalExcludedPath, '*') === false) {
+                $excludedPaths[] = $originalExcludedPath;
+            } else {
+                $excludedPaths = array_merge(
+                    $excludedPaths,
+                    $this->getExcludedDirsByPattern($originalExcludedPath)
+                );
             }
+        }
 
-            return $excludedPaths;
+        return $excludedPaths;
+    }
+
+    private function getExcludes(): array
+    {
+        if (isset($this->config->source->exclude) && is_array($this->config->source->exclude)) {
+            return $this->config->source->exclude;
+        }
+
+        if (isset($this->config->source->excludes) && is_array($this->config->source->excludes)) {
+            return $this->config->source->excludes;
         }
 
         return self::DEFAULT_EXCLUDE_DIRS;

--- a/tests/Config/InfectionConfigTest.php
+++ b/tests/Config/InfectionConfigTest.php
@@ -7,9 +7,7 @@
 
 declare(strict_types=1);
 
-
 namespace Infection\Tests\Config;
-
 
 use Infection\Config\InfectionConfig;
 use PHPUnit\Framework\TestCase;
@@ -74,9 +72,17 @@ class InfectionConfigTest extends TestCase
         $this->assertSame(InfectionConfig::DEFAULT_EXCLUDE_DIRS, $config->getSourceExcludePaths());
     }
 
-    public function test_it_returns_exclude_dirs_from_config()
+    public function test_it_returns_exclude_dirs_from_config_with_exclude_option()
     {
         $json = '{"source": {"exclude":["subfolder/excluded-folder"], "directories": ["source"]}}';
+        $config = new InfectionConfig(json_decode($json));
+
+        $this->assertSame(['subfolder/excluded-folder'], $config->getSourceExcludePaths());
+    }
+
+    public function test_it_returns_exclude_dirs_from_config_with_excludes_option()
+    {
+        $json = '{"source": {"excludes":["subfolder/excluded-folder"], "directories": ["source"]}}';
         $config = new InfectionConfig(json_decode($json));
 
         $this->assertSame(['subfolder/excluded-folder'], $config->getSourceExcludePaths());


### PR DESCRIPTION
As were discussed in the https://github.com/infection/infection/issues/103 I've added `excludes` option only. And I'd say that in the 0.8 we can remove `exclude` from the config file as there is no a lot of sense to support both of them

@borNfreee we can update documentation as well.