### PR TITLE
Make paths in config file relative to config file

### DIFF
--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -161,15 +161,10 @@ class InfectionConfig
      */
     private $configLocation;
 
-    public function __construct(\stdClass $config, Filesystem $filesystem, string $configLocation = null)
+    public function __construct(\stdClass $config, Filesystem $filesystem, string $configLocation)
     {
         $this->config = $config;
         $this->filesystem = $filesystem;
-
-        if ($configLocation === null) {
-            $configLocation = getcwd();
-        }
-
         $this->configLocation = $configLocation;
     }
 
@@ -179,7 +174,7 @@ class InfectionConfig
             return $this->configLocation . DIRECTORY_SEPARATOR . $this->config->phpUnit->configDir;
         }
 
-        return $this->configLocation ;
+        return $this->configLocation;
     }
 
     public function getPhpUnitCustomPath()
@@ -280,6 +275,6 @@ class InfectionConfig
             return $tmpDir;
         }
 
-        return sprintf('%s/%s', $this->configLocation , $tmpDir);
+        return sprintf('%s/%s', $this->configLocation, $tmpDir);
     }
 }

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -156,19 +156,30 @@ class InfectionConfig
      */
     private $filesystem;
 
-    public function __construct(\stdClass $config, Filesystem $filesystem)
+    /**
+     * @var string
+     */
+    private $configLocation;
+
+    public function __construct(\stdClass $config, Filesystem $filesystem, string $configLocation = null)
     {
         $this->config = $config;
         $this->filesystem = $filesystem;
+
+        if ($configLocation === null) {
+            $configLocation = getcwd();
+        }
+
+        $this->configLocation = $configLocation;
     }
 
     public function getPhpUnitConfigDir(): string
     {
         if (isset($this->config->phpUnit->configDir)) {
-            return getcwd() . DIRECTORY_SEPARATOR . $this->config->phpUnit->configDir;
+            return $this->configLocation . DIRECTORY_SEPARATOR . $this->config->phpUnit->configDir;
         }
 
-        return getcwd();
+        return $this->configLocation ;
     }
 
     public function getPhpUnitCustomPath()
@@ -269,6 +280,6 @@ class InfectionConfig
             return $tmpDir;
         }
 
-        return sprintf('%s/%s', getcwd(), $tmpDir);
+        return sprintf('%s/%s', $this->configLocation , $tmpDir);
     }
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -106,12 +106,14 @@ ASCII;
                 );
 
                 $infectionConfigFile = $c['locator']->locateAnyOf($configPaths);
+                $dir = \pathinfo($infectionConfigFile, PATHINFO_DIRNAME);
                 $json = file_get_contents($infectionConfigFile);
             } catch (\Exception $e) {
                 $json = '{}';
+                $dir = getcwd();
             }
 
-            return new InfectionConfig(json_decode($json), $c['filesystem']);
+            return new InfectionConfig(json_decode($json), $c['filesystem'], $dir);
         };
 
         $this->container['tmp.dir'] = function (Container $c): string {

--- a/tests/Config/InfectionConfigTest.php
+++ b/tests/Config/InfectionConfigTest.php
@@ -27,7 +27,7 @@ class InfectionConfigTest extends TestCase
 
     public function test_it_returns_default_timeout_with_no_config()
     {
-        $config = new InfectionConfig(new \stdClass(), $this->filesystem);
+        $config = new InfectionConfig(new \stdClass(), $this->filesystem, '/path/to/config');
 
         $this->assertSame(InfectionConfig::PROCESS_TIMEOUT_SECONDS, $config->getProcessTimeout());
     }
@@ -36,32 +36,32 @@ class InfectionConfigTest extends TestCase
     {
         $timeout = 3;
         $json = sprintf('{"timeout": %d}', $timeout);
-        $config = new InfectionConfig(json_decode($json), $this->filesystem);
+        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
 
         $this->assertSame($timeout, $config->getProcessTimeout());
     }
 
     public function test_it_returns_default_phpunit_config_dir_with_no_config()
     {
-        $config = new InfectionConfig(new \stdClass(), $this->filesystem);
+        $config = new InfectionConfig(new \stdClass(), $this->filesystem, '/path/to/config');
 
-        $this->assertSame(getcwd(), $config->getPhpUnitConfigDir());
+        $this->assertSame('/path/to/config', $config->getPhpUnitConfigDir());
     }
 
     public function test_it_returns_phpunit_config_dir_from_config()
     {
         $phpUnitConfigDir = 'app';
         $json = sprintf('{"phpUnit": {"configDir": "%s"}}', $phpUnitConfigDir);
-        $config = new InfectionConfig(json_decode($json), $this->filesystem);
+        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
 
-        $expected = getcwd() . '/app';
+        $expected = '/path/to/config/app';
 
         $this->assertSame(p($expected), p($config->getPhpUnitConfigDir()));
     }
 
     public function test_it_returns_default_source_dirs_with_no_config()
     {
-        $config = new InfectionConfig(new \stdClass(), $this->filesystem);
+        $config = new InfectionConfig(new \stdClass(), $this->filesystem, '/path/to/config');
 
         $this->assertSame(InfectionConfig::DEFAULT_SOURCE_DIRS, $config->getSourceDirs());
     }
@@ -70,14 +70,14 @@ class InfectionConfigTest extends TestCase
     {
         $excludedFolders = '["source-folder"]';
         $json = sprintf('{"source": {"directories": %s}}', $excludedFolders);
-        $config = new InfectionConfig(json_decode($json), $this->filesystem);
+        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
 
         $this->assertSame(['source-folder'], $config->getSourceDirs());
     }
 
     public function test_it_returns_default_exclude_dirs_with_no_config()
     {
-        $config = new InfectionConfig(new \stdClass(), $this->filesystem);
+        $config = new InfectionConfig(new \stdClass(), $this->filesystem, '/path/to/config');
 
         $this->assertSame(InfectionConfig::DEFAULT_EXCLUDE_DIRS, $config->getSourceExcludePaths());
     }
@@ -85,7 +85,7 @@ class InfectionConfigTest extends TestCase
     public function test_it_returns_exclude_dirs_from_config_with_excludes_option()
     {
         $json = '{"source": {"excludes":["subfolder/excluded-folder"], "directories": ["source"]}}';
-        $config = new InfectionConfig(json_decode($json), $this->filesystem);
+        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
 
         $this->assertSame(['subfolder/excluded-folder'], $config->getSourceExcludePaths());
     }
@@ -95,7 +95,7 @@ class InfectionConfigTest extends TestCase
         $srcDir = __DIR__ . '/../Fixtures/Files/phpunit/project-path';
         $json = sprintf('{"source": {"excludes":["exclude/exclude*"], "directories": ["%s"]}}', p($srcDir));
 
-        $config = new InfectionConfig(json_decode($json), $this->filesystem);
+        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
 
         $excludedDirs = $config->getSourceExcludePaths();
 
@@ -106,43 +106,43 @@ class InfectionConfigTest extends TestCase
     {
         $path = 'test-log.txt';
         $json = sprintf('{"logs": {"text": "%s"}}', $path);
-        $config = new InfectionConfig(json_decode($json), $this->filesystem);
+        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
 
         $this->assertSame($path, $config->getLogPathInfoFor('text'));
     }
 
     public function test_it_returns_an_empty_array_for_text_file_log_path_when_it_is_skipped()
     {
-        $config = new InfectionConfig(json_decode('{}'), $this->filesystem);
+        $config = new InfectionConfig(json_decode('{}'), $this->filesystem, '/path/to/config');
 
         $this->assertEmpty($config->getLogPathInfoFor('text'));
     }
 
     public function test_it_returns_default_temp_dir()
     {
-        $config = new InfectionConfig(json_decode('{}'), $this->filesystem);
+        $config = new InfectionConfig(json_decode('{}'), $this->filesystem, '/path/to/config');
 
         $this->assertSame(sys_get_temp_dir(), $config->getTmpDir());
     }
 
     public function test_it_returns_default_temp_dir_with_empty_setting()
     {
-        $config = new InfectionConfig(json_decode('{"tmpDir": ""}'), $this->filesystem);
+        $config = new InfectionConfig(json_decode('{"tmpDir": ""}'), $this->filesystem, '/path/to/config');
 
         $this->assertSame(sys_get_temp_dir(), $config->getTmpDir());
     }
 
     public function test_it_returns_temp_dir_from_config_with_absolute_path()
     {
-        $config = new InfectionConfig(json_decode('{"tmpDir": "/root/test"}'), $this->filesystem);
+        $config = new InfectionConfig(json_decode('{"tmpDir": "/root/test"}'), $this->filesystem, '/path/to/config');
 
         $this->assertSame('/root/test', $config->getTmpDir());
     }
 
     public function test_it_returns_temp_dir_from_config_with_relative_path()
     {
-        $config = new InfectionConfig(json_decode('{"tmpDir": "relative/folder"}'), $this->filesystem);
+        $config = new InfectionConfig(json_decode('{"tmpDir": "relative/folder"}'), $this->filesystem, '/path/to/config');
 
-        $this->assertSame(getcwd() . '/relative/folder', $config->getTmpDir());
+        $this->assertSame('/path/to/config/relative/folder', $config->getTmpDir());
     }
 }


### PR DESCRIPTION
This PR:

* [x] Makes all paths in the config file be relative to the config file.
* [x] Defaults to working directory if no config file is found

Fixes #142 