### PR TITLE
InfectionContainer now implements PSR-11 ContainerInterface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
 
 env:
   global:
-    - INFECTION_FLAGS='--threads=4 --min-msi=57 --min-covered-msi=86 --coverage=coverage --log-verbosity=3'
+    - INFECTION_FLAGS='--threads=4 --min-msi=62 --min-covered-msi=87 --coverage=coverage --log-verbosity=3'
     - PHPUNIT_BIN='vendor/bin/phpunit --coverage-clover=clover.xml --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml'
     - secure: RT8az62c2YI2j7Xccamhw0eCFbPMphfK2c5aZ0cUyQCFeLuc7qJ5Q0y0DIapOf7YbpLBwVwf53LQtV8doyhZ2ltTRHM2NDmOxUrkxFpc50+I2FGlsrlPWPSDL69Dc6VxEy6+S1rvUUJu6KIs1lGCrUG3lOxt/avzctyY1g8KdqkhIfNADH6pwMzRxkhOacsKkdnT24RoFdN4M4uXyn16VclFOCeLaVdEHYCdD248L0MuhTZQF5u0jq0SdgNGOPnetRQXHjQLVSfmuB2bI5FUTxHVwvf4nU3aKYXONi+EzBauDZXdO/opgNydbmhVUZtRsTeSh1OANhAPTvW+qdFcMbc3K90q3UMdIp8pZS9krRzJyfXe7BodnvkOu0ej2S4x2eE2EZphK7L21nu016CDo1y434UCJX+DI3Pn7SZ7ood8nOi7yfOzNeVklW6+n6k6bSmS2ya/DcpS6y/OuH/awtLat0hzmXUCHVNV9YiES1KwtlkUSJqtaZwtj8iXuuBwOWWV4u71bivpKEbF2L7+1GYy56ftv57JHbh6m2tWCoeUQc9oAzDb0sHeBhj4YFVhAd598860Q4WhRG9BWJT8guySRI0iXOSxDrvgtgr5okG3WD2/CJtnsVukdgXMvcXiLbxMXKeF7LMRJfkNjrn++311ZAMaRWJSfGNEivZlooQ=
 

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Infection\Command;
 
 use Infection\Console\Application;
-use Pimple\Psr11\Container;
+use Infection\Console\InfectionContainer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class BaseCommand extends Command
 {
     /**
-     * @var Container
+     * @var InfectionContainer
      */
     private $container;
 
@@ -35,10 +35,10 @@ abstract class BaseCommand extends Command
      */
     protected $output;
 
-    public function getContainer(): Container
+    public function getContainer(): InfectionContainer
     {
-        if ($this->container === null) {
-            $this->container = new Container($this->getApplication()->getContainer());
+        if (!$this->container) {
+            $this->container = $this->getApplication()->getContainer();
         }
 
         return $this->container;

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -172,7 +172,7 @@ final class InfectionCommand extends BaseCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $container = $this->getContainer();
-        $config = $container->get('infection.config');
+        $config = $container->getInfectionConfig();
 
         $bootstrap = $config->getBootstrap();
         if ($bootstrap) {

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -348,7 +348,7 @@ final class InfectionCommand extends BaseCommand
             ),
             new MutationTestingResultsLoggerSubscriber(
                 $this->output,
-                $this->getContainer()->get('infection.config'),
+                $this->getContainer()->getInfectionConfig(),
                 $metricsCalculator,
                 $this->getContainer()->get('filesystem'),
                 (int) $this->input->getOption('log-verbosity')

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -64,12 +64,12 @@ ASCII;
      */
     private $isDebuggerDisabled;
 
-    public function __construct(Container $container, string $name = self::NAME, string $version = self::VERSION)
+    public function __construct(InfectionContainer $container, string $name = self::NAME, string $version = self::VERSION)
     {
         $this->container = $container;
-        $this->isDebuggerDisabled = ('' === trim((string) getenv(XdebugHandler::ENV_DISABLE_XDEBUG)));
-        $this->isXdebugLoaded = \extension_loaded('xdebug');
-        $this->isUnderPhpdbg = PHP_SAPI == 'phpdbg';
+        $this->isDebuggerDisabled = $this->container['environment.debugger.disabled'];
+        $this->isXdebugLoaded = $this->container['environment.xdebug.loaded'];
+        $this->isUnderPhpdbg = $this->container['environment.phpdbg.used'];
 
         parent::__construct($name, $version);
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -57,6 +57,11 @@ ASCII;
     /**
      * @var bool
      */
+    private $isUnderPhpdbg;
+
+    /**
+     * @var bool
+     */
     private $isDebuggerDisabled;
 
     public function __construct(Container $container, string $name = self::NAME, string $version = self::VERSION)
@@ -64,6 +69,7 @@ ASCII;
         $this->container = $container;
         $this->isDebuggerDisabled = ('' === trim((string) getenv(XdebugHandler::ENV_DISABLE_XDEBUG)));
         $this->isXdebugLoaded = \extension_loaded('xdebug');
+        $this->isUnderPhpdbg = PHP_SAPI == 'phpdbg';
 
         parent::__construct($name, $version);
 
@@ -82,7 +88,7 @@ ASCII;
 
         $this->io = new SymfonyStyle($input, $output);
 
-        if (PHP_SAPI === 'phpdbg') {
+        if ($this->isUnderPhpdbg) {
             $this->io->writeln(sprintf(self::RUNNING_WITH_DEBUGGER_NOTE, PHP_SAPI));
         } elseif ($this->isXdebugLoaded) {
             $this->io->writeln(sprintf(self::RUNNING_WITH_DEBUGGER_NOTE, 'xdebug'));
@@ -91,7 +97,7 @@ ASCII;
         $xdebug = new XdebugHandler(new ConfigBuilder(sys_get_temp_dir()));
         $xdebug->check();
 
-        if (PHP_SAPI !== 'phpdbg'
+        if (!$this->isUnderPhpdbg
             && $this->isDebuggerDisabled
             && !$this->isXdebugLoaded
             && !$input->hasParameterOption('--coverage', true)

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -40,7 +40,7 @@ final class Application extends BaseApplication
 ASCII;
 
     /**
-     * @var Container
+     * @var InfectionContainer
      */
     private $container;
 
@@ -195,7 +195,7 @@ ASCII;
      */
     private function buildDynamicDependencies(InputInterface $input)
     {
-        $this->container['infection.config'] = function (Container $c) use ($input): InfectionConfig {
+        $this->container->setInfectionConfigInitializer(function (Container $c) use ($input): InfectionConfig {
             try {
                 $configPaths = [];
                 $customConfigPath = $input->getOption('configuration');
@@ -229,7 +229,7 @@ ASCII;
             }
 
             return new InfectionConfig($config, $c['filesystem'], $configLocation);
-        };
+        });
 
         $this->container['coverage.path'] = function (Container $c) use ($input): string {
             $existingCoveragePath = trim($input->getOption('coverage'));

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -172,7 +172,7 @@ ASCII;
         $output->getFormatter()->setStyle('high', new OutputFormatterStyle('green', null, ['bold']));
     }
 
-    public function getContainer(): Container
+    public function getContainer(): InfectionContainer
     {
         return $this->container;
     }

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -42,6 +42,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class InfectionContainer extends Container implements ContainerInterface
 {
+    const KEY_INFECTION_CONFIG = 'infection.config';
+
     public function __construct(array $values = [])
     {
         parent::__construct($values);
@@ -173,9 +175,14 @@ final class InfectionContainer extends Container implements ContainerInterface
         };
     }
 
+    public function setInfectionConfigInitializer(\Closure $initializer)
+    {
+        $this[self::KEY_INFECTION_CONFIG] = $initializer;
+    }
+
     public function getInfectionConfig(): InfectionConfig
     {
-        return $this['infection.config'];
+        return $this[self::KEY_INFECTION_CONFIG];
     }
 
     /**

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -33,13 +33,14 @@ use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 use Pimple\Container;
+use Psr\Container\ContainerInterface;
 use SebastianBergmann\Diff\Differ as BaseDiffer;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
  */
-final class InfectionContainer extends Container
+final class InfectionContainer extends Container implements ContainerInterface
 {
     public function __construct(array $values = [])
     {
@@ -172,8 +173,28 @@ final class InfectionContainer extends Container
         };
     }
 
-    private function getInfectionConfig(): InfectionConfig
+    public function getInfectionConfig(): InfectionConfig
     {
         return $this['infection.config'];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Psr\Container\ContainerInterface::get()
+     */
+    public function get($id)
+    {
+        return $this[$id];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Psr\Container\ContainerInterface::has()
+     */
+    public function has($id)
+    {
+        return isset($this[$id]);
     }
 }

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -16,6 +16,7 @@ use Infection\EventDispatcher\EventDispatcher;
 use Infection\Finder\Locator;
 use Infection\Mutant\MutantCreator;
 use Infection\Mutator\Util\MutatorsGenerator;
+use Infection\Php\XdebugHandler;
 use Infection\Process\Runner\Parallel\ParallelProcessRunner;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use Infection\TestFramework\Coverage\CachedTestFileDataProvider;
@@ -172,6 +173,18 @@ final class InfectionContainer extends Container implements ContainerInterface
             $mutatorConfig = $this->getInfectionConfig()->getMutatorsConfiguration();
 
             return (new MutatorsGenerator($mutatorConfig))->generate();
+        };
+
+        $this['environment.debugger.disabled'] = function (): bool {
+            return '' == trim((string) getenv(XdebugHandler::ENV_DISABLE_XDEBUG));
+        };
+
+        $this['environment.xdebug.loaded'] = function (): bool {
+            return \extension_loaded('xdebug');
+        };
+
+        $this['environment.phpdbg.used'] = function (): bool {
+            return PHP_SAPI == 'phpdbg';
         };
     }
 

--- a/tests/Console/InfectionContainerTest.php
+++ b/tests/Console/InfectionContainerTest.php
@@ -9,14 +9,29 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Console;
 
+use Infection\Config\InfectionConfig;
 use Infection\Console\InfectionContainer;
-use PHPUnit\Framework\TestCase;
+use Mockery;
 
-class InfectionContainerTest extends TestCase
+class InfectionContainerTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 {
     public function test_it_is_a_usable_container()
     {
         $container = new InfectionContainer();
         $this->assertArrayHasKey('project.dir', $container);
+    }
+
+    public function test_it_provides_infection_config()
+    {
+        $container = new InfectionContainer();
+
+        $container->setInfectionConfigInitializer(function () {
+            $infectionConfigMock = Mockery::mock(InfectionConfig::class);
+            $infectionConfigMock->shouldReceive('getTestFramework')->once()->andReturn('phpunit');
+
+            return $infectionConfigMock;
+        });
+
+        $this->assertSame('phpunit', $container->getInfectionConfig()->getTestFramework());
     }
 }


### PR DESCRIPTION
This PR:

- [x] InfectionContainer made implement ContainerInterface, one wrapper less
- [x] InfectionCommand directly uses InfectionContainer to access InfectionConfig
- [x] Minor refactoring in Application: check agains phpdbg like it is done against xdebug
- [x] Min MSI 57 -> 62, min covered MSI 86 -> 87
- [ ] Address review comments 