### PR TITLE
Add mutator that remove finally {} block

### DIFF
--- a/src/Mutator/Operator/Finally_.php
+++ b/src/Mutator/Operator/Finally_.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Operator;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+
+class Finally_ extends Mutator
+{
+    public function mutate(Node $node)
+    {
+        return new Node\Stmt\Nop();
+    }
+
+    public function shouldMutate(Node $node): bool
+    {
+        return $node instanceof Node\Stmt\Finally_;
+    }
+}

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -199,6 +199,7 @@ final class MutatorProfile
         'Break_' => Mutator\Operator\Break_::class,
         'Continue_' => Mutator\Operator\Continue_::class,
         'Throw_' => Mutator\Operator\Throw_::class,
+        'Finally_' => Mutator\Operator\Finally_::class,
 
         //Return Value
         'FloatNegation' => Mutator\ReturnValue\FloatNegation::class,

--- a/tests/Mutator/Operator/Finally_Test.php
+++ b/tests/Mutator/Operator/Finally_Test.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Operator;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class Finally_Test extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): array
+    {
+        return [
+            'It removes the finally statement' => [
+                <<<'PHP'
+<?php
+
+try {
+    $a = 1;
+} catch (\Exception $e) {
+    $a = 2;
+} finally {
+    $a = 3;
+}
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+try {
+    $a = 1;
+} catch (\Exception $e) {
+    $a = 2;
+} 
+PHP
+                ,
+            ],
+        ];
+    }
+}

--- a/tests/Mutator/Util/MutatorProfileTest.php
+++ b/tests/Mutator/Util/MutatorProfileTest.php
@@ -47,7 +47,7 @@ class MutatorProfileTest extends TestCase
                 $class,
                 MutatorProfile::FULL_MUTATOR_LIST,
                 sprintf(
-                    'The mutator "%s" located in "%s" has not been added to the FULL_MUTATOR_LIST in the Mutator Profile class' .
+                    'The mutator "%s" located in "%s" has not been added to the FULL_MUTATOR_LIST in the MutatorProfile class. ' .
                     'Please add it to ensure it can be used.',
                     $class,
                     $file->getPath()


### PR DESCRIPTION
This PR:

Adds new Mutator that removes `finally {}` block

- [x] Covered by tests
- [ ] Doc PR: TBD

Found one weird bug during testing this mutator on Infection itself

<img width="454" alt="bug-finally" src="https://user-images.githubusercontent.com/3725595/37867443-d3f8d220-2fa9-11e8-9e03-ea7df3d1aed0.png">

As you can see, when `try {}` or `catch {}` section has `return`, `break`, `continue`, then `finally` is not marked as covered. It can be either not covered (red line in HTML coverage report), or yellow (dead code) or white (N/A).

But it's not true as `finally` block is always executed: https://3v4l.org/ZX0Zh. 
