### PR TITLE
Replace mock creation function from getMockBuilder by createMock

### DIFF
--- a/tests/Config/ValueProvider/AbstractBaseProviderTest.php
+++ b/tests/Config/ValueProvider/AbstractBaseProviderTest.php
@@ -39,7 +39,7 @@ abstract class AbstractBaseProviderTest extends Mockery\Adapter\Phpunit\MockeryT
 
     protected function createStreamableInputInterfaceMock($stream = null, $interactive = true)
     {
-        $mock = $this->getMockBuilder(StreamableInputInterface::class)->getMock();
+        $mock = $this->createMock(StreamableInputInterface::class);
         $mock->expects($this->any())
             ->method('isInteractive')
             ->will($this->returnValue($interactive));

--- a/tests/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
+++ b/tests/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
@@ -21,14 +21,13 @@ class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProviderTest
     public function test_it_returns_null_if_executable_is_found()
     {
         $finderMock = Mockery::mock(TestFrameworkFinder::class);
-
         $finderMock->shouldReceive('find')->once();
 
-        $consoleMock = $this->getMockBuilder(ConsoleHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $provider = new PhpUnitCustomExecutablePathProvider($finderMock, $consoleMock, $this->getQuestionHelper());
+        $provider = new PhpUnitCustomExecutablePathProvider(
+            $finderMock,
+            $this->createMock(ConsoleHelper::class),
+            $this->getQuestionHelper()
+        );
 
         $result = $provider->get($this->createStreamableInputInterfaceMock(), $this->createOutputInterface());
 
@@ -38,17 +37,17 @@ class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProviderTest
     public function test_it_asks_question_if_no_config_is_found_in_current_dir()
     {
         $finderMock = Mockery::mock(TestFrameworkFinder::class);
-
         $finderMock->shouldReceive('find')->once()->andThrow(new FinderException());
 
-        $consoleMock = $this->getMockBuilder(ConsoleHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $consoleMock = $this->createMock(ConsoleHelper::class);
         $consoleMock->expects($this->once())->method('getQuestion')->willReturn('foobar');
-        $dialog = $this->getQuestionHelper();
 
-        $provider = new PhpUnitCustomExecutablePathProvider($finderMock, $consoleMock, $dialog);
+        $provider = new PhpUnitCustomExecutablePathProvider(
+            $finderMock,
+            $consoleMock,
+            $this->getQuestionHelper()
+        );
+
         $customExecutable = p(realpath(__DIR__ . '/../../Fixtures/Files/phpunit/phpunit.phar'));
 
         $path = $provider->get(
@@ -72,14 +71,14 @@ class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProviderTest
 
         $finderMock->shouldReceive('find')->once()->andThrow(new FinderException());
 
-        $consoleMock = $this->getMockBuilder(ConsoleHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $consoleMock = $this->createMock(ConsoleHelper::class);
         $consoleMock->expects($this->once())->method('getQuestion')->willReturn('foobar');
-        $dialog = $this->getQuestionHelper();
 
-        $provider = new PhpUnitCustomExecutablePathProvider($finderMock, $consoleMock, $dialog);
+        $provider = new PhpUnitCustomExecutablePathProvider(
+            $finderMock,
+            $consoleMock,
+            $this->getQuestionHelper()
+        );
 
         $provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("abc\n")),

--- a/tests/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -20,19 +20,21 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
 {
     public function test_it_calls_locator_in_the_current_dir()
     {
-        $locatorMock = $this->getMockBuilder(TestFrameworkConfigLocatorInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $locatorMock = $this->createMock(TestFrameworkConfigLocatorInterface::class);
         $locatorMock->expects($this->once())->method('locate');
 
-        $consoleMock = $this->getMockBuilder(ConsoleHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $provider = new TestFrameworkConfigPathProvider(
+            $locatorMock,
+            $this->createMock(ConsoleHelper::class),
+            $this->getQuestionHelper()
+        );
 
-        $provider = new TestFrameworkConfigPathProvider($locatorMock, $consoleMock, $this->getQuestionHelper());
-
-        $result = $provider->get($this->createStreamableInputInterfaceMock(), $this->createOutputInterface(), [], 'phpunit');
+        $result = $provider->get(
+            $this->createStreamableInputInterfaceMock(),
+            $this->createOutputInterface(),
+            [],
+            'phpunit'
+        );
 
         $this->assertNull($result);
     }
@@ -45,14 +47,11 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
         $locatorMock->shouldReceive('locate')->once()->andThrow(new \Exception());
         $locatorMock->shouldReceive('locate')->once()->andReturn(true);
 
-        $consoleMock = $this->getMockBuilder(ConsoleHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $consoleMock = $this->createMock(ConsoleHelper::class);
         $consoleMock->expects($this->once())->method('getQuestion')->willReturn('foobar');
-        $dialog = $this->getQuestionHelper();
 
-        $provider = new TestFrameworkConfigPathProvider($locatorMock, $consoleMock, $dialog);
+        $provider = new TestFrameworkConfigPathProvider($locatorMock, $consoleMock, $this->getQuestionHelper());
+
         $inputPhpUnitPath = realpath(__DIR__ . '/../../Fixtures/Files/phpunit');
 
         $path = $provider->get(
@@ -69,8 +68,6 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
     public function test_it_automatically_guesses_path()
     {
         $locatorMock = Mockery::mock(TestFrameworkConfigLocatorInterface::class);
-        $outputMock = Mockery::mock(OutputInterface::class);
-        $inputMock = Mockery::mock(InputInterface::class);
 
         $locatorMock->shouldReceive('locate')->once()->andThrow(new \Exception());
         $locatorMock->shouldReceive('locate')->once()->andReturn(true);
@@ -78,13 +75,11 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
         $consoleMock = Mockery::mock(ConsoleHelper::class);
         $consoleMock->shouldReceive('getQuestion')->never();
 
-        $dialog = $this->getQuestionHelper();
-
-        $provider = new TestFrameworkConfigPathProvider($locatorMock, $consoleMock, $dialog);
+        $provider = new TestFrameworkConfigPathProvider($locatorMock, $consoleMock, $this->getQuestionHelper());
 
         $path = $provider->get(
-            $inputMock,
-            $outputMock,
+            Mockery::mock(InputInterface::class),
+            Mockery::mock(OutputInterface::class),
             [],
             'phpunit'
         );
@@ -104,14 +99,10 @@ class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
         $locatorMock->shouldReceive('locate')->once()->andThrow(new \Exception());
         $locatorMock->shouldReceive('locate')->once()->andReturn(true);
 
-        $consoleMock = $this->getMockBuilder(ConsoleHelper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $consoleMock = $this->createMock(ConsoleHelper::class);
         $consoleMock->expects($this->once())->method('getQuestion')->willReturn('foobar');
-        $dialog = $this->getQuestionHelper();
 
-        $provider = new TestFrameworkConfigPathProvider($locatorMock, $consoleMock, $dialog);
+        $provider = new TestFrameworkConfigPathProvider($locatorMock, $consoleMock, $this->getQuestionHelper());
 
         $path = $provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("abc\n")),

--- a/tests/Mutator/Util/AbstractValueToNullReturnValueTest.php
+++ b/tests/Mutator/Util/AbstractValueToNullReturnValueTest.php
@@ -65,9 +65,7 @@ class AbstractValueToNullReturnValueTest extends TestCase
     public function test_return_type_is_node_identifier()
     {
         /** @var Node\Identifier $mockNode */
-        $mockNode = $this->getMockBuilder(Node\Identifier::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockNode = $this->createMock(Node\Identifier::class);
 
         $mockNode->name = null;
 
@@ -93,15 +91,11 @@ class AbstractValueToNullReturnValueTest extends TestCase
 
     public function test_return_type_is_nullable()
     {
-        $mockNode = $this->getMockBuilder(Node\NullableType::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $this->assertTrue(
             $this->invokeMethod(
                 $this->mockNode(
                     $this->mockFunction(
-                        $mockNode
+                        $this->createMock(Node\NullableType::class)
                     )
                 )
             )
@@ -123,15 +117,11 @@ class AbstractValueToNullReturnValueTest extends TestCase
 
     public function test_return_type_is_not_node_name()
     {
-        $mockNode = $this->getMockBuilder(Node\Name::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $this->assertFalse(
             $this->invokeMethod(
                 $this->mockNode(
                     $this->mockFunction(
-                        $mockNode
+                        $this->createMock(Node\Name::class)
                     )
                 )
             )

--- a/tests/Process/Listener/MutationTestingConsoleLoggerSubscriberTest.php
+++ b/tests/Process/Listener/MutationTestingConsoleLoggerSubscriberTest.php
@@ -47,10 +47,7 @@ class MutationTestingConsoleLoggerSubscriberTest extends TestCase
     {
         $this->output = $this->createMock(OutputInterface::class);
         $this->outputFormatter = $this->createMock(OutputFormatter::class);
-        $this->metricsCalculator = $this->getMockBuilder(MetricsCalculator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $this->metricsCalculator = $this->createMock(MetricsCalculator::class);
         $this->diffColorizer = $this->createMock(DiffColorizer::class);
     }
 

--- a/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
+++ b/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
@@ -43,19 +43,10 @@ class MutationTestingResultsLoggerSubscriberTest extends TestCase
 
     protected function setUp()
     {
-        $this->output = $this->getMockBuilder(OutputInterface::class)
-            ->getMock();
-
-        $this->infectionConfig = $this->getMockBuilder(InfectionConfig::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->metricsCalculator = $this->getMockBuilder(MetricsCalculator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->filesystem = $this->getMockBuilder(Filesystem::class)
-            ->getMock();
+        $this->output = $this->createMock(OutputInterface::class);
+        $this->infectionConfig = $this->createMock(InfectionConfig::class);
+        $this->metricsCalculator = $this->createMock(MetricsCalculator::class);
+        $this->filesystem = $this->createMock(Filesystem::class);
     }
 
     public function test_it_do_nothing_when_file_log_path_is_not_defined()


### PR DESCRIPTION
Very small "improvement" which replaces `getMockBuilder` by `createMock`. It a bit reduces lines of code