### PR TITLE
Use a transparent xdebug-free environment for all but the initial test process

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -11,6 +11,7 @@ namespace Infection\Console;
 
 use Composer\XdebugHandler\XdebugHandler;
 use Infection\Command;
+use Infection\Console\Util\PhpProcess;
 use PackageVersions\Versions;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
@@ -114,6 +115,13 @@ ASCII;
             ]);
 
             return 1;
+        }
+
+        /*
+         * If we're skipping Xdebug, setup a default Xdebug-free environment for all subprocesses
+         */
+        if ('' != XdebugHandler::getSkippedVersion()) {
+            PhpProcess::setupEnvironment();
         }
 
         return parent::run($input, $output);

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -121,7 +121,7 @@ ASCII;
          * If we're skipping Xdebug, setup a default Xdebug-free environment for all subprocesses
          */
         if ('' != XdebugHandler::getSkippedVersion()) {
-            PhpProcess::setupEnvironment();
+            PhpProcess::setupXdebugFreeEnvironment();
         }
 
         return parent::run($input, $output);

--- a/src/Console/Util/PhpProcess.php
+++ b/src/Console/Util/PhpProcess.php
@@ -51,6 +51,15 @@ final class PhpProcess extends Process
             return;
         }
 
+        /*
+         * Vanilla processes are expected to run in a vanilla, or the most original, environment.
+         *
+         * For that, we need to remove or reset all environment variables we set to setup our custom
+         * xdebug-free environment, later setting them back so we won't have to think again about it
+         * for the bulk of other processes, which not require xdebug to function, and work better
+         * without it.
+         */
+
         self::restoreVanillaEnvironment();
 
         parent::start($callback, $env);

--- a/src/Console/Util/PhpProcess.php
+++ b/src/Console/Util/PhpProcess.php
@@ -32,7 +32,7 @@ final class PhpProcess extends Process
      * - PHP_INI_SCAN_DIR should be made blank because our php.ini has all we need
      *   (a previous value can be found in XdebugHandler::getRestartSettings()["scanDir"])
      */
-    public static function setupEnvironment()
+    public static function setupXdebugFreeEnvironment()
     {
         if (!isset(self::$phprc)) {
             self::$phprc = getenv('PHPRC');
@@ -55,7 +55,7 @@ final class PhpProcess extends Process
 
         parent::start($callback, $env);
 
-        self::setupEnvironment();
+        self::setupXdebugFreeEnvironment();
     }
 
     private static function restoreVanillaEnvironment()

--- a/src/Console/Util/PhpProcess.php
+++ b/src/Console/Util/PhpProcess.php
@@ -46,7 +46,7 @@ final class PhpProcess extends Process
     {
         // Xdebug wasn't skipped, running as is
         if ('' == XdebugHandler::getSkippedVersion()) {
-            parent::start($callback, $env);
+            parent::start($callback, $env ?? []);
 
             return;
         }
@@ -62,7 +62,7 @@ final class PhpProcess extends Process
 
         self::restoreVanillaEnvironment();
 
-        parent::start($callback, $env);
+        parent::start($callback, $env ?? []);
 
         self::setupXdebugFreeEnvironment();
     }

--- a/src/Console/Util/PhpProcess.php
+++ b/src/Console/Util/PhpProcess.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Console\Util;
+
+use Composer\XdebugHandler\XdebugHandler;
+use Symfony\Component\Process\Process;
+
+/**
+ * Vanilla PHP process and utility functions
+ *
+ * @internal
+ */
+final class PhpProcess extends Process
+{
+    private static $phprc;
+
+    /**
+     * Setups a default Xdebug-free environment for all subprocesses:
+     *
+     * - PHPRC should point to our temporary php.ini (we need to save a previous value)
+     *
+     * - PHP_INI_SCAN_DIR should be made blank because our php.ini has all we need
+     *   (a previous value can be found in XdebugHandler::getRestartSettings()["scanDir"])
+     */
+    public static function setupEnvironment()
+    {
+        if (!isset(self::$phprc)) {
+            self::$phprc = getenv('PHPRC');
+        }
+
+        self::putenv('PHPRC', XdebugHandler::getRestartSettings()['tmpIni']);
+        self::putenv('PHP_INI_SCAN_DIR', '');
+    }
+
+    public function start(callable $callback = null, array $env = null)
+    {
+        // Xdebug wasn't skipped, running as is
+        if ('' == XdebugHandler::getSkippedVersion()) {
+            parent::start($callback, $env);
+
+            return;
+        }
+
+        self::restoreVanillaEnvironment();
+
+        parent::start($callback, $env);
+
+        self::setupEnvironment();
+    }
+
+    private static function restoreVanillaEnvironment()
+    {
+        self::putenv('PHPRC', self::$phprc);
+        self::putenv('PHP_INI_SCAN_DIR', XdebugHandler::getRestartSettings()['scanDir']);
+    }
+
+    private static function putenv($name, $value)
+    {
+        // getenv returns false if there was no variable => we must delete it
+        putenv(false === $value ? $name : $name . '=' . $value);
+
+        // Our parent will read vars from $_SERVER
+        $_SERVER[$name] = $value;
+
+        // $_ENV is typically empty, but update it if not
+        if (!empty($_ENV)) {
+            $_ENV[$name] = $value;
+        }
+    }
+}

--- a/src/Console/Util/PhpProcess.php
+++ b/src/Console/Util/PhpProcess.php
@@ -19,6 +19,9 @@ use Symfony\Component\Process\Process;
  */
 final class PhpProcess extends Process
 {
+    /**
+     * @var string|bool
+     */
     private static $phprc;
 
     /**
@@ -61,7 +64,11 @@ final class PhpProcess extends Process
         self::putenv('PHP_INI_SCAN_DIR', XdebugHandler::getRestartSettings()['scanDir']);
     }
 
-    private static function putenv($name, $value)
+    /**
+     * @param string $name
+     * @param string|bool $value either string or false
+     */
+    private static function putenv(string $name, $value)
     {
         // getenv returns false if there was no variable => we must delete it
         putenv(false === $value ? $name : $name . '=' . $value);

--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -55,19 +55,17 @@ class ProcessBuilder
         // If we're expecting to receive a code coverage, test process must run in a vanilla environment
         $processType = $skipCoverage ? Process::class : PhpProcess::class;
 
+        /** @var PhpProcess|Process $process */
         $process = new $processType(
             $this->testFrameworkAdapter->getExecutableCommandLine(
                 $this->testFrameworkAdapter->buildInitialConfigFile(),
                 $testFrameworkExtraOptions,
                 $includeArgs,
                 $phpExtraOptions
-            ),
-            null,
-            null,
-            null,
-            null
+            )
         );
 
+        $process->setTimeout(null); // ignore the default timeout of 60 seconds
         $process->inheritEnvironmentVariables();
 
         return $process;
@@ -79,13 +77,10 @@ class ProcessBuilder
             $this->testFrameworkAdapter->getExecutableCommandLine(
                 $this->testFrameworkAdapter->buildMutationConfigFile($mutant),
                 $testFrameworkExtraOptions
-            ),
-            null,
-            null,
-            null,
-            $this->timeout
+            )
         );
 
+        $process->setTimeout($this->timeout);
         $process->inheritEnvironmentVariables();
 
         return new MutantProcess($process, $mutant, $this->testFrameworkAdapter);

--- a/src/Process/ExecutableFinder/PhpExecutableFinder.php
+++ b/src/Process/ExecutableFinder/PhpExecutableFinder.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Process\ExecutableFinder;
 
-use Composer\XdebugHandler\XdebugHandler;
 use Symfony\Component\Process\PhpExecutableFinder as BasePhpExecutableFinder;
 
 /**
@@ -20,12 +19,8 @@ final class PhpExecutableFinder extends BasePhpExecutableFinder
     public function findArguments()
     {
         $arguments = [];
-        $tmpPhpConfigPath = XdebugHandler::getSkippedVersion() ? php_ini_loaded_file() : '';
 
-        if (!empty($tmpPhpConfigPath) && file_exists($tmpPhpConfigPath)) {
-            $arguments[] = '-c';
-            $arguments[] = $tmpPhpConfigPath;
-        } elseif ('phpdbg' === PHP_SAPI) {
+        if ('phpdbg' == PHP_SAPI) {
             $arguments[] = '-qrr';
         }
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -255,6 +255,15 @@ final class ProjectCodeTest extends TestCase
             return;
         }
 
+        /*
+         * We should consider only properties belonging to our classes, but not to foreign classes
+         * we're exteding from. E.g. we can't change Symfony\Component\Process\Process to not have
+         * a public propery it has.
+         */
+        $properties = array_filter($properties, function (\ReflectionProperty $property) use ($className) {
+            return $property->class == $className;
+        });
+
         $this->assertCount(
             0,
             $properties,

--- a/tests/Fixtures/e2e/Exec_Path/bin/test.bash
+++ b/tests/Fixtures/e2e/Exec_Path/bin/test.bash
@@ -1,2 +1,6 @@
 #!/usr/bin/env bash
-echo "Program finished with flying colors!"
+
+# This is a very complex program that may lauch some other programs including PHP programs
+
+echo -n "Program finished"
+php -r 'echo simplexml_load_string("<message> with flying colors!</message>");'

--- a/tests/Fixtures/e2e/Exec_Path/run_tests.bash
+++ b/tests/Fixtures/e2e/Exec_Path/run_tests.bash
@@ -2,6 +2,10 @@
 
 set -e
 
+tputx () {
+	test -x $(which tput) && tput "$@"
+}
+
 run () {
     local INFECTION=${1}
     local PHPARGS=${2}
@@ -16,8 +20,42 @@ run () {
 
 cd $(dirname "$0")
 
-PATH=$PATH:bin php vendor/bin/phpunit
+if [ "$PHPDBG" = "1" ]
+then
+    tputx bold
+    echo "Will be using phpdbg"
+    tputx sgr0
+fi
 
-PATH=$PATH:bin run "../../../../bin/infection"
+tputx bold
+echo "Initial test run outside Infection must be successful"
+tputx sgr0
+
+if [ "$PHPDBG" = "1" ]
+then
+    PATH=$PATH:bin phpdbg -qrr vendor/bin/phpunit --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml
+else
+    PATH=$PATH:bin php vendor/bin/phpunit --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml
+fi
+
+test -f coverage/phpunit.junit.xml
+test -f coverage/coverage-xml/RunShellScript.php.xml
+test -f coverage/coverage-xml/index.xml
+
+tputx bold
+echo "PHPUnit finished all right"
+echo "Pre-generated coverage..."
+tputx sgr0
+
+PATH=$PATH:bin run "../../../../bin/infection --coverage=coverage --quiet"
+diff -uw expected-output.txt infection-log.txt
+
+tputx bold
+echo "Internal coverage..."
+tputx sgr0
+
+PATH=$PATH:bin run "../../../../bin/infection --quiet"
 
 diff -w expected-output.txt infection-log.txt
+
+rm -vfr coverage

--- a/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
+++ b/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
@@ -12,7 +12,10 @@ namespace Infection\Tests\Process\ExecutableFinder;
 use Infection\Process\ExecutableFinder\PhpExecutableFinder;
 use PHPUnit\Framework\TestCase;
 
-class PhpExecutableFinderTest extends TestCase
+/**
+ * @internal
+ */
+final class PhpExecutableFinderTest extends TestCase
 {
     public function test_it_finds_needed_args()
     {

--- a/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
+++ b/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Process\ExecutableFinder;
+
+use Infection\Process\ExecutableFinder\PhpExecutableFinder;
+use PHPUnit\Framework\TestCase;
+
+class PhpExecutableFinderTest extends TestCase
+{
+    public function test_it_finds_needed_args()
+    {
+        $finder = new PhpExecutableFinder();
+
+        if ('phpdbg' == PHP_SAPI) {
+            $this->assertSame(['-qrr'], $finder->findArguments());
+
+            return;
+        }
+
+        $this->assertSame([], $finder->findArguments());
+    }
+}


### PR DESCRIPTION
Fixes #306
Fixes #332

(`make test` still fails because of missing `expect`, #304 should fix this problem too)