### PR TITLE
Remove `isIgnored` from the public API of Mutator class. Make methods final

### DIFF
--- a/src/Mutator/Arithmetic/Assignment.php
+++ b/src/Mutator/Arithmetic/Assignment.php
@@ -26,7 +26,7 @@ class Assignment extends Mutator
         return new Node\Expr\Assign($node->var, $node->expr, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\AssignOp;
     }

--- a/src/Mutator/Arithmetic/AssignmentEqual.php
+++ b/src/Mutator/Arithmetic/AssignmentEqual.php
@@ -26,7 +26,7 @@ class AssignmentEqual extends Mutator
         return new Node\Expr\Assign($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Equal && $node->left instanceof Node\Expr\Variable;
     }

--- a/src/Mutator/Arithmetic/BitwiseAnd.php
+++ b/src/Mutator/Arithmetic/BitwiseAnd.php
@@ -26,7 +26,7 @@ class BitwiseAnd extends Mutator
         return new Node\Expr\BinaryOp\BitwiseOr($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\BitwiseAnd;
     }

--- a/src/Mutator/Arithmetic/BitwiseNot.php
+++ b/src/Mutator/Arithmetic/BitwiseNot.php
@@ -26,7 +26,7 @@ class BitwiseNot extends Mutator
         return $node->expr;
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BitwiseNot;
     }

--- a/src/Mutator/Arithmetic/BitwiseOr.php
+++ b/src/Mutator/Arithmetic/BitwiseOr.php
@@ -26,7 +26,7 @@ class BitwiseOr extends Mutator
         return new Node\Expr\BinaryOp\BitwiseAnd($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\BitwiseOr;
     }

--- a/src/Mutator/Arithmetic/BitwiseXor.php
+++ b/src/Mutator/Arithmetic/BitwiseXor.php
@@ -26,7 +26,7 @@ class BitwiseXor extends Mutator
         return new Node\Expr\BinaryOp\BitwiseAnd($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\BitwiseXor;
     }

--- a/src/Mutator/Arithmetic/Decrement.php
+++ b/src/Mutator/Arithmetic/Decrement.php
@@ -36,7 +36,7 @@ class Decrement extends Mutator
         }
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof PreDec || $node instanceof PostDec;
     }

--- a/src/Mutator/Arithmetic/DivEqual.php
+++ b/src/Mutator/Arithmetic/DivEqual.php
@@ -26,7 +26,7 @@ class DivEqual extends Mutator
         return new Node\Expr\AssignOp\Mul($node->var, $node->expr, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\AssignOp\Div;
     }

--- a/src/Mutator/Arithmetic/Division.php
+++ b/src/Mutator/Arithmetic/Division.php
@@ -26,7 +26,7 @@ class Division extends Mutator
         return new Node\Expr\BinaryOp\Mul($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Div;
     }

--- a/src/Mutator/Arithmetic/Exponentiation.php
+++ b/src/Mutator/Arithmetic/Exponentiation.php
@@ -26,7 +26,7 @@ class Exponentiation extends Mutator
         return new Node\Expr\BinaryOp\Div($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Pow;
     }

--- a/src/Mutator/Arithmetic/Increment.php
+++ b/src/Mutator/Arithmetic/Increment.php
@@ -36,7 +36,7 @@ class Increment extends Mutator
         }
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof PreInc || $node instanceof PostInc;
     }

--- a/src/Mutator/Arithmetic/Minus.php
+++ b/src/Mutator/Arithmetic/Minus.php
@@ -26,7 +26,7 @@ class Minus extends Mutator
         return new Node\Expr\BinaryOp\Plus($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Minus;
     }

--- a/src/Mutator/Arithmetic/MinusEqual.php
+++ b/src/Mutator/Arithmetic/MinusEqual.php
@@ -26,7 +26,7 @@ class MinusEqual extends Mutator
         return new Node\Expr\AssignOp\Plus($node->var, $node->expr, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\AssignOp\Minus;
     }

--- a/src/Mutator/Arithmetic/ModEqual.php
+++ b/src/Mutator/Arithmetic/ModEqual.php
@@ -26,7 +26,7 @@ class ModEqual extends Mutator
         return new Node\Expr\AssignOp\Mul($node->var, $node->expr, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\AssignOp\Mod;
     }

--- a/src/Mutator/Arithmetic/Modulus.php
+++ b/src/Mutator/Arithmetic/Modulus.php
@@ -26,7 +26,7 @@ class Modulus extends Mutator
         return new Node\Expr\BinaryOp\Mul($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Mod;
     }

--- a/src/Mutator/Arithmetic/MulEqual.php
+++ b/src/Mutator/Arithmetic/MulEqual.php
@@ -26,7 +26,7 @@ class MulEqual extends Mutator
         return new Node\Expr\AssignOp\Div($node->var, $node->expr, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\AssignOp\Mul;
     }

--- a/src/Mutator/Arithmetic/Multiplication.php
+++ b/src/Mutator/Arithmetic/Multiplication.php
@@ -26,7 +26,7 @@ class Multiplication extends Mutator
         return new Node\Expr\BinaryOp\Div($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Mul;
     }

--- a/src/Mutator/Arithmetic/Plus.php
+++ b/src/Mutator/Arithmetic/Plus.php
@@ -27,7 +27,7 @@ class Plus extends Mutator
         return new Node\Expr\BinaryOp\Minus($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!($node instanceof Node\Expr\BinaryOp\Plus)) {
             return false;

--- a/src/Mutator/Arithmetic/PlusEqual.php
+++ b/src/Mutator/Arithmetic/PlusEqual.php
@@ -26,7 +26,7 @@ class PlusEqual extends Mutator
         return new Node\Expr\AssignOp\Minus($node->var, $node->expr, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\AssignOp\Plus;
     }

--- a/src/Mutator/Arithmetic/PowEqual.php
+++ b/src/Mutator/Arithmetic/PowEqual.php
@@ -26,7 +26,7 @@ class PowEqual extends Mutator
         return new Node\Expr\AssignOp\Div($node->var, $node->expr, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\AssignOp\Pow;
     }

--- a/src/Mutator/Arithmetic/ShiftLeft.php
+++ b/src/Mutator/Arithmetic/ShiftLeft.php
@@ -26,7 +26,7 @@ class ShiftLeft extends Mutator
         return new Node\Expr\BinaryOp\ShiftRight($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\ShiftLeft;
     }

--- a/src/Mutator/Arithmetic/ShiftRight.php
+++ b/src/Mutator/Arithmetic/ShiftRight.php
@@ -26,7 +26,7 @@ class ShiftRight extends Mutator
         return new Node\Expr\BinaryOp\ShiftLeft($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\ShiftRight;
     }

--- a/src/Mutator/Boolean/ArrayItem.php
+++ b/src/Mutator/Boolean/ArrayItem.php
@@ -26,7 +26,7 @@ class ArrayItem extends Mutator
         return new Node\Expr\BinaryOp\Greater($node->key, $node->value, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\ArrayItem && $node->key && ($this->isNodeWithSideEffects($node->value) || $this->isNodeWithSideEffects($node->key));
     }

--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -26,7 +26,7 @@ class FalseValue extends Mutator
         return new Node\Expr\ConstFetch(new Node\Name('true'));
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!($node instanceof Node\Expr\ConstFetch)) {
             return false;

--- a/src/Mutator/Boolean/LogicalAnd.php
+++ b/src/Mutator/Boolean/LogicalAnd.php
@@ -26,7 +26,7 @@ class LogicalAnd extends Mutator
         return new Node\Expr\BinaryOp\BooleanOr($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\BooleanAnd;
     }

--- a/src/Mutator/Boolean/LogicalLowerAnd.php
+++ b/src/Mutator/Boolean/LogicalLowerAnd.php
@@ -26,7 +26,7 @@ class LogicalLowerAnd extends Mutator
         return new Node\Expr\BinaryOp\LogicalOr($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\LogicalAnd;
     }

--- a/src/Mutator/Boolean/LogicalLowerOr.php
+++ b/src/Mutator/Boolean/LogicalLowerOr.php
@@ -26,7 +26,7 @@ class LogicalLowerOr extends Mutator
         return new Node\Expr\BinaryOp\LogicalAnd($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\LogicalOr;
     }

--- a/src/Mutator/Boolean/LogicalNot.php
+++ b/src/Mutator/Boolean/LogicalNot.php
@@ -26,7 +26,7 @@ class LogicalNot extends Mutator
         return $node->expr;
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!($node instanceof Node\Expr\BooleanNot)) {
             return false;

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -26,7 +26,7 @@ class LogicalOr extends Mutator
         return new Node\Expr\BinaryOp\BooleanAnd($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\BooleanOr;
     }

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -26,7 +26,7 @@ class TrueValue extends Mutator
         return new Node\Expr\ConstFetch(new Node\Name('false'));
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!($node instanceof Node\Expr\ConstFetch)) {
             return false;

--- a/src/Mutator/Boolean/Yield_.php
+++ b/src/Mutator/Boolean/Yield_.php
@@ -29,7 +29,7 @@ class Yield_ extends Mutator
         return $node;
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\Yield_ && $node->key;
     }

--- a/src/Mutator/ConditionalBoundary/GreaterThan.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThan.php
@@ -26,7 +26,7 @@ class GreaterThan extends Mutator
         return new Node\Expr\BinaryOp\GreaterOrEqual($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Greater;
     }

--- a/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
@@ -26,7 +26,7 @@ class GreaterThanOrEqualTo extends Mutator
         return new Node\Expr\BinaryOp\Greater($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\GreaterOrEqual;
     }

--- a/src/Mutator/ConditionalBoundary/LessThan.php
+++ b/src/Mutator/ConditionalBoundary/LessThan.php
@@ -26,7 +26,7 @@ class LessThan extends Mutator
         return new Node\Expr\BinaryOp\SmallerOrEqual($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Smaller;
     }

--- a/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
@@ -26,7 +26,7 @@ class LessThanOrEqualTo extends Mutator
         return new Node\Expr\BinaryOp\Smaller($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\SmallerOrEqual;
     }

--- a/src/Mutator/ConditionalNegotiation/Equal.php
+++ b/src/Mutator/ConditionalNegotiation/Equal.php
@@ -26,7 +26,7 @@ class Equal extends Mutator
         return new Node\Expr\BinaryOp\NotEqual($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Equal;
     }

--- a/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
@@ -26,7 +26,7 @@ class GreaterThanNegotiation extends Mutator
         return new Node\Expr\BinaryOp\SmallerOrEqual($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Greater;
     }

--- a/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
@@ -26,7 +26,7 @@ class GreaterThanOrEqualToNegotiation extends Mutator
         return new Node\Expr\BinaryOp\Smaller($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\GreaterOrEqual;
     }

--- a/src/Mutator/ConditionalNegotiation/Identical.php
+++ b/src/Mutator/ConditionalNegotiation/Identical.php
@@ -26,7 +26,7 @@ class Identical extends Mutator
         return new Node\Expr\BinaryOp\NotIdentical($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Identical;
     }

--- a/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
@@ -26,7 +26,7 @@ class LessThanNegotiation extends Mutator
         return new Node\Expr\BinaryOp\GreaterOrEqual($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Smaller;
     }

--- a/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
@@ -26,7 +26,7 @@ class LessThanOrEqualToNegotiation extends Mutator
         return new Node\Expr\BinaryOp\Greater($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\SmallerOrEqual;
     }

--- a/src/Mutator/ConditionalNegotiation/NotEqual.php
+++ b/src/Mutator/ConditionalNegotiation/NotEqual.php
@@ -26,7 +26,7 @@ class NotEqual extends Mutator
         return new Node\Expr\BinaryOp\Equal($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\NotEqual;
     }

--- a/src/Mutator/ConditionalNegotiation/NotIdentical.php
+++ b/src/Mutator/ConditionalNegotiation/NotIdentical.php
@@ -26,7 +26,7 @@ class NotIdentical extends Mutator
         return new Node\Expr\BinaryOp\Identical($node->left, $node->right, $node->getAttributes());
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\NotIdentical;
     }

--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -40,7 +40,7 @@ class ProtectedVisibility extends Mutator
         );
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!$node instanceof ClassMethod) {
             return false;

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -43,7 +43,7 @@ class PublicVisibility extends Mutator
         );
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!$node instanceof ClassMethod) {
             return false;

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -26,7 +26,7 @@ class DecrementInteger extends Mutator
         return new Node\Scalar\LNumber($node->value - 1);
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Scalar\LNumber && $node->value !== 1;
     }

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -26,7 +26,7 @@ class IncrementInteger extends Mutator
         return new Node\Scalar\LNumber($node->value + 1);
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Scalar\LNumber && $node->value !== 0;
     }

--- a/src/Mutator/Number/OneZeroFloat.php
+++ b/src/Mutator/Number/OneZeroFloat.php
@@ -30,7 +30,7 @@ class OneZeroFloat extends Mutator
         return new Node\Scalar\DNumber(0.0);
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Scalar\DNumber && ($node->value === 0.0 || $node->value === 1.0);
     }

--- a/src/Mutator/Number/OneZeroInteger.php
+++ b/src/Mutator/Number/OneZeroInteger.php
@@ -30,7 +30,7 @@ class OneZeroInteger extends Mutator
         return new Node\Scalar\LNumber(0);
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Scalar\LNumber && ($node->value === 0 || $node->value === 1);
     }

--- a/src/Mutator/Operator/Break_.php
+++ b/src/Mutator/Operator/Break_.php
@@ -20,7 +20,7 @@ class Break_ extends Mutator
         return new Node\Stmt\Continue_();
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!$node instanceof Node\Stmt\Break_) {
             return false;
@@ -28,10 +28,6 @@ class Break_ extends Mutator
 
         $parentNode = $node->getAttribute(ParentConnectorVisitor::PARENT_KEY);
 
-        if ($parentNode instanceof Node\Stmt\Case_) {
-            return false;
-        }
-
-        return true;
+        return !$parentNode instanceof Node\Stmt\Case_;
     }
 }

--- a/src/Mutator/Operator/Continue_.php
+++ b/src/Mutator/Operator/Continue_.php
@@ -20,7 +20,7 @@ class Continue_ extends Mutator
         return new Node\Stmt\Break_();
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!$node instanceof Node\Stmt\Continue_) {
             return false;

--- a/src/Mutator/Operator/Finally_.php
+++ b/src/Mutator/Operator/Finally_.php
@@ -19,7 +19,7 @@ class Finally_ extends Mutator
         return new Node\Stmt\Nop();
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Stmt\Finally_;
     }

--- a/src/Mutator/Operator/Throw_.php
+++ b/src/Mutator/Operator/Throw_.php
@@ -19,7 +19,7 @@ class Throw_ extends Mutator
         return new Node\Stmt\Expression($node->expr);
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Stmt\Throw_;
     }

--- a/src/Mutator/ReturnValue/FloatNegation.php
+++ b/src/Mutator/ReturnValue/FloatNegation.php
@@ -33,7 +33,7 @@ class FloatNegation extends Mutator
         );
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!$node instanceof Node\Stmt\Return_) {
             return false;

--- a/src/Mutator/ReturnValue/FunctionCall.php
+++ b/src/Mutator/ReturnValue/FunctionCall.php
@@ -31,7 +31,7 @@ class FunctionCall extends AbstractValueToNullReturnValue
         ];
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!$node instanceof Node\Stmt\Return_) {
             return false;

--- a/src/Mutator/ReturnValue/IntegerNegation.php
+++ b/src/Mutator/ReturnValue/IntegerNegation.php
@@ -33,7 +33,7 @@ class IntegerNegation extends Mutator
         );
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!$node instanceof Node\Stmt\Return_) {
             return false;

--- a/src/Mutator/ReturnValue/NewObject.php
+++ b/src/Mutator/ReturnValue/NewObject.php
@@ -31,7 +31,7 @@ class NewObject extends AbstractValueToNullReturnValue
         ];
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         if (!$node instanceof Node\Stmt\Return_) {
             return false;

--- a/src/Mutator/ReturnValue/This.php
+++ b/src/Mutator/ReturnValue/This.php
@@ -28,7 +28,7 @@ class This extends AbstractValueToNullReturnValue
         );
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Stmt\Return_ &&
             $node->expr instanceof Node\Expr\Variable &&

--- a/src/Mutator/Sort/Spaceship.php
+++ b/src/Mutator/Sort/Spaceship.php
@@ -26,7 +26,7 @@ class Spaceship extends Mutator
         return new Node\Expr\BinaryOp\Spaceship($node->right, $node->left);
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\BinaryOp\Spaceship;
     }

--- a/src/Mutator/Util/Mutator.php
+++ b/src/Mutator/Util/Mutator.php
@@ -47,6 +47,6 @@ abstract class Mutator
     {
         $parts = explode('\\', static::class);
 
-        return $parts[count($parts) - 1];
+        return end($parts);
     }
 }

--- a/src/Mutator/Util/Mutator.php
+++ b/src/Mutator/Util/Mutator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Util;
 
+use Infection\Visitor\ReflectionVisitor;
 use PhpParser\Node;
 
 abstract class Mutator
@@ -25,17 +26,27 @@ abstract class Mutator
 
     abstract public function mutate(Node $node);
 
-    abstract public function shouldMutate(Node $node): bool;
+    abstract protected function mutatesNode(Node $node): bool;
 
-    public static function getName(): string
+    final public function shouldMutate(Node $node): bool
+    {
+        if (!$this->mutatesNode($node)) {
+            return false;
+        }
+
+        $reflectionClass = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY, false);
+
+        if (!$reflectionClass) {
+            return true;
+        }
+
+        return !$this->config->isIgnored($reflectionClass->getName(), $node->getAttribute(ReflectionVisitor::FUNCTION_NAME, ''));
+    }
+
+    final public static function getName(): string
     {
         $parts = explode('\\', static::class);
 
         return $parts[count($parts) - 1];
-    }
-
-    public function isIgnored(string $class, string $method): bool
-    {
-        return $this->config->isIgnored($class, $method);
     }
 }

--- a/src/Mutator/ZeroIteration/For_.php
+++ b/src/Mutator/ZeroIteration/For_.php
@@ -27,7 +27,7 @@ class For_ extends Mutator
         );
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Stmt\For_;
     }

--- a/src/Mutator/ZeroIteration/Foreach_.php
+++ b/src/Mutator/ZeroIteration/Foreach_.php
@@ -28,7 +28,7 @@ class Foreach_ extends Mutator
         );
     }
 
-    public function shouldMutate(Node $node): bool
+    protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Stmt\Foreach_;
     }

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -75,15 +75,6 @@ class MutationsCollectorVisitor extends NodeVisitorAbstract
                 }
             }
 
-            if ($reflectionClass = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY, false)) {
-                if ($mutator->isIgnored(
-                    $reflectionClass->getName(),
-                    $node->getAttribute(ReflectionVisitor::FUNCTION_NAME, '')
-                )) {
-                    continue;
-                }
-            }
-
             $isCoveredByTest = $this->isCoveredByTest($isOnFunctionSignature, $node);
 
             if ($this->onlyCovered && !$isCoveredByTest) {


### PR DESCRIPTION
This PR:

- [x] Fixes https://github.com/infection/infection/issues/251
- [x] Covered by tests

The main idea is to reduce public API of `Mutator` class and improve future maintainability. Read more in #251 