### PR TITLE
Fix for PHPUnit's contradictory coverage reports

### DIFF
--- a/src/TestFramework/Coverage/CodeCoverageData.php
+++ b/src/TestFramework/Coverage/CodeCoverageData.php
@@ -93,12 +93,8 @@ class CodeCoverageData
         }
 
         foreach ($coverage[$filePath]['byMethod'] as $method => $coverageInfo) {
-            if ($coverageInfo['executed'] === 0) {
-                continue;
-            }
-
             if ($line >= $coverageInfo['startLine'] && $line <= $coverageInfo['endLine']) {
-                return true;
+                return $coverageInfo['executed'] || $coverageInfo['coverage'];
             }
         }
 

--- a/tests/TestFramework/Coverage/CodeCoverageDataTest.php
+++ b/tests/TestFramework/Coverage/CodeCoverageDataTest.php
@@ -221,7 +221,7 @@ class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
                             'endLine' => 5,
                             'executable' => 5,
                             'executed' => 0,
-                            'coverage' => 80,
+                            'coverage' => 0, // not executed method can't be covered
                         ],
                     ],
             ],


### PR DESCRIPTION
PHPUnit sometimes gives contradictory results, reporting a method both covered and not executed. Which can't be. 

It looks like this:
```xml
<method name="unpack" signature="unpack(callable $func)" start="34" end="39" 
     crap="1" executable="0" executed="0" coverage="100"/>
```

This PR:

- [x] Fixes #234
- [x] Covered by tests


