### PR TITLE
Fix: Ignore infection.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/*
 .php_cs.cache
 infection-cache
 .travis/infection-private.pem
+infection.json


### PR DESCRIPTION
This PR

* [x] ignores `infection.json`

Spotted in #209.

💁‍♂️ A configuration file `infection.json.dist` is checked in - I believe we should ignore `infection.json`, then.