### PR TITLE
Add contributing and PR github templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# How to contribute
+
+Contributions are always welcome. Here are a few guidelines to be aware of:
+ 
+ - Include unit or e2e tests for new behaviours introduced by PRs.
+ - Fixed bugs MUST be covered by test(s) to avoid regression.
+ - If you are on Unix-like system, run `./setup_environment.sh` to set up `pre-push` git hook.
+ - All code must follow the `PSR-2` coding standard. Please see [PSR-2](http://www.php-fig.org/psr/psr-2/) for more details. To make this as easy as possible, we use PHPCSFixer running two simple composer scripts: `composer cs:check` and `composer cs:fix`.
+ - Before implementing a new big feature, consider creating a new Issue on Github with RFC label. It will save your time when the core team is not going to accept it or has good recommendations about how to proceed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+This PR:
+
+- [ ] Adds new feature ...
+- [ ] Covered by tests
+- [ ] Doc PR: https://github.com/infection/site/pull/XXX
+
+<!--
+Remove if not relevant
+-->
+
+Fixes https://github.com/infection/infection/XXX
+
+<!--
+- Replace this comment by a detailed description of what your PR is solving.
+- Use labels for different kinds of PR like `performance`, `feature`, etc.
+- Use Milestone to show when this code is going to be released.
+
+Deprecations? don't forget to update UPGRADE-*.md files
+-->


### PR DESCRIPTION
In order to 

* Improve DX
* Force contributors to write tests
* Force contributors to create Documentation PRs when required
* Force contributors to set up `pre-push` hook
* Familiarize contributors with accepted standards and used tools

there are two new files that automatically recognized by Github and used when new PR is created.