### PR TITLE
Fix bug with PHPUnit relative paths when custom config dir is used

### DIFF
--- a/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
+++ b/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
@@ -35,12 +35,21 @@ class PathReplacer
     public function replaceInNode(\DOMNode $domElement)
     {
         if (!$this->filesystem->isAbsolutePath($domElement->nodeValue)) {
-            $domElement->nodeValue = sprintf(
+            $newPath = sprintf(
                 '%s%s%s',
                 $this->phpUnitConfigDir,
                 DIRECTORY_SEPARATOR,
-                ltrim($domElement->nodeValue, '\.\/')
+                ltrim($domElement->nodeValue, '\/')
             );
+
+            // remove all occurrences of "/./". realpath can't be used because of glob patterns
+            $newPath = str_replace(
+                sprintf('%s.%s', DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR),
+                DIRECTORY_SEPARATOR,
+                $newPath
+            );
+
+            $domElement->nodeValue = $newPath;
         }
     }
 }

--- a/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
+++ b/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
@@ -36,14 +36,13 @@ class PathReplacer
     {
         if (!$this->filesystem->isAbsolutePath($domElement->nodeValue)) {
             $newPath = sprintf(
-                '%s%s%s',
+                '%s/%s',
                 $this->phpUnitConfigDir,
-                DIRECTORY_SEPARATOR,
                 ltrim($domElement->nodeValue, '\/')
             );
 
             // remove all occurrences of "/./". realpath can't be used because of glob patterns
-            $newPath = str_replace('/./', DIRECTORY_SEPARATOR, $newPath);
+            $newPath = str_replace('/./', '/', $newPath);
 
             $domElement->nodeValue = $newPath;
         }

--- a/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
+++ b/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
@@ -43,11 +43,7 @@ class PathReplacer
             );
 
             // remove all occurrences of "/./". realpath can't be used because of glob patterns
-            $newPath = str_replace(
-                sprintf('%s.%s', DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR),
-                DIRECTORY_SEPARATOR,
-                $newPath
-            );
+            $newPath = str_replace('/./', DIRECTORY_SEPARATOR, $newPath);
 
             $domElement->nodeValue = $newPath;
         }

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/README.md
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/README.md
@@ -1,0 +1,14 @@
+# Title
+
+https://github.com/infection/infection/issues/199
+
+## Full Ticket
+
+| Question    | Answer
+| ------------| ---------------
+| Infection version | 0.8.0
+| Test Framework version | PHPUnit 7.0.2
+| PHP version | 7.2.1
+| Platform    | e.g. Ubuntu on Windows
+
+Relative path to PHPUnit bootstrap file being incorrectly built with version 0.8.0. Version 0.7.1 works exactly as expected. PR #165 seems like the likely cause, but with no clear solution.

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/build/phpunit.xml
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/build/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="../vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>../tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>../src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/composer.json
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Namespace_\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Namespace_\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/expected-output.txt
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/infection.json
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/infection.json
@@ -1,0 +1,14 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection-log.txt"
+    },
+    "phpUnit": {
+        "configDir": "build"
+    }
+}

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/src/SourceClass.php
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Namespace_;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Namespace_\Test;
+
+use Namespace_\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
@@ -47,6 +47,7 @@ class PathReplacerTest extends TestCase
         return [
             ['autoload.php', $this->projectPath . '/autoload.php'],
             ['./autoload.php', $this->projectPath . '/autoload.php'],
+            ['../autoload.php', $this->projectPath . '/../autoload.php'],
             ['/autoload.php', '/autoload.php'],
             ['./*Bundle', $this->projectPath . '/*Bundle'],
         ];


### PR DESCRIPTION
This PR:

Fixes bug https://github.com/infection/infection/issues/199 introduced in 0.8.0

- [x] Covered by tests

The reason of this bug is `ltrim()` function that with the second argument `\.\/` removes *all* dots on the left of the path

```php
ltrim('../vendor/autoload.php`, '\.\/'); // vendor/autoload.php
```