### PR TITLE
Ignore fixtures from cs fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,6 +9,7 @@ TXT;
 $finder = \PhpCsFixer\Finder::create()
    ->in('src')
    ->in('tests')
+   ->exclude('Fixtures')
    ->in('app')
 ;
 


### PR DESCRIPTION
Currently this is not *needed* but we may want to have 'unfixed' files in our Fixtures to run tests against. 

For example it broke a test in #123 