### PR TITLE
Fix: Don't mutate abstract methods

### DIFF
--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -55,6 +55,10 @@ class PublicVisibility extends Mutator
             return false;
         }
 
+        if ($node->isAbstract()) {
+            return false;
+        }
+
         return $node->isPublic();
     }
 

--- a/tests/Mutator/FunctionSignature/PublicVisibilityTest.php
+++ b/tests/Mutator/FunctionSignature/PublicVisibilityTest.php
@@ -215,6 +215,16 @@ interface TestInterface
 }
 PHP
             ],
+            'It does not mutate an abstract function' => [
+                <<<'PHP'
+<?php
+
+abstract class Test
+{
+    public abstract function foo(int $param, $test = 1) : bool;
+}
+PHP
+            ],
         ];
     }
 }


### PR DESCRIPTION
This PR:

* [x] Stops mutations from `public` to `protected` on abstract functions
* [ ] ~Stops mutations of default values of abstract functions~

See #166 

Note: If #67 gets integrated before the next release, its probably better to do this with reflection.

I excluded stopping mutation of default values in abstract functions for now.