### PR TITLE
Add option to not log mutations

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -176,9 +176,6 @@ class InfectionCommand extends BaseCommand
         $metricsCalculator = new MetricsCalculator();
 
         $this->registerSubscribers($metricsCalculator, $adapter);
-        if (!$input->getOption('log-verbosity') === LogVerbosity::NONE) {
-            $this->registerFileLoggerSubscriber($metricsCalculator);
-        }
 
         $processBuilder = new ProcessBuilder($adapter, $container->get('infection.config')->getProcessTimeout());
         $testFrameworkOptions = $this->getTestFrameworkExtraOptions($testFrameworkKey);
@@ -300,20 +297,14 @@ class InfectionCommand extends BaseCommand
                 $this->getContainer()->get('diff.colorizer'),
                 $this->input->getOption('show-mutations')
             ),
-        ];
-    }
-
-    private function registerFileLoggerSubscriber(MetricsCalculator $metricsCalculator)
-    {
-        $this->eventDispatcher->addSubscriber(
             new MutationTestingResultsLoggerSubscriber(
                 $this->output,
                 $this->getContainer()->get('infection.config'),
                 $metricsCalculator,
                 $this->getContainer()->get('filesystem'),
                 (int) $this->input->getOption('log-verbosity')
-            )
-        );
+            ),
+        ];
     }
 
     private function getCodeCoverageData(string $testFrameworkKey): CodeCoverageData

--- a/src/Console/LogVerbosity.php
+++ b/src/Console/LogVerbosity.php
@@ -11,4 +11,5 @@ final class LogVerbosity
 {
     const DEBUG = 1;
     const NORMAL = 2;
+    const NONE = 3;
 }

--- a/src/Console/LogVerbosity.php
+++ b/src/Console/LogVerbosity.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Console;
 
 final class LogVerbosity

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Logger;
 
 use Infection\Process\MutantProcess;

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Logger;
 
 use Infection\Mutant\MetricsCalculator;

--- a/src/Logger/ResultsLoggerTypes.php
+++ b/src/Logger/ResultsLoggerTypes.php
@@ -22,4 +22,8 @@ final class ResultsLoggerTypes
         ResultsLoggerTypes::SUMMARY_FILE,
         ResultsLoggerTypes::BADGE,
     ];
+
+    const ALLOWED_WITHOUT_LOGGING = [
+        ResultsLoggerTypes::BADGE,
+    ];
 }

--- a/src/Logger/SummaryFileLogger.php
+++ b/src/Logger/SummaryFileLogger.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Logger;
 
 class SummaryFileLogger extends FileLogger

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -85,15 +85,19 @@ class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
         $logTypes = $this->filterLogTypes($logTypes);
 
         foreach ($logTypes as $logType => $config) {
-            if ($this->logVerbosity !== LogVerbosity::NONE) {
-                $this->useLogger($logType, $config);
-            }
+            $this->useLogger($logType, $config);
         }
     }
 
     private function filterLogTypes(array $logTypes): array
     {
         foreach ($logTypes as $key => $value) {
+            if ($this->logVerbosity === LogVerbosity::NONE) {
+                if (!in_array($key, ResultsLoggerTypes::ALLOWED_WITHOUT_LOGGING, true)) {
+                    unset($logTypes[$key]);
+                }
+                continue;
+            }
             if (!in_array($key, ResultsLoggerTypes::ALL, true)) {
                 unset($logTypes[$key]);
             }

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -13,6 +13,8 @@ use Infection\Config\InfectionConfig;
 use Infection\Console\LogVerbosity;
 use Infection\EventDispatcher\EventSubscriberInterface;
 use Infection\Events\MutationTestingFinished;
+use Infection\Http\BadgeApiClient;
+use Infection\Logger\BadgeLogger;
 use Infection\Logger\DebugFileLogger;
 use Infection\Logger\ResultsLoggerTypes;
 use Infection\Logger\SummaryFileLogger;
@@ -127,6 +129,14 @@ class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
                     $this->fs,
 
                     $isDebugMode
+                ))->log();
+                break;
+            case ResultsLoggerTypes::BADGE:
+                (new BadgeLogger(
+                    $this->output,
+                    new BadgeApiClient($this->output),
+                    $this->metricsCalculator,
+                    $config
                 ))->log();
                 break;
         }

--- a/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
+++ b/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
@@ -165,4 +165,24 @@ class MutationTestingResultsLoggerSubscriberTest extends TestCase
 
         $dispatcher->dispatch(new MutationTestingFinished());
     }
+
+    public function test_it_reacts_on_mutation_testing_finished_and_no_file_logging()
+    {
+        $logTypes = ['text' => sys_get_temp_dir() . '/infection-log.txt'];
+
+        $this->infectionConfig->expects($this->once())
+            ->method('getLogsTypes')
+            ->willReturn($logTypes);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new MutationTestingResultsLoggerSubscriber(
+            $this->output,
+            $this->infectionConfig,
+            $this->metricsCalculator,
+            $this->filesystem,
+            LogVerbosity::NONE
+        ));
+
+        $dispatcher->dispatch(new MutationTestingFinished());
+    }
 }


### PR DESCRIPTION
This PR:

- [x] Adds new feature: Log verbosity 3, which stops logging to files alltogether, which may be usefull for use on CI environments. 
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/26