### PR TITLE
Make Tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@
 /infection-cache
 /.travis/infection-private.pem
 /infection.json
-/*.phar
+/*.phar*
 /build/bin/infection.phar
 /build/bin/infection.phar.pubkey

--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,11 @@ box.phar:
 	chmod a+x box.phar
 
 .travis/infection-private.pem:
-	openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout .travis/infection-private.pem -subj "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=example.com"
+	openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout .travis/infection-private.pem -out /dev/null -subj "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=example.com"
 
 .PHONY: clean
 clean:
+	rm -rf box.phar*
 	rm -rf build/bin/infection.phar
 	rm -rf /usr/local/bin/infection
 

--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,21 @@ phpstan: vendor $(PHPSTAN)
 validate:
 	composer validate --strict
 
-build/bin/infection.phar: app bin src vendor box.json.dist scoper.inc.php box.phar
+build/bin/infection.phar: app bin src vendor box.json.dist scoper.inc.php box.phar .travis/infection-private.pem
 	php box.phar compile
 
 box.phar:
 	wget https://github.com/humbug/box/releases/download/3.0.0-alpha.2/box.phar
 	chmod a+x box.phar
+
+.travis/infection-private.pem:
+	openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout .travis/infection-private.pem -subj "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=example.com"
+
+.PHONY: clean
+clean:
+	rm -rf build/bin/infection.phar
+	rm -rf /usr/local/bin/infection
+
+.PHONY: link
+link: build/bin/infection.phar
+	ln -s $(pwd)/build/bin/infection.phar /usr/local/bin/infection


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [ ] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

Fixes https://github.com/infection/infection/issues/318

I made a few tweaks to the make process, just to make it a little easier to work with phars locally.

1. Added a target for the .travis/infection-private.pem - I presume travis will add this automatically during a normal run, if it is so needed.
1. Added a `link` target - just a quick helper to link to /usr/local/bin/infection
1. Added a `clean` target - removes a previously created phar and link.
1. Updated .gitignore - If you run box.phar multiple times (IE: -B make flag), you phar file will become box.phar.1, box.phar.2, etc.