### PR TITLE
Custom mutators

### DIFF
--- a/tests/Config/InfectionConfigTest.php
+++ b/tests/Config/InfectionConfigTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Config;
 
 use Infection\Config\InfectionConfig;
+use Infection\Tests\Fixtures\StubMutator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use function Infection\Tests\normalizePath as p;
@@ -190,6 +191,22 @@ JSON;
                 ],
             ],
             (array) $config->getMutatorsConfiguration()['PublicVisibility']);
+    }
+
+    public function test_it_accepts_custom_mutators()
+    {
+        $config = <<<'JSON'
+{
+    "mutators": {
+        "Infection\\Tests\\Fixtures\\StubMutator": true
+    }
+}
+JSON;
+
+        $config = new InfectionConfig(json_decode($config), $this->filesystem, '/path/to/config');
+        $this->assertSame(
+            [StubMutator::class => true],
+            $config->getMutatorsConfiguration());
     }
 
     /**

--- a/tests/Fixtures/StubMutator.php
+++ b/tests/Fixtures/StubMutator.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Infection\Tests\Fixtures;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+
+class StubMutator extends Mutator
+{
+    public function mutate(Node $node)
+    {
+    }
+
+    public function mutatesNode(Node $node): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
This PR:

- Adds tests to make sure custom mutators can be used
  - Checks that the custom loader configuration gets loaded
  - Checks that custom mutator configuration adds a custom mutator instance

Because:

> As an enthusiastic infection tester,
> I want to add custom mutator classes,
> In order to unleash extra advanced mutation testing on my projects.

...and it turns out that yes, I can. This pull request makes that fact official by supplying the relevant tests.