### PR TITLE
InfectionConfig::getLogsTypes() - force operator order

### DIFF
--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -223,7 +223,7 @@ class InfectionConfig
 
     public function getLogsTypes(): array
     {
-        return (array) $this->config->logs ?? [];
+        return (array) ($this->config->logs ?? []);
     }
 
     private function getExcludedDirsByPattern(string $originalExcludedDir)

--- a/tests/Config/InfectionConfigTest.php
+++ b/tests/Config/InfectionConfigTest.php
@@ -145,6 +145,13 @@ class InfectionConfigTest extends TestCase
         $this->assertSame(['text' => 'app', 'debug' => 'location'], $config->getLogsTypes());
     }
 
+    public function test_it_correctly_gets_config_logs_if_missing()
+    {
+        $config = new InfectionConfig(new \stdClass(), $this->filesystem, '/path/to/config');
+
+        $this->assertSame([], $config->getLogsTypes());
+    }
+
     public function test_it_sets_ignored_mutators()
     {
         $config = <<<'JSON'


### PR DESCRIPTION
Else with a missing "logs" property in the config file a notice will come up:

> PHP Notice:  Undefined property: stdClass::$logs in src/Config/InfectionConfig.php on line 226

An example of a configuration causing the above error:

    {
        "source": {
            "directories": [
                "src/"
            ]
        }
    }

- [x] Covered by tests