### PR TITLE
Remove and add PHP_INI_SCAN_DIR at the right places

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -274,6 +274,11 @@ final class InfectionCommand extends BaseCommand
 
     private function applyMemoryLimitFromPhpUnitProcess(Process $process, PhpUnitAdapter $adapter)
     {
+        if (PHP_SAPI == 'phpdbg') {
+            // Under phpdbg we're using a system php.ini, can't add a memory limit there
+            return;
+        }
+
         $tempConfigPath = \php_ini_loaded_file();
 
         if (empty($tempConfigPath) || !file_exists($tempConfigPath) || !is_writable($tempConfigPath)) {

--- a/src/Php/ConfigBuilder.php
+++ b/src/Php/ConfigBuilder.php
@@ -31,6 +31,11 @@ final class ConfigBuilder
         $this->tempDir = $tempDir;
     }
 
+    public static function hasBuiltTempPhpConfig(): bool
+    {
+        return getenv(self::ENV_TEMP_PHP_CONFIG_PATH) !== false;
+    }
+
     /**
      * @return string|null config path
      *
@@ -38,7 +43,7 @@ final class ConfigBuilder
      */
     public function build()
     {
-        $tmpIniPath = (string) getenv(self::ENV_TEMP_PHP_CONFIG_PATH);
+        $tmpIniPath = getenv(self::ENV_TEMP_PHP_CONFIG_PATH);
 
         if (!empty($tmpIniPath) && file_exists($tmpIniPath)) {
             return $tmpIniPath;

--- a/src/Php/XdebugHandler.php
+++ b/src/Php/XdebugHandler.php
@@ -43,7 +43,7 @@ class XdebugHandler
         $this->configBuilder = $configBuilder;
 
         $this->isLoaded = extension_loaded('xdebug');
-        $this->envScanDir = (string) getenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR);
+        $this->envScanDir = getenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR);
     }
 
     public function check()
@@ -64,6 +64,14 @@ class XdebugHandler
                     putenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR . '=' . $args[1]);
                 } else {
                     putenv(ConfigBuilder::ENV_PHP_INI_SCAN_DIR);
+                    /*
+                     * We need to remove this variable not only from global environment,
+                     * but also from our internal environment, because our subprocesses
+                     * may inherit from it in certain circumstances.
+                     *
+                     * @see \Infection\Process\Builder\ProcessBuilder
+                     */
+                    unset($_SERVER[ConfigBuilder::ENV_PHP_INI_SCAN_DIR], $_ENV[ConfigBuilder::ENV_PHP_INI_SCAN_DIR]);
                 }
             }
         }

--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -100,10 +100,11 @@ class ProcessBuilder
 
         $this->envCache = array_replace($_ENV, $_SERVER);
         /*
-         * We use our own php.ini for CLI, hence all other .ini files must be ignored.
-         * For phpdbg no workarounds needed.
+         * We use our own php.ini for CLI, hence all other .ini files must be ignored, but:
+         * - For phpdbg no workarounds needed.
+         * - If we're not using our own php.ini, no workarounds needed either.
          */
-        if ('phpdbg' != PHP_SAPI) {
+        if ('phpdbg' != PHP_SAPI && ConfigBuilder::hasBuiltTempPhpConfig()) {
             $this->envCache[ConfigBuilder::ENV_PHP_INI_SCAN_DIR] = '';
         }
 

--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -100,9 +100,12 @@ class ProcessBuilder
 
         $this->envCache = array_replace($_ENV, $_SERVER);
         /*
-         * We use our own php.ini, hence all other .ini files must be ignored.
+         * We use our own php.ini for CLI, hence all other .ini files must be ignored.
+         * For phpdbg no workarounds needed.
          */
-        $this->envCache[ConfigBuilder::ENV_PHP_INI_SCAN_DIR] = '';
+        if ('phpdbg' != PHP_SAPI) {
+            $this->envCache[ConfigBuilder::ENV_PHP_INI_SCAN_DIR] = '';
+        }
 
         return $this->envCache;
     }

--- a/tests/Fixtures/e2e/Memory_Limit/php.ini
+++ b/tests/Fixtures/e2e/Memory_Limit/php.ini
@@ -1,7 +1,2 @@
 memory_limit = -1
 
-; These may be required on other platforms
-;extension=iconv.so
-;extension=mbstring.so
-
-zend_extension=xdebug.so

--- a/tests/Fixtures/e2e/Memory_Limit/run_tests.bash
+++ b/tests/Fixtures/e2e/Memory_Limit/run_tests.bash
@@ -14,6 +14,7 @@ run () {
     fi
 
     diff -u -w expected-output.txt infection-log.txt
+    git diff --exit-code php.ini
 }
 
 

--- a/tests/Fixtures/e2e/Memory_Limit/run_tests.bash
+++ b/tests/Fixtures/e2e/Memory_Limit/run_tests.bash
@@ -17,5 +17,5 @@ run () {
 }
 
 
-run "../../../../bin/infection --mutators=FalseValue" "-n -c php.ini"
+run "../../../../bin/infection --mutators=FalseValue" "-c php.ini"
 


### PR DESCRIPTION
Fixes #306

This tangled mess is because we're trying to disable xdebug when we would need it for sub-processes, and there's no right way to disable it for this process *only*, leaving sub-processes with xdebug enabled. If we use a custom php.ini, we have to include all .ini files in it, but then we have to ignore all those .ini files for us, for which we need to set envvar `PHP_INI_SCAN_DIR=`, which naturally propagates to our subprocesses, which brings us where we are.

A more proper solution to a general xdebug-avoidance problem would be to identify parts where xdebug is actually harmful, and run those parts in a subprocess with disabled xdebug.

Removing all xdebug workarounds right now would make Infection about 20% slower.

### Is it all about xdebug?

Not, not at all. My point is that we *should not* pollute any other process environment with `PHP_INI_SCAN_DIR=` but our own anyway. `PHP_INI_SCAN_DIR=` really breaks things. 

Say, a program we're mutating wants to start another PHP program that's going to read an XML file and do something with what it found. But it would not know that in needs to use a different `php.ini`, and with `PHP_INI_SCAN_DIR=` set that other program would not be able to read XML file like at all, because the extension it needs won't be loaded. We would be thinking: oh great, another mutant erred, but actually it won't be a mutant, but a bug in Infection that caused that error.
