### PR TITLE
Test against nightly php build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ matrix:
       env: SYMFONY_VERSION="^4.0"
     - php: 7.2
       env: SYMFONY_VERSION="^4.0" PHPDBG=1
+    - php: nightly
+  allow_failures:
+    - php: nightly
 
 env:
   global:


### PR DESCRIPTION
This PR:

- [x] Tests our build against the nightly php build, but allows it to fail, as the build might not be stable.

This can help us prepare for future php releases, and pick up on deprecations etc.
