### PR TITLE
Fix: Add vendor and temporary files to e2e gitignore

### DIFF
--- a/tests/Fixtures/e2e/.gitignore
+++ b/tests/Fixtures/e2e/.gitignore
@@ -1,2 +1,5 @@
+vendor/
+infection-log.txt
+infection-cache/
 composer.lock
 error.log


### PR DESCRIPTION
We do not want to commit these files to the repo, so it makes sense to ignore them. This was not an issue before as they were ignored in the main gitignore. That one was changed to only ignore those files in the root folder.