### PR TITLE
Enforce declare strict_types everywhere

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -24,7 +24,6 @@ return \PhpCsFixer\Config::create()
         '@PHP70Migration:risky' => true,
 
         'concat_space' => ['spacing' => 'one'],
-        'declare_strict_types' => false,
         'header_comment' => [
             'commentType' => 'PHPDoc',
             'header' => $header,

--- a/src/Config/Guesser/Guesser.php
+++ b/src/Config/Guesser/Guesser.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Config\Guesser;
 
 interface Guesser

--- a/src/Console/OutputFormatter/OutputFormatter.php
+++ b/src/Console/OutputFormatter/OutputFormatter.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Console\OutputFormatter;
 
 use Infection\Process\MutantProcess;

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -5,18 +5,32 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\StreamWrapper;
 
 final class IncludeInterceptor
 {
     const STREAM_OPEN_FOR_INCLUDE = 0x00000080;
 
+    /**
+     * @var resource
+     */
     public $context;
 
+    /**
+     * @var bool|resource
+     */
     private $fp;
 
+    /**
+     * @var string
+     */
     private static $intercept;
 
+    /**
+     * @var string
+     */
     private static $replacement;
 
     public static function intercept($file, $with)
@@ -64,9 +78,9 @@ final class IncludeInterceptor
             }
         }
         if (isset($this->context)) {
-            $this->fp = fopen($path, $mode, $options, $this->context);
+            $this->fp = fopen($path, $mode, (bool) $options, $this->context);
         } else {
-            $this->fp = fopen($path, $mode, $options);
+            $this->fp = fopen($path, $mode, (bool) $options);
         }
         self::enable();
 
@@ -216,7 +230,7 @@ final class IncludeInterceptor
     {
         switch ($option) {
             case STREAM_OPTION_BLOCKING:
-                return stream_set_blocking($this->fp, $arg1);
+                return stream_set_blocking($this->fp, (bool) $arg1);
             case STREAM_OPTION_READ_TIMEOUT:
                 return stream_set_timeout($this->fp, $arg1, $arg2);
             case STREAM_OPTION_WRITE_BUFFER:

--- a/tests/EventDispatcher/EventDispatcherTest.php
+++ b/tests/EventDispatcher/EventDispatcherTest.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Tests\EventDispatcher;
 
 use Infection\EventDispatcher\EventDispatcher;

--- a/tests/Mutant/Exception/MsiCalculationExceptionTest.php
+++ b/tests/Mutant/Exception/MsiCalculationExceptionTest.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Tests\Mutant\Exception;
 
 use Infection\Mutant\Exception\MsiCalculationException;

--- a/tests/Mutator/Boolean/LogicalLowerAndTest.php
+++ b/tests/Mutator/Boolean/LogicalLowerAndTest.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Tests\Mutator\Boolean;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;

--- a/tests/Mutator/Regex/PregQuoteTest.php
+++ b/tests/Mutator/Regex/PregQuoteTest.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Tests\Mutator\Regex;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;

--- a/tests/Mutator/Util/AbstractValueToNullReturnValueTest.php
+++ b/tests/Mutator/Util/AbstractValueToNullReturnValueTest.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Tests\Mutator\Util;
 
 use Infection\Mutator\Util\AbstractValueToNullReturnValue;

--- a/tests/TestFramework/Config/TestFrameworkConfigLocatorTest.php
+++ b/tests/TestFramework/Config/TestFrameworkConfigLocatorTest.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Tests\TestFramework\Config;
 
 use Infection\Finder\Exception\LocatorException;

--- a/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
+++ b/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Tests\TestFramework\Coverage;
 
 use Infection\TestFramework\Coverage\CachedTestFileDataProvider;

--- a/tests/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProviderTest.php
+++ b/tests/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProviderTest.php
@@ -5,6 +5,8 @@
  * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Infection\Tests\TestFramework\PhpUnit\Coverage;
 
 use Infection\TestFramework\PhpUnit\Coverage\PhpUnitTestFileDataProvider;


### PR DESCRIPTION
This PR:

- [x] Enables the `declare_strict_types` php-cs-fixer rule, and fixes the errors caused by enabling it
- [x] Covered by tests

Follows #277 