### PR TITLE
Fix: Use actual name

### DIFF
--- a/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
@@ -63,7 +63,7 @@ class InitialTestsConsoleLoggerSubscriber implements EventSubscriberInterface
             '',
             sprintf(
                 '%s version: %s',
-                ucfirst($this->testFrameworkAdapter->getName()),
+                $this->testFrameworkAdapter->getName(),
                 $version
             ),
             '',

--- a/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapter.php
+++ b/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapter.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Infection\TestFramework\PhpSpec\Adapter;
 
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
-use Infection\TestFramework\TestFrameworkTypes;
 
 class PhpSpecAdapter extends AbstractTestFrameworkAdapter
 {
@@ -41,6 +40,6 @@ class PhpSpecAdapter extends AbstractTestFrameworkAdapter
 
     public function getName(): string
     {
-        return TestFrameworkTypes::PHPSPEC;
+        return 'PhpSpec';
     }
 }

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Infection\TestFramework\PhpUnit\Adapter;
 
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
-use Infection\TestFramework\TestFrameworkTypes;
 
 class PhpUnitAdapter extends AbstractTestFrameworkAdapter
 {
@@ -40,6 +39,6 @@ class PhpUnitAdapter extends AbstractTestFrameworkAdapter
 
     public function getName(): string
     {
-        return TestFrameworkTypes::PHPUNIT;
+        return 'PHPUnit';
     }
 }

--- a/tests/Process/Listener/InitialTestsConsoleLoggerSubscriberTest.php
+++ b/tests/Process/Listener/InitialTestsConsoleLoggerSubscriberTest.php
@@ -51,7 +51,7 @@ class InitialTestsConsoleLoggerSubscriberTest extends Mockery\Adapter\Phpunit\Mo
         $output->shouldReceive('writeln')->once()->withArgs([[
             'Running initial test suite...',
             '',
-            'Phpunit version: unknown',
+            'PHPUnit version: unknown',
             '',
         ]]);
         $output->shouldReceive('getVerbosity')->andReturn(OutputInterface::VERBOSITY_QUIET);
@@ -59,7 +59,7 @@ class InitialTestsConsoleLoggerSubscriberTest extends Mockery\Adapter\Phpunit\Mo
         $progressBar = new ProgressBar($output);
 
         $testFramework = Mockery::mock(AbstractTestFrameworkAdapter::class);
-        $testFramework->shouldReceive('getName')->once()->andReturn('phpunit');
+        $testFramework->shouldReceive('getName')->once()->andReturn('PHPUnit');
         $testFramework->shouldReceive('getVersion')->andThrow(\InvalidArgumentException::class);
 
         $subscriber = new InitialTestsConsoleLoggerSubscriber(

--- a/tests/TestFramework/PhpSpec/Adapter/PhpSpecAdapterTest.php
+++ b/tests/TestFramework/PhpSpec/Adapter/PhpSpecAdapterTest.php
@@ -19,6 +19,13 @@ use Mockery;
 
 class PhpSpecAdapterTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 {
+    public function test_it_has_a_name()
+    {
+        $adapter = $this->getAdapter();
+
+        $this->assertSame('PhpSpec', $adapter->getName());
+    }
+
     public function test_it_determines_when_tests_do_not_pass()
     {
         $output = <<<OUTPUT

--- a/tests/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -19,18 +19,19 @@ use Mockery;
 
 class PhpUnitAdapterTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 {
+    public function test_it_has_a_name()
+    {
+        $adapter = $this->getAdapter();
+
+        $this->assertSame('PHPUnit', $adapter->getName());
+    }
+
     /**
      * @dataProvider passProvider
      */
     public function test_it_determines_whether_tests_pass_or_not($output, $expectedResult)
     {
-        $executableFined = Mockery::mock(AbstractExecutableFinder::class);
-        $initialConfigBuilder = Mockery::mock(InitialConfigBuilder::class);
-        $mutationConfigBuilder = Mockery::mock(MutationConfigBuilder::class);
-        $cliArgumentsBuilder = Mockery::mock(CommandLineArgumentsAndOptionsBuilder::class);
-        $versionParser = Mockery::mock(VersionParser::class);
-
-        $adapter = new PhpUnitAdapter($executableFined, $initialConfigBuilder, $mutationConfigBuilder, $cliArgumentsBuilder, $versionParser);
+        $adapter = $this->getAdapter();
 
         $result = $adapter->testsPass($output);
 
@@ -45,5 +46,22 @@ class PhpUnitAdapterTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             ['FAILURES!', false],
             ['ERRORS!', false],
         ];
+    }
+
+    private function getAdapter(): PhpUnitAdapter
+    {
+        $executableFined = Mockery::mock(AbstractExecutableFinder::class);
+        $initialConfigBuilder = Mockery::mock(InitialConfigBuilder::class);
+        $mutationConfigBuilder = Mockery::mock(MutationConfigBuilder::class);
+        $cliArgumentsBuilder = Mockery::mock(CommandLineArgumentsAndOptionsBuilder::class);
+        $versionParser = Mockery::mock(VersionParser::class);
+
+        return new PhpUnitAdapter(
+            $executableFined,
+            $initialConfigBuilder,
+            $mutationConfigBuilder,
+            $cliArgumentsBuilder,
+            $versionParser
+        );
     }
 }


### PR DESCRIPTION
This PR

* [x] uses the actual test framework name when rendering its version

💁‍♂️ Not sure where the name is of importance in other places, but I noticed that the names rendered aren't what the projects' maintainers use.

