### PR TITLE
Stop mutation of abstract methods default parameters

### DIFF
--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -72,10 +72,17 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
 
             $isOnFunctionSignature = $node->getAttribute(ReflectionVisitor::IS_ON_FUNCTION_SIGNATURE, false);
 
-            if (!$isOnFunctionSignature) {
-                if (!$node->getAttribute(ReflectionVisitor::IS_INSIDE_FUNCTION_KEY)) {
-                    continue;
-                }
+            if (!$isOnFunctionSignature
+                && !$node->getAttribute(ReflectionVisitor::IS_INSIDE_FUNCTION_KEY)
+            ) {
+                continue;
+            }
+
+            if ($isOnFunctionSignature
+                && ($methodNode = $node->getAttribute(ReflectionVisitor::FUNCTION_SCOPE_KEY))
+                && $methodNode->isAbstract()
+            ) {
+                continue;
             }
 
             $isCoveredByTest = $this->isCoveredByTest($isOnFunctionSignature, $node);

--- a/tests/Fixtures/e2e/Parameters_Coverage/expected-output.txt
+++ b/tests/Fixtures/e2e/Parameters_Coverage/expected-output.txt
@@ -1,4 +1,4 @@
-Total: 6
+Total: 5
 Killed mutants:
 ===============
 
@@ -8,9 +8,6 @@ Line 15
 
 Mutator: Identical
 Line 17
-
-Mutator: PublicVisibility
-Line 15
 
 Errors mutants:
 ===============

--- a/tests/Fixtures/e2e/Parameters_Coverage/src/AbstractSearcher.php
+++ b/tests/Fixtures/e2e/Parameters_Coverage/src/AbstractSearcher.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ParamCoverage;
+
+abstract class AbstractSearcher
+{
+    abstract public function search($value, bool $strict = false);
+}

--- a/tests/Fixtures/e2e/Parameters_Coverage/src/ArraySearcher.php
+++ b/tests/Fixtures/e2e/Parameters_Coverage/src/ArraySearcher.php
@@ -2,7 +2,7 @@
 
 namespace ParamCoverage;
 
-class ArraySearcher
+class ArraySearcher extends AbstractSearcher
 {
     private $items;
 


### PR DESCRIPTION
This PR:

- [x] Stops default parameters of abstract methods from being mutated. These are never covered by tests, so they never result in a killed mutant.
- [x] Covered by tests

```php
 abstract public function search($value, bool $strict = false);
```
Should not be mutated in any way, as it is never covered by tests