### PR TITLE
Add pre-push hook to reduce the number of failed builds on Travis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "cs:check": [
             "wget -nc http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar",
             "chmod a+x php-cs-fixer-v2.phar",
-            "./php-cs-fixer-v2.phar fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no --allow-risky=yes"
+            "./php-cs-fixer-v2.phar fix --config=.php_cs.dist -v --dry-run --stop-on-violation --allow-risky=yes"
         ],
         "cs:fix": [
             "./php-cs-fixer-v2.phar fix --config=.php_cs.dist -v --allow-risky=yes"

--- a/devTools/pre-push
+++ b/devTools/pre-push
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+composer analyze && ./vendor/bin/phpunit

--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ln -sf $(pwd)/devTools/pre-push $(pwd)/.git/hooks/pre-push


### PR DESCRIPTION
* Analyze code and run unit tests on push
* Use cache for PHPCsFixer

Push can be installed by `./setup_environment.sh`
Hooks can be skipped with `--no-verify` option like `git push origin HEAD --no-verify`