### PR TITLE
Mutation badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
   global:
     - INFECTION_FLAGS='--threads=4 --min-msi=57 --min-covered-msi=86 --coverage=coverage'
     - PHPUNIT_BIN='vendor/bin/phpunit --coverage-clover=clover.xml --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml'
+    - secure: RT8az62c2YI2j7Xccamhw0eCFbPMphfK2c5aZ0cUyQCFeLuc7qJ5Q0y0DIapOf7YbpLBwVwf53LQtV8doyhZ2ltTRHM2NDmOxUrkxFpc50+I2FGlsrlPWPSDL69Dc6VxEy6+S1rvUUJu6KIs1lGCrUG3lOxt/avzctyY1g8KdqkhIfNADH6pwMzRxkhOacsKkdnT24RoFdN4M4uXyn16VclFOCeLaVdEHYCdD248L0MuhTZQF5u0jq0SdgNGOPnetRQXHjQLVSfmuB2bI5FUTxHVwvf4nU3aKYXONi+EzBauDZXdO/opgNydbmhVUZtRsTeSh1OANhAPTvW+qdFcMbc3K90q3UMdIp8pZS9krRzJyfXe7BodnvkOu0ej2S4x2eE2EZphK7L21nu016CDo1y434UCJX+DI3Pn7SZ7ood8nOi7yfOzNeVklW6+n6k6bSmS2ya/DcpS6y/OuH/awtLat0hzmXUCHVNV9YiES1KwtlkUSJqtaZwtj8iXuuBwOWWV4u71bivpKEbF2L7+1GYy56ftv57JHbh6m2tWCoeUQc9oAzDb0sHeBhj4YFVhAd598860Q4WhRG9BWJT8guySRI0iXOSxDrvgtgr5okG3WD2/CJtnsVukdgXMvcXiLbxMXKeF7LMRJfkNjrn++311ZAMaRWJSfGNEivZlooQ=
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/infection/infection.svg?branch=master)](https://travis-ci.org/infection/infection) 
 [![Build status](https://ci.appveyor.com/api/projects/status/mvtqxecqdx9s4pw9/branch/master?svg=true)](https://ci.appveyor.com/project/borNfreee/infection/branch/master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/infection/infection/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/infection/infection/?branch=master) 
+[![Infection MSI](https://badge.stryker-mutator.io/github.com/infection/infection/mutation-badge)](https://infection.github.io)
 [![codecov](https://codecov.io/gh/infection/infection/branch/master/graph/badge.svg)](https://codecov.io/gh/infection/infection)
 [![Slack](https://img.shields.io/badge/slack-%23infection-green.svg?style=flat-square)](https://symfony.com/slack-invite)
 

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -11,7 +11,7 @@
     "logs": {
         "text": "infection-log.txt",
         "badge": {
-            "branch": "mutation-badge"
+            "branch": "master"
         }
     }
 }

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -9,6 +9,9 @@
         ]
     },
     "logs": {
-        "text": "infection-log.txt"
+        "text": "infection-log.txt",
+        "badge": {
+            "branch": "mutation-badge"
+        }
     }
 }

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -298,6 +298,7 @@ class InfectionCommand extends BaseCommand
                 $this->input->getOption('show-mutations')
             ),
             new MutationTestingResultsLoggerSubscriber(
+                $this->output,
                 $this->getContainer()->get('infection.config'),
                 $metricsCalculator,
                 $this->getContainer()->get('filesystem'),

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -22,11 +22,11 @@ use Infection\Mutant\Generator\MutationsGenerator;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutator\Mutator;
 use Infection\Process\Builder\ProcessBuilder;
-use Infection\Process\Listener\FileLoggerSubscriber\BaseFileLoggerSubscriber;
 use Infection\Process\Listener\InitialTestsConsoleLoggerSubscriber;
 use Infection\Process\Listener\MutantCreatingConsoleLoggerSubscriber;
 use Infection\Process\Listener\MutationGeneratingConsoleLoggerSubscriber;
 use Infection\Process\Listener\MutationTestingConsoleLoggerSubscriber;
+use Infection\Process\Listener\MutationTestingResultsLoggerSubscriber;
 use Infection\Process\Runner\InitialTestsRunner;
 use Infection\Process\Runner\MutationTestingRunner;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
@@ -297,7 +297,7 @@ class InfectionCommand extends BaseCommand
                 $this->getContainer()->get('diff.colorizer'),
                 $this->input->getOption('show-mutations')
             ),
-            new BaseFileLoggerSubscriber(
+            new MutationTestingResultsLoggerSubscriber(
                 $this->getContainer()->get('infection.config'),
                 $metricsCalculator,
                 $this->getContainer()->get('filesystem'),

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -221,14 +221,6 @@ class InfectionConfig
         return self::DEFAULT_EXCLUDE_DIRS;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getLogPathInfoFor(string $log)
-    {
-        return $this->config->logs->$log ?? null;
-    }
-
     public function getLogsTypes(): array
     {
         return (array) $this->config->logs ?? [];

--- a/src/Http/BadgeApiClient.php
+++ b/src/Http/BadgeApiClient.php
@@ -29,8 +29,8 @@ class BadgeApiClient
         string $apiKey,
         string $repositorySlug,
         string $branch,
-        float $mutationScore)
-    {
+        float $mutationScore
+    ) {
         $json = json_encode([
             'apiKey' => $apiKey,
             'repositorySlug' => $repositorySlug,

--- a/src/Http/BadgeApiClient.php
+++ b/src/Http/BadgeApiClient.php
@@ -9,9 +9,24 @@ declare(strict_types=1);
 
 namespace Infection\Http;
 
+use Symfony\Component\Console\Output\OutputInterface;
+
 class BadgeApiClient
 {
     const STRYKER_DASHBOARD_API_URL = 'https://dashboard.stryker-mutator.io/api/reports';
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * BadgeApiClient constructor.
+     */
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
 
     public function sendReport(
         string $apiKey,
@@ -34,8 +49,13 @@ class BadgeApiClient
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $json);
+        curl_setopt($ch, CURLOPT_HEADER, true);
 
-        curl_exec($ch);
+        $response = curl_exec($ch);
+
+        if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+            $this->output->writeln($response);
+        }
 
         curl_close($ch);
     }

--- a/src/Http/BadgeApiClient.php
+++ b/src/Http/BadgeApiClient.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Http;
+
+class BadgeApiClient
+{
+    const STRYKER_DASHBOARD_API_URL = 'https://dashboard.stryker-mutator.io/api/reports';
+
+    public function sendReport(
+        string $apiKey,
+        string $repositorySlug,
+        string $branch,
+        float $mutationScore)
+    {
+        $json = json_encode([
+            'apiKey' => $apiKey,
+            'repositorySlug' => $repositorySlug,
+            'branch' => $branch,
+            'mutationScore' => $mutationScore,
+        ]);
+
+        $ch = curl_init();
+
+        curl_setopt($ch, CURLOPT_URL, self::STRYKER_DASHBOARD_API_URL);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $json);
+
+        curl_exec($ch);
+
+        curl_close($ch);
+    }
+}

--- a/src/Http/BadgeApiClient.php
+++ b/src/Http/BadgeApiClient.php
@@ -20,9 +20,6 @@ class BadgeApiClient
      */
     private $output;
 
-    /**
-     * BadgeApiClient constructor.
-     */
     public function __construct(OutputInterface $output)
     {
         $this->output = $output;

--- a/src/Logger/BadgeLogger.php
+++ b/src/Logger/BadgeLogger.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class BadgeLogger implements MutationTestingResultsLogger
 {
     const ENV_INFECTION_BADGE_API_KEY = 'INFECTION_BADGE_API_KEY';
+
     /**
      * @var BadgeApiClient
      */

--- a/src/Logger/BadgeLogger.php
+++ b/src/Logger/BadgeLogger.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Logger;
+
+use Infection\Http\BadgeApiClient;
+use Infection\Mutant\MetricsCalculator;
+
+class BadgeLogger implements MutationTestingResultsLogger
+{
+    /**
+     * @var BadgeApiClient
+     */
+    private $badgeApiClient;
+
+    /**
+     * @var MetricsCalculator
+     */
+    private $metricsCalculator;
+
+    /**
+     * @var \stdClass
+     */
+    private $config;
+
+    public function __construct(BadgeApiClient $badgeApiClient, MetricsCalculator $metricsCalculator, \stdClass $config)
+    {
+        $this->badgeApiClient = $badgeApiClient;
+        $this->metricsCalculator = $metricsCalculator;
+        $this->config = $config;
+    }
+
+    public function log()
+    {
+        $travisBuild = getenv('TRAVIS');
+
+        if ($travisBuild !== 'true') {
+            return;
+        }
+
+        $pullRequest = getenv('TRAVIS_PULL_REQUEST');
+
+        if ($pullRequest !== 'false') {
+            return;
+        }
+
+        $apiKey = getenv('INFECTION_BADGE_API_KEY');
+        $repositorySlug = getenv('TRAVIS_REPO_SLUG');
+        $currentBranch = getenv('TRAVIS_BRANCH');
+
+        if ($apiKey && $repositorySlug && $currentBranch === $this->config->branch) {
+            $this->badgeApiClient->sendReport(
+                $apiKey,
+                'github.com/' . $repositorySlug,
+                $currentBranch,
+                $this->metricsCalculator->getMutationScoreIndicator()
+            );
+        }
+    }
+}

--- a/src/Logger/BadgeLogger.php
+++ b/src/Logger/BadgeLogger.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class BadgeLogger implements MutationTestingResultsLogger
 {
+    const ENV_INFECTION_BADGE_API_KEY = 'INFECTION_BADGE_API_KEY';
     /**
      * @var BadgeApiClient
      */
@@ -61,7 +62,7 @@ class BadgeLogger implements MutationTestingResultsLogger
             return;
         }
 
-        $apiKey = getenv('INFECTION_BADGE_API_KEY');
+        $apiKey = getenv(self::ENV_INFECTION_BADGE_API_KEY);
         $repositorySlug = getenv('TRAVIS_REPO_SLUG');
         $currentBranch = getenv('TRAVIS_BRANCH');
 

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -5,16 +5,14 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
-namespace Infection\Process\Listener\FileLoggerSubscriber;
+namespace Infection\Logger;
 
 use Infection\Process\MutantProcess;
 
 class DebugFileLogger extends FileLogger
 {
-    public function writeToFile()
+    protected function getLogLines(): array
     {
-        $logFilePath = $this->infectionConfig->getLogPathInfoFor('debug');
-
         $logs = [];
 
         $logs[] = 'Total: ' . $this->metricsCalculator->getTotalMutantsCount();
@@ -39,7 +37,7 @@ class DebugFileLogger extends FileLogger
             'Not Covered'
         );
 
-        $this->write($logs, $logFilePath);
+        return $logs;
     }
 
     /**

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -5,18 +5,17 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
-namespace Infection\Process\Listener\FileLoggerSubscriber;
+namespace Infection\Logger;
 
-use Infection\Config\InfectionConfig;
 use Infection\Mutant\MetricsCalculator;
 use Symfony\Component\Filesystem\Filesystem;
 
-abstract class FileLogger
+abstract class FileLogger implements MutationTestingResultsLogger
 {
     /**
-     * @var InfectionConfig
+     * @var string
      */
-    protected $infectionConfig;
+    private $logFilePath;
 
     /**
      * @var MetricsCalculator
@@ -34,29 +33,21 @@ abstract class FileLogger
     protected $isDebugMode;
 
     public function __construct(
-        InfectionConfig $infectionConfig,
+        string $logFilePath,
         MetricsCalculator $metricsCalculator,
         Filesystem $fs,
-        bool $isDebugMode = true
+        bool $isDebugMode
     ) {
-        $this->infectionConfig = $infectionConfig;
         $this->metricsCalculator = $metricsCalculator;
         $this->fs = $fs;
         $this->isDebugMode = $isDebugMode;
+        $this->logFilePath = $logFilePath;
     }
 
-    abstract public function writeToFile();
-
-    final protected function write(array $logs, string $logFilePath = null)
+    public function log()
     {
-        if ($logFilePath !== null) {
-            $this->fs->dumpFile(
-                $logFilePath,
-                implode(
-                    $logs,
-                    "\n"
-                )
-            );
-        }
+        $this->fs->dumpFile($this->logFilePath, implode($this->getLogLines(), "\n"));
     }
+
+    abstract protected function getLogLines(): array;
 }

--- a/src/Logger/MutationTestingResultsLogger.php
+++ b/src/Logger/MutationTestingResultsLogger.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Logger;
+
+interface MutationTestingResultsLogger
+{
+    /**
+     * Logs results of Mutation Testing to somewhere
+     */
+    public function log();
+}

--- a/src/Logger/ResultsLoggerTypes.php
+++ b/src/Logger/ResultsLoggerTypes.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Logger;
+
+final class ResultsLoggerTypes
+{
+    const TEXT_FILE = 'text';
+    const SUMMARY_FILE = 'summary';
+    const DEBUG_FILE = 'debug';
+    const BADGE = 'badge';
+}

--- a/src/Logger/ResultsLoggerTypes.php
+++ b/src/Logger/ResultsLoggerTypes.php
@@ -15,4 +15,11 @@ final class ResultsLoggerTypes
     const SUMMARY_FILE = 'summary';
     const DEBUG_FILE = 'debug';
     const BADGE = 'badge';
+
+    const ALL = [
+        ResultsLoggerTypes::TEXT_FILE,
+        ResultsLoggerTypes::DEBUG_FILE,
+        ResultsLoggerTypes::SUMMARY_FILE,
+        ResultsLoggerTypes::BADGE,
+    ];
 }

--- a/src/Logger/SummaryFileLogger.php
+++ b/src/Logger/SummaryFileLogger.php
@@ -5,13 +5,12 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
-namespace Infection\Process\Listener\FileLoggerSubscriber;
+namespace Infection\Logger;
 
 class SummaryFileLogger extends FileLogger
 {
-    public function writeToFile()
+    protected function getLogLines(): array
     {
-        $logFilePath = $this->infectionConfig->getLogPathInfoFor('summary');
         $logs = [];
 
         $logs[] = 'Total: ' . $this->metricsCalculator->getTotalMutantsCount();
@@ -21,6 +20,6 @@ class SummaryFileLogger extends FileLogger
         $logs[] = 'Timed Out: ' . $this->metricsCalculator->getTimedOutCount();
         $logs[] = 'Not Covered: ' . $this->metricsCalculator->getNotCoveredByTestsCount();
 
-        $this->write($logs, $logFilePath);
+        return $logs;
     }
 }

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -7,29 +7,25 @@
 
 declare(strict_types=1);
 
-namespace Infection\Process\Listener\FileLoggerSubscriber;
+namespace Infection\Logger;
 
 use Infection\Process\MutantProcess;
 
 class TextFileLogger extends FileLogger
 {
-    public function writeToFile()
+    protected function getLogLines(): array
     {
-        $logFilePath = $this->infectionConfig->getLogPathInfoFor('text');
+        $logs[] = $this->getLogParts($this->metricsCalculator->getEscapedMutantProcesses(), 'Escaped');
+        $logs[] = $this->getLogParts($this->metricsCalculator->getTimedOutProcesses(), 'Timeout');
 
-        if ($logFilePath) {
-            $logs[] = $this->getLogParts($this->metricsCalculator->getEscapedMutantProcesses(), 'Escaped');
-            $logs[] = $this->getLogParts($this->metricsCalculator->getTimedOutProcesses(), 'Timeout');
-
-            if ($this->isDebugMode) {
-                $logs[] = $this->getLogParts($this->metricsCalculator->getKilledMutantProcesses(), 'Killed');
-                $logs[] = $this->getLogParts($this->metricsCalculator->getErrorProcesses(), 'Errors');
-            }
-
-            $logs[] = $this->getLogParts($this->metricsCalculator->getNotCoveredMutantProcesses(), 'Not covered');
-
-            $this->write($logs, $logFilePath);
+        if ($this->isDebugMode) {
+            $logs[] = $this->getLogParts($this->metricsCalculator->getKilledMutantProcesses(), 'Killed');
+            $logs[] = $this->getLogParts($this->metricsCalculator->getErrorProcesses(), 'Errors');
         }
+
+        $logs[] = $this->getLogParts($this->metricsCalculator->getNotCoveredMutantProcesses(), 'Not covered');
+
+        return $logs;
     }
 
     /**

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -17,6 +17,7 @@ use Infection\Logger\DebugFileLogger;
 use Infection\Logger\SummaryFileLogger;
 use Infection\Logger\TextFileLogger;
 use Infection\Mutant\MetricsCalculator;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
@@ -47,12 +48,19 @@ class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
      */
     private $isDebugMode;
 
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
     public function __construct(
+        OutputInterface $output,
         InfectionConfig $infectionConfig,
         MetricsCalculator $metricsCalculator,
         Filesystem $fs,
         int $logVerbosity = LogVerbosity::DEBUG
     ) {
+        $this->output = $output;
         $this->infectionConfig = $infectionConfig;
         $this->metricsCalculator = $metricsCalculator;
         $this->fs = $fs;
@@ -131,7 +139,8 @@ class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
                 break;
             case self::BADGE:
                 (new BadgeLogger(
-                    new BadgeApiClient(),
+                    $this->output,
+                    new BadgeApiClient($this->output),
                     $this->metricsCalculator,
                     $config
                 ))->log();

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -89,7 +89,7 @@ class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
 
     private function filterLogTypes(array $logTypes): array
     {
-        foreach (ResultsLoggerTypes::ALL as $key => $value) {
+        foreach ($logTypes as $key => $value) {
             if (!in_array($key, ResultsLoggerTypes::ALL, true)) {
                 unset($logTypes[$key]);
             }

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -89,15 +89,8 @@ class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
 
     private function filterLogTypes(array $logTypes): array
     {
-        $allowedFileTypes = [
-            ResultsLoggerTypes::TEXT_FILE,
-            ResultsLoggerTypes::DEBUG_FILE,
-            ResultsLoggerTypes::SUMMARY_FILE,
-            ResultsLoggerTypes::BADGE,
-        ];
-
-        foreach ($logTypes as $key => $value) {
-            if (!in_array($key, $allowedFileTypes, true)) {
+        foreach (ResultsLoggerTypes::ALL as $key => $value) {
+            if (!in_array($key, ResultsLoggerTypes::ALL, true)) {
                 unset($logTypes[$key]);
             }
         }

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -14,6 +14,7 @@ use Infection\Events\MutationTestingFinished;
 use Infection\Http\BadgeApiClient;
 use Infection\Logger\BadgeLogger;
 use Infection\Logger\DebugFileLogger;
+use Infection\Logger\ResultsLoggerTypes;
 use Infection\Logger\SummaryFileLogger;
 use Infection\Logger\TextFileLogger;
 use Infection\Mutant\MetricsCalculator;
@@ -22,12 +23,6 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
 {
-    // TODO move to final class
-    const TEXT_FILE = 'text';
-    const SUMMARY_FILE = 'summary';
-    const DEBUG_FILE = 'debug';
-    const BADGE = 'badge';
-
     /**
      * @var InfectionConfig
      */
@@ -95,10 +90,10 @@ class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
     private function filterLogTypes(array $logTypes): array
     {
         $allowedFileTypes = [
-            self::TEXT_FILE,
-            self::DEBUG_FILE,
-            self::SUMMARY_FILE,
-            self::BADGE,
+            ResultsLoggerTypes::TEXT_FILE,
+            ResultsLoggerTypes::DEBUG_FILE,
+            ResultsLoggerTypes::SUMMARY_FILE,
+            ResultsLoggerTypes::BADGE,
         ];
 
         foreach ($logTypes as $key => $value) {
@@ -113,7 +108,7 @@ class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
     private function useLogger(string $logType, $config)
     {
         switch ($logType) {
-            case self::TEXT_FILE:
+            case ResultsLoggerTypes::TEXT_FILE:
                 (new TextFileLogger(
                     $config,
                     $this->metricsCalculator,
@@ -121,7 +116,7 @@ class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
                     $this->isDebugMode
                 ))->log();
                 break;
-            case self::SUMMARY_FILE:
+            case ResultsLoggerTypes::SUMMARY_FILE:
                 (new SummaryFileLogger(
                     $config,
                     $this->metricsCalculator,
@@ -129,7 +124,7 @@ class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
                     $this->isDebugMode
                 ))->log();
                 break;
-            case self::DEBUG_FILE:
+            case ResultsLoggerTypes::DEBUG_FILE:
                 (new DebugFileLogger(
                     $config,
                     $this->metricsCalculator,
@@ -137,7 +132,7 @@ class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
                     $this->isDebugMode
                 ))->log();
                 break;
-            case self::BADGE:
+            case ResultsLoggerTypes::BADGE:
                 (new BadgeLogger(
                     $this->output,
                     new BadgeApiClient($this->output),

--- a/tests/Config/InfectionConfigTest.php
+++ b/tests/Config/InfectionConfigTest.php
@@ -103,22 +103,6 @@ class InfectionConfigTest extends TestCase
         $this->assertCount(2, $excludedDirs);
     }
 
-    public function test_it_returns_text_file_log_path_when_exist()
-    {
-        $path = 'test-log.txt';
-        $json = sprintf('{"logs": {"text": "%s"}}', $path);
-        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
-
-        $this->assertSame($path, $config->getLogPathInfoFor('text'));
-    }
-
-    public function test_it_returns_an_empty_array_for_text_file_log_path_when_it_is_skipped()
-    {
-        $config = new InfectionConfig(json_decode('{}'), $this->filesystem, '/path/to/config');
-
-        $this->assertEmpty($config->getLogPathInfoFor('text'));
-    }
-
     public function test_it_returns_default_temp_dir()
     {
         $config = new InfectionConfig(json_decode('{}'), $this->filesystem, '/path/to/config');

--- a/tests/Logger/BadgeLoggerTest.php
+++ b/tests/Logger/BadgeLoggerTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Logger;
+
+use Infection\Http\BadgeApiClient;
+use Infection\Logger\BadgeLogger;
+use Infection\Mutant\MetricsCalculator;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BadgeLoggerTest extends MockeryTestCase
+{
+    /**
+     * @var OutputInterface|Mockery\MockInterface
+     */
+    private $output;
+
+    /**
+     * @var BadgeApiClient|Mockery\MockInterface
+     */
+    private $badgeApiClient;
+
+    /**
+     * @var MetricsCalculator|Mockery\MockInterface
+     */
+    private $metricsCalculator;
+
+    /**
+     * @var BadgeLogger
+     */
+    private $badgeLogger;
+
+    private static $env = [];
+
+    public static function setUpBeforeClass()
+    {
+        // Save current env state
+        $names = [
+            'TRAVIS',
+            'TRAVIS_BRANCH',
+            'TRAVIS_REPO_SLUG',
+            'TRAVIS_PULL_REQUEST',
+            BadgeLogger::ENV_INFECTION_BADGE_API_KEY,
+        ];
+
+        foreach ($names as $name) {
+            self::$env[$name] = getenv($name);
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        // Restore original env state
+        foreach (self::$env as $name => $value) {
+            if (false !== $value) {
+                putenv($name . '=' . $value);
+            } else {
+                putenv($name);
+            }
+        }
+    }
+
+    protected function setUp()
+    {
+        $this->output = Mockery::mock(OutputInterface::class);
+        $this->badgeApiClient = Mockery::mock(BadgeApiClient::class);
+        $this->metricsCalculator = Mockery::mock(MetricsCalculator::class);
+        $config = new \stdClass();
+        $config->branch = 'master';
+
+        $this->badgeLogger = new BadgeLogger(
+            $this->output,
+            $this->badgeApiClient,
+            $this->metricsCalculator,
+            $config
+        );
+    }
+
+    public function test_it_skips_logging_when_it_is_not_travis()
+    {
+        putenv('TRAVIS');
+        $this->output
+            ->shouldReceive('writeln')
+            ->withArgs(['Dashboard report has not been sent: it is not a Travis CI']);
+        $this->badgeApiClient->shouldReceive('sendReport')->never();
+
+        $this->badgeLogger->log();
+    }
+
+    public function test_it_skips_logging_when_it_is_pull_request()
+    {
+        putenv('TRAVIS=true');
+        putenv('TRAVIS_PULL_REQUEST=123');
+        $this->output
+            ->shouldReceive('writeln')
+            ->withArgs(['Dashboard report has not been sent: build is for a pull request (TRAVIS_PULL_REQUEST=123)']);
+        $this->badgeApiClient->shouldReceive('sendReport')->never();
+
+        $this->badgeLogger->log();
+    }
+
+    public function test_it_skips_logging_when_it_is_branch_not_from_config()
+    {
+        putenv('TRAVIS=true');
+        putenv('TRAVIS_PULL_REQUEST=false');
+        putenv('TRAVIS_REPO_SLUG=a/b');
+        putenv('TRAVIS_BRANCH=foo');
+        $this->output
+            ->shouldReceive('writeln')
+            ->withArgs(['Dashboard report has not been sent: Repository Slug=a/b, Branch=foo']);
+        $this->badgeApiClient->shouldReceive('sendReport')->never();
+
+        $this->badgeLogger->log();
+    }
+
+    public function test_it_sends_report_when_everything_is_ok()
+    {
+        putenv(BadgeLogger::ENV_INFECTION_BADGE_API_KEY . '=abc');
+        putenv('TRAVIS=true');
+        putenv('TRAVIS_PULL_REQUEST=false');
+        putenv('TRAVIS_REPO_SLUG=a/b');
+        putenv('TRAVIS_BRANCH=master');
+        $this->output->shouldReceive('writeln')->never();
+        $this->badgeApiClient
+            ->shouldReceive('sendReport')
+            ->once()
+            ->withArgs(['abc', 'github.com/a/b', 'master', 33.3]);
+        $this->metricsCalculator
+            ->shouldReceive('getMutationScoreIndicator')
+            ->andReturn(33.3);
+
+        $this->badgeLogger->log();
+    }
+}

--- a/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
+++ b/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
@@ -16,10 +16,16 @@ use Infection\Events\MutationTestingFinished;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Process\Listener\MutationTestingResultsLoggerSubscriber;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 class MutationTestingResultsLoggerSubscriberTest extends TestCase
 {
+    /**
+     * @var OutputInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $output;
+
     /**
      * @var InfectionConfig|\PHPUnit_Framework_MockObject_MockObject
      */
@@ -37,6 +43,9 @@ class MutationTestingResultsLoggerSubscriberTest extends TestCase
 
     protected function setUp()
     {
+        $this->output = $this->getMockBuilder(OutputInterface::class)
+            ->getMock();
+
         $this->infectionConfig = $this->getMockBuilder(InfectionConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -65,6 +74,7 @@ class MutationTestingResultsLoggerSubscriberTest extends TestCase
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new MutationTestingResultsLoggerSubscriber(
+            $this->output,
             $this->infectionConfig,
             $this->metricsCalculator,
             $this->filesystem
@@ -106,6 +116,7 @@ class MutationTestingResultsLoggerSubscriberTest extends TestCase
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new MutationTestingResultsLoggerSubscriber(
+            $this->output,
             $this->infectionConfig,
             $this->metricsCalculator,
             $this->filesystem
@@ -145,6 +156,7 @@ class MutationTestingResultsLoggerSubscriberTest extends TestCase
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new MutationTestingResultsLoggerSubscriber(
+            $this->output,
             $this->infectionConfig,
             $this->metricsCalculator,
             $this->filesystem,

--- a/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
+++ b/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
@@ -7,18 +7,18 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Process\Listener\FileLoggerSubscriber;
+namespace Infection\Tests\Process\Listener;
 
 use Infection\Config\InfectionConfig;
 use Infection\Console\LogVerbosity;
 use Infection\EventDispatcher\EventDispatcher;
 use Infection\Events\MutationTestingFinished;
 use Infection\Mutant\MetricsCalculator;
-use Infection\Process\Listener\FileLoggerSubscriber\BaseFileLoggerSubscriber;
+use Infection\Process\Listener\MutationTestingResultsLoggerSubscriber;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-class BaseFileLoggerSubscriberTest extends TestCase
+class MutationTestingResultsLoggerSubscriberTest extends TestCase
 {
     /**
      * @var InfectionConfig|\PHPUnit_Framework_MockObject_MockObject
@@ -60,15 +60,11 @@ class BaseFileLoggerSubscriberTest extends TestCase
         $this->metricsCalculator->expects($this->never())
             ->method('getNotCoveredMutantProcesses');
 
-        $this->infectionConfig->expects($this->any())
-            ->method('getLogPathInfoFor')
-            ->willReturn(null);
-
         $this->filesystem->expects($this->never())
             ->method('dumpFile');
 
         $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber(new BaseFileLoggerSubscriber(
+        $dispatcher->addSubscriber(new MutationTestingResultsLoggerSubscriber(
             $this->infectionConfig,
             $this->metricsCalculator,
             $this->filesystem
@@ -80,10 +76,6 @@ class BaseFileLoggerSubscriberTest extends TestCase
     public function test_it_reacts_on_mutation_testing_finished()
     {
         $logTypes = ['text' => sys_get_temp_dir() . '/infection-log.txt'];
-        $this->infectionConfig->expects($this->once())
-            ->method('getLogPathInfoFor')
-            ->with('text')
-            ->willReturn(sys_get_temp_dir() . '/infection-log.txt');
 
         $this->infectionConfig->expects($this->once())
             ->method('getLogsTypes')
@@ -113,7 +105,7 @@ class BaseFileLoggerSubscriberTest extends TestCase
             ->method('dumpFile');
 
         $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber(new BaseFileLoggerSubscriber(
+        $dispatcher->addSubscriber(new MutationTestingResultsLoggerSubscriber(
             $this->infectionConfig,
             $this->metricsCalculator,
             $this->filesystem
@@ -129,10 +121,6 @@ class BaseFileLoggerSubscriberTest extends TestCase
         $this->infectionConfig->expects($this->once())
             ->method('getLogsTypes')
             ->willReturn($logTypes);
-
-        $this->infectionConfig->expects($this->once())
-            ->method('getLogPathInfoFor')
-            ->willReturn(sys_get_temp_dir() . '/infection-log.txt');
 
         $this->metricsCalculator->expects($this->once())
             ->method('getEscapedMutantProcesses')
@@ -156,7 +144,7 @@ class BaseFileLoggerSubscriberTest extends TestCase
             ->method('dumpFile');
 
         $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber(new BaseFileLoggerSubscriber(
+        $dispatcher->addSubscriber(new MutationTestingResultsLoggerSubscriber(
             $this->infectionConfig,
             $this->metricsCalculator,
             $this->filesystem,


### PR DESCRIPTION
This PR adds a Mutation Badge feature

How it looks like (for current branch): [![Infection MSI](https://badge.stryker-mutator.io/github.com/infection/infection/mutation-badge)](https://infection.github.io)

Image code is: `[![Infection MSI](https://badge.stryker-mutator.io/github.com/infection/infection/mutation-badge)](https://infection.github.io)`

- [x] Covered by tests
- [x] Change `mutation-badge` to `master` before merging 
- [x] Doc PR https://github.com/infection/site/pull/25

Fixes https://github.com/infection/infection/issues/168

To understand how it works, read this: http://stryker-mutator.io/blog/2018-02-08/get-your-mutation-score-badge-now.html

We will use Stryker's Dashboard API. Currently, it will work only for Travis, other CI servers will be implemented on demand.

Configuration is quite easy: 

1. Go to https://dashboard.stryker-mutator.io and sign with your github account.
2. Flip the switch next to your repository (activate it)
3. Configure your API key in your project. It is possible to ncrypt this variable using the encrypted environment variables. For example:
`$ travis encrypt STRYKER_DASHBOARD_API_KEY=89b99910-04d8-4xxx-9x91-23d709x828b4 --add`
4. Configure the badge logger in your `infection.json` file

```json
{
   "logs": {
       "badge": {"branch": "master"}
   }
}
```