### PR TITLE
Allow coverage of function signatures of traits

### DIFF
--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -84,6 +84,10 @@ class CoverageXmlParser
 
         $methodsCoverageNodes = $xPath->query('/phpunit/file/class/method');
 
+        if (!$methodsCoverageNodes->length) {
+            $methodsCoverageNodes = $xPath->query('/phpunit/file/trait/method');
+        }
+
         return [
             $sourceFilePath => [
                 'byLine' => $this->getCoveredLinesData($lineCoverageNodes),

--- a/tests/Fixtures/Files/phpunit/coverage-xml/FirstLevel/SecondLevel/secondLevelTrait.php.xml
+++ b/tests/Fixtures/Files/phpunit/coverage-xml/FirstLevel/SecondLevel/secondLevelTrait.php.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright © 2017 Maks Rafalko
+  ~
+  ~ License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+  -->
+
+<phpunit xmlns="http://schema.phpunit.de/coverage/1.0">
+    <file name="secondLevelTrait.php" path="/FirstLevel/SecondLevel">
+        <totals>
+            <lines total="36" comments="6" code="30" executable="6" executed="4" percent="13.44"/>
+            <methods count="2" tested="0" percent="0.00"/>
+            <functions count="0" tested="0" percent="0"/>
+            <classes count="1" tested="0" percent="0.00"/>
+            <traits count="0" tested="0" percent="0"/>
+        </totals>
+        <trait name="Plus" start="11" executable="6" executed="4" crap="5.93">
+            <package full="" name="" sub="" category=""/>
+            <namespace name="Infection\Mutator\Arithmetic"/>
+            <method name="mutate" signature="mutate(Node $node)" start="19" end="22" crap="2" executable="1" executed="0" coverage="0"/>
+            <method name="shouldMutate" signature="shouldMutate(Node $node) : bool" start="24" end="35" crap="4.13" executable="5" executed="4" coverage="80"/>
+        </trait>
+        <coverage>
+            <line nr="11">
+                <covered by="Infection\Tests\Mutator\Arithmetic\PlusTest::test_it_should_mutate_plus_expression"/>
+                <covered by="Infection\Tests\Mutator\Arithmetic\PlusTest::test_it_should_not_mutate_plus_with_arrays"/>
+            </line>
+        </coverage>
+    </file>
+</phpunit>

--- a/tests/Fixtures/Files/phpunit/coverage-xml/index.xml
+++ b/tests/Fixtures/Files/phpunit/coverage-xml/index.xml
@@ -57,6 +57,15 @@
               <traits count="0" tested="0" percent="0"/>
             </totals>
           </file>
+          <file name="secondLevelTrait.php" href="FirstLevel/SecondLevel/secondLevelTrait.php.xml">
+            <totals>
+              <lines total="114" comments="22" code="92" executable="59" executed="0" percent="0.00"/>
+              <methods count="6" tested="0" percent="0.00"/>
+              <functions count="0" tested="0" percent="0"/>
+              <classes count="1" tested="0" percent="0.00"/>
+              <traits count="0" tested="0" percent="0"/>
+            </totals>
+          </file>
         </directory>
       </directory>
       <file name="zeroLevel.php" href="zeroLevel.php.xml">

--- a/tests/Fixtures/e2e/Trait_Coverage/README.md
+++ b/tests/Fixtures/e2e/Trait_Coverage/README.md
@@ -1,0 +1,153 @@
+# Correct Coverage of Traits
+
+* https://github.com/infection/infection/issues/189
+
+## Summary
+Although coverage of traits is correctly set in the coverage files, infections thinks some mutants are not covered, even though they are
+
+## Full Ticket
+
+| Question    | Answer
+| ------------| ---------------
+| Infection version | 0.7.1
+| Test Framework version | PHPUnit 6.5.6 
+| PHP version | PHP 7.1.14-1+ubuntu16.04.1+deb.sury.org+1
+| Platform    | Ubuntu 16.04.3 LTS
+| Github Repo | https://github.com/addiks/symfony_rdm
+
+Infection seems to ignore coverage on traits and just marks them as "not covered" even if they are marked as covered in the coverage-xml. The phpunit-test's also fail when i apply the proposed mutant-patch and execute the tests. That proves that the trait actually was executed in the tests.
+
+To demonstrate the issue as directly as possible i have created an example in my most recent project on github in a separate branch. You can see the [failing build here](https://travis-ci.org/addiks/symfony_rdm/builds/343762710). In that build you can also see the actual error and how infection get's executed.
+
+Also see: [The trait getting tested](https://github.com/addiks/symfony_rdm/blob/example_for_infection_trait_issue/Symfony/ExampleTrait.php), [the class implementing the trait that get's tested](https://github.com/addiks/symfony_rdm/blob/example_for_infection_trait_issue/Symfony/ExampleClass.php) and the [test that test's them both](https://github.com/addiks/symfony_rdm/blob/example_for_infection_trait_issue/Tests/Symfony/ExampleClassTest.php) and the  [coverage-xml that states that the trait actually get's executed](https://github.com/infection/infection/files/1739768/infection-trait-coverage.xml.zip) (lines 968 to 978).
+
+<!-- Please past your phpunit.xml[.dist] if no Github link to the repo provided -->
+<details>
+ <summary>phpunit.xml</summary>
+ 
+ ```xml
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+
+    <testsuites>
+        <testsuite name="Addiks-RDMBundle">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>DataLoader</directory>
+            <directory>Doctrine</directory>
+            <directory>Exception</directory>
+            <directory>Hydration</directory>
+            <directory>Mapping</directory>
+            <directory>Symfony</directory>
+            <directory>ValueResolver</directory>
+            <exclude>
+                <directory>vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+</phpunit>
+ ```
+</details>
+
+<!-- Remove this section if not needed -->
+<details>
+ <summary>Output with issue</summary>
+ 
+ ```bash
+$ vendor/bin/infection -s -vv --min-msi=100
+    ____      ____          __  _
+   /  _/___  / __/__  _____/ /_(_)___  ____ 
+   / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \
+ _/ // / / / __/  __/ /__/ /_/ / /_/ / / / /
+/___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/
+ 
+    0 [>---------------------------] < 1 secRunning initial test suite...
+
+PHPUnit version: 6.5.6
+
+   88 [============================] 7 secs
+
+Generate mutants...
+
+Processing source code files: 49/49
+Creating mutated files and processes: 174/174
+.: killed, M: escaped, S: uncovered, E: fatal error, T: timed out
+
+...EEEEE..........EEEE........................EE..   ( 50 / 174)
+..E...EEE...EE.E.EEE.E...EEEEEEE...E......EEEE....   (100 / 174)
+E................E......EEE.E.EEEE.S....EEEE.EE...   (150 / 174)
+.E...E...E.EE...E.EEEEEE                             (174 / 174)
+Escaped mutants:
+================
+
+
+Not covered mutants:
+====================
+
+
+1) /home/travis/build/addiks/symfony_rdm/Symfony/ExampleTrait.php:28    [M] PublicVisibility
+
+--- Original
++++ New
+@@ @@
+-    public function getFoo() : string
++    protected function getFoo() : string
+
+
+
+174 mutations were generated:
+     111 mutants were killed
+       1 mutants were not covered by tests
+       0 covered mutants were not detected
+      62 errors were encountered
+       0 time outs were encountered
+
+Metrics:
+         Mutation Score Indicator (MSI): 99%
+         Mutation Code Coverage: 99%
+         Covered Code MSI: 100%
+
+Please note that some mutants will inevitably be harmless (i.e. false positives).
+                                                                                
+ [ERROR] The minimum required MSI percentage should be 100%, but actual is 99%. 
+         Improve your tests!                                                    
+                                                                                
+The command "vendor/bin/infection -s -vv --min-msi=100" exited with 1.
+ ```
+</details>
+
+<details>
+ <summary>PHPUnit output with applied mutant-patch</summary>
+
+```bash
+$ vendor/bin/phpunit
+PHPUnit 6.5.6 by Sebastian Bergmann and contributors.
+
+............................................................E.... 65 / 82 ( 79%)
+.................                                                 82 / 82 (100%)
+
+Time: 351 ms, Memory: 14.00MB
+
+There was 1 error:
+
+1) Addiks\RDMBundle\Tests\Symfony\ExampleClassTest::shouldHaveFoo
+Error: Call to protected method Addiks\RDMBundle\Symfony\ExampleClass::getFoo() from context 'Addiks\RDMBundle\Tests\Symfony\ExampleClassTest'
+
+/usr/workspace/Privat/SymfonyRDM/Tests/Symfony/ExampleClassTest.php:34
+
+ERRORS!
+Tests: 82, Assertions: 109, Errors: 1.
+```
+</details>

--- a/tests/Fixtures/e2e/Trait_Coverage/composer.json
+++ b/tests/Fixtures/e2e/Trait_Coverage/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Trait_Coverage\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Trait_Coverage\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Trait_Coverage/expected-output.txt
+++ b/tests/Fixtures/e2e/Trait_Coverage/expected-output.txt
@@ -1,0 +1,41 @@
+Total: 7
+Killed mutants:
+===============
+
+
+Mutator: PublicVisibility
+Line 10
+
+Mutator: PublicVisibility
+Line 7
+
+Mutator: TrueValue
+Line 12
+
+Mutator: Plus
+Line 15
+
+Mutator: PublicVisibility
+Line 12
+
+Errors mutants:
+===============
+
+
+Escaped mutants:
+================
+
+
+Timed Out mutants:
+==================
+
+
+Not Covered mutants:
+====================
+
+
+Mutator: DecrementInteger
+Line 18
+
+Mutator: OneZeroInteger
+Line 18

--- a/tests/Fixtures/e2e/Trait_Coverage/infection.json
+++ b/tests/Fixtures/e2e/Trait_Coverage/infection.json
@@ -1,0 +1,11 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "debug": "infection-log.txt"
+    }
+}

--- a/tests/Fixtures/e2e/Trait_Coverage/phpunit.xml
+++ b/tests/Fixtures/e2e/Trait_Coverage/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Trait_Coverage/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Trait_Coverage/src/SourceClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Trait_Coverage;
+
+
+class SourceClass
+{
+    use SourceTrait;
+
+    public function hello(): string
+    {
+        return 'hello'. $this->world();
+    }
+}

--- a/tests/Fixtures/e2e/Trait_Coverage/src/SourceTrait.php
+++ b/tests/Fixtures/e2e/Trait_Coverage/src/SourceTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Trait_Coverage;
+
+trait SourceTrait
+{
+    public function world()
+    {
+        return ' World!';
+    }
+
+    public function add($num1, $num2, $value = true): int
+    {
+        if($value) {
+            return $num1 + $num2;
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixtures/e2e/Trait_Coverage/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Trait_Coverage/tests/SourceClassTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Trait_Coverage\Test;
+
+use Trait_Coverage\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello World!', $sourceClass->hello());
+    }
+    public function test_world()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame(' World!', $sourceClass->world());
+    }
+
+    public function test_add()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame(3, $sourceClass->add(1,2));
+    }
+}

--- a/tests/TestFramework/PhpUnit/Coverage/CoverageXmlParserTest.php
+++ b/tests/TestFramework/PhpUnit/Coverage/CoverageXmlParserTest.php
@@ -44,7 +44,7 @@ class CoverageXmlParserTest extends TestCase
         $coverage = $this->parser->parse($this->getXml());
 
         // zeroLevel / firstLevel / secondLevel
-        $this->assertCount(3, $coverage);
+        $this->assertCount(4, $coverage);
     }
 
     public function test_it_has_correct_coverage_data_for_each_file()
@@ -92,5 +92,31 @@ class CoverageXmlParserTest extends TestCase
         $coverage = $this->parser->parse($this->getXml());
 
         $this->assertSame($expectedByMethodArray, $coverage[$firstLevelAbsolutePath]['byMethod']);
+    }
+
+    public function test_it_adds_by_method_coverage_data_for_traits()
+    {
+        $pathToTrait = realpath($this->tempDir . '/FirstLevel/SecondLevel/secondLevelTrait.php');
+
+        $expectedByMethodArray = [
+            'mutate' => [
+                'startLine' => 19,
+                'endLine' => 22,
+                'executable' => 1,
+                'executed' => 0,
+                'coverage' => 0,
+            ],
+            'shouldMutate' => [
+                'startLine' => 24,
+                'endLine' => 35,
+                'executable' => 5,
+                'executed' => 4,
+                'coverage' => 80,
+            ],
+        ];
+
+        $coverage = $this->parser->parse($this->getXml());
+
+        $this->assertSame($expectedByMethodArray, $coverage[$pathToTrait]['byMethod']);
     }
 }


### PR DESCRIPTION
This PR:

- [x] Covered by tests

Fixes #189 

Coverage of traits is slightly different than classes  (the xml tag is `trait` instead of `class`). Which causes function signatures of Traits to display as not covered. This PR fixes that by checking for `trait` in the xml if it can't find `class`.

Includes a new e2e test, and a unit test to confirm the new behaviour. 