### PR TITLE
Reuse created mutant files to avoid traversing and pretty printing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 env:
   global:
-    - INFECTION_FLAGS='--threads=4 --min-msi=62 --min-covered-msi=88 --coverage=coverage'
+    - INFECTION_FLAGS='--threads=4 --min-msi=61 --min-covered-msi=88 --coverage=coverage'
     - PHPUNIT_BIN='vendor/bin/phpunit --coverage-clover=clover.xml --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml'
 
 cache:


### PR DESCRIPTION
Implemented [this idea](https://github.com/infection/infection/issues/75#issuecomment-357546689)

On my laptop, it saves 2s for infection itself. Not much, but still I think there is no need to traverse, pretty print files if we already have mutant on the filesystem.