### PR TITLE
Enhancement: test in multiple environments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ trim_trailing_whitespace=true
 insert_final_newline=true
 indent_style=space
 indent_size=4
+
+[Makefile]
+indent_style=tab

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,5 +5,26 @@ Contributions are always welcome. Here are a few guidelines to be aware of:
  - Include unit or e2e tests for new behaviours introduced by PRs.
  - Fixed bugs MUST be covered by test(s) to avoid regression.
  - If you are on Unix-like system, run `./setup_environment.sh` to set up `pre-push` git hook.
- - All code must follow the `PSR-2` coding standard. Please see [PSR-2](http://www.php-fig.org/psr/psr-2/) for more details. To make this as easy as possible, we use PHPCSFixer running two simple composer scripts: `composer cs:check` and `composer cs:fix`.
- - Before implementing a new big feature, consider creating a new Issue on Github with RFC label. It will save your time when the core team is not going to accept it or has good recommendations about how to proceed.
+ - All code must follow the `PSR-2` coding standard. Please see [PSR-2](https://www.php-fig.org/psr/psr-2/) for more details. 
+To make this as easy as possible, we use PHPCSFixer running two simple make commands: `make cs-check` and `make cs-fix`.
+ - Before implementing a new big feature, consider creating a new Issue on Github. It will save your time when the core team is not going to accept it or has good recommendations about how to proceed.
+ 
+## Tests
+
+The following commands can be ran to test on your local environment
+
+ - `./tests/e2e_tests` for end to end tests
+ - `bin/infection` to run infection on itself.
+
+We also provide a way to run these commands in different environments, e.g. different php versions and debuggers.
+
+ - `make test` will run all types of tests, on all environments.
+ - `make test-unit` will run all unit tests on different environments
+ - `make test-infection-phpdbg` will run infection with `phpdbg` against different php versions
+ - `make test-e2e-phpdbg` will run e2e tests with `phpdbg` against different php versions
+ - `make test-infection-xdebug` will run infection with `xdebug` against different php versions
+ - `make test-e2e-xdebug` will run e2e tests with `xdebug` against different php versions
+ - For all test commands, except `make test` you can add `-70`, `-71`, or `-72` to run it agains php 7.0, 7.1 or 7.2
+ So to run infection wtih phpdbg on php 7.1 you would run `make test-infection-phpdbg-71`
+
+To use these command you need to have [Docker](https://www.docker.com/get-docker) installed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
    fi
 
 script:
-  - composer analyze
+  - make analyze --keep-going
   - if [[ $PHPDBG != 1 ]]; then xdebug-enable; fi
   - if [[ $PHPDBG != 1 ]]; then $PHPUNIT_BIN; else phpdbg -qrr $PHPUNIT_BIN; fi
   - ./tests/e2e_tests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,125 @@
+PHP_CS_FIXER_FUTURE_MODE=1
+
+.PHONY: all
+#Run all checks, default when running 'make'
+all: analyze test
+
+#Non phony targets for phars etc.
+vendor: composer.json composer.lock
+	composer install
+
+build/cache:
+	mkdir -p build/cache
+
+php-cs-fixer-v2.phar:
+	wget -nc http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar
+	chmod a+x php-cs-fixer-v2.phar
+
+phpstan.phar:
+	wget -nc https://github.com/phpstan/phpstan/releases/download/0.9.1/phpstan.phar
+	chmod a+x phpstan.phar
+
+
+#All tests, (infection itself, phpunit, e2e) for different php version/ environments (xdebug or phpdbg)
+.PHONY: test test-unit test-infection-phpdbg test-e2e-phpdbg test-infection-xdebug test-e2e-xdebug test-final-private
+test: test-unit test-infection-phpdbg test-e2e-phpdbg test-infection-xdebug test-e2e-xdebug test-final-private
+
+test-final-private:
+	./tests/final_private_test
+
+.PHONY: test-unit test-unit-70 test-unit-71 test-unit-72
+#php unit tests
+test-unit: test-unit-70 test-unit-71 test-unit-72
+
+test-unit-70: vendor
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.0-cli php vendor/bin/phpunit
+
+test-unit-71: vendor
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.1-cli php vendor/bin/phpunit
+
+test-unit-72: vendor
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.2-cli php vendor/bin/phpunit
+
+
+.PHONY: test-infection-phpdbg test-infection-phpdbg-70 test-infection-phpdbg-71 test-infection-phpdbg-72
+#infection with phpdbg
+test-infection-phpdbg: test-infection-phpdbg-70 test-infection-phpdbg-71 test-infection-phpdbg-72
+
+test-infection-phpdbg-70: vendor
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.0-cli phpdbg -qrr bin/infection --threads=4
+
+test-infection-phpdbg-71: vendor
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.1-cli phpdbg -qrr bin/infection --threads=4
+
+test-infection-phpdbg-72: vendor
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.2-cli phpdbg -qrr bin/infection --threads=4
+
+
+.PHONY: test-e2e-phpdbg test-e2e-phpdbg-70 test-e2e-phpdbg-71 test-e2e-phpdbg-72
+#e2e tests with phpdbg
+test-e2e-phpdbg: test-e2e-phpdbg-70 test-e2e-phpdbg-71 test-e2e-phpdbg-72
+
+test-e2e-phpdbg-70: vendor
+	docker run -it --rm -e PHPDBG=1 -v "$$PWD":/opt/infection -w /opt/infection php:7.0-cli ./tests/e2e_tests
+
+test-e2e-phpdbg-71: vendor
+	docker run -it --rm -e PHPDBG=1 -v "$$PWD":/opt/infection -w /opt/infection php:7.1-cli ./tests/e2e_tests
+
+test-e2e-phpdbg-72: vendor
+	docker run -it --rm -e PHPDBG=1 -v "$$PWD":/opt/infection -w /opt/infection php:7.2-cli ./tests/e2e_tests
+
+
+.PHONY: test-infection-xdebug test-infection-xdebug-70 test-infection-xdebug-71 test-infection-xdebug-72
+#infection with xdebug
+test-infection-xdebug: test-infection-xdebug-70 test-infection-xdebug-71 test-infection-xdebug-72
+
+test-infection-xdebug-70: build-xdebug-70
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php70 php bin/infection --threads=4
+
+test-infection-xdebug-71: build-xdebug-71
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php71 php bin/infection --threads=4
+
+test-infection-xdebug-72: build-xdebug-72
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php72 php bin/infection --threads=4
+
+
+.PHONY: test-e2e-xdebug test-e2e-xdebug-70 test-e2e-xdebug-71 test-e2e-xdebug-72
+#e2e tests with xdebug
+test-e2e-xdebug: test-e2e-xdebug-70 test-e2e-xdebug-71 test-e2e-xdebug-72
+
+test-e2e-xdebug-70: build-xdebug-70
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php70 ./tests/e2e_tests
+
+test-e2e-xdebug-71: build-xdebug-71
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php71 ./tests/e2e_tests
+
+test-e2e-xdebug-72: build-xdebug-72
+	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php72 ./tests/e2e_tests
+
+
+.PHONY: build-xdebug-70 build-xdebug-71 build-xdebug-72
+#Building images with xdebug
+build-xdebug-70: vendor
+	docker build -t infection_php70 -f "$$PWD/devTools/Dockerfile-php70-xdebug" .
+
+build-xdebug-71: vendor
+	docker build -t infection_php71 -f "$$PWD/devTools/Dockerfile-php71-xdebug" .
+
+build-xdebug-72: vendor
+	docker build -t infection_php72 -f "$$PWD/devTools/Dockerfile-php72-xdebug" .
+
+#style checks/ static analysis
+.PHONY: analyze cs-fix cs-check phpstan validate update
+analyze: cs-check phpstan validate
+
+cs-fix: build/cache php-cs-fixer-v2.phar
+	./php-cs-fixer-v2.phar fix -v --cache-file=build/cache/.php_cs.cache
+
+cs-check: build/cache php-cs-fixer-v2.phar
+	./php-cs-fixer-v2.phar fix -v --cache-file=build/cache/.php_cs.cache --dry-run --stop-on-violation
+
+phpstan: phpstan.phar
+	./phpstan.phar analyse src tests --level=2 -c phpstan.neon --no-interaction --no-progress
+
+validate:
+	composer validate --strict

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ vendor: composer.json composer.lock
 build/cache:
 	mkdir -p build/cache
 
-$(PHP-CS-FIXER):
+./php-cs-fixer-v2.phar:
 	wget http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar
-	chmod a+x $(PHP-CS-FIXER)
+	chmod a+x ./php-cs-fixer-v2.phar
 
-$(PHPSTAN):
+./phpstan.phar:
 	wget https://github.com/phpstan/phpstan/releases/download/0.9.1/phpstan.phar
-	chmod a+x $(PHPSTAN)
+	chmod a+x ./phpstan.phar
 
 
 #All tests, (infection itself, phpunit, e2e) for different php version/ environments (xdebug or phpdbg)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 PHP_CS_FIXER_FUTURE_MODE=1
+PHPSTAN=./phpstan.phar
+PHP-CS-FIXER=./php-cs-fixer-v2.phar
 
 .PHONY: all
 #Run all checks, default when running 'make'
@@ -11,13 +13,13 @@ vendor: composer.json composer.lock
 build/cache:
 	mkdir -p build/cache
 
-php-cs-fixer-v2.phar:
-	wget -nc http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar
-	chmod a+x php-cs-fixer-v2.phar
+$(PHP-CS-FIXER):
+	wget http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar
+	chmod a+x $(PHP-CS-FIXER)
 
-phpstan.phar:
-	wget -nc https://github.com/phpstan/phpstan/releases/download/0.9.1/phpstan.phar
-	chmod a+x phpstan.phar
+$(PHPSTAN):
+	wget https://github.com/phpstan/phpstan/releases/download/0.9.1/phpstan.phar
+	chmod a+x $(PHPSTAN)
 
 
 #All tests, (infection itself, phpunit, e2e) for different php version/ environments (xdebug or phpdbg)
@@ -112,14 +114,14 @@ build-xdebug-72: vendor
 .PHONY: analyze cs-fix cs-check phpstan validate update
 analyze: cs-check phpstan validate
 
-cs-fix: build/cache php-cs-fixer-v2.phar
-	./php-cs-fixer-v2.phar fix -v --cache-file=build/cache/.php_cs.cache
+cs-fix: build/cache $(PHP-CS-FIXER)
+	$(PHP-CS-FIXER) fix -v --cache-file=build/cache/.php_cs.cache
 
-cs-check: build/cache php-cs-fixer-v2.phar
-	./php-cs-fixer-v2.phar fix -v --cache-file=build/cache/.php_cs.cache --dry-run --stop-on-violation
+cs-check: build/cache $(PHP-CS-FIXER)
+	$(PHP-CS-FIXER) fix -v --cache-file=build/cache/.php_cs.cache --dry-run --stop-on-violation
 
-phpstan: phpstan.phar
-	./phpstan.phar analyse src tests --level=2 -c phpstan.neon --no-interaction --no-progress
+phpstan: vendor $(PHPSTAN)
+	$(PHPSTAN) analyse src tests --level=2 -c phpstan.neon --no-interaction --no-progress
 
 validate:
 	composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -68,32 +68,5 @@
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^6.1"
     },
-    "bin": ["bin/infection"],
-    "scripts": {
-        "analyze": [
-            "@cs:check",
-            "@phpstan",
-            "@composer validate --strict"
-        ],
-        "phpstan": [
-            "wget -nc https://github.com/phpstan/phpstan/releases/download/0.9.1/phpstan.phar",
-            "chmod a+x phpstan.phar",
-            "./phpstan.phar analyse src tests --level=2 -c phpstan.neon --no-interaction --no-progress"
-        ],
-        "cs:check": [
-            "mkdir -p build/cache",
-            "wget -nc http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar",
-            "chmod a+x php-cs-fixer-v2.phar",
-            "PHP_CS_FIXER_FUTURE_MODE=1 ./php-cs-fixer-v2.phar fix -v --cache-file=build/cache/.php_cs.cache --dry-run --stop-on-violation"
-        ],
-        "cs:fix": [
-            "mkdir -p build/cache",
-            "PHP_CS_FIXER_FUTURE_MODE=1 ./php-cs-fixer-v2.phar fix -v --cache-file=build/cache/.php_cs.cache"
-        ],
-        "tests": [
-            "./vendor/bin/phpunit",
-            "./tests/e2e_tests",
-            "./tests/final_private_test"
-        ]
-    }
+    "bin": ["bin/infection"]
 }

--- a/devTools/Dockerfile-php70-xdebug
+++ b/devTools/Dockerfile-php70-xdebug
@@ -1,0 +1,4 @@
+FROM php:7.0-cli
+
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+

--- a/devTools/Dockerfile-php71-xdebug
+++ b/devTools/Dockerfile-php71-xdebug
@@ -1,0 +1,3 @@
+FROM php:7.1-cli
+
+RUN pecl install xdebug && docker-php-ext-enable xdebug

--- a/devTools/Dockerfile-php72-xdebug
+++ b/devTools/Dockerfile-php72-xdebug
@@ -1,0 +1,3 @@
+FROM php:7.2-cli
+
+RUN pecl install xdebug && docker-php-ext-enable xdebug

--- a/devTools/pre-push
+++ b/devTools/pre-push
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-composer analyze && ./vendor/bin/phpunit
+make analyze && ./vendor/bin/phpunit


### PR DESCRIPTION
This PR:

Adds the option to run tests in different environment with docker, with the following options:

* `test`: run everything
* `test-unit` run phpunit tests
* `test-infection-phpdbg` run infection with phpdbg
* ` test-e2e-phpdbg` run e2e tests with phpdbg
* ` test-infection-xdebug` run infection with xdebug
* `test-e2e-xdebug` run e2e tests with xdebug

For each of these options, except for plain `test` adding `-70`, `-71` or `-72` to it runs it ony for php 7.0, 7.1, or 7.2. So the following:
```bash
$ make test-infection-xdebug-70
```
will run infection with xdebug on php 7.0

It requires devs to be able to run `make ` and `docker`