### PR TITLE
Show installed version when Infection has been installed as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "require": {
         "php": "^7.0",
         "nikic/php-parser": "^4.0",
+        "ocramius/package-versions": "^1.2",
         "padraic/phar-updater": "^1.0.4",
         "pimple/pimple": "^3.2",
         "sebastian/diff": "^1.4 || ^2.0 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "29158905e9f1137b08bf5c411a6f49f7",
+    "content-hash": "6ad346428108db62258b6f0b5b52cbb1",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -56,6 +56,55 @@
                 "php"
             ],
             "time": "2018-02-28T20:39:30+00:00"
+        },
+        {
+            "name": "ocramius/package-versions",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "ad8a245decad4897cc6b432743913dad0d69753c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/ad8a245decad4897cc6b432743913dad0d69753c",
+                "reference": "ad8a245decad4897cc6b432743913dad0d69753c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "~7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.3",
+                "ext-zip": "*",
+                "humbug/humbug": "dev-master",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2017-11-24T11:07:03+00:00"
         },
         {
             "name": "padraic/humbug_get_contents",

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -14,6 +14,7 @@ use Infection\Config\Exception\InvalidConfigException;
 use Infection\Config\InfectionConfig;
 use Infection\Php\ConfigBuilder;
 use Infection\Php\XdebugHandler;
+use PackageVersions\Versions;
 use Pimple\Container;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
@@ -123,6 +124,17 @@ ASCII;
         $output->writeln(self::LOGO);
 
         return parent::doRun($input, $output);
+    }
+
+    public function getLongVersion()
+    {
+        if (self::VERSION === $this->getVersion()) {
+            $version = Versions::getVersion('infection/infection');
+
+            return sprintf('%s <info>%s</info>', $this->getName(), explode('@', $version)[0]);
+        }
+
+        return parent::getLongVersion();
     }
 
     protected function getDefaultCommands()


### PR DESCRIPTION
This PR fixes https://github.com/infection/infection/issues/208

I've implemented new dependency to take the current installed version. If you're not happy with it we can implement the same solution like @theofidry did in [Box](https://github.com/humbug/box/blob/master/src/Console/Application.php#L48-L60) - just remove package version when Infection installed as dependency 