### PR TITLE
Fix generated php.ini config file

### DIFF
--- a/src/Php/ConfigBuilder.php
+++ b/src/Php/ConfigBuilder.php
@@ -79,6 +79,13 @@ final class ConfigBuilder
         foreach ($originalIniPaths as $iniPath) {
             $content .= preg_replace($regex, ';$1', file_get_contents($iniPath)) . PHP_EOL;
         }
+        
+        $contents = implode(
+            PHP_EOL,
+            array_unique(
+                explode(PHP_EOL, $contents)
+            )
+        );
 
         return (bool) @file_put_contents($this->tmpIniPath, $content);
     }

--- a/src/Php/ConfigBuilder.php
+++ b/src/Php/ConfigBuilder.php
@@ -80,7 +80,7 @@ final class ConfigBuilder
             $content .= preg_replace($regex, ';$1', file_get_contents($iniPath)) . PHP_EOL;
         }
         
-        $contents = implode(
+        $content = implode(
             PHP_EOL,
             array_unique(
                 explode(PHP_EOL, $contents)

--- a/src/Php/ConfigBuilder.php
+++ b/src/Php/ConfigBuilder.php
@@ -83,7 +83,7 @@ final class ConfigBuilder
         $content = implode(
             PHP_EOL,
             array_unique(
-                explode(PHP_EOL, $contents)
+                explode(PHP_EOL, $content)
             )
         );
 


### PR DESCRIPTION
My PHP setup may be bit unorthodox (I'm using [phpbrew](https://github.com/phpbrew/phpbrew)) in the sense that I have different files for the configuration. Because of how they are included, there is no redundancy. However in the case of the `ConfigBuilder`, it simply collects the different configurations and put everything in a single file. The issue is that it may result in duplicated lines:

```
 Output:                                                                                                             
  ================                                                                                                    
                                                                                                                      
  Warning: Module 'blackfire' already loaded in Unknown on line 0                                                     
                                                                                                                      
  Warning: Module 'iconv' already loaded in Unknown on line 0                                                         
                                                                                                                      
  Warning: Module 'pdo_sqlite' already loaded in Unknown on line 0                                                    
                                                                                                                      
  Warning: Module 'redis' already loaded in Unknown on line 0                                                         
  #!/usr/bin/env php                                                                                                  
  PHPUnit 6.0.13 by Sebastian Bergmann and contributors.  
```

So I would just make sure there is no duplicated lines in the dumped content :)