### PR TITLE
ArrayItem Mutator

### DIFF
--- a/src/Mutator/Boolean/ArrayItem.php
+++ b/src/Mutator/Boolean/ArrayItem.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Boolean;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+
+class ArrayItem extends Mutator
+{
+    /**
+     * Replaces [$a->foo => $b->bar] with [$a->foo > $b->bar]
+     *
+     * @param Node $node
+     *
+     * @return Node\Expr\BinaryOp\Greater
+     */
+    public function mutate(Node $node)
+    {
+        return new Node\Expr\BinaryOp\Greater($node->key, $node->value, $node->getAttributes());
+    }
+
+    public function shouldMutate(Node $node): bool
+    {
+        return $node instanceof Node\Expr\ArrayItem && $node->key && ($this->isNodeWithSideEffects($node->value) || $this->isNodeWithSideEffects($node->key));
+    }
+
+    private function isNodeWithSideEffects(Node $node)
+    {
+        return
+            // __get() can have side-effects
+            $node instanceof Node\Expr\PropertyFetch ||
+            // these clearly can have side-effects
+            $node instanceof Node\Expr\MethodCall ||
+            $node instanceof Node\Expr\FuncCall;
+    }
+}

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -56,6 +56,7 @@ final class MutatorProfile
     ];
 
     const BOOLEAN = [
+        Mutator\Boolean\ArrayItem::class,
         Mutator\Boolean\FalseValue::class,
         Mutator\Boolean\LogicalAnd::class,
         Mutator\Boolean\LogicalLowerAnd::class,
@@ -158,6 +159,7 @@ final class MutatorProfile
         'ShiftRight' => Mutator\Arithmetic\ShiftRight::class,
 
         //Boolean
+        'ArrayItem' => Mutator\Boolean\ArrayItem::class,
         'FalseValue' => Mutator\Boolean\FalseValue::class,
         'LogicalAnd' => Mutator\Boolean\LogicalAnd::class,
         'LogicalLowerAnd' => Mutator\Boolean\LogicalLowerAnd::class,

--- a/tests/Mutator/Boolean/ArrayItemTest.php
+++ b/tests/Mutator/Boolean/ArrayItemTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Boolean;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class ArrayItemTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): \Generator
+    {
+        yield 'It mutates double arrow operator to a greater than comparison when operands can have side-effects' => [
+            <<<'PHP'
+<?php
+
+[$a->foo => $b->bar];
+[$a->foo() => bar()];
+[foo() => $b->bar];
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+[$a->foo > $b->bar];
+[$a->foo() > bar()];
+[foo() > $b->bar];
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate arrays without double arrow operator' => [
+            <<<'PHP'
+<?php
+
+[$b];
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate arrays when side-effects are not expected' => [
+            <<<'PHP'
+<?php
+
+['string' => 1];
+[true => false];
+[$a => $b];
+PHP
+            ,
+        ];
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds an ArrayItem Mutator
- [x] Covered by tests
- [x] Added to a relevant profile 
- [x] Doc PR: https://github.com/infection/site/pull/32

This mutator replaces `[$a->foo => $b->bar]` with `[$a->foo > $b->bar]` where one can reasonably expect side-effects to happen. 

Precisely, only those array items will be mutated which have either a function call, a method call, or a property fetch on either side of an item.

```php
[$a->foo => $b->bar];
[$a->foo() => bar()];
[foo() => $b->bar];
```
    
Will mutate to:

```php
[$a->foo > $b->bar];
[$a->foo() > bar()];
[foo() > $b->bar];
```

### Dogfooding
```
$ softlimit -m 500000000 bin/infection --threads=$(nproc) --mutators=ArrayItem

<skip>

.: killed, M: escaped, S: uncovered, E: fatal error, T: timed out

S...M....M.M.M..M.M                                  (19 / 19)

19 mutations were generated:
      12 mutants were killed
       1 mutants were not covered by tests
       6 covered mutants were not detected
       0 errors were encountered
       0 time outs were encountered

Metrics:
         Mutation Score Indicator (MSI): 63%
         Mutation Code Coverage: 95%
         Covered Code MSI: 67%

```

That's 6 escaped mutants for the Infection itself.
