### PR TITLE
Apply max level phpstan to src folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,8 @@ cs-check: build/cache $(PHP-CS-FIXER)
 	$(PHP-CS-FIXER) fix -v --cache-file=build/cache/.php_cs.cache --dry-run --stop-on-violation
 
 phpstan: vendor $(PHPSTAN)
-	$(PHPSTAN) analyse src tests --level=2 -c phpstan.neon --no-interaction --no-progress
+	$(PHPSTAN) analyse src --level=max -c ./devTools/phpstan-src.neon --no-interaction --no-progress
+	$(PHPSTAN) analyse tests --level=2 -c ./devTools/phpstan-tests.neon --no-interaction --no-progress
 
 validate:
 	composer validate --strict

--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -1,8 +1,7 @@
 parameters:
-    excludes_analyse:
-        - %currentWorkingDirectory%/tests/Fixtures/*
-
     ignoreErrors:
         - '#Access to an undefined property PhpParser\\Node(.*?)#'
         - '#Call to an undefined method PhpParser\\Node(.*?)#'
         - '#Cannot access property \$name on string.#'
+        - '#Accessing property \$expr on possibly null value of type PhpParser\\Node(.*?)#'
+        - '#expects PhpParser\\Node\\Identifier, string given.#'

--- a/devTools/phpstan-tests.neon
+++ b/devTools/phpstan-tests.neon
@@ -1,0 +1,3 @@
+parameters:
+    excludes_analyse:
+        - %currentWorkingDirectory%/tests/Fixtures/*

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -33,7 +33,6 @@ use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\MemoryUsageAware;
 use Infection\TestFramework\PhpSpec\PhpSpecExtraOptions;
-use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\PhpUnit\PhpUnitExtraOptions;
 use Infection\TestFramework\TestFrameworkExtraOptions;
@@ -276,7 +275,7 @@ final class InfectionCommand extends BaseCommand
         throw new \InvalidArgumentException('Incorrect formatter. Possible values: "dot", "progress"');
     }
 
-    private function applyMemoryLimitFromPhpUnitProcess(Process $process, PhpUnitAdapter $adapter)
+    private function applyMemoryLimitFromPhpUnitProcess(Process $process, MemoryUsageAware $adapter)
     {
         if (PHP_SAPI == 'phpdbg') {
             // Under phpdbg we're using a system php.ini, can't add a memory limit there

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -56,9 +56,9 @@ class InfectionConfig
         return $this->configLocation;
     }
 
-    public function getPhpUnitCustomPath()
+    public function getPhpUnitCustomPath(): string
     {
-        return $this->config->phpUnit->customPath ?? null;
+        return $this->config->phpUnit->customPath ?? '';
     }
 
     public function getProcessTimeout(): int

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -11,7 +11,6 @@ namespace Infection\Config\ValueProvider;
 
 use Infection\Config\ConsoleHelper;
 use Infection\Config\Guesser\PhpUnitPathGuesser;
-use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\TestFrameworkTypes;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -22,7 +21,7 @@ use Symfony\Component\Console\Question\Question;
 final class TestFrameworkConfigPathProvider
 {
     /**
-     * @var TestFrameworkConfigLocator
+     * @var TestFrameworkConfigLocatorInterface
      */
     private $testFrameworkConfigLocator;
     /**

--- a/src/Console/OutputFormatter/OutputFormatter.php
+++ b/src/Console/OutputFormatter/OutputFormatter.php
@@ -7,7 +7,6 @@
 
 namespace Infection\Console\OutputFormatter;
 
-use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessInterface;
 
 interface OutputFormatter
@@ -22,7 +21,7 @@ interface OutputFormatter
     /**
      * Triggered each time mutation process is finished for one Mutant
      *
-     * @param MutantProcess $mutantProcess
+     * @param MutantProcessInterface $mutantProcess
      * @param int $mutationCount
      */
     public function advance(MutantProcessInterface $mutantProcess, int $mutationCount);

--- a/src/Events/MutantProcessFinished.php
+++ b/src/Events/MutantProcessFinished.php
@@ -9,13 +9,12 @@ declare(strict_types=1);
 
 namespace Infection\Events;
 
-use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessInterface;
 
 final class MutantProcessFinished
 {
     /**
-     * @var MutantProcess
+     * @var MutantProcessInterface
      */
     private $mutantProcess;
 
@@ -25,7 +24,7 @@ final class MutantProcessFinished
     }
 
     /**
-     * @return MutantProcess
+     * @return MutantProcessInterface
      */
     public function getMutantProcess(): MutantProcessInterface
     {

--- a/src/Finder/Exception/FinderException.php
+++ b/src/Finder/Exception/FinderException.php
@@ -18,6 +18,13 @@ final class FinderException extends \RuntimeException
         );
     }
 
+    public static function phpExecutableNotFound(): self
+    {
+        return new self(
+            'Unable to locate the PHP executable on the local system. Please report this issue, and include details about your setup.'
+        );
+    }
+
     public static function testFrameworkNotFound(string $testFrameworkName): self
     {
         return new self(

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -33,7 +33,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
      */
     private $cachedPath;
 
-    public function __construct(string $testFrameworkName, string $customPath = null)
+    public function __construct(string $testFrameworkName, string $customPath = '')
     {
         $this->testFrameworkName = $testFrameworkName;
         $this->customPath = $customPath;
@@ -54,7 +54,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
 
     private function shouldUseCustomPath(): bool
     {
-        if (!isset($this->customPath)) {
+        if (!$this->customPath) {
             return false;
         }
 

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Logger;
 
-use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 
 final class DebugFileLogger extends FileLogger
 {
@@ -43,7 +43,7 @@ final class DebugFileLogger extends FileLogger
     }
 
     /**
-     * @param MutantProcess[] $processes
+     * @param MutantProcessInterface[] $processes
      * @param string $headlinePrefix
      *
      * @return string

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Logger;
 
-use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessInterface;
 
 final class TextFileLogger extends FileLogger
@@ -30,7 +29,7 @@ final class TextFileLogger extends FileLogger
     }
 
     /**
-     * @param MutantProcess[] $processes
+     * @param MutantProcessInterface[] $processes
      * @param string $headlinePrefix
      *
      * @return string

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -22,6 +22,7 @@ use Infection\Visitor\FullyQualifiedClassNameVisitor;
 use Infection\Visitor\MutationsCollectorVisitor;
 use Infection\Visitor\ParentConnectorVisitor;
 use Infection\Visitor\ReflectionVisitor;
+use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use Symfony\Component\Finder\SplFileInfo;
@@ -124,6 +125,7 @@ final class MutationsGenerator
      */
     private function getMutationsFromFile(SplFileInfo $file, bool $onlyCovered, array $mutators): array
     {
+        /** @var Node[] $initialStatements */
         $initialStatements = $this->parser->parse($file->getContents());
 
         $traverser = new NodeTraverser();

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -23,7 +23,7 @@ class MetricsCalculator
     private $killedCount = 0;
 
     /**
-     * @var MutantProcess[]
+     * @var MutantProcessInterface[]
      */
     private $killedMutantProcesses = [];
 
@@ -33,7 +33,7 @@ class MetricsCalculator
     private $errorCount = 0;
 
     /**
-     * @var MutantProcess[]
+     * @var MutantProcessInterface[]
      */
     private $errorProcesses = [];
 
@@ -43,7 +43,7 @@ class MetricsCalculator
     private $escapedCount = 0;
 
     /**
-     * @var MutantProcess[]
+     * @var MutantProcessInterface[]
      */
     private $escapedMutantProcesses = [];
 
@@ -53,7 +53,7 @@ class MetricsCalculator
     private $timedOutCount = 0;
 
     /**
-     * @var MutantProcess[]
+     * @var MutantProcessInterface[]
      */
     private $timedOutProcesses = [];
 
@@ -63,7 +63,7 @@ class MetricsCalculator
     private $notCoveredByTestsCount = 0;
 
     /**
-     * @var MutantProcess[]
+     * @var MutantProcessInterface[]
      */
     private $notCoveredMutantProcesses = [];
 
@@ -188,7 +188,7 @@ class MetricsCalculator
     }
 
     /**
-     * @return MutantProcess[]
+     * @return MutantProcessInterface[]
      */
     public function getEscapedMutantProcesses(): array
     {
@@ -196,7 +196,7 @@ class MetricsCalculator
     }
 
     /**
-     * @return MutantProcess[]
+     * @return MutantProcessInterface[]
      */
     public function getKilledMutantProcesses(): array
     {
@@ -204,7 +204,7 @@ class MetricsCalculator
     }
 
     /**
-     * @return MutantProcess[]
+     * @return MutantProcessInterface[]
      */
     public function getTimedOutProcesses(): array
     {
@@ -212,7 +212,7 @@ class MetricsCalculator
     }
 
     /**
-     * @return MutantProcess[]
+     * @return MutantProcessInterface[]
      */
     public function getNotCoveredMutantProcesses(): array
     {
@@ -225,7 +225,7 @@ class MetricsCalculator
     }
 
     /**
-     * @return MutantProcess[]
+     * @return MutantProcessInterface[]
      */
     public function getErrorProcesses(): array
     {

--- a/src/Mutant/Mutant.php
+++ b/src/Mutant/Mutant.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutant;
 
-use Infection\Mutation;
 use Infection\MutationInterface;
 
 final class Mutant implements MutantInterface
@@ -17,7 +16,7 @@ final class Mutant implements MutantInterface
     private $mutatedFilePath;
 
     /**
-     * @var Mutation
+     * @var MutationInterface
      */
     private $mutation;
 

--- a/src/Mutator/Boolean/NotIdenticalNotEqual.php
+++ b/src/Mutator/Boolean/NotIdenticalNotEqual.php
@@ -19,7 +19,7 @@ final class NotIdenticalNotEqual extends Mutator
      *
      * @param Node $node
      *
-     * @return Node\Expr\BinaryOp\Equal
+     * @return Node\Expr\BinaryOp\NotEqual
      */
     public function mutate(Node $node)
     {

--- a/src/Mutator/Boolean/Yield_.php
+++ b/src/Mutator/Boolean/Yield_.php
@@ -19,7 +19,7 @@ final class Yield_ extends Mutator
      *
      * @param Node $node
      *
-     * @return Node\Expr\Yield_
+     * @return Node|Node\Expr\Yield_
      */
     public function mutate(Node $node)
     {

--- a/src/Mutator/Util/MutatorsGenerator.php
+++ b/src/Mutator/Util/MutatorsGenerator.php
@@ -88,7 +88,7 @@ final class MutatorsGenerator
 
     /**
      * @param string $mutator
-     * @param array|bool $setting
+     * @param array|bool|\stdClass $setting
      */
     private function registerFromClass(string $mutator, $setting)
     {

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -16,7 +16,7 @@ use Infection\Events\MutantProcessFinished;
 use Infection\Events\MutationTestingFinished;
 use Infection\Events\MutationTestingStarted;
 use Infection\Mutant\MetricsCalculator;
-use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInterface
@@ -34,7 +34,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInt
     private $outputFormatter;
 
     /**
-     * @var MutantProcess[]
+     * @var MutantProcessInterface[]
      */
     private $mutantProcesses = [];
 
@@ -114,7 +114,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInt
     }
 
     /**
-     * @param MutantProcess[] $processes
+     * @param MutantProcessInterface[] $processes
      * @param string $headlinePrefix
      */
     private function showMutations(array $processes, string $headlinePrefix)

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Process;
 
-use Infection\Mutant\Mutant;
 use Infection\Mutant\MutantInterface;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Symfony\Component\Process\Process;
@@ -38,7 +37,7 @@ final class MutantProcess implements MutantProcessInterface
     private $process;
 
     /**
-     * @var Mutant
+     * @var MutantInterface
      */
     private $mutant;
 

--- a/src/Process/Runner/Parallel/ParallelProcessRunner.php
+++ b/src/Process/Runner/Parallel/ParallelProcessRunner.php
@@ -12,6 +12,7 @@ namespace Infection\Process\Runner\Parallel;
 use Infection\EventDispatcher\EventDispatcherInterface;
 use Infection\Events\MutantProcessFinished;
 use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
 use Symfony\Component\Process\Exception\LogicException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Exception\RuntimeException;
@@ -27,12 +28,12 @@ final class ParallelProcessRunner
     private $eventDispatcher;
 
     /**
-     * @var MutantProcess[]
+     * @var MutantProcessInterface[]
      */
     private $processesQueue;
 
     /**
-     * @var MutantProcess[]
+     * @var MutantProcessInterface[]
      */
     private $currentProcesses = [];
 
@@ -42,7 +43,7 @@ final class ParallelProcessRunner
     }
 
     /**
-     * @param MutantProcess[] $processes
+     * @param MutantProcessInterface[] $processes
      * @param int $threadCount
      * @param int $poll
      *
@@ -98,7 +99,7 @@ final class ParallelProcessRunner
     private function startProcess(): bool
     {
         $mutantProcess = array_shift($this->processesQueue);
-        /** @var MutantProcess $mutantProcess */
+        /** @var MutantProcessInterface $mutantProcess */
         $mutant = $mutantProcess->getMutant();
 
         if (!$mutant->isCoveredByTest()) {

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\TestFramework;
 
 use Infection\Finder\AbstractExecutableFinder;
+use Infection\Finder\Exception\FinderException;
 use Infection\Mutant\MutantInterface;
 use Infection\Process\ExecutableFinder\PhpExecutableFinder;
 use Infection\TestFramework\Config\InitialConfigBuilder;
@@ -145,7 +146,11 @@ abstract class AbstractTestFrameworkAdapter
     {
         if ($this->cachedPhpPath === null || $this->cachedIncludedArgs !== $includeArgs) {
             $this->cachedIncludedArgs = $includeArgs;
-            $this->cachedPhpPath = (new PhpExecutableFinder())->find($includeArgs);
+            $phpPath = (new PhpExecutableFinder())->find($includeArgs);
+            if ($phpPath === false) {
+                throw FinderException::phpExecutableNotFound();
+            }
+            $this->cachedPhpPath = $phpPath;
         }
 
         return $this->cachedPhpPath;

--- a/src/TestFramework/Coverage/CodeCoverageData.php
+++ b/src/TestFramework/Coverage/CodeCoverageData.php
@@ -37,7 +37,7 @@ class CodeCoverageData
     private $parser;
 
     /**
-     * @var TestFileDataProvider
+     * @var TestFileDataProvider|null
      */
     private $testFileDataProvider;
 

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -11,7 +11,6 @@ namespace Infection\TestFramework;
 
 use Infection\Config\InfectionConfig;
 use Infection\Finder\TestFrameworkFinder;
-use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapter;
 use Infection\TestFramework\PhpSpec\CommandLine\ArgumentsAndOptionsBuilder as PhpSpecArgumentsAndOptionsBuilder;
@@ -37,7 +36,7 @@ final class Factory
     private $xmlConfigurationHelper;
 
     /**
-     * @var TestFrameworkConfigLocator
+     * @var TestFrameworkConfigLocatorInterface
      */
     private $configLocator;
 

--- a/src/Visitor/MutatorVisitor.php
+++ b/src/Visitor/MutatorVisitor.php
@@ -17,7 +17,7 @@ use PhpParser\NodeVisitorAbstract;
 final class MutatorVisitor extends NodeVisitorAbstract
 {
     /**
-     * @var Mutation
+     * @var MutationInterface
      */
     private $mutation;
 

--- a/src/Visitor/ReflectionVisitor.php
+++ b/src/Visitor/ReflectionVisitor.php
@@ -23,12 +23,12 @@ final class ReflectionVisitor extends NodeVisitorAbstract
     private $scopeStack = [];
 
     /**
-     * @var \ReflectionClass
+     * @var \ReflectionClass|null
      */
     private $reflectionClass;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $methodName;
 

--- a/tests/Visitor/ReflectionVisitorTest.php
+++ b/tests/Visitor/ReflectionVisitorTest.php
@@ -138,7 +138,7 @@ class ReflectionVisitorTest extends TestCase
         ];
     }
 
-    private function getSpyVisitor(string $nodeClass): NodeVisitorAbstract
+    private function getSpyVisitor(string $nodeClass)
     {
         return new class($nodeClass) extends NodeVisitorAbstract {
             /** @var string */


### PR DESCRIPTION
This PR:

- [x] Sets the phpstan level for the `src/` folder to max, and fixes all issues found by phpstan.
- [x] Covered by tests

Most fixes are changing docblocks to the Interface it is hinted against, rather than the class.

We now also throw an error when the phpexectuable finder returns false, instead of failing on a harder to debug TypeError.