### PR TITLE
Use existing coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 env:
   global:
-    - INFECTION_FLAGS='--threads=4 --min-msi=60 --min-covered-msi=88'
+    - INFECTION_FLAGS='--threads=4 --min-msi=62 --min-covered-msi=90'
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ matrix:
 
 env:
   global:
-    - INFECTION_FLAGS='--threads=4 --min-msi=62 --min-covered-msi=90'
+    - INFECTION_FLAGS='--threads=4 --min-msi=62 --min-covered-msi=90 --coverage=coverage'
+    - PHPUNIT_BIN='vendor/bin/phpunit --coverage-clover=clover.xml --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml'
 
 cache:
   directories:
@@ -50,7 +51,7 @@ install:
 script:
   - composer analyze
   - if [[ $PHPDBG != 1 ]]; then xdebug-enable; fi
-  - if [[ $PHPDBG != 1 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml; else phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - if [[ $PHPDBG != 1 ]]; then $PHPUNIT_BIN; else phpdbg -qrr $PHPUNIT_BIN; fi
   - ./tests/e2e_tests
   - if [[ $PHPDBG != 1 ]]; then bin/infection $INFECTION_FLAGS; else phpdbg -qrr bin/infection $INFECTION_FLAGS; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 env:
   global:
-    - INFECTION_FLAGS='--threads=4 --min-msi=58 --min-covered-msi=88'
+    - INFECTION_FLAGS='--threads=4 --min-msi=60 --min-covered-msi=88'
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 env:
   global:
-    - INFECTION_FLAGS='--threads=4 --min-msi=62 --min-covered-msi=90 --coverage=coverage'
+    - INFECTION_FLAGS='--threads=4 --min-msi=62 --min-covered-msi=88 --coverage=coverage'
     - PHPUNIT_BIN='vendor/bin/phpunit --coverage-clover=clover.xml --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml'
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 env:
   global:
-    - INFECTION_FLAGS='--threads=4 --min-msi=59 --min-covered-msi=88'
+    - INFECTION_FLAGS='--threads=4 --min-msi=58 --min-covered-msi=88'
 
 cache:
   directories:

--- a/app/container.php
+++ b/app/container.php
@@ -31,6 +31,7 @@ use PhpParser\PrettyPrinter\Standard;
 use Pimple\Container;
 use SebastianBergmann\Diff\Differ as BaseDiffer;
 use Symfony\Component\Filesystem\Filesystem;
+use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
 
 $c = new Container();
 
@@ -69,6 +70,12 @@ $c['coverage.dir.phpspec'] = function (Container $c) {
 };
 
 $c['phpunit.junit.file.path'] = function (Container $c) {
+    $filePath = sprintf('%s/%s', $c['coverage.path'], PhpUnitAdapter::JUNIT_FILE_NAME);
+
+    if (!file_exists($filePath)) {
+        throw CoverageDoesNotExistException::forJunit($filePath);
+    }
+
     return sprintf('%s/%s', $c['coverage.path'], PhpUnitAdapter::JUNIT_FILE_NAME);
 };
 

--- a/app/container.php
+++ b/app/container.php
@@ -31,7 +31,6 @@ use PhpParser\PrettyPrinter\Standard;
 use Pimple\Container;
 use SebastianBergmann\Diff\Differ as BaseDiffer;
 use Symfony\Component\Filesystem\Filesystem;
-use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
 
 $c = new Container();
 
@@ -70,12 +69,6 @@ $c['coverage.dir.phpspec'] = function (Container $c) {
 };
 
 $c['phpunit.junit.file.path'] = function (Container $c) {
-    $filePath = sprintf('%s/%s', $c['coverage.path'], PhpUnitAdapter::JUNIT_FILE_NAME);
-
-    if (!file_exists($filePath)) {
-        throw CoverageDoesNotExistException::forJunit($filePath);
-    }
-
     return sprintf('%s/%s', $c['coverage.path'], PhpUnitAdapter::JUNIT_FILE_NAME);
 };
 

--- a/app/container.php
+++ b/app/container.php
@@ -56,12 +56,20 @@ $c['tmp.dir.creator'] = function (Container $c): TmpDirectoryCreator {
     return new TmpDirectoryCreator($c['filesystem']);
 };
 
-$c['coverage.dir.phpunit'] = function (Container $c): string {
-    return $c['tmp.dir'] . '/' . CodeCoverageData::PHP_UNIT_COVERAGE_DIR;
+$c['tmp.dir'] = function (Container $c): string {
+    return $c['tmp.dir.creator']->createAndGet($c['infection.config']->getTmpDir());
 };
 
-$c['coverage.dir.phpspec'] = function (Container $c): string {
-    return $c['tmp.dir'] . '/' . CodeCoverageData::PHP_SPEC_COVERAGE_DIR;
+$c['coverage.dir.phpunit'] = function (Container $c) {
+    return sprintf('%s/%s', $c['coverage.path'], CodeCoverageData::PHP_UNIT_COVERAGE_DIR);
+};
+
+$c['coverage.dir.phpspec'] = function (Container $c) {
+    return sprintf('%s/%s', $c['coverage.path'], CodeCoverageData::PHP_SPEC_COVERAGE_DIR);
+};
+
+$c['phpunit.junit.file.path'] = function (Container $c) {
+    return sprintf('%s/%s', $c['coverage.path'], PhpUnitAdapter::JUNIT_FILE_NAME);
 };
 
 $c['locator'] = function (Container $c): Locator {
@@ -104,10 +112,6 @@ $c['testframework.config.locator'] = function (Container $c): TestFrameworkConfi
 
 $c['diff.colorizer'] = function (): DiffColorizer {
     return new DiffColorizer();
-};
-
-$c['phpunit.junit.file.path'] = function (Container $c): string {
-    return $c['tmp.dir'] . '/' . PhpUnitAdapter::JUNIT_FILE_NAME;
 };
 
 $c['test.file.data.provider.phpunit'] = function (Container $c): TestFileDataProvider {

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -157,7 +157,7 @@ class InfectionCommand extends BaseCommand
     {
         $container = $this->getContainer();
         $testFrameworkKey = $input->getOption('test-framework');
-        $skipCoverage = strlen($input->getOption('coverage')) > 0;
+        $skipCoverage = strlen(trim($input->getOption('coverage'))) > 0;
         $adapter = $container->get('test.framework.factory')->create($testFrameworkKey, $skipCoverage);
 
         $metricsCalculator = new MetricsCalculator();

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -168,10 +168,7 @@ class InfectionCommand extends BaseCommand
         $testFrameworkOptions = $this->getTestFrameworkExtraOptions($testFrameworkKey);
 
         $initialTestsRunner = new InitialTestsRunner($processBuilder, $this->eventDispatcher);
-        $initialTestSuitProcess = $initialTestsRunner->run(
-            $testFrameworkOptions->getForInitialProcess(),
-            $skipCoverage
-        );
+        $initialTestSuitProcess = $initialTestsRunner->run($testFrameworkOptions->getForInitialProcess(), $skipCoverage);
 
         if (!$initialTestSuitProcess->isSuccessful()) {
             $this->logInitialTestsDoNotPass($initialTestSuitProcess, $testFrameworkKey);

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -155,7 +155,6 @@ class InfectionCommand extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        // todo throw exception if one of the report is absent
         $container = $this->getContainer();
         $testFrameworkKey = $input->getOption('test-framework');
         $skipCoverage = strlen($input->getOption('coverage')) > 0;

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -10,8 +10,6 @@ namespace Infection\Console;
 
 use Infection\Command;
 use Infection\Config\InfectionConfig;
-use Infection\TestFramework\Coverage\CodeCoverageData;
-use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
 use Pimple\Container;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -118,28 +118,15 @@ ASCII;
         };
 
         $this->container['coverage.path'] = function (Container $c) use ($input): string {
-            $existingCoveragePath = $this->getExistingCoveragePath(
-                $input,
-                $c['infection.config']->getPhpUnitConfigDir(),
-                $this->container['filesystem']
-            );
+            $existingCoveragePath = trim($input->getOption('coverage'));
 
-            return $existingCoveragePath ?: $c['tmp.dir'];
+            if ($existingCoveragePath === '') {
+                return $c['tmp.dir'];
+            }
+
+            return $c['filesystem']->isAbsolutePath($existingCoveragePath)
+                ? $existingCoveragePath
+                : sprintf('%s/%s', getcwd(), $existingCoveragePath);
         };
-    }
-
-    private function getExistingCoveragePath(InputInterface $input, string $configLocation, Filesystem $fileSystem): string
-    {
-        $existingCoveragePath = trim($input->getOption('coverage'));
-
-        if ($existingCoveragePath === '') {
-            return '';
-        }
-
-        if ($fileSystem->isAbsolutePath($existingCoveragePath)) {
-            return $existingCoveragePath;
-        }
-
-        return sprintf('%s/%s', $configLocation, $existingCoveragePath);
     }
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -118,22 +118,23 @@ ASCII;
         };
 
         $this->container['coverage.path'] = function (Container $c) use ($input): string {
-            $existingCoveragePath = $this->getExistingCoveragePath($input, $c['infection.config']->getPhpUnitConfigDir());
+            $existingCoveragePath = $this->getExistingCoveragePath(
+                $input,
+                $c['infection.config']->getPhpUnitConfigDir(),
+                $this->container['filesystem']
+            );
 
             return $existingCoveragePath ?: $c['tmp.dir'];
         };
     }
 
-    private function getExistingCoveragePath(InputInterface $input, string $configLocation): string
+    private function getExistingCoveragePath(InputInterface $input, string $configLocation, Filesystem $fileSystem): string
     {
-        $existingCoveragePath = $input->getOption('coverage');
+        $existingCoveragePath = trim($input->getOption('coverage'));
 
         if ($existingCoveragePath === '') {
             return '';
         }
-
-        /** @var Filesystem $fileSystem */
-        $fileSystem = $this->container['filesystem'];
 
         if ($fileSystem->isAbsolutePath($existingCoveragePath)) {
             return $existingCoveragePath;

--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -36,12 +36,13 @@ final class ProcessBuilder
      * Creates process with enabled debugger as test framework is going to use in the code coverage.
      *
      * @param string $testFrameworkExtraOptions
+     * @param bool $skipCoverage
      *
      * @return Process
      */
-    public function getProcessForInitialTestRun(string $testFrameworkExtraOptions = ''): Process
+    public function getProcessForInitialTestRun(string $testFrameworkExtraOptions, bool $skipCoverage): Process
     {
-        $includeArgs = PHP_SAPI === 'phpdbg';
+        $includeArgs = PHP_SAPI === 'phpdbg' || $skipCoverage;
 
         return new Process(
             $this->testFrameworkAdapter->getExecutableCommandLine(

--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -14,7 +14,7 @@ use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Process;
 
-final class ProcessBuilder
+class ProcessBuilder
 {
     /**
      * @var AbstractTestFrameworkAdapter

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -99,7 +99,6 @@ class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
 
     public function onMutationTestingFinished(MutationTestingFinished $event)
     {
-        // TODO [doc] write test -> run mutation for just this file. Should be 100%, 100%, 100%,
         $this->outputFormatter->finish();
 
         if ($this->showMutations) {

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -39,9 +39,11 @@ class InitialTestsRunner
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    public function run(string $testFrameworkExtraOptions): Process
+    public function run(string $testFrameworkExtraOptions, bool $skipCoverage): Process
     {
-        $process = $this->processBuilder->getProcessForInitialTestRun($testFrameworkExtraOptions);
+        $process = $this->processBuilder->getProcessForInitialTestRun($testFrameworkExtraOptions, $skipCoverage);
+
+        var_dump($process->getCommandLine());
 
         $this->eventDispatcher->dispatch(new InitialTestSuiteStarted());
 

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -43,8 +43,6 @@ class InitialTestsRunner
     {
         $process = $this->processBuilder->getProcessForInitialTestRun($testFrameworkExtraOptions, $skipCoverage);
 
-        var_dump($process->getCommandLine());
-
         $this->eventDispatcher->dispatch(new InitialTestSuiteStarted());
 
         $process->run(function ($type) use ($process) {

--- a/src/TestFramework/Coverage/CoverageDoesNotExistException.php
+++ b/src/TestFramework/Coverage/CoverageDoesNotExistException.php
@@ -23,4 +23,9 @@ class CoverageDoesNotExistException extends InfectionException
             )
         );
     }
+
+    public static function forJunit(string $filePath)
+    {
+        return new self(sprintf('Coverage report `junit` is not found in %s', $filePath));
+    }
 }

--- a/src/TestFramework/Coverage/CoverageDoesNotExistException.php
+++ b/src/TestFramework/Coverage/CoverageDoesNotExistException.php
@@ -24,8 +24,13 @@ class CoverageDoesNotExistException extends InfectionException
         );
     }
 
-    public static function forJunit(string $filePath)
+    public static function forJunit(string $filePath): self
     {
         return new self(sprintf('Coverage report `junit` is not found in %s', $filePath));
+    }
+
+    public static function forFileAtPath(string $fileName, string $path): self
+    {
+        return new self(sprintf('Source file %s was not found at %s', $fileName, $path));
     }
 }

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -27,7 +27,7 @@ final class Factory
     /**
      * @var string
      */
-    private $tempDir;
+    private $tmpDir;
 
     /**
      * @var XmlConfigurationHelper
@@ -60,7 +60,7 @@ final class Factory
     private $versionParser;
 
     public function __construct(
-        string $tempDir,
+        string $tmpDir,
         string $projectDir,
         TestFrameworkConfigLocator $configLocator,
         XmlConfigurationHelper $xmlConfigurationHelper,
@@ -68,7 +68,7 @@ final class Factory
         InfectionConfig $infectionConfig,
         VersionParser $versionParser
     ) {
-        $this->tempDir = $tempDir;
+        $this->tmpDir = $tmpDir;
         $this->configLocator = $configLocator;
         $this->xmlConfigurationHelper = $xmlConfigurationHelper;
         $this->projectDir = $projectDir;
@@ -77,7 +77,7 @@ final class Factory
         $this->versionParser = $versionParser;
     }
 
-    public function create(string $adapterName): AbstractTestFrameworkAdapter
+    public function create(string $adapterName, bool $skipCoverage): AbstractTestFrameworkAdapter
     {
         if ($adapterName === TestFrameworkTypes::PHPUNIT) {
             $phpUnitConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPUNIT);
@@ -85,8 +85,15 @@ final class Factory
 
             return new PhpUnitAdapter(
                 new TestFrameworkExecutableFinder(TestFrameworkTypes::PHPUNIT, $this->infectionConfig->getPhpUnitCustomPath()),
-                new InitialConfigBuilder($this->tempDir, $phpUnitConfigContent, $this->xmlConfigurationHelper, $this->jUnitFilePath, $this->infectionConfig->getSourceDirs()),
-                new MutationConfigBuilder($this->tempDir, $phpUnitConfigContent, $this->xmlConfigurationHelper, $this->projectDir),
+                new InitialConfigBuilder(
+                    $this->tmpDir,
+                    $phpUnitConfigContent,
+                    $this->xmlConfigurationHelper,
+                    $this->jUnitFilePath,
+                    $this->infectionConfig->getSourceDirs(),
+                    $skipCoverage
+                ),
+                new MutationConfigBuilder($this->tmpDir, $phpUnitConfigContent, $this->xmlConfigurationHelper, $this->projectDir),
                 new ArgumentsAndOptionsBuilder(),
                 $this->versionParser
             );
@@ -97,8 +104,9 @@ final class Factory
 
             return new PhpSpecAdapter(
                 new TestFrameworkExecutableFinder(TestFrameworkTypes::PHPSPEC),
-                new PhpSpecInitialConfigBuilder($this->tempDir, $phpSpecConfigPath),
-                new PhpSpecMutationConfigBuilder($this->tempDir, $phpSpecConfigPath, $this->projectDir),
+                // todo $skipCoverage ?
+                new PhpSpecInitialConfigBuilder($this->tmpDir, $phpSpecConfigPath),
+                new PhpSpecMutationConfigBuilder($this->tmpDir, $phpSpecConfigPath, $this->projectDir),
                 new PhpSpecArgumentsAndOptionsBuilder(),
                 $this->versionParser
             );

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -104,8 +104,7 @@ final class Factory
 
             return new PhpSpecAdapter(
                 new TestFrameworkExecutableFinder(TestFrameworkTypes::PHPSPEC),
-                // todo $skipCoverage ?
-                new PhpSpecInitialConfigBuilder($this->tmpDir, $phpSpecConfigPath),
+                new PhpSpecInitialConfigBuilder($this->tmpDir, $phpSpecConfigPath, $skipCoverage),
                 new PhpSpecMutationConfigBuilder($this->tmpDir, $phpSpecConfigPath, $this->projectDir),
                 new PhpSpecArgumentsAndOptionsBuilder(),
                 $this->versionParser

--- a/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
@@ -20,9 +20,9 @@ abstract class AbstractYamlConfiguration
      */
     protected $parsedYaml;
 
-    public function __construct(string $tempDirectory, array $parsedYaml)
+    public function __construct(string $tmpDir, array $parsedYaml)
     {
-        $this->tempDirectory = $tempDirectory;
+        $this->tempDirectory = $tmpDir;
         $this->parsedYaml = $parsedYaml;
     }
 

--- a/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpSpec\Config;
 
-use Infection\TestFramework\Coverage\CodeCoverageData;
-
 abstract class AbstractYamlConfiguration
 {
     /**
@@ -33,21 +31,6 @@ abstract class AbstractYamlConfiguration
     protected function isCodeCoverageExtension(string $extensionName): bool
     {
         return strpos($extensionName, 'CodeCoverage') !== false;
-    }
-
-    protected function updateCodeCoveragePath(array &$parsedYaml)
-    {
-        foreach ($parsedYaml['extensions'] as $extensionName => &$options) {
-            if (!$this->isCodeCoverageExtension($extensionName)) {
-                continue;
-            }
-
-            $options['format'] = ['xml'];
-            $options['output'] = [
-                'xml' => $this->tempDirectory . '/' . CodeCoverageData::PHP_SPEC_COVERAGE_DIR,
-            ];
-        }
-        unset($options);
     }
 
     protected function hasCodeCoverageExtension(array $parsedYaml): bool

--- a/src/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilder.php
@@ -23,10 +23,16 @@ class InitialConfigBuilder implements ConfigBuilder
      */
     private $originalYamlConfigPath;
 
-    public function __construct(string $tempDirectory, string $originalYamlConfigPath)
+    /**
+     * @var bool
+     */
+    private $skipCoverage;
+
+    public function __construct(string $tempDirectory, string $originalYamlConfigPath, bool $skipCoverage)
     {
         $this->tempDirectory = $tempDirectory;
         $this->originalYamlConfigPath = $originalYamlConfigPath;
+        $this->skipCoverage = $skipCoverage;
     }
 
     public function build(): string
@@ -35,7 +41,8 @@ class InitialConfigBuilder implements ConfigBuilder
 
         $yamlConfiguration = new InitialYamlConfiguration(
             $this->tempDirectory,
-            Yaml::parse(file_get_contents($this->originalYamlConfigPath))
+            Yaml::parse(file_get_contents($this->originalYamlConfigPath)),
+            $this->skipCoverage
         );
 
         file_put_contents($path, $yamlConfiguration->getYaml());

--- a/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
@@ -18,9 +18,9 @@ class InitialYamlConfiguration extends AbstractYamlConfiguration
      */
     private $skipCoverage;
 
-    public function __construct(string $tempDirectory, array $parsedYaml, bool $skipCoverage)
+    public function __construct(string $tmpDir, array $parsedYaml, bool $skipCoverage)
     {
-        parent::__construct($tempDirectory, $parsedYaml);
+        parent::__construct($tmpDir, $parsedYaml);
 
         $this->skipCoverage = $skipCoverage;
     }

--- a/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
@@ -68,8 +68,6 @@ class InitialYamlConfiguration extends AbstractYamlConfiguration
             }
 
             unset($parsedYaml['extensions'][$extensionName]);
-
-            break;
         }
 
         unset($options);

--- a/src/TestFramework/PhpSpec/Config/MutationYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/MutationYamlConfiguration.php
@@ -17,9 +17,9 @@ class MutationYamlConfiguration extends AbstractYamlConfiguration
      */
     protected $customAutoloadFilePath;
 
-    public function __construct($tempDirectory, array $parsedYaml, string $customAutoloadFilePath)
+    public function __construct($tmpDir, array $parsedYaml, string $customAutoloadFilePath)
     {
-        parent::__construct($tempDirectory, $parsedYaml);
+        parent::__construct($tmpDir, $parsedYaml);
 
         $this->customAutoloadFilePath = $customAutoloadFilePath;
     }

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -135,7 +135,7 @@ class CoverageXmlParser
         }
 
         throw new \Exception(
-            spritnf('Source file %s was not found at %s', $fileName, $path));
+            sprintf('Source file %s was not found at %s', $fileName, $path));
     }
 
     private function getCoveredLinesData(\DOMNodeList $lineCoverageNodes): array

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -134,7 +134,8 @@ class CoverageXmlParser
             return $realPath;
         }
 
-        throw new \Exception('Source file was not found');
+        throw new \Exception(
+            spritnf('Source file %s was not found at %s', $fileName, $path));
     }
 
     private function getCoveredLinesData(\DOMNodeList $lineCoverageNodes): array

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpUnit\Coverage;
 
+use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
+
 class CoverageXmlParser
 {
     /**
@@ -134,8 +136,7 @@ class CoverageXmlParser
             return $realPath;
         }
 
-        throw new \Exception(
-            sprintf('Source file %s was not found at %s', $fileName, $path));
+        throw CoverageDoesNotExistException::forFileAtPath($fileName, $path);
     }
 
     private function getCoveredLinesData(\DOMNodeList $lineCoverageNodes): array

--- a/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
+++ b/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpUnit\Coverage;
 
+use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
 use Infection\TestFramework\Coverage\TestFileDataProvider;
 use Infection\TestFramework\Coverage\TestFileNameNotFoundException;
 
@@ -47,6 +48,10 @@ class PhpUnitTestFileDataProvider implements TestFileDataProvider
     private function getXPath(): \DOMXPath
     {
         if ($this->xPath === null) {
+            if (!file_exists($this->jUnitFilePath)) {
+                throw CoverageDoesNotExistException::forJunit($this->jUnitFilePath);
+            }
+
             $dom = new \DOMDocument();
             $dom->loadXML(file_get_contents($this->jUnitFilePath));
 

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/README.md
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/README.md
@@ -1,0 +1,3 @@
+# Provide existing coverage files
+
+* Ensure coverage is not created if existing coverage files are provided

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/composer.json
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/composer.json
@@ -5,10 +5,13 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^6.1",
+        "phpspec/phpspec": "^4.3",
+        "leanphp/phpspec-code-coverage": "^4.0"
     },
     "autoload": {
         "psr-4": {
+            "spec\\": "spec/",
             "Namespace_\\": "src/"
         }
     },

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/composer.json
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Namespace_\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Namespace_\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/expected-output.txt
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/expected-output.txt
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/expected-output.txt
@@ -1,6 +1,44 @@
-Total: 1
-Killed: 1
-Errored: 0
-Escaped: 0
-Timed Out: 0
-Not Covered: 0
+Total: 8
+Killed mutants:
+===============
+
+
+Mutator: Plus
+Line 9
+
+Mutator: PublicVisibility
+Line 7
+
+Mutator: TrueValue
+Line 12
+
+Mutator: FalseValue
+Line 14
+
+Mutator: NotIdentical
+Line 14
+
+Mutator: TrueValue
+Line 15
+
+Mutator: PublicVisibility
+Line 12
+
+Errors mutants:
+===============
+
+
+Escaped mutants:
+================
+
+
+Timed Out mutants:
+==================
+
+
+Not Covered mutants:
+====================
+
+
+Mutator: FalseValue
+Line 17

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/coverage-xml/SourceClass.php.xml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/coverage-xml/SourceClass.php.xml
@@ -2,20 +2,27 @@
 <phpunit xmlns="http://schema.phpunit.de/coverage/1.0">
   <file name="SourceClass.php" path="/">
     <totals>
-      <lines total="11" comments="0" code="11" executable="1" executed="1" percent="100.00"/>
-      <methods count="1" tested="1" percent="100.00"/>
+      <lines total="19" comments="0" code="19" executable="4" executed="3" percent="75.00"/>
+      <methods count="2" tested="1" percent="50.00"/>
       <functions count="0" tested="0" percent="0"/>
-      <classes count="1" tested="1" percent="100.00"/>
+      <classes count="1" tested="0" percent="0.00"/>
       <traits count="0" tested="0" percent="0"/>
     </totals>
-    <class name="Namespace_\SourceClass" start="5" executable="1" executed="1" crap="1">
+    <class name="Namespace_\SourceClass" start="5" executable="4" executed="3" crap="3.14">
       <package full="" name="" sub="" category=""/>
       <namespace name="Namespace_"/>
-      <method name="hello" signature="hello(): string" start="7" end="10" crap="1" executable="1" executed="1" coverage="100"/>
+      <method name="add" signature="add($num1, $num2)" start="7" end="10" crap="1" executable="1" executed="1" coverage="100"/>
+      <method name="isTrue" signature="isTrue($value = true)" start="12" end="18" crap="2.15" executable="3" executed="2" coverage="66.666666666667"/>
     </class>
     <coverage>
       <line nr="9">
-        <covered by="Namespace_\Test\SourceClassTest::test_hello"/>
+        <covered by="Namespace_\Test\SourceClassTest::test_it_adds"/>
+      </line>
+      <line nr="14">
+        <covered by="Namespace_\Test\SourceClassTest::test_it_returns_true"/>
+      </line>
+      <line nr="15">
+        <covered by="Namespace_\Test\SourceClassTest::test_it_returns_true"/>
       </line>
     </coverage>
     <source>
@@ -44,12 +51,13 @@
         <token name="T_WHITESPACE"> </token>
         <token name="T_FUNCTION">function</token>
         <token name="T_WHITESPACE"> </token>
-        <token name="T_STRING">hello</token>
+        <token name="T_STRING">add</token>
         <token name="T_OPEN_BRACKET">(</token>
-        <token name="T_CLOSE_BRACKET">)</token>
-        <token name="T_COLON">:</token>
+        <token name="T_VARIABLE">$num1</token>
+        <token name="T_COMMA">,</token>
         <token name="T_WHITESPACE"> </token>
-        <token name="T_STRING">string</token>
+        <token name="T_VARIABLE">$num2</token>
+        <token name="T_CLOSE_BRACKET">)</token>
       </line>
       <line no="8">
         <token name="T_WHITESPACE">    </token>
@@ -59,17 +67,77 @@
         <token name="T_WHITESPACE">        </token>
         <token name="T_RETURN">return</token>
         <token name="T_WHITESPACE"> </token>
-        <token name="T_CONSTANT_ENCAPSED_STRING">'hello'</token>
+        <token name="T_VARIABLE">$num1</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_PLUS">+</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_VARIABLE">$num2</token>
         <token name="T_SEMICOLON">;</token>
       </line>
       <line no="10">
         <token name="T_WHITESPACE">    </token>
         <token name="T_CLOSE_CURLY">}</token>
       </line>
-      <line no="11">
+      <line no="11"/>
+      <line no="12">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_PUBLIC">public</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_FUNCTION">function</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">isTrue</token>
+        <token name="T_OPEN_BRACKET">(</token>
+        <token name="T_VARIABLE">$value</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_EQUAL">=</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">true</token>
+        <token name="T_CLOSE_BRACKET">)</token>
+      </line>
+      <line no="13">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_OPEN_CURLY">{</token>
+      </line>
+      <line no="14">
+        <token name="T_WHITESPACE">        </token>
+        <token name="T_IF">if</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_OPEN_BRACKET">(</token>
+        <token name="T_VARIABLE">$value</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_IS_NOT_IDENTICAL">!==</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">false</token>
+        <token name="T_CLOSE_BRACKET">)</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_OPEN_CURLY">{</token>
+      </line>
+      <line no="15">
+        <token name="T_WHITESPACE">            </token>
+        <token name="T_RETURN">return</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">true</token>
+        <token name="T_SEMICOLON">;</token>
+      </line>
+      <line no="16">
+        <token name="T_WHITESPACE">        </token>
         <token name="T_CLOSE_CURLY">}</token>
       </line>
-      <line no="12"/>
+      <line no="17">
+        <token name="T_WHITESPACE">        </token>
+        <token name="T_RETURN">return</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">false</token>
+        <token name="T_SEMICOLON">;</token>
+      </line>
+      <line no="18">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_CLOSE_CURLY">}</token>
+      </line>
+      <line no="19">
+        <token name="T_CLOSE_CURLY">}</token>
+      </line>
+      <line no="20"/>
     </source>
   </file>
 </phpunit>

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/coverage-xml/SourceClass.php.xml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/coverage-xml/SourceClass.php.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<phpunit xmlns="http://schema.phpunit.de/coverage/1.0">
+  <file name="SourceClass.php" path="/">
+    <totals>
+      <lines total="11" comments="0" code="11" executable="1" executed="1" percent="100.00"/>
+      <methods count="1" tested="1" percent="100.00"/>
+      <functions count="0" tested="0" percent="0"/>
+      <classes count="1" tested="1" percent="100.00"/>
+      <traits count="0" tested="0" percent="0"/>
+    </totals>
+    <class name="Namespace_\SourceClass" start="5" executable="1" executed="1" crap="1">
+      <package full="" name="" sub="" category=""/>
+      <namespace name="Namespace_"/>
+      <method name="hello" signature="hello(): string" start="7" end="10" crap="1" executable="1" executed="1" coverage="100"/>
+    </class>
+    <coverage>
+      <line nr="9">
+        <covered by="Namespace_\Test\SourceClassTest::test_hello"/>
+      </line>
+    </coverage>
+    <source>
+      <line no="1">
+        <token name="T_OPEN_TAG">&lt;?php</token>
+      </line>
+      <line no="2"/>
+      <line no="3">
+        <token name="T_NAMESPACE">namespace</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">Namespace_</token>
+        <token name="T_SEMICOLON">;</token>
+      </line>
+      <line no="4"/>
+      <line no="5">
+        <token name="T_CLASS">class</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">SourceClass</token>
+      </line>
+      <line no="6">
+        <token name="T_OPEN_CURLY">{</token>
+      </line>
+      <line no="7">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_PUBLIC">public</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_FUNCTION">function</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">hello</token>
+        <token name="T_OPEN_BRACKET">(</token>
+        <token name="T_CLOSE_BRACKET">)</token>
+        <token name="T_COLON">:</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">string</token>
+      </line>
+      <line no="8">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_OPEN_CURLY">{</token>
+      </line>
+      <line no="9">
+        <token name="T_WHITESPACE">        </token>
+        <token name="T_RETURN">return</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_CONSTANT_ENCAPSED_STRING">'hello'</token>
+        <token name="T_SEMICOLON">;</token>
+      </line>
+      <line no="10">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_CLOSE_CURLY">}</token>
+      </line>
+      <line no="11">
+        <token name="T_CLOSE_CURLY">}</token>
+      </line>
+      <line no="12"/>
+    </source>
+  </file>
+</phpunit>

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/coverage-xml/index.xml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/coverage-xml/index.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<phpunit xmlns="http://schema.phpunit.de/coverage/1.0">
+  <build time="Fri Feb 9 17:52:50 GMT+0000 2018" phpunit="6.5.6" coverage="5.3.0">
+    <runtime name="PHP" version="7.1.7" url="https://secure.php.net/"/>
+    <driver name="xdebug" version="2.6.0RC2"/>
+  </build>
+  <project source="src">
+    <tests>
+      <test name="Namespace_\Test\SourceClassTest::test_hello" size="unknown" result="0" status="PASSED"/>
+    </tests>
+    <directory name="/">
+      <totals>
+        <lines total="11" comments="0" code="11" executable="1" executed="1" percent="100.00"/>
+        <methods count="1" tested="1" percent="100.00"/>
+        <functions count="0" tested="0" percent="0"/>
+        <classes count="1" tested="1" percent="100.00"/>
+        <traits count="0" tested="0" percent="0"/>
+      </totals>
+      <file name="SourceClass.php" href="SourceClass.php.xml">
+        <totals>
+          <lines total="11" comments="0" code="11" executable="1" executed="1" percent="100.00"/>
+          <methods count="1" tested="1" percent="100.00"/>
+          <functions count="0" tested="0" percent="0"/>
+          <classes count="1" tested="1" percent="100.00"/>
+          <traits count="0" tested="0" percent="0"/>
+        </totals>
+      </file>
+    </directory>
+  </project>
+</phpunit>

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/coverage-xml/index.xml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/coverage-xml/index.xml
@@ -1,27 +1,28 @@
 <?xml version="1.0"?>
 <phpunit xmlns="http://schema.phpunit.de/coverage/1.0">
-  <build time="Fri Feb 9 17:52:50 GMT+0000 2018" phpunit="6.5.6" coverage="5.3.0">
+  <build time="Sat Feb 10 17:56:09 GMT+0000 2018" phpunit="6.5.6" coverage="5.3.0">
     <runtime name="PHP" version="7.1.7" url="https://secure.php.net/"/>
     <driver name="xdebug" version="2.6.0RC2"/>
   </build>
   <project source="src">
     <tests>
-      <test name="Namespace_\Test\SourceClassTest::test_hello" size="unknown" result="0" status="PASSED"/>
+      <test name="Namespace_\Test\SourceClassTest::test_it_adds" size="unknown" result="0" status="PASSED"/>
+      <test name="Namespace_\Test\SourceClassTest::test_it_returns_true" size="unknown" result="0" status="PASSED"/>
     </tests>
     <directory name="/">
       <totals>
-        <lines total="11" comments="0" code="11" executable="1" executed="1" percent="100.00"/>
-        <methods count="1" tested="1" percent="100.00"/>
+        <lines total="19" comments="0" code="19" executable="4" executed="3" percent="75.00"/>
+        <methods count="2" tested="1" percent="50.00"/>
         <functions count="0" tested="0" percent="0"/>
-        <classes count="1" tested="1" percent="100.00"/>
+        <classes count="1" tested="0" percent="0.00"/>
         <traits count="0" tested="0" percent="0"/>
       </totals>
       <file name="SourceClass.php" href="SourceClass.php.xml">
         <totals>
-          <lines total="11" comments="0" code="11" executable="1" executed="1" percent="100.00"/>
-          <methods count="1" tested="1" percent="100.00"/>
+          <lines total="19" comments="0" code="19" executable="4" executed="3" percent="75.00"/>
+          <methods count="2" tested="1" percent="50.00"/>
           <functions count="0" tested="0" percent="0"/>
-          <classes count="1" tested="1" percent="100.00"/>
+          <classes count="1" tested="0" percent="0.00"/>
           <traits count="0" tested="0" percent="0"/>
         </totals>
       </file>

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/phpspec-coverage-xml/SourceClass.php.xml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/phpspec-coverage-xml/SourceClass.php.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0"?>
+<phpunit xmlns="http://schema.phpunit.de/coverage/1.0">
+  <file name="SourceClass.php" path="/">
+    <totals>
+      <lines total="19" comments="0" code="19" executable="4" executed="3" percent="75.00"/>
+      <methods count="2" tested="1" percent="50.00"/>
+      <functions count="0" tested="0" percent="0"/>
+      <classes count="1" tested="0" percent="0.00"/>
+      <traits count="0" tested="0" percent="0"/>
+    </totals>
+    <class name="Namespace_\SourceClass" start="5" executable="4" executed="3" crap="3.14">
+      <package full="" name="" sub="" category=""/>
+      <namespace name="Namespace_"/>
+      <method name="add" signature="add($num1, $num2)" start="7" end="10" crap="1" executable="1" executed="1" coverage="100"/>
+      <method name="isTrue" signature="isTrue($value = true)" start="12" end="18" crap="2.15" executable="3" executed="2" coverage="66.666666666667"/>
+    </class>
+    <coverage>
+      <line nr="9">
+        <covered by="spec\Namespace_\SourceClassSpec::it_adds_numbers"/>
+      </line>
+      <line nr="14">
+        <covered by="spec\Namespace_\SourceClassSpec::it_returns_true"/>
+      </line>
+      <line nr="15">
+        <covered by="spec\Namespace_\SourceClassSpec::it_returns_true"/>
+      </line>
+    </coverage>
+    <source>
+      <line no="1">
+        <token name="T_OPEN_TAG">&lt;?php</token>
+      </line>
+      <line no="2"/>
+      <line no="3">
+        <token name="T_NAMESPACE">namespace</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">Namespace_</token>
+        <token name="T_SEMICOLON">;</token>
+      </line>
+      <line no="4"/>
+      <line no="5">
+        <token name="T_CLASS">class</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">SourceClass</token>
+      </line>
+      <line no="6">
+        <token name="T_OPEN_CURLY">{</token>
+      </line>
+      <line no="7">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_PUBLIC">public</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_FUNCTION">function</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">add</token>
+        <token name="T_OPEN_BRACKET">(</token>
+        <token name="T_VARIABLE">$num1</token>
+        <token name="T_COMMA">,</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_VARIABLE">$num2</token>
+        <token name="T_CLOSE_BRACKET">)</token>
+      </line>
+      <line no="8">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_OPEN_CURLY">{</token>
+      </line>
+      <line no="9">
+        <token name="T_WHITESPACE">        </token>
+        <token name="T_RETURN">return</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_VARIABLE">$num1</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_PLUS">+</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_VARIABLE">$num2</token>
+        <token name="T_SEMICOLON">;</token>
+      </line>
+      <line no="10">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_CLOSE_CURLY">}</token>
+      </line>
+      <line no="11"/>
+      <line no="12">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_PUBLIC">public</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_FUNCTION">function</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">isTrue</token>
+        <token name="T_OPEN_BRACKET">(</token>
+        <token name="T_VARIABLE">$value</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_EQUAL">=</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">true</token>
+        <token name="T_CLOSE_BRACKET">)</token>
+      </line>
+      <line no="13">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_OPEN_CURLY">{</token>
+      </line>
+      <line no="14">
+        <token name="T_WHITESPACE">        </token>
+        <token name="T_IF">if</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_OPEN_BRACKET">(</token>
+        <token name="T_VARIABLE">$value</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_IS_NOT_IDENTICAL">!==</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">false</token>
+        <token name="T_CLOSE_BRACKET">)</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_OPEN_CURLY">{</token>
+      </line>
+      <line no="15">
+        <token name="T_WHITESPACE">            </token>
+        <token name="T_RETURN">return</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">true</token>
+        <token name="T_SEMICOLON">;</token>
+      </line>
+      <line no="16">
+        <token name="T_WHITESPACE">        </token>
+        <token name="T_CLOSE_CURLY">}</token>
+      </line>
+      <line no="17">
+        <token name="T_WHITESPACE">        </token>
+        <token name="T_RETURN">return</token>
+        <token name="T_WHITESPACE"> </token>
+        <token name="T_STRING">false</token>
+        <token name="T_SEMICOLON">;</token>
+      </line>
+      <line no="18">
+        <token name="T_WHITESPACE">    </token>
+        <token name="T_CLOSE_CURLY">}</token>
+      </line>
+      <line no="19">
+        <token name="T_CLOSE_CURLY">}</token>
+      </line>
+      <line no="20"/>
+    </source>
+  </file>
+</phpunit>

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/phpspec-coverage-xml/index.xml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/phpspec-coverage-xml/index.xml
@@ -4,7 +4,7 @@
     <runtime name="PHP" version="7.1.7" url="https://secure.php.net/"/>
     <driver name="xdebug" version="2.6.0RC2"/>
   </build>
-  <project source="/Users/maksrafalko/sites/infection/tests/Fixtures/e2e/Provide_Existing_Coverage/src">
+  <project source="src">
     <tests>
       <test name="spec\Namespace_\SourceClassSpec::it_adds_numbers" size="unknown" result="0" status="PASSED"/>
       <test name="spec\Namespace_\SourceClassSpec::it_returns_true" size="unknown" result="0" status="PASSED"/>

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/phpspec-coverage-xml/index.xml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/phpspec-coverage-xml/index.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<phpunit xmlns="http://schema.phpunit.de/coverage/1.0">
+  <build time="Sat Feb 10 21:54:12 GMT+0000 2018" phpunit="5.3.0" coverage="5.3.0">
+    <runtime name="PHP" version="7.1.7" url="https://secure.php.net/"/>
+    <driver name="xdebug" version="2.6.0RC2"/>
+  </build>
+  <project source="/Users/maksrafalko/sites/infection/tests/Fixtures/e2e/Provide_Existing_Coverage/src">
+    <tests>
+      <test name="spec\Namespace_\SourceClassSpec::it_adds_numbers" size="unknown" result="0" status="PASSED"/>
+      <test name="spec\Namespace_\SourceClassSpec::it_returns_true" size="unknown" result="0" status="PASSED"/>
+    </tests>
+    <directory name="/">
+      <totals>
+        <lines total="19" comments="0" code="19" executable="4" executed="3" percent="75.00"/>
+        <methods count="2" tested="1" percent="50.00"/>
+        <functions count="0" tested="0" percent="0"/>
+        <classes count="1" tested="0" percent="0.00"/>
+        <traits count="0" tested="0" percent="0"/>
+      </totals>
+      <file name="SourceClass.php" href="SourceClass.php.xml">
+        <totals>
+          <lines total="19" comments="0" code="19" executable="4" executed="3" percent="75.00"/>
+          <methods count="2" tested="1" percent="50.00"/>
+          <functions count="0" tested="0" percent="0"/>
+          <classes count="1" tested="0" percent="0.00"/>
+          <traits count="0" tested="0" percent="0"/>
+        </totals>
+      </file>
+    </directory>
+  </project>
+</phpunit>

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/phpunit.junit.xml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/phpunit.junit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="Test Suite" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.008013">
+    <testsuite name="Namespace_\Test\SourceClassTest" file="tests/SourceClassTest.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.008013">
+      <testcase name="test_hello" class="Namespace_\Test\SourceClassTest" classname="Namespace_.Test.SourceClassTest" file="tests/SourceClassTest.php" line="10" assertions="1" time="0.008013"/>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/phpunit.junit.xml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection-coverage/phpunit.junit.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="Test Suite" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.008013">
-    <testsuite name="Namespace_\Test\SourceClassTest" file="tests/SourceClassTest.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.008013">
-      <testcase name="test_hello" class="Namespace_\Test\SourceClassTest" classname="Namespace_.Test.SourceClassTest" file="tests/SourceClassTest.php" line="10" assertions="1" time="0.008013"/>
+  <testsuite name="Test Suite" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.010499">
+    <testsuite name="Namespace_\Test\SourceClassTest" file="tests/SourceClassTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.010499">
+      <testcase name="test_it_adds" class="Namespace_\Test\SourceClassTest" classname="Namespace_.Test.SourceClassTest" file="tests/SourceClassTest.php" line="10" assertions="1" time="0.007975"/>
+      <testcase name="test_it_returns_true" class="Namespace_\Test\SourceClassTest" classname="Namespace_.Test.SourceClassTest" file="tests/SourceClassTest.php" line="16" assertions="1" time="0.002524"/>
     </testsuite>
   </testsuite>
 </testsuites>

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection.json
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 25,
+    "tmpDir": "infection-cache",
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection-log.txt"
+    }
+}

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection.json
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection.json
@@ -7,6 +7,6 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "debug": "infection-log.txt"
     }
 }

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/phpspec.yml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/phpspec.yml
@@ -1,0 +1,7 @@
+suites:
+  source_suite:
+    namespace: Namespace_
+    psr4_prefix: Namespace_
+
+extensions:
+  LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension: ~

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/phpunit.xml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/run_tests.bash
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/run_tests.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o pipefail
+set -e pipefail
 
 readonly INFECTION="../../../../bin/infection --coverage=infection-coverage"
 
@@ -25,11 +25,17 @@ then
     exit 1;
 fi
 
-#if [ "$PHPDBG" = "1" ]
-#then
-#    phpdbg -qrr $INFECTION  --coverage="infection-coverage" --test-framework=phpspec
-#else
-#    php $INFECTION
-#fi
-#
-#diff expected-output.txt infection-log.txt
+if [ "$PHPDBG" = "1" ]
+then
+    phpdbg -qrr $INFECTION --test-framework=phpspec
+else
+    php $INFECTION --test-framework=phpspec
+fi
+
+diff expected-output.txt infection-log.txt
+
+if [ -d "infection-cache/infection/phpspec-coverage-xml" ]
+then
+    echo "Infection should not generate phpspec-coverage-xml if path with existing files has been provided"
+    exit 1;
+fi

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/run_tests.bash
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/run_tests.bash
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+readonly INFECTION="../../../../bin/infection --coverage=infection-coverage"
+
+if [ "$PHPDBG" = "1" ]
+then
+    phpdbg -qrr $INFECTION
+else
+    php $INFECTION
+fi
+
+diff expected-output.txt infection-log.txt
+
+if [ -f "infection-cache/infection/phpunit.junit.xml" ]
+then
+    echo "Infection should not generate phpunit.junit.xml if path with existing files has been provided"
+    exit 1;
+fi
+
+if [ -d "infection-cache/infection/coverage-xml" ]
+then
+    echo "Infection should not generate coverage-xml if path with existing files has been provided"
+    exit 1;
+fi
+
+#if [ "$PHPDBG" = "1" ]
+#then
+#    phpdbg -qrr $INFECTION  --coverage="infection-coverage" --test-framework=phpspec
+#else
+#    php $INFECTION
+#fi
+#
+#diff expected-output.txt infection-log.txt

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/spec/SourceClassSpec.php
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/spec/SourceClassSpec.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace spec\Namespace_;
+
+use PhpSpec\ObjectBehavior;
+
+class SourceClassSpec extends ObjectBehavior
+{
+    public function it_adds_numbers()
+    {
+        $this->add(1, 2)->shouldReturn(3);
+    }
+
+    public function it_returns_true()
+    {
+        $this->isTrue()->shouldReturn(true);
+    }
+}

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Namespace_;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/src/SourceClass.php
@@ -4,8 +4,16 @@ namespace Namespace_;
 
 class SourceClass
 {
-    public function hello(): string
+    public function add($num1, $num2)
     {
-        return 'hello';
+        return $num1 + $num2;
+    }
+
+    public function isTrue($value = true)
+    {
+        if ($value !== false) {
+            return true;
+        }
+        return false;
     }
 }

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/tests/SourceClassTest.php
@@ -7,9 +7,15 @@ use PHPUnit\Framework\TestCase;
 
 class SourceClassTest extends TestCase
 {
-    public function test_hello()
+    public function test_it_adds()
     {
-        $sourceClass = new SourceClass();
-        $this->assertSame('hello', $sourceClass->hello());
+        $source = new SourceClass();
+        $this->assertSame(3, $source->add(1,2));
+    }
+
+    public function test_it_returns_true()
+    {
+        $source = new SourceClass();
+        $this->assertTrue($source->isTrue());
     }
 }

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Namespace_\Test;
+
+use Namespace_\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/Fixtures/e2e/Test_Frameworks/run_tests.bash
+++ b/tests/Fixtures/e2e/Test_Frameworks/run_tests.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o pipefail
+set -e pipefail
 
 readonly INFECTION=../../../../bin/infection
 
@@ -19,7 +19,7 @@ if [ "$PHPDBG" = "1" ]
 then
     phpdbg -qrr $INFECTION --test-framework=phpspec
 else
-    php $INFECTION
+    php $INFECTION --test-framework=phpspec
 fi
 
 diff expected-output.txt infection-log.txt

--- a/tests/Fixtures/e2e/standard_script.bash
+++ b/tests/Fixtures/e2e/standard_script.bash
@@ -2,7 +2,7 @@
 
 readonly INFECTION=../../../../bin/infection
 
-set -o pipefail
+set -e pipefail
 
 if [ "$PHPDBG" = "1" ]
 then

--- a/tests/Process/Builder/ProcessBuilderTest.php
+++ b/tests/Process/Builder/ProcessBuilderTest.php
@@ -23,7 +23,7 @@ class ProcessBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $builder = new ProcessBuilder($fwAdapter, 100);
 
-        $process = $builder->getProcessForInitialTestRun();
+        $process = $builder->getProcessForInitialTestRun('', false);
 
         $this->assertContains('getExecutableCommandLine', $process->getCommandLine());
         $this->assertNull($process->getTimeout());

--- a/tests/Process/Runner/InitialTestsRunnerTest.php
+++ b/tests/Process/Runner/InitialTestsRunnerTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Tests\Process\Runner;
+
+use Infection\EventDispatcher\EventDispatcherInterface;
+use Infection\Events\InitialTestCaseCompleted;
+use Infection\Events\InitialTestSuiteFinished;
+use Infection\Events\InitialTestSuiteStarted;
+use Infection\Process\Builder\ProcessBuilder;
+use Infection\Process\Runner\InitialTestsRunner;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Symfony\Component\Process\Process;
+
+class InitialTestsRunnerTest extends MockeryTestCase
+{
+    public function test_it_dispatches_events()
+    {
+        $process = Mockery::mock(Process::class);
+        $process->shouldReceive('run');
+
+        $processBuilder = Mockery::mock(ProcessBuilder::class);
+        $processBuilder
+            ->shouldReceive('getProcessForInitialTestRun')
+            ->withArgs(['', false])
+            ->andReturn($process);
+
+        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
+        $eventDispatcher->shouldReceive('dispatch')->with(Mockery::type(InitialTestSuiteStarted::class));
+        $eventDispatcher->shouldReceive('dispatch')->with(Mockery::type(InitialTestCaseCompleted::class));
+        $eventDispatcher->shouldReceive('dispatch')->with(Mockery::type(InitialTestSuiteFinished::class));
+
+        $testRunner = new InitialTestsRunner($processBuilder, $eventDispatcher);
+
+        $testRunner->run('', false);
+    }
+}

--- a/tests/TestFramework/FactoryTest.php
+++ b/tests/TestFramework/FactoryTest.php
@@ -31,6 +31,6 @@ class FactoryTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         );
 
         $this->expectException(\InvalidArgumentException::class);
-        $factory->create('Fake Test Framework');
+        $factory->create('Fake Test Framework', false);
     }
 }

--- a/tests/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
@@ -47,7 +47,7 @@ class InitialConfigBuilderTest extends TestCase
     {
         $originalYamlConfigPath = __DIR__ . '/../../../../Fixtures/Files/phpspec/phpspec.yml';
 
-        $builder = new InitialConfigBuilder($this->tmpDir, $originalYamlConfigPath);
+        $builder = new InitialConfigBuilder($this->tmpDir, $originalYamlConfigPath, false);
 
         $this->assertSame($this->tmpDir . '/phpspecConfiguration.initial.infection.yml', $builder->build());
     }

--- a/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
+++ b/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
@@ -30,9 +30,9 @@ class InitialYamlConfigurationTest extends TestCase
         'bootstrap' => '/path/to/adc',
     ];
 
-    protected function getConfigurationObject(array $configArray = [])
+    protected function getConfigurationObject(array $configArray = [], bool $skipCoverage = false)
     {
-        return new InitialYamlConfiguration($this->tempDir, $configArray ?: $this->defaultConfig, false);
+        return new InitialYamlConfiguration($this->tempDir, $configArray ?: $this->defaultConfig, $skipCoverage);
     }
 
     /**
@@ -53,6 +53,15 @@ class InitialYamlConfigurationTest extends TestCase
         $expectedPath = $this->tempDir . '/' . CodeCoverageData::PHP_SPEC_COVERAGE_DIR;
 
         $this->assertSame($expectedPath, $parsedYaml['extensions']['PhpSpecCodeCoverageExtension']['output']['xml']);
+    }
+
+    public function test_it_removes_coverage_extension_if_it_coverage_should_be_skipped()
+    {
+        $configuration = $this->getConfigurationObject([], true);
+
+        $parsedYaml = Yaml::parse($configuration->getYaml());
+
+        $this->assertArrayNotHasKey('PhpSpecCodeCoverageExtension', $parsedYaml['extensions']);
     }
 
     public function test_it_preserves_options_form_coverage_extension()

--- a/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
+++ b/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
@@ -32,7 +32,7 @@ class InitialYamlConfigurationTest extends TestCase
 
     protected function getConfigurationObject(array $configArray = [])
     {
-        return new InitialYamlConfiguration($this->tempDir, $configArray ?: $this->defaultConfig);
+        return new InitialYamlConfiguration($this->tempDir, $configArray ?: $this->defaultConfig, false);
     }
 
     /**

--- a/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
+++ b/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
@@ -19,6 +19,7 @@ class InitialYamlConfigurationTest extends TestCase
 
     private $defaultConfig = [
         'extensions' => [
+            'SomeOtherExtension' => [],
             'PhpSpecCodeCoverageExtension' => [
                 'format' => ['xml', 'text'],
                 'output' => [
@@ -38,9 +39,29 @@ class InitialYamlConfigurationTest extends TestCase
     /**
      * @expectedException \Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException
      */
-    public function test_it_throws_exception_when_no_coverage_extension()
+    public function test_it_throws_exception_when_extensions_array_is_empty()
     {
         $configuration = $this->getConfigurationObject(['extensions' => []]);
+
+        $configuration->getYaml();
+    }
+
+    /**
+     * @expectedException \Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException
+     */
+    public function test_it_throws_exception_when_extensions_array_is_not_present()
+    {
+        $configuration = $this->getConfigurationObject(['bootstrap' => '/path/to/adc']);
+
+        $configuration->getYaml();
+    }
+
+    /**
+     * @expectedException \Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException
+     */
+    public function test_it_throws_exception_when_no_extensions_have_no_coverage_one()
+    {
+        $configuration = $this->getConfigurationObject(['extensions' => ['a' => []]]);
 
         $configuration->getYaml();
     }
@@ -55,13 +76,16 @@ class InitialYamlConfigurationTest extends TestCase
         $this->assertSame($expectedPath, $parsedYaml['extensions']['PhpSpecCodeCoverageExtension']['output']['xml']);
     }
 
-    public function test_it_removes_coverage_extension_if_coverage_should_be_skipped()
+    public function test_it_removes_all_coverage_extensions_if_coverage_should_be_skipped()
     {
-        $configuration = $this->getConfigurationObject([], true);
+        $configuration = $this->getConfigurationObject(
+            ['extensions' => ['CodeCoverage1' => [], 'CodeCoverage2' => []]],
+            true
+        );
 
         $parsedYaml = Yaml::parse($configuration->getYaml());
 
-        $this->assertArrayNotHasKey('PhpSpecCodeCoverageExtension', $parsedYaml['extensions']);
+        $this->assertCount(0, $parsedYaml['extensions']);
     }
 
     public function test_it_preserves_options_form_coverage_extension()

--- a/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
+++ b/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
@@ -55,7 +55,7 @@ class InitialYamlConfigurationTest extends TestCase
         $this->assertSame($expectedPath, $parsedYaml['extensions']['PhpSpecCodeCoverageExtension']['output']['xml']);
     }
 
-    public function test_it_removes_coverage_extension_if_it_coverage_should_be_skipped()
+    public function test_it_removes_coverage_extension_if_coverage_should_be_skipped()
     {
         $configuration = $this->getConfigurationObject([], true);
 

--- a/tests/TestFramework/PhpSpec/Config/MutationYamlConfigurationTest.php
+++ b/tests/TestFramework/PhpSpec/Config/MutationYamlConfigurationTest.php
@@ -20,6 +20,7 @@ class MutationYamlConfigurationTest extends TestCase
 
     private $defaultConfig = [
         'extensions' => [
+            'FirstExtension' => [],
             'PhpSpecCodeCoverageExtension' => [
                 'format' => ['xml', 'text'],
                 'output' => [
@@ -46,8 +47,18 @@ class MutationYamlConfigurationTest extends TestCase
 
         $parsedYaml = Yaml::parse($configuration->getYaml());
 
-        $this->assertCount(1, $parsedYaml['extensions']);
+        $this->assertCount(2, $parsedYaml['extensions']);
         $this->assertArrayNotHasKey('PhpSpecCodeCoverageExtension', $parsedYaml['extensions']);
+    }
+
+    public function test_it_returns_same_extensions_when_no_coverage_extension_found()
+    {
+        $originalParsedYaml = ['bootstrap' => '/path/to/adc', 'extensions' => []];
+        $configuration = $this->getConfigurationObject($originalParsedYaml);
+
+        $parsedYaml = Yaml::parse($configuration->getYaml());
+
+        $this->assertCount(0, $parsedYaml['extensions']);
     }
 
     public function test_it_sets_custom_autoloader_path()

--- a/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -76,7 +76,8 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             file_get_contents($phpunitXmlPath),
             new XmlConfigurationHelper($replacer),
             $jUnitFilePath,
-            $srcDirs
+            $srcDirs,
+            false
         );
     }
 

--- a/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -62,7 +62,7 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->fileSystem->remove($this->workspace);
     }
 
-    private function createConfigBuilder($phpUnitXmlConfigPath = null)
+    private function createConfigBuilder(string $phpUnitXmlConfigPath = null, bool $skipCoverage = false)
     {
         $phpunitXmlPath = $phpUnitXmlConfigPath ?: __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit.xml';
 
@@ -77,7 +77,7 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             new XmlConfigurationHelper($replacer),
             $jUnitFilePath,
             $srcDirs,
-            false
+            $skipCoverage
         );
     }
 
@@ -129,6 +129,19 @@ class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertSame($this->tmpDir . '/coverage-xml', $logEntries[0]->getAttribute('target'));
         $this->assertSame('coverage-xml', $logEntries[0]->getAttribute('type'));
         $this->assertSame('junit', $logEntries[1]->getAttribute('type'));
+    }
+
+    public function test_it_does_not_add_coverage_loggers_if_should_be_skipped()
+    {
+        $this->createConfigBuilder(null, true);
+        $configurationPath = $this->builder->build();
+
+        $xml = file_get_contents($configurationPath);
+
+        /** @var \DOMNodeList $logEntries */
+        $logEntries = $this->queryXpath($xml, '/phpunit/logging/log');
+
+        $this->assertSame(0, $logEntries->length);
     }
 
     public function test_it_creates_coverage_filter_whitelist_node_if_does_not_exist()

--- a/tests/e2e_tests
+++ b/tests/e2e_tests
@@ -45,5 +45,5 @@ then
     exit 1
 fi
 
-echo "Success"
+echo -e "\nSuccess"
 exit 0


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/94
- [x] Allow to provide the path to folder with existing coverage report(s)
- [x] Disable Xdebug for Initial tests run if existing coverage provided
- [x] Documentation (https://github.com/infection/site/pull/20)
- [x] Reuse coverage on Travis to speed up builds
