### PR TITLE
Memory_Limit reliability fixes

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -277,6 +277,11 @@ final class InfectionCommand extends BaseCommand
 
     private function applyMemoryLimitFromPhpUnitProcess(Process $process, PhpUnitAdapter $adapter)
     {
+        if (PHP_SAPI == 'phpdbg') {
+            // Under phpdbg we're using a system php.ini, can't add a memory limit there
+            return;
+        }
+
         $tempConfigPath = \php_ini_loaded_file();
 
         if (empty($tempConfigPath) || !file_exists($tempConfigPath) || !is_writable($tempConfigPath)) {

--- a/tests/Fixtures/e2e/Memory_Limit/php.ini
+++ b/tests/Fixtures/e2e/Memory_Limit/php.ini
@@ -1,7 +1,0 @@
-memory_limit = -1
-
-; These may be required on other platforms
-;extension=iconv.so
-;extension=mbstring.so
-
-zend_extension=xdebug.so

--- a/tests/Fixtures/e2e/Memory_Limit/run_tests.bash
+++ b/tests/Fixtures/e2e/Memory_Limit/run_tests.bash
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+if [ "$PHPDBG" = "1" ]
+then
+    # Memory limit cannot be enforced from our custom php.ini
+    # under PHPDBG, hence this test shows nothing under PHPDBG
+    exit 0
+fi
+
 set -e
 
 run () {
@@ -17,5 +24,5 @@ run () {
 }
 
 
-run "../../../../bin/infection --mutators=FalseValue" "-n -c php.ini"
+run "../../../../bin/infection --mutators=FalseValue" "-d memory_limit=-1"
 

--- a/tests/Fixtures/e2e/Memory_Limit/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Memory_Limit/src/SourceClass.php
@@ -9,7 +9,7 @@ class SourceClass
         $result = [];
 
         do {
-            $result[] = new \SplFixedArray(1<<23);
+            $result[] = new \SplFixedArray(1<<22);
         } while (false);
 
         return count($result);


### PR DESCRIPTION
- PHP must be able to load other .ini files
- Memory limit cannot be enforced from our custom php.ini under PHPDBG
