### PR TITLE
Use project's bootstrap file in PHPUnit sub-processes rather than hardcoded `vendor/autoload.php`

### DIFF
--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -38,6 +38,11 @@ class MutationConfigBuilder extends ConfigBuilder
      */
     private $originalXmlConfigContent;
 
+    /**
+     * @var \DOMDocument
+     */
+    private $dom;
+
     public function __construct(string $tempDirectory, string $originalXmlConfigContent, XmlConfigurationHelper $xmlConfigurationHelper, string $projectDir)
     {
         $this->tempDirectory = $tempDirectory;
@@ -45,14 +50,17 @@ class MutationConfigBuilder extends ConfigBuilder
 
         $this->xmlConfigurationHelper = $xmlConfigurationHelper;
         $this->originalXmlConfigContent = $originalXmlConfigContent;
+
+        $this->dom = new \DOMDocument();
+        $this->dom->preserveWhiteSpace = false;
+        $this->dom->formatOutput = true;
+        $this->dom->loadXML($this->originalXmlConfigContent);
     }
 
     public function build(MutantInterface $mutant): string
     {
-        $dom = new \DOMDocument();
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML($this->originalXmlConfigContent);
+        // clone the dom document because it's mutated later
+        $dom = clone $this->dom;
 
         $xPath = new \DOMXPath($dom);
 

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/README.md
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/README.md
@@ -1,0 +1,8 @@
+# Title
+
+Fixes https://github.com/infection/infection/issues/320 issue
+
+## Summary
+This test ensures Infection uses bootstrap file from project's phpunit.xml.
+
+It's essential because bootstrap file can autoload, require additional classes or just have needed logic.

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/composer.json
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Namespace_\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Namespace_\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/custom-autoload.php
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/custom-autoload.php
@@ -1,0 +1,5 @@
+<?php
+
+require __DIR__ . '/src/CustomAutoloadedClass.php';
+
+require __DIR__ . '/vendor/autoload.php';

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/expected-output.txt
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/infection.json
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/infection.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection-log.txt"
+    },
+    "bootstrap": "./custom-autoload.php"
+}

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/phpunit.xml
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="./custom-autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/src/CustomAutoloadedClass.php
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/src/CustomAutoloadedClass.php
@@ -1,0 +1,9 @@
+<?php
+
+class CustomAutoloadedClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/tests/SourceClassTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Namespace_\Test;
+
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new \CustomAutoloadedClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -111,6 +111,7 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         );
 
         $this->assertSame($expectedCustomAutoloadFilePath, $resultAutoLoaderFilePath);
+        $this->assertContains('app/autoload2.php', file_get_contents($expectedCustomAutoloadFilePath));
     }
 
     public function test_it_sets_custom_autoloader_when_attribute_is_absent()
@@ -137,6 +138,7 @@ class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         );
 
         $this->assertSame($expectedCustomAutoloadFilePath, $resultAutoLoaderFilePath);
+        $this->assertContains('vendor/autoload.php', file_get_contents($expectedCustomAutoloadFilePath));
     }
 
     public function test_it_sets_stop_on_failure_flag()


### PR DESCRIPTION
This PR

- [x] Loads `bootstrap` file from project's `phpunit.xml` config for each Mutant proces
- [x] Covered by tests
- [x] Fixes https://github.com/infection/infection/issues/126 https://github.com/infection/infection/issues/320 https://github.com/infection/infection/issues/322
- [x] Docs: https://github.com/infection/site/pull/36

Since `ReflectionVisitor` uses `new \ReflectionClass()` code, it must know how to autoload project's classes. That's why we need to require custom project's bootstrap file not only for PHPUnit processes, but for Infection as well.

This is done by using `bootstrap` setting in `infection.json`, see added e2e test.