### PR TITLE
Use our own ConsoleOutput class over SymfonyStyle

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -234,7 +234,7 @@ final class InfectionCommand extends BaseCommand
             $testFrameworkOptions->getForMutantProcess()
         );
 
-        return $this->didRunPassConstraints($metricsCalculator);
+        return $this->hasRunPassedConstraints($metricsCalculator);
     }
 
     private function includeUserBootstrap(InfectionConfig $config)
@@ -439,7 +439,7 @@ final class InfectionCommand extends BaseCommand
      *
      * @return int
      */
-    private function didRunPassConstraints(MetricsCalculator $metricsCalculator): int
+    private function hasRunPassedConstraints(MetricsCalculator $metricsCalculator): int
     {
         if ($this->input->getOption('ignore-msi-with-no-mutations') && $metricsCalculator->getTotalMutantsCount() === 0) {
             return 0;

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -68,37 +68,37 @@ final class ConsoleOutput
 
     public function logBadMsiErrorMessage(MetricsCalculator $metricsCalculator, float $minMsi)
     {
-        if ($minMsi) {
-            $this->io->error(
-                sprintf(
-                    self::CI_FLAG_ERROR,
-                    'MSI',
-                    $minMsi,
-                    $metricsCalculator->getMutationScoreIndicator()
-                )
-            );
-
-            return;
+        if (!$minMsi) {
+            throw MsiCalculationException::create('min-msi');
         }
 
-        throw MsiCalculationException::create('min-msi');
+        $this->io->error(
+            sprintf(
+                self::CI_FLAG_ERROR,
+                'MSI',
+                $minMsi,
+                $metricsCalculator->getMutationScoreIndicator()
+            )
+        );
+
+        return;
     }
 
     public function logBadCoveredMsiErrorMessage(MetricsCalculator $metricsCalculator, float $minCoveredMsi)
     {
-        if ($minCoveredMsi) {
-            $this->io->error(
-                sprintf(
-                    self::CI_FLAG_ERROR,
-                    'Covered Code MSI',
-                    $minCoveredMsi,
-                    $metricsCalculator->getCoveredCodeMutationScoreIndicator()
-                )
-            );
-
-            return;
+        if (!$minCoveredMsi) {
+            throw MsiCalculationException::create('min-covered-msi');
         }
 
-        throw MsiCalculationException::create('min-covered-msi');
+        $this->io->error(
+            sprintf(
+                self::CI_FLAG_ERROR,
+                'Covered Code MSI',
+                $minCoveredMsi,
+                $metricsCalculator->getCoveredCodeMutationScoreIndicator()
+            )
+        );
+
+        return;
     }
 }

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -14,6 +14,9 @@ use Infection\Mutant\MetricsCalculator;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Process;
 
+/**
+ * @internal
+ */
 final class ConsoleOutput
 {
     const CI_FLAG_ERROR = 'The minimum required %s percentage should be %s%%, but actual is %s%%. Improve your tests!';

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Console;
+
+use Infection\Mutant\Exception\MsiCalculationException;
+use Infection\Mutant\MetricsCalculator;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
+
+final class ConsoleOutput
+{
+    const CI_FLAG_ERROR = 'The minimum required %s percentage should be %s%%, but actual is %s%%. Improve your tests!';
+
+    /**
+     * @var SymfonyStyle
+     */
+    private $io;
+
+    public function __construct(SymfonyStyle $io)
+    {
+        $this->io = $io;
+    }
+
+    public function logVerbosityDeprecationNotice(string $valueToUse)
+    {
+        $this->io->note('Numeric versions of log-verbosity have been deprecated, please use, ' . $valueToUse . ' to keep the same result');
+    }
+
+    public function logUnkownVerbosityOption(string $default)
+    {
+        $this->io->note('Running infection with an unknown log-verbosity option, falling back to ' . $default . ' option');
+    }
+
+    public function logInitialTestsDoNotPass(Process $initialTestSuitProcess, string $testFrameworkKey)
+    {
+        $lines = [
+            'Project tests must be in a passing state before running Infection.',
+            sprintf(
+                '%s reported an exit code of %d.',
+                $testFrameworkKey,
+                $initialTestSuitProcess->getExitCode()
+            ),
+            sprintf(
+                'Refer to the %s\'s output below:',
+                $testFrameworkKey
+            ),
+        ];
+
+        if ($stdOut = $initialTestSuitProcess->getOutput()) {
+            $lines[] = 'STDOUT:';
+            $lines[] = $stdOut;
+        }
+
+        if ($stdError = $initialTestSuitProcess->getErrorOutput()) {
+            $lines[] = 'STDERR:';
+            $lines[] = $stdError;
+        }
+
+        $this->io->error($lines);
+    }
+
+    public function logBadMsiErrorMessage(MetricsCalculator $metricsCalculator, float $minMsi)
+    {
+        if ($minMsi) {
+            $this->io->error(
+                sprintf(
+                    self::CI_FLAG_ERROR,
+                    'MSI',
+                    $minMsi,
+                    $metricsCalculator->getMutationScoreIndicator()
+                )
+            );
+
+            return;
+        }
+
+        throw MsiCalculationException::create('min-msi');
+    }
+
+    public function logBadCoveredMsiErrorMessage(MetricsCalculator $metricsCalculator, float $minCoveredMsi)
+    {
+        if ($minCoveredMsi) {
+            $this->io->error(
+                sprintf(
+                    self::CI_FLAG_ERROR,
+                    'Covered Code MSI',
+                    $minCoveredMsi,
+                    $metricsCalculator->getCoveredCodeMutationScoreIndicator()
+                )
+            );
+
+            return;
+        }
+
+        throw MsiCalculationException::create('min-covered-msi');
+    }
+}

--- a/src/Console/LogVerbosity.php
+++ b/src/Console/LogVerbosity.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Infection\Console;
 
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class LogVerbosity
 {
@@ -39,7 +38,7 @@ final class LogVerbosity
         self::NONE_INTEGER => self::NONE,
     ];
 
-    public static function convertVerbosityLevel(InputInterface $input, SymfonyStyle $io)
+    public static function convertVerbosityLevel(InputInterface $input, ConsoleOutput $io)
     {
         $verbosityLevel = $input->getOption('log-verbosity');
         if (in_array($verbosityLevel, self::ALLOWED_OPTIONS)) {
@@ -48,12 +47,12 @@ final class LogVerbosity
 
         if (array_key_exists((int) $verbosityLevel, self::ALLOWED_OPTIONS)) {
             $input->setOption('log-verbosity', self::ALLOWED_OPTIONS[$verbosityLevel]);
-            $io->note('Numeric versions of log-verbosity have been deprecated, please use, ' . self::ALLOWED_OPTIONS[$verbosityLevel] . ' to keep the same result');
+            $io->logVerbosityDeprecationNotice(self::ALLOWED_OPTIONS[$verbosityLevel]);
 
             return;
         }
 
-        $io->note('Running infection with an unknown log-verbosity option, falling back to \'default\' option');
+        $io->logUnkownVerbosityOption(self::NORMAL);
         $input->setOption('log-verbosity', self::NORMAL);
     }
 }

--- a/tests/Console/ConsoleOutputTest.php
+++ b/tests/Console/ConsoleOutputTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Console;
+
+use Infection\Console\ConsoleOutput;
+use Infection\Mutant\Exception\MsiCalculationException;
+use Infection\Mutant\MetricsCalculator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
+
+class ConsoleOutputTest extends TestCase
+{
+    public function test_log_verbosity_deprecation_notice()
+    {
+        $option = 'all';
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects($this->once())->method('note')
+            ->with(
+                'Numeric versions of log-verbosity have been deprecated, please use, ' . $option . ' to keep the same result'
+            );
+
+        $consoleOutput = new ConsoleOutput($io);
+        $consoleOutput->logVerbosityDeprecationNotice($option);
+    }
+
+    public function test_log_unknown_verbosity_option()
+    {
+        $option = 'default';
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects($this->once())->method('note')
+            ->with(
+                'Running infection with an unknown log-verbosity option, falling back to ' . $option . ' option'
+            );
+
+        $consoleOutput = new ConsoleOutput($io);
+        $consoleOutput->logUnkownVerbosityOption($option);
+    }
+
+    public function test_log_initial_tests_do_not_pass()
+    {
+        $testFrameworkKey = 'phpunit';
+        $process = $this->createMock(Process::class);
+        $process->expects($this->once())->method('getExitCode')->willReturn(0);
+        $process->expects($this->once())->method('getOutput')->willReturn('output string');
+        $process->expects($this->once())->method('getErrorOutput')->willReturn('error string');
+
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects($this->once())->method('error')->with(
+            [
+                'Project tests must be in a passing state before running Infection.',
+                'phpunit reported an exit code of 0.',
+                'Refer to the phpunit\'s output below:',
+                'STDOUT:',
+                'output string',
+                'STDERR:',
+                'error string',
+            ]
+        );
+
+        $console = new ConsoleOutput($io);
+        $console->logInitialTestsDoNotPass($process, $testFrameworkKey);
+    }
+
+    public function test_log_bad_msi_error_message()
+    {
+        $metrics = $this->createMock(MetricsCalculator::class);
+        $metrics->expects($this->once())->method('getMutationScoreIndicator')->willReturn('75.0');
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects($this->once())->method('error')->with(
+            'The minimum required MSI percentage should be 25%, but actual is 75%. Improve your tests!'
+        );
+
+        $console = new ConsoleOutput($io);
+
+        $console->logBadMsiErrorMessage($metrics, 25.0);
+    }
+
+    public function test_log_bad_msi_error_message_throws_error_on_faulty_msi()
+    {
+        $io = $this->createMock(SymfonyStyle::class);
+        $consoleOutput = new ConsoleOutput($io);
+
+        $this->expectException(MsiCalculationException::class);
+
+        $consoleOutput->logBadMsiErrorMessage(new MetricsCalculator(), 0.0);
+    }
+
+    public function test_log_bad_covered_msi_error_message_throws_error_on_faulty_msi()
+    {
+        $io = $this->createMock(SymfonyStyle::class);
+        $consoleOutput = new ConsoleOutput($io);
+
+        $this->expectException(MsiCalculationException::class);
+
+        $consoleOutput->logBadCoveredMsiErrorMessage(new MetricsCalculator(), 0.0);
+    }
+
+    public function test_log_bad_covered_msi_error_message()
+    {
+        $metrics = $this->createMock(MetricsCalculator::class);
+        $metrics->expects($this->once())->method('getCoveredCodeMutationScoreIndicator')->willReturn('75.0');
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects($this->once())->method('error')->with(
+            'The minimum required Covered Code MSI percentage should be 25%, but actual is 75%. Improve your tests!'
+        );
+
+        $console = new ConsoleOutput($io);
+
+        $console->logBadCoveredMsiErrorMessage($metrics, 25.0);
+    }
+}

--- a/tests/Console/LogVerbosityTest.php
+++ b/tests/Console/LogVerbosityTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Console;
 
+use Infection\Console\ConsoleOutput;
 use Infection\Console\LogVerbosity;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
@@ -21,7 +22,7 @@ class LogVerbosityTest extends MockeryTestCase
     {
         $input = $this->setInputExpectationsWhenItDoesNotChange(LogVerbosity::NORMAL);
 
-        LogVerbosity::convertVerbosityLevel($input, Mockery::mock(SymfonyStyle::class));
+        LogVerbosity::convertVerbosityLevel($input, new ConsoleOutput(Mockery::mock(SymfonyStyle::class)));
     }
 
     /**
@@ -38,7 +39,7 @@ class LogVerbosityTest extends MockeryTestCase
             ->withArgs(['Numeric versions of log-verbosity have been deprecated, please use, ' . $output . ' to keep the same result'])
             ->once();
 
-        LogVerbosity::convertVerbosityLevel($input, $io);
+        LogVerbosity::convertVerbosityLevel($input, new ConsoleOutput($io));
     }
 
     public function provideConvertedLogVerbosity()
@@ -64,10 +65,10 @@ class LogVerbosityTest extends MockeryTestCase
         $input = $this->setInputExpectationsWhenItDoesChange('asdf', LogVerbosity::NORMAL);
         $io = Mockery::mock(SymfonyStyle::class);
         $io->shouldReceive('note')
-            ->withArgs(['Running infection with an unknown log-verbosity option, falling back to \'default\' option'])
+            ->withArgs(['Running infection with an unknown log-verbosity option, falling back to default option'])
             ->once();
 
-        LogVerbosity::convertVerbosityLevel($input, $io);
+        LogVerbosity::convertVerbosityLevel($input, new ConsoleOutput($io));
     }
 
     /**


### PR DESCRIPTION
This PR:

Extracts console output logic from the `InfectionCommand` class into its own class.
