### PR TITLE
Fix: No need to update composer twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ before_install:
       openssl aes-256-cbc -K $encrypted_4dbefe709cef_key -iv $encrypted_4dbefe709cef_iv -in .ci/secrets.tar.enc -out .ci/secrets.tar -d
       tar xvf .ci/secrets.tar -C .ci
     fi;
-  - composer selfupdate
   - source .ci/xdebug.sh
   - xdebug-disable
 


### PR DESCRIPTION
This PR

- [x] avoids running `composer self–update` twice on Travis CI

💁‍♂️ For reference, see

* https://travis-ci.org/infection/infection/jobs/390874802#L509
* https://travis-ci.org/infection/infection/jobs/390874802#L544