### PR TITLE
Allow Absolute Path to phpunit.xml(.dist)

### DIFF
--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -49,17 +49,16 @@ class InfectionConfig
 
     public function getPhpUnitConfigDir(): string
     {
-        $issetPhpUnitConfigDir = isset($this->config->phpUnit->configDir);
+        if (!isset($this->config->phpUnit->configDir)) {
+            return $this->configLocation;
+        }
 
-        if ($issetPhpUnitConfigDir && $this->filesystem->isAbsolutePath($this->config->phpUnit->configDir)) {
+        if ($this->filesystem->isAbsolutePath($this->config->phpUnit->configDir)) {
             return $this->config->phpUnit->configDir;
         }
 
-        if ($issetPhpUnitConfigDir) {
-            return $this->configLocation . \DIRECTORY_SEPARATOR . $this->config->phpUnit->configDir;
-        }
+        return $this->configLocation . \DIRECTORY_SEPARATOR . $this->config->phpUnit->configDir;
 
-        return $this->configLocation;
     }
 
     public function getPhpUnitCustomPath(): string

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -58,7 +58,6 @@ class InfectionConfig
         }
 
         return $this->configLocation . \DIRECTORY_SEPARATOR . $this->config->phpUnit->configDir;
-
     }
 
     public function getPhpUnitCustomPath(): string

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -49,7 +49,13 @@ class InfectionConfig
 
     public function getPhpUnitConfigDir(): string
     {
-        if (isset($this->config->phpUnit->configDir)) {
+        $issetPhpUnitConfigDir = isset($this->config->phpUnit->configDir);
+
+        if ($issetPhpUnitConfigDir && $this->filesystem->isAbsolutePath($this->config->phpUnit->configDir)) {
+            return $this->config->phpUnit->configDir;
+        }
+
+        if ($issetPhpUnitConfigDir) {
             return $this->configLocation . \DIRECTORY_SEPARATOR . $this->config->phpUnit->configDir;
         }
 

--- a/tests/Config/InfectionConfigTest.php
+++ b/tests/Config/InfectionConfigTest.php
@@ -58,9 +58,7 @@ final class InfectionConfigTest extends TestCase
         $json = sprintf('{"phpUnit": {"configDir": "%s"}}', $absolutePath);
         $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
 
-        $expected = $absolutePath;
-
-        $this->assertSame(p($expected), p($config->getPhpUnitConfigDir()));
+        $this->assertSame(p($absolutePath), p($config->getPhpUnitConfigDir()));
     }
 
     public function test_it_returns_phpunit_config_dir_from_config()

--- a/tests/Config/InfectionConfigTest.php
+++ b/tests/Config/InfectionConfigTest.php
@@ -52,6 +52,17 @@ final class InfectionConfigTest extends TestCase
         $this->assertSame('/path/to/config', $config->getPhpUnitConfigDir());
     }
 
+    public function test_it_returns_phpunit_absolute_dir_from_config_with_absolute_path()
+    {
+        $absolutePath = '/app';
+        $json = sprintf('{"phpUnit": {"configDir": "%s"}}', $absolutePath);
+        $config = new InfectionConfig(json_decode($json), $this->filesystem, '/path/to/config');
+
+        $expected = $absolutePath;
+
+        $this->assertSame(p($expected), p($config->getPhpUnitConfigDir()));
+    }
+
     public function test_it_returns_phpunit_config_dir_from_config()
     {
         $phpUnitConfigDir = 'app';


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [x] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

In some project I would like to use infection on my own module, when pphpunit config file is outside the module dir. In such situation using an absolute path might be the the way to resolve the issue.