### PR TITLE
Fix: using custom path to TestFramework

### DIFF
--- a/src/Finder/Exception/FinderException.php
+++ b/src/Finder/Exception/FinderException.php
@@ -28,4 +28,14 @@ class FinderException extends \RuntimeException
             )
         );
     }
+
+    public static function testCustomPathDoesNotExist(string $testFrameworkName, string $customPath): self
+    {
+        return new self(
+            sprintf('The custom path to %s was set as "%s" but this file did not exist.',
+                $testFrameworkName,
+                $customPath
+            )
+        );
+    }
 }

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -82,7 +82,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
     private function findTestFramework(): string
     {
         if ($this->doesCustomPathExist()) {
-            $this->customPath;
+            return $this->customPath;
         }
 
         $candidates = [$this->testFrameworkName, $this->testFrameworkName . '.phar'];

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -39,7 +39,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
     public function find(): string
     {
         if ($this->cachedPath === null) {
-            if (!$this->doesCustomPathExist()) {
+            if (!$this->shouldUseCustomPath()) {
                 $this->addVendorFolderToPath();
             }
 
@@ -49,9 +49,17 @@ class TestFrameworkFinder extends AbstractExecutableFinder
         return $this->cachedPath;
     }
 
-    private function doesCustomPathExist(): bool
+    private function shouldUseCustomPath(): bool
     {
-        return $this->customPath && file_exists($this->customPath);
+        if (null === $this->customPath) {
+            return false;
+        }
+
+        if (file_exists($this->customPath)) {
+            return true;
+        }
+
+        throw FinderException::testCustomPathDoesNotExist($this->testFrameworkName, $this->customPath);
     }
 
     private function addVendorFolderToPath()
@@ -81,7 +89,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
 
     private function findTestFramework(): string
     {
-        if ($this->doesCustomPathExist()) {
+        if ($this->shouldUseCustomPath()) {
             return $this->customPath;
         }
 

--- a/tests/Finder/TestFrameworkFinderTest.php
+++ b/tests/Finder/TestFrameworkFinderTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Finder;
+
+use Infection\Finder\SourceFilesFinder;
+use Infection\Finder\TestFrameworkFinder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder;
+
+class TestFrameworkFinderTest extends TestCase
+{
+    public function test_it_can_load_a_custom_path(): void
+    {
+        $filename = '/tmp/infection-test-framework-finder-test' . uniqid('', false);
+
+        touch($filename);
+
+        $frameworkFinder = new TestFrameworkFinder('not-used', $filename);
+
+        static::assertEquals($filename, $frameworkFinder->find(), 'Should return the custom path');
+    }
+}

--- a/tests/Finder/TestFrameworkFinderTest.php
+++ b/tests/Finder/TestFrameworkFinderTest.php
@@ -11,27 +11,49 @@ namespace Infection\Tests\Finder;
 
 use Infection\Finder\Exception\FinderException;
 use Infection\Finder\TestFrameworkFinder;
+use Infection\Utils\TmpDirectoryCreator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 class TestFrameworkFinderTest extends TestCase
 {
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem;
+
+    /**
+     * @var string
+     */
+    private $workspace;
+
+    /**
+     * @var string
+     */
+    private $tmpDir;
+
+    protected function setUp()
+    {
+        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+
+        $this->fileSystem = new Filesystem();
+        $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);
+    }
+
     public function test_it_can_load_a_custom_path()
     {
-        $fileSystem = new Filesystem();
-        $filename = $fileSystem->tempnam(sys_get_temp_dir(), 'infection-test');
-        $fileSystem->touch([$filename]);
+        $filename = $this->fileSystem->tempnam($this->tmpDir, 'test');
 
         $frameworkFinder = new TestFrameworkFinder('not-used', $filename);
 
-        static::assertEquals($filename, $frameworkFinder->find(), 'Should return the custom path');
-
-        $fileSystem->remove([$filename]);
+        $this->assertEquals($filename, $frameworkFinder->find(), 'Should return the custom path');
     }
 
     public function test_invalid_custom_path_throws_exception()
     {
-        $filename = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $filename = $this->fileSystem->tempnam($this->tmpDir, 'test');
+        // Remove it so that the file doesn't exist
+        $this->fileSystem->remove($filename);
 
         $frameworkFinder = new TestFrameworkFinder('not-used', $filename);
 
@@ -39,5 +61,10 @@ class TestFrameworkFinderTest extends TestCase
         $this->expectExceptionMessageRegExp('/custom path/');
 
         $frameworkFinder->find();
+    }
+
+    protected function tearDown()
+    {
+        $this->fileSystem->remove($this->workspace);
     }
 }

--- a/tests/Finder/TestFrameworkFinderTest.php
+++ b/tests/Finder/TestFrameworkFinderTest.php
@@ -12,23 +12,26 @@ namespace Infection\Tests\Finder;
 use Infection\Finder\Exception\FinderException;
 use Infection\Finder\TestFrameworkFinder;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
 
 class TestFrameworkFinderTest extends TestCase
 {
     public function test_it_can_load_a_custom_path()
     {
-        $filename = '/tmp/infection-test-framework-finder-test' . uniqid('', false);
-
-        touch($filename);
+        $fileSystem = new Filesystem();
+        $filename = $fileSystem->tempnam(sys_get_temp_dir(), 'infection-test');
+        $fileSystem->touch([$filename]);
 
         $frameworkFinder = new TestFrameworkFinder('not-used', $filename);
 
         static::assertEquals($filename, $frameworkFinder->find(), 'Should return the custom path');
+
+        $fileSystem->remove([$filename]);
     }
 
     public function test_invalid_custom_path_throws_exception()
     {
-        $filename = '/tmp/infection-test-framework-finder-test' . uniqid('', false);
+        $filename = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
 
         $frameworkFinder = new TestFrameworkFinder('not-used', $filename);
 

--- a/tests/Finder/TestFrameworkFinderTest.php
+++ b/tests/Finder/TestFrameworkFinderTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Finder;
 
+use Infection\Finder\Exception\FinderException;
 use Infection\Finder\SourceFilesFinder;
 use Infection\Finder\TestFrameworkFinder;
 use PHPUnit\Framework\TestCase;
@@ -25,5 +26,17 @@ class TestFrameworkFinderTest extends TestCase
         $frameworkFinder = new TestFrameworkFinder('not-used', $filename);
 
         static::assertEquals($filename, $frameworkFinder->find(), 'Should return the custom path');
+    }
+
+    public function test_invalid_custom_path_throws_exception(): void
+    {
+        $filename = '/tmp/infection-test-framework-finder-test' . uniqid('', false);
+
+        $frameworkFinder = new TestFrameworkFinder('not-used', $filename);
+
+        $this->expectException(FinderException::class);
+        $this->expectExceptionMessageRegExp('/custom path/');
+
+        $frameworkFinder->find();
     }
 }

--- a/tests/Finder/TestFrameworkFinderTest.php
+++ b/tests/Finder/TestFrameworkFinderTest.php
@@ -10,14 +10,12 @@ declare(strict_types=1);
 namespace Infection\Tests\Finder;
 
 use Infection\Finder\Exception\FinderException;
-use Infection\Finder\SourceFilesFinder;
 use Infection\Finder\TestFrameworkFinder;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Finder\Finder;
 
 class TestFrameworkFinderTest extends TestCase
 {
-    public function test_it_can_load_a_custom_path(): void
+    public function test_it_can_load_a_custom_path()
     {
         $filename = '/tmp/infection-test-framework-finder-test' . uniqid('', false);
 
@@ -28,7 +26,7 @@ class TestFrameworkFinderTest extends TestCase
         static::assertEquals($filename, $frameworkFinder->find(), 'Should return the custom path');
     }
 
-    public function test_invalid_custom_path_throws_exception(): void
+    public function test_invalid_custom_path_throws_exception()
     {
         $filename = '/tmp/infection-test-framework-finder-test' . uniqid('', false);
 


### PR DESCRIPTION
This PR:

- [x] Covered by tests

Fixes https://github.com/infection/infection/issues/217

* As a user, I want to use a custom path to the TestFramework (fixes #217)
* As a user, I want a descriptive error message if my custom path does not exist, rather than use a fallback