### PR TITLE
Fix: Reference schema relative to phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
          colors="true"
 >


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` relative to `phpunit.xml`

💁‍♂️ This way it will always reference the schema that is actually installed, and there will be no need to point to a new location when `phpunit/phpunit` is updated.