### PR TITLE
Statement mutators: Assign, MethodCall

### DIFF
--- a/src/Mutator/Statement/Assign.php
+++ b/src/Mutator/Statement/Assign.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Statement;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+
+class Assign extends Mutator
+{
+    public function mutate(Node $node)
+    {
+        return new Node\Expr\BinaryOp\BooleanOr(new Node\Expr\ConstFetch(new Node\Name('true')), $node, $node->getAttributes());
+    }
+
+    public function shouldMutate(Node $node): bool
+    {
+        // Expr_Assign -> (Variable | PropertyFetch) + (MethodCall | Variable | PropertyFetch)
+        return $node instanceof Node\Expr\Assign &&
+            ($node->var instanceof  Node\Expr\Variable || $node->var instanceof  Node\Expr\PropertyFetch) &&
+            ($node->expr instanceof Node\Expr\MethodCall || $node->expr instanceof Node\Expr\FuncCall ||
+                $node->expr instanceof Node\Expr\Variable || $node->expr instanceof Node\Expr\PropertyFetch);
+    }
+}

--- a/src/Mutator/Statement/MethodCallFalse.php
+++ b/src/Mutator/Statement/MethodCallFalse.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Statement;
 
-class MethodCallFalse extends MethodCallTrue
+use Infection\Mutator\Util\AbstractMethodCall;
+
+class MethodCallFalse extends AbstractMethodCall
 {
     const REPLACEMENT = 'false';
 }

--- a/src/Mutator/Statement/MethodCallFalse.php
+++ b/src/Mutator/Statement/MethodCallFalse.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Statement;
+
+class MethodCallFalse extends MethodCallTrue
+{
+    const REPLACEMENT = 'false';
+}

--- a/src/Mutator/Statement/MethodCallNull.php
+++ b/src/Mutator/Statement/MethodCallNull.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Statement;
 
-class MethodCallNull extends MethodCallTrue
+use Infection\Mutator\Util\AbstractMethodCall;
+
+class MethodCallNull extends AbstractMethodCall
 {
     const REPLACEMENT = 'null';
 }

--- a/src/Mutator/Statement/MethodCallNull.php
+++ b/src/Mutator/Statement/MethodCallNull.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Statement;
+
+class MethodCallNull extends MethodCallTrue
+{
+    const REPLACEMENT = 'null';
+}

--- a/src/Mutator/Statement/MethodCallTrue.php
+++ b/src/Mutator/Statement/MethodCallTrue.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Statement;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+
+class MethodCallTrue extends Mutator
+{
+    const REPLACEMENT = 'true';
+
+    public function mutate(Node $node)
+    {
+        return new Node\Expr\ConstFetch(new Node\Name(static::REPLACEMENT));
+    }
+
+    public function shouldMutate(Node $node): bool
+    {
+        return $node instanceof Node\Expr\MethodCall || $node instanceof Node\Expr\FuncCall;
+    }
+}

--- a/src/Mutator/Statement/MethodCallTrue.php
+++ b/src/Mutator/Statement/MethodCallTrue.php
@@ -9,20 +9,9 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Statement;
 
-use Infection\Mutator\Util\Mutator;
-use PhpParser\Node;
+use Infection\Mutator\Util\AbstractMethodCall;
 
-class MethodCallTrue extends Mutator
+class MethodCallTrue extends AbstractMethodCall
 {
     const REPLACEMENT = 'true';
-
-    public function mutate(Node $node)
-    {
-        return new Node\Expr\ConstFetch(new Node\Name(static::REPLACEMENT));
-    }
-
-    public function shouldMutate(Node $node): bool
-    {
-        return $node instanceof Node\Expr\MethodCall || $node instanceof Node\Expr\FuncCall;
-    }
 }

--- a/src/Mutator/Util/AbstractMethodCall.php
+++ b/src/Mutator/Util/AbstractMethodCall.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Util;
+
+use PhpParser\Node;
+
+abstract class AbstractMethodCall extends Mutator
+{
+    public function mutate(Node $node)
+    {
+        return new Node\Expr\ConstFetch(new Node\Name(static::REPLACEMENT));
+    }
+
+    public function shouldMutate(Node $node): bool
+    {
+        return $node instanceof Node\Expr\MethodCall || $node instanceof Node\Expr\FuncCall;
+    }
+}

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -24,6 +24,7 @@ final class MutatorProfile
         '@operator' => self::OPERATOR,
         '@return_value' => self::RETURN_VALUE,
         '@sort' => self::SORT,
+        '@statement' => self::STATEMENT,
         '@zero_iteration' => self::ZERO_ITERATION,
 
         //Special Profiles
@@ -113,6 +114,9 @@ final class MutatorProfile
         Mutator\Sort\Spaceship::class,
     ];
 
+    const STATEMENT = [
+    ];
+
     const ZERO_ITERATION = [
         Mutator\ZeroIteration\Foreach_::class,
         Mutator\ZeroIteration\For_::class,
@@ -128,6 +132,7 @@ final class MutatorProfile
         '@operator',
         '@return_value',
         '@sort',
+        '@statement',
         '@zero_iteration',
     ];
 

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -116,6 +116,9 @@ final class MutatorProfile
 
     const STATEMENT = [
         Mutator\Statement\Assign::class,
+        Mutator\Statement\MethodCallFalse::class,
+        Mutator\Statement\MethodCallNull::class,
+        Mutator\Statement\MethodCallTrue::class,
     ];
 
     const ZERO_ITERATION = [
@@ -214,6 +217,9 @@ final class MutatorProfile
 
         //Statement
         'Assign' => Mutator\Statement\Assign::class,
+        'MethodCallFalse' => Mutator\Statement\MethodCallFalse::class,
+        'MethodCallNull' => Mutator\Statement\MethodCallNull::class,
+        'MethodCallTrue' => Mutator\Statement\MethodCallTrue::class,
 
         //Zero Iteration
         'Foreach_' => Mutator\ZeroIteration\Foreach_::class,

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -115,6 +115,7 @@ final class MutatorProfile
     ];
 
     const STATEMENT = [
+        Mutator\Statement\Assign::class,
     ];
 
     const ZERO_ITERATION = [
@@ -210,6 +211,9 @@ final class MutatorProfile
 
         //Sort
         'Spaceship' => Mutator\Sort\Spaceship::class,
+
+        //Statement
+        'Assign' => Mutator\Statement\Assign::class,
 
         //Zero Iteration
         'Foreach_' => Mutator\ZeroIteration\Foreach_::class,

--- a/tests/Mutator/Statement/AssignTest.php
+++ b/tests/Mutator/Statement/AssignTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Statement;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class AssignTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): \Generator
+    {
+        yield 'It mutates method calls assignments' => [
+            <<<'PHP'
+<?php
+
+$a = $b;
+$var->a = $b;
+$var->a = count($a);
+$var->b = $var->a;
+$var->c = $var->foo();
+$d = $var->foo();
+if ($bar->baz && $foo->a = $baz->b()) {
+}
+
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+true || ($a = $b);
+true || ($var->a = $b);
+true || ($var->a = count($a));
+true || ($var->b = $var->a);
+true || ($var->c = $var->foo());
+true || ($d = $var->foo());
+if ($bar->baz && (true || ($foo->a = $baz->b()))) {
+}
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate constant assignments' => [
+            <<<'PHP'
+<?php
+
+$a = 1;
+$var->b = false;
+$foo->bar = [];
+PHP
+            ,
+        ];
+    }
+}

--- a/tests/Mutator/Statement/MethodCallFalseTest.php
+++ b/tests/Mutator/Statement/MethodCallFalseTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Statement;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class MethodCallFalseTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): array
+    {
+        return [
+            'It removes method calls' => [
+                <<<'PHP'
+<?php
+
+bar();
+$a = bar();
+$var->foo();
+$var->foo() == 1;
+$var->foo()->bar();
+$var->foo()->bar()->baz();
+$var->foo()->bar()->baz() == $var;
+if ($bar || $var->foo()) {
+}
+if ($var->foo()->bar() == 1) {
+}
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+false;
+$a = false;
+false;
+false == 1;
+false;
+false;
+false == $var;
+if ($bar || false) {
+}
+if (false == 1) {
+}
+PHP
+                ,
+            ],
+        ];
+    }
+}

--- a/tests/Mutator/Statement/MethodCallNullTest.php
+++ b/tests/Mutator/Statement/MethodCallNullTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Statement;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class MethodCallNullTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): array
+    {
+        return [
+            'It removes method calls' => [
+                <<<'PHP'
+<?php
+
+bar();
+$a = bar();
+$var->foo();
+$var->foo() == 1;
+$var->foo()->bar();
+$var->foo()->bar()->baz();
+$var->foo()->bar()->baz() == $var;
+if ($bar || $var->foo()) {
+}
+if ($var->foo()->bar() == 1) {
+}
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+null;
+$a = null;
+null;
+null == 1;
+null;
+null;
+null == $var;
+if ($bar || null) {
+}
+if (null == 1) {
+}
+PHP
+                ,
+            ],
+        ];
+    }
+}

--- a/tests/Mutator/Statement/MethodCallTrueTest.php
+++ b/tests/Mutator/Statement/MethodCallTrueTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Statement;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class MethodCallTrueTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): array
+    {
+        return [
+            'It removes method calls' => [
+                <<<'PHP'
+<?php
+
+bar();
+$a = bar();
+$var->foo();
+$var->foo() == 1;
+$var->foo()->bar();
+$var->foo()->bar()->baz();
+$var->foo()->bar()->baz() == $var;
+if ($bar || $var->foo()) {
+}
+if ($var->foo()->bar() == 1) {
+}
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+true;
+$a = true;
+true;
+true == 1;
+true;
+true;
+true == $var;
+if ($bar || true) {
+}
+if (true == 1) {
+}
+PHP
+                ,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds a new type of *Statement* mutators
- [x] Adds an Assign Statement mutator
- [x] Adds a family of MethodCall Mutators
- [x] Covered by tests
- [ ] Doc PR: TBD
- [ ] MSI percentages need to be updated.

### Statement mutators

Statement mutators change or disable entire statements. Requested in #53.

### Assign Statement mutator

This mutator tries to disable assignments, while trying to not to cause clear and straight errors. This feat is achieved by prepending an assignment with `true ||`, thus making the assignment essentially void.

This code:
```php
if ($a = $foo->b()) {
    $c = true;
}
```
Becomes:
```php
if (true || $a = $foo->b()) {
    $c = true;
}
```
Assign mutator will only mutate if...
- There's a variable or a property on the left of an assignment, and if
- There's a method call, function call, variable, or property on the right.

Constant assignments are left unscathed.

### MethodCall Mutators

There's three mutators in this family: MethodCallFalse, MethodCallNull, MethodCallTrue.

These mutators replace any method or function call with `null`, `true`, or `false`. This way even if a method/function call is embedded in another construct, be it an `if` or another method call, there won't be a language error.

```php
if ($bar || $var->foo()) {
}
```
Becomes either of:

```php
if ($bar || false) {
}

if ($bar || true) {
}

if ($bar || null) {
}
```
Instead of `$bar` there could be another method call that would not be mutated on this iteration. And there could be logical *and* instead of *or*: these mutators cover all bases.

### What gives?

Overall this should fix #53.

Please tell me if these are okay and I can go on with a doc PR.

----

BTW I'm OK if these mutators will go to the long discussed `@nightmare` profile since they add quite a lot of mutations.

| Mutator          | Mutations     | Killed        | Escaped       | Errors       | 
| ---------------- | ------------- | ------------- | ------------- |------------- |
| Assign           | 437           | 281           | 27            | 1            |
| MethodCallFalse  | 1275          | 583           | 116           | 3            |
| MethodCallNull   | 1275          | 582           | 117           | 3            |
| MethodCallTrue   | 1275          | 563           | 135           | 4            |

```
$ softlimit -m 500000000 bin/infection --threads=4 --mutators=@statement
You are running Infection with xdebug enabled.
    ____      ____          __  _
   /  _/___  / __/__  _____/ /_(_)___  ____ 
   / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \
 _/ // / / / __/  __/ /__/ /_/ / /_/ / / / /
/___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/
 
Running initial test suite...

PHPUnit version: 6.1.0

  450 [============================] 14 secs

Generate mutants...

Processing source code files: 186/186
Creating mutated files and processes: 4271/4271
.: killed, M: escaped, S: uncovered, E: fatal error, T: timed out

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS   (  50 / 4271)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS   ( 100 / 4271)

<skip>

...................................MMM........MM..   (4150 / 4271)
........MM...................................MM.M.   (4200 / 4271)
..MMMMMMM.MMMMM......M..............MM........M..M   (4250 / 4271)
.....................                                (4271 / 4271)

4271 mutations were generated:
    2032 mutants were killed
    1830 mutants were not covered by tests
     401 covered mutants were not detected
       8 errors were encountered
       0 time outs were encountered

Metrics:
         Mutation Score Indicator (MSI): 48%
         Mutation Code Coverage: 57%
         Covered Code MSI: 84%

Please note that some mutants will inevitably be harmless (i.e. false positives).
```
That's 4271 extra mutations to a thousand currently generated, but 401 escaped mutants and only 8 errors.

### Errors

I'm not sure if these errors are avoidable:
```
-        $isDoubledLogicalNot = $node->expr instanceof Node\Expr\BooleanNot || $node->getAttribute('parent') instanceof Node\Expr\BooleanNot;
+        $isDoubledLogicalNot = $node->expr instanceof Node\Expr\BooleanNot || false instanceof Node\Expr\BooleanNot;
```

```
-        $updater->getStrategy()->setPackageName(self::PACKAGE_NAME);
+        false->setPackageName(self::PACKAGE_NAME);
```