### PR TITLE
Add php unit cs fixer rules

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -22,7 +22,7 @@ return \PhpCsFixer\Config::create()
         '@Symfony:risky' => true,
         '@PHP70Migration' => true,
         '@PHP70Migration:risky' => true,
-
+        '@PHPUnit60Migration:risky' => true,
         'concat_space' => ['spacing' => 'one'],
         'header_comment' => [
             'commentType' => 'PHPDoc',
@@ -41,6 +41,12 @@ return \PhpCsFixer\Config::create()
         'ordered_imports' => true,
         'phpdoc_align' => false,
         'phpdoc_summary' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
+        'php_unit_strict' => true,
+        'php_unit_test_annotation' => [
+            'style' => 'prefix',
+            'case' => 'snake',
+        ],
         'yoda_style' => false,
     ])
     ->setFinder($finder)

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -162,7 +162,8 @@ final class ProjectCodeTest extends TestCase
         }
 
         $this->assertInternalType(
-            'string', $docBlock,
+            'string',
+            $docBlock,
             sprintf(
                 'The "%s" class is not an extension point, and should be marked as internal.',
                 $className
@@ -302,7 +303,8 @@ final class ProjectCodeTest extends TestCase
         $docBlock = $rc->getDocComment();
 
         $this->assertInternalType(
-            'string', $docBlock,
+            'string',
+            $docBlock,
             sprintf(
                 'Test class  "%s" must be marked internal.',
                 $className

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -161,8 +161,8 @@ final class ProjectCodeTest extends TestCase
             return;
         }
 
-        $this->assertTrue(
-            is_string($docBlock),
+        $this->assertInternalType(
+            'string', $docBlock,
             sprintf(
                 'The "%s" class is not an extension point, and should be marked as internal.',
                 $className
@@ -301,8 +301,8 @@ final class ProjectCodeTest extends TestCase
         $rc = new \ReflectionClass($className);
         $docBlock = $rc->getDocComment();
 
-        $this->assertTrue(
-            is_string($docBlock),
+        $this->assertInternalType(
+            'string', $docBlock,
             sprintf(
                 'Test class  "%s" must be marked internal.',
                 $className

--- a/tests/Config/Guesser/SourceDirGuesserTest.php
+++ b/tests/Config/Guesser/SourceDirGuesserTest.php
@@ -92,15 +92,14 @@ JSON;
         $this->assertSame(['sources', 'libs'], $guesser->guess());
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage autoload section does not match the expected JSON schema
-     */
     public function test_it_throw_invalid_autoload_exception()
     {
         $guesser = new SourceDirGuesser(
             json_decode('{"autoload":{"psr-4": [{"NameSpace\\//": ["sources", "libs"]}]}}')
         );
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('autoload section does not match the expected JSON schema');
 
         $guesser->guess();
     }

--- a/tests/Config/InfectionConfigTest.php
+++ b/tests/Config/InfectionConfigTest.php
@@ -198,7 +198,7 @@ JSON;
             '/path/to/config'
         );
 
-        $this->assertEquals($result, $testSubject->{$methodName}());
+        $this->assertSame($result, $testSubject->{$methodName}());
     }
 
     public function configDataProvider(): \Generator

--- a/tests/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
+++ b/tests/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
@@ -14,6 +14,7 @@ use Infection\Config\ValueProvider\PhpUnitCustomExecutablePathProvider;
 use Infection\Finder\Exception\FinderException;
 use Infection\Finder\TestFrameworkFinder;
 use Mockery;
+use Symfony\Component\Console\Exception\RuntimeException as SymfonyRuntimeException;
 use function Infection\Tests\normalizePath as p;
 
 /**
@@ -61,9 +62,6 @@ final class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProvider
         $this->assertSame($customExecutable, $path);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
-     */
     public function test_validates_incorrect_dir()
     {
         if (!$this->hasSttyAvailable()) {
@@ -82,6 +80,8 @@ final class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProvider
             $consoleMock,
             $this->getQuestionHelper()
         );
+
+        $this->expectException(SymfonyRuntimeException::class);
 
         $provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("abc\n")),

--- a/tests/Config/ValueProvider/SourceDirsProviderTest.php
+++ b/tests/Config/ValueProvider/SourceDirsProviderTest.php
@@ -107,9 +107,6 @@ final class SourceDirsProviderTest extends AbstractBaseProviderTest
         $this->assertSame(['.'], $sourceDirs);
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function test_it_throws_exception_when_current_dir_is_selected_with_another_dir()
     {
         $consoleMock = Mockery::mock(ConsoleHelper::class);
@@ -121,6 +118,8 @@ final class SourceDirsProviderTest extends AbstractBaseProviderTest
         $sourceDirGuesser->method('guess')->willReturn(['src']);
 
         $provider = new SourceDirsProvider($consoleMock, $dialog, $sourceDirGuesser);
+
+        $this->expectException(\LogicException::class);
 
         $provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("0,1\n")),

--- a/tests/Config/ValueProvider/TimeoutProviderTest.php
+++ b/tests/Config/ValueProvider/TimeoutProviderTest.php
@@ -55,7 +55,6 @@ final class TimeoutProviderTest extends AbstractBaseProviderTest
 
     /**
      * @dataProvider validatorProvider
-     * @expectedException \RuntimeException
      */
     public function test_it_does_not_allow_invalid_values($inputValue)
     {
@@ -65,6 +64,8 @@ final class TimeoutProviderTest extends AbstractBaseProviderTest
         $dialog = $this->getQuestionHelper();
 
         $provider = new TimeoutProvider($consoleMock, $dialog);
+
+        $this->expectException(\RuntimeException::class);
 
         $timeout = $provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("{$inputValue}\n")),

--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -127,7 +127,7 @@ final class E2ETest extends TestCase
 
     private function runOnE2EFixture($path): string
     {
-        $this->assertTrue(is_dir($path));
+        $this->assertDirectoryExists($path);
         chdir($path);
 
         $this->installComposerDeps();
@@ -242,7 +242,7 @@ final class E2ETest extends TestCase
         $exitCode = $application->run($input, $output);
 
         // Leaving window open to negative tests (e.g. where Infection is expected to fail)
-        $this->assertEquals($expectedExitCode, $exitCode, "Unexpected exit code. Check with command's output for details.");
+        $this->assertSame($expectedExitCode, $exitCode, "Unexpected exit code. Check with command's output for details.");
 
         return $output->fetch();
     }

--- a/tests/Finder/TestFrameworkFinderTest.php
+++ b/tests/Finder/TestFrameworkFinderTest.php
@@ -49,7 +49,7 @@ final class TestFrameworkFinderTest extends TestCase
 
         $frameworkFinder = new TestFrameworkFinder('not-used', $filename);
 
-        $this->assertEquals($filename, $frameworkFinder->find(), 'Should return the custom path');
+        $this->assertSame($filename, $frameworkFinder->find(), 'Should return the custom path');
     }
 
     public function test_invalid_custom_path_throws_exception()

--- a/tests/Mutant/MutantCreatorTest.php
+++ b/tests/Mutant/MutantCreatorTest.php
@@ -28,7 +28,7 @@ final class MutantCreatorTest extends MockeryTestCase
      */
     private $directory;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->directory = \sys_get_temp_dir() . '/infection/MutantCreator';
@@ -42,7 +42,7 @@ PHP
 );
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
         unlink($this->directory . self::TEST_FILE_NAME);

--- a/tests/Mutator/Util/AbstractValueToNullReturnValueTest.php
+++ b/tests/Mutator/Util/AbstractValueToNullReturnValueTest.php
@@ -21,7 +21,7 @@ final class AbstractValueToNullReturnValueTest extends TestCase
 {
     protected $testSubject = null;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->testSubject = $this->getMockBuilder(AbstractValueToNullReturnValue::class)
             ->disableOriginalConstructor()

--- a/tests/TestFramework/Coverage/CodeCoverageDataTest.php
+++ b/tests/TestFramework/Coverage/CodeCoverageDataTest.php
@@ -12,6 +12,7 @@ namespace Infection\Tests\TestFramework\Coverage;
 use Infection\Mutation;
 use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
+use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\TestFrameworkTypes;
 use Mockery;
@@ -171,14 +172,13 @@ final class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $this->assertCount(6, $codeCoverageData->getAllTestsFor($mutation));
     }
 
-    /**
-     * @expectedException \Infection\TestFramework\Coverage\CoverageDoesNotExistException
-     */
     public function test_it_throws_an_exception_when_no_coverage_found()
     {
         $coverageXmlParserMock = Mockery::mock(CoverageXmlParser::class);
 
         $coverage = new CodeCoverageData('/abc', $coverageXmlParserMock, TestFrameworkTypes::PHPUNIT);
+
+        $this->expectException(CoverageDoesNotExistException::class);
 
         $coverage->hasTests('/abc/def.php');
     }

--- a/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
+++ b/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
@@ -11,6 +11,7 @@ namespace Infection\Tests\TestFramework\PhpSpec\Config;
 
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\PhpSpec\Config\InitialYamlConfiguration;
+use Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 
@@ -40,32 +41,26 @@ final class InitialYamlConfigurationTest extends TestCase
         return new InitialYamlConfiguration($this->tempDir, $configArray ?: $this->defaultConfig, $skipCoverage);
     }
 
-    /**
-     * @expectedException \Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException
-     */
     public function test_it_throws_exception_when_extensions_array_is_empty()
     {
         $configuration = $this->getConfigurationObject(['extensions' => []]);
+        $this->expectException(NoCodeCoverageException::class);
 
         $configuration->getYaml();
     }
 
-    /**
-     * @expectedException \Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException
-     */
     public function test_it_throws_exception_when_extensions_array_is_not_present()
     {
         $configuration = $this->getConfigurationObject(['bootstrap' => '/path/to/adc']);
+        $this->expectException(NoCodeCoverageException::class);
 
         $configuration->getYaml();
     }
 
-    /**
-     * @expectedException \Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException
-     */
     public function test_it_throws_exception_when_no_extensions_have_no_coverage_one()
     {
         $configuration = $this->getConfigurationObject(['extensions' => ['a' => []]]);
+        $this->expectException(NoCodeCoverageException::class);
 
         $configuration->getYaml();
     }

--- a/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -187,7 +187,7 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
         $configurationPath = $this->builder->build($this->mutant);
 
-        $this->assertEquals(1, $this->queryXpath(file_get_contents($configurationPath), '/phpunit/testsuite')->length);
+        $this->assertSame(1, $this->queryXpath(file_get_contents($configurationPath), '/phpunit/testsuite')->length);
     }
 
     public function test_it_removes_original_loggers()

--- a/tests/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProviderTest.php
+++ b/tests/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProviderTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpUnit\Coverage;
 
+use Infection\TestFramework\Coverage\TestFileNameNotFoundException;
 use Infection\TestFramework\PhpUnit\Coverage\PhpUnitTestFileDataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -29,11 +30,10 @@ final class PhpUnitTestFileDataProviderTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Infection\TestFramework\Coverage\TestFileNameNotFoundException
-     */
     public function test_it_throws_an_exception_if_class_is_not_found()
     {
+        $this->expectException(TestFileNameNotFoundException::class);
+
         $this->infoProvider->getTestFileInfo('abc');
     }
 

--- a/tests/Utils/VersionParserTest.php
+++ b/tests/Utils/VersionParserTest.php
@@ -37,11 +37,10 @@ final class VersionParserTest extends TestCase
         $this->assertSame($expectedVersion, $result);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function test_it_throws_exception_when_content_has_no_version_substring()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->versionParser->parse('abc');
     }
 


### PR DESCRIPTION
Adding these rules will cut down the number of inconsistencies within
our test suite.

This PR:

- [x] Adds new php-cs-fixer rules for phpunit tests.

The following rules got added:
* `php_unit_set_up_tear_down_visibility` 
> Changes the visibility of the `setUp()` and `tearDown()` functions of PHPUnit to protected, to match the PHPUnit TestCase.

* `php_unit_strict`
> PHPUnit methods like `assertSame` should be used instead of `assertEquals`.

* `php_unit_test_annotation`   Configured to prefix methods with `@test` and to use snake case.
> Adds or removes `@test` annotations from tests, following configuration.

```bash
$ ./php-cs-fixer-v2.phar describe @PHPUnit60Migration:risky 
Description of @PHPUnit60Migration:risky set.

 * php_unit_dedicate_assert risky
   | PHPUnit assertions like "assertInternalType", "assertFileExists", should be used over "assertTrue".
   | Configuration: ['target' => '5.6']

 * php_unit_expectation risky
   | Usages of `->setExpectedException*` methods MUST be replaced by `->expectException*` methods.
   | Configuration: ['target' => '5.6']

 * php_unit_mock risky
   | Usages of `->getMock` and `->getMockWithoutInvokingTheOriginalConstructor` methods MUST be replaced by `->createMock` or `->createPartialMock` methods.
   | Configuration: ['target' => '5.5']

 * php_unit_namespaced risky
   | PHPUnit classes MUST be used in namespaced version, eg `\PHPUnit\Framework\TestCase` instead of `\PHPUnit_Framework_TestCase`.
   | Configuration: ['target' => '6.0']

 * php_unit_no_expectation_annotation risky
   | Usages of `@expectedException*` annotations MUST be replaced by `->setExpectedException*` methods.
   | Configuration: ['target' => '4.3']
```

This means we are using all phpunit rules of php-cs-fixer, except those related to covers annotation.