### PR TITLE
Add Assignment Mutator

### DIFF
--- a/src/Mutator/Arithmetic/Assignment.php
+++ b/src/Mutator/Arithmetic/Assignment.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Arithmetic;
+
+use Infection\Mutator\Mutator;
+use PhpParser\Node;
+
+class Assignment extends Mutator
+{
+    /**
+     * Replaces "+=", "*=", ".=", and similar with a plain "="
+     *
+     * @param Node $node
+     *
+     * @return Node\Expr\Assign
+     */
+    public function mutate(Node $node)
+    {
+        return new Node\Expr\Assign($node->var, $node->expr, $node->getAttributes());
+    }
+
+    public function shouldMutate(Node $node): bool
+    {
+        return $node instanceof Node\Expr\AssignOp;
+    }
+}

--- a/tests/Mutator/Arithmetic/AssignmentTest.php
+++ b/tests/Mutator/Arithmetic/AssignmentTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Arithmetic;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class AssignmentTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): array
+    {
+        return [
+            'It changes compound assignments to simple assignments' => [
+                <<<'PHP'
+<?php
+
+$a += $b;
+$a -= $b;
+$a *= $b;
+$a **= $b;
+$a /= $b;
+$a %= $b;
+$a .= $b;
+$a &= $b;
+$a |= $b;
+$a ^= $b;
+$a <<= $b;
+$a >>= $b;
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$a = $b;
+$a = $b;
+$a = $b;
+$a = $b;
+$a = $b;
+$a = $b;
+$a = $b;
+$a = $b;
+$a = $b;
+$a = $b;
+$a = $b;
+$a = $b;
+PHP
+                ,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Mutator replaces "+=", "*=", ".=", and similar with a plain "=". 

A very easy typo that may be hard to notice if there's not enough tests.

This PR:

- [x] Adds new feature: Assignment Mutator
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/28