### PR TITLE
Fix performance issue in SourceFilesFinder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 env:
   global:
-    - INFECTION_FLAGS='--threads=4 --min-msi=62 --min-covered-msi=88 --coverage=coverage'
+    - INFECTION_FLAGS='--threads=4 --min-msi=61 --min-covered-msi=88 --coverage=coverage'
     - PHPUNIT_BIN='vendor/bin/phpunit --coverage-clover=clover.xml --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml'
 
 cache:

--- a/src/Finder/Iterator/RealPathFilterIterator.php
+++ b/src/Finder/Iterator/RealPathFilterIterator.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+declare(strict_types=1);
+
+namespace Infection\Finder\Iterator;
+
+use Symfony\Component\Finder\Iterator\MultiplePcreFilterIterator;
+
+class RealPathFilterIterator extends MultiplePcreFilterIterator
+{
+    /**
+     * Filters the iterator values.
+     *
+     * @return bool true if the value should be kept, false otherwise
+     */
+    public function accept()
+    {
+        $filename = $this->current()->getRealPath();
+
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $filename = str_replace('\\', '/', $filename);
+        }
+
+        return $this->isAccepted($filename);
+    }
+
+    /**
+     * Converts strings to regexp.
+     *
+     * PCRE patterns are left unchanged.
+     *
+     * Default conversion:
+     *     'lorem/ipsum/dolor' ==>  'lorem\/ipsum\/dolor/'
+     *
+     * Use only / as directory separator (on Windows also).
+     *
+     * @param string $str Pattern: regexp or dirname
+     *
+     * @return string regexp corresponding to a given string or regexp
+     */
+    protected function toRegex($str)
+    {
+        return $this->isRegex($str) ? $str : '/' . preg_quote($str, '/') . '/';
+    }
+}


### PR DESCRIPTION
During testing infection with `phpdbg`, I noticed that it takes 10+ seconds to run 7 tests from `SourceFilesFinderTest` file. 

The reason is this line:

https://github.com/infection/infection/blob/44751a5835ec44e7f2754ddcf21a2012f8219c23/src/Finder/SourceFilesFinder.php#L43

If `--filter` is provided, infection tries to find particular files in *all* folders in the root of the project, including `vendor`. 

The more vendors project has, the more seconds it takes to find files when infection is used with `--filter` option.

Unfortunately, Symfony Finder does not allow to pass `source.directories` array from `infection.json` and then filter files starting from the root folder, because it uses relative paths

https://github.com/symfony/finder/blob/8b08180f2b7ccb41062366b9ad91fbc4f1af8601/Iterator/PathFilterIterator.php#L29

It means if we pass `src` to `$finder->in('src')` method, we can't use `$finder->path('src/Some/Folder/File.php')` anymore, since all file names start without `src/` prefix.

To save compatibility with previous infection version, where we allow relative paths like `src/whatever.php`, there is a new iterator wrapper that works with realPath instead of relative path.

Before:

```bash
vendor/bin/phpunit
PHPUnit 6.1.0 by Sebastian Bergmann and contributors.

...............................................................  63 / 397 ( 15%)
............................................................... 126 / 397 ( 31%)
............................................................... 189 / 397 ( 47%)
............................................................... 252 / 397 ( 63%)
............................................................... 315 / 397 ( 79%)
............................................................... 378 / 397 ( 95%)
...................                                             397 / 397 (100%)

Time: 13.23 seconds, Memory: 16.00MB
------^

OK (397 tests, 671 assertions)
```

After:

```bash
vendor/bin/phpunit
PHPUnit 6.1.0 by Sebastian Bergmann and contributors.

...............................................................  63 / 397 ( 15%)
............................................................... 126 / 397 ( 31%)
............................................................... 189 / 397 ( 47%)
............................................................... 252 / 397 ( 63%)
............................................................... 315 / 397 ( 79%)
............................................................... 378 / 397 ( 95%)
...................                                             397 / 397 (100%)

Time: 3.59 seconds, Memory: 16.00MB
------^

OK (397 tests, 671 assertions)
```

