### PR TITLE
Skip XdebugHandlerTest when infection is running via phpdbg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,26 @@ sudo: false
 matrix:
   include:
     - php: 7.0
-      env: INFECTION=1
+    - php: 7.0
+      env: PHPDBG=1
     - php: 7.1
-      env: INFECTION=1
     - php: 7.1
-      env: INFECTION=1 SYMFONY_VERSION="^4.0"
+      env: PHPDBG=1
+    - php: 7.1
+      env: SYMFONY_VERSION="^4.0"
+    - php: 7.1
+      env: SYMFONY_VERSION="^4.0" PHPDBG=1
     - php: 7.2
-      env: INFECTION=1
     - php: 7.2
-      env: INFECTION=1 SYMFONY_VERSION="^4.0"
+      env: PHPDBG=1
+    - php: 7.2
+      env: SYMFONY_VERSION="^4.0"
+    - php: 7.2
+      env: SYMFONY_VERSION="^4.0" PHPDBG=1
+
+env:
+  global:
+    - INFECTION_FLAGS='--threads=4 --min-msi=59 --min-covered-msi=87'
 
 cache:
   directories:
@@ -38,10 +49,10 @@ install:
 
 script:
   - composer analyze
-  - xdebug-enable
-  - vendor/bin/phpunit --coverage-clover=clover.xml
+  - if [[ $PHPDBG != 1 ]]; then xdebug-enable; fi
+  - if [[ $PHPDBG != 1 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml; else phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
   - ./tests/e2e_tests
-  - if [[ $INFECTION == 1 ]]; then bin/infection --threads=4 --min-msi=61 --min-covered-msi=87; fi
+  - if [[ $PHPDBG != 1 ]]; then bin/infection $INFECTION_FLAGS; else phpdbg -qrr bin/infection $INFECTION_FLAGS; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/tests/Fixtures/e2e/standard_script.bash
+++ b/tests/Fixtures/e2e/standard_script.bash
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-php ../../../../bin/infection
+if [[ $PHPDBG=1 ]]
+then
+    phpdbg -qrr ../../../../bin/infection
+else
+    php ../../../../bin/infection
+fi
+
 if [ $? != 0 ]
 then
     echo "error - fault while running infection"

--- a/tests/Php/XdebugHandlerTest.php
+++ b/tests/Php/XdebugHandlerTest.php
@@ -47,6 +47,10 @@ class XdebugHandlerTest extends TestCase
 
     protected function setUp()
     {
+        if (PHP_SAPI === 'phpdbg') {
+            $this->markTestSkipped();
+        }
+
         putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS);
         putenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG);
         putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);


### PR DESCRIPTION
We need to skip `XdebugHandlerTest` when infection is running via `phpdbg -qrr bin/infection`. So right now infection is not working with phpdbg as we expect.

p.s. Suggest to add phpdbg to travis to avoid issues like that in future. Please vote and I'll try to add it in the current PR 