### PR TITLE
Add infection-log.txt as a build artifact on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@ platform:
   - x64
 clone_folder: c:\projects\workspace
 
+artifacts:
+  - path: infection-log.txt
+
 environment:
   matrix:
   - dependencies: highest
@@ -68,7 +71,7 @@ install:
 test_script:
     - cd c:\projects\workspace
     - vendor\bin\phpunit --coverage-clover=clover.xml --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml
-    - php bin/infection --threads=4 --log-verbosity=none --coverage=coverage
+    - php bin/infection --threads=4 --coverage=coverage
 
 after_test:
   - ps: |


### PR DESCRIPTION
This is a try to add `infection-log.txt` as a build artifact on AppVeyor

It should help debugging windows failures from https://github.com/infection/infection/issues/351

Documentation: https://www.appveyor.com/docs/packaging-artifacts/
Config example: https://www.appveyor.com/docs/appveyor-yml/