### PR TITLE
Making all non-extended classes final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ script:
   - if [[ $PHPDBG != 1 ]]; then xdebug-enable; fi
   - if [[ $PHPDBG != 1 ]]; then $PHPUNIT_BIN; else phpdbg -qrr $PHPUNIT_BIN; fi
   - ./tests/e2e_tests
+  - ./tests/final_private_test
   - if [[ $NO_DEBUGGER == 1 ]]; then xdebug-disable; fi
   - if [[ $PHPDBG != 1 ]]; then
       bin/infection $INFECTION_FLAGS;

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,8 @@
         ],
         "tests": [
             "./vendor/bin/phpunit",
-            "./tests/e2e_tests"
+            "./tests/e2e_tests",
+            "./tests/final_private_test"
         ]
     }
 }

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ConfigureCommand extends BaseCommand
+final class ConfigureCommand extends BaseCommand
 {
     protected function configure()
     {

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -45,7 +45,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Process;
 
-class InfectionCommand extends BaseCommand
+final class InfectionCommand extends BaseCommand
 {
     const CI_FLAG_ERROR = 'The minimum required %s percentage should be %s%%, but actual is %s%%. Improve your tests!';
 

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SelfUpdateCommand extends Command
+final class SelfUpdateCommand extends Command
 {
     const PACKAGE_NAME = 'infection/infection';
     const FILE_NAME = 'infection.phar';

--- a/src/Config/ConsoleHelper.php
+++ b/src/Config/ConsoleHelper.php
@@ -12,6 +12,9 @@ namespace Infection\Config;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @internal
+ */
 class ConsoleHelper
 {
     /**

--- a/src/Config/Guesser/PhpUnitPathGuesser.php
+++ b/src/Config/Guesser/PhpUnitPathGuesser.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Config\Guesser;
 
-class PhpUnitPathGuesser implements Guesser
+final class PhpUnitPathGuesser implements Guesser
 {
     const CURRENT_DIR_PATH = '.';
 

--- a/src/Config/Guesser/SourceDirGuesser.php
+++ b/src/Config/Guesser/SourceDirGuesser.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Infection\Config\Guesser;
 
+/**
+ * @internal
+ */
 class SourceDirGuesser implements Guesser
 {
     private $composerJsonContent;

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -11,6 +11,9 @@ namespace Infection\Config;
 
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @internal
+ */
 class InfectionConfig
 {
     const PROCESS_TIMEOUT_SECONDS = 10;

--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Filesystem\Filesystem;
 
-class ExcludeDirsProvider
+final class ExcludeDirsProvider
 {
     const EXCLUDED_ROOT_DIRS = ['vendor', 'tests', 'test'];
 

--- a/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
+++ b/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
-class PhpUnitCustomExecutablePathProvider
+final class PhpUnitCustomExecutablePathProvider
 {
     /**
      * @var TestFrameworkFinder

--- a/src/Config/ValueProvider/SourceDirsProvider.php
+++ b/src/Config/ValueProvider/SourceDirsProvider.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 
-class SourceDirsProvider
+final class SourceDirsProvider
 {
     /**
      * @var ConsoleHelper

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -12,6 +12,7 @@ namespace Infection\Config\ValueProvider;
 use Infection\Config\ConsoleHelper;
 use Infection\Config\Guesser\PhpUnitPathGuesser;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
+use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\TestFrameworkTypes;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -34,7 +35,7 @@ final class TestFrameworkConfigPathProvider
      */
     private $questionHelper;
 
-    public function __construct(TestFrameworkConfigLocator $testFrameworkConfigLocator, ConsoleHelper $consoleHelper, QuestionHelper $questionHelper)
+    public function __construct(TestFrameworkConfigLocatorInterface $testFrameworkConfigLocator, ConsoleHelper $consoleHelper, QuestionHelper $questionHelper)
     {
         $this->testFrameworkConfigLocator = $testFrameworkConfigLocator;
         $this->consoleHelper = $consoleHelper;

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
-class TestFrameworkConfigPathProvider
+final class TestFrameworkConfigPathProvider
 {
     /**
      * @var TestFrameworkConfigLocator

--- a/src/Config/ValueProvider/TextLogFileProvider.php
+++ b/src/Config/ValueProvider/TextLogFileProvider.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
-class TextLogFileProvider
+final class TextLogFileProvider
 {
     const TEXT_LOG_FILE_NAME = 'infection-log.txt';
 

--- a/src/Config/ValueProvider/TimeoutProvider.php
+++ b/src/Config/ValueProvider/TimeoutProvider.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
-class TimeoutProvider
+final class TimeoutProvider
 {
     /**
      * @var ConsoleHelper

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class Application extends BaseApplication
+final class Application extends BaseApplication
 {
     const NAME = 'Infection - PHP Mutation Testing Framework';
     const VERSION = '@package_version@';

--- a/src/Console/Exception/InfectionException.php
+++ b/src/Console/Exception/InfectionException.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Infection\Console\Exception;
 
+/**
+ * @internal
+ */
 class InfectionException extends \Exception
 {
     public static function configurationAborted()

--- a/src/Console/Exception/InvalidOptionException.php
+++ b/src/Console/Exception/InvalidOptionException.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Console\Exception;
 
-class InvalidOptionException extends InfectionException
+final class InvalidOptionException extends InfectionException
 {
     public static function withMessage(string $message)
     {

--- a/src/Console/OutputFormatter/AbstractOutputFormatter.php
+++ b/src/Console/OutputFormatter/AbstractOutputFormatter.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Console\OutputFormatter;
 
-use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 
 /**
  * Abstract empty class to simplify particular implementations
@@ -23,7 +23,7 @@ abstract class AbstractOutputFormatter implements OutputFormatter
         $this->callsCount = 0;
     }
 
-    public function advance(MutantProcess $mutantProcess, int $mutationCount)
+    public function advance(MutantProcessInterface $mutantProcess, int $mutationCount)
     {
         ++$this->callsCount;
     }

--- a/src/Console/OutputFormatter/AbstractOutputFormatter.php
+++ b/src/Console/OutputFormatter/AbstractOutputFormatter.php
@@ -14,7 +14,7 @@ use Infection\Process\MutantProcess;
 /**
  * Abstract empty class to simplify particular implementations
  */
-class AbstractOutputFormatter implements OutputFormatter
+abstract class AbstractOutputFormatter implements OutputFormatter
 {
     protected $callsCount = 0;
 

--- a/src/Console/OutputFormatter/DotFormatter.php
+++ b/src/Console/OutputFormatter/DotFormatter.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Console\OutputFormatter;
 
 use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class DotFormatter extends AbstractOutputFormatter
@@ -41,7 +42,7 @@ final class DotFormatter extends AbstractOutputFormatter
         ]);
     }
 
-    public function advance(MutantProcess $mutantProcess, int $mutationCount)
+    public function advance(MutantProcessInterface $mutantProcess, int $mutationCount)
     {
         parent::advance($mutantProcess, $mutationCount);
 

--- a/src/Console/OutputFormatter/DotFormatter.php
+++ b/src/Console/OutputFormatter/DotFormatter.php
@@ -12,7 +12,7 @@ namespace Infection\Console\OutputFormatter;
 use Infection\Process\MutantProcess;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DotFormatter extends AbstractOutputFormatter
+final class DotFormatter extends AbstractOutputFormatter
 {
     const DOTS_PER_ROW = 50;
 

--- a/src/Console/OutputFormatter/OutputFormatter.php
+++ b/src/Console/OutputFormatter/OutputFormatter.php
@@ -8,6 +8,7 @@
 namespace Infection\Console\OutputFormatter;
 
 use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 
 interface OutputFormatter
 {
@@ -24,7 +25,7 @@ interface OutputFormatter
      * @param MutantProcess $mutantProcess
      * @param int $mutationCount
      */
-    public function advance(MutantProcess $mutantProcess, int $mutationCount);
+    public function advance(MutantProcessInterface $mutantProcess, int $mutationCount);
 
     /**
      * Triggered when mutation testing is finished

--- a/src/Console/OutputFormatter/ProgressFormatter.php
+++ b/src/Console/OutputFormatter/ProgressFormatter.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Console\OutputFormatter;
 
-use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 
 final class ProgressFormatter extends AbstractOutputFormatter
@@ -31,7 +31,7 @@ final class ProgressFormatter extends AbstractOutputFormatter
         $this->progressBar->start($mutationCount);
     }
 
-    public function advance(MutantProcess $mutantProcess, int $mutationCount)
+    public function advance(MutantProcessInterface $mutantProcess, int $mutationCount)
     {
         parent::advance($mutantProcess, $mutationCount);
 

--- a/src/Console/OutputFormatter/ProgressFormatter.php
+++ b/src/Console/OutputFormatter/ProgressFormatter.php
@@ -12,7 +12,7 @@ namespace Infection\Console\OutputFormatter;
 use Infection\Process\MutantProcess;
 use Symfony\Component\Console\Helper\ProgressBar;
 
-class ProgressFormatter extends AbstractOutputFormatter
+final class ProgressFormatter extends AbstractOutputFormatter
 {
     /**
      * @var ProgressBar

--- a/src/Differ/DiffColorizer.php
+++ b/src/Differ/DiffColorizer.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Infection\Differ;
 
+/**
+ * @internal
+ */
 class DiffColorizer
 {
     public function colorize(string $diff)

--- a/src/Differ/Differ.php
+++ b/src/Differ/Differ.php
@@ -11,6 +11,9 @@ namespace Infection\Differ;
 
 use SebastianBergmann\Diff\Differ as BaseDiffer;
 
+/**
+ * @internal
+ */
 class Differ
 {
     const DIFF_MAX_LINES = 12;

--- a/src/EventDispatcher/EventDispatcher.php
+++ b/src/EventDispatcher/EventDispatcher.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Infection\EventDispatcher;
 
+/**
+ * @internal
+ */
 class EventDispatcher implements EventDispatcherInterface, ContainsListenersInterface
 {
     /**

--- a/src/Events/InitialTestCaseCompleted.php
+++ b/src/Events/InitialTestCaseCompleted.php
@@ -9,6 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-class InitialTestCaseCompleted
+final class InitialTestCaseCompleted
 {
 }

--- a/src/Events/InitialTestSuiteFinished.php
+++ b/src/Events/InitialTestSuiteFinished.php
@@ -9,6 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-class InitialTestSuiteFinished
+final class InitialTestSuiteFinished
 {
 }

--- a/src/Events/InitialTestSuiteStarted.php
+++ b/src/Events/InitialTestSuiteStarted.php
@@ -9,6 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-class InitialTestSuiteStarted
+final class InitialTestSuiteStarted
 {
 }

--- a/src/Events/MutableFileProcessed.php
+++ b/src/Events/MutableFileProcessed.php
@@ -9,6 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-class MutableFileProcessed
+final class MutableFileProcessed
 {
 }

--- a/src/Events/MutantCreated.php
+++ b/src/Events/MutantCreated.php
@@ -9,6 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-class MutantCreated
+final class MutantCreated
 {
 }

--- a/src/Events/MutantProcessFinished.php
+++ b/src/Events/MutantProcessFinished.php
@@ -11,7 +11,7 @@ namespace Infection\Events;
 
 use Infection\Process\MutantProcess;
 
-class MutantProcessFinished
+final class MutantProcessFinished
 {
     /**
      * @var MutantProcess

--- a/src/Events/MutantProcessFinished.php
+++ b/src/Events/MutantProcessFinished.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Events;
 
 use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 
 final class MutantProcessFinished
 {
@@ -18,7 +19,7 @@ final class MutantProcessFinished
      */
     private $mutantProcess;
 
-    public function __construct(MutantProcess $mutantProcess)
+    public function __construct(MutantProcessInterface $mutantProcess)
     {
         $this->mutantProcess = $mutantProcess;
     }
@@ -26,7 +27,7 @@ final class MutantProcessFinished
     /**
      * @return MutantProcess
      */
-    public function getMutantProcess(): MutantProcess
+    public function getMutantProcess(): MutantProcessInterface
     {
         return $this->mutantProcess;
     }

--- a/src/Events/MutantsCreatingFinished.php
+++ b/src/Events/MutantsCreatingFinished.php
@@ -9,6 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-class MutantsCreatingFinished
+final class MutantsCreatingFinished
 {
 }

--- a/src/Events/MutantsCreatingStarted.php
+++ b/src/Events/MutantsCreatingStarted.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-class MutantsCreatingStarted
+final class MutantsCreatingStarted
 {
     /**
      * @var int

--- a/src/Events/MutationGeneratingFinished.php
+++ b/src/Events/MutationGeneratingFinished.php
@@ -9,6 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-class MutationGeneratingFinished
+final class MutationGeneratingFinished
 {
 }

--- a/src/Events/MutationGeneratingStarted.php
+++ b/src/Events/MutationGeneratingStarted.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-class MutationGeneratingStarted
+final class MutationGeneratingStarted
 {
     /**
      * @var int

--- a/src/Events/MutationTestingFinished.php
+++ b/src/Events/MutationTestingFinished.php
@@ -9,6 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-class MutationTestingFinished
+final class MutationTestingFinished
 {
 }

--- a/src/Events/MutationTestingStarted.php
+++ b/src/Events/MutationTestingStarted.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-class MutationTestingStarted
+final class MutationTestingStarted
 {
     /**
      * @var int

--- a/src/Finder/Exception/FinderException.php
+++ b/src/Finder/Exception/FinderException.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Finder\Exception;
 
-class FinderException extends \RuntimeException
+final class FinderException extends \RuntimeException
 {
     public static function composerNotFound(): self
     {

--- a/src/Finder/Exception/LocatorException.php
+++ b/src/Finder/Exception/LocatorException.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Finder\Exception;
 
-class LocatorException extends \RuntimeException
+final class LocatorException extends \RuntimeException
 {
     public static function fileOrDirectoryDoesNotExist(string $name): self
     {

--- a/src/Finder/Iterator/RealPathFilterIterator.php
+++ b/src/Finder/Iterator/RealPathFilterIterator.php
@@ -11,7 +11,7 @@ namespace Infection\Finder\Iterator;
 
 use Symfony\Component\Finder\Iterator\MultiplePcreFilterIterator;
 
-class RealPathFilterIterator extends MultiplePcreFilterIterator
+final class RealPathFilterIterator extends MultiplePcreFilterIterator
 {
     /**
      * Filters the iterator values.

--- a/src/Finder/Locator.php
+++ b/src/Finder/Locator.php
@@ -12,7 +12,7 @@ namespace Infection\Finder;
 use Infection\Finder\Exception\LocatorException;
 use Symfony\Component\Filesystem\Filesystem;
 
-class Locator
+final class Locator
 {
     /**
      * @var string[]

--- a/src/Finder/SourceFilesFinder.php
+++ b/src/Finder/SourceFilesFinder.php
@@ -12,7 +12,7 @@ namespace Infection\Finder;
 use Infection\Finder\Iterator\RealPathFilterIterator;
 use Symfony\Component\Finder\Finder;
 
-class SourceFilesFinder extends Finder
+final class SourceFilesFinder extends Finder
 {
     /**
      * @var string[]

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -13,6 +13,9 @@ use Infection\Finder\Exception\FinderException;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
+/**
+ * @internal
+ */
 class TestFrameworkFinder extends AbstractExecutableFinder
 {
     /**

--- a/src/Http/BadgeApiClient.php
+++ b/src/Http/BadgeApiClient.php
@@ -11,6 +11,9 @@ namespace Infection\Http;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @internal
+ */
 class BadgeApiClient
 {
     const STRYKER_DASHBOARD_API_URL = 'https://dashboard.stryker-mutator.io/api/reports';

--- a/src/Logger/BadgeLogger.php
+++ b/src/Logger/BadgeLogger.php
@@ -13,7 +13,7 @@ use Infection\Http\BadgeApiClient;
 use Infection\Mutant\MetricsCalculator;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class BadgeLogger implements MutationTestingResultsLogger
+final class BadgeLogger implements MutationTestingResultsLogger
 {
     const ENV_INFECTION_BADGE_API_KEY = 'INFECTION_BADGE_API_KEY';
 

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -11,7 +11,7 @@ namespace Infection\Logger;
 
 use Infection\Process\MutantProcess;
 
-class DebugFileLogger extends FileLogger
+final class DebugFileLogger extends FileLogger
 {
     protected function getLogLines(): array
     {

--- a/src/Logger/SummaryFileLogger.php
+++ b/src/Logger/SummaryFileLogger.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Logger;
 
-class SummaryFileLogger extends FileLogger
+final class SummaryFileLogger extends FileLogger
 {
     protected function getLogLines(): array
     {

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -11,7 +11,7 @@ namespace Infection\Logger;
 
 use Infection\Process\MutantProcess;
 
-class TextFileLogger extends FileLogger
+final class TextFileLogger extends FileLogger
 {
     protected function getLogLines(): array
     {

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Logger;
 
 use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 
 final class TextFileLogger extends FileLogger
 {
@@ -65,7 +66,7 @@ final class TextFileLogger extends FileLogger
         ];
     }
 
-    private function getMutatorFirstLine(int $index, MutantProcess $mutantProcess): string
+    private function getMutatorFirstLine(int $index, MutantProcessInterface $mutantProcess): string
     {
         $mutation = $mutantProcess->getMutant()->getMutation();
 

--- a/src/Mutant/Exception/MsiCalculationException.php
+++ b/src/Mutant/Exception/MsiCalculationException.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutant\Exception;
 
-class MsiCalculationException extends \LogicException
+final class MsiCalculationException extends \LogicException
 {
     public static function create(string $type): self
     {

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -26,7 +26,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use Symfony\Component\Finder\SplFileInfo;
 
-class MutationsGenerator
+final class MutationsGenerator
 {
     /**
      * @var array source directories

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Mutant;
 
 use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 
 class MetricsCalculator
 {
@@ -68,7 +69,7 @@ class MetricsCalculator
      */
     private $totalMutantsCount = 0;
 
-    public function collect(MutantProcess $mutantProcess)
+    public function collect(MutantProcessInterface $mutantProcess)
     {
         ++$this->totalMutantsCount;
 

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -12,6 +12,9 @@ namespace Infection\Mutant;
 use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessInterface;
 
+/**
+ * @internal
+ */
 class MetricsCalculator
 {
     /**

--- a/src/Mutant/Mutant.php
+++ b/src/Mutant/Mutant.php
@@ -10,8 +10,9 @@ declare(strict_types=1);
 namespace Infection\Mutant;
 
 use Infection\Mutation;
+use Infection\MutationInterface;
 
-class Mutant
+final class Mutant implements MutantInterface
 {
     private $mutatedFilePath;
 
@@ -35,7 +36,7 @@ class Mutant
      */
     private $coverageTests;
 
-    public function __construct(string $mutatedFilePath, Mutation $mutation, string $diff, bool $isCoveredByTest, array $coverageTests)
+    public function __construct(string $mutatedFilePath, MutationInterface $mutation, string $diff, bool $isCoveredByTest, array $coverageTests)
     {
         $this->mutatedFilePath = $mutatedFilePath;
         $this->mutation = $mutation;
@@ -49,7 +50,7 @@ class Mutant
         return $this->mutatedFilePath;
     }
 
-    public function getMutation(): Mutation
+    public function getMutation(): MutationInterface
     {
         return $this->mutation;
     }

--- a/src/Mutant/MutantCreator.php
+++ b/src/Mutant/MutantCreator.php
@@ -17,7 +17,7 @@ use Infection\Visitor\MutatorVisitor;
 use PhpParser\NodeTraverser;
 use PhpParser\PrettyPrinter\Standard;
 
-class MutantCreator
+final class MutantCreator
 {
     /**
      * @var string

--- a/src/Mutant/MutantCreator.php
+++ b/src/Mutant/MutantCreator.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Infection\Mutant;
 
 use Infection\Differ\Differ;
-use Infection\Mutation;
+use Infection\MutationInterface;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\Visitor\CloneVisitor;
 use Infection\Visitor\MutatorVisitor;
@@ -46,7 +46,7 @@ final class MutantCreator
         $this->prettyPrinter = $prettyPrinter;
     }
 
-    public function create(Mutation $mutation, CodeCoverageData $codeCoverageData): Mutant
+    public function create(MutationInterface $mutation, CodeCoverageData $codeCoverageData): MutantInterface
     {
         $mutatedFilePath = sprintf('%s/mutant.%s.infection.php', $this->tempDir, $mutation->getHash());
 
@@ -65,7 +65,7 @@ final class MutantCreator
         );
     }
 
-    private function createMutatedCode(Mutation $mutation, string $mutatedFilePath): string
+    private function createMutatedCode(MutationInterface $mutation, string $mutatedFilePath): string
     {
         if (file_exists($mutatedFilePath)) {
             return file_get_contents($mutatedFilePath);

--- a/src/Mutant/MutantInterface.php
+++ b/src/Mutant/MutantInterface.php
@@ -11,6 +11,9 @@ namespace Infection\Mutant;
 
 use Infection\MutationInterface;
 
+/**
+ * @see Mutant
+ */
 interface MutantInterface
 {
     public function getMutatedFilePath(): string;

--- a/src/Mutant/MutantInterface.php
+++ b/src/Mutant/MutantInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutant;
+
+use Infection\MutationInterface;
+
+interface MutantInterface
+{
+    public function getMutatedFilePath(): string;
+
+    public function getMutation(): MutationInterface;
+
+    public function getDiff(): string;
+
+    public function isCoveredByTest(): bool;
+
+    public function getCoverageTests(): array;
+}

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -12,7 +12,7 @@ namespace Infection;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Mutation
+final class Mutation implements MutationInterface
 {
     /**
      * @var Mutator

--- a/src/MutationInterface.php
+++ b/src/MutationInterface.php
@@ -11,6 +11,9 @@ namespace Infection;
 
 use Infection\Mutator\Util\Mutator;
 
+/**
+ * @see Mutation
+ */
 interface MutationInterface
 {
     public function getMutator(): Mutator;

--- a/src/MutationInterface.php
+++ b/src/MutationInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection;
+
+use Infection\Mutator\Util\Mutator;
+
+interface MutationInterface
+{
+    public function getMutator(): Mutator;
+
+    public function getAttributes(): array;
+
+    public function getOriginalFilePath(): string;
+
+    public function getMutatedNodeClass(): string;
+
+    public function getHash(): string;
+
+    public function getOriginalFileAst(): array;
+
+    public function isOnFunctionSignature(): bool;
+
+    public function isCoveredByTest(): bool;
+}

--- a/src/Mutator/Arithmetic/Assignment.php
+++ b/src/Mutator/Arithmetic/Assignment.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Assignment extends Mutator
+final class Assignment extends Mutator
 {
     /**
      * Replaces "+=", "*=", ".=", and similar with a plain "="

--- a/src/Mutator/Arithmetic/AssignmentEqual.php
+++ b/src/Mutator/Arithmetic/AssignmentEqual.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class AssignmentEqual extends Mutator
+final class AssignmentEqual extends Mutator
 {
     /**
      * Replaces "==" with a "=".

--- a/src/Mutator/Arithmetic/BitwiseAnd.php
+++ b/src/Mutator/Arithmetic/BitwiseAnd.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class BitwiseAnd extends Mutator
+final class BitwiseAnd extends Mutator
 {
     /**
      * Replaces "&" with "|"

--- a/src/Mutator/Arithmetic/BitwiseNot.php
+++ b/src/Mutator/Arithmetic/BitwiseNot.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class BitwiseNot extends Mutator
+final class BitwiseNot extends Mutator
 {
     /**
      * Replaces "~" with "" (removed)

--- a/src/Mutator/Arithmetic/BitwiseOr.php
+++ b/src/Mutator/Arithmetic/BitwiseOr.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class BitwiseOr extends Mutator
+final class BitwiseOr extends Mutator
 {
     /**
      * Replaces "|" with "&"

--- a/src/Mutator/Arithmetic/BitwiseXor.php
+++ b/src/Mutator/Arithmetic/BitwiseXor.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class BitwiseXor extends Mutator
+final class BitwiseXor extends Mutator
 {
     /**
      * Replaces "^" with "&"

--- a/src/Mutator/Arithmetic/Decrement.php
+++ b/src/Mutator/Arithmetic/Decrement.php
@@ -16,7 +16,7 @@ use PhpParser\Node\Expr\PostInc;
 use PhpParser\Node\Expr\PreDec;
 use PhpParser\Node\Expr\PreInc;
 
-class Decrement extends Mutator
+final class Decrement extends Mutator
 {
     /**
      * Replaces "--" with "++"

--- a/src/Mutator/Arithmetic/DivEqual.php
+++ b/src/Mutator/Arithmetic/DivEqual.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class DivEqual extends Mutator
+final class DivEqual extends Mutator
 {
     /**
      * Replaces "/=" with "*="

--- a/src/Mutator/Arithmetic/Division.php
+++ b/src/Mutator/Arithmetic/Division.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Division extends Mutator
+final class Division extends Mutator
 {
     /**
      * Replaces "/" with "*"

--- a/src/Mutator/Arithmetic/Exponentiation.php
+++ b/src/Mutator/Arithmetic/Exponentiation.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Exponentiation extends Mutator
+final class Exponentiation extends Mutator
 {
     /**
      * Replaces "**" with "/"

--- a/src/Mutator/Arithmetic/Increment.php
+++ b/src/Mutator/Arithmetic/Increment.php
@@ -16,7 +16,7 @@ use PhpParser\Node\Expr\PostInc;
 use PhpParser\Node\Expr\PreDec;
 use PhpParser\Node\Expr\PreInc;
 
-class Increment extends Mutator
+final class Increment extends Mutator
 {
     /**
      * Replaces "++" with "--"

--- a/src/Mutator/Arithmetic/Minus.php
+++ b/src/Mutator/Arithmetic/Minus.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Minus extends Mutator
+final class Minus extends Mutator
 {
     /**
      * Replaces "-" with "+"

--- a/src/Mutator/Arithmetic/MinusEqual.php
+++ b/src/Mutator/Arithmetic/MinusEqual.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class MinusEqual extends Mutator
+final class MinusEqual extends Mutator
 {
     /**
      * Replaces "-=" with "+="

--- a/src/Mutator/Arithmetic/ModEqual.php
+++ b/src/Mutator/Arithmetic/ModEqual.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class ModEqual extends Mutator
+final class ModEqual extends Mutator
 {
     /**
      * Replaces "%=" with "*="

--- a/src/Mutator/Arithmetic/Modulus.php
+++ b/src/Mutator/Arithmetic/Modulus.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Modulus extends Mutator
+final class Modulus extends Mutator
 {
     /**
      * Replaces "%" with "*"

--- a/src/Mutator/Arithmetic/MulEqual.php
+++ b/src/Mutator/Arithmetic/MulEqual.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class MulEqual extends Mutator
+final class MulEqual extends Mutator
 {
     /**
      * Replaces "*=" with "/="

--- a/src/Mutator/Arithmetic/Multiplication.php
+++ b/src/Mutator/Arithmetic/Multiplication.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Multiplication extends Mutator
+final class Multiplication extends Mutator
 {
     /**
      * Replaces "*" with "/"

--- a/src/Mutator/Arithmetic/Plus.php
+++ b/src/Mutator/Arithmetic/Plus.php
@@ -13,7 +13,7 @@ use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 
-class Plus extends Mutator
+final class Plus extends Mutator
 {
     /**
      * Replaces "+" with "-"

--- a/src/Mutator/Arithmetic/PlusEqual.php
+++ b/src/Mutator/Arithmetic/PlusEqual.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class PlusEqual extends Mutator
+final class PlusEqual extends Mutator
 {
     /**
      * Replaces "+=" with "-="

--- a/src/Mutator/Arithmetic/PowEqual.php
+++ b/src/Mutator/Arithmetic/PowEqual.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class PowEqual extends Mutator
+final class PowEqual extends Mutator
 {
     /**
      * Replaces "**=" with "/="

--- a/src/Mutator/Arithmetic/ShiftLeft.php
+++ b/src/Mutator/Arithmetic/ShiftLeft.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class ShiftLeft extends Mutator
+final class ShiftLeft extends Mutator
 {
     /**
      * Replaces "<<" with ">>"

--- a/src/Mutator/Arithmetic/ShiftRight.php
+++ b/src/Mutator/Arithmetic/ShiftRight.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Arithmetic;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class ShiftRight extends Mutator
+final class ShiftRight extends Mutator
 {
     /**
      * Replaces ">>" with "<<"

--- a/src/Mutator/Boolean/ArrayItem.php
+++ b/src/Mutator/Boolean/ArrayItem.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Boolean;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class ArrayItem extends Mutator
+final class ArrayItem extends Mutator
 {
     /**
      * Replaces [$a->foo => $b->bar] with [$a->foo > $b->bar]

--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Boolean;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class FalseValue extends Mutator
+final class FalseValue extends Mutator
 {
     /**
      * Replaces "false" with "true"

--- a/src/Mutator/Boolean/LogicalAnd.php
+++ b/src/Mutator/Boolean/LogicalAnd.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Boolean;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class LogicalAnd extends Mutator
+final class LogicalAnd extends Mutator
 {
     /**
      * Replaces "&&" with "||"

--- a/src/Mutator/Boolean/LogicalLowerAnd.php
+++ b/src/Mutator/Boolean/LogicalLowerAnd.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Boolean;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class LogicalLowerAnd extends Mutator
+final class LogicalLowerAnd extends Mutator
 {
     /**
      * Replcaes "and" with "or"

--- a/src/Mutator/Boolean/LogicalLowerOr.php
+++ b/src/Mutator/Boolean/LogicalLowerOr.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Boolean;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class LogicalLowerOr extends Mutator
+final class LogicalLowerOr extends Mutator
 {
     /**
      * Replcaes "or" with "and"

--- a/src/Mutator/Boolean/LogicalNot.php
+++ b/src/Mutator/Boolean/LogicalNot.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Boolean;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class LogicalNot extends Mutator
+final class LogicalNot extends Mutator
 {
     /**
      * Replaces "!something" with "something"

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Boolean;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class LogicalOr extends Mutator
+final class LogicalOr extends Mutator
 {
     /**
      * Replaces "||" with "&&"

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Boolean;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class TrueValue extends Mutator
+final class TrueValue extends Mutator
 {
     /**
      * Replaces "true" with "false"

--- a/src/Mutator/Boolean/Yield_.php
+++ b/src/Mutator/Boolean/Yield_.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Boolean;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Yield_ extends Mutator
+final class Yield_ extends Mutator
 {
     /**
      * Replaces `yield $a => $b;` with `yield $a > $b;`

--- a/src/Mutator/ConditionalBoundary/GreaterThan.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThan.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalBoundary;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class GreaterThan extends Mutator
+final class GreaterThan extends Mutator
 {
     /**
      * Replaces ">" with ">="

--- a/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalBoundary;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class GreaterThanOrEqualTo extends Mutator
+final class GreaterThanOrEqualTo extends Mutator
 {
     /**
      * Replaces ">=" with ">"

--- a/src/Mutator/ConditionalBoundary/LessThan.php
+++ b/src/Mutator/ConditionalBoundary/LessThan.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalBoundary;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class LessThan extends Mutator
+final class LessThan extends Mutator
 {
     /**
      * Replaces "<" with "<="

--- a/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalBoundary;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class LessThanOrEqualTo extends Mutator
+final class LessThanOrEqualTo extends Mutator
 {
     /**
      * Replaces "<=" with "<"

--- a/src/Mutator/ConditionalNegotiation/Equal.php
+++ b/src/Mutator/ConditionalNegotiation/Equal.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalNegotiation;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Equal extends Mutator
+final class Equal extends Mutator
 {
     /**
      * Replaces "==" with "!="

--- a/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalNegotiation;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class GreaterThanNegotiation extends Mutator
+final class GreaterThanNegotiation extends Mutator
 {
     /**
      * Replaces ">" with "<="

--- a/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalNegotiation;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class GreaterThanOrEqualToNegotiation extends Mutator
+final class GreaterThanOrEqualToNegotiation extends Mutator
 {
     /**
      * Replaces ">=" with "<"

--- a/src/Mutator/ConditionalNegotiation/Identical.php
+++ b/src/Mutator/ConditionalNegotiation/Identical.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalNegotiation;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Identical extends Mutator
+final class Identical extends Mutator
 {
     /**
      * Replaces "===" with "!=="

--- a/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalNegotiation;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class LessThanNegotiation extends Mutator
+final class LessThanNegotiation extends Mutator
 {
     /**
      * Replaces "<" with ">="

--- a/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalNegotiation;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class LessThanOrEqualToNegotiation extends Mutator
+final class LessThanOrEqualToNegotiation extends Mutator
 {
     /**
      * Replaces "<=" with ">"

--- a/src/Mutator/ConditionalNegotiation/NotEqual.php
+++ b/src/Mutator/ConditionalNegotiation/NotEqual.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalNegotiation;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class NotEqual extends Mutator
+final class NotEqual extends Mutator
 {
     /**
      * Replaces "!=" with "=="

--- a/src/Mutator/ConditionalNegotiation/NotIdentical.php
+++ b/src/Mutator/ConditionalNegotiation/NotIdentical.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ConditionalNegotiation;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class NotIdentical extends Mutator
+final class NotIdentical extends Mutator
 {
     /**
      * Replaces "!==" with "==="

--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -15,7 +15,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 
-class ProtectedVisibility extends Mutator
+final class ProtectedVisibility extends Mutator
 {
     /**
      * Replaces "protected function..." with "private function ..."

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -16,7 +16,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 
-class PublicVisibility extends Mutator
+final class PublicVisibility extends Mutator
 {
     use InterfaceParentTrait;
 

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Number;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class DecrementInteger extends Mutator
+final class DecrementInteger extends Mutator
 {
     /**
      * Decrements an integer by 1.

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Number;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class IncrementInteger extends Mutator
+final class IncrementInteger extends Mutator
 {
     /**
      * Increments an integer by 1.

--- a/src/Mutator/Number/OneZeroFloat.php
+++ b/src/Mutator/Number/OneZeroFloat.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Number;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class OneZeroFloat extends Mutator
+final class OneZeroFloat extends Mutator
 {
     /**
      * Replaces "0.0" with "1.0" or "1.0" with "0.0"

--- a/src/Mutator/Number/OneZeroInteger.php
+++ b/src/Mutator/Number/OneZeroInteger.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Number;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class OneZeroInteger extends Mutator
+final class OneZeroInteger extends Mutator
 {
     /**
      * Replaces "0" with "1" or "1" with "0"

--- a/src/Mutator/Operator/Break_.php
+++ b/src/Mutator/Operator/Break_.php
@@ -13,7 +13,7 @@ use Infection\Mutator\Util\Mutator;
 use Infection\Visitor\ParentConnectorVisitor;
 use PhpParser\Node;
 
-class Break_ extends Mutator
+final class Break_ extends Mutator
 {
     public function mutate(Node $node)
     {

--- a/src/Mutator/Operator/Continue_.php
+++ b/src/Mutator/Operator/Continue_.php
@@ -13,7 +13,7 @@ use Infection\Mutator\Util\Mutator;
 use Infection\Visitor\ParentConnectorVisitor;
 use PhpParser\Node;
 
-class Continue_ extends Mutator
+final class Continue_ extends Mutator
 {
     public function mutate(Node $node)
     {

--- a/src/Mutator/Operator/Finally_.php
+++ b/src/Mutator/Operator/Finally_.php
@@ -13,7 +13,7 @@ use Infection\Mutator\Util\Mutator;
 use Infection\Visitor\ParentConnectorVisitor;
 use PhpParser\Node;
 
-class Finally_ extends Mutator
+final class Finally_ extends Mutator
 {
     public function mutate(Node $node)
     {

--- a/src/Mutator/Operator/Throw_.php
+++ b/src/Mutator/Operator/Throw_.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Operator;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Throw_ extends Mutator
+final class Throw_ extends Mutator
 {
     public function mutate(Node $node)
     {

--- a/src/Mutator/ReturnValue/FloatNegation.php
+++ b/src/Mutator/ReturnValue/FloatNegation.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ReturnValue;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class FloatNegation extends Mutator
+final class FloatNegation extends Mutator
 {
     /**
      * Replaces any float with negated float

--- a/src/Mutator/ReturnValue/FunctionCall.php
+++ b/src/Mutator/ReturnValue/FunctionCall.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ReturnValue;
 use Infection\Mutator\Util\AbstractValueToNullReturnValue;
 use PhpParser\Node;
 
-class FunctionCall extends AbstractValueToNullReturnValue
+final class FunctionCall extends AbstractValueToNullReturnValue
 {
     /**
      * Replaces "return func();" with "func(); return null;"

--- a/src/Mutator/ReturnValue/IntegerNegation.php
+++ b/src/Mutator/ReturnValue/IntegerNegation.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ReturnValue;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class IntegerNegation extends Mutator
+final class IntegerNegation extends Mutator
 {
     /**
      * Replaces any integer with negated integer value.

--- a/src/Mutator/ReturnValue/NewObject.php
+++ b/src/Mutator/ReturnValue/NewObject.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ReturnValue;
 use Infection\Mutator\Util\AbstractValueToNullReturnValue;
 use PhpParser\Node;
 
-class NewObject extends AbstractValueToNullReturnValue
+final class NewObject extends AbstractValueToNullReturnValue
 {
     /**
      * Replace "return new Something(anything);" with "new Something(anything); return null;"

--- a/src/Mutator/ReturnValue/This.php
+++ b/src/Mutator/ReturnValue/This.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ReturnValue;
 use Infection\Mutator\Util\AbstractValueToNullReturnValue;
 use PhpParser\Node;
 
-class This extends AbstractValueToNullReturnValue
+final class This extends AbstractValueToNullReturnValue
 {
     /**
      * Replaces "return $this;" with "return null;"

--- a/src/Mutator/Sort/Spaceship.php
+++ b/src/Mutator/Sort/Spaceship.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Sort;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Spaceship extends Mutator
+final class Spaceship extends Mutator
 {
     /**
      * Swaps the arguments in the Spaceship operator <=>

--- a/src/Mutator/Util/MutatorConfig.php
+++ b/src/Mutator/Util/MutatorConfig.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Util;
 
-class MutatorConfig
+final class MutatorConfig
 {
     /**
      * @var array

--- a/src/Mutator/Util/MutatorsGenerator.php
+++ b/src/Mutator/Util/MutatorsGenerator.php
@@ -11,7 +11,7 @@ namespace Infection\Mutator\Util;
 
 use Infection\Config\Exception\InvalidConfigException;
 
-class MutatorsGenerator
+final class MutatorsGenerator
 {
     /**
      * @var array

--- a/src/Mutator/ZeroIteration/For_.php
+++ b/src/Mutator/ZeroIteration/For_.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ZeroIteration;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class For_ extends Mutator
+final class For_ extends Mutator
 {
     public function mutate(Node $node)
     {

--- a/src/Mutator/ZeroIteration/Foreach_.php
+++ b/src/Mutator/ZeroIteration/Foreach_.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\ZeroIteration;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class Foreach_ extends Mutator
+final class Foreach_ extends Mutator
 {
     public function mutate(Node $node)
     {

--- a/src/Php/XdebugHandler.php
+++ b/src/Php/XdebugHandler.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Infection\Php;
 
+/**
+ * @internal
+ */
 class XdebugHandler
 {
     const ENV_DISABLE_XDEBUG = 'INFECTION_DISABLE_XDEBUG';

--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Process\Builder;
 
-use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantInterface;
 use Infection\Process\MutantProcess;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Symfony\Component\Process\Process;
@@ -68,7 +68,7 @@ class ProcessBuilder
         return $process;
     }
 
-    public function getProcessForMutant(Mutant $mutant, string $testFrameworkExtraOptions = ''): MutantProcess
+    public function getProcessForMutant(MutantInterface $mutant, string $testFrameworkExtraOptions = ''): MutantProcess
     {
         $process = new Process(
             $this->testFrameworkAdapter->getExecutableCommandLine(

--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -14,6 +14,9 @@ use Infection\Process\MutantProcess;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Symfony\Component\Process\Process;
 
+/**
+ * @internal
+ */
 class ProcessBuilder
 {
     /**

--- a/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
@@ -17,7 +17,7 @@ use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class InitialTestsConsoleLoggerSubscriber implements EventSubscriberInterface
+final class InitialTestsConsoleLoggerSubscriber implements EventSubscriberInterface
 {
     /**
      * @var OutputInterface

--- a/src/Process/Listener/MutantCreatingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutantCreatingConsoleLoggerSubscriber.php
@@ -16,7 +16,7 @@ use Infection\Events\MutantsCreatingStarted;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MutantCreatingConsoleLoggerSubscriber implements EventSubscriberInterface
+final class MutantCreatingConsoleLoggerSubscriber implements EventSubscriberInterface
 {
     /**
      * @var OutputInterface

--- a/src/Process/Listener/MutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationGeneratingConsoleLoggerSubscriber.php
@@ -16,7 +16,7 @@ use Infection\Events\MutationGeneratingStarted;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MutationGeneratingConsoleLoggerSubscriber implements EventSubscriberInterface
+final class MutationGeneratingConsoleLoggerSubscriber implements EventSubscriberInterface
 {
     /**
      * @var OutputInterface

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -19,7 +19,7 @@ use Infection\Mutant\MetricsCalculator;
 use Infection\Process\MutantProcess;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
+final class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
 {
     const PAD_LENGTH = 8;
 

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -23,7 +23,7 @@ use Infection\Mutant\MetricsCalculator;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
-class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
+final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
 {
     /**
      * @var InfectionConfig

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -14,7 +14,7 @@ use Infection\Mutant\MutantInterface;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Symfony\Component\Process\Process;
 
-class MutantProcess
+final class MutantProcess implements MutantProcessInterface
 {
     const CODE_KILLED = 0;
     const CODE_ESCAPED = 1;

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Process;
 
 use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantInterface;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Symfony\Component\Process\Process;
 
@@ -51,7 +52,7 @@ class MutantProcess
      */
     private $testFrameworkAdapter;
 
-    public function __construct(Process $process, Mutant $mutant, AbstractTestFrameworkAdapter $testFrameworkAdapter)
+    public function __construct(Process $process, MutantInterface $mutant, AbstractTestFrameworkAdapter $testFrameworkAdapter)
     {
         $this->process = $process;
         $this->mutant = $mutant;
@@ -68,7 +69,7 @@ class MutantProcess
         return $this->process;
     }
 
-    public function getMutant(): Mutant
+    public function getMutant(): MutantInterface
     {
         return $this->mutant;
     }

--- a/src/Process/MutantProcessInterface.php
+++ b/src/Process/MutantProcessInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Process;
+
+use Infection\Mutant\MutantInterface;
+use Symfony\Component\Process\Process;
+
+interface MutantProcessInterface
+{
+    public function getProcess(): Process;
+
+    public function getMutant(): MutantInterface;
+
+    public function markTimeout();
+
+    public function getResultCode(): int;
+}

--- a/src/Process/MutantProcessInterface.php
+++ b/src/Process/MutantProcessInterface.php
@@ -12,6 +12,9 @@ namespace Infection\Process;
 use Infection\Mutant\MutantInterface;
 use Symfony\Component\Process\Process;
 
+/**
+ * @see MutantProcess
+ */
 interface MutantProcessInterface
 {
     public function getProcess(): Process;

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -16,7 +16,7 @@ use Infection\Events\InitialTestSuiteStarted;
 use Infection\Process\Builder\ProcessBuilder;
 use Symfony\Component\Process\Process;
 
-class InitialTestsRunner
+final class InitialTestsRunner
 {
     /**
      * @var ProcessBuilder

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -22,7 +22,7 @@ use Infection\Process\MutantProcess;
 use Infection\Process\Runner\Parallel\ParallelProcessRunner;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 
-class MutationTestingRunner
+final class MutationTestingRunner
 {
     /**
      * @var ProcessBuilder

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -19,7 +19,7 @@ use Infection\Mutant\MutantCreator;
 use Infection\Mutation;
 use Infection\MutationInterface;
 use Infection\Process\Builder\ProcessBuilder;
-use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 use Infection\Process\Runner\Parallel\ParallelProcessRunner;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 
@@ -63,7 +63,7 @@ final class MutationTestingRunner
         $this->eventDispatcher->dispatch(new MutantsCreatingStarted($mutantCount));
 
         $processes = array_map(
-            function (MutationInterface $mutation) use ($codeCoverageData, $testFrameworkExtraOptions): MutantProcess {
+            function (MutationInterface $mutation) use ($codeCoverageData, $testFrameworkExtraOptions): MutantProcessInterface {
                 $mutant = $this->mutantCreator->create($mutation, $codeCoverageData);
 
                 $process = $this->processBuilder->getProcessForMutant($mutant, $testFrameworkExtraOptions);

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -17,6 +17,7 @@ use Infection\Events\MutationTestingFinished;
 use Infection\Events\MutationTestingStarted;
 use Infection\Mutant\MutantCreator;
 use Infection\Mutation;
+use Infection\MutationInterface;
 use Infection\Process\Builder\ProcessBuilder;
 use Infection\Process\MutantProcess;
 use Infection\Process\Runner\Parallel\ParallelProcessRunner;
@@ -62,7 +63,7 @@ final class MutationTestingRunner
         $this->eventDispatcher->dispatch(new MutantsCreatingStarted($mutantCount));
 
         $processes = array_map(
-            function (Mutation $mutation) use ($codeCoverageData, $testFrameworkExtraOptions): MutantProcess {
+            function (MutationInterface $mutation) use ($codeCoverageData, $testFrameworkExtraOptions): MutantProcess {
                 $mutant = $this->mutantCreator->create($mutation, $codeCoverageData);
 
                 $process = $this->processBuilder->getProcessForMutant($mutant, $testFrameworkExtraOptions);

--- a/src/Process/Runner/Parallel/ParallelProcessRunner.php
+++ b/src/Process/Runner/Parallel/ParallelProcessRunner.php
@@ -19,7 +19,7 @@ use Symfony\Component\Process\Exception\RuntimeException;
 /**
  * This ProcessManager is a simple wrapper to enable parallel processing using Symfony Process component.
  */
-class ParallelProcessRunner
+final class ParallelProcessRunner
 {
     /**
      * @var EventDispatcherInterface

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -7,7 +7,7 @@
 
 namespace Infection\StreamWrapper;
 
-class IncludeInterceptor
+final class IncludeInterceptor
 {
     const STREAM_OPEN_FOR_INCLUDE = 0x00000080;
 

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Infection\TestFramework;
 
 use Infection\Finder\AbstractExecutableFinder;
-use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantInterface;
 use Infection\Process\ExecutableFinder\PhpExecutableFinder;
 use Infection\TestFramework\Config\InitialConfigBuilder;
 use Infection\TestFramework\Config\MutationConfigBuilder;
@@ -155,7 +155,7 @@ abstract class AbstractTestFrameworkAdapter
         return $this->initialConfigBuilder->build();
     }
 
-    public function buildMutationConfigFile(Mutant $mutant): string
+    public function buildMutationConfigFile(MutantInterface $mutant): string
     {
         return $this->mutationConfigBuilder->build($mutant);
     }

--- a/src/TestFramework/Config/MutationConfigBuilder.php
+++ b/src/TestFramework/Config/MutationConfigBuilder.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Config;
 
-use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantInterface;
 
 abstract class MutationConfigBuilder
 {
-    abstract public function build(Mutant $mutant): string;
+    abstract public function build(MutantInterface $mutant): string;
 
     protected function getInterceptorFileContent(string $interceptorPath, string $originalFilePath, string $mutatedFilePath): string
     {

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -11,7 +11,7 @@ namespace Infection\TestFramework\Config;
 
 use Infection\Finder\Exception\LocatorException;
 
-class TestFrameworkConfigLocator
+final class TestFrameworkConfigLocator implements TestFrameworkConfigLocatorInterface
 {
     const DEFAULT_EXTENSIONS = [
         'xml',

--- a/src/TestFramework/Config/TestFrameworkConfigLocatorInterface.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocatorInterface.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Config;
 
+/**
+ * @see TestFrameworkConfigLocator
+ */
 interface TestFrameworkConfigLocatorInterface
 {
     public function locate(string $testFrameworkName, string $customDir = null): string;

--- a/src/TestFramework/Config/TestFrameworkConfigLocatorInterface.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocatorInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\TestFramework\Config;
+
+interface TestFrameworkConfigLocatorInterface
+{
+    public function locate(string $testFrameworkName, string $customDir = null): string;
+}

--- a/src/TestFramework/Coverage/CachedTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/CachedTestFileDataProvider.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Coverage;
 
-class CachedTestFileDataProvider implements TestFileDataProvider
+final class CachedTestFileDataProvider implements TestFileDataProvider
 {
     /**
      * @var TestFileDataProvider

--- a/src/TestFramework/Coverage/CodeCoverageData.php
+++ b/src/TestFramework/Coverage/CodeCoverageData.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Coverage;
 
-use Infection\Mutation;
+use Infection\MutationInterface;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 
 class CodeCoverageData
@@ -101,7 +101,7 @@ class CodeCoverageData
         return false;
     }
 
-    public function getAllTestsFor(Mutation $mutation): array
+    public function getAllTestsFor(MutationInterface $mutation): array
     {
         if (!$mutation->isCoveredByTest()) {
             return [];

--- a/src/TestFramework/Coverage/CodeCoverageData.php
+++ b/src/TestFramework/Coverage/CodeCoverageData.php
@@ -12,6 +12,9 @@ namespace Infection\TestFramework\Coverage;
 use Infection\MutationInterface;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 
+/**
+ * @internal
+ */
 class CodeCoverageData
 {
     const PHP_UNIT_COVERAGE_DIR = 'coverage-xml';

--- a/src/TestFramework/Coverage/CoverageDoesNotExistException.php
+++ b/src/TestFramework/Coverage/CoverageDoesNotExistException.php
@@ -11,7 +11,7 @@ namespace Infection\TestFramework\Coverage;
 
 use Infection\Console\Exception\InfectionException;
 
-class CoverageDoesNotExistException extends InfectionException
+final class CoverageDoesNotExistException extends InfectionException
 {
     public static function with(string $coverageIndexFilePath, string $testFrameworkKey, string $tempDir): self
     {

--- a/src/TestFramework/Coverage/TestFileNameNotFoundException.php
+++ b/src/TestFramework/Coverage/TestFileNameNotFoundException.php
@@ -9,6 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Coverage;
 
-class TestFileNameNotFoundException extends \Exception
+final class TestFileNameNotFoundException extends \Exception
 {
 }

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -12,6 +12,7 @@ namespace Infection\TestFramework;
 use Infection\Config\InfectionConfig;
 use Infection\Finder\TestFrameworkFinder;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
+use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapter;
 use Infection\TestFramework\PhpSpec\CommandLine\ArgumentsAndOptionsBuilder as PhpSpecArgumentsAndOptionsBuilder;
 use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder as PhpSpecInitialConfigBuilder;
@@ -63,7 +64,7 @@ final class Factory
     public function __construct(
         string $tmpDir,
         string $projectDir,
-        TestFrameworkConfigLocator $configLocator,
+        TestFrameworkConfigLocatorInterface $configLocator,
         XmlConfigurationHelper $xmlConfigurationHelper,
         string $jUnitFilePath,
         InfectionConfig $infectionConfig,

--- a/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapter.php
+++ b/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapter.php
@@ -11,7 +11,7 @@ namespace Infection\TestFramework\PhpSpec\Adapter;
 
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 
-class PhpSpecAdapter extends AbstractTestFrameworkAdapter
+final class PhpSpecAdapter extends AbstractTestFrameworkAdapter
 {
     const ERROR_REGEXPS = [
         '/Fatal error\:/',

--- a/src/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -11,7 +11,7 @@ namespace Infection\TestFramework\PhpSpec\CommandLine;
 
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 
-class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilder
+final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilder
 {
     public function build(string $configPath, string $extraOptions): string
     {

--- a/src/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilder.php
@@ -13,6 +13,9 @@ use Infection\TestFramework\Config\InitialConfigBuilder as ConfigBuilder;
 use Infection\TestFramework\PhpSpec\Config\InitialYamlConfiguration;
 use Symfony\Component\Yaml\Yaml;
 
+/**
+ * @internal
+ */
 class InitialConfigBuilder implements ConfigBuilder
 {
     /**

--- a/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpSpec\Config\Builder;
 
-use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantInterface;
 use Infection\TestFramework\Config\MutationConfigBuilder as ConfigBuilder;
 use Infection\TestFramework\PhpSpec\Config\MutationYamlConfiguration;
 use Symfony\Component\Yaml\Yaml;
@@ -37,7 +37,7 @@ class MutationConfigBuilder extends ConfigBuilder
         $this->projectDir = $projectDir;
     }
 
-    public function build(Mutant $mutant): string
+    public function build(MutantInterface $mutant): string
     {
         $customAutoloadFilePath = sprintf(
             '%s/interceptor.phpspec.autoload.%s.infection.php',
@@ -64,7 +64,7 @@ class MutationConfigBuilder extends ConfigBuilder
         return $path;
     }
 
-    private function createCustomAutoloadWithInterceptor(Mutant $mutant, array $parsedYaml): string
+    private function createCustomAutoloadWithInterceptor(MutantInterface $mutant, array $parsedYaml): string
     {
         $originalFilePath = $mutant->getMutation()->getOriginalFilePath();
         $mutatedFilePath = $mutant->getMutatedFilePath();
@@ -88,7 +88,7 @@ AUTOLOAD;
         );
     }
 
-    private function buildPath(Mutant $mutant): string
+    private function buildPath(MutantInterface $mutant): string
     {
         $fileName = sprintf('phpspecConfiguration.%s.infection.yml', $mutant->getMutation()->getHash());
 

--- a/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
@@ -14,6 +14,9 @@ use Infection\TestFramework\Config\MutationConfigBuilder as ConfigBuilder;
 use Infection\TestFramework\PhpSpec\Config\MutationYamlConfiguration;
 use Symfony\Component\Yaml\Yaml;
 
+/**
+ * @internal
+ */
 class MutationConfigBuilder extends ConfigBuilder
 {
     /**

--- a/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
@@ -12,7 +12,7 @@ namespace Infection\TestFramework\PhpSpec\Config;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Symfony\Component\Yaml\Yaml;
 
-class InitialYamlConfiguration extends AbstractYamlConfiguration
+final class InitialYamlConfiguration extends AbstractYamlConfiguration
 {
     /**
      * @var bool

--- a/src/TestFramework/PhpSpec/Config/MutationYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/MutationYamlConfiguration.php
@@ -11,7 +11,7 @@ namespace Infection\TestFramework\PhpSpec\Config;
 
 use Symfony\Component\Yaml\Yaml;
 
-class MutationYamlConfiguration extends AbstractYamlConfiguration
+final class MutationYamlConfiguration extends AbstractYamlConfiguration
 {
     /**
      * @var string

--- a/src/TestFramework/PhpSpec/Config/NoCodeCoverageException.php
+++ b/src/TestFramework/PhpSpec/Config/NoCodeCoverageException.php
@@ -9,6 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpSpec\Config;
 
-class NoCodeCoverageException extends \Exception
+final class NoCodeCoverageException extends \Exception
 {
 }

--- a/src/TestFramework/PhpSpec/PhpSpecExtraOptions.php
+++ b/src/TestFramework/PhpSpec/PhpSpecExtraOptions.php
@@ -11,7 +11,7 @@ namespace Infection\TestFramework\PhpSpec;
 
 use Infection\TestFramework\TestFrameworkExtraOptions;
 
-class PhpSpecExtraOptions extends TestFrameworkExtraOptions
+final class PhpSpecExtraOptions extends TestFrameworkExtraOptions
 {
     protected function getInitialRunOnlyOptions(): array
     {

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -12,7 +12,7 @@ namespace Infection\TestFramework\PhpUnit\Adapter;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Infection\TestFramework\MemoryUsageAware;
 
-class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements MemoryUsageAware
+final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements MemoryUsageAware
 {
     const JUNIT_FILE_NAME = 'phpunit.junit.xml';
 

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -11,7 +11,7 @@ namespace Infection\TestFramework\PhpUnit\CommandLine;
 
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 
-class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilder
+final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilder
 {
     public function build(string $configPath, string $extraOptions): string
     {

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -13,6 +13,9 @@ use Infection\TestFramework\Config\InitialConfigBuilder as ConfigBuilder;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 
+/**
+ * @internal
+ */
 class InitialConfigBuilder implements ConfigBuilder
 {
     /**

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpUnit\Config\Builder;
 
-use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantInterface;
 use Infection\TestFramework\Config\MutationConfigBuilder as ConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 
@@ -54,7 +54,7 @@ class MutationConfigBuilder extends ConfigBuilder
         $xmlConfigurationHelper->removeExistingPrinters($this->dom, $this->xPath);
     }
 
-    public function build(Mutant $mutant): string
+    public function build(MutantInterface $mutant): string
     {
         $customAutoloadFilePath = sprintf(
             '%s/interceptor.autoload.%s.infection.php',
@@ -74,7 +74,7 @@ class MutationConfigBuilder extends ConfigBuilder
         return $path;
     }
 
-    private function createCustomAutoloadWithInterceptor(Mutant $mutant): string
+    private function createCustomAutoloadWithInterceptor(MutantInterface $mutant): string
     {
         $originalFilePath = $mutant->getMutation()->getOriginalFilePath();
         $mutatedFilePath = $mutant->getMutatedFilePath();
@@ -94,7 +94,7 @@ AUTOLOAD;
         return sprintf($customAutoload, $this->getInterceptorFileContent($interceptorPath, $originalFilePath, $mutatedFilePath));
     }
 
-    private function buildPath(Mutant $mutant): string
+    private function buildPath(MutantInterface $mutant): string
     {
         $fileName = sprintf('phpunitConfiguration.%s.infection.xml', $mutant->getMutation()->getHash());
 

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -13,6 +13,9 @@ use Infection\Mutant\MutantInterface;
 use Infection\TestFramework\Config\MutationConfigBuilder as ConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 
+/**
+ * @internal
+ */
 class MutationConfigBuilder extends ConfigBuilder
 {
     /**

--- a/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
+++ b/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
@@ -11,7 +11,7 @@ namespace Infection\TestFramework\PhpUnit\Config\Path;
 
 use Symfony\Component\Filesystem\Filesystem;
 
-class PathReplacer
+final class PathReplacer
 {
     /**
      * @var Filesystem

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -11,6 +11,9 @@ namespace Infection\TestFramework\PhpUnit\Config;
 
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 
+/**
+ * @internal
+ */
 class XmlConfigurationHelper
 {
     /**

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -11,6 +11,9 @@ namespace Infection\TestFramework\PhpUnit\Coverage;
 
 use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
 
+/**
+ * @internal
+ */
 class CoverageXmlParser
 {
     /**

--- a/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
+++ b/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
@@ -13,7 +13,7 @@ use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
 use Infection\TestFramework\Coverage\TestFileDataProvider;
 use Infection\TestFramework\Coverage\TestFileNameNotFoundException;
 
-class PhpUnitTestFileDataProvider implements TestFileDataProvider
+final class PhpUnitTestFileDataProvider implements TestFileDataProvider
 {
     /**
      * @var string

--- a/src/TestFramework/PhpUnit/PhpUnitExtraOptions.php
+++ b/src/TestFramework/PhpUnit/PhpUnitExtraOptions.php
@@ -11,7 +11,7 @@ namespace Infection\TestFramework\PhpUnit;
 
 use Infection\TestFramework\TestFrameworkExtraOptions;
 
-class PhpUnitExtraOptions extends TestFrameworkExtraOptions
+final class PhpUnitExtraOptions extends TestFrameworkExtraOptions
 {
     protected function getInitialRunOnlyOptions(): array
     {

--- a/src/Utils/TmpDirectoryCreator.php
+++ b/src/Utils/TmpDirectoryCreator.php
@@ -11,7 +11,7 @@ namespace Infection\Utils;
 
 use Symfony\Component\Filesystem\Filesystem;
 
-class TmpDirectoryCreator
+final class TmpDirectoryCreator
 {
     /**
      * @private

--- a/src/Utils/VersionParser.php
+++ b/src/Utils/VersionParser.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Infection\Utils;
 
+/**
+ * @internal
+ */
 class VersionParser
 {
     const VERSION_REGEX = '/(?<version>[0-9]+\.[0-9]+\.?[0-9]*)(?<prerelease>-[0-9a-zA-Z.]+)?(?<build>\+[0-9a-zA-Z.]+)?/';

--- a/src/Visitor/CloneVisitor.php
+++ b/src/Visitor/CloneVisitor.php
@@ -12,7 +12,7 @@ namespace Infection\Visitor;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
-class CloneVisitor extends NodeVisitorAbstract
+final class CloneVisitor extends NodeVisitorAbstract
 {
     public function enterNode(Node $origNode)
     {

--- a/src/Visitor/FullyQualifiedClassNameVisitor.php
+++ b/src/Visitor/FullyQualifiedClassNameVisitor.php
@@ -19,7 +19,7 @@ use PhpParser\NodeVisitorAbstract;
  *      $node->name                    // Plus
  *      $node->fullyQualifiedClassName // Infection\Mutator\Plus
  */
-class FullyQualifiedClassNameVisitor extends NodeVisitorAbstract
+final class FullyQualifiedClassNameVisitor extends NodeVisitorAbstract
 {
     private $namespace;
 

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -15,7 +15,7 @@ use Infection\TestFramework\Coverage\CodeCoverageData;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
-class MutationsCollectorVisitor extends NodeVisitorAbstract
+final class MutationsCollectorVisitor extends NodeVisitorAbstract
 {
     /**
      * @var Mutator[]

--- a/src/Visitor/MutatorVisitor.php
+++ b/src/Visitor/MutatorVisitor.php
@@ -13,7 +13,7 @@ use Infection\Mutation;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
-class MutatorVisitor extends NodeVisitorAbstract
+final class MutatorVisitor extends NodeVisitorAbstract
 {
     /**
      * @var Mutation

--- a/src/Visitor/MutatorVisitor.php
+++ b/src/Visitor/MutatorVisitor.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Visitor;
 
 use Infection\Mutation;
+use Infection\MutationInterface;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
@@ -20,7 +21,7 @@ final class MutatorVisitor extends NodeVisitorAbstract
      */
     private $mutation;
 
-    public function __construct(Mutation $mutation)
+    public function __construct(MutationInterface $mutation)
     {
         $this->mutation = $mutation;
     }

--- a/src/Visitor/ParentConnectorVisitor.php
+++ b/src/Visitor/ParentConnectorVisitor.php
@@ -12,7 +12,7 @@ namespace Infection\Visitor;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
-class ParentConnectorVisitor extends NodeVisitorAbstract
+final class ParentConnectorVisitor extends NodeVisitorAbstract
 {
     const PARENT_KEY = 'parent';
 

--- a/src/Visitor/ReflectionVisitor.php
+++ b/src/Visitor/ReflectionVisitor.php
@@ -12,7 +12,7 @@ namespace Infection\Visitor;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
-class ReflectionVisitor extends NodeVisitorAbstract
+final class ReflectionVisitor extends NodeVisitorAbstract
 {
     const REFLECTION_CLASS_KEY = 'reflectionClass';
     const IS_INSIDE_FUNCTION_KEY = 'isInsideFunction';

--- a/tests/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -11,7 +11,7 @@ namespace Infection\Tests\Config\ValueProvider;
 
 use Infection\Config\ConsoleHelper;
 use Infection\Config\ValueProvider\TestFrameworkConfigPathProvider;
-use Infection\TestFramework\Config\TestFrameworkConfigLocator;
+use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Mockery;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,7 +20,7 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
 {
     public function test_it_calls_locator_in_the_current_dir()
     {
-        $locatorMock = $this->getMockBuilder(TestFrameworkConfigLocator::class)
+        $locatorMock = $this->getMockBuilder(TestFrameworkConfigLocatorInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -39,7 +39,7 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
 
     public function test_it_asks_question_if_no_config_is_found_in_current_dir()
     {
-        $locatorMock = Mockery::mock(TestFrameworkConfigLocator::class);
+        $locatorMock = Mockery::mock(TestFrameworkConfigLocatorInterface::class);
 
         $locatorMock->shouldReceive('locate')->once()->andThrow(new \Exception());
         $locatorMock->shouldReceive('locate')->once()->andThrow(new \Exception());
@@ -68,7 +68,7 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
 
     public function test_it_automatically_guesses_path()
     {
-        $locatorMock = Mockery::mock(TestFrameworkConfigLocator::class);
+        $locatorMock = Mockery::mock(TestFrameworkConfigLocatorInterface::class);
         $outputMock = Mockery::mock(OutputInterface::class);
         $inputMock = Mockery::mock(InputInterface::class);
 
@@ -98,7 +98,7 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
             $this->markTestSkipped('Stty is not available');
         }
 
-        $locatorMock = Mockery::mock(TestFrameworkConfigLocator::class);
+        $locatorMock = Mockery::mock(TestFrameworkConfigLocatorInterface::class);
 
         $locatorMock->shouldReceive('locate')->once()->andThrow(new \Exception());
         $locatorMock->shouldReceive('locate')->once()->andThrow(new \Exception());

--- a/tests/Mutant/MetricsCalculatorTest.php
+++ b/tests/Mutant/MetricsCalculatorTest.php
@@ -11,6 +11,7 @@ namespace Infection\Tests\Mutant;
 
 use Infection\Mutant\MetricsCalculator;
 use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 use Mockery;
 use Symfony\Component\Process\Process;
 
@@ -42,19 +43,19 @@ class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $process = Mockery::mock(Process::class);
         $process->shouldReceive('stop');
 
-        $notCoveredMutantProcess = Mockery::mock(MutantProcess::class);
+        $notCoveredMutantProcess = Mockery::mock(MutantProcessInterface::class);
         $notCoveredMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_NOT_COVERED);
 
-        $passMutantProcess = Mockery::mock(MutantProcess::class);
+        $passMutantProcess = Mockery::mock(MutantProcessInterface::class);
         $passMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_ESCAPED);
 
-        $timedOutMutantProcess = Mockery::mock(MutantProcess::class);
+        $timedOutMutantProcess = Mockery::mock(MutantProcessInterface::class);
         $timedOutMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_TIMED_OUT);
 
-        $killedMutantProcess = Mockery::mock(MutantProcess::class);
+        $killedMutantProcess = Mockery::mock(MutantProcessInterface::class);
         $killedMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_KILLED);
 
-        $errorMutantProcess = Mockery::mock(MutantProcess::class);
+        $errorMutantProcess = Mockery::mock(MutantProcessInterface::class);
         $errorMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_ERROR);
 
         $calculator = new MetricsCalculator();

--- a/tests/Mutant/MutantCreatorTest.php
+++ b/tests/Mutant/MutantCreatorTest.php
@@ -11,7 +11,7 @@ namespace Infection\Tests\Mutant;
 
 use Infection\Differ\Differ;
 use Infection\Mutant\MutantCreator;
-use Infection\Mutation;
+use Infection\MutationInterface;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PhpParser\PrettyPrinter\Standard;
@@ -30,7 +30,7 @@ class MutantCreatorTest extends MockeryTestCase
             ->withArgs(['The Print', '<?php return \'This is a diff\';'])
             ->andReturn('This is the Diff');
 
-        $mutation = \Mockery::mock(Mutation::class);
+        $mutation = \Mockery::mock(MutationInterface::class);
         $mutation->shouldReceive('getHash')->andReturn('hash');
         $mutation->shouldReceive('getOriginalFilePath')->andReturn('original/path');
         $mutation->shouldReceive('getOriginalFileAst')->andReturn(['ast']);

--- a/tests/Process/Builder/ProcessBuilderTest.php
+++ b/tests/Process/Builder/ProcessBuilderTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Process\Builder;
 
-use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantInterface;
 use Infection\Process\Builder\ProcessBuilder;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Mockery;
@@ -38,7 +38,7 @@ class ProcessBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
         $builder = new ProcessBuilder($fwAdapter, 100);
 
-        $process = $builder->getProcessForMutant(Mockery::mock(Mutant::class))->getProcess();
+        $process = $builder->getProcessForMutant(Mockery::mock(MutantInterface::class))->getProcess();
 
         $this->assertContains('getExecutableCommandLine', $process->getCommandLine());
         $this->assertSame(100.0, $process->getTimeout());

--- a/tests/Process/Listener/MutationTestingConsoleLoggerSubscriberTest.php
+++ b/tests/Process/Listener/MutationTestingConsoleLoggerSubscriberTest.php
@@ -17,7 +17,7 @@ use Infection\Events\MutationTestingFinished;
 use Infection\Events\MutationTestingStarted;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Process\Listener\MutationTestingConsoleLoggerSubscriber;
-use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -91,7 +91,7 @@ class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             false
         ));
 
-        $dispatcher->dispatch(new MutantProcessFinished($this->createMock(MutantProcess::class)));
+        $dispatcher->dispatch(new MutantProcessFinished($this->createMock(MutantProcessInterface::class)));
     }
 
     public function test_it_reacts_on_mutation_testing_finished()

--- a/tests/Process/MutantProcessTest.php
+++ b/tests/Process/MutantProcessTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Process;
 
-use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantInterface;
 use Infection\Process\MutantProcess;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Mockery;
@@ -21,7 +21,7 @@ class MutantProcessTest extends MockeryTestCase
     public function test_it_handles_not_covered_mutant()
     {
         $process = Mockery::mock(Process::class);
-        $mutant = Mockery::mock(Mutant::class);
+        $mutant = Mockery::mock(MutantInterface::class);
         $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(false);
         $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
 
@@ -33,7 +33,7 @@ class MutantProcessTest extends MockeryTestCase
     public function test_it_handles_timeout()
     {
         $process = Mockery::mock(Process::class);
-        $mutant = Mockery::mock(Mutant::class);
+        $mutant = Mockery::mock(MutantInterface::class);
         $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
         $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
 
@@ -47,7 +47,7 @@ class MutantProcessTest extends MockeryTestCase
     {
         $process = Mockery::mock(Process::class);
         $process->shouldReceive('getExitCode')->once()->andReturn(126);
-        $mutant = Mockery::mock(Mutant::class);
+        $mutant = Mockery::mock(MutantInterface::class);
         $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
         $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
 
@@ -62,7 +62,7 @@ class MutantProcessTest extends MockeryTestCase
         $process->shouldReceive('getExitCode')->once()->andReturn(0);
         $process->shouldReceive('getOutput')->once()->andReturn('...');
 
-        $mutant = Mockery::mock(Mutant::class);
+        $mutant = Mockery::mock(MutantInterface::class);
         $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
 
         $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
@@ -79,7 +79,7 @@ class MutantProcessTest extends MockeryTestCase
         $process->shouldReceive('getExitCode')->once()->andReturn(0);
         $process->shouldReceive('getOutput')->once()->andReturn('...');
 
-        $mutant = Mockery::mock(Mutant::class);
+        $mutant = Mockery::mock(MutantInterface::class);
         $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
 
         $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);

--- a/tests/TestFramework/Coverage/CodeCoverageDataTest.php
+++ b/tests/TestFramework/Coverage/CodeCoverageDataTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage;
 
 use Infection\Mutation;
-use Infection\Mutator\FunctionSignature\PublicVisibility;
 use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
@@ -141,7 +140,7 @@ class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            Mockery::mock(PublicVisibility::class),
+            Mockery::mock(Mutator::class),
             ['startLine' => 1],
             'PHPParser\Node\Stmt\ClassMethod',
             true,
@@ -159,7 +158,7 @@ class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            Mockery::mock(PublicVisibility::class),
+            Mockery::mock(Mutator::class),
             ['startLine' => 24],
             'PHPParser\Node\Stmt\ClassMethod',
             true,

--- a/tests/TestFramework/Coverage/CodeCoverageDataTest.php
+++ b/tests/TestFramework/Coverage/CodeCoverageDataTest.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage;
 
 use Infection\Mutation;
-use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
+use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\TestFrameworkTypes;
@@ -105,7 +105,7 @@ class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            Mockery::mock(Plus::class),
+            Mockery::mock(Mutator::class),
             ['startLine' => 1],
             'PHPParser\Node\Expr\BinaryOp\Plus',
             false,
@@ -123,7 +123,7 @@ class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            Mockery::mock(Plus::class),
+            Mockery::mock(Mutator::class),
             ['startLine' => 26],
             'PHPParser\Node\Expr\BinaryOp\Plus',
             false,

--- a/tests/TestFramework/FactoryTest.php
+++ b/tests/TestFramework/FactoryTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework;
 
 use Infection\Config\InfectionConfig;
-use Infection\TestFramework\Config\TestFrameworkConfigLocator;
+use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\Factory;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use Infection\Utils\VersionParser;
@@ -24,7 +24,7 @@ class FactoryTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $factory = new Factory(
             '',
             '',
-            Mockery::mock(TestFrameworkConfigLocator::class),
+            Mockery::mock(TestFrameworkConfigLocatorInterface::class),
             Mockery::mock(XmlConfigurationHelper::class),
             '',
             new InfectionConfig(new \stdClass(), new Filesystem(), ''),

--- a/tests/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpSpec\Config\Builder;
 
-use Infection\Mutant\Mutant;
-use Infection\Mutation;
+use Infection\Mutant\MutantInterface;
+use Infection\MutationInterface;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
 use Infection\Utils\TmpDirectoryCreator;
 use Mockery;
@@ -48,11 +48,11 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $projectDir = '/project/dir';
         $originalYamlConfigPath = __DIR__ . '/../../../../Fixtures/Files/phpspec/phpspec.yml';
 
-        $mutation = Mockery::mock(Mutation::class);
+        $mutation = Mockery::mock(MutationInterface::class);
         $mutation->shouldReceive('getHash')->andReturn('a1b2c3');
         $mutation->shouldReceive('getOriginalFilePath')->andReturn('/original/file/path');
 
-        $mutant = Mockery::mock(Mutant::class);
+        $mutant = Mockery::mock(MutantInterface::class);
         $mutant->shouldReceive('getMutation')->andReturn($mutation);
         $mutant->shouldReceive('getMutatedFilePath')->andReturn('/mutated/file/path');
 
@@ -68,11 +68,11 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $projectDir = '/project/dir';
         $originalYamlConfigPath = __DIR__ . '/../../../../Fixtures/Files/phpspec/phpspec.with.bootstrap.yml';
 
-        $mutation = Mockery::mock(Mutation::class);
+        $mutation = Mockery::mock(MutationInterface::class);
         $mutation->shouldReceive('getHash')->andReturn('a1b2c3');
         $mutation->shouldReceive('getOriginalFilePath')->andReturn('/original/file/path');
 
-        $mutant = Mockery::mock(Mutant::class);
+        $mutant = Mockery::mock(MutantInterface::class);
         $mutant->shouldReceive('getMutation')->andReturn($mutation);
         $mutant->shouldReceive('getMutatedFilePath')->andReturn('/mutated/file/path');
 

--- a/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpUnit\Config\Builder;
 
-use Infection\Mutant\Mutant;
-use Infection\Mutation;
+use Infection\Mutant\MutantInterface;
+use Infection\MutationInterface;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
@@ -60,11 +60,11 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $projectDir = '/project/dir';
         $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit.xml';
 
-        $this->mutation = Mockery::mock(Mutation::class);
+        $this->mutation = Mockery::mock(MutationInterface::class);
         $this->mutation->shouldReceive('getHash')->andReturn(self::HASH);
         $this->mutation->shouldReceive('getOriginalFilePath')->andReturn('/original/file/path');
 
-        $this->mutant = Mockery::mock(Mutant::class);
+        $this->mutant = Mockery::mock(MutantInterface::class);
         $this->mutant->shouldReceive('getMutation')->andReturn($this->mutation);
         $this->mutant->shouldReceive('getMutatedFilePath')->andReturn('/mutated/file/path');
         $this->mutant->shouldReceive('getMutatedFileCode')->andReturn('<?php');

--- a/tests/Visitor/MutatorVisitorTest.php
+++ b/tests/Visitor/MutatorVisitorTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Visitor;
 
 use Infection\Mutation;
+use Infection\MutationInterface;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
 use Infection\Mutator\Util\MutatorConfig;
 use Infection\Visitor\MutatorVisitor;
@@ -25,7 +26,7 @@ class MutatorVisitorTest extends TestCase
     /**
      * @dataProvider providesMutationCases
      */
-    public function test_it_mutates_the_correct_node(array $inputAst, string $outputCode, Mutation $mutation)
+    public function test_it_mutates_the_correct_node(array $inputAst, string $outputCode, MutationInterface $mutation)
     {
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new MutatorVisitor($mutation));

--- a/tests/final_private_test
+++ b/tests/final_private_test
@@ -1,0 +1,9 @@
+#!/bin/sh
+cd $(dirname "$0")/..
+
+for file in $(git grep -l ^class src/); do
+    grep -q "@internal" $file && continue;
+    echo "$file should be made either final or internal";
+    trap 'exit 1' EXIT
+done
+


### PR DESCRIPTION
This PR:

- [x] Makes most classes `final`, and some - `abstract`
- [x] Covered by tests

There was a discussion on if it is the right thing to [make constants instead of methods](https://github.com/infection/infection/pull/269#issuecomment-377230338), where it was decided it is proper so because every class should be consistent. Yet the entire discussion could have been avoided if the class in subject was unambiguously marked as not designed for inheritance.

This PR marks most classes (135 to be exact) that are not extended in this project as final. In some cases where classes were extensively mocked in tests, then interfaces were added to allow unrestricted mocking and future extension. In other cases these mocked classes were marked as `@internal`.

It is all not as bright. This change comes with a price:

- It will be slightly more difficult to refactor finalized classes.
- It will be slightly more difficult to navigate in code: given an abstract interface it won't be possible to jump to the concrete class with a single click right in the IDE.

Since there's work begun in #278 to allow externally provided mutators, this change also will declare what is not allowed to be extended, and what is more so, by implementing an interface, or by subclassing a known abstract class.

---

There's still more work to be done: a number of classes are still neither abstract nor final. It isn't possible to make them final outright because they're mocked in tests at times, or inherited from. Whenever it is the right thing to add an interface for each of these classes to allow mocking while making them final, is an open question. Probably best would be to address it in a separate PR. (All below were tagged as `@internal` for time being.)

| Mocked count | Class name |
|  ---- | ---- |
|13  |  ConsoleHelper           |
|9   |  CodeCoverageData        |
|3   |  VersionParser           |
|3   |  TestFrameworkFinder     |
|2   |  MutationConfigBuilder   |
|2   |  InitialConfigBuilder    |
|2   |  CoverageXmlParser       |
|1   |  XmlConfigurationHelper  |
|1   |  ProcessBuilder          |
|1   |  MetricsCalculator       |
|1   |  EventDispatcher         |
|1   |  Differ                  |
|1   |  BadgeApiClient          |
|0   |  XdebugHandler           |
|0   |  SourceDirGuesser        |
|0   |  InfectionException      |
|0   |  InfectionConfig         |
|0   |  DiffColorizer           |

```bash
# command for the report above
for class in $(git grep "^class" src/ | cut -f2 -d' ' | sort | uniq);
do echo "$(git grep $class::class | grep ::mock | wc -l) | $class |";
done | sort -rh | column -t | sed 's/^/|/'
```
