### PR TITLE
Yield Mutator

### DIFF
--- a/src/Mutator/Boolean/Yield_.php
+++ b/src/Mutator/Boolean/Yield_.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Boolean;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+
+class Yield_ extends Mutator
+{
+    /**
+     * Replaces `yield $a => $b;` with `yield $a > $b;`
+     *
+     * @param Node $node
+     *
+     * @return Node\Expr\Yield_
+     */
+    public function mutate(Node $node)
+    {
+        $node->value = new Node\Expr\BinaryOp\Greater($node->key, $node->value, $node->getAttributes());
+        $node->key = null;
+
+        return $node;
+    }
+
+    public function shouldMutate(Node $node): bool
+    {
+        return $node instanceof Node\Expr\Yield_ && $node->key;
+    }
+}

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -164,6 +164,7 @@ final class MutatorProfile
         'LogicalNot' => Mutator\Boolean\LogicalNot::class,
         'LogicalOr' => Mutator\Boolean\LogicalOr::class,
         'TrueValue' => Mutator\Boolean\TrueValue::class,
+        'Yield_' => Mutator\Boolean\Yield_::class,
 
         //Conditional Boundary
         'GreaterThan' => Mutator\ConditionalBoundary\GreaterThan::class,

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -63,6 +63,7 @@ final class MutatorProfile
         Mutator\Boolean\LogicalNot::class,
         Mutator\Boolean\LogicalOr::class,
         Mutator\Boolean\TrueValue::class,
+        Mutator\Boolean\Yield_::class,
     ];
 
     const CONDITIONAL_BOUNDARY = [

--- a/tests/Mutator/Boolean/Yield_Test.php
+++ b/tests/Mutator/Boolean/Yield_Test.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Boolean;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class Yield_Test extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): \Generator
+    {
+        yield 'It mutates a yield with a double arrow to a yield with a greater than comparison' => [
+            <<<'PHP'
+<?php
+
+(yield $a => $b);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+(yield $a > $b);
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate yields without a double arrow operator' => [
+            <<<'PHP'
+<?php
+
+(yield $b);
+PHP
+            ,
+        ];
+    }
+}


### PR DESCRIPTION
Replaces `yield $a => $b;` with `yield $a > $b;`

This PR:

- [x] Adds Yield Mutator
- [x] Covered by tests
- [x] Added to a relevant profile (blocked by #241)
- [x] Doc PR: https://github.com/infection/site/pull/31
