### PR TITLE
Add Protected and Public Visiblity tests

### DIFF
--- a/tests/Fixtures/Autoloaded/ProtectedVisibility/pv-non-same-method-parent.php
+++ b/tests/Fixtures/Autoloaded/ProtectedVisibility/pv-non-same-method-parent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ProtectedNonSameAbstract;
+
+abstract class ProtectedNonSameAbstract
+{
+    protected abstract function foo();
+}
+class Child extends ProtectedNonSameAbstract
+{
+    protected function foo()
+    {
+    }
+    protected function bar()
+    {
+    }
+}

--- a/tests/Fixtures/Autoloaded/PublicVisibility/pv-non-same-method-parent.php
+++ b/tests/Fixtures/Autoloaded/PublicVisibility/pv-non-same-method-parent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace NonSameAbstract;
+
+abstract class NonSameAbstract
+{
+    public abstract function foo();
+}
+class Child extends NonSameAbstract
+{
+    public function foo()
+    {
+    }
+    public function bar()
+    {
+    }
+}

--- a/tests/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -173,6 +173,29 @@ class Child extends SameParent
 PHP
             ,
         ];
+
+        yield 'it does mutate non-inherited methods' => [
+            $this->getFileContent('pv-non-same-method-parent.php'),
+            <<<'PHP'
+<?php
+
+namespace ProtectedNonSameAbstract;
+
+abstract class ProtectedNonSameAbstract
+{
+    protected abstract function foo();
+}
+class Child extends ProtectedNonSameAbstract
+{
+    protected function foo()
+    {
+    }
+    private function bar()
+    {
+    }
+}
+PHP
+        ];
     }
 
     private function getFileContent(string $file): string

--- a/tests/Mutator/FunctionSignature/PublicVisibilityTest.php
+++ b/tests/Mutator/FunctionSignature/PublicVisibilityTest.php
@@ -224,6 +224,29 @@ class Child extends SameParent
 PHP
             ,
         ];
+
+        yield 'it does mutate non-inherited methods' => [
+            $this->getFileContent('pv-non-same-method-parent.php'),
+            <<<'PHP'
+<?php
+
+namespace NonSameAbstract;
+
+abstract class NonSameAbstract
+{
+    public abstract function foo();
+}
+class Child extends NonSameAbstract
+{
+    public function foo()
+    {
+    }
+    protected function bar()
+    {
+    }
+}
+PHP
+        ];
     }
 
     private function getFileContent(string $file): string


### PR DESCRIPTION
This PR:
Adds a test to prove that non-inherited function visibility still gets mutated.