### PR TITLE
Do not decrement integer 0 when it is being compared with the result of count()

### DIFF
--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -18,7 +18,7 @@ use PhpParser\Node;
  */
 final class DecrementInteger extends Mutator
 {
-    private const COUNT_NAME = 'count';
+    const COUNT_NAME = 'count';
 
     /**
      * Decrements an integer by 1

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Mutator\Number;
 
 use Infection\Mutator\Util\Mutator;
+use Infection\Visitor\ParentConnectorVisitor;
 use PhpParser\Node;
 
 /**
@@ -31,6 +32,30 @@ final class DecrementInteger extends Mutator
 
     protected function mutatesNode(Node $node): bool
     {
-        return $node instanceof Node\Scalar\LNumber && $node->value != 1;
+        if (!$node instanceof Node\Scalar\LNumber || $node->value === 1) {
+            return false;
+        }
+
+        return !$this->isZeroComparedWithCountResult($node);
+    }
+
+    private function isZeroComparedWithCountResult(Node $node): bool
+    {
+        if ($node->value !== 0) {
+            return false;
+        }
+
+        $parentNode = $node->getAttribute(ParentConnectorVisitor::PARENT_KEY);
+
+        if (!$parentNode instanceof Node\Expr\BinaryOp\Identical
+            && !$parentNode instanceof Node\Expr\BinaryOp\NotIdentical
+            && !$parentNode instanceof Node\Expr\BinaryOp\Equal
+            && !$parentNode instanceof Node\Expr\BinaryOp\NotEqual
+            && !$parentNode instanceof Node\Expr\BinaryOp\Greater
+            && !$parentNode instanceof Node\Expr\BinaryOp\GreaterOrEqual) {
+            return false;
+        }
+
+        return $parentNode->left instanceof Node\Expr\FuncCall && $parentNode->left->name->toString() === 'count';
     }
 }

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -18,6 +18,8 @@ use PhpParser\Node;
  */
 final class DecrementInteger extends Mutator
 {
+    private const COUNT_NAME = 'count';
+
     /**
      * Decrements an integer by 1
      *
@@ -56,6 +58,17 @@ final class DecrementInteger extends Mutator
             return false;
         }
 
-        return $parentNode->left instanceof Node\Expr\FuncCall && $parentNode->left->name->toString() === 'count';
+        $isLeftPartCount = $parentNode->left instanceof Node\Expr\FuncCall
+            && $this->getLowercaseMethodName($parentNode, 'left') === self::COUNT_NAME;
+
+        $isRightPartCount = $parentNode->right instanceof Node\Expr\FuncCall
+            && $this->getLowercaseMethodName($parentNode, 'right') === self::COUNT_NAME;
+
+        return $isLeftPartCount || $isRightPartCount;
+    }
+
+    private function getLowercaseMethodName(Node $node, string $part): string
+    {
+        return strtolower($node->{$part}->name->toString());
     }
 }

--- a/tests/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/Mutator/Number/DecrementIntegerTest.php
@@ -65,6 +65,26 @@ if (count($a) === 0) {
 PHP
                 ,
             ],
+            'It does not decrement zero with yoda style when it is being compared as identical with result of count()' => [
+                <<<'PHP'
+<?php
+
+if (0 === count($a)) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It does not decrement zero with when it is being compared as identical with result of cOunT()' => [
+                <<<'PHP'
+<?php
+
+if (cOunT($a) === 0) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
             'It does not decrement zero when it is being compared as not identical with result of count()' => [
                 <<<'PHP'
 <?php
@@ -128,6 +148,24 @@ PHP
 <?php
 
 if (count($a) < -1) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It decrements zero when it is compared any other, not count() function' => [
+                <<<'PHP'
+<?php
+
+if (abs($a) === 0) {
+    echo 'bar';
+}
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+if (abs($a) === -1) {
     echo 'bar';
 }
 PHP

--- a/tests/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/Mutator/Number/DecrementIntegerTest.php
@@ -55,6 +55,102 @@ if ($foo < 1) {
 PHP
                 ,
             ],
+            'It does not decrement zero when it is being compared as identical with result of count()' => [
+                <<<'PHP'
+<?php
+
+if (count($a) === 0) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It does not decrement zero when it is being compared as not identical with result of count()' => [
+                <<<'PHP'
+<?php
+
+if (count($a) !== 0) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It does not decrement zero when it is compared as equal with result of count()' => [
+                <<<'PHP'
+<?php
+
+if (count($a) == 0) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It does not decrement zero when it is compared as not equal with result of count()' => [
+                <<<'PHP'
+<?php
+
+if (count($a) != 0) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It does not decrement zero when it is compared as more than count()' => [
+                <<<'PHP'
+<?php
+
+if (count($a) > 0) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It does not decrement zero when it is compared as more or equal than count()' => [
+                <<<'PHP'
+<?php
+
+if (count($a) >= 0) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It decrements zero when it is compared as less than count()' => [
+                <<<'PHP'
+<?php
+
+if (count($a) < 0) {
+    echo 'bar';
+}
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+if (count($a) < -1) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It decrements zero when it is compared as less or equal than count()' => [
+                <<<'PHP'
+<?php
+
+if (count($a) <= 0) {
+    echo 'bar';
+}
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+if (count($a) <= -1) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
             'It decrements zero' => [
                 <<<'PHP'
 <?php


### PR DESCRIPTION
Do not decrement integer 0 when it is being compared with the result of `count()`

Incorrect mutation:

```diff
- if (count($a) === 0) {
+ if (count($a) === -1) {
```

This PR:

- [x] Fixes https://github.com/infection/infection/issues/364
- [x] Covered by tests
