### PR TITLE
Ignore Config_Framework E2E test on Windows as it's a known bug

### DIFF
--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -95,6 +95,11 @@ final class E2ETest extends TestCase
      */
     public function test_it_runs_an_e2e_test_with_success(string $fullPath)
     {
+        if ('\\' == \DIRECTORY_SEPARATOR && 'Config_Framework' == basename((string) $fullPath)) {
+            $this->markTestIncomplete("Ignoring this test on Windows because it's a know bug");
+            // Development tracked at https://github.com/infection/infection/issues/377
+        }
+
         $this->runOnE2EFixture($fullPath);
     }
 


### PR DESCRIPTION
Ignore Config_Framework E2E test on Windows as it's a known bug #377.

There's little point in tagging most PR with a failed build where they fail not because a given PR is buggy, but because of  #377. Surely when time comes this workaround has to be removed.

Either #362 or this should be merged, if any. I'm in favor of a proper fix if there is.