### PR TITLE
e2e Memory_Limit test fixture should timeout later

### DIFF
--- a/tests/Fixtures/e2e/Memory_Limit/infection.json
+++ b/tests/Fixtures/e2e/Memory_Limit/infection.json
@@ -1,5 +1,5 @@
 {
-    "timeout": 1,
+    "timeout": 20,
     "source": {
         "directories": [
             "src"


### PR DESCRIPTION
This PR:

- [x] Fixes issue with Memory_Limit test fixture failing on Travis sometimes. [E.g. like on this build.](https://travis-ci.org/infection/infection/builds/359696852?utm_source=github_status&utm_medium=notification)
