### PR TITLE
Fix appveyor build

### DIFF
--- a/tests/Finder/LocatorTest.php
+++ b/tests/Finder/LocatorTest.php
@@ -99,14 +99,15 @@ class LocatorTest extends TestCase
         $found = $locator->locateAnyOf(['file.txt', 'secondfile.txt']);
         $this->assertStringEndsWith(
             'tests/Fixtures/Locator/file.txt',
-            $found,
+            p($found),
             'Found an incorrect file, orders may be broken.'
         );
 
         $found = $locator->locateAnyOf(['secondfile.txt', 'file.txt']);
+
         $this->assertStringEndsWith(
             'tests/Fixtures/Locator/secondfile.txt',
-            $found,
+            p($found),
             'Found an incorrect file, orders may be broken.'
         );
     }
@@ -117,9 +118,10 @@ class LocatorTest extends TestCase
         $locator = new Locator([$projectPath]);
 
         $found = $locator->locateAnyOf(['fakefile.txt', 'secondfile.txt', 'thirdfile.txt']);
+
         $this->assertStringEndsWith(
             'tests/Fixtures/Locator/secondfile.txt',
-            $found,
+            p($found),
             'Found an incorrect file, orders may be broken.'
         );
     }

--- a/tests/TestFramework/Config/TestFrameworkConfigLocatorTest.php
+++ b/tests/TestFramework/Config/TestFrameworkConfigLocatorTest.php
@@ -8,6 +8,7 @@
 namespace Infection\Tests\TestFramework\Config;
 
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
+use function Infection\Tests\normalizePath as p;
 
 class TestFrameworkConfigLocatorTest extends \PHPUnit\Framework\TestCase
 {
@@ -33,7 +34,7 @@ class TestFrameworkConfigLocatorTest extends \PHPUnit\Framework\TestCase
 
         $this->assertStringEndsWith(
             'tests/Fixtures/ConfigLocator/DistFile/phpunit.xml.dist',
-            $output,
+            p($output),
             'Did not find the correct phpunit.xml.dist file.'
         );
     }
@@ -47,7 +48,7 @@ class TestFrameworkConfigLocatorTest extends \PHPUnit\Framework\TestCase
 
         $this->assertStringEndsWith(
             'tests/Fixtures/ConfigLocator/XmlFile/phpunit.xml',
-            $output,
+            p($output),
             'Did not find the correct phpunit.xml file.'
         );
     }
@@ -61,7 +62,7 @@ class TestFrameworkConfigLocatorTest extends \PHPUnit\Framework\TestCase
 
         $this->assertStringEndsWith(
             'tests/Fixtures/ConfigLocator/BothXmlAndDist/phpunit.xml',
-            $output,
+            p($output),
             'Did not find the correct phpunit.xml file.'
         );
     }
@@ -75,7 +76,7 @@ class TestFrameworkConfigLocatorTest extends \PHPUnit\Framework\TestCase
 
         $this->assertStringEndsWith(
             'tests/Fixtures/ConfigLocator/DistFile/phpunit.xml.dist',
-            $output,
+            p($output),
             'Did not find the correct phpunit.xml.dist file.'
         );
 


### PR DESCRIPTION
Whatever bug was causing appveyor to fail beforehand appears to havebeen fixed. It was now failing due to tests not converting the string to a 'realpath', which caused some issues due to windowspaths. This change should fix all occurrences of this error