### PR TITLE
Run a unit test in a separate process

### DIFF
--- a/tests/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/StreamWrapper/IncludeInterceptorTest.php
@@ -48,13 +48,17 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
          * if any of our tests fail for any reason.
          *
          * Silenced a warning here: stream_wrapper_restore(): file:// was never changed, nothing to restore
-         * (this warning will never happed in normal circumstances)
+         * (this warning will never happen in normal circumstances)
          */
         @IncludeInterceptor::disable();
 
         array_map('unlink', self::$files);
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function test_it_throws_an_exception_if_not_configured()
     {
         $this->expectException(\RuntimeException::class);


### PR DESCRIPTION
I ran tests with https://github.com/fiunchinho/phpunit-randomizer and found that `test_it_throws_an_exception_if_not_configured` had to be ran first in order to pass its test. By running it in a separate process it isn't dependent on other tests.

After the fix i ran the whole test suite 100 times with different seeds, and the include interceptor tests specifically 1000 times, but no other errors were found.