### PR TITLE
Add a debug version of infection

### DIFF
--- a/bin/infection-debug
+++ b/bin/infection-debug
@@ -1,0 +1,8 @@
+#!/usr/bin/env php
+<?php
+
+set_error_handler(function($errno, $errstr) {
+    var_dump($errno, $errstr);
+}, E_ALL);
+
+require __DIR__ . '/infection';


### PR DESCRIPTION
This PR:

Adds a debug version of infection, which can be ran by `bin/infection-debug`. This is the most bare-bones version that will help with issues like this: https://github.com/infection/infection/pull/263#issuecomment-377037768

Another idea i played around with is some kind of PSR-3 logger which can be called statically, to help with debugging. But i'm not a fan of cluttering the source-code with tons of debug statements.

Running it on the current source code reveals this error right away:
`Not inheriting environment variables is deprecated since Symfony 3.3 and will always happen in 4.0. Set "Process::inheritEnvironmentVariables()" to true instead.`