### PR TITLE
Look for .bat on Windows first

### DIFF
--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -99,8 +99,16 @@ class TestFrameworkFinder extends AbstractExecutableFinder
         $candidates = [
             $this->testFrameworkName,
             $this->testFrameworkName . '.phar',
-            $this->testFrameworkName . '.bat',
         ];
+
+        /*
+         * There's a glitch where ExecutableFinder would find a non-executable
+         * file on Windows, even if there's a proper executable .bat by its side.
+         * Therefore we have to explicitly look for a .bat.
+         */
+        if ('\\' == DIRECTORY_SEPARATOR) {
+            array_unshift($candidates, $this->testFrameworkName . '.bat');
+        }
 
         $finder = new ExecutableFinder();
 

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -123,7 +123,7 @@ abstract class AbstractTestFrameworkAdapter
     {
         $frameworkPath = realpath($frameworkPath);
 
-        if (\defined('PHP_WINDOWS_VERSION_BUILD')) {
+        if ('\\' == DIRECTORY_SEPARATOR) {
             if (false !== strpos($frameworkPath, '.bat')) {
                 return $frameworkPath;
             }


### PR DESCRIPTION
In response to https://github.com/infection/infection/issues/351#issuecomment-389636843

Fixes #351

Related PR: https://github.com/symfony/symfony/pull/27303

(backslash check is pretty standard way to check for a Windows build, e.g. see https://github.com/symfony/symfony/commit/559273ec1c8d8b00156a36b13230a82f3d3b554c)