### PR TITLE
Error when composer fails to run

### DIFF
--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -68,7 +68,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
 
         try {
             $process = new Process(sprintf('%s %s', $this->findComposer(), 'config bin-dir'));
-            $process->run();
+            $process->mustRun();
             $vendorPath = trim($process->getOutput());
         } catch (\RuntimeException $e) {
             $candidate = getcwd() . '/vendor/bin';


### PR DESCRIPTION
If a stock `composer` fails because of a PHP error (broken plugins...), a fallback wasn't used.

