### PR TITLE
DX: use benefits of symfony/force-lowest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,18 @@ matrix:
     - php: 7.1
       env: PHPDBG=1
     - php: 7.1
-      env: SYMFONY_VERSION="^4.0"
+      env: SYMFONY_VERSION="v4.0"
     - php: 7.1
-      env: SYMFONY_VERSION="^4.0" PHPDBG=1
+      env: SYMFONY_VERSION="v4.0" PHPDBG=1
     - php: 7.2
     - php: 7.2
       env: NO_DEBUGGER=1
     - php: 7.2
       env: PHPDBG=1
     - php: 7.2
-      env: SYMFONY_VERSION="^4.0"
+      env: SYMFONY_VERSION="v4.0"
     - php: 7.2
-      env: SYMFONY_VERSION="^4.0" PHPDBG=1
+      env: SYMFONY_VERSION="v4.0" PHPDBG=1
 
 env:
   global:
@@ -45,16 +45,13 @@ before_install:
   - xdebug-disable
 
 install:
-  - composer install
   - |
    if [ "${SYMFONY_VERSION}" != "" ]; then
       composer config --unset platform.php
-      composer require \
-        symfony/console:${SYMFONY_VERSION} \
-        symfony/process:${SYMFONY_VERSION} \
-        symfony/finder:${SYMFONY_VERSION} \
-        symfony/yaml:${SYMFONY_VERSION}
+      composer require --no-update symfony/force-lowest:$SYMFONY_VERSION
+      composer require --no-update symfony/lts:$(echo $SYMFONY_VERSION | grep -o 'v[0-9]\+') || true
    fi
+ - composer install
 
 script:
   - composer analyze


### PR DESCRIPTION
(Sorry for removing template, I don't find it matching DX type of code changes)

Proposed change would bring 2 DX benefits:
- no need to list and manually maintain list of used Sf components in travis config file thanks to usage of meta-packages that already contains all Sf components (don't worry, this change won't make composer to install all components ;) )
- use `composer require` with `--no-update` will not trigger installation process, just change `composer.json` file. thanks to that we can first adjust composer file on the fly, and then install everything at once. (instead of currently installing version X, and then reinstalling to version Y)