### PR TITLE
Enhancement: enable native function invocation cs rule

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -30,6 +30,9 @@ return \PhpCsFixer\Config::create()
             'location' => 'after_open',
             'separate' => 'bottom',
         ],
+        'native_function_invocation' => [
+            'include' => ['@compiler_optimized']
+        ],
         'no_useless_else'=> true,
         'ordered_class_elements' => [
             'order' => [

--- a/src/Config/Guesser/SourceDirGuesser.php
+++ b/src/Config/Guesser/SourceDirGuesser.php
@@ -45,7 +45,7 @@ class SourceDirGuesser implements Guesser
         $dirs = $this->parsePsrSection((array) $this->composerJsonContent->autoload->{$psr});
 
         // we don't want to mix different framework's folders like "app" for Symfony
-        if (in_array('src', $dirs, true)) {
+        if (\in_array('src', $dirs, true)) {
             return ['src'];
         }
 
@@ -57,7 +57,7 @@ class SourceDirGuesser implements Guesser
         $dirs = [];
 
         foreach ($autoloadDirs as $path) {
-            if (!is_array($path) && !is_string($path)) {
+            if (!\is_array($path) && !\is_string($path)) {
                 throw new \LogicException('autoload section does not match the expected JSON schema');
             }
 
@@ -73,7 +73,7 @@ class SourceDirGuesser implements Guesser
      */
     private function parsePath($path, array &$dirs)
     {
-        if (is_array($path)) {
+        if (\is_array($path)) {
             array_walk_recursive(
                 $path,
                 function ($el) use (&$dirs) {
@@ -82,7 +82,7 @@ class SourceDirGuesser implements Guesser
             );
         }
 
-        if (is_string($path)) {
+        if (\is_string($path)) {
             $dirs[] = trim($path, \DIRECTORY_SEPARATOR);
         }
     }

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -92,7 +92,7 @@ class InfectionConfig
 
     private function getExcludes(): array
     {
-        if (isset($this->config->source->excludes) && is_array($this->config->source->excludes)) {
+        if (isset($this->config->source->excludes) && \is_array($this->config->source->excludes)) {
             return $this->config->source->excludes;
         }
 
@@ -121,7 +121,7 @@ class InfectionConfig
                     array_map(
                         function ($excludeDir) use ($srcDir) {
                             return ltrim(
-                                substr_replace($excludeDir, '', 0, strlen($srcDir)),
+                                substr_replace($excludeDir, '', 0, \strlen($srcDir)),
                                 \DIRECTORY_SEPARATOR
                             );
                         },

--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -67,13 +67,13 @@ final class ExcludeDirsProvider
 
         if ($sourceDirs == ['.']) {
             foreach (self::EXCLUDED_ROOT_DIRS as $dir) {
-                if (in_array($dir, $dirsInCurrentDir, true)) {
+                if (\in_array($dir, $dirsInCurrentDir, true)) {
                     $excludedDirs[] = $dir;
                 }
             }
 
             $autocompleteValues = $dirsInCurrentDir;
-        } elseif (count($sourceDirs) == 1) {
+        } elseif (\count($sourceDirs) == 1) {
             $globDirs = array_filter(glob($sourceDirs[0] . '/*'), 'is_dir');
 
             $autocompleteValues = array_map(

--- a/src/Config/ValueProvider/SourceDirsProvider.php
+++ b/src/Config/ValueProvider/SourceDirsProvider.php
@@ -63,7 +63,7 @@ final class SourceDirsProvider
 
         $sourceFolders = $this->questionHelper->ask($input, $output, $question);
 
-        if (in_array('.', $sourceFolders, true) && count($sourceFolders) > 1) {
+        if (\in_array('.', $sourceFolders, true) && \count($sourceFolders) > 1) {
             throw new \LogicException('You cannot use current folder "." with other subfolders');
         }
 

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -207,7 +207,7 @@ final class InfectionContainer extends Container
 
             $config = json_decode($json);
 
-            if (is_string($infectionConfigFile) && null === $config && JSON_ERROR_NONE !== json_last_error()) {
+            if (\is_string($infectionConfigFile) && null === $config && JSON_ERROR_NONE !== json_last_error()) {
                 throw InvalidConfigException::invalidJson(
                     $infectionConfigFile,
                     json_last_error_msg()

--- a/src/Console/LogVerbosity.php
+++ b/src/Console/LogVerbosity.php
@@ -44,7 +44,7 @@ final class LogVerbosity
     public static function convertVerbosityLevel(InputInterface $input, ConsoleOutput $io)
     {
         $verbosityLevel = $input->getOption('log-verbosity');
-        if (in_array($verbosityLevel, self::ALLOWED_OPTIONS)) {
+        if (\in_array($verbosityLevel, self::ALLOWED_OPTIONS)) {
             return;
         }
 

--- a/src/Console/OutputFormatter/DotFormatter.php
+++ b/src/Console/OutputFormatter/DotFormatter.php
@@ -76,7 +76,7 @@ final class DotFormatter extends AbstractOutputFormatter
         }
 
         if ($lastDot || $endOfRow) {
-            $length = strlen((string) $mutationCount);
+            $length = \strlen((string) $mutationCount);
             $format = sprintf('   (%%%dd / %%%dd)', $length, $length);
 
             $this->output->write(sprintf($format, $this->callsCount, $mutationCount));

--- a/src/EventDispatcher/EventDispatcher.php
+++ b/src/EventDispatcher/EventDispatcher.php
@@ -24,7 +24,7 @@ final class EventDispatcher implements EventDispatcherInterface
      */
     public function dispatch($event)
     {
-        $name = get_class($event);
+        $name = \get_class($event);
 
         foreach ($this->getListeners($name) as $listener) {
             $listener($event);

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -71,7 +71,7 @@ final class DebugFileLogger extends FileLogger
 
         return [
             $headline,
-            str_repeat('=', strlen($headline)),
+            str_repeat('=', \strlen($headline)),
             '',
         ];
     }

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -65,7 +65,7 @@ final class TextFileLogger extends FileLogger
 
         return [
             $headline,
-            str_repeat('=', strlen($headline)),
+            str_repeat('=', \strlen($headline)),
             '',
         ];
     }

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -86,7 +86,7 @@ final class MutationsGenerator
         $this->excludeDirsOrFiles = $excludeDirsOrFiles;
         $this->defaultMutators = $defaultMutators;
         $this->whitelistedMutatorNames = $whitelistedMutatorNames;
-        $this->whitelistedMutatorNamesCount = count($whitelistedMutatorNames);
+        $this->whitelistedMutatorNamesCount = \count($whitelistedMutatorNames);
         $this->eventDispatcher = $eventDispatcher;
         $this->parser = $parser;
     }

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -98,7 +98,7 @@ final class Mutation implements MutationInterface
     public function getHash(): string
     {
         if (!isset($this->hash)) {
-            $mutatorClass = get_class($this->getMutator());
+            $mutatorClass = \get_class($this->getMutator());
             $attributes = $this->getAttributes();
             $attributeValues = [
                 $mutatorClass,

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -73,7 +73,7 @@ final class PublicVisibility extends Mutator
 
     private function isBlacklistedFunction(Node\Identifier $name): bool
     {
-        return in_array(
+        return \in_array(
             $name->name,
             [
                 '__construct',

--- a/src/Mutator/Util/AbstractValueToNullReturnValue.php
+++ b/src/Mutator/Util/AbstractValueToNullReturnValue.php
@@ -37,7 +37,7 @@ abstract class AbstractValueToNullReturnValue extends Mutator
         }
 
         // scalar typehint
-        if (is_string($returnType)) {
+        if (\is_string($returnType)) {
             return false;
         }
 

--- a/src/Mutator/Util/MutatorConfig.php
+++ b/src/Mutator/Util/MutatorConfig.php
@@ -26,11 +26,11 @@ final class MutatorConfig
 
     public function isIgnored(string $class, string $method): bool
     {
-        if (in_array($class, $this->ignoreConfig)) {
+        if (\in_array($class, $this->ignoreConfig)) {
             return true;
         }
 
-        if (in_array($class . '::' . $method, $this->ignoreConfig)) {
+        if (\in_array($class . '::' . $method, $this->ignoreConfig)) {
             return true;
         }
 

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -125,7 +125,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInt
         $this->output->writeln([
             '',
             $headline,
-            str_repeat('=', strlen($headline)),
+            str_repeat('=', \strlen($headline)),
             '',
         ]);
 

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -101,12 +101,12 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
     {
         foreach ($logTypes as $key => $value) {
             if ($this->logVerbosity == LogVerbosity::NONE) {
-                if (!in_array($key, ResultsLoggerTypes::ALLOWED_WITHOUT_LOGGING, true)) {
+                if (!\in_array($key, ResultsLoggerTypes::ALLOWED_WITHOUT_LOGGING, true)) {
                     unset($logTypes[$key]);
                 }
                 continue;
             }
-            if (!in_array($key, ResultsLoggerTypes::ALL, true)) {
+            if (!\in_array($key, ResultsLoggerTypes::ALL, true)) {
                 unset($logTypes[$key]);
             }
         }

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -92,7 +92,7 @@ final class MutantProcess implements MutantProcessInterface
             return self::CODE_TIMED_OUT;
         }
 
-        if (!in_array($this->getProcess()->getExitCode(), self::NOT_FATAL_ERROR_CODES, true)) {
+        if (!\in_array($this->getProcess()->getExitCode(), self::NOT_FATAL_ERROR_CODES, true)) {
             return self::CODE_ERROR;
         }
 

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -61,7 +61,7 @@ final class MutationTestingRunner
 
     public function run(int $threadCount, CodeCoverageData $codeCoverageData, string $testFrameworkExtraOptions)
     {
-        $mutantCount = count($this->mutations);
+        $mutantCount = \count($this->mutations);
 
         $this->eventDispatcher->dispatch(new MutantsCreatingStarted($mutantCount));
 

--- a/src/Process/Runner/Parallel/ParallelProcessRunner.php
+++ b/src/Process/Runner/Parallel/ParallelProcessRunner.php
@@ -60,12 +60,12 @@ final class ParallelProcessRunner
         }
 
         // fix maxParallel to be max the number of processes or positive
-        $maxParallel = min(max($threadCount, 1), count($this->processesQueue));
+        $maxParallel = min(max($threadCount, 1), \count($this->processesQueue));
 
         // start the initial batch of processes
         do {
             $this->startProcess();
-        } while ($this->processesQueue && count($this->currentProcesses) < $maxParallel);
+        } while ($this->processesQueue && \count($this->currentProcesses) < $maxParallel);
 
         do {
             usleep($poll);

--- a/src/TestFramework/Coverage/CodeCoverageData.php
+++ b/src/TestFramework/Coverage/CodeCoverageData.php
@@ -65,11 +65,11 @@ class CodeCoverageData
         $coveredLineTestMethods = array_filter(
             $coverageData[$filePath]['byLine'],
             function ($testMethods) {
-                return count($testMethods) > 0;
+                return \count($testMethods) > 0;
             }
         );
 
-        return count($coveredLineTestMethods) > 0;
+        return \count($coveredLineTestMethods) > 0;
     }
 
     public function hasTestsOnLine(string $filePath, int $line): bool
@@ -154,7 +154,7 @@ class CodeCoverageData
                 throw CoverageDoesNotExistException::with(
                     $coverageIndexFilePath,
                     $this->testFrameworkKey,
-                    dirname($coverageIndexFilePath, 2)
+                    \dirname($coverageIndexFilePath, 2)
                 );
             }
 

--- a/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
@@ -74,7 +74,7 @@ class MutationConfigBuilder extends ConfigBuilder
 
         $originalBootstrap = $this->getOriginalBootstrapFilePath($parsedYaml);
         $autoloadPlaceholder = $originalBootstrap ? "require_once '{$originalBootstrap}';" : '';
-        $interceptorPath = dirname(__DIR__, 4) . '/StreamWrapper/IncludeInterceptor.php';
+        $interceptorPath = \dirname(__DIR__, 4) . '/StreamWrapper/IncludeInterceptor.php';
 
         $customAutoload = <<<AUTOLOAD
 <?php

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -94,7 +94,7 @@ class MutationConfigBuilder extends ConfigBuilder
     {
         $originalFilePath = $mutant->getMutation()->getOriginalFilePath();
         $mutatedFilePath = $mutant->getMutatedFilePath();
-        $interceptorPath = dirname(__DIR__, 4) . '/StreamWrapper/IncludeInterceptor.php';
+        $interceptorPath = \dirname(__DIR__, 4) . '/StreamWrapper/IncludeInterceptor.php';
 
         $customAutoload = <<<AUTOLOAD
 <?php
@@ -189,7 +189,7 @@ AUTOLOAD;
         $uniqueTests = [];
 
         foreach ($coverageTests as $coverageTest) {
-            if (!in_array($coverageTest['testFilePath'], $usedFileNames, true)) {
+            if (!\in_array($coverageTest['testFilePath'], $usedFileNames, true)) {
                 $uniqueTests[] = $coverageTest;
                 $usedFileNames[] = $coverageTest['testFilePath'];
             }

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -96,7 +96,7 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
                 $this->fileAst,
                 $mutator,
                 $node->getAttributes(),
-                get_class($node),
+                \get_class($node),
                 $isOnFunctionSignature,
                 $isCoveredByTest
             );

--- a/src/Visitor/MutatorVisitor.php
+++ b/src/Visitor/MutatorVisitor.php
@@ -43,7 +43,7 @@ final class MutatorVisitor extends NodeVisitorAbstract
         $isEqualPosition = $attributes['startTokenPos'] == $mutatedAttributes['startTokenPos'] &&
             $attributes['endTokenPos'] == $mutatedAttributes['endTokenPos'];
 
-        if ($isEqualPosition && $this->mutation->getMutatedNodeClass() == get_class($node)) {
+        if ($isEqualPosition && $this->mutation->getMutatedNodeClass() == \get_class($node)) {
             return $mutator->mutate($node);
             // TODO STOP TRAVERSING
             // TODO check all built-in visitors, in particular FirstFindingVisitor

--- a/src/Visitor/ParentConnectorVisitor.php
+++ b/src/Visitor/ParentConnectorVisitor.php
@@ -29,7 +29,7 @@ final class ParentConnectorVisitor extends NodeVisitorAbstract
     public function enterNode(Node $node)
     {
         if (!empty($this->stack)) {
-            $node->setAttribute(self::PARENT_KEY, $this->stack[count($this->stack) - 1]);
+            $node->setAttribute(self::PARENT_KEY, $this->stack[\count($this->stack) - 1]);
         }
 
         $this->stack[] = $node;

--- a/src/Visitor/ReflectionVisitor.php
+++ b/src/Visitor/ReflectionVisitor.php
@@ -67,7 +67,7 @@ final class ReflectionVisitor extends NodeVisitorAbstract
             $node->setAttribute(self::REFLECTION_CLASS_KEY, $this->reflectionClass);
             $node->setAttribute(self::FUNCTION_NAME, $this->methodName);
         } elseif ($isInsideFunction) {
-            $node->setAttribute(self::FUNCTION_SCOPE_KEY, $this->scopeStack[count($this->scopeStack) - 1]);
+            $node->setAttribute(self::FUNCTION_SCOPE_KEY, $this->scopeStack[\count($this->scopeStack) - 1]);
             $node->setAttribute(self::REFLECTION_CLASS_KEY, $this->reflectionClass);
             $node->setAttribute(self::FUNCTION_NAME, $this->methodName);
         }

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -182,7 +182,7 @@ final class ProjectCodeTest extends TestCase
     public function test_all_concrete_classes_have_tests(string $className)
     {
         $testClass = preg_replace('/Infection/', 'Infection\\Tests', $className, 1) . 'Test';
-        if (in_array($className, self::$nonTestedConcreteClasses)) {
+        if (\in_array($className, self::$nonTestedConcreteClasses)) {
             $this->assertFalse(class_exists($testClass),
                 sprintf(
                     'Class "%s" has a corresponding unit test "%s", and can be removed from the non tested class list',
@@ -229,7 +229,7 @@ final class ProjectCodeTest extends TestCase
         $rc = new \ReflectionClass($className);
         $docBlock = $rc->getDocComment();
 
-        if (in_array($className, self::$extensionPoints)) {
+        if (\in_array($className, self::$extensionPoints)) {
             if ($docBlock === false) {
                 $this->markTestSkipped(
                     sprintf(
@@ -278,7 +278,7 @@ final class ProjectCodeTest extends TestCase
     {
         $rc = new \ReflectionClass($className);
 
-        if (in_array($className, self::$nonFinalNonExtensionClasses)) {
+        if (\in_array($className, self::$nonFinalNonExtensionClasses)) {
             $this->addToAssertionCount(1);
 
             return;

--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -223,7 +223,7 @@ final class E2ETest extends TestCase
 
     private function runInfection(int $expectedExitCode, array $argvExtra = []): string
     {
-        if (!extension_loaded('xdebug') && \PHP_SAPI !== 'phpdbg') {
+        if (!\extension_loaded('xdebug') && \PHP_SAPI !== 'phpdbg') {
             $this->markTestSkipped("Infection from within PHPUnit won't run without xdebug or phpdbg");
         }
 

--- a/tests/Finder/TestFrameworkFinderTest.php
+++ b/tests/Finder/TestFrameworkFinderTest.php
@@ -81,8 +81,8 @@ final class TestFrameworkFinderTest extends TestCase
         $this->assertContains('vendor', $pathAfterTest);
 
         $this->assertGreaterThan(
-            strlen($path),
-            strlen($pathAfterTest),
+            \strlen($path),
+            \strlen($pathAfterTest),
             'PATH with vendor added is shorter than without it added, make sure it isn\'t overwritten.'
         );
     }

--- a/tests/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/Mutant/Generator/MutationsGeneratorTest.php
@@ -141,7 +141,7 @@ final class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCa
     private function createMutationGenerator(CodeCoverageData $codeCoverageDataMock, array $whitelistedMutatorNames = [], MutatorConfig $mutatorConfig = null)
     {
         $srcDirs = [
-            dirname(__DIR__, 2) . '/Fixtures/Files/Mutation/OneFile',
+            \dirname(__DIR__, 2) . '/Fixtures/Files/Mutation/OneFile',
         ];
         $excludedDirsOrFiles = [];
 

--- a/tests/Mutator/AbstractMutatorTestCase.php
+++ b/tests/Mutator/AbstractMutatorTestCase.php
@@ -51,7 +51,7 @@ abstract class AbstractMutatorTestCase extends TestCase
 
     protected function getMutator(): Mutator
     {
-        $class = get_class($this);
+        $class = \get_class($this);
         $mutator = substr(str_replace('\Tests', '', $class), 0, -4);
 
         return new $mutator(new MutatorConfig([]));

--- a/tests/Mutator/Util/MutatorsGeneratorTest.php
+++ b/tests/Mutator/Util/MutatorsGeneratorTest.php
@@ -31,7 +31,7 @@ final class MutatorsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
     public static function setUpBeforeClass()
     {
         foreach (MutatorProfile::DEFAULT as $profileName) {
-            self::$countDefaultMutators += count(MutatorProfile::MUTATOR_PROFILE_LIST[$profileName]);
+            self::$countDefaultMutators += \count(MutatorProfile::MUTATOR_PROFILE_LIST[$profileName]);
         }
     }
 
@@ -50,7 +50,7 @@ final class MutatorsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
         ]);
         $mutators = $mutatorGenerator->generate();
 
-        $this->assertCount(count(MutatorProfile::BOOLEAN), $mutators);
+        $this->assertCount(\count(MutatorProfile::BOOLEAN), $mutators);
     }
 
     public function test_mutators_can_be_ignored()
@@ -72,7 +72,7 @@ final class MutatorsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
         ]);
         $mutators = $mutatorGenerator->generate();
 
-        $this->assertCount(self::$countDefaultMutators - count(MutatorProfile::BOOLEAN), $mutators);
+        $this->assertCount(self::$countDefaultMutators - \count(MutatorProfile::BOOLEAN), $mutators);
     }
 
     public function test_names_can_be_ignored()
@@ -151,7 +151,7 @@ final class MutatorsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
         ]);
         $mutators = $mutatorGenerator->generate();
 
-        $this->assertCount(count(MutatorProfile::BOOLEAN), $mutators);
+        $this->assertCount(\count(MutatorProfile::BOOLEAN), $mutators);
 
         $this->assertArrayNotHasKey(Plus::getName(), $mutators);
 
@@ -166,7 +166,7 @@ final class MutatorsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
         ]);
         $mutators = $mutatorGenerator->generate();
 
-        $this->assertCount(count(MutatorProfile::BOOLEAN), $mutators);
+        $this->assertCount(\count(MutatorProfile::BOOLEAN), $mutators);
 
         $this->assertArrayNotHasKey(Plus::getName(), $mutators);
     }

--- a/tests/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/StreamWrapper/IncludeInterceptorTest.php
@@ -172,7 +172,7 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
          * cannot handle any of these
          */
 
-        $this->assertGreaterThan(0, count(glob(__DIR__ . '/*')));
+        $this->assertGreaterThan(0, \count(glob(__DIR__ . '/*')));
 
         $tempnam = tempnam('', basename(__FILE__, 'php'));
         unlink($tempnam);


### PR DESCRIPTION
This PR:

- Adds the `native_function_invocation` php-cs-fixer rule, with the `@compiler_optimized` setting.

This means that only functions which are cached as opcodes will be prefixed. As these are the functions that will see the most benefit from doing so.

```bash
$ ./php-cs-fixer-v2.phar describe native_function_invocation
Description of native_function_invocation rule.
Add leading `\` before function invocation to speed up resolving.

Fixer applying this rule is risky.
Risky when any of the functions are overridden.

Fixer is configurable using following options:
* exclude (array): list of functions to ignore; defaults to []
* include (array): list of function names or sets to fix. Defined sets are `@internal` (all native functions), `@all` (all global functions) and `@compiler_optimized` (functions that are specially optimized by Zend); defaults to ['@internal']
* scope ('all', 'namespaced'): only fix function calls that are made within a namespace or fix all; defaults to 'all'
```
