### PR TITLE
Made AbstractExecutableFinder work without PATH

### DIFF
--- a/src/Finder/AbstractExecutableFinder.php
+++ b/src/Finder/AbstractExecutableFinder.php
@@ -22,7 +22,8 @@ abstract class AbstractExecutableFinder
     protected function searchNonExecutables(array $probableNames, array $extraDirectories = [])
     {
         $dirs = array_merge(
-            explode(PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
+            // We are not guaranteed to have a path set, even though that's usually the case
+            explode(PATH_SEPARATOR, getenv('PATH') ?: getenv('Path') ?: ''),
             $extraDirectories
         );
 


### PR DESCRIPTION
With no PATH set Infection fails with a TypeError:

```
$ PATH= /usr/bin/php ./bin/infection
 
PHP Fatal error:  Uncaught TypeError: explode() expects parameter 2 to be string, boolean given in src/Finder/AbstractExecutableFinder.php:25
Stack trace:
#0 src/Finder/AbstractExecutableFinder.php(25): explode(':', false)
#1 src/Finder/ComposerExecutableFinder.php(38): Infection\Finder\AbstractExecutableFinder->searchNonExecutables(Array, Array)
#2 src/Finder/TestFrameworkFinder.php(90): Infection\Finder\ComposerExecutableFinder->find()
#3 src/Finder/TestFrameworkFinder.php(73): Infection\Finder\TestFrameworkFinder->findComposer()
#4 src/Finder/TestFrameworkFinder.php(46): Infection\Finder\TestFrameworkFinder->addVendorFolderToPath()
#5 src/TestFramework/AbstractTestFrameworkAdapter.php(101): Infection\Finder\TestFrameworkFinder->find()
#6 src/Process/Builder/ProcessBuilder. in src/Finder/AbstractExecutableFinder.php on line 25
```