### PR TITLE
Check `flock` exists on current OS. If not - skip it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ PHP-CS-FIXER=./php-cs-fixer-v2.phar
 PHPUNIT=vendor/bin/phpunit
 
 DOCKER_RUN=docker run -t --rm -v "$$PWD":/opt/infection -w /opt/infection
-DOCKER_RUN_70=flock devTools/*php70*.json $(DOCKER_RUN) infection_php70
-DOCKER_RUN_71=flock devTools/*php71*.json $(DOCKER_RUN) infection_php71
-DOCKER_RUN_72=flock devTools/*php72*.json $(DOCKER_RUN) infection_php72
+DOCKER_RUN_70=type -t flock && flock devTools/*php70*.json & $(DOCKER_RUN) infection_php70
+DOCKER_RUN_71=type -t flock && flock devTools/*php71*.json & $(DOCKER_RUN) infection_php71
+DOCKER_RUN_72=type -t flock && flock devTools/*php72*.json & $(DOCKER_RUN) infection_php72
 
 .PHONY: all
 #Run all checks, default when running 'make'


### PR DESCRIPTION
Now it's impossible to run for example `make test-unit-70` on MacOS because it doesn't have `flock` function

`-bash: flock: command not found`

This update checks if it exists, and if not - continues execution instead of failing with the error above.

I'm newbie in bash, so advice on how to do it better would be very useful.