### PR TITLE
If PATH is not set, continue infection execution with fallback

### DIFF
--- a/src/Finder/AbstractExecutableFinder.php
+++ b/src/Finder/AbstractExecutableFinder.php
@@ -21,17 +21,23 @@ abstract class AbstractExecutableFinder
      */
     protected function searchNonExecutables(array $probableNames, array $extraDirectories = [])
     {
+        $path = getenv('PATH') ?: getenv('Path');
+
+        if (!$path) {
+            return null;
+        }
+
         $dirs = array_merge(
-            explode(PATH_SEPARATOR, getenv('PATH') ?: getenv('Path')),
+            explode(PATH_SEPARATOR, $path),
             $extraDirectories
         );
 
         foreach ($dirs as $dir) {
             foreach ($probableNames as $name) {
-                $path = sprintf('%s/%s', $dir, $name);
+                $fileName = sprintf('%s/%s', $dir, $name);
 
-                if (file_exists($path)) {
-                    return $path;
+                if (file_exists($fileName)) {
+                    return $fileName;
                 }
             }
         }

--- a/tests/Fixtures/e2e/Empty_Path/README.md
+++ b/tests/Fixtures/e2e/Empty_Path/README.md
@@ -1,0 +1,9 @@
+# Title
+
+* Link to github ticket if relevant
+
+## Summary
+Short summary of the ticket
+
+## Full Ticket
+Full github ticket

--- a/tests/Fixtures/e2e/Empty_Path/README.md
+++ b/tests/Fixtures/e2e/Empty_Path/README.md
@@ -1,9 +1,8 @@
 # Title
 
-* Link to github ticket if relevant
+Fixes https://github.com/infection/infection/issues/295
 
 ## Summary
-Short summary of the ticket
 
-## Full Ticket
-Full github ticket
+If PATH/Path is not set, fall back to `vendor/bin` in ComposerExecutableFinder
+and continue Infection execution instead of displaying a weird error

--- a/tests/Fixtures/e2e/Empty_Path/bootstrap
+++ b/tests/Fixtures/e2e/Empty_Path/bootstrap
@@ -1,0 +1,6 @@
+#!/usr/bin/env php
+<?php
+
+putenv('PATH=');
+
+require __DIR__ . '/../../../../bin/infection';

--- a/tests/Fixtures/e2e/Empty_Path/composer.json
+++ b/tests/Fixtures/e2e/Empty_Path/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Namespace_\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Namespace_\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Empty_Path/expected-output.txt
+++ b/tests/Fixtures/e2e/Empty_Path/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/Empty_Path/infection.json
+++ b/tests/Fixtures/e2e/Empty_Path/infection.json
@@ -1,0 +1,11 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection-log.txt"
+    }
+}

--- a/tests/Fixtures/e2e/Empty_Path/phpunit.xml
+++ b/tests/Fixtures/e2e/Empty_Path/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Empty_Path/run_tests.bash
+++ b/tests/Fixtures/e2e/Empty_Path/run_tests.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e pipefail
+
+readonly INFECTION="../../../../bin/infection --ignore-msi-with-no-mutations --filter=notExistentFile.php --min-msi=100"
+
+if [ "$PHPDBG" = "1" ]
+then
+    PATH= $(which phpdbg) -qrr $INFECTION
+else
+    PATH= $(which php) $INFECTION
+fi
+
+diff expected-output.txt infection-log.txt

--- a/tests/Fixtures/e2e/Empty_Path/run_tests.bash
+++ b/tests/Fixtures/e2e/Empty_Path/run_tests.bash
@@ -2,13 +2,13 @@
 
 set -e pipefail
 
-readonly INFECTION="../../../../bin/infection --ignore-msi-with-no-mutations --filter=notExistentFile.php --min-msi=100"
+readonly INFECTION="./bootstrap"
 
 if [ "$PHPDBG" = "1" ]
 then
-    PATH= $(which phpdbg) -qrr $INFECTION
+    $(which phpdbg) -qrr $INFECTION
 else
-    PATH= $(which php) $INFECTION
+    $(which php) $INFECTION
 fi
 
 diff expected-output.txt infection-log.txt

--- a/tests/Fixtures/e2e/Empty_Path/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Empty_Path/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Namespace_;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/Empty_Path/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Empty_Path/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Namespace_\Test;
+
+use Namespace_\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}


### PR DESCRIPTION
If PATH/Path is not set, fall back to `vendor/bin` in `ComposerExecutableFinder`
and continue Infection execution instead of displaying a weird error

Fixes https://github.com/infection/infection/issues/295
