### PR TITLE
Updating Dist Config File Locator

### DIFF
--- a/src/Finder/Exception/LocatorException.php
+++ b/src/Finder/Exception/LocatorException.php
@@ -23,7 +23,7 @@ class LocatorException extends \RuntimeException
         );
     }
 
-    public static function multipleFilesDoNoExist(string $path, array $files): self
+    public static function multipleFilesDoNotExist(string $path, array $files): self
     {
         return new self(
             sprintf(

--- a/src/Finder/Exception/LocatorException.php
+++ b/src/Finder/Exception/LocatorException.php
@@ -23,6 +23,17 @@ class LocatorException extends \RuntimeException
         );
     }
 
+    public static function multipleFilesDoNoExist(string $path, array $files): self
+    {
+        return new self(
+            sprintf(
+                'The path %s does not contain any of the requested files: %s',
+                $path,
+                implode(', ', $files)
+            )
+        );
+    }
+
     public static function filesNotFound(): self
     {
         return new self('Files are not found');

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -13,6 +13,15 @@ use Infection\Finder\Exception\LocatorException;
 
 class TestFrameworkConfigLocator
 {
+    const DEFAULT_EXTENSIONS = [
+        'xml',
+        'yml',
+        'xml.dist',
+        'yml.dist',
+        'dist.xml',
+        'dist.yml',
+    ];
+
     /**
      * @var string
      */
@@ -28,7 +37,7 @@ class TestFrameworkConfigLocator
         $dir = $customDir ?: $this->configDir;
         $triedFiles = [];
 
-        foreach ($this->getDefaultExtensions() as $extension) {
+        foreach (static::DEFAULT_EXTENSIONS as $extension) {
             $conf = sprintf('%s/%s.%s', $dir, $testFrameworkName, $extension);
 
             if (file_exists($conf)) {
@@ -42,17 +51,5 @@ class TestFrameworkConfigLocator
             $dir,
             $triedFiles
         );
-    }
-
-    private function getDefaultExtensions(): array
-    {
-        return [
-            'xml',
-            'yml',
-            'xml.dist',
-            'yml.dist',
-            'dist.xml',
-            'dist.yml',
-        ];
     }
 }

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -44,7 +44,7 @@ class TestFrameworkConfigLocator
         );
     }
 
-    private function getDefaultExtensions() : array
+    private function getDefaultExtensions(): array
     {
         return [
             'xml',
@@ -52,7 +52,7 @@ class TestFrameworkConfigLocator
             'xml.dist',
             'yml.dist',
             'dist.xml',
-            'dist.yml'
+            'dist.yml',
         ];
     }
 }

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -47,7 +47,7 @@ class TestFrameworkConfigLocator
             $triedFiles[] = sprintf('%s.%s', $testFrameworkName, $extension);
         }
 
-        throw LocatorException::multipleFilesDoNoExist(
+        throw LocatorException::multipleFilesDoNotExist(
             $dir,
             $triedFiles
         );

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -27,16 +27,17 @@ class TestFrameworkConfigLocator
 
         foreach (['xml', 'yml'] as $extension) {
             $conf = sprintf('%s/%s.%s', $dir, $testFrameworkName, $extension);
+            $altConf = sprintf('%s/%s.dist.%s', $dir, $testFrameworkName, $extension);
 
             if (file_exists($conf)) {
                 return realpath($conf);
-            }
-
-            if (file_exists($conf . '.dist')) {
+            } elseif (file_exists($conf . '.dist')) {
                 return realpath($conf . '.dist');
+            } elseif (file_exists($altConf)) {
+                return realpath($altConf);
             }
         }
 
-        throw new \RuntimeException(sprintf('Unable to locate %s.(xml|yml)(.dist) file.', $testFrameworkName));
+        throw new \RuntimeException(sprintf('Unable to locate %s(.dist).(xml|yml)(.dist) file.', $testFrameworkName));
     }
 }

--- a/tests/TestFramework/Config/TestFrameworkConfigLocatorTest.php
+++ b/tests/TestFramework/Config/TestFrameworkConfigLocatorTest.php
@@ -7,6 +7,7 @@
 
 namespace Infection\Tests\TestFramework\Config;
 
+use Infection\Finder\Exception\LocatorException;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use function Infection\Tests\normalizePath as p;
 
@@ -19,8 +20,13 @@ class TestFrameworkConfigLocatorTest extends \PHPUnit\Framework\TestCase
         $dir = $this->baseDir . 'NoFiles/';
         $locator = new TestFrameworkConfigLocator($dir);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Unable to locate phpunit(.dist).(xml|yml)(.dist) file.');
+        $this->expectException(LocatorException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'The path %s does not contain any of the requested files: phpunit.xml, phpunit.yml, phpunit.xml.dist, phpunit.yml.dist, phpunit.dist.xml, phpunit.dist.yml',
+                $dir
+            )
+        );
 
         $locator->locate('phpunit');
     }
@@ -94,7 +100,7 @@ class TestFrameworkConfigLocatorTest extends \PHPUnit\Framework\TestCase
             'Did not find the correct phpunit.xml.dist file.'
         );
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(LocatorException::class);
         $locator->locate('phpunit' . $dir . 'NoFiles/');
     }
 }

--- a/tests/TestFramework/Config/TestFrameworkConfigLocatorTest.php
+++ b/tests/TestFramework/Config/TestFrameworkConfigLocatorTest.php
@@ -20,7 +20,7 @@ class TestFrameworkConfigLocatorTest extends \PHPUnit\Framework\TestCase
         $locator = new TestFrameworkConfigLocator($dir);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Unable to locate phpunit.(xml|yml)(.dist) file.');
+        $this->expectExceptionMessage('Unable to locate phpunit(.dist).(xml|yml)(.dist) file.');
 
         $locator->locate('phpunit');
     }
@@ -34,6 +34,20 @@ class TestFrameworkConfigLocatorTest extends \PHPUnit\Framework\TestCase
 
         $this->assertStringEndsWith(
             'tests/Fixtures/ConfigLocator/DistFile/phpunit.xml.dist',
+            p($output),
+            'Did not find the correct phpunit.xml.dist file.'
+        );
+    }
+
+    public function test_it_can_find_an_alt_dist_file()
+    {
+        $dir = $this->baseDir . 'AltDistFile/';
+        $locator = new TestFrameworkConfigLocator($dir);
+
+        $output = $locator->locate('phpunit');
+
+        $this->assertStringEndsWith(
+            'tests/Fixtures/ConfigLocator/AltDistFile/phpunit.dist.xml',
             p($output),
             'Did not find the correct phpunit.xml.dist file.'
         );


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [x] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

This PR is to compliment PR #143. Codeception doesn't use the .yml.dist format and instead uses .dist.yml. This PR updates the functionality such that the system will also look for a .dist.yml.