### PR TITLE
[Mutator] Remove type cast operators

### DIFF
--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -107,6 +107,6 @@ final class TestFrameworkConfigPathProvider
 
         $testFrameworkConfigLocation = $this->questionHelper->ask($input, $output, $question);
 
-        return (string) $testFrameworkConfigLocation;
+        return $testFrameworkConfigLocation;
     }
 }

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -92,6 +92,7 @@ final class Mutation implements MutationInterface
         $mutatorClass = get_class($this->getMutator());
         $attributes = $this->getAttributes();
         $attributeValues = [
+            $mutatorClass,
             $attributes['startLine'],
             $attributes['endLine'],
             $attributes['startTokenPos'],

--- a/src/Mutator/Cast/AbstractCastMutator.php
+++ b/src/Mutator/Cast/AbstractCastMutator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Cast;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+
+abstract class AbstractCastMutator extends Mutator
+{
+    public function mutate(Node $node)
+    {
+        return $node->expr;
+    }
+}

--- a/src/Mutator/Cast/AbstractCastMutator.php
+++ b/src/Mutator/Cast/AbstractCastMutator.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
 
 declare(strict_types=1);
 

--- a/src/Mutator/Cast/CastArray.php
+++ b/src/Mutator/Cast/CastArray.php
@@ -12,7 +12,7 @@ namespace Infection\Mutator\Cast;
 use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class CastInt extends Mutator
+class CastArray extends Mutator
 {
     public function mutate(Node $node)
     {
@@ -21,6 +21,6 @@ class CastInt extends Mutator
 
     protected function mutatesNode(Node $node): bool
     {
-        return $node instanceof Node\Expr\Cast\Int_;
+        return $node instanceof Node\Expr\Cast\Array_;
     }
 }

--- a/src/Mutator/Cast/CastArray.php
+++ b/src/Mutator/Cast/CastArray.php
@@ -9,16 +9,10 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Cast;
 
-use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class CastArray extends Mutator
+final class CastArray extends AbstractCastMutator
 {
-    public function mutate(Node $node)
-    {
-        return $node->expr;
-    }
-
     protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\Cast\Array_;

--- a/src/Mutator/Cast/CastBool.php
+++ b/src/Mutator/Cast/CastBool.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Cast;
+
+use PhpParser\Node;
+
+final class CastBool extends AbstractCastMutator
+{
+    protected function mutatesNode(Node $node): bool
+    {
+        return $node instanceof Node\Expr\Cast\Bool_;
+    }
+}

--- a/src/Mutator/Cast/CastFloat.php
+++ b/src/Mutator/Cast/CastFloat.php
@@ -9,16 +9,10 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Cast;
 
-use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class CastFloat extends Mutator
+final class CastFloat extends AbstractCastMutator
 {
-    public function mutate(Node $node)
-    {
-        return $node->expr;
-    }
-
     protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\Cast\Double;

--- a/src/Mutator/Cast/CastFloat.php
+++ b/src/Mutator/Cast/CastFloat.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
 
 declare(strict_types=1);
 

--- a/src/Mutator/Cast/CastFloat.php
+++ b/src/Mutator/Cast/CastFloat.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Cast;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+
+class CastFloat extends Mutator
+{
+    public function mutate(Node $node)
+    {
+        return $node->expr;
+    }
+
+    protected function mutatesNode(Node $node): bool
+    {
+        return $node instanceof Node\Expr\Cast\Double;
+    }
+}

--- a/src/Mutator/Cast/CastInt.php
+++ b/src/Mutator/Cast/CastInt.php
@@ -9,16 +9,10 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Cast;
 
-use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
-class CastInt extends Mutator
+final class CastInt extends AbstractCastMutator
 {
-    public function mutate(Node $node)
-    {
-        return $node->expr;
-    }
-
     protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\Cast\Int_;

--- a/src/Mutator/Cast/CastInt.php
+++ b/src/Mutator/Cast/CastInt.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Cast;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+
+class CastInt extends Mutator
+{
+    public function mutate(Node $node)
+    {
+        return $node->expr;
+    }
+
+    protected function mutatesNode(Node $node): bool
+    {
+        return $node instanceof Node\Expr\Cast\Int_;
+    }
+}

--- a/src/Mutator/Cast/CastObject.php
+++ b/src/Mutator/Cast/CastObject.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Cast;
+
+use PhpParser\Node;
+
+final class CastObject extends AbstractCastMutator
+{
+    protected function mutatesNode(Node $node): bool
+    {
+        return $node instanceof Node\Expr\Cast\Object_;
+    }
+}

--- a/src/Mutator/Cast/CastString.php
+++ b/src/Mutator/Cast/CastString.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Cast;
+
+use PhpParser\Node;
+
+final class CastString extends AbstractCastMutator
+{
+    protected function mutatesNode(Node $node): bool
+    {
+        return $node instanceof Node\Expr\Cast\String_;
+    }
+}

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -124,10 +124,11 @@ final class MutatorProfile
     ];
 
     const CAST = [
-        Mutator\Cast\CastInt::class,
+        Mutator\Cast\CastArray::class,
         Mutator\Cast\CastBool::class,
         Mutator\Cast\CastFloat::class,
-        Mutator\Cast\CastArray::class,
+        Mutator\Cast\CastInt::class,
+        Mutator\Cast\CastObject::class,
         Mutator\Cast\CastString::class,
     ];
 
@@ -233,6 +234,7 @@ final class MutatorProfile
         'CastBool' => Mutator\Cast\CastBool::class,
         'CastFloat' => Mutator\Cast\CastFloat::class,
         'CastInt' => Mutator\Cast\CastInt::class,
+        'CastObject' => Mutator\Cast\CastObject::class,
         'CastString' => Mutator\Cast\CastString::class,
     ];
 }

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -126,6 +126,7 @@ final class MutatorProfile
     const CAST = [
         Mutator\Cast\CastInt::class,
         Mutator\Cast\CastFloat::class,
+        Mutator\Cast\CastArray::class,
     ];
 
     const DEFAULT = [
@@ -228,5 +229,6 @@ final class MutatorProfile
         // Cast
         'CastInt' => Mutator\Cast\CastInt::class,
         'CastFloat' => Mutator\Cast\CastFloat::class,
+        'CastArray' => Mutator\Cast\CastArray::class,
     ];
 }

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -25,6 +25,7 @@ final class MutatorProfile
         '@return_value' => self::RETURN_VALUE,
         '@sort' => self::SORT,
         '@zero_iteration' => self::ZERO_ITERATION,
+        '@cast' => self::CAST,
 
         //Special Profiles
         '@default' => self::DEFAULT,
@@ -120,6 +121,10 @@ final class MutatorProfile
     const ZERO_ITERATION = [
         Mutator\ZeroIteration\Foreach_::class,
         Mutator\ZeroIteration\For_::class,
+    ];
+
+    const CAST = [
+        Mutator\Cast\CastInt::class,
     ];
 
     const DEFAULT = [
@@ -218,5 +223,8 @@ final class MutatorProfile
         //Zero Iteration
         'Foreach_' => Mutator\ZeroIteration\Foreach_::class,
         'For_' => Mutator\ZeroIteration\For_::class,
+
+        // Cast
+        'CastInt' => Mutator\Cast\CastInt::class,
     ];
 }

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -128,6 +128,7 @@ final class MutatorProfile
         Mutator\Cast\CastBool::class,
         Mutator\Cast\CastFloat::class,
         Mutator\Cast\CastArray::class,
+        Mutator\Cast\CastString::class,
     ];
 
     const DEFAULT = [
@@ -228,9 +229,10 @@ final class MutatorProfile
         'For_' => Mutator\ZeroIteration\For_::class,
 
         // Cast
-        'CastInt' => Mutator\Cast\CastInt::class,
+        'CastArray' => Mutator\Cast\CastArray::class,
         'CastBool' => Mutator\Cast\CastBool::class,
         'CastFloat' => Mutator\Cast\CastFloat::class,
-        'CastArray' => Mutator\Cast\CastArray::class,
+        'CastInt' => Mutator\Cast\CastInt::class,
+        'CastString' => Mutator\Cast\CastString::class,
     ];
 }

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -125,6 +125,7 @@ final class MutatorProfile
 
     const CAST = [
         Mutator\Cast\CastInt::class,
+        Mutator\Cast\CastBool::class,
         Mutator\Cast\CastFloat::class,
         Mutator\Cast\CastArray::class,
     ];
@@ -228,6 +229,7 @@ final class MutatorProfile
 
         // Cast
         'CastInt' => Mutator\Cast\CastInt::class,
+        'CastBool' => Mutator\Cast\CastBool::class,
         'CastFloat' => Mutator\Cast\CastFloat::class,
         'CastArray' => Mutator\Cast\CastArray::class,
     ];

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -125,6 +125,7 @@ final class MutatorProfile
 
     const CAST = [
         Mutator\Cast\CastInt::class,
+        Mutator\Cast\CastFloat::class,
     ];
 
     const DEFAULT = [
@@ -226,5 +227,6 @@ final class MutatorProfile
 
         // Cast
         'CastInt' => Mutator\Cast\CastInt::class,
+        'CastFloat' => Mutator\Cast\CastFloat::class,
     ];
 }

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -27,13 +27,13 @@ final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements Memor
         }
 
         // OK (XX tests, YY assertions)
-        $isOk = (bool) preg_match('/OK\s\(/', $output);
+        $isOk = preg_match('/OK\s\(/', $output);
 
         // "OK, but incomplete, skipped, or risky tests!"
-        $isOkWithInfo = (bool) preg_match('/OK\s?,/', $output);
+        $isOkWithInfo = preg_match('/OK\s?,/', $output);
 
         // "Warnings!" - e.g. when deprecated functions are used, but tests pass
-        $isWarning = (bool) preg_match('/warnings!/i', $output);
+        $isWarning = preg_match('/warnings!/i', $output);
 
         return $isOk || $isOkWithInfo || $isWarning;
     }

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -153,7 +153,7 @@ class CoverageXmlParser
 
         foreach ($lineCoverageNodes as $lineCoverageNode) {
             /** @var \DOMNode $lineCoverageNode */
-            $lineNumber = (int) $lineCoverageNode->getAttribute('nr');
+            $lineNumber = $lineCoverageNode->getAttribute('nr');
 
             foreach ($lineCoverageNode->childNodes as $coveredNode) {
                 if ($coveredNode->nodeName == 'covered') {

--- a/tests/Config/ValueProvider/TimeoutProviderTest.php
+++ b/tests/Config/ValueProvider/TimeoutProviderTest.php
@@ -33,6 +33,23 @@ class TimeoutProviderTest extends AbstractBaseProviderTest
         $this->assertSame(InfectionConfig::PROCESS_TIMEOUT_SECONDS, $timeout);
     }
 
+    public function test_it_casts_any_value_to_integer()
+    {
+        $consoleMock = Mockery::mock(ConsoleHelper::class);
+        $consoleMock->shouldReceive('getQuestion')->once()->andReturn('?');
+
+        $dialog = $this->getQuestionHelper();
+
+        $provider = new TimeoutProvider($consoleMock, $dialog);
+
+        $timeout = $provider->get(
+            $this->createStreamableInputInterfaceMock($this->getInputStream("13\n")),
+            $this->createOutputInterface()
+        );
+
+        $this->assertSame(13, $timeout);
+    }
+
     /**
      * @dataProvider validatorProvider
      * @expectedException \RuntimeException
@@ -60,6 +77,7 @@ class TimeoutProviderTest extends AbstractBaseProviderTest
             ['str'],
             [0],
             [-1],
+            [0.1],
         ];
     }
 }

--- a/tests/MutationTest.php
+++ b/tests/MutationTest.php
@@ -38,7 +38,7 @@ class MutationTest extends TestCase
             true
         );
 
-        $this->assertSame('5f52c44bcebde86a7ee79d0080c0e12a', $mutation->getHash());
+        $this->assertSame('e5e3a33955c4819395090c16e8df6f76', $mutation->getHash());
     }
 
     public function test_it_correctly_sets_is_on_function_signature()

--- a/tests/Mutator/Cast/CastArrayTest.php
+++ b/tests/Mutator/Cast/CastArrayTest.php
@@ -11,7 +11,7 @@ namespace Infection\Tests\Mutator\Cast;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-class CastFloatTest extends AbstractMutatorTestCase
+class CastArrayTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases
@@ -23,21 +23,17 @@ class CastFloatTest extends AbstractMutatorTestCase
 
     public function provideMutationCases(): \Generator
     {
-        yield 'It removes casting to float' => [
+        yield 'It removes casting to array' => [
             <<<'PHP'
 <?php
 
-(float) '1.1';
-(double) '1.1';
-(real) '1.1';
+(array) 1.0;
 PHP
             ,
             <<<'PHP'
 <?php
 
-'1.1';
-'1.1';
-'1.1';
+1.0;
 PHP
             ,
         ];

--- a/tests/Mutator/Cast/CastBoolTest.php
+++ b/tests/Mutator/Cast/CastBoolTest.php
@@ -11,7 +11,7 @@ namespace Infection\Tests\Mutator\Cast;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-class CastIntTest extends AbstractMutatorTestCase
+class CastBoolTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases
@@ -23,19 +23,19 @@ class CastIntTest extends AbstractMutatorTestCase
 
     public function provideMutationCases(): \Generator
     {
-        yield 'It removes casting to int' => [
+        yield 'It removes casting to bool' => [
             <<<'PHP'
 <?php
 
-(int) 1.0;
-(integer) 1.0;
+(bool) 1;
+(boolean) 1;
 PHP
             ,
             <<<'PHP'
 <?php
 
-1.0;
-1.0;
+1;
+1;
 PHP
             ,
         ];

--- a/tests/Mutator/Cast/CastFloatTest.php
+++ b/tests/Mutator/Cast/CastFloatTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Cast;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class CastFloatTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): \Generator
+    {
+        yield 'It removes casting to float' => [
+            <<<'PHP'
+<?php
+
+(float) '1.1';
+(double) '1.1';
+(real) '1.1';
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+'1.1';
+'1.1';
+'1.1';
+PHP
+            ,
+        ];
+    }
+}

--- a/tests/Mutator/Cast/CastIntTest.php
+++ b/tests/Mutator/Cast/CastIntTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Cast;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class CastIntTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): \Generator
+    {
+        yield 'It removes casting to int' => [
+            <<<'PHP'
+<?php
+
+(int) 1.0;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+1.0;
+PHP
+            ,
+        ];
+    }
+}

--- a/tests/Mutator/Cast/CastIntTest.php
+++ b/tests/Mutator/Cast/CastIntTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
 
 declare(strict_types=1);
 

--- a/tests/Mutator/Cast/CastObjectTest.php
+++ b/tests/Mutator/Cast/CastObjectTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Cast;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class CastObjectTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): \Generator
+    {
+        yield 'It removes casting to object' => [
+            <<<'PHP'
+<?php
+
+(object) ['test' => 1];
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+['test' => 1];
+PHP
+            ,
+        ];
+    }
+}

--- a/tests/Mutator/Cast/CastStringTest.php
+++ b/tests/Mutator/Cast/CastStringTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Cast;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+class CastStringTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null)
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): \Generator
+    {
+        yield 'It removes casting to string' => [
+            <<<'PHP'
+<?php
+
+(string) 1.0;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+1.0;
+PHP
+            ,
+        ];
+    }
+}

--- a/tests/Mutator/Util/MutatorProfileTest.php
+++ b/tests/Mutator/Util/MutatorProfileTest.php
@@ -38,6 +38,7 @@ class MutatorProfileTest extends TestCase
             ->name('*.php')
             ->in('src/Mutator')
             ->exclude('Util')
+            ->notName('/Abstract.*/')
             ->files();
 
         foreach ($files as $file) {


### PR DESCRIPTION
Here is an RFC for a new set of mutators that remove type casting. I find them useful because for example these mutators found several places in Infection itself where type casting is redundant and not needed

- [x] Covered by tests
- [x] Other mutators from http://php.net/manual/en/language.types.type-juggling.php#language.types.typecasting `(object)`, `(unset)`, etc.
- [x] Doc PR: https://github.com/infection/site/commit/02b017c01cbd780a43f6ebf49d8b013c634ed5dc

To kill several mutant, a couple of new tests were added that cover type casting logic.

I would like to hear your feedback (objections if any) before moving forward