### PR TITLE
Run cs fixer

### DIFF
--- a/bin/infection
+++ b/bin/infection
@@ -39,7 +39,7 @@ if (!isset($file)) {
 require $file;
 unset($file);
 
-if (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') {
+if (\PHP_SAPI !== 'cli' && \PHP_SAPI !== 'phpdbg') {
     echo 'Warning: Infection may only be invoked from a command line', PHP_EOL;
 }
 

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -279,7 +279,7 @@ final class InfectionCommand extends BaseCommand
 
     private function applyMemoryLimitFromPhpUnitProcess(Process $process, MemoryUsageAware $adapter)
     {
-        if (PHP_SAPI == 'phpdbg') {
+        if (\PHP_SAPI == 'phpdbg') {
             // Under phpdbg we're using a system php.ini, can't add a memory limit there
             return;
         }
@@ -420,7 +420,7 @@ final class InfectionCommand extends BaseCommand
     private function hasDebuggerOrCoverageOption(): bool
     {
         return $this->skipCoverage
-            || PHP_SAPI === 'phpdbg'
+            || \PHP_SAPI === 'phpdbg'
             || \extension_loaded('xdebug')
             || XdebugHandler::getSkippedVersion()
             || $this->isXdebugIncludedInInitialTestPhpOptions();

--- a/src/Config/Guesser/SourceDirGuesser.php
+++ b/src/Config/Guesser/SourceDirGuesser.php
@@ -83,7 +83,7 @@ class SourceDirGuesser implements Guesser
         }
 
         if (is_string($path)) {
-            $dirs[] = trim($path, DIRECTORY_SEPARATOR);
+            $dirs[] = trim($path, \DIRECTORY_SEPARATOR);
         }
     }
 }

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -50,7 +50,7 @@ class InfectionConfig
     public function getPhpUnitConfigDir(): string
     {
         if (isset($this->config->phpUnit->configDir)) {
-            return $this->configLocation . DIRECTORY_SEPARATOR . $this->config->phpUnit->configDir;
+            return $this->configLocation . \DIRECTORY_SEPARATOR . $this->config->phpUnit->configDir;
         }
 
         return $this->configLocation;
@@ -122,7 +122,7 @@ class InfectionConfig
                         function ($excludeDir) use ($srcDir) {
                             return ltrim(
                                 substr_replace($excludeDir, '', 0, strlen($srcDir)),
-                                DIRECTORY_SEPARATOR
+                                \DIRECTORY_SEPARATOR
                             );
                         },
                         $unpackedPaths

--- a/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
+++ b/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
@@ -58,7 +58,7 @@ final class PhpUnitCustomExecutablePathProvider
             $question->setValidator($this->getValidator());
 
             return str_replace(
-                DIRECTORY_SEPARATOR,
+                \DIRECTORY_SEPARATOR,
                 '/',
                 $this->questionHelper->ask($input, $output, $question)
             );

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -71,8 +71,8 @@ ASCII;
 
         $this->io = new SymfonyStyle($input, $output);
 
-        if (PHP_SAPI === 'phpdbg') {
-            $this->io->writeln(sprintf(self::RUNNING_WITH_DEBUGGER_NOTE, PHP_SAPI));
+        if (\PHP_SAPI === 'phpdbg') {
+            $this->io->writeln(sprintf(self::RUNNING_WITH_DEBUGGER_NOTE, \PHP_SAPI));
         } elseif (\extension_loaded('xdebug')) {
             $this->io->writeln(sprintf(self::RUNNING_WITH_DEBUGGER_NOTE, 'xdebug'));
         }

--- a/src/Finder/Iterator/RealPathFilterIterator.php
+++ b/src/Finder/Iterator/RealPathFilterIterator.php
@@ -25,7 +25,7 @@ final class RealPathFilterIterator extends MultiplePcreFilterIterator
     {
         $filename = $this->current()->getRealPath();
 
-        if ('\\' == DIRECTORY_SEPARATOR) {
+        if ('\\' == \DIRECTORY_SEPARATOR) {
             $filename = str_replace('\\', '/', $filename);
         }
 

--- a/src/Finder/Locator.php
+++ b/src/Finder/Locator.php
@@ -44,7 +44,7 @@ final class Locator
         }
 
         foreach ($this->paths as $path) {
-            $file = $path . DIRECTORY_SEPARATOR . $name;
+            $file = $path . \DIRECTORY_SEPARATOR . $name;
 
             if ($this->filesystem->exists($file)) {
                 return realpath($file);

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -106,7 +106,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
          * file on Windows, even if there's a proper executable .bat by its side.
          * Therefore we have to explicitly look for a .bat.
          */
-        if ('\\' == DIRECTORY_SEPARATOR) {
+        if ('\\' == \DIRECTORY_SEPARATOR) {
             array_unshift($candidates, $this->testFrameworkName . '.bat');
         }
 

--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -50,7 +50,7 @@ class ProcessBuilder
         bool $skipCoverage,
         array $phpExtraOptions = []
     ): Process {
-        $includeArgs = PHP_SAPI == 'phpdbg';
+        $includeArgs = \PHP_SAPI == 'phpdbg';
 
         // If we're expecting to receive a code coverage, test process must run in a vanilla environment
         $processType = $skipCoverage ? Process::class : PhpProcess::class;

--- a/src/Process/ExecutableFinder/PhpExecutableFinder.php
+++ b/src/Process/ExecutableFinder/PhpExecutableFinder.php
@@ -20,7 +20,7 @@ final class PhpExecutableFinder extends BasePhpExecutableFinder
     {
         $arguments = [];
 
-        if ('phpdbg' == PHP_SAPI) {
+        if ('phpdbg' == \PHP_SAPI) {
             $arguments[] = '-qrr';
         }
 

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -123,7 +123,7 @@ abstract class AbstractTestFrameworkAdapter
     {
         $frameworkPath = realpath($frameworkPath);
 
-        if ('\\' == DIRECTORY_SEPARATOR) {
+        if ('\\' == \DIRECTORY_SEPARATOR) {
             if (false !== strpos($frameworkPath, '.bat')) {
                 return $frameworkPath;
             }
@@ -142,7 +142,7 @@ abstract class AbstractTestFrameworkAdapter
          *
          * This lets folks use, say, a bash wrapper over phpunit.
          */
-        if ('cli' == PHP_SAPI && empty($phpExtraArgs) && is_executable($frameworkPath) && `command -v php`) {
+        if ('cli' == \PHP_SAPI && empty($phpExtraArgs) && is_executable($frameworkPath) && `command -v php`) {
             return sprintf(
                 '%s %s',
                 'exec',

--- a/tests/AutoReview/MutatorTest.php
+++ b/tests/AutoReview/MutatorTest.php
@@ -122,7 +122,7 @@ final class MutatorTest extends TestCase
                 return sprintf(
                     '%s\\%s%s%s',
                     'Infection\\Mutator',
-                    strtr($file->getRelativePath(), DIRECTORY_SEPARATOR, '\\'),
+                    strtr($file->getRelativePath(), \DIRECTORY_SEPARATOR, '\\'),
                     $file->getRelativePath() ? '\\' : '',
                     $file->getBasename('.' . $file->getExtension())
                 );

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -503,7 +503,7 @@ final class ProjectCodeTest extends TestCase
                 return sprintf(
                     '%s\\%s%s%s',
                     'Infection',
-                    strtr($file->getRelativePath(), DIRECTORY_SEPARATOR, '\\'),
+                    strtr($file->getRelativePath(), \DIRECTORY_SEPARATOR, '\\'),
                     $file->getRelativePath() ? '\\' : '',
                     $file->getBasename('.' . $file->getExtension())
                 );
@@ -548,7 +548,7 @@ final class ProjectCodeTest extends TestCase
             static function (SplFileInfo $file) {
                 return sprintf(
                     'Infection\\Tests\\%s%s%s',
-                    strtr($file->getRelativePath(), DIRECTORY_SEPARATOR, '\\'),
+                    strtr($file->getRelativePath(), \DIRECTORY_SEPARATOR, '\\'),
                     $file->getRelativePath() ? '\\' : '',
                     $file->getBasename('.' . $file->getExtension())
                 );

--- a/tests/Config/ValueProvider/ExcludeDirsProviderTest.php
+++ b/tests/Config/ValueProvider/ExcludeDirsProviderTest.php
@@ -93,8 +93,8 @@ final class ExcludeDirsProviderTest extends AbstractBaseProviderTest
             $this->markTestSkipped('Stty is not available');
         }
 
-        $dir1 = $this->workspace . DIRECTORY_SEPARATOR . 'test' . DIRECTORY_SEPARATOR;
-        $dir2 = $this->workspace . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR;
+        $dir1 = $this->workspace . \DIRECTORY_SEPARATOR . 'test' . \DIRECTORY_SEPARATOR;
+        $dir2 = $this->workspace . \DIRECTORY_SEPARATOR . 'foo' . \DIRECTORY_SEPARATOR;
 
         \mkdir($dir1);
         \mkdir($dir2);

--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -223,7 +223,7 @@ final class E2ETest extends TestCase
 
     private function runInfection(int $expectedExitCode, array $argvExtra = []): string
     {
-        if (!extension_loaded('xdebug') && PHP_SAPI !== 'phpdbg') {
+        if (!extension_loaded('xdebug') && \PHP_SAPI !== 'phpdbg') {
             $this->markTestSkipped("Infection from within PHPUnit won't run without xdebug or phpdbg");
         }
 

--- a/tests/Finder/TestFrameworkFinderTest.php
+++ b/tests/Finder/TestFrameworkFinderTest.php
@@ -38,7 +38,7 @@ final class TestFrameworkFinderTest extends TestCase
 
     protected function setUp()
     {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->workspace = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
 
         $this->fileSystem = new Filesystem();
         $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -20,5 +20,5 @@ namespace Infection\Tests;
  */
 function normalizePath(string $value): string
 {
-    return str_replace(DIRECTORY_SEPARATOR, '/', $value);
+    return str_replace(\DIRECTORY_SEPARATOR, '/', $value);
 }

--- a/tests/Mutator/Arithmetic/DecrementTest.php
+++ b/tests/Mutator/Arithmetic/DecrementTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Infection\Mutator\Arithmetic\Decrement;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**

--- a/tests/Mutator/Arithmetic/DivisionTest.php
+++ b/tests/Mutator/Arithmetic/DivisionTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Infection\Mutator\Arithmetic\Division;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**

--- a/tests/Mutator/Arithmetic/IncrementTest.php
+++ b/tests/Mutator/Arithmetic/IncrementTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Infection\Mutator\Arithmetic\Increment;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**

--- a/tests/Mutator/Arithmetic/MinusTest.php
+++ b/tests/Mutator/Arithmetic/MinusTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Infection\Mutator\Arithmetic\Minus;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**

--- a/tests/Mutator/Arithmetic/MultiplicationTest.php
+++ b/tests/Mutator/Arithmetic/MultiplicationTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Infection\Mutator\Arithmetic\Multiplication;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**

--- a/tests/Mutator/Arithmetic/PlusTest.php
+++ b/tests/Mutator/Arithmetic/PlusTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Infection\Mutator\Arithmetic\Plus;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;

--- a/tests/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\FunctionSignature;
 
-use Infection\Mutator\FunctionSignature\ProtectedVisibility;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**

--- a/tests/Mutator/FunctionSignature/PublicVisibilityTest.php
+++ b/tests/Mutator/FunctionSignature/PublicVisibilityTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\FunctionSignature;
 
-use Infection\Mutator\FunctionSignature\PublicVisibility;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**

--- a/tests/Mutator/ReturnValue/FunctionCallTest.php
+++ b/tests/Mutator/ReturnValue/FunctionCallTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ReturnValue;
 
-use Infection\Mutator\ReturnValue\FunctionCall;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**

--- a/tests/Mutator/ReturnValue/NewObjectTest.php
+++ b/tests/Mutator/ReturnValue/NewObjectTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ReturnValue;
 
-use Infection\Mutator\ReturnValue\NewObject;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**

--- a/tests/Mutator/ReturnValue/ThisTest.php
+++ b/tests/Mutator/ReturnValue/ThisTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ReturnValue;
 
-use Infection\Mutator\ReturnValue\This;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**

--- a/tests/Mutator/Sort/SpaceshipTest.php
+++ b/tests/Mutator/Sort/SpaceshipTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Sort;
 
-use Infection\Mutator\Sort\Spaceship;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**

--- a/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
+++ b/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
@@ -21,7 +21,7 @@ final class PhpExecutableFinderTest extends TestCase
     {
         $finder = new PhpExecutableFinder();
 
-        if ('phpdbg' == PHP_SAPI) {
+        if ('phpdbg' == \PHP_SAPI) {
             $this->assertSame(['-qrr'], $finder->findArguments());
 
             return;

--- a/tests/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
@@ -36,7 +36,7 @@ final class InitialConfigBuilderTest extends TestCase
 
     protected function setUp()
     {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->workspace = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
         $this->fileSystem = new Filesystem();
 
         $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);

--- a/tests/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
@@ -35,7 +35,7 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
     protected function setUp()
     {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->workspace = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
 
         $this->fileSystem = new Filesystem();
         $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);

--- a/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -51,7 +51,7 @@ final class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTest
 
     protected function setUp()
     {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->workspace = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
 
         $this->fileSystem = new Filesystem();
         $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);

--- a/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -53,7 +53,7 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
     protected function setUp()
     {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->workspace = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
 
         $this->fileSystem = new Filesystem();
         $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);

--- a/tests/Utils/TmpDirectoryCreatorTest.php
+++ b/tests/Utils/TmpDirectoryCreatorTest.php
@@ -37,7 +37,7 @@ final class TmpDirectoryCreatorTest extends TestCase
     {
         $this->fileSystem = new Filesystem();
         $this->creator = new TmpDirectoryCreator($this->fileSystem);
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->workspace = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
     }
 
     protected function tearDown()


### PR DESCRIPTION
The latest version of php-cs-fixer updated the symfony profile, whihc now includes the `native_constant_invocation` rule with the following settings:
```
* native_constant_invocation risky
   | Add leading `\` before constant invocation of internal constant to speed up resolving. Constant name match is case-sensitive, except for `null`, `false` and `true`.
   | Configuration: ['fix_built_in' => false, 'include' => ['DIRECTORY_SEPARATOR', 'PHP_SAPI', 'PHP_VERSION_ID']]
```