### PR TITLE
Ignore MSI violations with zero mutations

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -205,8 +205,6 @@ class InfectionCommand extends BaseCommand
         );
 
         $mutations = $mutationsGenerator->generate($input->getOption('only-covered'), $input->getOption('filter'));
-        $ignoreMsi = (bool) $input->getOption('ignore-msi-with-no-mutations');
-        $hasGeneratedMutations = \count($mutations) > 0;
 
         $mutationTestingRunner = new MutationTestingRunner(
             $processBuilder,
@@ -222,22 +220,20 @@ class InfectionCommand extends BaseCommand
             $testFrameworkOptions->getForMutantProcess()
         );
 
+        $ignoreMsi = (bool) $input->getOption('ignore-msi-with-no-mutations');
+
+        if ($ignoreMsi && \count($mutations) === 0) {
+            return 0;
+        }
+
         if ($this->hasBadMsi($metricsCalculator)) {
             $this->io->error($this->getBadMsiErrorMessage($metricsCalculator));
-
-            if (!$hasGeneratedMutations && $ignoreMsi) {
-                return 0;
-            }
 
             return 1;
         }
 
         if ($this->hasBadCoveredMsi($metricsCalculator)) {
             $this->io->error($this->getBadCoveredMsiErrorMessage($metricsCalculator));
-
-            if (!$hasGeneratedMutations && $ignoreMsi) {
-                return 0;
-            }
 
             return 1;
         }

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/README.md
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/README.md
@@ -1,0 +1,9 @@
+# Title
+
+* Link to github ticket if relevant
+
+## Summary
+Short summary of the ticket
+
+## Full Ticket
+Full github ticket

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/README.md
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/README.md
@@ -1,9 +1,3 @@
 # Title
 
-* Link to github ticket if relevant
-
-## Summary
-Short summary of the ticket
-
-## Full Ticket
-Full github ticket
+When no mutations are generated, MSI should be ignored

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/composer.json
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "NamespaceIgnore_\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "NamespaceIgnore_\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/composer.json
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Namespace_\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Namespace_\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/expected-output.txt
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 0
+Killed: 0
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/infection.json
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/infection.json
@@ -1,0 +1,11 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection-log.txt"
+    }
+}

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/phpunit.xml
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/run_tests.bash
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/run_tests.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e pipefail
+
+readonly INFECTION="../../../../bin/infection --ignore-msi-with-no-mutations --filter=notExistentFile.php --min-msi=100"
+
+if [ "$PHPDBG" = "1" ]
+then
+    phpdbg -qrr $INFECTION
+else
+    php $INFECTION
+fi
+
+diff expected-output.txt infection-log.txt

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/src/SourceClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace NamespaceIgnore_;
 
 class SourceClass
 {

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Namespace_;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/tests/SourceClassTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Namespace_\Test;
+namespace NamespaceIgnore_\Test;
 
-use Namespace_\SourceClass;
+use NamespaceIgnore_\SourceClass;
 use PHPUnit\Framework\TestCase;
 
 class SourceClassTest extends TestCase

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Namespace_\Test;
+
+use Namespace_\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}


### PR DESCRIPTION

- [x] Covered by tests
- [x] Doc PR https://github.com/infection/site/pull/22

We have a [task](https://github.com/phpro/grumphp/blob/master/doc/tasks/infection.md) for Infection in [Grumphp](https://github.com/phpro/grumphp). The Grumphp task uses the `--filter` option of infection so I only listens on changed files.

When Infection runs with a required MSI percentage and there are no mutations generated, Infection results in a failure since the required percentage is not reached.

This PR fast-exits Infection when no mutations are generated.


```
Running initial test suite...

PhpSpec version: 3.4.3



Generate mutants...



.: killed, M: escaped, S: uncovered, E: fatal error, T: timed out



0 mutations were generated:
       0 mutants were killed
       0 mutants were not covered by tests
       0 covered mutants were not detected
       0 errors were encountered
       0 time outs were encountered

Metrics:
         Mutation Score Indicator (MSI): 0%
         Mutation Code Coverage: 0%
         Covered Code MSI: 0%

Please note that some mutants will inevitably be harmless (i.e. false positives).


 [ERROR] The minimum required MSI percentage should be 100%, but actual is 0%.
         Improve your tests!



Creating mutated files and processes:    0/0
```