### PR TITLE
Use our own Docker images for all testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ build/cache:
 #All tests, (infection itself, phpunit, e2e) for different php version/ environments (xdebug or phpdbg)
 .PHONY: test test-unit test-infection-phpdbg test-e2e-phpdbg test-infection-xdebug test-e2e-xdebug
 test: test-unit test-infection-phpdbg test-e2e-phpdbg test-infection-xdebug test-e2e-xdebug
+	# All tests finished without errors
 
 .PHONY: test-unit test-unit-70 test-unit-71 test-unit-72
 #php unit tests

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PHPSTAN=./phpstan.phar
 PHP-CS-FIXER=./php-cs-fixer-v2.phar
 PHPUNIT=vendor/bin/phpunit
 
-DOCKER_RUN=docker run -t --rm -e PHPDBG=1 -v "$$PWD":/opt/infection -w /opt/infection
+DOCKER_RUN=docker run -t --rm -v "$$PWD":/opt/infection -w /opt/infection
 DOCKER_RUN_70=$(DOCKER_RUN) infection_php70
 DOCKER_RUN_71=$(DOCKER_RUN) infection_php71
 DOCKER_RUN_72=$(DOCKER_RUN) infection_php72
@@ -67,13 +67,13 @@ test-infection-phpdbg-72: build-xdebug-72
 test-e2e-phpdbg: test-e2e-phpdbg-70 test-e2e-phpdbg-71 test-e2e-phpdbg-72
 
 test-e2e-phpdbg-70: build-xdebug-70
-	$(DOCKER_RUN_70) ./tests/e2e_tests
+	$(DOCKER_RUN_70) env PHPDBG=1 ./tests/e2e_tests
 
 test-e2e-phpdbg-71: build-xdebug-71
-	$(DOCKER_RUN_71) ./tests/e2e_tests
+	$(DOCKER_RUN_71) env PHPDBG=1 ./tests/e2e_tests
 
 test-e2e-phpdbg-72: build-xdebug-72
-	$(DOCKER_RUN_72) ./tests/e2e_tests
+	$(DOCKER_RUN_72) env PHPDBG=1 ./tests/e2e_tests
 
 
 .PHONY: test-infection-xdebug test-infection-xdebug-70 test-infection-xdebug-71 test-infection-xdebug-72

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 PHP_CS_FIXER_FUTURE_MODE=1
 PHPSTAN=./phpstan.phar
 PHP-CS-FIXER=./php-cs-fixer-v2.phar
+PHPUNIT=vendor/bin/phpunit
+
+DOCKER_RUN=docker run -t --rm -e PHPDBG=1 -v "$$PWD":/opt/infection -w /opt/infection
+DOCKER_RUN_70=$(DOCKER_RUN) infection_php70
+DOCKER_RUN_71=$(DOCKER_RUN) infection_php71
+DOCKER_RUN_72=$(DOCKER_RUN) infection_php72
 
 .PHONY: all
 #Run all checks, default when running 'make'
@@ -32,42 +38,42 @@ test-final-private:
 #php unit tests
 test-unit: test-unit-70 test-unit-71 test-unit-72
 
-test-unit-70: vendor
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.0-cli php vendor/bin/phpunit
+test-unit-70: build-xdebug-70
+	$(DOCKER_RUN_70) $(PHPUNIT)
 
-test-unit-71: vendor
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.1-cli php vendor/bin/phpunit
+test-unit-71: build-xdebug-71
+	$(DOCKER_RUN_71) $(PHPUNIT)
 
-test-unit-72: vendor
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.2-cli php vendor/bin/phpunit
+test-unit-72: build-xdebug-72
+	$(DOCKER_RUN_72) $(PHPUNIT)
 
 
 .PHONY: test-infection-phpdbg test-infection-phpdbg-70 test-infection-phpdbg-71 test-infection-phpdbg-72
 #infection with phpdbg
 test-infection-phpdbg: test-infection-phpdbg-70 test-infection-phpdbg-71 test-infection-phpdbg-72
 
-test-infection-phpdbg-70: vendor
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.0-cli phpdbg -qrr bin/infection --threads=4
+test-infection-phpdbg-70: build-xdebug-70
+	$(DOCKER_RUN_70) phpdbg -qrr bin/infection --threads=4
 
-test-infection-phpdbg-71: vendor
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.1-cli phpdbg -qrr bin/infection --threads=4
+test-infection-phpdbg-71: build-xdebug-71
+	$(DOCKER_RUN_71) phpdbg -qrr bin/infection --threads=4
 
-test-infection-phpdbg-72: vendor
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection php:7.2-cli phpdbg -qrr bin/infection --threads=4
+test-infection-phpdbg-72: build-xdebug-72
+	$(DOCKER_RUN_72) phpdbg -qrr bin/infection --threads=4
 
 
 .PHONY: test-e2e-phpdbg test-e2e-phpdbg-70 test-e2e-phpdbg-71 test-e2e-phpdbg-72
 #e2e tests with phpdbg
 test-e2e-phpdbg: test-e2e-phpdbg-70 test-e2e-phpdbg-71 test-e2e-phpdbg-72
 
-test-e2e-phpdbg-70: vendor
-	docker run -it --rm -e PHPDBG=1 -v "$$PWD":/opt/infection -w /opt/infection php:7.0-cli ./tests/e2e_tests
+test-e2e-phpdbg-70: build-xdebug-70
+	$(DOCKER_RUN_70) ./tests/e2e_tests
 
-test-e2e-phpdbg-71: vendor
-	docker run -it --rm -e PHPDBG=1 -v "$$PWD":/opt/infection -w /opt/infection php:7.1-cli ./tests/e2e_tests
+test-e2e-phpdbg-71: build-xdebug-71
+	$(DOCKER_RUN_71) ./tests/e2e_tests
 
-test-e2e-phpdbg-72: vendor
-	docker run -it --rm -e PHPDBG=1 -v "$$PWD":/opt/infection -w /opt/infection php:7.2-cli ./tests/e2e_tests
+test-e2e-phpdbg-72: build-xdebug-72
+	$(DOCKER_RUN_72) ./tests/e2e_tests
 
 
 .PHONY: test-infection-xdebug test-infection-xdebug-70 test-infection-xdebug-71 test-infection-xdebug-72
@@ -75,13 +81,13 @@ test-e2e-phpdbg-72: vendor
 test-infection-xdebug: test-infection-xdebug-70 test-infection-xdebug-71 test-infection-xdebug-72
 
 test-infection-xdebug-70: build-xdebug-70
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php70 php bin/infection --threads=4
+	$(DOCKER_RUN_70) php bin/infection --threads=4
 
 test-infection-xdebug-71: build-xdebug-71
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php71 php bin/infection --threads=4
+	$(DOCKER_RUN_71) php bin/infection --threads=4
 
 test-infection-xdebug-72: build-xdebug-72
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php72 php bin/infection --threads=4
+	$(DOCKER_RUN_72) php bin/infection --threads=4
 
 
 .PHONY: test-e2e-xdebug test-e2e-xdebug-70 test-e2e-xdebug-71 test-e2e-xdebug-72
@@ -89,25 +95,31 @@ test-infection-xdebug-72: build-xdebug-72
 test-e2e-xdebug: test-e2e-xdebug-70 test-e2e-xdebug-71 test-e2e-xdebug-72
 
 test-e2e-xdebug-70: build-xdebug-70
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php70 ./tests/e2e_tests
+	$(DOCKER_RUN_70) ./tests/e2e_tests
 
-test-e2e-xdebug-71: build-xdebug-71
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php71 ./tests/e2e_tests
+test-e2e-xdebug-71: vendor
+	$(DOCKER_RUN_71) ./tests/e2e_tests
 
-test-e2e-xdebug-72: build-xdebug-72
-	docker run -it --rm -v "$$PWD":/opt/infection -w /opt/infection infection_php72 ./tests/e2e_tests
+test-e2e-xdebug-72: vendor
+	$(DOCKER_RUN_72) ./tests/e2e_tests
 
 
 .PHONY: build-xdebug-70 build-xdebug-71 build-xdebug-72
 #Building images with xdebug
-build-xdebug-70: vendor
-	docker build -t infection_php70 -f "$$PWD/devTools/Dockerfile-php70-xdebug" .
+build-xdebug-70: vendor devTools/Dockerfile-php70-xdebug.json
+devTools/Dockerfile-php70-xdebug.json: devTools/Dockerfile-php70-xdebug
+	docker build -t infection_php70 -f devTools/Dockerfile-php70-xdebug .
+	docker image inspect infection_php70 >> devTools/Dockerfile-php70-xdebug.json
 
-build-xdebug-71: vendor
-	docker build -t infection_php71 -f "$$PWD/devTools/Dockerfile-php71-xdebug" .
+build-xdebug-71: vendor devTools/Dockerfile-php71-xdebug.json
+devTools/Dockerfile-php71-xdebug.json: devTools/Dockerfile-php71-xdebug
+	docker build -t infection_php71 -f devTools/Dockerfile-php71-xdebug .
+	docker image inspect infection_php71 >> devTools/Dockerfile-php71-xdebug.json
 
-build-xdebug-72: vendor
-	docker build -t infection_php72 -f "$$PWD/devTools/Dockerfile-php72-xdebug" .
+build-xdebug-72: vendor devTools/Dockerfile-php72-xdebug.json
+devTools/Dockerfile-php72-xdebug.json: devTools/Dockerfile-php72-xdebug
+	docker build -t infection_php72 -f devTools/Dockerfile-php72-xdebug .
+	docker image inspect infection_php72 >> devTools/Dockerfile-php72-xdebug.json
 
 #style checks/ static analysis
 .PHONY: analyze cs-fix cs-check phpstan validate auto-review

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ PHP-CS-FIXER=./php-cs-fixer-v2.phar
 PHPUNIT=vendor/bin/phpunit
 
 DOCKER_RUN=docker run -t --rm -v "$$PWD":/opt/infection -w /opt/infection
-DOCKER_RUN_70=$(DOCKER_RUN) infection_php70
-DOCKER_RUN_71=$(DOCKER_RUN) infection_php71
-DOCKER_RUN_72=$(DOCKER_RUN) infection_php72
+DOCKER_RUN_70=flock devTools/*php70*.json $(DOCKER_RUN) infection_php70
+DOCKER_RUN_71=flock devTools/*php71*.json $(DOCKER_RUN) infection_php71
+DOCKER_RUN_72=flock devTools/*php72*.json $(DOCKER_RUN) infection_php72
 
 .PHONY: all
 #Run all checks, default when running 'make'

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,8 @@ build/cache:
 	chmod a+x ./phpstan.phar
 
 #All tests, (infection itself, phpunit, e2e) for different php version/ environments (xdebug or phpdbg)
-.PHONY: test test-unit test-infection-phpdbg test-e2e-phpdbg test-infection-xdebug test-e2e-xdebug test-final-private
-test: test-unit test-infection-phpdbg test-e2e-phpdbg test-infection-xdebug test-e2e-xdebug test-final-private
-
-test-final-private:
-	./tests/final_private_test
+.PHONY: test test-unit test-infection-phpdbg test-e2e-phpdbg test-infection-xdebug test-e2e-xdebug
+test: test-unit test-infection-phpdbg test-e2e-phpdbg test-infection-xdebug test-e2e-xdebug
 
 .PHONY: test-unit test-unit-70 test-unit-71 test-unit-72
 #php unit tests

--- a/devTools/.gitignore
+++ b/devTools/.gitignore
@@ -1,0 +1,1 @@
+Docker*.json

--- a/devTools/Dockerfile-php70-xdebug
+++ b/devTools/Dockerfile-php70-xdebug
@@ -1,4 +1,5 @@
 FROM php:7.0-cli
 
 RUN pecl install xdebug && docker-php-ext-enable xdebug
+RUN apt-get -y update && apt-get install -y expect
 

--- a/devTools/Dockerfile-php70-xdebug
+++ b/devTools/Dockerfile-php70-xdebug
@@ -2,4 +2,6 @@ FROM php:7.0-cli
 
 RUN pecl install xdebug && docker-php-ext-enable xdebug
 RUN apt-get -y update && apt-get install -y expect
+RUN useradd --shell /bin/bash infection
 
+USER infection

--- a/devTools/Dockerfile-php71-xdebug
+++ b/devTools/Dockerfile-php71-xdebug
@@ -2,3 +2,6 @@ FROM php:7.1-cli
 
 RUN pecl install xdebug && docker-php-ext-enable xdebug
 RUN apt-get -y update && apt-get install -y expect
+RUN useradd --shell /bin/bash infection
+
+USER infection

--- a/devTools/Dockerfile-php71-xdebug
+++ b/devTools/Dockerfile-php71-xdebug
@@ -1,3 +1,4 @@
 FROM php:7.1-cli
 
 RUN pecl install xdebug && docker-php-ext-enable xdebug
+RUN apt-get -y update && apt-get install -y expect

--- a/devTools/Dockerfile-php72-xdebug
+++ b/devTools/Dockerfile-php72-xdebug
@@ -1,3 +1,4 @@
 FROM php:7.2-cli
 
 RUN pecl install xdebug && docker-php-ext-enable xdebug
+RUN apt-get -y update && apt-get install -y expect

--- a/devTools/Dockerfile-php72-xdebug
+++ b/devTools/Dockerfile-php72-xdebug
@@ -2,3 +2,6 @@ FROM php:7.2-cli
 
 RUN pecl install xdebug && docker-php-ext-enable xdebug
 RUN apt-get -y update && apt-get install -y expect
+RUN useradd --shell /bin/bash infection
+
+USER infection

--- a/tests/Fixtures/e2e/Custom_tmp_dir/infection.json
+++ b/tests/Fixtures/e2e/Custom_tmp_dir/infection.json
@@ -8,5 +8,5 @@
     "logs": {
         "summary": "infection-log.txt"
     },
-    "tmpDir": "infection-cache"
+    "tmpDir": "/tmp/infection-cache"
 }


### PR DESCRIPTION
- Install expect because it is needed to e2e testing
- Skip XDebugHandler tests if xdebug isn't used
- Permit parallel execution e.g. with `make -j -Otarget test`

TODO:

- [x] blocked by #329
- [x] `make test-infection-xdebug-70` is failing with `Code Coverage does not exist` for some reason.
- [x] `make test-e2e-xdebug-72` finds previously undiscovered mutants 
