### PR TITLE
Pretty formatting for error message when xdebug and phpdbg are not used

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -4,9 +4,6 @@
  *
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
-use Infection\Php\ConfigBuilder;
-use Infection\Php\XdebugHandler;
-
 $files = [
     __DIR__ . '/../../../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
@@ -35,20 +32,5 @@ if (!defined('INFECTION_COMPOSER_INSTALL')) {
 }
 
 require INFECTION_COMPOSER_INSTALL;
-
-$isDebuggerDisabled = empty((string) getenv(XdebugHandler::ENV_DISABLE_XDEBUG));
-
-$xdebug = new XdebugHandler(new ConfigBuilder(sys_get_temp_dir()));
-$xdebug->check();
-unset($xdebug);
-
-if (PHP_SAPI !== 'phpdbg' && $isDebuggerDisabled && !extension_loaded('xdebug')) {
-    fwrite(
-        STDERR,
-        'You need to use phpdbg or install and enable xdebug in order to allow for code coverage generation.' . PHP_EOL
-    );
-
-    die(1);
-}
 
 $container = require __DIR__ . '/container.php';

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -47,6 +47,7 @@ use Symfony\Component\Process\Process;
 
 /**
  * @method Application getApplication()
+ * @method SymfonyStyle getIO()
  */
 class InfectionCommand extends BaseCommand
 {
@@ -432,7 +433,7 @@ class InfectionCommand extends BaseCommand
             }
         }
 
-        $this->io = new SymfonyStyle($input, $output);
+        $this->io = $this->getApplication()->getIO();
         $this->eventDispatcher = $this->getContainer()->get('dispatcher');
     }
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -78,16 +78,19 @@ ASCII;
         $this->io = new SymfonyStyle($input, $output);
 
         if (PHP_SAPI === 'phpdbg') {
-            $this->io->note(sprintf(self::RUNNING_WITH_NOTE, PHP_SAPI));
+            $this->io->writeln(sprintf(self::RUNNING_WITH_NOTE, PHP_SAPI));
         } elseif ($this->isXdebugLoaded) {
-            $this->io->note(sprintf(self::RUNNING_WITH_NOTE, 'xdebug'));
+            $this->io->writeln(sprintf(self::RUNNING_WITH_NOTE, 'xdebug'));
         }
 
         $xdebug = new XdebugHandler(new ConfigBuilder(sys_get_temp_dir()));
         $xdebug->check();
 
         if (PHP_SAPI !== 'phpdbg' && $this->isDebuggerDisabled && !$this->isXdebugLoaded) {
-            $this->io->error('You need to use phpdbg or install and enable xdebug in order to allow for code coverage generation.');
+            $this->io->error([
+                'Neither phpdbg or xdebug has been found. One of those is required by Infection in order to generate coverage data. Either:',
+                '- Enable xdebug and run infection again' . PHP_EOL . '- Use phpdbg: phpdbg -qrr infection',
+            ]);
 
             return 1;
         }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -26,6 +26,7 @@ class Application extends BaseApplication
 {
     const NAME = 'Infection - PHP Mutation Testing Framework';
     const VERSION = '@package_version@';
+    const RUNNING_WITH_NOTE = 'You are running Infection with %s enabled.';
     const LOGO = <<<'ASCII'
     ____      ____          __  _
    /  _/___  / __/__  _____/ /_(_)___  ____ 
@@ -76,9 +77,9 @@ ASCII;
         $this->io = new SymfonyStyle($input, $output);
 
         if (PHP_SAPI === 'phpdbg') {
-            $this->io->note('You are running Infection with phpdbg enabled.');
+            $this->io->note(sprintf(self::RUNNING_WITH_NOTE, PHP_SAPI));
         } elseif ($this->isXdebugLoaded) {
-            $this->io->note('You are running Infection with xdebug enabled.');
+            $this->io->note(sprintf(self::RUNNING_WITH_NOTE, 'xdebug'));
         }
 
         $xdebug = new XdebugHandler(new ConfigBuilder(sys_get_temp_dir()));

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -59,7 +59,8 @@ ASCII;
     public function __construct(Container $container, string $name = self::NAME, string $version = self::VERSION)
     {
         $this->container = $container;
-        $this->isDebuggerDisabled = empty((string) getenv(XdebugHandler::ENV_DISABLE_XDEBUG));
+        $this->isDebuggerDisabled = ('' === trim((string) getenv(XdebugHandler::ENV_DISABLE_XDEBUG)));
+        $this->isXdebugLoaded = \extension_loaded('xdebug');
 
         parent::__construct($name, $version);
     }
@@ -84,12 +85,11 @@ ASCII;
 
         $xdebug = new XdebugHandler(new ConfigBuilder(sys_get_temp_dir()));
         $xdebug->check();
-        unset($xdebug);
 
-        if (PHP_SAPI !== 'phpdbg' && $this->isDebuggerDisabled && !\extension_loaded('xdebug')) {
+        if (PHP_SAPI !== 'phpdbg' && $this->isDebuggerDisabled && !$this->isXdebugLoaded) {
             $this->io->error('You need to use phpdbg or install and enable xdebug in order to allow for code coverage generation.');
 
-            die(1);
+            return 1;
         }
 
         return parent::run($input, $output);


### PR DESCRIPTION
This PR is bringing pretty formatting for the error message (which @theofidry suggested to do in the https://github.com/infection/infection/issues/137) when phpdbg and xdebug are not used.

Also we will add notes when Infection is running via phpdbg or xdebug.

Note for phpdbg (the same will be for xdebug).
![Image with phpdbg](https://i.imgur.com/x2mwcNj.png)

When phpdbg and xdebug are not enabled
![Image](https://i.imgur.com/SmmnJPU.png)
