### PR TITLE
Heuristics to set memory limit for mutants running with PHPUnit

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -30,6 +30,7 @@ use Infection\Process\Runner\InitialTestsRunner;
 use Infection\Process\Runner\MutationTestingRunner;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Infection\TestFramework\Coverage\CodeCoverageData;
+use Infection\TestFramework\MemoryUsageAware;
 use Infection\TestFramework\PhpSpec\PhpSpecExtraOptions;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
@@ -194,7 +195,7 @@ class InfectionCommand extends BaseCommand
         }
 
         // We only apply a memory limit if there isn't one set
-        if ($adapter instanceof PhpUnitAdapter && ini_get('memory_limit') === '-1') {
+        if ($adapter instanceof MemoryUsageAware && ini_get('memory_limit') === '-1') {
             $this->applyMemoryLimitFromPhpUnitProcess($initialTestSuitProcess, $adapter);
         }
 

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -31,6 +31,7 @@ use Infection\Process\Runner\MutationTestingRunner;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\PhpSpec\PhpSpecExtraOptions;
+use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\PhpUnit\PhpUnitExtraOptions;
 use Infection\TestFramework\TestFrameworkExtraOptions;
@@ -192,6 +193,11 @@ class InfectionCommand extends BaseCommand
             return 1;
         }
 
+        // We only apply a memory limit if there isn't one set
+        if ($adapter instanceof PhpUnitAdapter && ini_get('memory_limit') === '-1') {
+            $this->applyMemoryLimitFromPhpUnitProcess($initialTestSuitProcess, $adapter);
+        }
+
         $codeCoverageData = $this->getCodeCoverageData($testFrameworkKey);
         $mutationsGenerator = new MutationsGenerator(
             $container->get('src.dirs'),
@@ -251,6 +257,37 @@ class InfectionCommand extends BaseCommand
         }
 
         throw new \InvalidArgumentException('Incorrect formatter. Possible values: "dot", "progress"');
+    }
+
+    private function applyMemoryLimitFromPhpUnitProcess(Process $process, PhpUnitAdapter $adapter)
+    {
+        $tempConfigPath = \php_ini_loaded_file();
+
+        if (empty($tempConfigPath) || !file_exists($tempConfigPath)) {
+            // Cannot add a memory limit when there's no php.ini
+            return;
+        }
+
+        $memoryLimit = $adapter->getMemoryUsed($process->getOutput());
+
+        if ($memoryLimit < 0) {
+            // Cannot detect memory used, not setting any limits
+            return;
+        }
+
+        /*
+         * Since we know how much memory the initial test suite used,
+         * and only if we know, we can enforce a memory limit upon all
+         * mutation processes. Limit is set to be twice the known amount,
+         * because if we know that a normal test suite used X megabytes,
+         * if a mutants uses a lot more, this is a definite error.
+         *
+         * By default we let a mutant process use twice as much more
+         * memory as an initial test suite consumed.
+         */
+        $memoryLimit *= 2;
+
+        file_put_contents($tempConfigPath, PHP_EOL . sprintf('memory_limit = %dM', $memoryLimit), FILE_APPEND);
     }
 
     private function registerSubscribers(

--- a/src/TestFramework/MemoryUsageAware.php
+++ b/src/TestFramework/MemoryUsageAware.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\TestFramework;
+
+interface MemoryUsageAware
+{
+    /**
+     * Reports memory used by a test suite.
+     *
+     * @param string $output
+     *
+     * @return float
+     */
+    public function getMemoryUsed(string $output): float;
+}

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -10,8 +10,9 @@ declare(strict_types=1);
 namespace Infection\TestFramework\PhpUnit\Adapter;
 
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\TestFramework\MemoryUsageAware;
 
-class PhpUnitAdapter extends AbstractTestFrameworkAdapter
+class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements MemoryUsageAware
 {
     const JUNIT_FILE_NAME = 'phpunit.junit.xml';
 

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -37,6 +37,15 @@ class PhpUnitAdapter extends AbstractTestFrameworkAdapter
         return $isOk || $isOkWithInfo || $isWarning;
     }
 
+    public function getMemoryUsed(string $output): float
+    {
+        if (preg_match('/Memory: (\d+(?:\.\d+))MB/', $output, $match)) {
+            return (float) $match[1];
+        }
+
+        return -1;
+    }
+
     public function getName(): string
     {
         return 'PHPUnit';

--- a/tests/Fixtures/e2e/Memory_Limit/README.md
+++ b/tests/Fixtures/e2e/Memory_Limit/README.md
@@ -1,0 +1,17 @@
+# Test for heuristics to set memory limit for mutants
+
+[PR #258](https://github.com/infection/infection/pull/258)
+
+[Issue #247](https://github.com/infection/infection/issues/247)
+
+## Summary
+
+Mutant processes are only limited by the time they could take before timing out. They should also be limited by the amount of memory they consume. This could lead to all kind of nasty issues, including having OOM Killer come for unconcerned processes, especially those having unsaved data.
+
+## Resolution
+
+Since we know how much memory the initial test suite used, and only if we know, we can enforce a memory limit upon all mutation processes. Limit is set to be twice the known amount, because if we know that a normal test suite used X megabytes, if a mutant uses a lot more, this is a definite error.
+
+Memory limit is introduced by altering a known temporary php.ini to include a directive to enable the limit as the very last line. We only apply a memory limit if there isn't one set.
+
+So far this fix can only be applied to PHPUnit. Other testing suites are not reporting memory usage.

--- a/tests/Fixtures/e2e/Memory_Limit/composer.json
+++ b/tests/Fixtures/e2e/Memory_Limit/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Namespace_\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Namespace_\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Memory_Limit/expected-output.txt
+++ b/tests/Fixtures/e2e/Memory_Limit/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 0
+Errored: 1
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/Memory_Limit/infection.json
+++ b/tests/Fixtures/e2e/Memory_Limit/infection.json
@@ -1,0 +1,11 @@
+{
+    "timeout": 1,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection-log.txt"
+    }
+}

--- a/tests/Fixtures/e2e/Memory_Limit/php.ini
+++ b/tests/Fixtures/e2e/Memory_Limit/php.ini
@@ -1,0 +1,7 @@
+memory_limit = -1
+
+; These may be required on other platforms
+;extension=iconv.so
+;extension=mbstring.so
+
+zend_extension=xdebug.so

--- a/tests/Fixtures/e2e/Memory_Limit/phpunit.xml
+++ b/tests/Fixtures/e2e/Memory_Limit/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Memory_Limit/run_tests.bash
+++ b/tests/Fixtures/e2e/Memory_Limit/run_tests.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+run () {
+    local INFECTION=${1}
+    local PHPARGS=${2}
+
+    if [ "$PHPDBG" = "1" ]
+    then
+        phpdbg $PHPARGS -qrr $INFECTION
+    else
+        php $PHPARGS $INFECTION
+    fi
+
+    diff -u -w expected-output.txt infection-log.txt
+}
+
+
+run "../../../../bin/infection --mutators=FalseValue" "-n -c php.ini"
+

--- a/tests/Fixtures/e2e/Memory_Limit/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Memory_Limit/src/SourceClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Namespace_;
+
+class SourceClass
+{
+    public function count(): int
+    {
+        $result = [];
+
+        do {
+            $result[] = new \SplFixedArray(1<<23);
+        } while (false);
+
+        return count($result);
+    }
+}

--- a/tests/Fixtures/e2e/Memory_Limit/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Memory_Limit/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Namespace_\Test;
+
+use Namespace_\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_count()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame(1, $sourceClass->count());
+    }
+}

--- a/tests/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -11,6 +11,7 @@ namespace Infection\Tests\TestFramework\PhpUnit\Adapter;
 
 use Infection\Finder\AbstractExecutableFinder;
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
+use Infection\TestFramework\MemoryUsageAware;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
 use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
@@ -46,6 +47,12 @@ class PhpUnitAdapterTest extends Mockery\Adapter\Phpunit\MockeryTestCase
             ['FAILURES!', false],
             ['ERRORS!', false],
         ];
+    }
+
+    public function test_it_conforms_to_memory_usage_aware()
+    {
+        $adapter = $this->getAdapter();
+        $this->assertInstanceOf(MemoryUsageAware::class, $adapter);
     }
 
     /**

--- a/tests/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -48,6 +48,27 @@ class PhpUnitAdapterTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         ];
     }
 
+    /**
+     * @dataProvider memoryReportProvider
+     */
+    public function test_it_determines_used_memory_amount($output, $expectedResult)
+    {
+        $adapter = $this->getAdapter();
+
+        $result = $adapter->getMemoryUsed($output);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function memoryReportProvider()
+    {
+        return [
+            ['Memory: 8.00MB', 8.0],
+            ['Memory: 68.00MB', 68.0],
+            ['Time: 2.51 seconds', -1.0],
+        ];
+    }
+
     private function getAdapter(): PhpUnitAdapter
     {
         $executableFined = Mockery::mock(AbstractExecutableFinder::class);


### PR DESCRIPTION
Since we know how much memory the initial test suite used, and only if we know, we can enforce a memory limit upon all mutation processes. Limit is set to be twice the known amount, because if we know that a normal test suite used X megabytes, if a mutant uses a lot more, this is a definite error.
    
Memory limit is introduced by altering a known temporary php.ini to include a directive to enable the limit as the very last line. We only apply a memory limit if there isn't one set.

This PR assumes no default memory limits.

This PR:

- [x] Adds heuristics to set memory limit for mutants running with PHPUnit ...
- [x] Covered by tests
- [x] Fixes #247 as far I concerned

I rather hope this PR will be more satisfactory to @theofidry and others who didn't like an idea of a default memory limit. We are not forcing a default upon anyone here.