### PR TITLE
Introduce PregMatchMatches mutator

### DIFF
--- a/src/Mutator/Regex/PregMatchMatches.php
+++ b/src/Mutator/Regex/PregMatchMatches.php
@@ -37,28 +37,27 @@ final class PregMatchMatches extends Mutator
             return false;
         }
 
-        if ($node->name instanceof Node\Expr\Variable ||
+        if (!$node->name instanceof Node\Name ||
             strtolower((string) $node->name) !== 'preg_match') {
             return false;
         }
 
-        return $this->isAllowedByReturnType($node) && \count($node->args) >= 3;
+        return \count($node->args) >= 3 && $this->isAllowedByReturnType($node);
     }
 
     private function isAllowedByReturnType(Node $node): bool
     {
-        if (($parent = $node->getAttribute(ParentConnectorVisitor::PARENT_KEY)) instanceof Node\Stmt\Return_) {
-            $functionScope = $parent->getAttribute(ReflectionVisitor::FUNCTION_SCOPE_KEY);
-            $returnType = $functionScope->getReturnType();
-            if ($returnType instanceof Node\Identifier) {
-                $returnType = $returnType->name;
-            }
-            // no return value specified
-            if (null !== $returnType) {
-                return false;
-            }
+        if (!(($parent = $node->getAttribute(ParentConnectorVisitor::PARENT_KEY)) instanceof Node\Stmt\Return_)) {
+            return true;
         }
 
-        return true;
+        $functionScope = $parent->getAttribute(ReflectionVisitor::FUNCTION_SCOPE_KEY);
+        $returnType = $functionScope->getReturnType();
+
+        if ($returnType instanceof Node\Identifier) {
+            $returnType = $returnType->name;
+        }
+
+        return null === $returnType;
     }
 }

--- a/src/Mutator/Regex/PregMatchMatches.php
+++ b/src/Mutator/Regex/PregMatchMatches.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Regex;
+
+use Infection\Mutator\Util\Mutator;
+use Infection\Visitor\ParentConnectorVisitor;
+use Infection\Visitor\ReflectionVisitor;
+use PhpParser\Node;
+
+/**
+ * @internal
+ */
+final class PregMatchMatches extends Mutator
+{
+    /**
+     * Replaces "preg_match('/a/', 'b', $foo);" with "$foo = array();"
+     *
+     * @param Node|Node\Expr\FuncCall $node
+     *
+     * @return Node\Expr\Assign
+     */
+    public function mutate(Node $node)
+    {
+        return new Node\Expr\Assign($node->args[2]->value, new Node\Expr\Array_());
+    }
+
+    protected function mutatesNode(Node $node): bool
+    {
+        if (!$node instanceof Node\Expr\FuncCall) {
+            return false;
+        }
+
+        if ($node->name instanceof Node\Expr\Variable ||
+            strtolower((string) $node->name) !== 'preg_match') {
+            return false;
+        }
+
+        return $this->isAllowedByReturnType($node) && \count($node->args) >= 3;
+    }
+
+    private function isAllowedByReturnType(Node $node): bool
+    {
+        if (($parent = $node->getAttribute(ParentConnectorVisitor::PARENT_KEY)) instanceof Node\Stmt\Return_) {
+            $functionScope = $parent->getAttribute(ReflectionVisitor::FUNCTION_SCOPE_KEY);
+            $returnType = $functionScope->getReturnType();
+            if ($returnType instanceof Node\Identifier) {
+                $returnType = $returnType->name;
+            }
+            // no return value specified
+            if (null !== $returnType) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -113,6 +113,7 @@ final class MutatorProfile
 
     public const REGEX = [
         Mutator\Regex\PregQuote::class,
+        Mutator\Regex\PregMatchMatches::class,
     ];
 
     public const RETURN_VALUE = [
@@ -229,6 +230,7 @@ final class MutatorProfile
 
         //Regex
         'PregQuote' => Mutator\Regex\PregQuote::class,
+        'PregMatchMatches' => Mutator\Regex\PregMatchMatches::class,
 
         //Return Value
         'FloatNegation' => Mutator\ReturnValue\FloatNegation::class,

--- a/tests/Fixtures/Autoloaded/RegexMatchMatches/ReturnNotAllowed.php
+++ b/tests/Fixtures/Autoloaded/RegexMatchMatches/ReturnNotAllowed.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace RegexMatchMatches;
+
+class ReturnNotAllowed
+{
+    public function foo() : int
+    {
+        return preg_match('/a/', 'foobar', $matches);
+    }
+}

--- a/tests/Fixtures/Autoloaded/RegexMatchMatches/ReturnTypes.php
+++ b/tests/Fixtures/Autoloaded/RegexMatchMatches/ReturnTypes.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace RegexMatchMatches;
+
+class ReturnTypes
+{
+    public function foo()
+    {
+        return preg_match('/a/', 'foobar', $matches);
+    }
+}

--- a/tests/Mutator/Regex/PregMatchMatchesTest.php
+++ b/tests/Mutator/Regex/PregMatchMatchesTest.php
@@ -22,7 +22,7 @@ final class PregMatchMatchesTest extends AbstractMutatorTestCase
      * @param string $input
      * @param string|null $output
      */
-    public function test_mutator(string $input, string $output = null)
+    public function test_mutator(string $input, string $output = null): void
     {
         $this->doTest($input, $output);
     }
@@ -51,6 +51,7 @@ $foo = 'preg_match';
 $foo('/a/', 'b', $bar);
 PHP
         ];
+
         yield 'It mutates if preg_match is incorrectly cased' => [
           <<<'PHP'
 <?php
@@ -64,6 +65,7 @@ PHP
 $foo = array();
 PHP
         ];
+
         yield 'It does not mutate if there are less than 3 arguments' => [
             <<<'PHP'
 <?php
@@ -105,6 +107,34 @@ PHP
 
         yield 'It does not mutate if the return type does not allow it' => [
             file_get_contents(__DIR__ . '/../../Fixtures/Autoloaded/RegexMatchMatches/ReturnNotAllowed.php'),
+        ];
+
+        yield 'It mutates correctly even with four arguments' => [
+            <<<'PHP'
+<?php
+
+preg_match('/a/', 'b', $foo, PREG_OFFSET_CAPTURE);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$foo = array();
+PHP
+        ];
+
+        yield 'It mutates correctly even with five arguments' => [
+            <<<'PHP'
+<?php
+
+preg_match('/a/', 'b', $foo, PREG_OFFSET_CAPTURE, 3);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$foo = array();
+PHP
         ];
     }
 }

--- a/tests/Mutator/Regex/PregMatchMatchesTest.php
+++ b/tests/Mutator/Regex/PregMatchMatchesTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Regex;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+/**
+ * @internal
+ */
+final class PregMatchMatchesTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider providesMutatorCases
+     *
+     * @param string $input
+     * @param string|null $output
+     */
+    public function test_mutator(string $input, string $output = null)
+    {
+        $this->doTest($input, $output);
+    }
+
+    public function providesMutatorCases(): \Generator
+    {
+        yield 'It mutates ' => [
+            <<<'PHP'
+<?php
+
+preg_match('/a/', 'b', $foo);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$foo = array();
+PHP
+        ];
+
+        yield 'It does not mutate if the function is a variable' => [
+            <<<'PHP'
+<?php
+
+$foo = 'preg_match';
+$foo('/a/', 'b', $bar);
+PHP
+        ];
+        yield 'It mutates if preg_match is incorrectly cased' => [
+          <<<'PHP'
+<?php
+
+PreG_maTch('/a/', 'b', $foo);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$foo = array();
+PHP
+        ];
+        yield 'It does not mutate if there are less than 3 arguments' => [
+            <<<'PHP'
+<?php
+
+preg_match('/asdfa/', 'foo');
+PHP
+        ];
+
+        yield 'It mutates correctly if the 3rd variable is a property' => [
+            <<<'PHP'
+<?php
+
+preg_match('/a/', 'b', $a->b);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$a->b = array();
+PHP
+        ];
+
+        yield 'It mutates if the return type allows it' => [
+            file_get_contents(__DIR__ . '/../../Fixtures/Autoloaded/RegexMatchMatches/ReturnTypes.php'),
+            <<<'PHP'
+<?php
+
+namespace RegexMatchMatches;
+
+class ReturnTypes
+{
+    public function foo()
+    {
+        return $matches = array();
+    }
+}
+PHP
+        ];
+
+        yield 'It does not mutate if the return type does not allow it' => [
+            file_get_contents(__DIR__ . '/../../Fixtures/Autoloaded/RegexMatchMatches/ReturnNotAllowed.php'),
+        ];
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds new feature, the `PregMatchMatches` mutator.
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/53

```diff

- preg_match('/a/', 'b', $foo);
+ $foo = array();
```

cc: @addono
