### PR TITLE
Enhancement: Implement number to string mutator

### DIFF
--- a/src/Mutator/Number/NumberToString.php
+++ b/src/Mutator/Number/NumberToString.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Number;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+
+/**
+ * @internal
+ */
+final class NumberToString extends Mutator
+{
+    /**
+     * Casts a number to string.
+     *
+     * @param Node $node
+     *
+     * @return Node\Scalar\String_
+     */
+    public function mutate(Node $node)
+    {
+        return new Node\Scalar\String_((string) $node->value);
+    }
+
+    protected function mutatesNode(Node $node): bool
+    {
+        return $node instanceof Node\Scalar\DNumber || $node instanceof Node\Scalar\LNumber;
+    }
+}

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -100,6 +100,7 @@ final class MutatorProfile
     const NUMBER = [
         Mutator\Number\DecrementInteger::class,
         Mutator\Number\IncrementInteger::class,
+        Mutator\Number\NumberToString::class,
         Mutator\Number\OneZeroInteger::class,
         Mutator\Number\OneZeroFloat::class,
     ];

--- a/tests/Mutator/Number/NumberToStringTest.php
+++ b/tests/Mutator/Number/NumberToStringTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Number;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+/**
+ * @internal
+ */
+final class NumberToStringTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider providerNumber
+     */
+    public function test_it_casts_a_number_to_string($number)
+    {
+        $code = <<<PHP
+<?php
+
+echo ${number};
+PHP;
+
+        $mutatedCode = $this->mutate($code);
+
+        $expectedMutatedCode = <<<PHP
+<?php
+
+echo '${number}';
+PHP;
+
+        $this->assertSame($expectedMutatedCode, $mutatedCode);
+    }
+
+    public function providerNumber(): array
+    {
+        return [
+            [1.23],
+            [123],
+        ];
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements a number to string mutator

💁‍♂️ Not sure, would it make sense to implement the reverse as well?