### PR TITLE
Refactor MutationsCollectorVisitor

### DIFF
--- a/src/Mutant/MutantCreator.php
+++ b/src/Mutant/MutantCreator.php
@@ -56,27 +56,13 @@ class MutantCreator
 
         $diff = $this->differ->diff($originalPrettyPrintedFile, $mutatedCode);
 
-        $isCoveredByTest = $this->isCoveredByTest($mutation, $codeCoverageData);
-
         return new Mutant(
             $mutatedFilePath,
             $mutation,
             $diff,
-            $isCoveredByTest,
+            $mutation->isCoveredByTest(),
             $codeCoverageData->getAllTestsFor($mutation)
         );
-    }
-
-    private function isCoveredByTest(Mutation $mutation, CodeCoverageData $codeCoverageData): bool
-    {
-        $line = $mutation->getAttributes()['startLine'];
-        $filePath = $mutation->getOriginalFilePath();
-
-        if ($mutation->isOnFunctionSignature()) {
-            return $codeCoverageData->hasExecutedMethodOnLine($filePath, $line);
-        }
-
-        return $codeCoverageData->hasTestsOnLine($filePath, $line);
     }
 
     private function createMutatedCode(Mutation $mutation, string $mutatedFilePath): string

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -44,13 +44,19 @@ class Mutation
      */
     private $isOnFunctionSignature;
 
+    /**
+     * @var bool
+     */
+    private $isCoveredByTest;
+
     public function __construct(
         string $originalFilePath,
         array $originalFileAst,
         Mutator $mutator,
         array $attributes,
         string $mutatedNodeClass,
-        bool $isOnFunctionSignature
+        bool $isOnFunctionSignature,
+        bool $isCoveredByTest
     ) {
         $this->originalFilePath = $originalFilePath;
         $this->originalFileAst = $originalFileAst;
@@ -58,6 +64,7 @@ class Mutation
         $this->attributes = $attributes;
         $this->mutatedNodeClass = $mutatedNodeClass;
         $this->isOnFunctionSignature = $isOnFunctionSignature;
+        $this->isCoveredByTest = $isCoveredByTest;
     }
 
     public function getMutator(): Mutator
@@ -106,5 +113,10 @@ class Mutation
     public function isOnFunctionSignature(): bool
     {
         return $this->isOnFunctionSignature;
+    }
+
+    public function isCoveredByTest(): bool
+    {
+        return $this->isCoveredByTest;
     }
 }

--- a/src/TestFramework/Coverage/CodeCoverageData.php
+++ b/src/TestFramework/Coverage/CodeCoverageData.php
@@ -107,6 +107,10 @@ class CodeCoverageData
 
     public function getAllTestsFor(Mutation $mutation): array
     {
+        if (!$mutation->isCoveredByTest()) {
+            return [];
+        }
+
         $filePath = $mutation->getOriginalFilePath();
         $line = $mutation->getAttributes()['startLine'];
 

--- a/tests/Fixtures/Files/Mutation/OneFile/OneFile.php
+++ b/tests/Fixtures/Files/Mutation/OneFile/OneFile.php
@@ -11,6 +11,8 @@ namespace Infection\Tests\Fixtures\Files\Mutation\OneFile;
 
 class OneFile
 {
+    const FOO = 1 + 2;
+
     public function foo($value = true): int
     {
         return 33 + 44;

--- a/tests/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/Mutant/Generator/MutationsGeneratorTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutant\Generator;
 
+use Infection\Config\Exception\InvalidConfigException;
 use Infection\EventDispatcher\EventDispatcher;
 use Infection\Mutant\Generator\MutationsGenerator;
 use Infection\Mutator\Arithmetic\Decrement;
@@ -122,15 +123,16 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertCount(0, $mutations);
     }
 
-    public function test_whitelist_is_case_insensitive()
+    public function test_whitelist_is_case_sensitive()
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
 
-        $generator = $this->createMutationGenerator($codeCoverageDataMock, [Decrement::getName()]);
+        $generator = $this->createMutationGenerator($codeCoverageDataMock, [strtolower(Decrement::getName())]);
 
-        $mutations = $generator->generate(false);
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('not recognized');
 
-        $this->assertCount(0, $mutations);
+        $generator->generate(false);
     }
 
     private function createMutationGenerator(CodeCoverageData $codeCoverageDataMock, array $whitelistedMutatorNames = [], MutatorConfig $mutatorConfig = null)

--- a/tests/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/Mutant/Generator/MutationsGeneratorTest.php
@@ -29,8 +29,8 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     public function test_it_collects_plus_mutation()
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->andReturn(false);
+        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->once()->andReturn(true);
+        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->twice()->andReturn(false);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
@@ -42,8 +42,8 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     public function test_it_collects_public_visibility_mutation()
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->andReturn(true);
+        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->once()->andReturn(true);
+        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->twice()->andReturn(true);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
@@ -56,8 +56,7 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     public function test_it_can_skip_not_covered_on_file_level()
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(false);
-        $codeCoverageDataMock->shouldReceive('hasTests')->andReturn(false);
+        $codeCoverageDataMock->shouldReceive('hasTests')->once()->andReturn(false);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
@@ -69,9 +68,9 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     public function test_it_can_skip_not_covered_on_file_line_level()
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
-        $codeCoverageDataMock->shouldReceive('hasTests')->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(false);
-        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->andReturn(true);
+        $codeCoverageDataMock->shouldReceive('hasTests')->once()->andReturn(true);
+        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->once()->andReturn(false);
+        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->twice()->andReturn(true);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
@@ -85,9 +84,9 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     public function test_it_can_skip_not_covered_on_file_line_for_visibility()
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
-        $codeCoverageDataMock->shouldReceive('hasTests')->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(false);
-        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->andReturn(false);
+        $codeCoverageDataMock->shouldReceive('hasTests')->once()->andReturn(true);
+        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->once()->andReturn(false);
+        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->twice()->andReturn(false);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
@@ -99,9 +98,7 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     public function test_it_can_skip_ignored_classes()
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
-        $codeCoverageDataMock->shouldReceive('hasTests')->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(false);
-        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->andReturn(false);
+        $codeCoverageDataMock->shouldReceive('hasTests')->once()->andReturn(true);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock, [], new MutatorConfig([
             'ignore' => [
@@ -117,7 +114,6 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     public function test_it_executes_only_whitelisted_mutators()
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(true);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock, [Decrement::getName()]);
 
@@ -129,7 +125,6 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     public function test_whitelist_is_case_insensitive()
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(true);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock, [Decrement::getName()]);
 

--- a/tests/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/Mutant/Generator/MutationsGeneratorTest.php
@@ -29,7 +29,7 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
         $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('isLineFunctionSignature')->andReturn(false);
+        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->andReturn(false);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
@@ -42,7 +42,7 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
         $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('isLineFunctionSignature')->andReturn(true);
+        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->andReturn(true);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
@@ -71,12 +71,6 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $codeCoverageDataMock->shouldReceive('hasTests')->andReturn(true);
         $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(false);
         $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('isLineFunctionSignature')
-            ->withArgs([Mockery::any(), 14])
-            ->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('isLineFunctionSignature')
-            ->andReturn(false)
-            ->byDefault();
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
@@ -92,7 +86,6 @@ class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
         $codeCoverageDataMock->shouldReceive('hasTests')->andReturn(true);
         $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->andReturn(false);
-        $codeCoverageDataMock->shouldReceive('isLineFunctionSignature')->andReturn(false);
         $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->andReturn(false);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);

--- a/tests/Mutant/MutantCreatorTest.php
+++ b/tests/Mutant/MutantCreatorTest.php
@@ -36,6 +36,7 @@ class MutantCreatorTest extends MockeryTestCase
         $mutation->shouldReceive('getOriginalFileAst')->andReturn(['ast']);
         $mutation->shouldReceive('getAttributes')->andReturn(['startLine' => 1]);
         $mutation->shouldReceive('isOnFunctionSignature')->andReturn(true);
+        $mutation->shouldReceive('isCoveredByTest')->andReturn(true);
 
         $coverage = \Mockery::mock(CodeCoverageData::class);
         $coverage->shouldReceive('hasExecutedMethodOnLine')->andReturn(true);

--- a/tests/Mutant/MutantCreatorTest.php
+++ b/tests/Mutant/MutantCreatorTest.php
@@ -36,7 +36,7 @@ class MutantCreatorTest extends MockeryTestCase
         $mutation->shouldReceive('getOriginalFileAst')->andReturn(['ast']);
         $mutation->shouldReceive('getAttributes')->andReturn(['startLine' => 1]);
         $mutation->shouldReceive('isOnFunctionSignature')->andReturn(true);
-        $mutation->shouldReceive('isCoveredByTest')->andReturn(true);
+        $mutation->shouldReceive('isCoveredByTest')->once()->andReturn(true);
 
         $coverage = \Mockery::mock(CodeCoverageData::class);
         $coverage->shouldReceive('hasExecutedMethodOnLine')->andReturn(true);

--- a/tests/MutationTest.php
+++ b/tests/MutationTest.php
@@ -34,7 +34,8 @@ class MutationTest extends TestCase
             $mutator,
             $attributes,
             'Interface_',
-            false
+            false,
+            true
         );
 
         $this->assertSame('5f52c44bcebde86a7ee79d0080c0e12a', $mutation->getHash());
@@ -58,7 +59,8 @@ class MutationTest extends TestCase
             $mutator,
             $attributes,
             'Interface_',
-            false
+            false,
+            true
         );
 
         $this->assertFalse($mutation->isOnFunctionSignature());
@@ -83,7 +85,8 @@ class MutationTest extends TestCase
             $mutator,
             $attributes,
             'Interface_',
-            false
+            false,
+            true
         );
 
         $this->assertSame($fileAst, $mutation->getOriginalFileAst());

--- a/tests/TestFramework/Coverage/CodeCoverageDataTest.php
+++ b/tests/TestFramework/Coverage/CodeCoverageDataTest.php
@@ -108,7 +108,8 @@ class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             Mockery::mock(Plus::class),
             ['startLine' => 1],
             'PHPParser\Node\Expr\BinaryOp\Plus',
-            false
+            false,
+            true
         );
 
         $this->assertCount(0, $codeCoverageData->getAllTestsFor($mutation));
@@ -125,7 +126,8 @@ class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             Mockery::mock(Plus::class),
             ['startLine' => 26],
             'PHPParser\Node\Expr\BinaryOp\Plus',
-            false
+            false,
+            true
         );
 
         $this->assertCount(2, $codeCoverageData->getAllTestsFor($mutation));
@@ -142,6 +144,7 @@ class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             Mockery::mock(PublicVisibility::class),
             ['startLine' => 1],
             'PHPParser\Node\Stmt\ClassMethod',
+            true,
             true
         );
 
@@ -159,6 +162,7 @@ class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             Mockery::mock(PublicVisibility::class),
             ['startLine' => 24],
             'PHPParser\Node\Stmt\ClassMethod',
+            true,
             true
         );
 

--- a/tests/Visitor/MutatorVisitorTest.php
+++ b/tests/Visitor/MutatorVisitorTest.php
@@ -90,6 +90,7 @@ PHP
                     'endTokenPos' => 48,
                 ],
                 ClassMethod::class,
+                true,
                 true
             ),
         ];
@@ -136,6 +137,7 @@ PHP
                     'endTokenPos' => 50,
                 ],
                 ClassMethod::class,
+                true,
                 true
             ),
         ];
@@ -189,6 +191,7 @@ PHP
                     'endTokenPos' => 48,
                 ],
                 ClassMethod::class,
+                true,
                 true
             ),
         ];


### PR DESCRIPTION
* Tag mutations as non-covered as early as we know it. Don't do it again later on.
* Exit early if a mutant can't mutate in MutationsCollectorVisitor.
* Tests updated to account for updated interface of a Mutation

- [x] Covered by tests

