### PR TITLE
Enhancement: Use all the columns when running phpunit

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,7 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
          colors="true"
+         columns="max"
 >
     <testsuites>
         <testsuite name="Application Test Suite">


### PR DESCRIPTION
This PR

* [x] uses all the columns available in the terminal when running `phpunit`


### Before

```
PHPUnit 6.1.0 by Sebastian Bergmann and contributors.

...............................................................  63 / 320 ( 19%)
............................................................... 126 / 320 ( 39%)
............................................................... 189 / 320 ( 59%)
............................................................... 252 / 320 ( 78%)
............................................................... 315 / 320 ( 98%)
.....                                                           320 / 320 (100%)

Time: 1.04 seconds, Memory: 18.00MB

OK (320 tests, 578 assertions)
```

### After

```
PHPUnit 6.1.0 by Sebastian Bergmann and contributors.

............................................................................................................................................................................................................................. 221 / 320 ( 69%)
...................................................................................................                                                                                                                           320 / 320 (100%)

Time: 1.05 seconds, Memory: 18.00MB

OK (320 tests, 578 assertions)
```