### PR TITLE
Enhacement: native function invocation cs fixer rule

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -26,6 +26,7 @@ return \PhpCsFixer\Config::create()
             'separate' => 'bottom',
         ],
         'is_null' => true,
+        'native_function_invocation' => true,
         'ordered_imports' => true,
         'phpdoc_align' => false,
         'phpdoc_summary' => false,

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -14,8 +14,8 @@ $files = [
 ];
 
 foreach ($files as $file) {
-    if (file_exists($file)) {
-        define('INFECTION_COMPOSER_INSTALL', $file);
+    if (\file_exists($file)) {
+        \define('INFECTION_COMPOSER_INSTALL', $file);
 
         break;
     }
@@ -23,8 +23,8 @@ foreach ($files as $file) {
 
 unset($files);
 
-if (!defined('INFECTION_COMPOSER_INSTALL')) {
-    fwrite(
+if (!\defined('INFECTION_COMPOSER_INSTALL')) {
+    \fwrite(
         STDERR,
         'You need to set up the project dependencies using Composer:' . PHP_EOL . PHP_EOL .
         '    composer install' . PHP_EOL . PHP_EOL .
@@ -36,14 +36,14 @@ if (!defined('INFECTION_COMPOSER_INSTALL')) {
 
 require INFECTION_COMPOSER_INSTALL;
 
-$isDebuggerDisabled = empty((string) getenv(XdebugHandler::ENV_DISABLE_XDEBUG));
+$isDebuggerDisabled = empty((string) \getenv(XdebugHandler::ENV_DISABLE_XDEBUG));
 
-$xdebug = new XdebugHandler(new ConfigBuilder(sys_get_temp_dir()));
+$xdebug = new XdebugHandler(new ConfigBuilder(\sys_get_temp_dir()));
 $xdebug->check();
 unset($xdebug);
 
-if (PHP_SAPI !== 'phpdbg' && $isDebuggerDisabled && !extension_loaded('xdebug')) {
-    fwrite(
+if (PHP_SAPI !== 'phpdbg' && $isDebuggerDisabled && !\extension_loaded('xdebug')) {
+    \fwrite(
         STDERR,
         'You need to use phpdbg or install and enable xdebug in order to allow for code coverage generation.' . PHP_EOL
     );

--- a/app/container.php
+++ b/app/container.php
@@ -42,7 +42,7 @@ $c['exclude.paths'] = function (Container $c): array {
     return $c['infection.config']->getSourceExcludePaths();
 };
 
-$c['project.dir'] = getcwd();
+$c['project.dir'] = \getcwd();
 
 $c['phpunit.config.dir'] = function (Container $c): string {
     return $c['infection.config']->getPhpUnitConfigDir();

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -33,7 +33,7 @@ class ConfigureCommand extends BaseCommand
                 'test-framework',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Name of the Test framework to use (' . implode(', ', TestFrameworkTypes::TYPES) . ')',
+                'Name of the Test framework to use (' . \implode(', ', TestFrameworkTypes::TYPES) . ')',
                 TestFrameworkTypes::PHPUNIT
             );
     }
@@ -50,7 +50,7 @@ class ConfigureCommand extends BaseCommand
             '',
         ]);
 
-        $dirsInCurrentDir = array_filter(glob('*'), 'is_dir');
+        $dirsInCurrentDir = \array_filter(\glob('*'), 'is_dir');
         $testFrameworkConfigLocator = new TestFrameworkConfigLocator('.');
 
         $questionHelper = $this->getHelper('question');
@@ -89,7 +89,7 @@ class ConfigureCommand extends BaseCommand
 
         $output->writeln([
             '',
-            sprintf(
+            \sprintf(
                 'Configuration file "<comment>%s</comment>" was created.',
                 InfectionConfig::CONFIG_FILE_NAME . '.dist'
             ),
@@ -138,6 +138,6 @@ class ConfigureCommand extends BaseCommand
             $configObject->logs->text = $textLogFilePath;
         }
 
-        file_put_contents(InfectionConfig::CONFIG_FILE_NAME . '.dist', json_encode($configObject, JSON_PRETTY_PRINT));
+        \file_put_contents(InfectionConfig::CONFIG_FILE_NAME . '.dist', \json_encode($configObject, JSON_PRETTY_PRINT));
     }
 }

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -275,8 +275,8 @@ class InfectionCommand extends BaseCommand
 
     private function getCodeCoverageData(string $testFrameworkKey): CodeCoverageData
     {
-        $coverageDir = $this->getContainer()->get(sprintf('coverage.dir.%s', $testFrameworkKey));
-        $testFileDataProviderServiceId = sprintf('test.file.data.provider.%s', $testFrameworkKey);
+        $coverageDir = $this->getContainer()->get(\sprintf('coverage.dir.%s', $testFrameworkKey));
+        $testFileDataProviderServiceId = \sprintf('test.file.data.provider.%s', $testFrameworkKey);
         $testFileDataProviderService = $this->getContainer()->has($testFileDataProviderServiceId)
             ? $this->getContainer()->get($testFileDataProviderServiceId)
             : null;
@@ -288,12 +288,12 @@ class InfectionCommand extends BaseCommand
     {
         $lines = [
             'Project tests must be in a passing state before running Infection.',
-            sprintf(
+            \sprintf(
                 '%s reported an exit code of %d.',
-                ucfirst($testFrameworkKey),
+                \ucfirst($testFrameworkKey),
                 $initialTestSuitProcess->getExitCode()
             ),
-            sprintf(
+            \sprintf(
                 'Refer to the %s\'s output below:',
                 $testFrameworkKey
             ),
@@ -329,7 +329,7 @@ class InfectionCommand extends BaseCommand
     private function getBadMsiErrorMessage(MetricsCalculator $metricsCalculator): string
     {
         if ($minMsi = (float) $this->input->getOption('min-msi')) {
-            return sprintf(
+            return \sprintf(
                 self::CI_FLAG_ERROR,
                 'MSI',
                 $minMsi,
@@ -343,7 +343,7 @@ class InfectionCommand extends BaseCommand
     private function getBadCoveredMsiErrorMessage(MetricsCalculator $metricsCalculator): string
     {
         if ($minCoveredMsi = (float) $this->input->getOption('min-covered-msi')) {
-            return sprintf(
+            return \sprintf(
                 self::CI_FLAG_ERROR,
                 'Covered Code MSI',
                 $minCoveredMsi,
@@ -360,18 +360,18 @@ class InfectionCommand extends BaseCommand
             return [];
         }
 
-        $trimmedMutators = trim($mutators);
+        $trimmedMutators = \trim($mutators);
 
         if ($trimmedMutators === '') {
             throw InvalidOptionException::withMessage('The "--mutators" option requires a value.');
         }
 
-        return explode(',', $mutators);
+        return \explode(',', $mutators);
     }
 
     private function getDefaultMutators(): array
     {
-        return array_map(
+        return \array_map(
             function (string $class): Mutator {
                 return $this->getContainer()->get($class);
             },
@@ -401,11 +401,11 @@ class InfectionCommand extends BaseCommand
         parent::initialize($input, $output);
 
         $customConfigPath = $input->getOption('configuration');
-        $configExists = $customConfigPath && file_exists($customConfigPath);
+        $configExists = $customConfigPath && \file_exists($customConfigPath);
 
         if (!$configExists) {
-            $configExists = file_exists(InfectionConfig::CONFIG_FILE_NAME)
-                || file_exists(InfectionConfig::CONFIG_FILE_NAME . '.dist');
+            $configExists = \file_exists(InfectionConfig::CONFIG_FILE_NAME)
+                || \file_exists(InfectionConfig::CONFIG_FILE_NAME . '.dist');
         }
 
         if (!$configExists) {

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -155,23 +155,23 @@ class SelfUpdateCommand extends Command
                 $newVersion = $updater->getNewVersion();
 
                 $this->output->writeln('<fg=green>Infection has been updated.</fg=green>');
-                $this->output->writeln(sprintf(
+                $this->output->writeln(\sprintf(
                     '<fg=green>Current version is:</fg=green> <options=bold>%s</options=bold>.',
                     $newVersion
                 ));
-                $this->output->writeln(sprintf(
+                $this->output->writeln(\sprintf(
                     '<fg=green>Previous version was:</fg=green> <options=bold>%s</options=bold>.',
                     $oldVersion
                 ));
             } else {
                 $this->output->writeln('<fg=green>Infection is currently up to date.</fg=green>');
-                $this->output->writeln(sprintf(
+                $this->output->writeln(\sprintf(
                     '<fg=green>Current version is:</fg=green> <options=bold>%s</options=bold>.',
                     $oldVersion
                 ));
             }
         } catch (\Exception $e) {
-            $this->output->writeln(sprintf('Error: <fg=yellow>%s</fg=yellow>', $e->getMessage()));
+            $this->output->writeln(\sprintf('Error: <fg=yellow>%s</fg=yellow>', $e->getMessage()));
         }
         $this->output->write(PHP_EOL);
         $this->output->writeln('You can also select update stability using --pre (alpha/beta/rc) or --stable.');
@@ -187,7 +187,7 @@ class SelfUpdateCommand extends Command
                 $this->output->writeln('<fg=red>Rollback failed for reasons unknown.</fg=red>');
             }
         } catch (\Exception $e) {
-            $this->output->writeln(sprintf('Error: <fg=yellow>%s</fg=yellow>', $e->getMessage()));
+            $this->output->writeln(\sprintf('Error: <fg=yellow>%s</fg=yellow>', $e->getMessage()));
         }
     }
 
@@ -202,7 +202,7 @@ class SelfUpdateCommand extends Command
 
     protected function printCurrentLocalVersion()
     {
-        $this->output->writeln(sprintf(
+        $this->output->writeln(\sprintf(
             'Your current local build version is: <options=bold>%s</options=bold>',
             $this->version
         ));
@@ -230,18 +230,18 @@ class SelfUpdateCommand extends Command
 
         try {
             if ($updater->hasUpdate()) {
-                $this->output->writeln(sprintf(
+                $this->output->writeln(\sprintf(
                     'The current %s build available remotely is: <options=bold>%s</options=bold>',
                     $stability,
                     $updater->getNewVersion()
                 ));
             } elseif (false == $updater->getNewVersion()) {
-                $this->output->writeln(sprintf('There are no %s builds available.', $stability));
+                $this->output->writeln(\sprintf('There are no %s builds available.', $stability));
             } else {
-                $this->output->writeln(sprintf('You have the current %s build installed.', $stability));
+                $this->output->writeln(\sprintf('You have the current %s build installed.', $stability));
             }
         } catch (\Exception $e) {
-            $this->output->writeln(sprintf('Error: <fg=yellow>%s</fg=yellow>', $e->getMessage()));
+            $this->output->writeln(\sprintf('Error: <fg=yellow>%s</fg=yellow>', $e->getMessage()));
         }
     }
 }

--- a/src/Config/ConsoleHelper.php
+++ b/src/Config/ConsoleHelper.php
@@ -35,7 +35,7 @@ class ConsoleHelper
     public function getQuestion($question, $default = null, $sep = ':')
     {
         return $default
-            ? sprintf('<info>%s</info> [<comment>%s</comment>]%s ', $question, $default, $sep)
-            : sprintf('<info>%s</info>%s ', $question, $sep);
+            ? \sprintf('<info>%s</info> [<comment>%s</comment>]%s ', $question, $default, $sep)
+            : \sprintf('<info>%s</info>%s ', $question, $sep);
     }
 }

--- a/src/Config/Guesser/PhpUnitPathGuesser.php
+++ b/src/Config/Guesser/PhpUnitPathGuesser.php
@@ -42,7 +42,7 @@ class PhpUnitPathGuesser implements Guesser
     {
         foreach ($parsedPaths as $namespace => $parsedPath) {
             // for old Symfony prjects (<=2.7) phpunit.xml is located in ./app folder
-            if (strpos($namespace, 'SymfonyStandard') !== false && trim($parsedPath, '/') === 'app') {
+            if (\strpos($namespace, 'SymfonyStandard') !== false && \trim($parsedPath, '/') === 'app') {
                 return 'app';
             }
         }

--- a/src/Config/Guesser/SourceDirGuesser.php
+++ b/src/Config/Guesser/SourceDirGuesser.php
@@ -41,7 +41,7 @@ class SourceDirGuesser implements Guesser
         $dirs = $this->parsePsrSection((array) $this->composerJsonContent->autoload->{$psr});
 
         // we don't want to mix different framework's folders like "app" for Symfony
-        if (in_array('src', $dirs, true)) {
+        if (\in_array('src', $dirs, true)) {
             return ['src'];
         }
 
@@ -53,7 +53,7 @@ class SourceDirGuesser implements Guesser
         $dirs = [];
 
         foreach ($autoloadDirs as $path) {
-            if (!is_array($path) && !is_string($path)) {
+            if (!\is_array($path) && !\is_string($path)) {
                 throw new \LogicException('autoload section does not match the expected JSON schema');
             }
 
@@ -69,8 +69,8 @@ class SourceDirGuesser implements Guesser
      */
     private function parsePath($path, array &$dirs)
     {
-        if (is_array($path)) {
-            array_walk_recursive(
+        if (\is_array($path)) {
+            \array_walk_recursive(
                 $path,
                 function ($el) use (&$dirs) {
                     $this->parsePath($el, $dirs);
@@ -78,8 +78,8 @@ class SourceDirGuesser implements Guesser
             );
         }
 
-        if (is_string($path)) {
-            $dirs[] = trim($path, DIRECTORY_SEPARATOR);
+        if (\is_string($path)) {
+            $dirs[] = \trim($path, DIRECTORY_SEPARATOR);
         }
     }
 }

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -198,10 +198,10 @@ class InfectionConfig
         $excludedPaths = [];
 
         foreach ($originalExcludedPaths as $originalExcludedPath) {
-            if (strpos($originalExcludedPath, '*') === false) {
+            if (\strpos($originalExcludedPath, '*') === false) {
                 $excludedPaths[] = $originalExcludedPath;
             } else {
-                $excludedPaths = array_merge(
+                $excludedPaths = \array_merge(
                     $excludedPaths,
                     $this->getExcludedDirsByPattern($originalExcludedPath)
                 );
@@ -213,7 +213,7 @@ class InfectionConfig
 
     private function getExcludes(): array
     {
-        if (isset($this->config->source->excludes) && is_array($this->config->source->excludes)) {
+        if (isset($this->config->source->excludes) && \is_array($this->config->source->excludes)) {
             return $this->config->source->excludes;
         }
 
@@ -239,18 +239,18 @@ class InfectionConfig
         $srcDirs = $this->getSourceDirs();
 
         foreach ($srcDirs as $srcDir) {
-            $unpackedPaths = glob(
-                sprintf('%s/%s', $srcDir, $originalExcludedDir),
+            $unpackedPaths = \glob(
+                \sprintf('%s/%s', $srcDir, $originalExcludedDir),
                 GLOB_ONLYDIR
             );
 
             if ($unpackedPaths) {
-                $excludedDirs = array_merge(
+                $excludedDirs = \array_merge(
                     $excludedDirs,
-                    array_map(
+                    \array_map(
                         function ($excludeDir) use ($srcDir) {
-                            return ltrim(
-                                substr_replace($excludeDir, '', 0, strlen($srcDir)),
+                            return \ltrim(
+                                \substr_replace($excludeDir, '', 0, \strlen($srcDir)),
                                 DIRECTORY_SEPARATOR
                             );
                         },
@@ -266,7 +266,7 @@ class InfectionConfig
     public function getTmpDir(): string
     {
         if (empty($this->config->tmpDir)) {
-            return sys_get_temp_dir();
+            return \sys_get_temp_dir();
         }
 
         $tmpDir = $this->config->tmpDir;
@@ -275,6 +275,6 @@ class InfectionConfig
             return $tmpDir;
         }
 
-        return sprintf('%s/%s', $this->configLocation, $tmpDir);
+        return \sprintf('%s/%s', $this->configLocation, $tmpDir);
     }
 }

--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -63,18 +63,18 @@ class ExcludeDirsProvider
 
         if ($sourceDirs === ['.']) {
             foreach (self::EXCLUDED_ROOT_DIRS as $dir) {
-                if (in_array($dir, $dirsInCurrentDir, true)) {
+                if (\in_array($dir, $dirsInCurrentDir, true)) {
                     $excludedDirs[] = $dir;
                 }
             }
 
             $autocompleteValues = $dirsInCurrentDir;
-        } elseif (count($sourceDirs) === 1) {
-            $globDirs = array_filter(glob($sourceDirs[0] . '/*'), 'is_dir');
+        } elseif (\count($sourceDirs) === 1) {
+            $globDirs = \array_filter(\glob($sourceDirs[0] . '/*'), 'is_dir');
 
-            $autocompleteValues = array_map(
+            $autocompleteValues = \array_map(
                 function (string $dir) use ($sourceDirs) {
-                    return str_replace($sourceDirs[0] . '/', '', $dir);
+                    return \str_replace($sourceDirs[0] . '/', '', $dir);
                 },
                 $globDirs
             );
@@ -90,13 +90,13 @@ class ExcludeDirsProvider
             }
         }
 
-        return array_unique($excludedDirs);
+        return \array_unique($excludedDirs);
     }
 
     private function getValidator(Locator $locator)
     {
         return function ($answer) use ($locator) {
-            if (!$answer || strpos($answer, '*') !== false) {
+            if (!$answer || \strpos($answer, '*') !== false) {
                 return $answer;
             }
 

--- a/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
+++ b/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
@@ -53,7 +53,7 @@ class PhpUnitCustomExecutablePathProvider
             $question = new Question($questionText);
             $question->setValidator($this->getValidator());
 
-            return str_replace(
+            return \str_replace(
                 DIRECTORY_SEPARATOR,
                 '/',
                 $this->questionHelper->ask($input, $output, $question)
@@ -66,10 +66,10 @@ class PhpUnitCustomExecutablePathProvider
     private function getValidator(): \Closure
     {
         return function ($answerPath) {
-            $answerPath = $answerPath ? trim($answerPath) : $answerPath;
+            $answerPath = $answerPath ? \trim($answerPath) : $answerPath;
 
-            if (!$answerPath || !file_exists($answerPath)) {
-                throw new \RuntimeException(sprintf('Custom path "%s" is incorrect.', $answerPath));
+            if (!$answerPath || !\file_exists($answerPath)) {
+                throw new \RuntimeException(\sprintf('Custom path "%s" is incorrect.', $answerPath));
             }
 
             return $answerPath;

--- a/src/Config/ValueProvider/SourceDirsProvider.php
+++ b/src/Config/ValueProvider/SourceDirsProvider.php
@@ -39,10 +39,10 @@ class SourceDirsProvider
 
         $guessedSourceDirs = null;
 
-        if (file_exists('composer.json')) {
-            $content = json_decode(file_get_contents('composer.json'));
+        if (\file_exists('composer.json')) {
+            $content = \json_decode(\file_get_contents('composer.json'));
 
-            if (json_last_error() !== JSON_ERROR_NONE) {
+            if (\json_last_error() !== JSON_ERROR_NONE) {
                 throw new \LogicException('composer.json does not contain valid JSON');
             }
 
@@ -50,21 +50,21 @@ class SourceDirsProvider
             $guessedSourceDirs = $sourceDirGuesser->guess();
         }
 
-        $defaultValues = $guessedSourceDirs ? implode(',', $guessedSourceDirs) : null;
+        $defaultValues = $guessedSourceDirs ? \implode(',', $guessedSourceDirs) : null;
 
         $questionText = $this->consoleHelper->getQuestion(
             'Which source directories do you want to include (comma separated)?',
             $defaultValues
         );
 
-        $choices = array_merge(['.'], array_values($dirsInCurrentDir));
+        $choices = \array_merge(['.'], \array_values($dirsInCurrentDir));
 
         $question = new ChoiceQuestion($questionText, $choices, $defaultValues);
         $question->setMultiselect(true);
 
         $sourceFolders = $this->questionHelper->ask($input, $output, $question);
 
-        if (in_array('.', $sourceFolders, true) && count($sourceFolders) > 1) {
+        if (\in_array('.', $sourceFolders, true) && \count($sourceFolders) > 1) {
             throw new \LogicException('You cannot use current folder "." with other subfolders');
         }
 

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -51,11 +51,11 @@ class TestFrameworkConfigPathProvider
                 return $this->askTestFrameworkConfigLocation($input, $output, $dirsInCurrentDir, $testFramework, null);
             }
 
-            if (!file_exists('composer.json')) {
+            if (!\file_exists('composer.json')) {
                 return $this->askTestFrameworkConfigLocation($input, $output, $dirsInCurrentDir, $testFramework, null);
             }
 
-            $phpUnitPathGuesser = new PhpUnitPathGuesser(json_decode(file_get_contents('composer.json')));
+            $phpUnitPathGuesser = new PhpUnitPathGuesser(\json_decode(\file_get_contents('composer.json')));
             $defaultValue = $phpUnitPathGuesser->guess();
 
             if ($defaultValue) {
@@ -75,14 +75,14 @@ class TestFrameworkConfigPathProvider
     private function getValidator(string $testFramework): \Closure
     {
         return function (string $answerDir) use ($testFramework): string {
-            $answerDir = trim($answerDir);
+            $answerDir = \trim($answerDir);
 
             if (!$answerDir) {
                 return $answerDir;
             }
 
-            if (!is_dir($answerDir)) {
-                throw new \RuntimeException(sprintf('Could not find "%s" directory.', $answerDir));
+            if (!\is_dir($answerDir)) {
+                throw new \RuntimeException(\sprintf('Could not find "%s" directory.', $answerDir));
             }
 
             $this->testFrameworkConfigLocator->locate($testFramework, $answerDir);
@@ -93,7 +93,7 @@ class TestFrameworkConfigPathProvider
 
     private function askTestFrameworkConfigLocation(InputInterface $input, OutputInterface $output, array $dirsInCurrentDir, string $testFramework, $defaultValue): string
     {
-        $question = sprintf(
+        $question = \sprintf(
             'Where is your <comment>%s.(xml|yml)(.dist)</comment> configuration located?',
             $testFramework
         );

--- a/src/Config/ValueProvider/TimeoutProvider.php
+++ b/src/Config/ValueProvider/TimeoutProvider.php
@@ -41,7 +41,7 @@ class TimeoutProvider
 
         $timeoutQuestion = new Question($questionText, InfectionConfig::PROCESS_TIMEOUT_SECONDS);
         $timeoutQuestion->setValidator(function ($answer) {
-            if (!$answer || !is_numeric($answer) || (int) $answer <= 0) {
+            if (!$answer || !\is_numeric($answer) || (int) $answer <= 0) {
                 throw new \RuntimeException('Timeout should be an integer greater than 0');
             }
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -52,12 +52,12 @@ ASCII;
 
     protected function getDefaultCommands()
     {
-        $commands = array_merge(parent::getDefaultCommands(), [
+        $commands = \array_merge(parent::getDefaultCommands(), [
             new Command\ConfigureCommand(),
             new Command\InfectionCommand(),
         ]);
 
-        if (0 === strpos(__FILE__, 'phar:')) {
+        if (0 === \strpos(__FILE__, 'phar:')) {
             $commands[] = new Command\SelfUpdateCommand();
         }
 
@@ -99,7 +99,7 @@ ASCII;
                     $configPaths[] = $customConfigPath;
                 }
 
-                array_push(
+                \array_push(
                     $configPaths,
                     InfectionConfig::CONFIG_FILE_NAME,
                     InfectionConfig::CONFIG_FILE_NAME . '.dist'
@@ -107,13 +107,13 @@ ASCII;
 
                 $infectionConfigFile = $c['locator']->locateAnyOf($configPaths);
                 $dir = \pathinfo($infectionConfigFile, PATHINFO_DIRNAME);
-                $json = file_get_contents($infectionConfigFile);
+                $json = \file_get_contents($infectionConfigFile);
             } catch (\Exception $e) {
                 $json = '{}';
-                $dir = getcwd();
+                $dir = \getcwd();
             }
 
-            return new InfectionConfig(json_decode($json), $c['filesystem'], $dir);
+            return new InfectionConfig(\json_decode($json), $c['filesystem'], $dir);
         };
 
         $this->container['tmp.dir'] = function (Container $c): string {

--- a/src/Console/OutputFormatter/DotFormatter.php
+++ b/src/Console/OutputFormatter/DotFormatter.php
@@ -67,14 +67,14 @@ class DotFormatter extends AbstractOutputFormatter
         $lastDot = $mutationCount === $this->callsCount;
 
         if ($lastDot && !$endOfRow) {
-            $this->output->write(str_repeat(' ', self::DOTS_PER_ROW - $remainder));
+            $this->output->write(\str_repeat(' ', self::DOTS_PER_ROW - $remainder));
         }
 
         if ($lastDot || $endOfRow) {
-            $length = strlen((string) $mutationCount);
-            $format = sprintf('   (%%%dd / %%%dd)', $length, $length);
+            $length = \strlen((string) $mutationCount);
+            $format = \sprintf('   (%%%dd / %%%dd)', $length, $length);
 
-            $this->output->write(sprintf($format, $this->callsCount, $mutationCount));
+            $this->output->write(\sprintf($format, $this->callsCount, $mutationCount));
 
             if ($this->callsCount !== $mutationCount) {
                 $this->output->writeln('');

--- a/src/Differ/DiffColorizer.php
+++ b/src/Differ/DiffColorizer.php
@@ -14,16 +14,16 @@ class DiffColorizer
     {
         $lines = array();
 
-        foreach (explode("\n", $diff) as $line) {
-            if (0 === strpos($line, '-')) {
-                $lines[] = sprintf('<diff-del>%s</diff-del>', $line);
-            } elseif (0 === strpos($line, '+')) {
-                $lines[] = sprintf('<diff-add>%s</diff-add>', $line);
+        foreach (\explode("\n", $diff) as $line) {
+            if (0 === \strpos($line, '-')) {
+                $lines[] = \sprintf('<diff-del>%s</diff-del>', $line);
+            } elseif (0 === \strpos($line, '+')) {
+                $lines[] = \sprintf('<diff-add>%s</diff-add>', $line);
             } else {
                 $lines[] = $line;
             }
         }
 
-        return sprintf('<code>%s%s</code>', "\n", implode("\n", $lines));
+        return \sprintf('<code>%s%s</code>', "\n", \implode("\n", $lines));
     }
 }

--- a/src/Differ/Differ.php
+++ b/src/Differ/Differ.php
@@ -43,13 +43,13 @@ class Differ
     {
         $diff = $this->differ->diff($from, $to);
 
-        if (preg_match(
+        if (\preg_match(
             '/(?:[^\n]*(\n)){' . self::DIFF_MAX_LINES . '}/',
             $diff,
             $matches,
             PREG_OFFSET_CAPTURE
         )) {
-            $diff = substr($diff, 0, $matches[1][1]);
+            $diff = \substr($diff, 0, $matches[1][1]);
         }
 
         return $diff;

--- a/src/EventDispatcher/EventDispatcher.php
+++ b/src/EventDispatcher/EventDispatcher.php
@@ -20,7 +20,7 @@ class EventDispatcher implements EventDispatcherInterface, ContainsListenersInte
      */
     public function dispatch($event)
     {
-        $name = get_class($event);
+        $name = \get_class($event);
 
         foreach ($this->getListeners($name) as $listener) {
             $listener($event);

--- a/src/Finder/AbstractExecutableFinder.php
+++ b/src/Finder/AbstractExecutableFinder.php
@@ -23,15 +23,15 @@ abstract class AbstractExecutableFinder
      */
     protected function searchNonExecutables(array $probableNames, array $extraDirectories = [], bool $includeArgs = true)
     {
-        $dirs = array_merge(
-            explode(PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
+        $dirs = \array_merge(
+            \explode(PATH_SEPARATOR, \getenv('PATH') ?: \getenv('Path')),
             $extraDirectories
         );
 
         foreach ($dirs as $dir) {
             foreach ($probableNames as $name) {
-                $path = sprintf('%s/%s', $dir, $name);
-                if (file_exists($path)) {
+                $path = \sprintf('%s/%s', $dir, $name);
+                if (\file_exists($path)) {
                     return $this->makeExecutable($path, $includeArgs);
                 }
             }
@@ -40,7 +40,7 @@ abstract class AbstractExecutableFinder
 
     protected function makeExecutable(string $path, bool $includeArgs = true): string
     {
-        return sprintf(
+        return \sprintf(
             '%s %s',
             (new PhpExecutableFinder())->find($includeArgs),
             $path

--- a/src/Finder/ComposerExecutableFinder.php
+++ b/src/Finder/ComposerExecutableFinder.php
@@ -16,7 +16,7 @@ final class ComposerExecutableFinder extends AbstractExecutableFinder
     {
         $probable = ['composer', 'composer.phar'];
         $finder = new ExecutableFinder();
-        $immediatePaths = [getcwd(), realpath(getcwd() . '/../'), realpath(getcwd() . '/../../')];
+        $immediatePaths = [\getcwd(), \realpath(\getcwd() . '/../'), \realpath(\getcwd() . '/../../')];
 
         foreach ($probable as $name) {
             if ($path = $finder->find($name, null, $immediatePaths)) {

--- a/src/Finder/Exception/LocatorException.php
+++ b/src/Finder/Exception/LocatorException.php
@@ -12,13 +12,13 @@ class LocatorException extends \RuntimeException
 {
     public static function fileOrDirectoryDoesNotExist(string $name): self
     {
-        return new self(sprintf('The file/directory "%s" does not exist.', $name));
+        return new self(\sprintf('The file/directory "%s" does not exist.', $name));
     }
 
     public static function filesOrDirectoriesDoNotExist(string $name, array $paths): self
     {
         return new self(
-            sprintf('The file/folder "%s" does not exist (in: %s).', $name, implode(', ', $paths))
+            \sprintf('The file/folder "%s" does not exist (in: %s).', $name, \implode(', ', $paths))
         );
     }
 

--- a/src/Finder/Locator.php
+++ b/src/Finder/Locator.php
@@ -33,7 +33,7 @@ class Locator
     {
         if ($this->filesystem->isAbsolutePath($name)) {
             if ($this->filesystem->exists($name)) {
-                return realpath($name);
+                return \realpath($name);
             }
 
             throw LocatorException::fileOrDirectoryDoesNotExist($name);
@@ -45,7 +45,7 @@ class Locator
             $file = $path . DIRECTORY_SEPARATOR . $name;
 
             if ($this->filesystem->exists($file)) {
-                return realpath($file);
+                return \realpath($file);
             }
         }
 
@@ -61,7 +61,7 @@ class Locator
         try {
             return $this->locate($fileNames[0]);
         } catch (\Exception $e) {
-            array_shift($fileNames);
+            \array_shift($fileNames);
 
             return $this->locateAnyOf($fileNames);
         }
@@ -76,9 +76,9 @@ class Locator
         $paths = $this->paths;
 
         if ($additionalPath !== null) {
-            array_unshift($paths, $additionalPath);
+            \array_unshift($paths, $additionalPath);
         }
 
-        return array_unique($paths);
+        return \array_unique($paths);
     }
 }

--- a/src/Finder/SourceFilesFinder.php
+++ b/src/Finder/SourceFilesFinder.php
@@ -29,7 +29,7 @@ class SourceFilesFinder
     {
         $finder = new Finder();
 
-        array_walk($this->excludeDirectories, function ($excludePath) use ($finder) {
+        \array_walk($this->excludeDirectories, function ($excludePath) use ($finder) {
             $finder->notPath($excludePath);
         });
 
@@ -41,8 +41,8 @@ class SourceFilesFinder
 
         $finder->in('.')->files();
 
-        $filters = explode(',', $filter);
-        array_walk($filters, function ($fileFilter) use ($finder) {
+        $filters = \explode(',', $filter);
+        \array_walk($filters, function ($fileFilter) use ($finder) {
             $finder->path($fileFilter);
         });
 

--- a/src/Finder/TestFrameworkExecutableFinder.php
+++ b/src/Finder/TestFrameworkExecutableFinder.php
@@ -60,18 +60,18 @@ class TestFrameworkExecutableFinder extends AbstractExecutableFinder
     {
         $vendorPath = null;
         try {
-            $process = new Process(sprintf('%s %s', $this->findComposer(), 'config bin-dir'));
+            $process = new Process(\sprintf('%s %s', $this->findComposer(), 'config bin-dir'));
             $process->run();
-            $vendorPath = trim($process->getOutput());
+            $vendorPath = \trim($process->getOutput());
         } catch (\RuntimeException $e) {
-            $candidate = getcwd() . '/vendor/bin';
-            if (file_exists($candidate)) {
+            $candidate = \getcwd() . '/vendor/bin';
+            if (\file_exists($candidate)) {
                 $vendorPath = $candidate;
             }
         }
 
         if (null !== $vendorPath) {
-            putenv('PATH=' . $vendorPath . PATH_SEPARATOR . getenv('PATH'));
+            \putenv('PATH=' . $vendorPath . PATH_SEPARATOR . \getenv('PATH'));
         }
     }
 
@@ -90,19 +90,19 @@ class TestFrameworkExecutableFinder extends AbstractExecutableFinder
         $finder = new ExecutableFinder();
 
         foreach ($candidates as $name) {
-            if ($path = $finder->find($name, null, [getcwd()])) {
+            if ($path = $finder->find($name, null, [\getcwd()])) {
                 return $this->makeExecutable($path, $includeArgs);
             }
         }
 
-        $result = $this->searchNonExecutables($candidates, [getcwd()], $includeArgs);
+        $result = $this->searchNonExecutables($candidates, [\getcwd()], $includeArgs);
 
         if (null !== $result) {
             return $result;
         }
 
         throw new TestFrameworkExecutableFinderNotFound(
-            sprintf(
+            \sprintf(
                 'Unable to locate a %s executable on local system. Ensure that %s is installed and available.',
                 $this->testFrameworkName,
                 $this->testFrameworkName
@@ -121,22 +121,22 @@ class TestFrameworkExecutableFinder extends AbstractExecutableFinder
      */
     protected function makeExecutable(string $path, bool $includeArgs = true): string
     {
-        $path = realpath($path);
+        $path = \realpath($path);
         $phpFinder = new PhpExecutableFinder();
 
         if (\defined('PHP_WINDOWS_VERSION_BUILD')) {
-            if (false !== strpos($path, '.bat')) {
+            if (false !== \strpos($path, '.bat')) {
                 return $path;
             }
 
-            return sprintf('%s %s', $phpFinder->find($includeArgs), $path);
+            return \sprintf('%s %s', $phpFinder->find($includeArgs), $path);
         }
 
-        return sprintf('%s %s %s', 'exec', $phpFinder->find($includeArgs), $path);
+        return \sprintf('%s %s %s', 'exec', $phpFinder->find($includeArgs), $path);
     }
 
     private function doesCustomPathExist(): bool
     {
-        return $this->customPath && file_exists($this->customPath);
+        return $this->customPath && \file_exists($this->customPath);
     }
 }

--- a/src/Mutant/Exception/MsiCalculationException.php
+++ b/src/Mutant/Exception/MsiCalculationException.php
@@ -12,7 +12,7 @@ class MsiCalculationException extends \LogicException
 {
     public static function create(string $type): self
     {
-        return new self(sprintf(
+        return new self(\sprintf(
             'Seems like something is wrong with calculations and %s options.', $type
         ));
     }

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -78,8 +78,8 @@ class MutationsGenerator
         $this->codeCoverageData = $codeCoverageData;
         $this->excludeDirsOrFiles = $excludeDirsOrFiles;
         $this->defaultMutators = $defaultMutators;
-        $this->whitelistedMutatorNames = array_map('strtolower', $whitelistedMutatorNames);
-        $this->whitelistedMutatorNamesCount = count($whitelistedMutatorNames);
+        $this->whitelistedMutatorNames = \array_map('strtolower', $whitelistedMutatorNames);
+        $this->whitelistedMutatorNamesCount = \count($whitelistedMutatorNames);
         $this->eventDispatcher = $eventDispatcher;
         $this->parser = $parser;
     }
@@ -108,7 +108,7 @@ class MutationsGenerator
 
         $this->eventDispatcher->dispatch(new MutationGeneratingFinished());
 
-        return array_merge(...$allFilesMutations);
+        return \array_merge(...$allFilesMutations);
     }
 
     /**
@@ -149,10 +149,10 @@ class MutationsGenerator
     private function getMutators(): array
     {
         if ($this->whitelistedMutatorNamesCount > 0) {
-            return array_filter(
+            return \array_filter(
                 $this->defaultMutators,
                 function (Mutator $mutator): bool {
-                    return in_array(strtolower($mutator->getName()), $this->whitelistedMutatorNames, true);
+                    return \in_array(\strtolower($mutator->getName()), $this->whitelistedMutatorNames, true);
                 }
             );
         }

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -106,7 +106,7 @@ class MetricsCalculator
         $defeatedTotal = $this->killedCount + $this->timedOutCount + $this->errorCount;
 
         if ($this->totalMutantsCount) {
-            $detectionRateAll = round(100 * ($defeatedTotal / $this->totalMutantsCount));
+            $detectionRateAll = \round(100 * ($defeatedTotal / $this->totalMutantsCount));
         }
 
         return $detectionRateAll;
@@ -123,7 +123,7 @@ class MetricsCalculator
         $coveredByTestsTotal = $this->totalMutantsCount - $this->notCoveredByTestsCount;
 
         if ($this->totalMutantsCount) {
-            $coveredRate = round(100 * ($coveredByTestsTotal / $this->totalMutantsCount));
+            $coveredRate = \round(100 * ($coveredByTestsTotal / $this->totalMutantsCount));
         }
 
         return $coveredRate;
@@ -136,7 +136,7 @@ class MetricsCalculator
         $defeatedTotal = $this->killedCount + $this->timedOutCount + $this->errorCount;
 
         if ($coveredByTestsTotal) {
-            $detectionRateTested = round(100 * ($defeatedTotal / $coveredByTestsTotal));
+            $detectionRateTested = \round(100 * ($defeatedTotal / $coveredByTestsTotal));
         }
 
         return $detectionRateTested;

--- a/src/Mutant/MutantCreator.php
+++ b/src/Mutant/MutantCreator.php
@@ -59,11 +59,11 @@ class MutantCreator
         $mutatedStatements = $traverser->traverse($originalStatements);
 
         $mutatedCode = $this->prettyPrinter->prettyPrintFile($mutatedStatements);
-        $mutatedFilePath = sprintf('%s/mutant.%s.infection.php', $this->tempDir, $mutation->getHash());
+        $mutatedFilePath = \sprintf('%s/mutant.%s.infection.php', $this->tempDir, $mutation->getHash());
 
         $diff = $this->differ->diff($originalPrettyPrintedFile, $mutatedCode);
 
-        file_put_contents($mutatedFilePath, $mutatedCode);
+        \file_put_contents($mutatedFilePath, $mutatedCode);
 
         $isCoveredByTest = $this->isCoveredByTest($mutation, $codeCoverageData);
 

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -81,7 +81,7 @@ class Mutation
 
     public function getHash(): string
     {
-        $mutatorClass = get_class($this->getMutator());
+        $mutatorClass = \get_class($this->getMutator());
         $attributes = $this->getAttributes();
         $attributeValues = [
             $attributes['startLine'],
@@ -92,9 +92,9 @@ class Mutation
             $attributes['endFilePos'],
         ];
 
-        $hashKeys = array_merge([$this->getOriginalFilePath(), $mutatorClass], $attributeValues);
+        $hashKeys = \array_merge([$this->getOriginalFilePath(), $mutatorClass], $attributeValues);
 
-        return md5(implode('_', $hashKeys));
+        return \md5(\implode('_', $hashKeys));
     }
 
     public function getOriginalFileAst(): array

--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -31,6 +31,6 @@ class FalseValue extends Mutator
             return false;
         }
 
-        return strtolower($node->name->getFirst()) === 'false';
+        return \strtolower($node->name->getFirst()) === 'false';
     }
 }

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -31,6 +31,6 @@ class TrueValue extends Mutator
             return false;
         }
 
-        return strtolower($node->name->getFirst()) === 'true';
+        return \strtolower($node->name->getFirst()) === 'true';
     }
 }

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -60,7 +60,7 @@ class PublicVisibility extends Mutator
 
     private function isBlacklistedFunction(string $name): bool
     {
-        return in_array(
+        return \in_array(
             $name,
             [
                 '__construct',

--- a/src/Mutator/Mutator.php
+++ b/src/Mutator/Mutator.php
@@ -18,8 +18,8 @@ abstract class Mutator
 
     public function getName(): string
     {
-        $parts = explode('\\', static::class);
+        $parts = \explode('\\', static::class);
 
-        return $parts[count($parts) - 1];
+        return $parts[\count($parts) - 1];
     }
 }

--- a/src/Mutator/ReturnValue/AbstractValueToNullReturnValue.php
+++ b/src/Mutator/ReturnValue/AbstractValueToNullReturnValue.php
@@ -27,7 +27,7 @@ abstract class AbstractValueToNullReturnValue extends Mutator
         }
 
         // scalar typehint
-        if (is_string($returnType)) {
+        if (\is_string($returnType)) {
             return false;
         }
 

--- a/src/Php/ConfigBuilder.php
+++ b/src/Php/ConfigBuilder.php
@@ -37,16 +37,16 @@ final class ConfigBuilder
      */
     public function build()
     {
-        $tmpIniPath = (string) getenv(self::ENV_TEMP_PHP_CONFIG_PATH);
+        $tmpIniPath = (string) \getenv(self::ENV_TEMP_PHP_CONFIG_PATH);
 
-        if (!empty($tmpIniPath) && file_exists($tmpIniPath)) {
+        if (!empty($tmpIniPath) && \file_exists($tmpIniPath)) {
             return $tmpIniPath;
         }
 
         $iniPaths = PhpIniHelper::get();
 
         if ($this->writeTempIni($iniPaths)) {
-            $additional = count($iniPaths) > 1;
+            $additional = \count($iniPaths) > 1;
 
             $this->setEnvironment($additional);
 
@@ -63,31 +63,31 @@ final class ConfigBuilder
      */
     private function writeTempIni(array $originalIniPaths): bool
     {
-        if (!($this->tmpIniPath = tempnam($this->tempDir, 'infection'))) {
+        if (!($this->tmpIniPath = \tempnam($this->tempDir, 'infection'))) {
             return false;
         }
 
         // $originalIniPaths is either empty or has at least one element
         if (empty($originalIniPaths[0])) {
-            array_shift($originalIniPaths);
+            \array_shift($originalIniPaths);
         }
 
         $content = '';
         $regex = '/^\s*(zend_extension\s*=.*xdebug.*)$/mi';
 
         foreach ($originalIniPaths as $iniPath) {
-            $content .= preg_replace($regex, ';$1', file_get_contents($iniPath)) . PHP_EOL;
+            $content .= \preg_replace($regex, ';$1', \file_get_contents($iniPath)) . PHP_EOL;
         }
 
-        return (bool) @file_put_contents($this->tmpIniPath, $content);
+        return (bool) @\file_put_contents($this->tmpIniPath, $content);
     }
 
     private function setEnvironment(bool $additional): bool
     {
-        if ($additional && !putenv(self::ENV_PHP_INI_SCAN_DIR . '=')) {
+        if ($additional && !\putenv(self::ENV_PHP_INI_SCAN_DIR . '=')) {
             return false;
         }
 
-        return putenv(self::ENV_TEMP_PHP_CONFIG_PATH . '=' . $this->tmpIniPath);
+        return \putenv(self::ENV_TEMP_PHP_CONFIG_PATH . '=' . $this->tmpIniPath);
     }
 }

--- a/src/Php/PhpIniHelper.php
+++ b/src/Php/PhpIniHelper.php
@@ -17,17 +17,17 @@ final class PhpIniHelper
      */
     public static function get(): array
     {
-        if ($env = (string) getenv(self::ENV_ORIGINALS_PHP_INIS)) {
-            return explode(PATH_SEPARATOR, $env);
+        if ($env = (string) \getenv(self::ENV_ORIGINALS_PHP_INIS)) {
+            return \explode(PATH_SEPARATOR, $env);
         }
 
-        $paths = [(string) php_ini_loaded_file()];
+        $paths = [(string) \php_ini_loaded_file()];
 
-        if ($scanned = php_ini_scanned_files()) {
-            $paths = array_merge($paths, array_map('trim', explode(',', $scanned)));
+        if ($scanned = \php_ini_scanned_files()) {
+            $paths = \array_merge($paths, \array_map('trim', \explode(',', $scanned)));
         }
 
-        putenv(self::ENV_ORIGINALS_PHP_INIS . '=' . implode(PATH_SEPARATOR, $paths));
+        \putenv(self::ENV_ORIGINALS_PHP_INIS . '=' . \implode(PATH_SEPARATOR, $paths));
 
         return $paths;
     }

--- a/src/Php/XdebugHandler.php
+++ b/src/Php/XdebugHandler.php
@@ -38,13 +38,13 @@ class XdebugHandler
     {
         $this->configBuilder = $configBuilder;
 
-        $this->isLoaded = extension_loaded('xdebug');
-        $this->envScanDir = (string) getenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR);
+        $this->isLoaded = \extension_loaded('xdebug');
+        $this->envScanDir = (string) \getenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR);
     }
 
     public function check()
     {
-        $args = explode('|', (string) getenv(self::ENV_DISABLE_XDEBUG));
+        $args = \explode('|', (string) \getenv(self::ENV_DISABLE_XDEBUG));
         if ($this->needsRestart($args[0])) {
             if ($this->prepareRestart()) {
                 $this->restart($this->getCommand());
@@ -52,14 +52,14 @@ class XdebugHandler
         }
 
         if (self::RESTART_HANDLE === $args[0]) {
-            putenv(self::ENV_DISABLE_XDEBUG);
+            \putenv(self::ENV_DISABLE_XDEBUG);
 
             if (false !== $this->envScanDir) {
                 // $args[1] contains the original value
                 if (isset($args[1])) {
-                    putenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR . '=' . $args[1]);
+                    \putenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR . '=' . $args[1]);
                 } else {
-                    putenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR);
+                    \putenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR);
                 }
             }
         }
@@ -90,7 +90,7 @@ class XdebugHandler
      */
     private function setEnvironment(): bool
     {
-        return putenv(self::ENV_DISABLE_XDEBUG . '=' . self::RESTART_HANDLE);
+        return \putenv(self::ENV_DISABLE_XDEBUG . '=' . self::RESTART_HANDLE);
     }
 
     /**
@@ -100,12 +100,12 @@ class XdebugHandler
      */
     private function getCommand(): string
     {
-        $params = array_merge(
+        $params = \array_merge(
             [PHP_BINARY, '-c', $this->tmpIniPath],
             $this->getScriptArgs($_SERVER['argv'])
         );
 
-        return implode(' ', array_map([$this, 'escape'], $params));
+        return \implode(' ', \array_map([$this, 'escape'], $params));
     }
 
     /**
@@ -125,7 +125,7 @@ class XdebugHandler
         }
 
         $offset = \count($args) > 1 ? 2 : 1;
-        array_splice($args, $offset, 0, '--ansi');
+        \array_splice($args, $offset, 0, '--ansi');
 
         return $args;
     }
@@ -143,28 +143,28 @@ class XdebugHandler
      */
     private function escape(string $arg, bool $meta = true): string
     {
-        if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
-            return escapeshellarg($arg);
+        if (!\defined('PHP_WINDOWS_VERSION_BUILD')) {
+            return \escapeshellarg($arg);
         }
 
-        $quote = strpbrk($arg, " \t") !== false || $arg === '';
-        $arg = preg_replace('/(\\\\*)"/', '$1$1\\"', $arg, -1, $quotesCount);
+        $quote = \strpbrk($arg, " \t") !== false || $arg === '';
+        $arg = \preg_replace('/(\\\\*)"/', '$1$1\\"', $arg, -1, $quotesCount);
 
         if ($meta) {
-            $meta = $quotesCount || preg_match('/%[^%]+%/', $arg);
+            $meta = $quotesCount || \preg_match('/%[^%]+%/', $arg);
 
             if (!$meta && !$quote) {
-                $quote = strpbrk($arg, '^&|<>()') !== false;
+                $quote = \strpbrk($arg, '^&|<>()') !== false;
             }
         }
 
         if ($quote) {
-            $arg = preg_replace('/(\\\\*)$/', '$1$1', $arg);
+            $arg = \preg_replace('/(\\\\*)$/', '$1$1', $arg);
             $arg = '"' . $arg . '"';
         }
 
         if ($meta) {
-            $arg = preg_replace('/(["^&|<>()%])/', '^$1', $arg);
+            $arg = \preg_replace('/(["^&|<>()%])/', '^$1', $arg);
         }
 
         return $arg;
@@ -177,7 +177,7 @@ class XdebugHandler
      */
     protected function restart(string $command)
     {
-        passthru($command, $exitCode);
+        \passthru($command, $exitCode);
 
         exit($exitCode);
     }

--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -72,7 +72,7 @@ final class ProcessBuilder
                 $testFrameworkExtraOptions
             ),
             null,
-            array_replace($_ENV, $_SERVER),
+            \array_replace($_ENV, $_SERVER),
             null,
             $this->timeout
         );

--- a/src/Process/ExecutableFinder/PhpExecutableFinder.php
+++ b/src/Process/ExecutableFinder/PhpExecutableFinder.php
@@ -17,9 +17,9 @@ final class PhpExecutableFinder extends BasePhpExecutableFinder
     {
         $arguments = [];
 
-        $tempConfigPath = (string) getenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
+        $tempConfigPath = (string) \getenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
 
-        if (!empty($tempConfigPath) && file_exists($tempConfigPath)) {
+        if (!empty($tempConfigPath) && \file_exists($tempConfigPath)) {
             $arguments[] = '-c';
             $arguments[] = $tempConfigPath;
         } elseif ('phpdbg' === PHP_SAPI) {

--- a/src/Process/Listener/FileLoggerSubscriber/BaseFileLoggerSubscriber.php
+++ b/src/Process/Listener/FileLoggerSubscriber/BaseFileLoggerSubscriber.php
@@ -86,7 +86,7 @@ class BaseFileLoggerSubscriber implements EventSubscriberInterface
         ];
 
         foreach ($logTypes as $key => $value) {
-            if (!in_array($key, $allowedFileTypes)) {
+            if (!\in_array($key, $allowedFileTypes)) {
                 unset($logTypes[$key]);
             }
         }

--- a/src/Process/Listener/FileLoggerSubscriber/DebugFileLogger.php
+++ b/src/Process/Listener/FileLoggerSubscriber/DebugFileLogger.php
@@ -59,16 +59,16 @@ class DebugFileLogger extends FileLogger
             $logParts[] = 'Line ' . $mutation->getAttributes()['startLine'];
         }
 
-        return implode($logParts, "\n") . "\n";
+        return \implode($logParts, "\n") . "\n";
     }
 
     private function getHeadlineParts(string $headlinePrefix): array
     {
-        $headline = sprintf('%s mutants:', $headlinePrefix);
+        $headline = \sprintf('%s mutants:', $headlinePrefix);
 
         return [
             $headline,
-            str_repeat('=', strlen($headline)),
+            \str_repeat('=', \strlen($headline)),
             '',
         ];
     }

--- a/src/Process/Listener/FileLoggerSubscriber/FileLogger.php
+++ b/src/Process/Listener/FileLoggerSubscriber/FileLogger.php
@@ -52,7 +52,7 @@ abstract class FileLogger
         if ($logFilePath !== null) {
             $this->fs->dumpFile(
                 $logFilePath,
-                implode(
+                \implode(
                     $logs,
                     "\n"
                 )

--- a/src/Process/Listener/FileLoggerSubscriber/TextFileLogger.php
+++ b/src/Process/Listener/FileLoggerSubscriber/TextFileLogger.php
@@ -54,16 +54,16 @@ class TextFileLogger extends FileLogger
             }
         }
 
-        return implode($logParts, "\n");
+        return \implode($logParts, "\n");
     }
 
     private function getHeadlineParts(string $headlinePrefix): array
     {
-        $headline = sprintf('%s mutants:', $headlinePrefix);
+        $headline = \sprintf('%s mutants:', $headlinePrefix);
 
         return [
             $headline,
-            str_repeat('=', strlen($headline)),
+            \str_repeat('=', \strlen($headline)),
             '',
         ];
     }
@@ -72,7 +72,7 @@ class TextFileLogger extends FileLogger
     {
         $mutation = $mutantProcess->getMutant()->getMutation();
 
-        return sprintf(
+        return \sprintf(
             '%d) %s:%d    [M] %s',
             $index + 1,
             $mutation->getOriginalFilePath(),

--- a/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
@@ -60,7 +60,7 @@ class InitialTestsConsoleLoggerSubscriber implements EventSubscriberInterface
         $this->output->writeln([
             'Running initial test suite...',
             '',
-            sprintf(
+            \sprintf(
                 '%s version: %s',
                 $this->testFrameworkAdapter->getName(),
                 $version

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -119,12 +119,12 @@ class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
      */
     private function showMutations(array $processes, string $headlinePrefix)
     {
-        $headline = sprintf('%s mutants:', $headlinePrefix);
+        $headline = \sprintf('%s mutants:', $headlinePrefix);
 
         $this->output->writeln([
             '',
             $headline,
-            str_repeat('=', strlen($headline)),
+            \str_repeat('=', \strlen($headline)),
             '',
         ]);
 
@@ -133,7 +133,7 @@ class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
 
             $this->output->writeln([
                 '',
-                sprintf(
+                \sprintf(
                     '%d) %s:%d    [M] %s',
                     $index + 1,
                     $mutation->getOriginalFilePath(),
@@ -176,12 +176,12 @@ class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
 
     private function getPadded($subject, int $padLength = self::PAD_LENGTH): string
     {
-        return str_pad((string) $subject, $padLength, ' ', STR_PAD_LEFT);
+        return \str_pad((string) $subject, $padLength, ' ', STR_PAD_LEFT);
     }
 
     private function addIndentation(string $string): string
     {
-        return str_repeat(' ', self::PAD_LENGTH + 1) . $string;
+        return \str_repeat(' ', self::PAD_LENGTH + 1) . $string;
     }
 
     private function getPercentageTag(float $percentage)

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -87,7 +87,7 @@ class MutantProcess
             return self::CODE_TIMED_OUT;
         }
 
-        if (!in_array($this->getProcess()->getExitCode(), self::NOT_FATAL_ERROR_CODES, true)) {
+        if (!\in_array($this->getProcess()->getExitCode(), self::NOT_FATAL_ERROR_CODES, true)) {
             return self::CODE_ERROR;
         }
 

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -56,11 +56,11 @@ class MutationTestingRunner
 
     public function run(int $threadCount, CodeCoverageData $codeCoverageData, string $testFrameworkExtraOptions)
     {
-        $mutantCount = count($this->mutations);
+        $mutantCount = \count($this->mutations);
 
         $this->eventDispatcher->dispatch(new MutantsCreatingStarted($mutantCount));
 
-        $processes = array_map(
+        $processes = \array_map(
             function (Mutation $mutation) use ($codeCoverageData, $testFrameworkExtraOptions): MutantProcess {
                 $mutant = $this->mutantCreator->create($mutation, $codeCoverageData);
 

--- a/src/Process/Runner/Parallel/ParallelProcessRunner.php
+++ b/src/Process/Runner/Parallel/ParallelProcessRunner.php
@@ -45,11 +45,11 @@ class ParallelProcessRunner
         $processesQueue = $processes;
 
         // fix maxParallel to be max the number of processes or positive
-        $maxParallel = min(abs($threadCount), count($processesQueue));
+        $maxParallel = \min(\abs($threadCount), \count($processesQueue));
 
         // get the first stack of processes to start at the same time
         /** @var MutantProcess[] $currentProcesses */
-        $currentProcesses = array_splice($processesQueue, 0, $maxParallel);
+        $currentProcesses = \array_splice($processesQueue, 0, $maxParallel);
 
         // start the initial stack of processes
         foreach ($currentProcesses as $process) {
@@ -57,7 +57,7 @@ class ParallelProcessRunner
         }
 
         do {
-            usleep($poll);
+            \usleep($poll);
 
             // remove all finished processes from the stack
             foreach ($currentProcesses as $index => $mutantProcess) {
@@ -75,11 +75,11 @@ class ParallelProcessRunner
                     unset($currentProcesses[$index]);
 
                     // directly add and start new process after the previous finished
-                    if (count($processesQueue) > 0) {
+                    if (\count($processesQueue) > 0) {
                         $nextProcessFound = false;
 
                         do {
-                            $nextProcess = array_shift($processesQueue);
+                            $nextProcess = \array_shift($processesQueue);
                             $mutant = $nextProcess->getMutant();
 
                             if ($mutant->isCoveredByTest()) {
@@ -89,11 +89,11 @@ class ParallelProcessRunner
                             } else {
                                 $this->eventDispatcher->dispatch(new MutantProcessFinished($nextProcess));
                             }
-                        } while (!$nextProcessFound && count($processesQueue) > 0);
+                        } while (!$nextProcessFound && \count($processesQueue) > 0);
                     }
                 }
             }
             // continue loop while there are processes being executed or waiting for execution
-        } while (count($processesQueue) > 0 || count($currentProcesses) > 0);
+        } while (\count($processesQueue) > 0 || \count($currentProcesses) > 0);
     }
 }

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -21,12 +21,12 @@ class IncludeInterceptor
 
     public static function intercept($file, $with)
     {
-        if (!file_exists($file)) {
+        if (!\file_exists($file)) {
             throw new \InvalidArgumentException(
                 'File to intercept and replace does not exist: ' . $file
             );
         }
-        if (!file_exists($with)) {
+        if (!\file_exists($with)) {
             throw new \InvalidArgumentException(
                 'File to replace intercepted file with does not exist: ' . $file
             );
@@ -42,13 +42,13 @@ class IncludeInterceptor
                 'Set a file to intercept and its replacement before enabling wrapper'
             );
         }
-        stream_wrapper_unregister('file');
-        stream_wrapper_register('file', __CLASS__);
+        \stream_wrapper_unregister('file');
+        \stream_wrapper_register('file', __CLASS__);
     }
 
     public static function disable()
     {
-        stream_wrapper_restore('file');
+        \stream_wrapper_restore('file');
     }
 
     public function stream_open($path, $mode, $options)
@@ -56,17 +56,17 @@ class IncludeInterceptor
         self::disable();
         $including = (bool) ($options & self::STREAM_OPEN_FOR_INCLUDE);
         if ($including) {
-            if ($path == self::$intercept || realpath($path) == self::$intercept) {
-                $this->fp = fopen(self::$replacement, 'r');
+            if ($path == self::$intercept || \realpath($path) == self::$intercept) {
+                $this->fp = \fopen(self::$replacement, 'r');
                 self::enable();
 
                 return true;
             }
         }
         if (isset($this->context)) {
-            $this->fp = fopen($path, $mode, $options, $this->context);
+            $this->fp = \fopen($path, $mode, $options, $this->context);
         } else {
-            $this->fp = fopen($path, $mode, $options);
+            $this->fp = \fopen($path, $mode, $options);
         }
         self::enable();
 
@@ -75,7 +75,7 @@ class IncludeInterceptor
 
     public function dir_closedir()
     {
-        closedir($this->fp);
+        \closedir($this->fp);
 
         return true;
     }
@@ -84,9 +84,9 @@ class IncludeInterceptor
     {
         self::disable();
         if (isset($this->context)) {
-            $this->fp = opendir($path, $this->context);
+            $this->fp = \opendir($path, $this->context);
         } else {
-            $this->fp = opendir($path);
+            $this->fp = \opendir($path);
         }
         self::enable();
 
@@ -95,12 +95,12 @@ class IncludeInterceptor
 
     public function dir_readdir()
     {
-        return readdir($this->fp);
+        return \readdir($this->fp);
     }
 
     public function dir_rewinddir()
     {
-        rewinddir($this->fp);
+        \rewinddir($this->fp);
 
         return true;
     }
@@ -112,9 +112,9 @@ class IncludeInterceptor
         $isRecursive = (bool) ($options & STREAM_MKDIR_RECURSIVE);
 
         if (isset($this->context)) {
-            $return = mkdir($path, $mode, $isRecursive, $this->context);
+            $return = \mkdir($path, $mode, $isRecursive, $this->context);
         } else {
-            $return = mkdir($path, $mode, $isRecursive);
+            $return = \mkdir($path, $mode, $isRecursive);
         }
         self::enable();
 
@@ -125,9 +125,9 @@ class IncludeInterceptor
     {
         self::disable();
         if (isset($this->context)) {
-            $return = rename($path_from, $path_to, $this->context);
+            $return = \rename($path_from, $path_to, $this->context);
         } else {
-            $return = rename($path_from, $path_to);
+            $return = \rename($path_from, $path_to);
         }
         self::enable();
 
@@ -138,9 +138,9 @@ class IncludeInterceptor
     {
         self::disable();
         if (isset($this->context)) {
-            $return = rmdir($path, $this->context);
+            $return = \rmdir($path, $this->context);
         } else {
-            $return = rmdir($path);
+            $return = \rmdir($path);
         }
         self::enable();
 
@@ -154,22 +154,22 @@ class IncludeInterceptor
 
     public function stream_close()
     {
-        return fclose($this->fp);
+        return \fclose($this->fp);
     }
 
     public function stream_eof()
     {
-        return feof($this->fp);
+        return \feof($this->fp);
     }
 
     public function stream_flush()
     {
-        return fflush($this->fp);
+        return \fflush($this->fp);
     }
 
     public function stream_lock($operation)
     {
-        return flock($this->fp, $operation);
+        return \flock($this->fp, $operation);
     }
 
     public function stream_metadata($path, $option, $value)
@@ -178,21 +178,21 @@ class IncludeInterceptor
         switch ($option) {
             case STREAM_META_TOUCH:
                 if (empty($value)) {
-                    $return = touch($path);
+                    $return = \touch($path);
                 } else {
-                    $return = touch($path, $value[0], $value[1]);
+                    $return = \touch($path, $value[0], $value[1]);
                 }
                 break;
             case STREAM_META_OWNER_NAME:
             case STREAM_META_OWNER:
-                $return = chown($path, $value);
+                $return = \chown($path, $value);
                 break;
             case STREAM_META_GROUP_NAME:
             case STREAM_META_GROUP:
-                $return = chgrp($path, $value);
+                $return = \chgrp($path, $value);
                 break;
             case STREAM_META_ACCESS:
-                $return = chmod($path, $value);
+                $return = \chmod($path, $value);
                 break;
             default:
                 throw new \RuntimeException('Unknown stream_metadata option');
@@ -204,55 +204,55 @@ class IncludeInterceptor
 
     public function stream_read($count)
     {
-        return fread($this->fp, $count);
+        return \fread($this->fp, $count);
     }
 
     public function stream_seek($offset, $whence = SEEK_SET)
     {
-        return fseek($this->fp, $offset, $whence) === 0;
+        return \fseek($this->fp, $offset, $whence) === 0;
     }
 
     public function stream_set_option($option, $arg1, $arg2)
     {
         switch ($option) {
             case STREAM_OPTION_BLOCKING:
-                return stream_set_blocking($this->fp, $arg1);
+                return \stream_set_blocking($this->fp, $arg1);
             case STREAM_OPTION_READ_TIMEOUT:
-                return stream_set_timeout($this->fp, $arg1, $arg2);
+                return \stream_set_timeout($this->fp, $arg1, $arg2);
             case STREAM_OPTION_WRITE_BUFFER:
-                return stream_set_write_buffer($this->fp, $arg1);
+                return \stream_set_write_buffer($this->fp, $arg1);
             case STREAM_OPTION_READ_BUFFER:
-                return stream_set_read_buffer($this->fp, $arg1);
+                return \stream_set_read_buffer($this->fp, $arg1);
         }
     }
 
     public function stream_stat()
     {
-        return fstat($this->fp);
+        return \fstat($this->fp);
     }
 
     public function stream_tell()
     {
-        return ftell($this->fp);
+        return \ftell($this->fp);
     }
 
     public function stream_truncate($new_size)
     {
-        return ftruncate($this->fp, $new_size);
+        return \ftruncate($this->fp, $new_size);
     }
 
     public function stream_write($data)
     {
-        return fwrite($this->fp, $data);
+        return \fwrite($this->fp, $data);
     }
 
     public function unlink($path)
     {
         self::disable();
         if (isset($this->context)) {
-            $return = unlink($path, $this->context);
+            $return = \unlink($path, $this->context);
         } else {
-            $return = unlink($path);
+            $return = \unlink($path);
         }
         self::enable();
 
@@ -262,7 +262,7 @@ class IncludeInterceptor
     public function url_stat($path)
     {
         self::disable();
-        $return = is_readable($path) ? stat($path) : false;
+        $return = \is_readable($path) ? \stat($path) : false;
         self::enable();
 
         return $return;

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -75,7 +75,7 @@ abstract class AbstractTestFrameworkAdapter
      */
     public function getExecutableCommandLine(string $configPath, string $extraOptions, bool $includePhpArgs = true): string
     {
-        return sprintf(
+        return \sprintf(
             '%s %s',
             $this->phpExecutableFinder->find($includePhpArgs),
             $this->argumentsAndOptionsBuilder->build($configPath, $extraOptions)
@@ -95,7 +95,7 @@ abstract class AbstractTestFrameworkAdapter
     public function getVersion(): string
     {
         $process = new Process(
-            sprintf(
+            \sprintf(
                 '%s %s',
                 $this->phpExecutableFinder->find(),
                 '--version'

--- a/src/TestFramework/Config/MutationConfigBuilder.php
+++ b/src/TestFramework/Config/MutationConfigBuilder.php
@@ -18,10 +18,10 @@ abstract class MutationConfigBuilder
     {
         $infectionPhar = '';
 
-        if (0 === strpos(__FILE__, 'phar:')) {
-            $infectionPhar = sprintf(
+        if (0 === \strpos(__FILE__, 'phar:')) {
+            $infectionPhar = \sprintf(
                 '\Phar::loadPhar("%s", "%s");',
-                str_replace('phar://', '', \Phar::running(true)),
+                \str_replace('phar://', '', \Phar::running(true)),
                 'infection.phar'
             );
         }

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -25,17 +25,17 @@ class TestFrameworkConfigLocator
         $dir = $customDir ?: $this->configDir;
 
         foreach (['xml', 'yml'] as $extension) {
-            $conf = sprintf('%s/%s.%s', $dir, $testFrameworkName, $extension);
+            $conf = \sprintf('%s/%s.%s', $dir, $testFrameworkName, $extension);
 
-            if (file_exists($conf)) {
-                return realpath($conf);
+            if (\file_exists($conf)) {
+                return \realpath($conf);
             }
 
-            if (file_exists($conf . '.dist')) {
-                return realpath($conf . '.dist');
+            if (\file_exists($conf . '.dist')) {
+                return \realpath($conf . '.dist');
             }
         }
 
-        throw new \RuntimeException(sprintf('Unable to locate %s.(xml|yml)(.dist) file.', $testFrameworkName));
+        throw new \RuntimeException(\sprintf('Unable to locate %s.(xml|yml)(.dist) file.', $testFrameworkName));
     }
 }

--- a/src/TestFramework/Coverage/CachedTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/CachedTestFileDataProvider.php
@@ -27,7 +27,7 @@ class CachedTestFileDataProvider implements TestFileDataProvider
 
     public function getTestFileInfo(string $fullyQualifiedClassName): array
     {
-        if (array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
+        if (\array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
             return $this->testFileInfoCache[$fullyQualifiedClassName];
         }
 

--- a/src/TestFramework/Coverage/CodeCoverageData.php
+++ b/src/TestFramework/Coverage/CodeCoverageData.php
@@ -58,14 +58,14 @@ class CodeCoverageData
             return false;
         }
 
-        $coveredLineTestMethods = array_filter(
+        $coveredLineTestMethods = \array_filter(
             $coverageData[$filePath]['byLine'],
             function ($testMethods) {
-                return count($testMethods) > 0;
+                return \count($testMethods) > 0;
             }
         );
 
-        return count($coveredLineTestMethods) > 0;
+        return \count($coveredLineTestMethods) > 0;
     }
 
     public function hasTestsOnLine(string $filePath, int $line): bool
@@ -87,7 +87,7 @@ class CodeCoverageData
     {
         $coverage = $this->getCoverage();
 
-        if (!array_key_exists($filePath, $coverage)) {
+        if (!\array_key_exists($filePath, $coverage)) {
             return false;
         }
 
@@ -146,15 +146,15 @@ class CodeCoverageData
         if (null === $this->coverage) {
             $coverageIndexFilePath = $this->coverageDir . '/' . self::COVERAGE_INDEX_FILE_NAME;
 
-            if (!file_exists($coverageIndexFilePath)) {
+            if (!\file_exists($coverageIndexFilePath)) {
                 throw CoverageDoesNotExistException::with(
                     $coverageIndexFilePath,
                     $this->testFrameworkKey,
-                    dirname($coverageIndexFilePath, 2)
+                    \dirname($coverageIndexFilePath, 2)
                 );
             }
 
-            $coverageIndexFileContent = file_get_contents($coverageIndexFilePath);
+            $coverageIndexFileContent = \file_get_contents($coverageIndexFilePath);
             $coverage = $this->parser->parse($coverageIndexFileContent);
 
             $coverage = $this->addTestExecutionInfo($coverage);
@@ -176,7 +176,7 @@ class CodeCoverageData
         foreach ($newCoverage as $sourceFilePath => &$fileCoverageData) {
             foreach ($fileCoverageData['byLine'] as $line => &$lineCoverageData) {
                 foreach ($lineCoverageData as &$test) {
-                    $class = explode('::', $test['testMethod'])[0];
+                    $class = \explode('::', $test['testMethod'])[0];
 
                     $testFileData = $this->testFileDataProvider->getTestFileInfo($class);
 
@@ -200,10 +200,10 @@ class CodeCoverageData
 
         foreach ($coverage[$filePath]['byMethod'] as $method => $coverageInfo) {
             if ($line >= $coverageInfo['startLine'] && $line <= $coverageInfo['endLine']) {
-                $allLines = range($coverageInfo['startLine'], $coverageInfo['endLine']);
+                $allLines = \range($coverageInfo['startLine'], $coverageInfo['endLine']);
 
                 foreach ($allLines as $lineInExecutedMethod) {
-                    if (array_key_exists($lineInExecutedMethod, $this->getCoverage()[$filePath]['byLine'])) {
+                    if (\array_key_exists($lineInExecutedMethod, $this->getCoverage()[$filePath]['byLine'])) {
                         $tests[] = $this->getCoverage()[$filePath]['byLine'][$lineInExecutedMethod];
                     }
                 }
@@ -212,6 +212,6 @@ class CodeCoverageData
             }
         }
 
-        return array_merge(...$tests);
+        return \array_merge(...$tests);
     }
 }

--- a/src/TestFramework/Coverage/CoverageDoesNotExistException.php
+++ b/src/TestFramework/Coverage/CoverageDoesNotExistException.php
@@ -15,7 +15,7 @@ class CoverageDoesNotExistException extends InfectionException
     public static function with(string $coverageIndexFilePath, string $testFrameworkKey, string $tempDir): self
     {
         return new self(
-            sprintf(
+            \sprintf(
                 'Code Coverage does not exist. File %s is not found. Check %s version Infection was run with and generated config files inside %s.',
                 $coverageIndexFilePath,
                 $testFrameworkKey,

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -81,7 +81,7 @@ final class Factory
     {
         if ($adapterName === TestFrameworkTypes::PHPUNIT) {
             $phpUnitConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPUNIT);
-            $phpUnitConfigContent = file_get_contents($phpUnitConfigPath);
+            $phpUnitConfigContent = \file_get_contents($phpUnitConfigPath);
 
             return new PhpUnitAdapter(
                 new TestFrameworkExecutableFinder(TestFrameworkTypes::PHPUNIT, $this->infectionConfig->getPhpUnitCustomPath()),
@@ -105,9 +105,9 @@ final class Factory
         }
 
         throw new \InvalidArgumentException(
-            sprintf(
+            \sprintf(
                 'Invalid name of test framework. Available names are: %s',
-                implode(', ', [TestFrameworkTypes::PHPUNIT, TestFrameworkTypes::PHPSPEC])
+                \implode(', ', [TestFrameworkTypes::PHPUNIT, TestFrameworkTypes::PHPSPEC])
             )
         );
     }

--- a/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapter.php
+++ b/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapter.php
@@ -19,17 +19,17 @@ class PhpSpecAdapter extends AbstractTestFrameworkAdapter
 
     public function testsPass(string $output): bool
     {
-        $lines = explode(PHP_EOL, $output);
+        $lines = \explode(PHP_EOL, $output);
 
         foreach ($lines as $line) {
-            if (preg_match('%not ok \\d+ - %', $line)
-                && !preg_match('%# TODO%', $line)) {
+            if (\preg_match('%not ok \\d+ - %', $line)
+                && !\preg_match('%# TODO%', $line)) {
                 return false;
             }
         }
 
         foreach (self::ERROR_REGEXPS as $regExp) {
-            if (preg_match($regExp, $output)) {
+            if (\preg_match($regExp, $output)) {
                 return false;
             }
         }

--- a/src/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -16,13 +16,13 @@ class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilde
     {
         $options = ['run'];
 
-        $options[] = sprintf('--config=%s', $configPath);
+        $options[] = \sprintf('--config=%s', $configPath);
         $options[] = '--no-ansi';
         $options[] = '--format=tap';
         $options[] = '--stop-on-failure';
 
         $options[] = $extraOptions;
 
-        return implode(' ', $options);
+        return \implode(' ', $options);
     }
 }

--- a/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
@@ -32,7 +32,7 @@ abstract class AbstractYamlConfiguration
 
     protected function isCodeCoverageExtension(string $extensionName): bool
     {
-        return strpos($extensionName, 'CodeCoverage') !== false;
+        return \strpos($extensionName, 'CodeCoverage') !== false;
     }
 
     protected function updateCodeCoveragePath(array &$parsedYaml)
@@ -52,7 +52,7 @@ abstract class AbstractYamlConfiguration
 
     protected function hasCodeCoverageExtension(array $parsedYaml): bool
     {
-        if (!array_key_exists('extensions', $parsedYaml)) {
+        if (!\array_key_exists('extensions', $parsedYaml)) {
             return false;
         }
 

--- a/src/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilder.php
@@ -35,10 +35,10 @@ class InitialConfigBuilder implements ConfigBuilder
 
         $yamlConfiguration = new InitialYamlConfiguration(
             $this->tempDirectory,
-            Yaml::parse(file_get_contents($this->originalYamlConfigPath))
+            Yaml::parse(\file_get_contents($this->originalYamlConfigPath))
         );
 
-        file_put_contents($path, $yamlConfiguration->getYaml());
+        \file_put_contents($path, $yamlConfiguration->getYaml());
 
         return $path;
     }

--- a/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
@@ -38,15 +38,15 @@ class MutationConfigBuilder extends ConfigBuilder
 
     public function build(Mutant $mutant): string
     {
-        $customAutoloadFilePath = sprintf(
+        $customAutoloadFilePath = \sprintf(
             '%s/interceptor.phpspec.autoload.%s.infection.php',
             $this->tempDirectory,
             $mutant->getMutation()->getHash()
         );
 
-        $parsedYaml = Yaml::parse(file_get_contents($this->originalYamlConfigPath));
+        $parsedYaml = Yaml::parse(\file_get_contents($this->originalYamlConfigPath));
 
-        file_put_contents($customAutoloadFilePath, $this->createCustomAutoloadWithInterceptor($mutant, $parsedYaml));
+        \file_put_contents($customAutoloadFilePath, $this->createCustomAutoloadWithInterceptor($mutant, $parsedYaml));
 
         $yamlConfiguration = new MutationYamlConfiguration(
             $this->tempDirectory,
@@ -58,7 +58,7 @@ class MutationConfigBuilder extends ConfigBuilder
 
         $path = $this->buildPath($mutant);
 
-        file_put_contents($path, $newYaml);
+        \file_put_contents($path, $newYaml);
 
         return $path;
     }
@@ -70,7 +70,7 @@ class MutationConfigBuilder extends ConfigBuilder
 
         $originalBootstrap = $this->getOriginalBootstrapFilePath($parsedYaml);
         $autoloadPlaceholder = $originalBootstrap ? "require_once '{$originalBootstrap}';" : '';
-        $interceptorPath = dirname(__DIR__, 4) . '/StreamWrapper/IncludeInterceptor.php';
+        $interceptorPath = \dirname(__DIR__, 4) . '/StreamWrapper/IncludeInterceptor.php';
 
         $customAutoload = <<<AUTOLOAD
 <?php
@@ -80,7 +80,7 @@ class MutationConfigBuilder extends ConfigBuilder
 
 AUTOLOAD;
 
-        return sprintf(
+        return \sprintf(
             $customAutoload,
             $autoloadPlaceholder,
             $this->getInterceptorFileContent($interceptorPath, $originalFilePath, $mutatedFilePath)
@@ -89,7 +89,7 @@ AUTOLOAD;
 
     private function buildPath(Mutant $mutant): string
     {
-        $fileName = sprintf('phpspecConfiguration.%s.infection.yml', $mutant->getMutation()->getHash());
+        $fileName = \sprintf('phpspecConfiguration.%s.infection.yml', $mutant->getMutation()->getHash());
 
         return $this->tempDirectory . '/' . $fileName;
     }
@@ -101,10 +101,10 @@ AUTOLOAD;
      */
     private function getOriginalBootstrapFilePath(array $parsedYaml)
     {
-        if (!array_key_exists('bootstrap', $parsedYaml)) {
+        if (!\array_key_exists('bootstrap', $parsedYaml)) {
             return null;
         }
 
-        return sprintf('%s/%s', $this->projectDir, $parsedYaml['bootstrap']);
+        return \sprintf('%s/%s', $this->projectDir, $parsedYaml['bootstrap']);
     }
 }

--- a/src/TestFramework/PhpSpec/Config/MutationYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/MutationYamlConfiguration.php
@@ -46,7 +46,7 @@ class MutationYamlConfiguration extends AbstractYamlConfiguration
             }
         }
 
-        return array_merge($parsedYaml, ['extensions' => $filteredExtensions]);
+        return \array_merge($parsedYaml, ['extensions' => $filteredExtensions]);
     }
 
     private function setCustomAutoLoaderPath(array $config): array

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -16,22 +16,22 @@ class PhpUnitAdapter extends AbstractTestFrameworkAdapter
 
     public function testsPass(string $output): bool
     {
-        if (preg_match('/failures!/i', $output)) {
+        if (\preg_match('/failures!/i', $output)) {
             return false;
         }
 
-        if (preg_match('/errors!/i', $output)) {
+        if (\preg_match('/errors!/i', $output)) {
             return false;
         }
 
         // OK (XX tests, YY assertions)
-        $isOk = (bool) preg_match('/OK\s\(/', $output);
+        $isOk = (bool) \preg_match('/OK\s\(/', $output);
 
         // "OK, but incomplete, skipped, or risky tests!"
-        $isOkWithInfo = (bool) preg_match('/OK\s?,/', $output);
+        $isOkWithInfo = (bool) \preg_match('/OK\s?,/', $output);
 
         // "Warnings!" - e.g. when deprecated functions are used, but tests pass
-        $isWarning = (bool) preg_match('/warnings!/i', $output);
+        $isWarning = (bool) \preg_match('/warnings!/i', $output);
 
         return $isOk || $isOkWithInfo || $isWarning;
     }

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -16,11 +16,11 @@ class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilde
     {
         $options = [];
 
-        $options[] = sprintf('--configuration %s', $configPath);
+        $options[] = \sprintf('--configuration %s', $configPath);
         $options[] = '--stop-on-failure';
 
         $options[] = $extraOptions;
 
-        return implode(' ', $options);
+        return \implode(' ', $options);
     }
 }

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -67,7 +67,7 @@ class InitialConfigBuilder implements ConfigBuilder
         $this->addCodeCoverageLogger($dom, $xPath);
         $this->addJUnitLogger($dom, $xPath);
 
-        file_put_contents($path, $dom->saveXML());
+        \file_put_contents($path, $dom->saveXML());
 
         return $path;
     }
@@ -134,7 +134,7 @@ class InitialConfigBuilder implements ConfigBuilder
 
     private function getNode(\DOMDocument $dom, \DOMXPath $xPath, string $nodeName)
     {
-        $nodeList = $xPath->query(sprintf('/phpunit/%s', $nodeName));
+        $nodeList = $xPath->query(\sprintf('/phpunit/%s', $nodeName));
 
         if ($nodeList->length) {
             return $nodeList->item(0);

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -55,7 +55,7 @@ class MutationConfigBuilder extends ConfigBuilder
 
     public function build(Mutant $mutant): string
     {
-        $customAutoloadFilePath = sprintf(
+        $customAutoloadFilePath = \sprintf(
             '%s/interceptor.autoload.%s.infection.php',
             $this->tempDirectory,
             $mutant->getMutation()->getHash()
@@ -64,11 +64,11 @@ class MutationConfigBuilder extends ConfigBuilder
         $this->setCustomAutoLoaderPath($customAutoloadFilePath);
         $this->setFilteredTestsToRun($mutant->getCoverageTests());
 
-        file_put_contents($customAutoloadFilePath, $this->createCustomAutoloadWithInterceptor($mutant));
+        \file_put_contents($customAutoloadFilePath, $this->createCustomAutoloadWithInterceptor($mutant));
 
         $path = $this->buildPath($mutant);
 
-        file_put_contents($path, $this->dom->saveXML());
+        \file_put_contents($path, $this->dom->saveXML());
 
         return $path;
     }
@@ -77,10 +77,10 @@ class MutationConfigBuilder extends ConfigBuilder
     {
         $originalFilePath = $mutant->getMutation()->getOriginalFilePath();
         $mutatedFilePath = $mutant->getMutatedFilePath();
-        $interceptorPath = dirname(__DIR__, 4) . '/StreamWrapper/IncludeInterceptor.php';
+        $interceptorPath = \dirname(__DIR__, 4) . '/StreamWrapper/IncludeInterceptor.php';
 
         // TODO change to what it was (e.g. app/autoload - see simplehabits)
-        $autoload = sprintf('%s/vendor/autoload.php', $this->projectDir);
+        $autoload = \sprintf('%s/vendor/autoload.php', $this->projectDir);
 
         $customAutoload = <<<AUTOLOAD
 <?php
@@ -90,12 +90,12 @@ require_once '{$autoload}';
 
 AUTOLOAD;
 
-        return sprintf($customAutoload, $this->getInterceptorFileContent($interceptorPath, $originalFilePath, $mutatedFilePath));
+        return \sprintf($customAutoload, $this->getInterceptorFileContent($interceptorPath, $originalFilePath, $mutatedFilePath));
     }
 
     private function buildPath(Mutant $mutant): string
     {
-        $fileName = sprintf('phpunitConfiguration.%s.infection.xml', $mutant->getMutation()->getHash());
+        $fileName = \sprintf('phpunitConfiguration.%s.infection.xml', $mutant->getMutation()->getHash());
 
         return $this->tempDirectory . '/' . $fileName;
     }
@@ -151,14 +151,14 @@ AUTOLOAD;
         $uniqueCoverageTests = $this->unique($coverageTests);
 
         // sort tests to run the fastest first
-        usort(
+        \usort(
             $uniqueCoverageTests,
             function (array $a, array $b) {
                 return $a['time'] <=> $b['time'];
             }
         );
 
-        $uniqueTestFilePaths = array_column($uniqueCoverageTests, 'testFilePath');
+        $uniqueTestFilePaths = \array_column($uniqueCoverageTests, 'testFilePath');
 
         foreach ($uniqueTestFilePaths as $testFilePath) {
             $file = $this->dom->createElement('file', $testFilePath);
@@ -175,7 +175,7 @@ AUTOLOAD;
         $uniqueTests = [];
 
         foreach ($coverageTests as $coverageTest) {
-            if (!in_array($coverageTest['testFilePath'], $usedFileNames, true)) {
+            if (!\in_array($coverageTest['testFilePath'], $usedFileNames, true)) {
                 $uniqueTests[] = $coverageTest;
                 $usedFileNames[] = $coverageTest['testFilePath'];
             }

--- a/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
+++ b/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
@@ -34,11 +34,11 @@ class PathReplacer
     public function replaceInNode(\DOMNode $domElement)
     {
         if (!$this->filesystem->isAbsolutePath($domElement->nodeValue)) {
-            $domElement->nodeValue = sprintf(
+            $domElement->nodeValue = \sprintf(
                 '%s%s%s',
                 $this->phpUnitConfigDir,
                 DIRECTORY_SEPARATOR,
-                ltrim($domElement->nodeValue, '\.\/')
+                \ltrim($domElement->nodeValue, '\.\/')
             );
         }
     }

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -31,7 +31,7 @@ class XmlConfigurationHelper
             '//file',
         ];
 
-        $nodes = $xPath->query(implode('|', $queries));
+        $nodes = $xPath->query(\implode('|', $queries));
 
         foreach ($nodes as $node) {
             $this->pathReplacer->replaceInNode($node);

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -44,7 +44,7 @@ class CoverageXmlParser
             $coverage[] = $fileCoverage;
         }
 
-        return array_merge(...$coverage);
+        return \array_merge(...$coverage);
     }
 
     /**
@@ -55,8 +55,8 @@ class CoverageXmlParser
      */
     private function processXmlFileCoverage(string $relativeCoverageFilePath, string $projectSource): array
     {
-        $absolutePath = realpath($this->coverageDir . '/' . $relativeCoverageFilePath);
-        $coverageFileXml = file_get_contents($absolutePath);
+        $absolutePath = \realpath($this->coverageDir . '/' . $relativeCoverageFilePath);
+        $coverageFileXml = \file_get_contents($absolutePath);
 
         $dom = new \DOMDocument();
         $dom->loadXML($this->removeNamespace($coverageFileXml));
@@ -99,7 +99,7 @@ class CoverageXmlParser
      */
     private function removeNamespace(string $xml): string
     {
-        return preg_replace('/xmlns=\".*?\"/', '', $xml);
+        return \preg_replace('/xmlns=\".*?\"/', '', $xml);
     }
 
     /**
@@ -120,15 +120,15 @@ class CoverageXmlParser
         if (!$relativeFilePath) {
             // path is not present for old versions of PHPUnit, so parse the source file path from
             // the path of XML coverage file
-            $relativeFilePath = str_replace(
-                sprintf('%s.xml', $fileName),
+            $relativeFilePath = \str_replace(
+                \sprintf('%s.xml', $fileName),
                     '',
                     $relativeCoverageFilePath
             );
         }
 
-        $path = $projectSource . '/' . ltrim($relativeFilePath, '/') . '/' . $fileName;
-        $realPath = realpath($path);
+        $path = $projectSource . '/' . \ltrim($relativeFilePath, '/') . '/' . $fileName;
+        $realPath = \realpath($path);
 
         if ($realPath) {
             return $realPath;

--- a/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
+++ b/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
@@ -32,10 +32,10 @@ class PhpUnitTestFileDataProvider implements TestFileDataProvider
     {
         $xPath = $this->getXPath();
 
-        $nodes = $xPath->query(sprintf('//testsuite[@name="%s"]', $fullyQualifiedClassName));
+        $nodes = $xPath->query(\sprintf('//testsuite[@name="%s"]', $fullyQualifiedClassName));
 
         if ($nodes->length === 0) {
-            throw new TestFileNameNotFoundException(sprintf('For FQCN: %s', $fullyQualifiedClassName));
+            throw new TestFileNameNotFoundException(\sprintf('For FQCN: %s', $fullyQualifiedClassName));
         }
 
         return [
@@ -48,7 +48,7 @@ class PhpUnitTestFileDataProvider implements TestFileDataProvider
     {
         if ($this->xPath === null) {
             $dom = new \DOMDocument();
-            $dom->loadXML(file_get_contents($this->jUnitFilePath));
+            $dom->loadXML(\file_get_contents($this->jUnitFilePath));
 
             $this->xPath = new \DOMXPath($dom);
         }

--- a/src/TestFramework/TestFrameworkExtraOptions.php
+++ b/src/TestFramework/TestFrameworkExtraOptions.php
@@ -32,9 +32,9 @@ abstract class TestFrameworkExtraOptions
         $extraOptions = $this->extraOptions;
 
         foreach ($this->getInitialRunOnlyOptions() as $initialRunOnlyOption) {
-            $extraOptions = preg_replace(sprintf('/%s[\=| ]([^ ]+)/', $initialRunOnlyOption), '', $extraOptions);
+            $extraOptions = \preg_replace(\sprintf('/%s[\=| ]([^ ]+)/', $initialRunOnlyOption), '', $extraOptions);
         }
 
-        return preg_replace('/\s+/', ' ', trim($extraOptions));
+        return \preg_replace('/\s+/', ' ', \trim($extraOptions));
     }
 }

--- a/src/Utils/TmpDirectoryCreator.php
+++ b/src/Utils/TmpDirectoryCreator.php
@@ -35,7 +35,7 @@ class TmpDirectoryCreator
     public function createAndGet(string $tempDir): string
     {
         if ($this->path === null) {
-            $path = sprintf('%s/%s', $tempDir, self::BASE_DIR_NAME);
+            $path = \sprintf('%s/%s', $tempDir, self::BASE_DIR_NAME);
 
             $this->fileSystem->mkdir($path, 0777);
 

--- a/src/Utils/VersionParser.php
+++ b/src/Utils/VersionParser.php
@@ -15,7 +15,7 @@ class VersionParser
     public function parse(string $content): string
     {
         $matches = [];
-        $matched = preg_match(self::VERSION_REGEX, $content, $matches);
+        $matched = \preg_match(self::VERSION_REGEX, $content, $matches);
 
         if (!$matched) {
             throw new \InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.');

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -83,7 +83,7 @@ class MutationsCollectorVisitor extends NodeVisitorAbstract
                     $this->fileAst,
                     $mutator,
                     $node->getAttributes(),
-                    get_class($node),
+                    \get_class($node),
                     $isOnFunctionSignature
                 );
             }

--- a/src/Visitor/MutatorVisitor.php
+++ b/src/Visitor/MutatorVisitor.php
@@ -25,7 +25,7 @@ class MutatorVisitor extends NodeVisitorAbstract
     {
         $attributes = $node->getAttributes();
 
-        if (!array_key_exists('startTokenPos', $attributes)) {
+        if (!\array_key_exists('startTokenPos', $attributes)) {
             return null;
         }
 
@@ -35,7 +35,7 @@ class MutatorVisitor extends NodeVisitorAbstract
         $isEqualPosition = $attributes['startTokenPos'] === $mutatedAttributes['startTokenPos'] &&
             $attributes['endTokenPos'] === $mutatedAttributes['endTokenPos'];
 
-        if ($isEqualPosition && $this->mutation->getMutatedNodeClass() === get_class($node)) {
+        if ($isEqualPosition && $this->mutation->getMutatedNodeClass() === \get_class($node)) {
             return $mutator->mutate($node);
             // TODO STOP TRAVERSING
             // TODO check all built-in visitors, in particular FirstFindingVisitor

--- a/src/Visitor/ParentConnectorVisitor.php
+++ b/src/Visitor/ParentConnectorVisitor.php
@@ -25,7 +25,7 @@ class ParentConnectorVisitor extends NodeVisitorAbstract
     public function enterNode(Node $node)
     {
         if (!empty($this->stack)) {
-            $node->setAttribute(self::PARENT_KEY, $this->stack[count($this->stack) - 1]);
+            $node->setAttribute(self::PARENT_KEY, $this->stack[\count($this->stack) - 1]);
         }
 
         $this->stack[] = $node;
@@ -33,6 +33,6 @@ class ParentConnectorVisitor extends NodeVisitorAbstract
 
     public function leaveNode(Node $node)
     {
-        array_pop($this->stack);
+        \array_pop($this->stack);
     }
 }

--- a/src/Visitor/WrappedFunctionInfoCollectorVisitor.php
+++ b/src/Visitor/WrappedFunctionInfoCollectorVisitor.php
@@ -39,14 +39,14 @@ class WrappedFunctionInfoCollectorVisitor extends NodeVisitorAbstract
         if ($this->isFunctionLikeNode($node)) {
             $this->scopeStack[] = $node;
         } elseif ($isInsideFunction) {
-            $node->setAttribute(self::FUNCTION_SCOPE_KEY, $this->scopeStack[count($this->scopeStack) - 1]);
+            $node->setAttribute(self::FUNCTION_SCOPE_KEY, $this->scopeStack[\count($this->scopeStack) - 1]);
         }
     }
 
     public function leaveNode(Node $node)
     {
         if ($this->isFunctionLikeNode($node)) {
-            array_pop($this->scopeStack);
+            \array_pop($this->scopeStack);
         }
     }
 

--- a/tests/Config/Guesser/PhpUnitPathGuesserTest.php
+++ b/tests/Config/Guesser/PhpUnitPathGuesserTest.php
@@ -25,7 +25,7 @@ class PhpUnitPathGuesserTest extends TestCase
     }
 }
 CODE;
-        $guesser = new PhpUnitPathGuesser(json_decode($composerJson));
+        $guesser = new PhpUnitPathGuesser(\json_decode($composerJson));
 
         $this->assertSame('app', $guesser->guess());
     }
@@ -41,7 +41,7 @@ CODE;
     }
 }
 CODE;
-        $guesser = new PhpUnitPathGuesser(json_decode($composerJson));
+        $guesser = new PhpUnitPathGuesser(\json_decode($composerJson));
 
         $this->assertSame('.', $guesser->guess());
     }

--- a/tests/Config/Guesser/SourceDirGuesserTest.php
+++ b/tests/Config/Guesser/SourceDirGuesserTest.php
@@ -25,7 +25,7 @@ class SourceDirGuesserTest extends TestCase
     }
 }
 CODE;
-        $guesser = new SourceDirGuesser(json_decode($composerJson));
+        $guesser = new SourceDirGuesser(\json_decode($composerJson));
 
         $this->assertSame(['abc', 'namespace'], $guesser->guess());
     }
@@ -42,7 +42,7 @@ CODE;
     }
 }
 CODE;
-        $guesser = new SourceDirGuesser(json_decode($composerJson));
+        $guesser = new SourceDirGuesser(\json_decode($composerJson));
 
         $this->assertSame(['src'], $guesser->guess());
     }
@@ -58,14 +58,14 @@ CODE;
     }
 }
 CODE;
-        $guesser = new SourceDirGuesser(json_decode($composerJson));
+        $guesser = new SourceDirGuesser(\json_decode($composerJson));
 
         $this->assertSame(['src'], $guesser->guess());
     }
 
     public function test_it_returns_null_when_does_not_have_autoload()
     {
-        $guesser = new SourceDirGuesser(json_decode('{}'));
+        $guesser = new SourceDirGuesser(\json_decode('{}'));
 
         $this->assertNull($guesser->guess());
     }
@@ -73,7 +73,7 @@ CODE;
     public function test_it_returns_only_src_if_contains_array_of_paths()
     {
         $guesser = new SourceDirGuesser(
-            json_decode('{"autoload":{"psr-0": {"": ["src", "libs"]}}}')
+            \json_decode('{"autoload":{"psr-0": {"": ["src", "libs"]}}}')
         );
 
         $this->assertSame(['src'], $guesser->guess());
@@ -82,7 +82,7 @@ CODE;
     public function test_it_returns_list_if_contains_array_of_paths_without_src()
     {
         $guesser = new SourceDirGuesser(
-            json_decode('{"autoload":{"psr-4": {"NameSpace\\//": ["sources", "libs"]}}}')
+            \json_decode('{"autoload":{"psr-4": {"NameSpace\\//": ["sources", "libs"]}}}')
         );
 
         $this->assertSame(['sources', 'libs'], $guesser->guess());
@@ -95,7 +95,7 @@ CODE;
     public function test_it_throw_invalid_autoload_exception()
     {
         $guesser = new SourceDirGuesser(
-            json_decode('{"autoload":{"psr-4": [{"NameSpace\\//": ["sources", "libs"]}]}}')
+            \json_decode('{"autoload":{"psr-4": [{"NameSpace\\//": ["sources", "libs"]}]}}')
         );
 
         $guesser->guess();

--- a/tests/Config/InfectionConfigTest.php
+++ b/tests/Config/InfectionConfigTest.php
@@ -35,8 +35,8 @@ class InfectionConfigTest extends TestCase
     public function test_it_returns_timeout_from_config()
     {
         $timeout = 3;
-        $json = sprintf('{"timeout": %d}', $timeout);
-        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
+        $json = \sprintf('{"timeout": %d}', $timeout);
+        $config = new InfectionConfig(\json_decode($json), $this->filesystem, '/path/to/config');
 
         $this->assertSame($timeout, $config->getProcessTimeout());
     }
@@ -51,8 +51,8 @@ class InfectionConfigTest extends TestCase
     public function test_it_returns_phpunit_config_dir_from_config()
     {
         $phpUnitConfigDir = 'app';
-        $json = sprintf('{"phpUnit": {"configDir": "%s"}}', $phpUnitConfigDir);
-        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
+        $json = \sprintf('{"phpUnit": {"configDir": "%s"}}', $phpUnitConfigDir);
+        $config = new InfectionConfig(\json_decode($json), $this->filesystem, '/path/to/config');
 
         $expected = '/path/to/config/app';
 
@@ -69,8 +69,8 @@ class InfectionConfigTest extends TestCase
     public function test_it_returns_source_dirs_from_config()
     {
         $excludedFolders = '["source-folder"]';
-        $json = sprintf('{"source": {"directories": %s}}', $excludedFolders);
-        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
+        $json = \sprintf('{"source": {"directories": %s}}', $excludedFolders);
+        $config = new InfectionConfig(\json_decode($json), $this->filesystem, '/path/to/config');
 
         $this->assertSame(['source-folder'], $config->getSourceDirs());
     }
@@ -85,7 +85,7 @@ class InfectionConfigTest extends TestCase
     public function test_it_returns_exclude_dirs_from_config_with_excludes_option()
     {
         $json = '{"source": {"excludes":["subfolder/excluded-folder"], "directories": ["source"]}}';
-        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
+        $config = new InfectionConfig(\json_decode($json), $this->filesystem, '/path/to/config');
 
         $this->assertSame(['subfolder/excluded-folder'], $config->getSourceExcludePaths());
     }
@@ -93,9 +93,9 @@ class InfectionConfigTest extends TestCase
     public function test_it_excludes_by_glob_patterns()
     {
         $srcDir = __DIR__ . '/../Fixtures/Files/phpunit/project-path';
-        $json = sprintf('{"source": {"excludes":["exclude/exclude*"], "directories": ["%s"]}}', p($srcDir));
+        $json = \sprintf('{"source": {"excludes":["exclude/exclude*"], "directories": ["%s"]}}', p($srcDir));
 
-        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
+        $config = new InfectionConfig(\json_decode($json), $this->filesystem, '/path/to/config');
 
         $excludedDirs = $config->getSourceExcludePaths();
 
@@ -105,43 +105,43 @@ class InfectionConfigTest extends TestCase
     public function test_it_returns_text_file_log_path_when_exist()
     {
         $path = 'test-log.txt';
-        $json = sprintf('{"logs": {"text": "%s"}}', $path);
-        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
+        $json = \sprintf('{"logs": {"text": "%s"}}', $path);
+        $config = new InfectionConfig(\json_decode($json), $this->filesystem, '/path/to/config');
 
         $this->assertSame($path, $config->getLogPathInfoFor('text'));
     }
 
     public function test_it_returns_an_empty_array_for_text_file_log_path_when_it_is_skipped()
     {
-        $config = new InfectionConfig(json_decode('{}'), $this->filesystem, '/path/to/config');
+        $config = new InfectionConfig(\json_decode('{}'), $this->filesystem, '/path/to/config');
 
         $this->assertEmpty($config->getLogPathInfoFor('text'));
     }
 
     public function test_it_returns_default_temp_dir()
     {
-        $config = new InfectionConfig(json_decode('{}'), $this->filesystem, '/path/to/config');
+        $config = new InfectionConfig(\json_decode('{}'), $this->filesystem, '/path/to/config');
 
-        $this->assertSame(sys_get_temp_dir(), $config->getTmpDir());
+        $this->assertSame(\sys_get_temp_dir(), $config->getTmpDir());
     }
 
     public function test_it_returns_default_temp_dir_with_empty_setting()
     {
-        $config = new InfectionConfig(json_decode('{"tmpDir": ""}'), $this->filesystem, '/path/to/config');
+        $config = new InfectionConfig(\json_decode('{"tmpDir": ""}'), $this->filesystem, '/path/to/config');
 
-        $this->assertSame(sys_get_temp_dir(), $config->getTmpDir());
+        $this->assertSame(\sys_get_temp_dir(), $config->getTmpDir());
     }
 
     public function test_it_returns_temp_dir_from_config_with_absolute_path()
     {
-        $config = new InfectionConfig(json_decode('{"tmpDir": "/root/test"}'), $this->filesystem, '/path/to/config');
+        $config = new InfectionConfig(\json_decode('{"tmpDir": "/root/test"}'), $this->filesystem, '/path/to/config');
 
         $this->assertSame('/root/test', $config->getTmpDir());
     }
 
     public function test_it_returns_temp_dir_from_config_with_relative_path()
     {
-        $config = new InfectionConfig(json_decode('{"tmpDir": "relative/folder"}'), $this->filesystem, '/path/to/config');
+        $config = new InfectionConfig(\json_decode('{"tmpDir": "relative/folder"}'), $this->filesystem, '/path/to/config');
 
         $this->assertSame('/path/to/config/relative/folder', $config->getTmpDir());
     }

--- a/tests/Config/ValueProvider/AbstractBaseProviderTest.php
+++ b/tests/Config/ValueProvider/AbstractBaseProviderTest.php
@@ -24,16 +24,16 @@ abstract class AbstractBaseProviderTest extends Mockery\Adapter\Phpunit\MockeryT
 
     protected function getInputStream($input)
     {
-        $stream = fopen('php://memory', 'r+', false);
-        fwrite($stream, $input);
-        rewind($stream);
+        $stream = \fopen('php://memory', 'r+', false);
+        \fwrite($stream, $input);
+        \rewind($stream);
 
         return $stream;
     }
 
     protected function createOutputInterface()
     {
-        return new StreamOutput(fopen('php://memory', 'r+', false));
+        return new StreamOutput(\fopen('php://memory', 'r+', false));
     }
 
     protected function createStreamableInputInterfaceMock($stream = null, $interactive = true)
@@ -58,7 +58,7 @@ abstract class AbstractBaseProviderTest extends Mockery\Adapter\Phpunit\MockeryT
             return self::$stty;
         }
 
-        exec('stty 2>&1', $output, $exitcode);
+        \exec('stty 2>&1', $output, $exitcode);
 
         return self::$stty = $exitcode === 0;
     }

--- a/tests/Config/ValueProvider/ExcludeDirsProviderTest.php
+++ b/tests/Config/ValueProvider/ExcludeDirsProviderTest.php
@@ -114,7 +114,7 @@ class ExcludeDirsProviderTest extends AbstractBaseProviderTest
 
     public function excludeDirsProvider()
     {
-        return array_map(
+        return \array_map(
             function (string $excludedRootDir) {
                 return [$excludedRootDir, [$excludedRootDir, 'src']];
             },

--- a/tests/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
+++ b/tests/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
@@ -48,7 +48,7 @@ class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProviderTest
         $dialog = $this->getQuestionHelper();
 
         $provider = new PhpUnitCustomExecutablePathProvider($finderMock, $consoleMock, $dialog);
-        $customExecutable = p(realpath(__DIR__ . '/../../Fixtures/Files/phpunit/phpunit.phar'));
+        $customExecutable = p(\realpath(__DIR__ . '/../../Fixtures/Files/phpunit/phpunit.phar'));
 
         $path = $provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("{$customExecutable}\n")),

--- a/tests/Config/ValueProvider/SourceDirsProviderTest.php
+++ b/tests/Config/ValueProvider/SourceDirsProviderTest.php
@@ -16,7 +16,7 @@ class SourceDirsProviderTest extends AbstractBaseProviderTest
 {
     public function test_it_uses_guesser_and_default_value()
     {
-        if (stripos(PHP_OS, 'WIN') === 0) {
+        if (\stripos(PHP_OS, 'WIN') === 0) {
             $this->markTestSkipped('Stty is not available');
         }
 

--- a/tests/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -52,7 +52,7 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
         $dialog = $this->getQuestionHelper();
 
         $provider = new TestFrameworkConfigPathProvider($locatorMock, $consoleMock, $dialog);
-        $inputPhpUnitPath = realpath(__DIR__ . '/../../Fixtures/Files/phpunit');
+        $inputPhpUnitPath = \realpath(__DIR__ . '/../../Fixtures/Files/phpunit');
 
         $path = $provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("{$inputPhpUnitPath}\n")),

--- a/tests/Differ/DifferTest.php
+++ b/tests/Differ/DifferTest.php
@@ -77,7 +77,7 @@ CODE;
 
         $diff = $differ->diff($source1, $source2);
 
-        if (substr_count($diff, "\n") < Differ::DIFF_MAX_LINES - 1) {
+        if (\substr_count($diff, "\n") < Differ::DIFF_MAX_LINES - 1) {
             $this->markTestSkipped('See https://github.com/sebastianbergmann/diff/pull/59');
         }
 

--- a/tests/Finder/LocatorTest.php
+++ b/tests/Finder/LocatorTest.php
@@ -31,7 +31,7 @@ class LocatorTest extends TestCase
      */
     public function test_determines_real_path_to_file(string $fileName, string $pathPostfix)
     {
-        $projectPath = realpath(__DIR__ . '/../Fixtures/Files/phpunit/project-path');
+        $projectPath = \realpath(__DIR__ . '/../Fixtures/Files/phpunit/project-path');
 
         $locator = new Locator([$projectPath], $this->filesystem);
 
@@ -57,7 +57,7 @@ class LocatorTest extends TestCase
         $locator = new Locator([$projectPath], $this->filesystem);
 
         $this->expectException(LocatorException::class);
-        $this->expectExceptionMessage(sprintf(
+        $this->expectExceptionMessage(\sprintf(
             'The file/folder "autoload.php" does not exist (in: %s).',
             $projectPath
         ));
@@ -67,14 +67,14 @@ class LocatorTest extends TestCase
 
     public function test_it_throws_an_exception_if_file_or_folder_does_not_exist_when_absolute_path_is_given()
     {
-        $projectPath = realpath(__DIR__ . '/../Fixtures/Locator');
+        $projectPath = \realpath(__DIR__ . '/../Fixtures/Locator');
 
         $locator = new Locator([''], $this->filesystem);
 
         $invalidPath = $projectPath . 'autoload.php';
 
         $this->expectException(LocatorException::class);
-        $this->expectExceptionMessage(sprintf(
+        $this->expectExceptionMessage(\sprintf(
             'The file/directory "%s" does not exist.',
             $invalidPath
         ));
@@ -84,7 +84,7 @@ class LocatorTest extends TestCase
 
     public function test_locate_any_throws_exception_if_empty_array_provided()
     {
-        $projectPath = realpath(__DIR__ . '/../Fixtures/Files/phpunit/project-path');
+        $projectPath = \realpath(__DIR__ . '/../Fixtures/Files/phpunit/project-path');
         $locator = new Locator([$projectPath], $this->filesystem);
 
         $this->expectException(LocatorException::class);
@@ -95,7 +95,7 @@ class LocatorTest extends TestCase
 
     public function test_it_returns_first_possible_file()
     {
-        $projectPath = realpath(__DIR__ . '/../Fixtures/Locator');
+        $projectPath = \realpath(__DIR__ . '/../Fixtures/Locator');
         $locator = new Locator([$projectPath], $this->filesystem);
 
         $found = $locator->locateAnyOf(['file.txt', 'secondfile.txt']);
@@ -116,7 +116,7 @@ class LocatorTest extends TestCase
 
     public function test_it_returns_the_file_even_if_some_dont_exists()
     {
-        $projectPath = realpath(__DIR__ . '/../Fixtures/Locator');
+        $projectPath = \realpath(__DIR__ . '/../Fixtures/Locator');
         $locator = new Locator([$projectPath], $this->filesystem);
 
         $found = $locator->locateAnyOf(['fakefile.txt', 'secondfile.txt', 'thirdfile.txt']);
@@ -130,7 +130,7 @@ class LocatorTest extends TestCase
 
     public function test_it_throws_an_error_if_none_of_the_files_exist()
     {
-        $projectPath = realpath(__DIR__ . '/../Fixtures/Files/phpunit/project-path');
+        $projectPath = \realpath(__DIR__ . '/../Fixtures/Files/phpunit/project-path');
         $locator = new Locator([$projectPath], $this->filesystem);
 
         $this->expectException(LocatorException::class);

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -17,5 +17,5 @@ namespace Infection\Tests;
  */
 function normalizePath(string $value): string
 {
-    return str_replace(DIRECTORY_SEPARATOR, '/', $value);
+    return \str_replace(DIRECTORY_SEPARATOR, '/', $value);
 }

--- a/tests/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/Mutant/Generator/MutationsGeneratorTest.php
@@ -126,7 +126,7 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     private function createMutationGenerator(CodeCoverageData $codeCoverageDataMock, array $whitelistedMutatorNames = [])
     {
         $srcDirs = [
-            dirname(__DIR__, 2) . '/Fixtures/Files/Mutation/OneFile',
+            \dirname(__DIR__, 2) . '/Fixtures/Files/Mutation/OneFile',
         ];
         $excludedDirsOrFiles = [];
 

--- a/tests/Php/ConfigBuilderTest.php
+++ b/tests/Php/ConfigBuilderTest.php
@@ -24,23 +24,23 @@ class ConfigBuilderTest extends TestCase
     public static function setUpBeforeClass()
     {
         // Save current state
-        self::$envOriginal = getenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
+        self::$envOriginal = \getenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
     }
 
     public static function tearDownAfterClass()
     {
         // Restore original state
         if (false !== self::$envOriginal) {
-            putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH . '=' . self::$envOriginal);
+            \putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH . '=' . self::$envOriginal);
         } else {
-            putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
+            \putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
         }
     }
 
     protected function setUp()
     {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . microtime(true) . random_int(100, 999);
-        mkdir($this->workspace, 0777, true);
+        $this->workspace = \sys_get_temp_dir() . DIRECTORY_SEPARATOR . \microtime(true) . \random_int(100, 999);
+        \mkdir($this->workspace, 0777, true);
     }
 
     protected function tearDown()
@@ -50,11 +50,11 @@ class ConfigBuilderTest extends TestCase
 
     public function test_it_builds_return_existing_path()
     {
-        $builder = new ConfigBuilder(sys_get_temp_dir());
+        $builder = new ConfigBuilder(\sys_get_temp_dir());
 
         $file = $this->workspace . DIRECTORY_SEPARATOR . 'infectionTest';
 
-        touch($file);
+        \touch($file);
 
         $this->setEnv($file);
 
@@ -63,6 +63,6 @@ class ConfigBuilderTest extends TestCase
 
     private function setEnv(string $path)
     {
-        putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH . '=' . $path);
+        \putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH . '=' . $path);
     }
 }

--- a/tests/Php/Mock/XdebugHandlerMock.php
+++ b/tests/Php/Mock/XdebugHandlerMock.php
@@ -17,10 +17,10 @@ class XdebugHandlerMock extends XdebugHandler
 
     public function __construct($isLoaded = null)
     {
-        parent::__construct(new ConfigBuilder(sys_get_temp_dir()));
+        parent::__construct(new ConfigBuilder(\sys_get_temp_dir()));
 
         $isLoaded = null === $isLoaded ? true : $isLoaded;
-        $class = new \ReflectionClass(get_parent_class($this));
+        $class = new \ReflectionClass(\get_parent_class($this));
 
         $prop = $class->getProperty('isLoaded');
         $prop->setAccessible(true);

--- a/tests/Php/PhpIniHelperTest.php
+++ b/tests/Php/PhpIniHelperTest.php
@@ -18,16 +18,16 @@ class PhpIniHelperTest extends TestCase
     public static function setUpBeforeClass()
     {
         // Save current state
-        self::$envOriginal = getenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS);
+        self::$envOriginal = \getenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS);
     }
 
     public static function tearDownAfterClass()
     {
         // Restore original state
         if (false !== self::$envOriginal) {
-            putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS . '=' . self::$envOriginal);
+            \putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS . '=' . self::$envOriginal);
         } else {
-            putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS);
+            \putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS);
         }
     }
 
@@ -55,6 +55,6 @@ class PhpIniHelperTest extends TestCase
 
     private function setEnv(array $paths)
     {
-        putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS . '=' . implode(PATH_SEPARATOR, $paths));
+        \putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS . '=' . \implode(PATH_SEPARATOR, $paths));
     }
 }

--- a/tests/Php/XdebugHandlerTest.php
+++ b/tests/Php/XdebugHandlerTest.php
@@ -31,7 +31,7 @@ class XdebugHandlerTest extends TestCase
         ];
 
         foreach ($names as $name) {
-            self::$env[$name] = getenv($name);
+            self::$env[$name] = \getenv($name);
         }
     }
 
@@ -40,9 +40,9 @@ class XdebugHandlerTest extends TestCase
         // Restore original state
         foreach (self::$env as $name => $value) {
             if (false !== $value) {
-                putenv($name . '=' . $value);
+                \putenv($name . '=' . $value);
             } else {
-                putenv($name);
+                \putenv($name);
             }
         }
     }
@@ -53,9 +53,9 @@ class XdebugHandlerTest extends TestCase
             $this->markTestSkipped();
         }
 
-        putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS);
-        putenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG);
-        putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
+        \putenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS);
+        \putenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG);
+        \putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
     }
 
     public function test_it_restart_when_loaded()
@@ -66,7 +66,7 @@ class XdebugHandlerTest extends TestCase
         $xdebug->check();
         $this->assertTrue($xdebug->restarted);
 
-        $this->assertInternalType('string', getenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS));
+        $this->assertInternalType('string', \getenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS));
     }
 
     public function test_it_not_restart_when_loaded()
@@ -76,13 +76,13 @@ class XdebugHandlerTest extends TestCase
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
         $this->assertFalse($xdebug->restarted);
-        $this->assertFalse(getenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS));
+        $this->assertFalse(\getenv(PhpIniHelper::ENV_ORIGINALS_PHP_INIS));
     }
 
     public function test_it_not_restart_when_loaded_and_allowed()
     {
         $loaded = true;
-        putenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG . '=1');
+        \putenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG . '=1');
 
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
@@ -96,12 +96,12 @@ class XdebugHandlerTest extends TestCase
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
         $expected = XdebugHandlerMock::RESTART_HANDLE;
-        $this->assertEquals($expected, getenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG));
+        $this->assertEquals($expected, \getenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG));
 
         // Mimic restart
         $xdebug = new XdebugHandlerMock($loaded);
         $xdebug->check();
         $this->assertFalse($xdebug->restarted);
-        $this->assertFalse(getenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG));
+        $this->assertFalse(\getenv(XdebugHandlerMock::ENV_DISABLE_XDEBUG));
     }
 }

--- a/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
+++ b/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
@@ -22,10 +22,10 @@ class PhpExecutableFinderTest extends TestCase
 
     public function setUp()
     {
-        putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
+        \putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH);
 
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . microtime(true) . random_int(100, 999);
-        mkdir($this->workspace, 0777, true);
+        $this->workspace = \sys_get_temp_dir() . DIRECTORY_SEPARATOR . \microtime(true) . \random_int(100, 999);
+        \mkdir($this->workspace, 0777, true);
     }
 
     public function test_it_find_temp_php_config()
@@ -34,9 +34,9 @@ class PhpExecutableFinderTest extends TestCase
 
         $tempConfig = $this->workspace . DIRECTORY_SEPARATOR . 'php.ini';
 
-        touch($tempConfig);
+        \touch($tempConfig);
 
-        putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH . '=' . $tempConfig);
+        \putenv(ConfigBuilder::ENV_TEMP_PHP_CONFIG_PATH . '=' . $tempConfig);
 
         $this->assertSame(['-c', $tempConfig], $finder->findArguments());
     }

--- a/tests/Process/Listener/FileLoggerSubscriber/BaseFileLoggerSubscriberTest.php
+++ b/tests/Process/Listener/FileLoggerSubscriber/BaseFileLoggerSubscriberTest.php
@@ -78,11 +78,11 @@ class BaseFileLoggerSubscriberTest extends TestCase
 
     public function test_it_reacts_on_mutation_testing_finished()
     {
-        $logTypes = ['text' => sys_get_temp_dir() . '/infection-log.txt'];
+        $logTypes = ['text' => \sys_get_temp_dir() . '/infection-log.txt'];
         $this->infectionConfig->expects($this->once())
             ->method('getLogPathInfoFor')
             ->with('text')
-            ->willReturn(sys_get_temp_dir() . '/infection-log.txt');
+            ->willReturn(\sys_get_temp_dir() . '/infection-log.txt');
 
         $this->infectionConfig->expects($this->once())
             ->method('getLogsTypes')
@@ -123,7 +123,7 @@ class BaseFileLoggerSubscriberTest extends TestCase
 
     public function test_it_reacts_on_mutation_testing_finished_and_debug_mode_off()
     {
-        $logTypes = ['text' => sys_get_temp_dir() . '/infection-log.txt'];
+        $logTypes = ['text' => \sys_get_temp_dir() . '/infection-log.txt'];
 
         $this->infectionConfig->expects($this->once())
             ->method('getLogsTypes')
@@ -131,7 +131,7 @@ class BaseFileLoggerSubscriberTest extends TestCase
 
         $this->infectionConfig->expects($this->once())
             ->method('getLogPathInfoFor')
-            ->willReturn(sys_get_temp_dir() . '/infection-log.txt');
+            ->willReturn(\sys_get_temp_dir() . '/infection-log.txt');
 
         $this->metricsCalculator->expects($this->once())
             ->method('getEscapedMutantProcesses')

--- a/tests/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -25,6 +25,6 @@ class ArgumentsAndOptionsBuilderTest extends TestCase
         $this->assertContains('--format=tap', $command);
         $this->assertContains('--stop-on-failure', $command);
         $this->assertContains('--verbose', $command);
-        $this->assertContains(sprintf('--config=%s', $configPath), $command);
+        $this->assertContains(\sprintf('--config=%s', $configPath), $command);
     }
 }

--- a/tests/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
@@ -32,7 +32,7 @@ class InitialConfigBuilderTest extends TestCase
 
     protected function setUp()
     {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->workspace = \sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
         $this->fileSystem = new Filesystem();
 
         $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);

--- a/tests/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
@@ -31,7 +31,7 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     protected function setUp()
     {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->workspace = \sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
 
         $this->fileSystem = new Filesystem();
         $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);
@@ -80,7 +80,7 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertSame($this->tmpDir . '/phpspecConfiguration.a1b2c3.infection.yml', $builder->build($mutant));
         $this->assertContains(
             "require_once '/project/dir/bootstrap.php';",
-            file_get_contents($this->tmpDir . '/interceptor.phpspec.autoload.a1b2c3.infection.php')
+            \file_get_contents($this->tmpDir . '/interceptor.phpspec.autoload.a1b2c3.infection.php')
         );
     }
 }

--- a/tests/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -22,6 +22,6 @@ class ArgumentsAndOptionsBuilderTest extends TestCase
 
         $this->assertContains('--stop-on-failure', $command);
         $this->assertContains('--verbose', $command);
-        $this->assertContains(sprintf('--configuration %s', $configPath), $command);
+        $this->assertContains(\sprintf('--configuration %s', $configPath), $command);
     }
 }

--- a/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -47,12 +47,12 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     protected function setUp()
     {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->workspace = \sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
 
         $this->fileSystem = new Filesystem();
         $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);
 
-        $this->pathToProject = p(realpath(__DIR__ . '/../../../../Fixtures/Files/phpunit/project-path'));
+        $this->pathToProject = p(\realpath(__DIR__ . '/../../../../Fixtures/Files/phpunit/project-path'));
 
         $this->createConfigBuilder();
     }
@@ -73,7 +73,7 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $this->builder = new InitialConfigBuilder(
             $this->tmpDir,
-            file_get_contents($phpunitXmlPath),
+            \file_get_contents($phpunitXmlPath),
             new XmlConfigurationHelper($replacer),
             $jUnitFilePath,
             $srcDirs
@@ -84,7 +84,7 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $configurationPath = $this->builder->build();
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         /** @var \DOMNodeList $directories */
         $directories = $this->queryXpath($xml, '/phpunit/testsuites/testsuite/directory');
@@ -97,7 +97,7 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $configurationPath = $this->builder->build();
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         $value = p($this->queryXpath($xml, '/phpunit/@bootstrap')[0]->nodeValue);
 
@@ -108,7 +108,7 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $configurationPath = $this->builder->build();
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         $nodeList = $this->queryXpath($xml, '/phpunit/logging/log[@type="coverage-html"]');
 
@@ -119,7 +119,7 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $configurationPath = $this->builder->build();
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         /** @var \DOMNodeList $logEntries */
         $logEntries = $this->queryXpath($xml, '/phpunit/logging/log');
@@ -137,7 +137,7 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $configurationPath = $this->builder->build();
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         /** @var \DOMNodeList $filterNodes */
         $filterNodes = $this->queryXpath($xml, '/phpunit/filter/whitelist/directory');
@@ -149,7 +149,7 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $configurationPath = $this->builder->build();
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         /** @var \DOMNodeList $filterNodes */
         $filterNodes = $this->queryXpath($xml, '/phpunit/filter/whitelist/directory');
@@ -161,7 +161,7 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $configurationPath = $this->builder->build();
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         /** @var \DOMNodeList $filterNodes */
         $filterNodes = $this->queryXpath($xml, '/phpunit/@printerClass');

--- a/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -49,12 +49,12 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     protected function setUp()
     {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->workspace = \sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
 
         $this->fileSystem = new Filesystem();
         $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);
 
-        $this->pathToProject = p(realpath(__DIR__ . '/../../../../Fixtures/Files/phpunit/project-path'));
+        $this->pathToProject = p(\realpath(__DIR__ . '/../../../../Fixtures/Files/phpunit/project-path'));
 
         $projectDir = '/project/dir';
         $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit.xml';
@@ -72,7 +72,7 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $this->builder = new MutationConfigBuilder(
             $this->tmpDir,
-            file_get_contents($phpunitXmlPath),
+            \file_get_contents($phpunitXmlPath),
             $this->xmlConfigurationHelper,
             $projectDir
         );
@@ -99,11 +99,11 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $configurationPath = $this->builder->build($this->mutant);
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         $resultAutoLoaderFilePath = $this->queryXpath($xml, '/phpunit/@bootstrap')[0]->nodeValue;
 
-        $expectedCustomAutoloadFilePath = sprintf(
+        $expectedCustomAutoloadFilePath = \sprintf(
             '%s/interceptor.autoload.%s.infection.php',
             $this->tmpDir,
             self::HASH
@@ -118,18 +118,18 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpuit_without_bootstrap.xml';
         $this->builder = new MutationConfigBuilder(
             $this->tmpDir,
-            file_get_contents($phpunitXmlPath),
+            \file_get_contents($phpunitXmlPath),
             $this->xmlConfigurationHelper,
             'project/dir'
         );
 
         $configurationPath = $this->builder->build($this->mutant);
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         $resultAutoLoaderFilePath = $this->queryXpath($xml, '/phpunit/@bootstrap')[0]->nodeValue;
 
-        $expectedCustomAutoloadFilePath = sprintf(
+        $expectedCustomAutoloadFilePath = \sprintf(
             '%s/interceptor.autoload.%s.infection.php',
             $this->tmpDir,
             self::HASH
@@ -144,7 +144,7 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $configurationPath = $this->builder->build($this->mutant);
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         $value = $this->queryXpath($xml, '/phpunit/@stopOnFailure')[0]->nodeValue;
 
@@ -157,7 +157,7 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $configurationPath = $this->builder->build($this->mutant);
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         $value = $this->queryXpath($xml, '/phpunit/@colors')[0]->nodeValue;
 
@@ -174,14 +174,14 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $this->builder = new MutationConfigBuilder(
             $this->tmpDir,
-            file_get_contents($phpunitXmlPath),
+            \file_get_contents($phpunitXmlPath),
             $xmlConfigurationHelper,
             $this->pathToProject
         );
 
         $configurationPath = $this->builder->build($this->mutant);
 
-        $this->assertEquals(1, $this->queryXpath(file_get_contents($configurationPath), '/phpunit/testsuite')->length);
+        $this->assertEquals(1, $this->queryXpath(\file_get_contents($configurationPath), '/phpunit/testsuite')->length);
     }
 
     public function test_it_removes_original_loggers()
@@ -190,7 +190,7 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $configurationPath = $this->builder->build($this->mutant);
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
         $nodeList = $this->queryXpath($xml, '/phpunit/logging/log[@type="coverage-html"]');
 
         $this->assertSame(0, $nodeList->length);
@@ -202,7 +202,7 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $configurationPath = $this->builder->build($this->mutant);
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         /** @var \DOMNodeList $filterNodes */
         $filterNodes = $this->queryXpath($xml, '/phpunit/@printerClass');
@@ -218,7 +218,7 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $configurationPath = $this->builder->build($this->mutant);
 
-        $xml = file_get_contents($configurationPath);
+        $xml = \file_get_contents($configurationPath);
 
         $files = [];
         $nodes = $this->queryXpath($xml, '/phpunit/testsuites/testsuite/file');

--- a/tests/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
@@ -22,7 +22,7 @@ class PathReplacerTest extends TestCase
 
     protected function setUp()
     {
-        $this->projectPath = p(realpath(__DIR__ . '/../../../../Fixtures/Files/phpunit/project-path'));
+        $this->projectPath = p(\realpath(__DIR__ . '/../../../../Fixtures/Files/phpunit/project-path'));
     }
 
     /**

--- a/tests/TestFramework/PhpUnit/Coverage/CoverageXmlParserTest.php
+++ b/tests/TestFramework/PhpUnit/Coverage/CoverageXmlParserTest.php
@@ -29,12 +29,12 @@ class CoverageXmlParserTest extends TestCase
 
     protected function getXml()
     {
-        $xml = file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpunit/coverage-xml/index.xml');
+        $xml = \file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpunit/coverage-xml/index.xml');
 
         // replace dummy source path with the real path
-        return preg_replace(
+        return \preg_replace(
             '/(source=\").*?(\")/',
-            sprintf('$1%s$2', realpath($this->srcDir)),
+            \sprintf('$1%s$2', \realpath($this->srcDir)),
             $xml
         );
     }
@@ -51,9 +51,9 @@ class CoverageXmlParserTest extends TestCase
     {
         $coverage = $this->parser->parse($this->getXml());
 
-        $zeroLevelAbsolutePath = realpath($this->tempDir . '/zeroLevel.php');
-        $firstLevelAbsolutePath = realpath($this->tempDir . '/FirstLevel/firstLevel.php');
-        $secondLevelAbsolutePath = realpath($this->tempDir . '/FirstLevel/SecondLevel/secondLevel.php');
+        $zeroLevelAbsolutePath = \realpath($this->tempDir . '/zeroLevel.php');
+        $firstLevelAbsolutePath = \realpath($this->tempDir . '/FirstLevel/firstLevel.php');
+        $secondLevelAbsolutePath = \realpath($this->tempDir . '/FirstLevel/SecondLevel/secondLevel.php');
 
         $this->assertArrayHasKey($zeroLevelAbsolutePath, $coverage);
         $this->assertArrayHasKey($firstLevelAbsolutePath, $coverage);
@@ -71,7 +71,7 @@ class CoverageXmlParserTest extends TestCase
 
     public function test_it_adds_by_method_coverage_data()
     {
-        $firstLevelAbsolutePath = realpath($this->tempDir . '/FirstLevel/firstLevel.php');
+        $firstLevelAbsolutePath = \realpath($this->tempDir . '/FirstLevel/firstLevel.php');
         $expectedByMethodArray = [
             'mutate' => [
                 'startLine' => 19,

--- a/tests/Utils/TmpDirectoryCreatorTest.php
+++ b/tests/Utils/TmpDirectoryCreatorTest.php
@@ -33,7 +33,7 @@ class TmpDirectoryCreatorTest extends TestCase
     {
         $this->fileSystem = new Filesystem();
         $this->creator = new TmpDirectoryCreator($this->fileSystem);
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->workspace = \sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
     }
 
     protected function tearDown()


### PR DESCRIPTION
This PR:

* [x] Adds the `native_function_invocation` rule
* [x] Runs `composer cs:fix`

>* **native_function_invocation**
Add leading ``\`` before function invocation of internal function to speed up resolving.
*Risky rule: risky when any of the functions are overridden.*
Configuration options:
> - ``exclude`` (``array``): list of functions to ignore; defaults to ``[]``