### PR TITLE
Add a For Loop mutator & test

### DIFF
--- a/src/Mutator/ZeroIteration/For_.php
+++ b/src/Mutator/ZeroIteration/For_.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\ZeroIteration;
+
+use Infection\Mutator\Mutator;
+use PhpParser\Node;
+
+class For_ extends Mutator
+{
+    public function mutate(Node $node)
+    {
+        return new Node\Stmt\For_(
+            [
+                'init' => $node->init,
+                'cond' => [new Node\Expr\ConstFetch(new Node\Name('false'))],
+                'loop' => $node->loop,
+                'stmts' => $node->stmts,
+            ],
+            $node->getAttributes()
+        );
+    }
+
+    public function shouldMutate(Node $node): bool
+    {
+        return $node instanceof Node\Stmt\For_;
+    }
+}

--- a/tests/Mutator/ZeroIteration/For_Test.php
+++ b/tests/Mutator/ZeroIteration/For_Test.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\ZeroIteration;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class For_Test extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): array
+    {
+        return [
+            'It mutates to false in for loop condition' => [
+                <<<'PHP'
+<?php
+
+$array = [1, 2];
+
+for($i = 0; $i < count($array); $i++) {
+}
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$array = [1, 2];
+for ($i = 0; false; $i++) {
+}
+PHP
+                ,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds new feature: For Loop Mutator
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/27

This mutator serves the same purpose as the `ForEach_` mutator, except for For Loops.