### PR TITLE
Improve PregQuote check

### DIFF
--- a/src/Mutator/Regex/PregQuote.php
+++ b/src/Mutator/Regex/PregQuote.php
@@ -32,7 +32,7 @@ final class PregQuote extends Mutator
     protected function mutatesNode(Node $node): bool
     {
         return $node instanceof Node\Expr\FuncCall &&
-            !$node->name instanceof Node\Expr\Variable &&
+            $node->name instanceof Node\Name &&
             strtolower((string) $node->name) == 'preg_quote';
     }
 }

--- a/tests/Mutator/Regex/PregQuoteTest.php
+++ b/tests/Mutator/Regex/PregQuoteTest.php
@@ -189,12 +189,17 @@ function bar($input)
 PHP
         ];
 
-        yield 'It does not mutate when the function name is a variable' => [
+        yield 'It does not mutate when the function name can\'t be determined' => [
             <<<'PHP'
 <?php
 
-$b = 'preg_quote';
-$a = $b($foo->bar(), '/');
+$a = $method($foo->bar(), '/');
+$b = ('preg_quote')('/asdf/', '/');
+$c = $class->{'foo'}('/asdf/');
+$d = Foo::{'foo'}('/asdf/');
+$e = Foo::$bar('/asdf/');
+$f = ($foo->bar)('/asdf/');
+
 PHP
         ];
     }


### PR DESCRIPTION
If the node is anything other than the direct function call we can't determine what it is, so we should skip it.

Should fix the error in #382