### PR TITLE
Fix test framework detection in ConfigureCommand

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -74,7 +74,7 @@ final class InfectionCommand extends BaseCommand
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Name of the Test framework to use (phpunit, phpspec)',
-                null
+                ''
             )
             ->addOption(
                 'test-framework-options',

--- a/tests/Fixtures/e2e/Unconfigured/run_tests.bash
+++ b/tests/Fixtures/e2e/Unconfigured/run_tests.bash
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+run () {
+    local INFECTION=${1}
+    local PHPARGS=${2}
+
+    if [ "$PHPDBG" = "1" ]
+    then
+        phpdbg $PHPARGS -qrr $INFECTION
+    else
+        php $PHPARGS $INFECTION
+    fi
+}
+
+test -x $(which tput) && tput setaf 2 # green
+if run "../../../../bin/infection" "" < /dev/null 2>&1 | grep -s 'Infection config generator requires an interactive mode.'; then
+	exit 0;
+fi
+
+test -x $(which tput) && tput setaf 1 # red
+echo "Infection configuration master did not start."
+
+exit 1;
+


### PR DESCRIPTION
This PR:

- [x] Adds an E2E test for ConfigureCommand in a non-interactive mode
- [x] Fixes #286
