### PR TITLE
Run unit tests on PHP 7.0 on pre-push

### DIFF
--- a/devTools/pre-push
+++ b/devTools/pre-push
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make analyze && ./vendor/bin/phpunit
+make analyze && make test-unit-70


### PR DESCRIPTION
We should run unit tests on PHP 7.0 rather than PHP intalled on the host machine of the developer.

It will help to avoid situations like [this](https://github.com/infection/infection/pull/365#discussion_r192553842)
