### PR TITLE
Allow easy Docker testing on Mac OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,12 @@ PHPSTAN=./phpstan.phar
 PHP-CS-FIXER=./php-cs-fixer-v2.phar
 PHPUNIT=vendor/bin/phpunit
 
+FLOCK=./devTools/flock
+
 DOCKER_RUN=docker run -t --rm -v "$$PWD":/opt/infection -w /opt/infection
-DOCKER_RUN_70=flock devTools/*php70*.json $(DOCKER_RUN) infection_php70
-DOCKER_RUN_71=flock devTools/*php71*.json $(DOCKER_RUN) infection_php71
-DOCKER_RUN_72=flock devTools/*php72*.json $(DOCKER_RUN) infection_php72
+DOCKER_RUN_70=$(FLOCK) devTools/*php70*.json $(DOCKER_RUN) infection_php70
+DOCKER_RUN_71=$(FLOCK) devTools/*php71*.json $(DOCKER_RUN) infection_php71
+DOCKER_RUN_72=$(FLOCK) devTools/*php72*.json $(DOCKER_RUN) infection_php72
 
 .PHONY: all
 #Run all checks, default when running 'make'

--- a/devTools/Dockerfile-php70-xdebug
+++ b/devTools/Dockerfile-php70-xdebug
@@ -1,7 +1,9 @@
 FROM php:7.0-cli
 
 RUN pecl install xdebug && docker-php-ext-enable xdebug
-RUN apt-get -y update && apt-get install -y expect
-RUN useradd --shell /bin/bash infection
+RUN apt-get -y update && apt-get install -y expect git zip
+RUN curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN useradd --home-dir /opt/infection --shell /bin/bash infection
 
 USER infection

--- a/devTools/Dockerfile-php71-xdebug
+++ b/devTools/Dockerfile-php71-xdebug
@@ -1,7 +1,9 @@
 FROM php:7.1-cli
 
 RUN pecl install xdebug && docker-php-ext-enable xdebug
-RUN apt-get -y update && apt-get install -y expect
-RUN useradd --shell /bin/bash infection
+RUN apt-get -y update && apt-get install -y expect git zip
+RUN curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN useradd --home-dir /opt/infection --shell /bin/bash infection
 
 USER infection

--- a/devTools/Dockerfile-php72-xdebug
+++ b/devTools/Dockerfile-php72-xdebug
@@ -1,7 +1,9 @@
 FROM php:7.2-cli
 
 RUN pecl install xdebug && docker-php-ext-enable xdebug
-RUN apt-get -y update && apt-get install -y expect
-RUN useradd --shell /bin/bash infection
+RUN apt-get -y update && apt-get install -y expect git zip
+RUN curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN useradd --home-dir /opt/infection --shell /bin/bash infection
 
 USER infection

--- a/devTools/flock
+++ b/devTools/flock
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ -x "$(command -v flock)" ]; then
+  flock "$@"
+  exit $?
+fi
+
+# Executing the original command as it is
+shift
+"$@"
+

--- a/tests/Fixtures/e2e/Parameters_Coverage/composer.json
+++ b/tests/Fixtures/e2e/Parameters_Coverage/composer.json
@@ -11,5 +11,11 @@
         "psr-4": {
             "ParamCoverage\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "platform": {
+            "php": "7.0.8"
+        },
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
Testing if flock exists or not needs somewhat more complicated logic than one wants to add to single line in a Makefile. Therefore this wrapper. Should fix the problem from #368 


This PR also includes two small fixes to make Docker testing run more smoothly in most circumstances. 


