### PR TITLE
Fix: Throw exception if config file contains invalid JSON

### DIFF
--- a/src/Config/Exception/InvalidConfigException.php
+++ b/src/Config/Exception/InvalidConfigException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Config\Exception;
+
+final class InvalidConfigException extends \RuntimeException
+{
+    public static function invalidJson(string $configFile, string $errorMessage): self
+    {
+        return new self(sprintf(
+            'The configuration file "%s" does not contain valid JSON: %s.',
+            $configFile,
+            $errorMessage
+        ));
+    }
+}

--- a/tests/Config/Exception/InvalidConfigExceptionTest.php
+++ b/tests/Config/Exception/InvalidConfigExceptionTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Config\Exception;
+
+use Infection\Config\Exception\InvalidConfigException;
+use PHPUnit\Framework\TestCase;
+
+final class InvalidConfigExceptionTest extends TestCase
+{
+    public function testExtendsRuntimeException()
+    {
+        $exception = new InvalidConfigException();
+
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
+    }
+
+    public function testInvalidJsonCreatesException()
+    {
+        $configFile = __DIR__ . '/../../../infection.json.dist';
+        $errorMessage = 'That does not look right.';
+
+        $exception = InvalidConfigException::invalidJson(
+            $configFile,
+            $errorMessage
+        );
+
+        $this->assertInstanceOf(InvalidConfigException::class, $exception);
+
+        $expected = sprintf(
+            'The configuration file "%s" does not contain valid JSON: %s.',
+            $configFile,
+            $errorMessage
+        );
+
+        $this->assertSame($expected, $exception->getMessage());
+    }
+}


### PR DESCRIPTION
This PR

- [x] throws an exception in `Console\Application` when invalid JSON was found in a configuration file

Fixes https://github.com/infection/infection/issues/205.

💁‍♂️ Not sure, should I add an end-to-end test for this?