### PR TITLE
Fix: Disable xdebug before composer analyze on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ cache:
 
 before_install:
   - composer selfupdate
+  - source .travis/xdebug.sh
+  - xdebug-disable
 
 install:
   - composer install
@@ -36,6 +38,7 @@ install:
 
 script:
   - composer analyze
+  - xdebug-enable
   - vendor/bin/phpunit --coverage-clover=clover.xml
   - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=61 --min-covered-msi=87; fi
 

--- a/.travis/xdebug.sh
+++ b/.travis/xdebug.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# See
+#
+# - https://docs.travis-ci.com/user/languages/php#Disabling-preinstalled-PHP-extensions
+# - https://docs.travis-ci.com/user/languages/php#Custom-PHP-configuration
+
+config="/home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini"
+
+function xdebug-disable() {
+    if [[ -f $config ]]; then
+        cp $config /tmp
+        phpenv config-rm xdebug.ini
+    fi
+}
+
+function xdebug-enable() {
+    if [[ -f "/tmp/xdebug.ini" ]]; then
+        phpenv config-add /tmp/xdebug.ini
+    fi
+}


### PR DESCRIPTION
php-cs-fixer takes a major preformance hit when xdebug is enabled.
This pr disables xdebug on travis before that is ran, and enables it again when it is required