### PR TITLE
Add Assignment Equal Mutator

### DIFF
--- a/src/Mutator/Arithmetic/AssignmentEqual.php
+++ b/src/Mutator/Arithmetic/AssignmentEqual.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Arithmetic;
+
+use Infection\Mutator\Mutator;
+use PhpParser\Node;
+
+class AssignmentEqual extends Mutator
+{
+    /**
+     * Replaces "==" with a "=".
+     *
+     * @param Node $node
+     *
+     * @return Node\Expr\Assign
+     */
+    public function mutate(Node $node)
+    {
+        return new Node\Expr\Assign($node->left, $node->right, $node->getAttributes());
+    }
+
+    public function shouldMutate(Node $node): bool
+    {
+        return $node instanceof Node\Expr\BinaryOp\Equal && $node->left instanceof Node\Expr\Variable;
+    }
+}

--- a/tests/Mutator/Arithmetic/AssignmentEqualTest.php
+++ b/tests/Mutator/Arithmetic/AssignmentEqualTest.php
@@ -48,7 +48,25 @@ if (1 == $a) {
 }
 PHP
                         ,
-                ],
+            ],
+            'It does not try to assign a variable to a class constant' => [
+                        <<<'PHP'
+<?php
+
+if (BaseClass::CLASS_CONST == $a) {
+}
+PHP
+                        ,
+            ],
+            'It does not try to assign a variable to a built in constant' => [
+                        <<<'PHP'
+<?php
+
+if (PHP_EOL == $a) {
+}
+PHP
+                        ,
+            ],
         ];
     }
 }

--- a/tests/Mutator/Arithmetic/AssignmentEqualTest.php
+++ b/tests/Mutator/Arithmetic/AssignmentEqualTest.php
@@ -67,6 +67,15 @@ if (PHP_EOL == $a) {
 PHP
                         ,
             ],
+            'It does not try to assign a scalar to a result of a function call' => [
+                        <<<'PHP'
+<?php
+
+if ($x->getFoo() == 1) {
+}
+PHP
+                        ,
+            ],
         ];
     }
 }

--- a/tests/Mutator/Arithmetic/AssignmentEqualTest.php
+++ b/tests/Mutator/Arithmetic/AssignmentEqualTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Arithmetic;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class AssignmentEqualTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): array
+    {
+        return [
+            'It mutates a comparison to an assignment' => [
+                <<<'PHP'
+<?php
+
+if ($a == $b) {
+}
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+if ($a = $b) {
+}
+PHP
+                ,
+            ],
+            'It does not mutate comparsion to an impossible assignment' => [
+                        <<<'PHP'
+<?php
+
+if (1 == $a) {
+}
+PHP
+                        ,
+                ],
+        ];
+    }
+}


### PR DESCRIPTION
Replaces "==" with a "=".
 
It will only mutate if there's a variable on the left like here:
```php
if ($variable == BaseClass::CLASS_CONST) {
// mutates to... if ($variable = BaseClass::CLASS_CONST) {
```
This type of errors is main reason why this and other projects adopted Yoda notation for conditionals.

This PR:

- [x] Adds Assignment Equal Mutator
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/29
