### PR TITLE
Problem with a custom PATH

### DIFF
--- a/tests/Fixtures/e2e/Exec_Path/bin/test.bash
+++ b/tests/Fixtures/e2e/Exec_Path/bin/test.bash
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Program finished with flying colors!"

--- a/tests/Fixtures/e2e/Exec_Path/composer.json
+++ b/tests/Fixtures/e2e/Exec_Path/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Namespace_\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Namespace_\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Exec_Path/expected-output.txt
+++ b/tests/Fixtures/e2e/Exec_Path/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 8
+Killed: 6
+Errored: 0
+Escaped: 1
+Timed Out: 0
+Not Covered: 1

--- a/tests/Fixtures/e2e/Exec_Path/infection.json
+++ b/tests/Fixtures/e2e/Exec_Path/infection.json
@@ -1,0 +1,11 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection-log.txt"
+    }
+}

--- a/tests/Fixtures/e2e/Exec_Path/phpunit.xml
+++ b/tests/Fixtures/e2e/Exec_Path/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Exec_Path/run_tests.bash
+++ b/tests/Fixtures/e2e/Exec_Path/run_tests.bash
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+run () {
+    local INFECTION=${1}
+    local PHPARGS=${2}
+
+    if [ "$PHPDBG" = "1" ]
+    then
+        phpdbg $PHPARGS -qrr $INFECTION
+    else
+        php $PHPARGS $INFECTION
+    fi
+}
+
+cd $(dirname "$0")
+
+PATH=$PATH:bin php vendor/bin/phpunit
+
+PATH=$PATH:bin run "../../../../bin/infection"
+
+diff -w expected-output.txt infection-log.txt

--- a/tests/Fixtures/e2e/Exec_Path/src/RunShellScript.php
+++ b/tests/Fixtures/e2e/Exec_Path/src/RunShellScript.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Namespace_;
+
+class RunShellScript
+{
+    public function hello(): string
+    {
+    	exec('test.bash', $output, $returnVal);
+
+		if ($returnVal > 0) {
+			throw new \RuntimeException("Failed to run a program");
+		}
+
+		return $output[0];
+    }
+}

--- a/tests/Fixtures/e2e/Exec_Path/tests/RunShellScriptTest.php
+++ b/tests/Fixtures/e2e/Exec_Path/tests/RunShellScriptTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Namespace_\Test;
+
+use Namespace_\RunShellScript;
+use PHPUnit\Framework\TestCase;
+
+class RunShellScriptTest extends TestCase
+{
+    public function test_hello()
+    {
+    	$runner = new RunShellScript();
+    	$this->assertSame('Program finished with flying colors!', $runner->hello());
+    }
+}


### PR DESCRIPTION
Subprocesses may need to have a custom PATH to run commands of their choice: e.g. one of our subjects may want to run a bash script. Infection should pass through `PATH` (and `Path`) as it is, at very least.
