### PR TITLE
Exclude XdebugHandler from infection coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 env:
   global:
-    - INFECTION_FLAGS='--threads=4 --min-msi=57 --min-covered-msi=84'
+    - INFECTION_FLAGS='--threads=4 --min-msi=59 --min-covered-msi=85'
 
 cache:
   directories:

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -3,6 +3,9 @@
     "source": {
         "directories": [
             "src"
+        ],
+        "excludes": [
+            "Php/XdebugHandler.php"
         ]
     },
     "logs": {

--- a/tests/Php/XdebugHandlerTest.php
+++ b/tests/Php/XdebugHandlerTest.php
@@ -13,6 +13,9 @@ use Infection\Php\PhpIniHelper;
 use Infection\Tests\Php\Mock\XdebugHandlerMock;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Infection\Php\XdebugHandler
+ */
 class XdebugHandlerTest extends TestCase
 {
     private static $env = [];


### PR DESCRIPTION
This PR:

* [x] Excludes XdebugHandler from mutation

This should make sure we get the same msi etc on all runs of travis.