### PR TITLE
Add -j as a shortcut for the --threads option.

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -82,7 +82,7 @@ class InfectionCommand extends BaseCommand
             )
             ->addOption(
                 'threads',
-                null,
+                'j',
                 InputOption::VALUE_REQUIRED,
                 'Threads count',
                 1


### PR DESCRIPTION
It's a common convention in many other programs: make, GNU parallel... Just to name a few.

This PR:

- [x] Adds new feature: `-j` as a shortcut for the `--threads` option.
- [x] Doc PR: https://github.com/infection/site/pull/30

