### PR TITLE
TestFrameworkConfigPathProvider needs strings for all inputs, not nulls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,11 @@ cache:
     - $HOME/.composer/cache
     - build/cache
 
+addons:
+  apt:
+    packages:
+    - expect
+
 before_install:
   - composer selfupdate
   - source .travis/xdebug.sh

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -50,11 +50,11 @@ final class TestFrameworkConfigPathProvider
             return null;
         } catch (\Exception $e) {
             if ($testFramework !== TestFrameworkTypes::PHPUNIT) {
-                return $this->askTestFrameworkConfigLocation($input, $output, $dirsInCurrentDir, $testFramework, null);
+                return $this->askTestFrameworkConfigLocation($input, $output, $dirsInCurrentDir, $testFramework, '');
             }
 
             if (!file_exists('composer.json')) {
-                return $this->askTestFrameworkConfigLocation($input, $output, $dirsInCurrentDir, $testFramework, null);
+                return $this->askTestFrameworkConfigLocation($input, $output, $dirsInCurrentDir, $testFramework, '');
             }
 
             $phpUnitPathGuesser = new PhpUnitPathGuesser(json_decode(file_get_contents('composer.json')));
@@ -93,7 +93,7 @@ final class TestFrameworkConfigPathProvider
         };
     }
 
-    private function askTestFrameworkConfigLocation(InputInterface $input, OutputInterface $output, array $dirsInCurrentDir, string $testFramework, $defaultValue): string
+    private function askTestFrameworkConfigLocation(InputInterface $input, OutputInterface $output, array $dirsInCurrentDir, string $testFramework, string $defaultValue): string
     {
         $question = sprintf(
             'Where is your <comment>%s.(xml|yml)(.dist)</comment> configuration located?',

--- a/tests/Fixtures/e2e/Configure/composer.json
+++ b/tests/Fixtures/e2e/Configure/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Namespace_\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Namespace_\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Configure/do_configure.expect
+++ b/tests/Fixtures/e2e/Configure/do_configure.expect
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 set timeout 20
-eval spawn ../../../../bin/infection
+eval spawn $env(INFECTION)
 
 proc configure {input} {
     expect $input {
@@ -18,7 +18,6 @@ configure "timeout in seconds"
 configure "text log file?"
 
 expect "Please note that some mutants will inevitably be harmless"
-#expect eof
 
 send_user "Test succeeded!\n"
 exit 0

--- a/tests/Fixtures/e2e/Configure/do_configure.expect
+++ b/tests/Fixtures/e2e/Configure/do_configure.expect
@@ -18,7 +18,7 @@ configure "timeout in seconds"
 configure "text log file?"
 
 expect "Please note that some mutants will inevitably be harmless"
-expect eof
+#expect eof
 
 send_user "Test succeeded!\n"
-
+exit 0

--- a/tests/Fixtures/e2e/Configure/do_configure.expect
+++ b/tests/Fixtures/e2e/Configure/do_configure.expect
@@ -1,0 +1,24 @@
+#!/usr/bin/env expect
+set timeout 20
+eval spawn ../../../../bin/infection
+
+proc configure {input} {
+    expect $input {
+        send "\r"
+    } timeout {
+        send_user "Test failed\n"
+        exit 1
+    }
+}
+
+configure "directories do you want to include"
+configure "Any directories to exclude from"
+configure "configuration located?"
+configure "timeout in seconds"
+configure "text log file?"
+
+expect "Please note that some mutants will inevitably be harmless"
+expect eof
+
+send_user "Test succeeded!\n"
+

--- a/tests/Fixtures/e2e/Configure/infection.json.test
+++ b/tests/Fixtures/e2e/Configure/infection.json.test
@@ -1,0 +1,11 @@
+{
+    "timeout": 10,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "infection-log.txt"
+    }
+}

--- a/tests/Fixtures/e2e/Configure/phpunit.xml
+++ b/tests/Fixtures/e2e/Configure/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Configure/run_tests.bash
+++ b/tests/Fixtures/e2e/Configure/run_tests.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if test ! -f "$(which expect)"; then
+    test -x $(which tput) && tput setaf 1 # red
+    echo "Please install expect; it is readily available from apt and brew"
+    exit 1;
+fi
+
+cd $(dirname $0)
+rm -f infection.json.dist
+
+set -e
+
+./do_configure.expect
+
+test -f infection.json.dist
+diff -u infection.json.test infection.json.dist

--- a/tests/Fixtures/e2e/Configure/run_tests.bash
+++ b/tests/Fixtures/e2e/Configure/run_tests.bash
@@ -11,6 +11,14 @@ rm -f infection.json.dist
 
 set -e
 
+if [ "$PHPDBG" = "1" ]
+then
+    INFECTION="phpdbg -qrr ../../../../bin/infection"
+else
+    INFECTION="php ../../../../bin/infection"
+fi
+export INFECTION
+
 ./do_configure.expect
 
 test -f infection.json.dist


### PR DESCRIPTION
- [x] Fixes #288
- [x] Adds an E2E test for initial configuration
