### PR TITLE
Fixture/Demo for IdenticalEqual/NotIdenticalNotEqual mutators

### DIFF
--- a/tests/Fixtures/e2e/Identical_Mutator_Example/README.md
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/README.md
@@ -1,0 +1,10 @@
+# Demo for IdenticalEqual/NotIdenticalNotEqual mutators
+
+Typically one needs to use `===` and `!==` when there is a need to:
+
+- Distinguish between `null`, `false`, `0`, and between `1` and `true`; `strpos` is a very well known companion of the identity operator.
+- Where unwanted type juggling can be expected: string vs number comparison `1 == '1a'`, float vs. int, `'0.' == '0.0'`, and so on.
+
+In many of these situations it easy to miss critical edge cases while writing tests.
+These mutators let one see if their tests really exhaustive in regard of identical or not identical operators.
+Otherwise put, if mutations from these mutators escape, tests are not good enough, which is also true for all other mutators.

--- a/tests/Fixtures/e2e/Identical_Mutator_Example/composer.json
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Namespace_\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Namespace_\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Identical_Mutator_Example/expected-output.txt
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 7
+Killed: 5
+Errored: 0
+Escaped: 2
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/Identical_Mutator_Example/infection.json
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/infection.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection-log.txt"
+    },
+    "tmpDir": "."
+}

--- a/tests/Fixtures/e2e/Identical_Mutator_Example/phpunit.xml
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Identical_Mutator_Example/src/StringEnvelope.php
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/src/StringEnvelope.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Namespace_;
+
+class StringEnvelope
+{
+    const THIS_IS_FALSE = false;
+
+    private $input;
+
+    public function __construct($input)
+    {
+        $this->input = $input;
+    }
+
+    public function hasSubstring($substring): bool
+    {
+        return self::THIS_IS_FALSE !== $this->findPosition($substring);
+    }
+
+    public function hasNotSubstring($substring): bool
+    {
+        return self::THIS_IS_FALSE === $this->findPosition($substring);
+    }
+
+    private function findPosition($substring)
+    {
+        return strpos($this->input, $substring);
+    }
+}

--- a/tests/Fixtures/e2e/Identical_Mutator_Example/tests/StringEnvelopeTest.php
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/tests/StringEnvelopeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Namespace_\Test;
+
+use PHPUnit\Framework\TestCase;
+use Namespace_\StringEnvelope;
+
+class StringEnvelopeTest extends TestCase
+{
+    public function testHasSubstring()
+    {
+        $sourceClass = new StringEnvelope('The quick brown fox jumps over the lazy dog');
+        $this->assertTrue($sourceClass->hasSubstring('quick'));
+        $this->assertFalse($sourceClass->hasSubstring('slow'));
+        // Test suite is incomplete without this test; it was left out intentionally
+        //$this->assertTrue($sourceClass->hasSubstring('The'));
+    }
+
+    public function testHasNotSubstring()
+    {
+        $sourceClass = new StringEnvelope('The quick brown fox jumps over the lazy dog');
+        $this->assertTrue($sourceClass->hasNotSubstring('slow'));
+        $this->assertFalse($sourceClass->hasNotSubstring('quick'));
+        // Test suite is incomplete without this test; it was left out intentionally
+        //$this->assertFalse($sourceClass->hasNotSubstring('The'));
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds an E2E test with a demo for IdenticalEqual/NotIdenticalNotEqual mutators

This demo was created in response to the question raised by #391.

### Escaped mutants
```
1) src/StringEnvelope.php:18    [M] NotIdenticalNotEqual
--- Original
+++ New
@@ @@
-        return self::THIS_IS_FALSE !== $this->findPosition($substring);
+        return self::THIS_IS_FALSE != $this->findPosition($substring);

2) src/StringEnvelope.php:23    [M] IdenticalEqual
--- Original
+++ New
@@ @@
-        return self::THIS_IS_FALSE === $this->findPosition($substring);
+        return self::THIS_IS_FALSE == $this->findPosition($substring);
```