### PR TITLE
Use loaded ini settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
 
 env:
   global:
-    - INFECTION_FLAGS='--threads=4 --min-msi=57 --min-covered-msi=86 --coverage=coverage'
+    - INFECTION_FLAGS='--threads=4 --min-msi=56 --min-covered-msi=86 --coverage=coverage'
     - PHPUNIT_BIN='vendor/bin/phpunit --coverage-clover=clover.xml --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml'
 
 cache:

--- a/src/Php/ConfigBuilder.php
+++ b/src/Php/ConfigBuilder.php
@@ -85,7 +85,7 @@ final class ConfigBuilder
 
         $content .= $this->mergeLoadedConfig($loaded, $config);
         // Work-around for https://bugs.php.net/bug.php?id=75932
-        $content .= 'opcache.enable_cli=0'.PHP_EOL;
+        $content .= 'opcache.enable_cli=0' . PHP_EOL;
 
         return (bool) @file_put_contents($this->tmpIniPath, $content);
     }
@@ -112,6 +112,7 @@ final class ConfigBuilder
      * @return string
      *
      * @see https://github.com/composer/xdebug-handler/blob/master/src/XdebugHandler.php
+     *
      * @license MIT composer/xdebug-handler
      */
     private function mergeLoadedConfig(array $loadedConfig, array $iniConfig)
@@ -125,11 +126,12 @@ final class ConfigBuilder
             if (!isset($iniConfig[$name]) || $iniConfig[$name] !== $value) {
                 // Based on main -d option handling in php-src/sapi/cli/php_cli.c
                 if ($value && !ctype_alnum($value)) {
-                    $value = '"'.str_replace('"', '\\"', $value).'"';
+                    $value = '"' . str_replace('"', '\\"', $value) . '"';
                 }
-                $content .= $name.'='.$value.PHP_EOL;
+                $content .= $name . '=' . $value . PHP_EOL;
             }
         }
+
         return $content;
     }
 }

--- a/src/Php/ConfigBuilder.php
+++ b/src/Php/ConfigBuilder.php
@@ -80,6 +80,13 @@ final class ConfigBuilder
             $content .= preg_replace($regex, ';$1', file_get_contents($iniPath)) . PHP_EOL;
         }
 
+        $loaded = ini_get_all(null, false);
+        $config = parse_ini_string($content);
+
+        $content .= $this->mergeLoadedConfig($loaded, $config);
+        // Work-around for https://bugs.php.net/bug.php?id=75932
+        $content .= 'opcache.enable_cli=0'.PHP_EOL;
+
         return (bool) @file_put_contents($this->tmpIniPath, $content);
     }
 
@@ -90,5 +97,39 @@ final class ConfigBuilder
         }
 
         return putenv(self::ENV_TEMP_PHP_CONFIG_PATH . '=' . $this->tmpIniPath);
+    }
+
+    /**
+     * Returns default or changed settings for the tmp ini
+     *
+     * Ini settings can be passed on the command line using the -d option. To
+     * preserve these, all loaded settings that are either not present or
+     * different from those in the ini files are added at the end of the tmp ini.
+     *
+     * @param array $loadedConfig All current ini settings
+     * @param array $iniConfig Settings from user ini files
+     *
+     * @return string
+     *
+     * @see https://github.com/composer/xdebug-handler/blob/master/src/XdebugHandler.php
+     * @license MIT composer/xdebug-handler
+     */
+    private function mergeLoadedConfig(array $loadedConfig, array $iniConfig)
+    {
+        $content = '';
+        foreach ($loadedConfig as $name => $value) {
+            // Values will either be null, string or array (HHVM only)
+            if (!is_string($value) || strpos($name, 'xdebug') === 0) {
+                continue;
+            }
+            if (!isset($iniConfig[$name]) || $iniConfig[$name] !== $value) {
+                // Based on main -d option handling in php-src/sapi/cli/php_cli.c
+                if ($value && !ctype_alnum($value)) {
+                    $value = '"'.str_replace('"', '\\"', $value).'"';
+                }
+                $content .= $name.'='.$value.PHP_EOL;
+            }
+        }
+        return $content;
     }
 }


### PR DESCRIPTION
The original issue was reported by @sanmai in #252:

>right now `php -dmemory_limit=512M` infection has no effect on child processes

The issue is actually not specific to this peculiar parameter but any parameter overriden with the
`-d` option.

Indeed when building the temporary ini file, we are only looking at the settings coming from the
scanned files. Those settings however can be changed with the `-d` option. So provided you have:

```
// php.ini
param=X

// console
$ php -dparam=Y infection
```

We _should_ have in the temporary ini file `param=Y`.

<hr/>

Note that this issue is fixed by https://github.com/composer/xdebug-handler so we won't have this issue again when moving to it.