### PR TITLE
Run a test framework executable as it is

### DIFF
--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -96,7 +96,12 @@ class TestFrameworkFinder extends AbstractExecutableFinder
             return $this->customPath;
         }
 
-        $candidates = [$this->testFrameworkName, $this->testFrameworkName . '.phar'];
+        $candidates = [
+            $this->testFrameworkName,
+            $this->testFrameworkName . '.phar',
+            $this->testFrameworkName . '.bat',
+        ];
+
         $finder = new ExecutableFinder();
 
         foreach ($candidates as $name) {

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -136,6 +136,23 @@ abstract class AbstractTestFrameworkAdapter
             );
         }
 
+        /*
+         * Run an executable as it is if we're using a standard CLI and
+         * there's a standard interpreter available on PATH.
+         *
+         * This lets folks use, say, a bash wrapper over phpunit.
+         */
+        if ('cli' == PHP_SAPI && empty($phpExtraArgs) && is_executable($frameworkPath) && `command -v php`) {
+            return sprintf(
+                '%s %s',
+                'exec',
+                $frameworkPath
+            );
+        }
+
+        /*
+         * In all other cases run it with a choosen PHP interpreter
+         */
         return sprintf(
             '%s %s %s %s',
             'exec',

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -151,7 +151,7 @@ abstract class AbstractTestFrameworkAdapter
         }
 
         /*
-         * In all other cases run it with a choosen PHP interpreter
+         * In all other cases run it with a chosen PHP interpreter
          */
         return sprintf(
             '%s %s %s %s',

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/README.md
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/README.md
@@ -1,0 +1,7 @@
+# PHPUnit executable is not always a PHP script
+
+Relevant issues:
+
+https://github.com/infection/infection/issues/300
+https://github.com/infection/infection/issues/351
+

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/composer.json
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Namespace_\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Namespace_\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/expected-output.txt
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/infection.json
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/infection.json
@@ -1,0 +1,11 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection-log.txt"
+    }
+}

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/phpunit.bat
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/phpunit.bat
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+# Checking for this file we can see if our wrapper was really used
+touch phpunit.bat.canary
+
+vendor/bin/phpunit-actual "$@"

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/phpunit.xml
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/run_tests.bash
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/run_tests.bash
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -e
+
+tputx () {
+    test -x $(which tput) && tput "$@"
+}
+
+run () {
+    local INFECTION=${1}
+    local PHPARGS=${2}
+
+    if [ "$PHPDBG" = "1" ]
+    then
+        phpdbg $PHPARGS -qrr $INFECTION
+    else
+        php $PHPARGS $INFECTION
+    fi
+}
+
+cd $(dirname "$0")
+
+if [ "$PHPDBG" = "1" ]
+then
+    tputx bold
+    echo "Will be using phpdbg"
+    tputx sgr0
+fi
+
+if [ -e vendor/bin/phpunit ]
+then
+    tputx bold
+    echo "Switching to our wrapper..."
+    mv -v vendor/bin/phpunit vendor/bin/phpunit-actual
+    tputx sgr0
+fi
+
+rm -f phpunit.bat.canary
+
+run "../../../../bin/infection --quiet"
+diff -w expected-output.txt infection-log.txt
+
+test -f phpunit.bat.canary && rm phpunit.bat.canary
+
+tputx bold
+echo "Success!"
+tputx sgr0

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Namespace_;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Namespace_\Test;
+
+use Namespace_\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}


### PR DESCRIPTION
Run a test framework executable as it is if we're using a standard CLI, and there's a standard interpreter available on PATH.

This lets folks use, say, a bash wrapper over phpunit.

Fixes #300

- [x] E2E test added