### PR TITLE
Add a mandatory memory limit for PHPUnit sub-processes

### DIFF
--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -14,6 +14,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class InfectionConfig
 {
     const PROCESS_TIMEOUT_SECONDS = 10;
+    const PROCESS_MEMORY_LIMIT = '128M';
     const DEFAULT_SOURCE_DIRS = ['.'];
     const DEFAULT_EXCLUDE_DIRS = ['vendor'];
     const CONFIG_FILE_NAME = 'infection.json';

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -52,6 +52,7 @@ class MutationConfigBuilder extends ConfigBuilder
         $xmlConfigurationHelper->deactivateColours($this->xPath);
         $xmlConfigurationHelper->removeExistingLoggers($this->dom, $this->xPath);
         $xmlConfigurationHelper->removeExistingPrinters($this->dom, $this->xPath);
+        $xmlConfigurationHelper->addMemoryLimit($this->xPath, $this->dom);
     }
 
     public function build(Mutant $mutant): string

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpUnit\Config;
 
+use Infection\Config\InfectionConfig;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 
 class XmlConfigurationHelper
@@ -79,5 +80,26 @@ class XmlConfigurationHelper
         if ($nodeList->length) {
             $dom->documentElement->removeAttribute('printerClass');
         }
+    }
+
+    public function addMemoryLimit(\DOMXPath $xPath, \DOMDocument $dom)
+    {
+        if ($xPath->query('/phpunit/php/ini[@name="memory_limit"]')->length) {
+            return;
+        }
+
+        $nodeList = $xPath->query('/phpunit/php');
+
+        if ($nodeList->length) {
+            $node = $nodeList[0];
+        } else {
+            $node = $dom->createElement('php');
+            $xPath->query('/phpunit')[0]->appendChild($node);
+        }
+
+        $element = $dom->createElement('ini');
+        $element->setAttribute('name', 'memory_limit');
+        $element->setAttribute('value', InfectionConfig::PROCESS_MEMORY_LIMIT);
+        $node->appendChild($element);
     }
 }

--- a/tests/Fixtures/Files/phpunit/phpunit_with_ini_set.xml
+++ b/tests/Fixtures/Files/phpunit/phpunit_with_ini_set.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit>
+    <php>
+        <ini name="example" value="test"/>
+    </php>
+</phpunit>

--- a/tests/Fixtures/Files/phpunit/phpunit_with_memory_limit.xml
+++ b/tests/Fixtures/Files/phpunit/phpunit_with_memory_limit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit>
+    <php>
+        <ini name="memory_limit" value="64M"/>
+    </php>
+</phpunit>

--- a/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -113,18 +113,25 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertSame($expectedCustomAutoloadFilePath, $resultAutoLoaderFilePath);
     }
 
+    private function builderFromFile(string $phpunitXmlPath): MutationConfigBuilder
+    {
+        $replacer = new PathReplacer($this->fileSystem, $this->pathToProject);
+        $xmlConfigurationHelper = new XmlConfigurationHelper($replacer);
+
+        return new MutationConfigBuilder(
+            $this->tmpDir,
+            file_get_contents($phpunitXmlPath),
+            $xmlConfigurationHelper,
+            $this->pathToProject
+        );
+    }
+
     public function test_it_sets_custom_autoloader_when_attribute_is_absent()
     {
         $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
         $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpuit_without_bootstrap.xml';
-        $this->builder = new MutationConfigBuilder(
-            $this->tmpDir,
-            file_get_contents($phpunitXmlPath),
-            $this->xmlConfigurationHelper,
-            'project/dir'
-        );
 
-        $configurationPath = $this->builder->build($this->mutant);
+        $configurationPath = $this->builderFromFile($phpunitXmlPath)->build($this->mutant);
 
         $xml = file_get_contents($configurationPath);
 
@@ -170,17 +177,8 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
 
         $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit_root_test_suite.xml';
-        $replacer = new PathReplacer($this->fileSystem, $this->pathToProject);
-        $xmlConfigurationHelper = new XmlConfigurationHelper($replacer);
 
-        $this->builder = new MutationConfigBuilder(
-            $this->tmpDir,
-            file_get_contents($phpunitXmlPath),
-            $xmlConfigurationHelper,
-            $this->pathToProject
-        );
-
-        $configurationPath = $this->builder->build($this->mutant);
+        $configurationPath = $this->builderFromFile($phpunitXmlPath)->build($this->mutant);
 
         $this->assertEquals(1, $this->queryXpath(file_get_contents($configurationPath), '/phpunit/testsuite')->length);
     }
@@ -226,20 +224,11 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     public function test_it_does_not_add_memory_limit_if_exist()
     {
-        $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit_with_memory_limit.xml';
-        $replacer = new PathReplacer($this->fileSystem, $this->pathToProject);
-        $xmlConfigurationHelper = new XmlConfigurationHelper($replacer);
-
-        $this->builder = new MutationConfigBuilder(
-            $this->tmpDir,
-            file_get_contents($phpunitXmlPath),
-            $xmlConfigurationHelper,
-            $this->pathToProject
-        );
-
         $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
 
-        $configurationPath = $this->builder->build($this->mutant);
+        $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit_with_memory_limit.xml';
+
+        $configurationPath = $this->builderFromFile($phpunitXmlPath)->build($this->mutant);
 
         $xml = file_get_contents($configurationPath);
 
@@ -251,20 +240,11 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     public function test_it_does_not_extra_php_node()
     {
-        $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit_with_ini_set.xml';
-        $replacer = new PathReplacer($this->fileSystem, $this->pathToProject);
-        $xmlConfigurationHelper = new XmlConfigurationHelper($replacer);
-
-        $this->builder = new MutationConfigBuilder(
-            $this->tmpDir,
-            file_get_contents($phpunitXmlPath),
-            $xmlConfigurationHelper,
-            $this->pathToProject
-        );
-
         $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
 
-        $configurationPath = $this->builder->build($this->mutant);
+        $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit_with_ini_set.xml';
+
+        $configurationPath = $this->builderFromFile($phpunitXmlPath)->build($this->mutant);
 
         $xml = file_get_contents($configurationPath);
 

--- a/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -210,6 +210,70 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertSame(0, $filterNodes->length);
     }
 
+    public function test_it_adds_memory_limit_if_not_exist()
+    {
+        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+
+        $configurationPath = $this->builder->build($this->mutant);
+
+        $xml = file_get_contents($configurationPath);
+
+        /** @var \DOMNodeList $filterNodes */
+        $filterNodes = $this->queryXpath($xml, '/phpunit/php/ini[@name="memory_limit"]');
+
+        $this->assertSame(1, $filterNodes->length);
+    }
+
+    public function test_it_does_not_add_memory_limit_if_exist()
+    {
+        $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit_with_memory_limit.xml';
+        $replacer = new PathReplacer($this->fileSystem, $this->pathToProject);
+        $xmlConfigurationHelper = new XmlConfigurationHelper($replacer);
+
+        $this->builder = new MutationConfigBuilder(
+            $this->tmpDir,
+            file_get_contents($phpunitXmlPath),
+            $xmlConfigurationHelper,
+            $this->pathToProject
+        );
+
+        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+
+        $configurationPath = $this->builder->build($this->mutant);
+
+        $xml = file_get_contents($configurationPath);
+
+        /** @var \DOMNodeList $filterNodes */
+        $filterNodes = $this->queryXpath($xml, '/phpunit/php/ini[@name="memory_limit"]');
+
+        $this->assertSame(1, $filterNodes->length);
+    }
+
+    public function test_it_does_not_extra_php_node()
+    {
+        $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit_with_ini_set.xml';
+        $replacer = new PathReplacer($this->fileSystem, $this->pathToProject);
+        $xmlConfigurationHelper = new XmlConfigurationHelper($replacer);
+
+        $this->builder = new MutationConfigBuilder(
+            $this->tmpDir,
+            file_get_contents($phpunitXmlPath),
+            $xmlConfigurationHelper,
+            $this->pathToProject
+        );
+
+        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+
+        $configurationPath = $this->builder->build($this->mutant);
+
+        $xml = file_get_contents($configurationPath);
+
+        /** @var \DOMNodeList $filterNodes */
+        $filterNodes = $this->queryXpath($xml, '/phpunit/php');
+
+        $this->assertSame(1, $filterNodes->length);
+    }
+
     /**
      * @dataProvider coverageTestsProvider
      */


### PR DESCRIPTION
This PR:

- [x] Adds a mandatory memory limit for PHPUnit sub-processes
- [x] Covered by tests
- [ ] Doc PR: ?

### Rationale

Infection is a command line program. Command line programs are expected to behave. Because they are expected to behave, there are usually no particular limits in terms of memory consumption. Command line programs are responsible for the commands they launch. So must be Infection. 

Currently there is no limits on how much memory a child process may consume other than by time. Since the main function of Infection is to cause unexpected bugs in programs it runs, there must be at least some limits in place to make sure new bugs do not cause more damage than they should.

There's a default time limit of 20 seconds. Current programs have no problem consuming many gigabytes of RAM in the allotted time limit. Therefore, it is not enough to have a time limit only.

### Methodology

Memory limit is introduced by altering `phpunit.xml` to include it. 

```
<php>
    <ini name="memory_limit" value="128M"/>
</php>
```

The memory limit is default to 128Mb, which is an accepted default for most web apps.

If there is a memory limit already defined, it won't be overridden. Therefore, this feature requires no configuration whatsoever. 

Fixes #247
