### PR TITLE
Clean up after Mutation testing has been finished

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -29,6 +29,7 @@ use Infection\Process\Listener\InitialTestsConsoleLoggerSubscriber;
 use Infection\Process\Listener\MutantCreatingConsoleLoggerSubscriber;
 use Infection\Process\Listener\MutationGeneratingConsoleLoggerSubscriber;
 use Infection\Process\Listener\MutationTestingConsoleLoggerSubscriber;
+use Infection\Process\Listener\CleanUpAfterMutationTestingFinishedSubscriber;
 use Infection\Process\Listener\MutationTestingResultsLoggerSubscriber;
 use Infection\Process\Runner\InitialTestsRunner;
 use Infection\Process\Runner\MutationTestingRunner;
@@ -355,6 +356,10 @@ final class InfectionCommand extends BaseCommand
                 $metricsCalculator,
                 $this->getContainer()->get('filesystem'),
                 $this->input->getOption('log-verbosity')
+            ),
+            new CleanUpAfterMutationTestingFinishedSubscriber(
+                $this->getContainer()->get('filesystem'),
+                $this->getContainer()->get('tmp.dir')
             ),
         ];
     }

--- a/src/EventDispatcher/EventSubscriberInterface.php
+++ b/src/EventDispatcher/EventSubscriberInterface.php
@@ -14,8 +14,5 @@ namespace Infection\EventDispatcher;
  */
 interface EventSubscriberInterface
 {
-    /**
-     * @return array
-     */
-    public function getSubscribedEvents();
+    public function getSubscribedEvents(): array;
 }

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -35,18 +35,25 @@ abstract class FileLogger implements MutationTestingResultsLogger
     /**
      * @var bool
      */
+    protected $isDebugVerbosity;
+
+    /**
+     * @var bool
+     */
     protected $isDebugMode;
 
     public function __construct(
         string $logFilePath,
         MetricsCalculator $metricsCalculator,
         Filesystem $fs,
+        bool $isDebugVerbosity,
         bool $isDebugMode
     ) {
+        $this->logFilePath = $logFilePath;
         $this->metricsCalculator = $metricsCalculator;
         $this->fs = $fs;
+        $this->isDebugVerbosity = $isDebugVerbosity;
         $this->isDebugMode = $isDebugMode;
-        $this->logFilePath = $logFilePath;
     }
 
     public function log()

--- a/src/Logger/SummaryFileLogger.php
+++ b/src/Logger/SummaryFileLogger.php
@@ -16,15 +16,13 @@ final class SummaryFileLogger extends FileLogger
 {
     protected function getLogLines(): array
     {
-        $logs = [];
-
-        $logs[] = 'Total: ' . $this->metricsCalculator->getTotalMutantsCount();
-        $logs[] = 'Killed: ' . $this->metricsCalculator->getKilledCount();
-        $logs[] = 'Errored: ' . $this->metricsCalculator->getErrorCount();
-        $logs[] = 'Escaped: ' . $this->metricsCalculator->getEscapedCount();
-        $logs[] = 'Timed Out: ' . $this->metricsCalculator->getTimedOutCount();
-        $logs[] = 'Not Covered: ' . $this->metricsCalculator->getNotCoveredByTestsCount();
-
-        return $logs;
+        return [
+            'Total: ' . $this->metricsCalculator->getTotalMutantsCount(),
+            'Killed: ' . $this->metricsCalculator->getKilledCount(),
+            'Errored: ' . $this->metricsCalculator->getErrorCount(),
+            'Escaped: ' . $this->metricsCalculator->getEscapedCount(),
+            'Timed Out: ' . $this->metricsCalculator->getTimedOutCount(),
+            'Not Covered: ' . $this->metricsCalculator->getNotCoveredByTestsCount(),
+        ];
     }
 }

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -21,7 +21,7 @@ final class TextFileLogger extends FileLogger
         $logs[] = $this->getLogParts($this->metricsCalculator->getEscapedMutantProcesses(), 'Escaped');
         $logs[] = $this->getLogParts($this->metricsCalculator->getTimedOutProcesses(), 'Timeout');
 
-        if ($this->isDebugMode) {
+        if ($this->isDebugVerbosity) {
             $logs[] = $this->getLogParts($this->metricsCalculator->getKilledMutantProcesses(), 'Killed');
             $logs[] = $this->getLogParts($this->metricsCalculator->getErrorProcesses(), 'Errors');
         }
@@ -42,11 +42,13 @@ final class TextFileLogger extends FileLogger
         $logParts = $this->getHeadlineParts($headlinePrefix);
 
         foreach ($processes as $index => $mutantProcess) {
-            $isShowFullFormat = $this->isDebugMode && $mutantProcess->getProcess()->isStarted();
+            $isShowFullFormat = $this->isDebugVerbosity && $mutantProcess->getProcess()->isStarted();
 
             $logParts[] = '';
             $logParts[] = $this->getMutatorFirstLine($index, $mutantProcess);
-            $logParts[] = $isShowFullFormat ? $mutantProcess->getProcess()->getCommandLine() : '';
+
+            $logParts[] = $this->isDebugMode ? $mutantProcess->getProcess()->getCommandLine() : '';
+
             $logParts[] = $mutantProcess->getMutant()->getDiff();
 
             if ($isShowFullFormat) {

--- a/src/Mutant/MutantCreator.php
+++ b/src/Mutant/MutantCreator.php
@@ -70,6 +70,10 @@ final class MutantCreator
 
     private function createMutatedCode(MutationInterface $mutation, string $mutatedFilePath): string
     {
+        if (file_exists($mutatedFilePath)) {
+            return file_get_contents($mutatedFilePath);
+        }
+
         $traverser = new NodeTraverser();
 
         $traverser->addVisitor(new CloneVisitor());

--- a/src/Mutant/MutantCreator.php
+++ b/src/Mutant/MutantCreator.php
@@ -70,9 +70,6 @@ final class MutantCreator
 
     private function createMutatedCode(MutationInterface $mutation, string $mutatedFilePath): string
     {
-        if (file_exists($mutatedFilePath)) {
-            return file_get_contents($mutatedFilePath);
-        }
         $traverser = new NodeTraverser();
 
         $traverser->addVisitor(new CloneVisitor());

--- a/src/Process/Listener/CleanUpAfterMutationTestingFinishedSubscriber.php
+++ b/src/Process/Listener/CleanUpAfterMutationTestingFinishedSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Process\Listener;
+
+use Infection\EventDispatcher\EventSubscriberInterface;
+use Infection\Events\MutationTestingFinished;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class CleanUpAfterMutationTestingFinishedSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string
+     */
+    private $tmpDir;
+
+    public function __construct(Filesystem $filesystem, string $tmpDir)
+    {
+        $this->filesystem = $filesystem;
+        $this->tmpDir = $tmpDir;
+    }
+
+    public function getSubscribedEvents(): array
+    {
+        return [
+            MutationTestingFinished::class => [$this, 'onMutationTestingFinished'],
+        ];
+    }
+
+    public function onMutationTestingFinished(MutationTestingFinished $event)
+    {
+        $this->filesystem->remove($this->tmpDir);
+    }
+}

--- a/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
@@ -44,7 +44,7 @@ final class InitialTestsConsoleLoggerSubscriber implements EventSubscriberInterf
         $this->testFrameworkAdapter = $testFrameworkAdapter;
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             InitialTestSuiteStarted::class => [$this, 'onInitialTestSuiteStarted'],

--- a/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
@@ -37,11 +37,13 @@ final class InitialTestsConsoleLoggerSubscriber implements EventSubscriberInterf
      */
     private $testFrameworkAdapter;
 
-    public function __construct(OutputInterface $output, ProgressBar $progressBar, AbstractTestFrameworkAdapter $testFrameworkAdapter)
+    public function __construct(OutputInterface $output, AbstractTestFrameworkAdapter $testFrameworkAdapter)
     {
         $this->output = $output;
-        $this->progressBar = $progressBar;
         $this->testFrameworkAdapter = $testFrameworkAdapter;
+
+        $this->progressBar = new ProgressBar($this->output);
+        $this->progressBar->setFormat('verbose');
     }
 
     public function getSubscribedEvents(): array

--- a/src/Process/Listener/MutantCreatingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutantCreatingConsoleLoggerSubscriber.php
@@ -37,7 +37,7 @@ final class MutantCreatingConsoleLoggerSubscriber implements EventSubscriberInte
         $this->output = $output;
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             MutantsCreatingStarted::class => [$this, 'onMutantsCreatingStarted'],

--- a/src/Process/Listener/MutantCreatingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutantCreatingConsoleLoggerSubscriber.php
@@ -31,10 +31,12 @@ final class MutantCreatingConsoleLoggerSubscriber implements EventSubscriberInte
      */
     private $progressBar;
 
-    public function __construct(OutputInterface $output, ProgressBar $progressBar)
+    public function __construct(OutputInterface $output)
     {
-        $this->progressBar = $progressBar;
         $this->output = $output;
+
+        $this->progressBar = new ProgressBar($this->output);
+        $this->progressBar->setFormat('Creating mutated files and processes: %current%/%max%');
     }
 
     public function getSubscribedEvents(): array

--- a/src/Process/Listener/MutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationGeneratingConsoleLoggerSubscriber.php
@@ -31,10 +31,12 @@ final class MutationGeneratingConsoleLoggerSubscriber implements EventSubscriber
      */
     private $progressBar;
 
-    public function __construct(OutputInterface $output, ProgressBar $progressBar)
+    public function __construct(OutputInterface $output)
     {
         $this->output = $output;
-        $this->progressBar = $progressBar;
+
+        $this->progressBar = new ProgressBar($this->output);
+        $this->progressBar->setFormat('Processing source code files: %current%/%max%');
     }
 
     public function getSubscribedEvents(): array

--- a/src/Process/Listener/MutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationGeneratingConsoleLoggerSubscriber.php
@@ -37,7 +37,7 @@ final class MutationGeneratingConsoleLoggerSubscriber implements EventSubscriber
         $this->progressBar = $progressBar;
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             MutationGeneratingStarted::class => [$this, 'onMutationGeneratingStarted'],

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -77,7 +77,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInt
         $this->mutationCount = 0;
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             MutationTestingStarted::class => [$this, 'onMutationTestingStarted'],

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -73,8 +73,6 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInt
         $this->metricsCalculator = $metricsCalculator;
         $this->showMutations = $showMutations;
         $this->diffColorizer = $diffColorizer;
-
-        $this->mutationCount = 0;
     }
 
     public function getSubscribedEvents(): array

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -68,10 +68,7 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
         $this->logVerbosity = $logVerbosity;
     }
 
-    /**
-     * @return array
-     */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             MutationTestingFinished::class => [$this, 'onMutationTestingFinished'],

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -54,18 +54,25 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
      */
     private $output;
 
+    /**
+     * @var bool
+     */
+    private $isDebugMode;
+
     public function __construct(
         OutputInterface $output,
         InfectionConfig $infectionConfig,
         MetricsCalculator $metricsCalculator,
         Filesystem $fs,
-        string $logVerbosity = LogVerbosity::NORMAL
+        string $logVerbosity,
+        bool $isDebugMode
     ) {
         $this->output = $output;
         $this->infectionConfig = $infectionConfig;
         $this->metricsCalculator = $metricsCalculator;
         $this->fs = $fs;
         $this->logVerbosity = $logVerbosity;
+        $this->isDebugMode = $isDebugMode;
     }
 
     public function getSubscribedEvents(): array
@@ -109,14 +116,16 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
 
     private function useLogger(string $logType, $config)
     {
-        $isDebugMode = $this->logVerbosity == LogVerbosity::DEBUG;
+        $isDebugVerbosity = $this->logVerbosity == LogVerbosity::DEBUG;
+
         switch ($logType) {
             case ResultsLoggerTypes::TEXT_FILE:
                 (new TextFileLogger(
                     $config,
                     $this->metricsCalculator,
                     $this->fs,
-                    $isDebugMode
+                    $isDebugVerbosity,
+                    $this->isDebugMode
                 ))->log();
                 break;
             case ResultsLoggerTypes::SUMMARY_FILE:
@@ -124,7 +133,8 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
                     $config,
                     $this->metricsCalculator,
                     $this->fs,
-                     $isDebugMode
+                     $isDebugVerbosity,
+                    $this->isDebugMode
                 ))->log();
                 break;
             case ResultsLoggerTypes::DEBUG_FILE:
@@ -132,7 +142,8 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
                     $config,
                     $this->metricsCalculator,
                     $this->fs,
-                    $isDebugMode
+                    $isDebugVerbosity,
+                    $this->isDebugMode
                 ))->log();
                 break;
             case ResultsLoggerTypes::BADGE:
@@ -148,7 +159,8 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
                     $config,
                     $this->metricsCalculator,
                     $this->fs,
-                    $isDebugMode
+                    $isDebugVerbosity,
+                    $this->isDebugMode
                 ))->log();
                 break;
         }

--- a/tests/Finder/Iterator/RealPathFilterIteratorTest.php
+++ b/tests/Finder/Iterator/RealPathFilterIteratorTest.php
@@ -44,12 +44,12 @@ final class RealPathFilterIteratorTest extends TestCase
 
     public function providesFinders()
     {
-        yield 'RealPathFileItterator' => [
+        yield 'RealPathFileIterator' => [
             MockRealPathFinder::class,
             1,
         ];
 
-        yield 'Symfony PathFileItterator' => [
+        yield 'Symfony PathFileIterator' => [
             MockRelativePathFinder::class,
             0,
         ];

--- a/tests/Fixtures/UserEventSubscriber.php
+++ b/tests/Fixtures/UserEventSubscriber.php
@@ -13,7 +13,7 @@ class UserEventSubscriber implements EventSubscriberInterface
 {
     public $count = 0;
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             UserWasCreated::class => [$this, '__invoke'],

--- a/tests/Fixtures/e2e/Config_Bootstrap/infection.json
+++ b/tests/Fixtures/e2e/Config_Bootstrap/infection.json
@@ -8,5 +8,6 @@
     "logs": {
         "summary": "infection-log.txt"
     },
-    "bootstrap": "src/bootstrap.php"
+    "bootstrap": "src/bootstrap.php",
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Config_Framework/infection.json
+++ b/tests/Fixtures/e2e/Config_Framework/infection.json
@@ -8,5 +8,6 @@
     "logs": {
         "debug": "infection-log.txt"
     },
-    "testFramework" : "phpspec"
+    "testFramework" : "phpspec",
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Custom_tmp_dir/infection.json
+++ b/tests/Fixtures/e2e/Custom_tmp_dir/infection.json
@@ -8,5 +8,5 @@
     "logs": {
         "summary": "infection-log.txt"
     },
-    "tmpDir": "/tmp/infection-cache"
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Empty_Path/infection.json
+++ b/tests/Fixtures/e2e/Empty_Path/infection.json
@@ -7,5 +7,6 @@
     },
     "logs": {
         "summary": "infection-log.txt"
-    }
+    },
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Example_Test/infection.json
+++ b/tests/Fixtures/e2e/Example_Test/infection.json
@@ -7,5 +7,6 @@
     },
     "logs": {
         "summary": "infection-log.txt"
-    }
+    },
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Exec_Path/infection.json
+++ b/tests/Fixtures/e2e/Exec_Path/infection.json
@@ -7,5 +7,6 @@
     },
     "logs": {
         "summary": "infection-log.txt"
-    }
+    },
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/infection.json
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/infection.json
@@ -7,5 +7,6 @@
     },
     "logs": {
         "summary": "infection-log.txt"
-    }
+    },
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Memory_Limit/infection.json
+++ b/tests/Fixtures/e2e/Memory_Limit/infection.json
@@ -7,5 +7,6 @@
     },
     "logs": {
         "summary": "infection-log.txt"
-    }
+    },
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/infection.json
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/infection.json
@@ -10,5 +10,6 @@
     },
     "phpUnit": {
         "configDir": "build"
-    }
+    },
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Parameters_Coverage/infection.json
+++ b/tests/Fixtures/e2e/Parameters_Coverage/infection.json
@@ -7,5 +7,6 @@
     },
     "logs": {
         "debug": "infection-log.txt"
-    }
+    },
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/infection.json
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/infection.json
@@ -7,5 +7,6 @@
     },
     "logs": {
         "summary": "infection-log.txt"
-    }
+    },
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Profiles_Ignore_Combination/infection.json
+++ b/tests/Fixtures/e2e/Profiles_Ignore_Combination/infection.json
@@ -21,5 +21,6 @@
             ]
         },
         "TrueValue": true
-    }
+    },
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection.json
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection.json
@@ -1,6 +1,6 @@
 {
     "timeout": 25,
-    "tmpDir": "infection-cache",
+    "tmpDir": ".",
     "source": {
         "directories": [
             "src"

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/infection.json
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/infection.json
@@ -8,5 +8,6 @@
     "logs": {
         "summary": "infection-log.txt"
     },
-    "bootstrap": "./custom-autoload.php"
+    "bootstrap": "./custom-autoload.php",
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Test_Frameworks/infection.json
+++ b/tests/Fixtures/e2e/Test_Frameworks/infection.json
@@ -7,5 +7,6 @@
     },
     "logs": {
         "debug": "infection-log.txt"
-    }
+    },
+    "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Trait_Coverage/expected-output.txt
+++ b/tests/Fixtures/e2e/Trait_Coverage/expected-output.txt
@@ -4,6 +4,9 @@ Killed mutants:
 
 
 Mutator: PublicVisibility
+Line 10
+
+Mutator: PublicVisibility
 Line 7
 
 Mutator: TrueValue
@@ -14,9 +17,6 @@ Line 15
 
 Mutator: PublicVisibility
 Line 12
-
-Mutator: PublicVisibility
-Line 10
 
 Errors mutants:
 ===============

--- a/tests/Fixtures/e2e/Trait_Coverage/expected-output.txt
+++ b/tests/Fixtures/e2e/Trait_Coverage/expected-output.txt
@@ -4,9 +4,6 @@ Killed mutants:
 
 
 Mutator: PublicVisibility
-Line 10
-
-Mutator: PublicVisibility
 Line 7
 
 Mutator: TrueValue
@@ -17,6 +14,9 @@ Line 15
 
 Mutator: PublicVisibility
 Line 12
+
+Mutator: PublicVisibility
+Line 10
 
 Errors mutants:
 ===============

--- a/tests/Fixtures/e2e/Trait_Coverage/infection.json
+++ b/tests/Fixtures/e2e/Trait_Coverage/infection.json
@@ -7,5 +7,6 @@
     },
     "logs": {
         "debug": "infection-log.txt"
-    }
+    },
+    "tmpDir": "."
 }

--- a/tests/Logger/PerMutatorLoggerTest.php
+++ b/tests/Logger/PerMutatorLoggerTest.php
@@ -28,7 +28,8 @@ final class PerMutatorLoggerTest extends TestCase
     {
         $fs = $this->createMock(Filesystem::class);
         $fs->expects($this->once())
-            ->method('dumpFile')->with(
+            ->method('dumpFile')
+            ->with(
                 sys_get_temp_dir() . '/fake-file.md',
                 "# Effects per Mutator\n" .
                 "\n" .
@@ -37,10 +38,12 @@ final class PerMutatorLoggerTest extends TestCase
                 "| For_ | 15 | 10 | 0 | 0 | 0 | 67| 100|\n" .
                 '| PregQuote | 5 | 0 | 0 | 0 | 0 | 0| 0|'
             );
+
         $perMutatorLogger = new PerMutatorLogger(
             sys_get_temp_dir() . '/fake-file.md',
             $this->createMetricsCalculator(),
             $fs,
+            true,
             true
         );
 

--- a/tests/Process/Listener/CleanUpAfterMutationTestingFinishedSubscriberTest.php
+++ b/tests/Process/Listener/CleanUpAfterMutationTestingFinishedSubscriberTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Process\Listener;
+
+use Infection\Events\MutationTestingFinished;
+use Infection\Process\Listener\CleanUpAfterMutationTestingFinishedSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class CleanUpAfterMutationTestingFinishedSubscriberTest extends TestCase
+{
+    public function test_it_execute_remove_on_mutation_testing_finished()
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->expects($this->once())
+            ->method('remove');
+
+        $subscriber = new CleanUpAfterMutationTestingFinishedSubscriber($filesystem, sys_get_temp_dir());
+
+        $subscriber->onMutationTestingFinished(new MutationTestingFinished());
+    }
+}

--- a/tests/Process/Listener/InitialTestsConsoleLoggerSubscriberTest.php
+++ b/tests/Process/Listener/InitialTestsConsoleLoggerSubscriberTest.php
@@ -14,7 +14,6 @@ use Infection\Events\InitialTestSuiteStarted;
 use Infection\Process\Listener\InitialTestsConsoleLoggerSubscriber;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Mockery;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -29,20 +28,12 @@ final class InitialTestsConsoleLoggerSubscriberTest extends Mockery\Adapter\Phpu
         $output->shouldReceive('writeln');
         $output->shouldReceive('getVerbosity')->andReturn(OutputInterface::VERBOSITY_QUIET);
 
-        $progressBar = new ProgressBar($output);
-
         $testFramework = Mockery::mock(AbstractTestFrameworkAdapter::class);
         $testFramework->shouldReceive('getName')->once();
         $testFramework->shouldReceive('getVersion')->once();
 
-        $subscriber = new InitialTestsConsoleLoggerSubscriber(
-            $output,
-            $progressBar,
-            $testFramework
-        );
-
         $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber($subscriber);
+        $dispatcher->addSubscriber(new InitialTestsConsoleLoggerSubscriber($output, $testFramework));
 
         $dispatcher->dispatch(new InitialTestSuiteStarted());
     }
@@ -59,20 +50,12 @@ final class InitialTestsConsoleLoggerSubscriberTest extends Mockery\Adapter\Phpu
         ]]);
         $output->shouldReceive('getVerbosity')->andReturn(OutputInterface::VERBOSITY_QUIET);
 
-        $progressBar = new ProgressBar($output);
-
         $testFramework = Mockery::mock(AbstractTestFrameworkAdapter::class);
         $testFramework->shouldReceive('getName')->once()->andReturn('PHPUnit');
         $testFramework->shouldReceive('getVersion')->andThrow(\InvalidArgumentException::class);
 
-        $subscriber = new InitialTestsConsoleLoggerSubscriber(
-            $output,
-            $progressBar,
-            $testFramework
-        );
-
         $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber($subscriber);
+        $dispatcher->addSubscriber(new InitialTestsConsoleLoggerSubscriber($output, $testFramework));
 
         $dispatcher->dispatch(new InitialTestSuiteStarted());
     }

--- a/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
+++ b/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
@@ -16,7 +16,6 @@ use Infection\Events\MutationTestingFinished;
 use Infection\Logger\ResultsLoggerTypes;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Process\Listener\MutationTestingResultsLoggerSubscriber;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -27,22 +26,22 @@ use Symfony\Component\Filesystem\Filesystem;
 final class MutationTestingResultsLoggerSubscriberTest extends TestCase
 {
     /**
-     * @var OutputInterface|MockObject
+     * @var OutputInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $output;
 
     /**
-     * @var InfectionConfig|MockObject
+     * @var InfectionConfig|\PHPUnit_Framework_MockObject_MockObject
      */
     private $infectionConfig;
 
     /**
-     * @var Filesystem|MockObject
+     * @var Filesystem|\PHPUnit_Framework_MockObject_MockObject
      */
     private $filesystem;
 
     /**
-     * @var MetricsCalculator|MockObject
+     * @var MetricsCalculator|\PHPUnit_Framework_MockObject_MockObject
      */
     private $metricsCalculator;
 

--- a/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
+++ b/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
@@ -16,6 +16,7 @@ use Infection\Events\MutationTestingFinished;
 use Infection\Logger\ResultsLoggerTypes;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Process\Listener\MutationTestingResultsLoggerSubscriber;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -26,22 +27,22 @@ use Symfony\Component\Filesystem\Filesystem;
 final class MutationTestingResultsLoggerSubscriberTest extends TestCase
 {
     /**
-     * @var OutputInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var OutputInterface|MockObject
      */
     private $output;
 
     /**
-     * @var InfectionConfig|\PHPUnit_Framework_MockObject_MockObject
+     * @var InfectionConfig|MockObject
      */
     private $infectionConfig;
 
     /**
-     * @var Filesystem|\PHPUnit_Framework_MockObject_MockObject
+     * @var Filesystem|MockObject
      */
     private $filesystem;
 
     /**
-     * @var MetricsCalculator|\PHPUnit_Framework_MockObject_MockObject
+     * @var MetricsCalculator|MockObject
      */
     private $metricsCalculator;
 
@@ -72,7 +73,9 @@ final class MutationTestingResultsLoggerSubscriberTest extends TestCase
             $this->output,
             $this->infectionConfig,
             $this->metricsCalculator,
-            $this->filesystem
+            $this->filesystem,
+            LogVerbosity::DEBUG,
+            true
         ));
 
         $dispatcher->dispatch(new MutationTestingFinished());
@@ -115,7 +118,8 @@ final class MutationTestingResultsLoggerSubscriberTest extends TestCase
             $this->infectionConfig,
             $this->metricsCalculator,
             $this->filesystem,
-            LogVerbosity::DEBUG
+            LogVerbosity::DEBUG,
+            true
         ));
 
         $dispatcher->dispatch(new MutationTestingFinished());
@@ -155,7 +159,9 @@ final class MutationTestingResultsLoggerSubscriberTest extends TestCase
             $this->output,
             $this->infectionConfig,
             $this->metricsCalculator,
-            $this->filesystem
+            $this->filesystem,
+            LogVerbosity::NORMAL,
+            false
         ));
 
         $dispatcher->dispatch(new MutationTestingFinished());
@@ -175,7 +181,8 @@ final class MutationTestingResultsLoggerSubscriberTest extends TestCase
             $this->infectionConfig,
             $this->metricsCalculator,
             $this->filesystem,
-            LogVerbosity::NONE
+            LogVerbosity::NONE,
+            true
         ));
 
         $dispatcher->dispatch(new MutationTestingFinished());
@@ -205,7 +212,8 @@ final class MutationTestingResultsLoggerSubscriberTest extends TestCase
             $this->infectionConfig,
             $this->metricsCalculator,
             $this->filesystem,
-            LogVerbosity::DEBUG
+            LogVerbosity::DEBUG,
+            true
         ));
 
         $dispatcher->dispatch(new MutationTestingFinished());


### PR DESCRIPTION
Remove all files from the temporary dir after infection finished mutation testing.

Cover: https://github.com/infection/infection/issues/356

p.s. Doesn't cover cleanup when interrupting the command