### PR TITLE
Makefile updated to optionally run without a .phar 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@ PHPSTAN=./phpstan.phar
 PHP-CS-FIXER=./php-cs-fixer-v2.phar
 PHPUNIT=vendor/bin/phpunit
 INFECTION=build/bin/infection.phar
+
+# URLs to download all tools
 BOX_URL="https://github.com/humbug/box/releases/download/3.0.0-alpha.5/box.phar"
+PHP-CS-FIXER_URL="https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar"
+PHPSTAN_URL="https://github.com/phpstan/phpstan/releases/download/0.9.1/phpstan.phar"
 
 DOCKER_RUN=docker run -t --rm -v "$$PWD":/opt/infection -w /opt/infection
 DOCKER_RUN_70=flock devTools/*php70*.json $(DOCKER_RUN) infection_php70
@@ -22,11 +26,11 @@ build/cache:
 	mkdir -p build/cache
 
 ./php-cs-fixer-v2.phar:
-	wget https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar
+	wget $(PHP-CS-FIXER_URL)
 	chmod a+x ./php-cs-fixer-v2.phar
 
 ./phpstan.phar:
-	wget https://github.com/phpstan/phpstan/releases/download/0.9.1/phpstan.phar
+	wget $(PHPSTAN_URL)
 	chmod a+x ./phpstan.phar
 
 #All tests, (infection itself, phpunit, e2e) for different php version/ environments (xdebug or phpdbg)

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ validate:
 auto-review: vendor
 	vendor/bin/phpunit --group=auto-review
 
-build/bin/infection.phar: bin src vendor box.phar box.json
+build/bin/infection.phar: $(shell find bin/ src/ -type f) box.phar box.json .git/HEAD
 	php box.phar compile
 
 box.json: box.json.dist

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PHPSTAN=./phpstan.phar
 PHP-CS-FIXER=./php-cs-fixer-v2.phar
 PHPUNIT=vendor/bin/phpunit
 INFECTION=build/bin/infection.phar
+BOX_URL="https://github.com/humbug/box/releases/download/3.0.0-alpha.5/box.phar"
 
 DOCKER_RUN=docker run -t --rm -v "$$PWD":/opt/infection -w /opt/infection
 DOCKER_RUN_70=flock devTools/*php70*.json $(DOCKER_RUN) infection_php70
@@ -147,5 +148,5 @@ box.json: box.json.dist
 	cat box.json.dist | sed -E 's/\"key\": \".+\",//g' | sed -E 's/\"algorithm\": \".+\",//g' > box.json
 
 box.phar:
-	wget https://github.com/humbug/box/releases/download/3.0.0-alpha.5/box.phar
+	wget $(BOX_URL)
 	chmod a+x box.phar

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PHP_CS_FIXER_FUTURE_MODE=1
 PHPSTAN=./phpstan.phar
 PHP-CS-FIXER=./php-cs-fixer-v2.phar
 PHPUNIT=vendor/bin/phpunit
+INFECTION=build/bin/infection.phar
 
 DOCKER_RUN=docker run -t --rm -v "$$PWD":/opt/infection -w /opt/infection
 DOCKER_RUN_70=flock devTools/*php70*.json $(DOCKER_RUN) infection_php70
@@ -64,14 +65,14 @@ test-infection-phpdbg-72: build-xdebug-72
 #e2e tests with phpdbg
 test-e2e-phpdbg: test-e2e-phpdbg-70 test-e2e-phpdbg-71 test-e2e-phpdbg-72
 
-test-e2e-phpdbg-70: build-xdebug-70 build/bin/infection.phar
-	$(DOCKER_RUN_70) env PHPDBG=1 ./tests/e2e_tests
+test-e2e-phpdbg-70: build-xdebug-70 $(INFECTION)
+	$(DOCKER_RUN_70) env PHPDBG=1 ./tests/e2e_tests $(INFECTION)
 
-test-e2e-phpdbg-71: build-xdebug-71 build/bin/infection.phar
-	$(DOCKER_RUN_71) env PHPDBG=1 ./tests/e2e_tests
+test-e2e-phpdbg-71: build-xdebug-71 $(INFECTION)
+	$(DOCKER_RUN_71) env PHPDBG=1 ./tests/e2e_tests $(INFECTION)
 
-test-e2e-phpdbg-72: build-xdebug-72 build/bin/infection.phar
-	$(DOCKER_RUN_72) env PHPDBG=1 ./tests/e2e_tests
+test-e2e-phpdbg-72: build-xdebug-72 $(INFECTION)
+	$(DOCKER_RUN_72) env PHPDBG=1 ./tests/e2e_tests $(INFECTION)
 
 
 .PHONY: test-infection-xdebug test-infection-xdebug-70 test-infection-xdebug-71 test-infection-xdebug-72
@@ -92,14 +93,14 @@ test-infection-xdebug-72: build-xdebug-72
 #e2e tests with xdebug
 test-e2e-xdebug: test-e2e-xdebug-70 test-e2e-xdebug-71 test-e2e-xdebug-72
 
-test-e2e-xdebug-70: build-xdebug-70 build/bin/infection.phar
-	$(DOCKER_RUN_70) ./tests/e2e_tests
+test-e2e-xdebug-70: build-xdebug-70 $(INFECTION)
+	$(DOCKER_RUN_70) ./tests/e2e_tests $(INFECTION)
 
-test-e2e-xdebug-71: build-xdebug-71 build/bin/infection.phar
-	$(DOCKER_RUN_71) ./tests/e2e_tests
+test-e2e-xdebug-71: build-xdebug-71 $(INFECTION)
+	$(DOCKER_RUN_71) ./tests/e2e_tests $(INFECTION)
 
-test-e2e-xdebug-72: build-xdebug-72 build/bin/infection.phar
-	$(DOCKER_RUN_72) ./tests/e2e_tests
+test-e2e-xdebug-72: build-xdebug-72 $(INFECTION)
+	$(DOCKER_RUN_72) ./tests/e2e_tests $(INFECTION)
 
 
 .PHONY: build-xdebug-70 build-xdebug-71 build-xdebug-72


### PR DESCRIPTION
- [x] infection.phar should be rebuild if any of our source files change (not yet including vendor)
- [x] It should be possible to choose an executable used for e2e; .phar is the default, but testing with a standard executable is as simple as `make INFECTION=bin/infection`
- [x] Moved URL to download Box to the head of Makefile, also configurable