### PR TITLE
Ensure mutated code is always valid

### DIFF
--- a/tests/Mutator/AbstractMutatorTestCase.php
+++ b/tests/Mutator/AbstractMutatorTestCase.php
@@ -12,7 +12,6 @@ namespace Infection\Tests\Mutator;
 use Infection\Mutator\Util\Mutator;
 use Infection\Mutator\Util\MutatorConfig;
 use Infection\Tests\Fixtures\SimpleMutatorVisitor;
-use Infection\Utils\TmpDirectoryCreator;
 use Infection\Visitor\CloneVisitor;
 use Infection\Visitor\FullyQualifiedClassNameVisitor;
 use Infection\Visitor\ParentConnectorVisitor;
@@ -22,7 +21,6 @@ use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Filesystem\Filesystem;
 
 abstract class AbstractMutatorTestCase extends TestCase
 {
@@ -30,21 +28,6 @@ abstract class AbstractMutatorTestCase extends TestCase
      * @var Mutator
      */
     protected $mutator;
-
-    /**
-     * @var Filesystem
-     */
-    private $fileSystem;
-
-    /**
-     * @var string
-     */
-    private $workspace;
-
-    /**
-     * @var string
-     */
-    private $tmpDir;
 
     public function doTest(string $inputCode, string $expectedCode = null)
     {
@@ -72,16 +55,6 @@ abstract class AbstractMutatorTestCase extends TestCase
     protected function setUp()
     {
         $this->mutator = $this->getMutator();
-
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
-
-        $this->fileSystem = new Filesystem();
-        $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);
-    }
-
-    protected function tearDown()
-    {
-        $this->fileSystem->remove($this->workspace);
     }
 
     protected function getNodes(string $code): array
@@ -110,20 +83,16 @@ abstract class AbstractMutatorTestCase extends TestCase
         return $prettyPrinter->prettyPrintFile($mutatedNodes);
     }
 
-    private function assertSyntaxIsValid($realMutatedCode)
+    private function assertSyntaxIsValid(string $realMutatedCode)
     {
-        $filename = $this->fileSystem->tempnam($this->tmpDir, 'mutator');
-        file_put_contents($filename, $realMutatedCode);
-
-        exec(sprintf('php -l %s', $filename), $output, $returnCode);
+        exec(sprintf('echo %s | php -l', escapeshellarg($realMutatedCode)), $output, $returnCode);
 
         $this->assertSame(
             0,
             $returnCode,
             sprintf(
-                'Mutator %s produces invalid code in %s',
-                $this->getMutator()::getName(),
-                $filename
+                'Mutator %s produces invalid code',
+                $this->getMutator()::getName()
             )
         );
     }

--- a/tests/Mutator/Boolean/Yield_Test.php
+++ b/tests/Mutator/Boolean/Yield_Test.php
@@ -27,13 +27,19 @@ class Yield_Test extends AbstractMutatorTestCase
             <<<'PHP'
 <?php
 
-(yield $a => $b);
+function test()
+{
+    (yield $a => $b);
+}
 PHP
             ,
             <<<'PHP'
 <?php
 
-(yield $a > $b);
+function test()
+{
+    (yield $a > $b);
+}
 PHP
             ,
         ];
@@ -42,7 +48,10 @@ PHP
             <<<'PHP'
 <?php
 
-(yield $b);
+function test()
+{
+    (yield $b);
+}
 PHP
             ,
         ];


### PR DESCRIPTION
This PR adds a check *in unit tests* that mutated code is always valid.

Extracted from https://github.com/infection/infection/issues/262 and [this](https://github.com/infection/infection/issues/262#issuecomment-379547689) comment in particular

For reference: 

> Created Mutant with invalid syntax must be considered as a bug in Infection.

Concerns about this PR:

* It slows down Mutators tests (from 5s to 15s)
* I'm not sure it's the best way of PHP linting, but this is the simplest one that I was able to find

With this new assertion we are sure that at least tested cases produce valid code for each Mutator.

Thoughts?