### PR TITLE
Enable strict_comparison cs fixer rule

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -50,6 +50,7 @@ return \PhpCsFixer\Config::create()
             'style' => 'prefix',
             'case' => 'snake',
         ],
+        'strict_comparison' => true,
         'yoda_style' => false,
     ])
     ->setFinder($finder)

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ matrix:
       env: SYMFONY_VERSION="^4.0"
     - php: 7.2
       env: SYMFONY_VERSION="^4.0" PHPDBG=1
+    - php: nightly
+  allow_failures:
+    - php: nightly
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
 
 env:
   global:
-    - INFECTION_FLAGS='--threads=4 --min-msi=68 --min-covered-msi=77 --coverage=coverage --log-verbosity=none'
+    - INFECTION_FLAGS='--threads=4 --min-msi=66 --min-covered-msi=75 --coverage=coverage --log-verbosity=none'
     - PHPUNIT_BIN='vendor/bin/phpunit --coverage-clover=clover.xml --coverage-xml=coverage/coverage-xml --log-junit=coverage/phpunit.junit.xml'
     - secure: RT8az62c2YI2j7Xccamhw0eCFbPMphfK2c5aZ0cUyQCFeLuc7qJ5Q0y0DIapOf7YbpLBwVwf53LQtV8doyhZ2ltTRHM2NDmOxUrkxFpc50+I2FGlsrlPWPSDL69Dc6VxEy6+S1rvUUJu6KIs1lGCrUG3lOxt/avzctyY1g8KdqkhIfNADH6pwMzRxkhOacsKkdnT24RoFdN4M4uXyn16VclFOCeLaVdEHYCdD248L0MuhTZQF5u0jq0SdgNGOPnetRQXHjQLVSfmuB2bI5FUTxHVwvf4nU3aKYXONi+EzBauDZXdO/opgNydbmhVUZtRsTeSh1OANhAPTvW+qdFcMbc3K90q3UMdIp8pZS9krRzJyfXe7BodnvkOu0ej2S4x2eE2EZphK7L21nu016CDo1y434UCJX+DI3Pn7SZ7ood8nOi7yfOzNeVklW6+n6k6bSmS2ya/DcpS6y/OuH/awtLat0hzmXUCHVNV9YiES1KwtlkUSJqtaZwtj8iXuuBwOWWV4u71bivpKEbF2L7+1GYy56ftv57JHbh6m2tWCoeUQc9oAzDb0sHeBhj4YFVhAd598860Q4WhRG9BWJT8guySRI0iXOSxDrvgtgr5okG3WD2/CJtnsVukdgXMvcXiLbxMXKeF7LMRJfkNjrn++311ZAMaRWJSfGNEivZlooQ=
 

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -279,7 +279,7 @@ final class InfectionCommand extends BaseCommand
 
     private function applyMemoryLimitFromPhpUnitProcess(Process $process, MemoryUsageAware $adapter)
     {
-        if (\PHP_SAPI == 'phpdbg') {
+        if (\PHP_SAPI === 'phpdbg') {
             // Under phpdbg we're using a system php.ini, can't add a memory limit there
             return;
         }

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -227,7 +227,7 @@ final class SelfUpdateCommand extends Command
         $stability = 'stable';
 
         if ($updater->getStrategy() instanceof GithubStrategy
-            && $updater->getStrategy()->getStability() == GithubStrategy::UNSTABLE
+            && $updater->getStrategy()->getStability() === GithubStrategy::UNSTABLE
         ) {
             $stability = 'pre-release';
         }
@@ -239,7 +239,7 @@ final class SelfUpdateCommand extends Command
                     $stability,
                     $updater->getNewVersion()
                 ));
-            } elseif (false == $updater->getNewVersion()) {
+            } elseif (false === $updater->getNewVersion()) {
                 $this->output->writeln(sprintf('There are no %s builds available.', $stability));
             } else {
                 $this->output->writeln(sprintf('You have the current %s build installed.', $stability));

--- a/src/Config/Guesser/PhpUnitPathGuesser.php
+++ b/src/Config/Guesser/PhpUnitPathGuesser.php
@@ -46,7 +46,7 @@ final class PhpUnitPathGuesser implements Guesser
     {
         foreach ($parsedPaths as $namespace => $parsedPath) {
             // for old Symfony prjects (<=2.7) phpunit.xml is located in ./app folder
-            if (strpos($namespace, 'SymfonyStandard') !== false && trim($parsedPath, '/') == 'app') {
+            if (strpos($namespace, 'SymfonyStandard') !== false && trim($parsedPath, '/') === 'app') {
                 return 'app';
             }
         }

--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -65,7 +65,7 @@ final class ExcludeDirsProvider
         );
         $excludedDirs = [];
 
-        if ($sourceDirs == ['.']) {
+        if ($sourceDirs === ['.']) {
             foreach (self::EXCLUDED_ROOT_DIRS as $dir) {
                 if (\in_array($dir, $dirsInCurrentDir, true)) {
                     $excludedDirs[] = $dir;
@@ -73,7 +73,7 @@ final class ExcludeDirsProvider
             }
 
             $autocompleteValues = $dirsInCurrentDir;
-        } elseif (\count($sourceDirs) == 1) {
+        } elseif (\count($sourceDirs) === 1) {
             $globDirs = array_filter(glob($sourceDirs[0] . '/*'), 'is_dir');
 
             $autocompleteValues = array_map(

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -51,7 +51,7 @@ final class TestFrameworkConfigPathProvider
 
             return null;
         } catch (\Exception $e) {
-            if ($testFramework != TestFrameworkTypes::PHPUNIT) {
+            if ($testFramework !== TestFrameworkTypes::PHPUNIT) {
                 return $this->askTestFrameworkConfigLocation($input, $output, $dirsInCurrentDir, $testFramework, '');
             }
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -96,7 +96,7 @@ ASCII;
         /*
          * If we're skipping Xdebug, setup a default Xdebug-free environment for all subprocesses
          */
-        if ('' != XdebugHandler::getSkippedVersion()) {
+        if ('' !== XdebugHandler::getSkippedVersion()) {
             PhpProcess::setupXdebugFreeEnvironment();
         }
 

--- a/src/Console/Util/PhpProcess.php
+++ b/src/Console/Util/PhpProcess.php
@@ -45,7 +45,7 @@ final class PhpProcess extends Process
     public function start(callable $callback = null, array $env = null)
     {
         // Xdebug wasn't skipped, running as is
-        if ('' == XdebugHandler::getSkippedVersion()) {
+        if ('' === XdebugHandler::getSkippedVersion()) {
             parent::start($callback, $env ?? []);
 
             return;

--- a/src/Finder/Iterator/RealPathFilterIterator.php
+++ b/src/Finder/Iterator/RealPathFilterIterator.php
@@ -25,7 +25,7 @@ final class RealPathFilterIterator extends MultiplePcreFilterIterator
     {
         $filename = $this->current()->getRealPath();
 
-        if ('\\' == \DIRECTORY_SEPARATOR) {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
             $filename = str_replace('\\', '/', $filename);
         }
 

--- a/src/Finder/SourceFilesFinder.php
+++ b/src/Finder/SourceFilesFinder.php
@@ -48,7 +48,7 @@ final class SourceFilesFinder extends Finder
 
         $this->in($this->sourceDirectories)->files();
 
-        if ('' == $filter) {
+        if ('' === $filter) {
             $this->name('*.php');
 
             return $this;

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -106,7 +106,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
          * file on Windows, even if there's a proper executable .bat by its side.
          * Therefore we have to explicitly look for a .bat.
          */
-        if ('\\' == \DIRECTORY_SEPARATOR) {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
             array_unshift($candidates, $this->testFrameworkName . '.bat');
         } else {
             // yet always looking for .bat for testing with .bat not on Windows

--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -35,6 +35,6 @@ final class FalseValue extends Mutator
             return false;
         }
 
-        return strtolower($node->name->getFirst()) == 'false';
+        return strtolower($node->name->getFirst()) === 'false';
     }
 }

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -35,6 +35,6 @@ final class TrueValue extends Mutator
             return false;
         }
 
-        return strtolower($node->name->getFirst()) == 'true';
+        return strtolower($node->name->getFirst()) === 'true';
     }
 }

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -31,6 +31,6 @@ final class IncrementInteger extends Mutator
 
     protected function mutatesNode(Node $node): bool
     {
-        return $node instanceof Node\Scalar\LNumber && $node->value != 0;
+        return $node instanceof Node\Scalar\LNumber && $node->value !== 0;
     }
 }

--- a/src/Mutator/Number/OneZeroFloat.php
+++ b/src/Mutator/Number/OneZeroFloat.php
@@ -26,7 +26,7 @@ final class OneZeroFloat extends Mutator
      */
     public function mutate(Node $node)
     {
-        if ($node->value == 0.0) {
+        if ($node->value === 0.0) {
             return new Node\Scalar\DNumber(1.0);
         }
 
@@ -35,6 +35,6 @@ final class OneZeroFloat extends Mutator
 
     protected function mutatesNode(Node $node): bool
     {
-        return $node instanceof Node\Scalar\DNumber && ($node->value == 0.0 || $node->value == 1.0);
+        return $node instanceof Node\Scalar\DNumber && ($node->value === 0.0 || $node->value === 1.0);
     }
 }

--- a/src/Mutator/Number/OneZeroInteger.php
+++ b/src/Mutator/Number/OneZeroInteger.php
@@ -26,7 +26,7 @@ final class OneZeroInteger extends Mutator
      */
     public function mutate(Node $node)
     {
-        if ($node->value == 0) {
+        if ($node->value === 0) {
             return new Node\Scalar\LNumber(1);
         }
 
@@ -35,6 +35,6 @@ final class OneZeroInteger extends Mutator
 
     protected function mutatesNode(Node $node): bool
     {
-        return $node instanceof Node\Scalar\LNumber && ($node->value == 0 || $node->value == 1);
+        return $node instanceof Node\Scalar\LNumber && ($node->value === 0 || $node->value === 1);
     }
 }

--- a/src/Mutator/Regex/PregQuote.php
+++ b/src/Mutator/Regex/PregQuote.php
@@ -33,6 +33,6 @@ final class PregQuote extends Mutator
     {
         return $node instanceof Node\Expr\FuncCall &&
             $node->name instanceof Node\Name &&
-            strtolower((string) $node->name) == 'preg_quote';
+            strtolower((string) $node->name) === 'preg_quote';
     }
 }

--- a/src/Mutator/ReturnValue/FloatNegation.php
+++ b/src/Mutator/ReturnValue/FloatNegation.php
@@ -52,7 +52,7 @@ final class FloatNegation extends Mutator
             return false;
         }
 
-        if ($expr->value == 0.0) {
+        if ($expr->value === 0.0) {
             return false;
         }
 

--- a/src/Mutator/ReturnValue/IntegerNegation.php
+++ b/src/Mutator/ReturnValue/IntegerNegation.php
@@ -52,7 +52,7 @@ final class IntegerNegation extends Mutator
             return false;
         }
 
-        if ($expr->value == 0) {
+        if ($expr->value === 0) {
             return false;
         }
 

--- a/src/Mutator/ReturnValue/This.php
+++ b/src/Mutator/ReturnValue/This.php
@@ -35,7 +35,7 @@ final class This extends AbstractValueToNullReturnValue
     {
         return $node instanceof Node\Stmt\Return_ &&
             $node->expr instanceof Node\Expr\Variable &&
-            $node->expr->name == 'this'
+            $node->expr->name === 'this'
             && $this->isNullReturnValueAllowed($node);
     }
 }

--- a/src/Process/Builder/ProcessBuilder.php
+++ b/src/Process/Builder/ProcessBuilder.php
@@ -50,7 +50,7 @@ class ProcessBuilder
         bool $skipCoverage,
         array $phpExtraOptions = []
     ): Process {
-        $includeArgs = \PHP_SAPI == 'phpdbg';
+        $includeArgs = \PHP_SAPI === 'phpdbg';
 
         // If we're expecting to receive a code coverage, test process must run in a vanilla environment
         $processType = $skipCoverage ? Process::class : PhpProcess::class;

--- a/src/Process/ExecutableFinder/PhpExecutableFinder.php
+++ b/src/Process/ExecutableFinder/PhpExecutableFinder.php
@@ -20,7 +20,7 @@ final class PhpExecutableFinder extends BasePhpExecutableFinder
     {
         $arguments = [];
 
-        if ('phpdbg' == \PHP_SAPI) {
+        if ('phpdbg' === \PHP_SAPI) {
             $arguments[] = '-qrr';
         }
 

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -100,7 +100,7 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
     private function filterLogTypes(array $logTypes): array
     {
         foreach ($logTypes as $key => $value) {
-            if ($this->logVerbosity == LogVerbosity::NONE) {
+            if ($this->logVerbosity === LogVerbosity::NONE) {
                 if (!\in_array($key, ResultsLoggerTypes::ALLOWED_WITHOUT_LOGGING, true)) {
                     unset($logTypes[$key]);
                 }
@@ -116,7 +116,7 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
 
     private function useLogger(string $logType, $config)
     {
-        $isDebugVerbosity = $this->logVerbosity == LogVerbosity::DEBUG;
+        $isDebugVerbosity = $this->logVerbosity === LogVerbosity::DEBUG;
 
         switch ($logType) {
             case ResultsLoggerTypes::TEXT_FILE:

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -73,7 +73,7 @@ final class IncludeInterceptor
         self::disable();
         $including = (bool) ($options & self::STREAM_OPEN_FOR_INCLUDE);
         if ($including) {
-            if ($path == self::$intercept || realpath($path) == self::$intercept) {
+            if ($path === self::$intercept || realpath($path) === self::$intercept) {
                 $this->fp = fopen(self::$replacement, 'r');
                 self::enable();
 

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -123,7 +123,7 @@ abstract class AbstractTestFrameworkAdapter
     {
         $frameworkPath = realpath($frameworkPath);
 
-        if ('\\' == \DIRECTORY_SEPARATOR) {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
             if (false !== strpos($frameworkPath, '.bat')) {
                 return $frameworkPath;
             }
@@ -139,7 +139,7 @@ abstract class AbstractTestFrameworkAdapter
         /*
          * That's an empty options list by all means, we need to see it as such
          */
-        if ($phpExtraArgs == ['']) {
+        if ($phpExtraArgs === ['']) {
             $phpExtraArgs = [];
         }
 
@@ -149,7 +149,7 @@ abstract class AbstractTestFrameworkAdapter
          *
          * This lets folks use, say, a bash wrapper over phpunit.
          */
-        if ('cli' == \PHP_SAPI && empty($phpExtraArgs) && is_executable($frameworkPath) && `command -v php`) {
+        if ('cli' === \PHP_SAPI && empty($phpExtraArgs) && is_executable($frameworkPath) && `command -v php`) {
             return sprintf(
                 '%s %s',
                 'exec',

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -83,7 +83,7 @@ final class Factory
 
     public function create(string $adapterName, bool $skipCoverage): AbstractTestFrameworkAdapter
     {
-        if ($adapterName == TestFrameworkTypes::PHPUNIT) {
+        if ($adapterName === TestFrameworkTypes::PHPUNIT) {
             $phpUnitConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPUNIT);
             $phpUnitConfigContent = file_get_contents($phpUnitConfigPath);
 
@@ -103,7 +103,7 @@ final class Factory
             );
         }
 
-        if ($adapterName == TestFrameworkTypes::PHPSPEC) {
+        if ($adapterName === TestFrameworkTypes::PHPSPEC) {
             $phpSpecConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPSPEC);
 
             return new PhpSpecAdapter(

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -156,7 +156,7 @@ class CoverageXmlParser
             $lineNumber = $lineCoverageNode->getAttribute('nr');
 
             foreach ($lineCoverageNode->childNodes as $coveredNode) {
-                if ($coveredNode->nodeName == 'covered') {
+                if ($coveredNode->nodeName === 'covered') {
                     $testMethod = $coveredNode->getAttribute('by');
 
                     $fileCoverage[$lineNumber][] = ['testMethod' => $testMethod];

--- a/src/Visitor/MutatorVisitor.php
+++ b/src/Visitor/MutatorVisitor.php
@@ -40,10 +40,10 @@ final class MutatorVisitor extends NodeVisitorAbstract
         $mutator = $this->mutation->getMutator();
         $mutatedAttributes = $this->mutation->getAttributes();
 
-        $isEqualPosition = $attributes['startTokenPos'] == $mutatedAttributes['startTokenPos'] &&
-            $attributes['endTokenPos'] == $mutatedAttributes['endTokenPos'];
+        $isEqualPosition = $attributes['startTokenPos'] === $mutatedAttributes['startTokenPos'] &&
+            $attributes['endTokenPos'] === $mutatedAttributes['endTokenPos'];
 
-        if ($isEqualPosition && $this->mutation->getMutatedNodeClass() == \get_class($node)) {
+        if ($isEqualPosition && $this->mutation->getMutatedNodeClass() === \get_class($node)) {
             return $mutator->mutate($node);
             // TODO STOP TRAVERSING
             // TODO check all built-in visitors, in particular FirstFindingVisitor

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -350,7 +350,7 @@ final class ProjectCodeTest extends TestCase
          * a public propery it has.
          */
         $properties = array_filter($properties, function (\ReflectionProperty $property) use ($className) {
-            return $property->class == $className;
+            return $property->class === $className;
         });
 
         $this->assertCount(

--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -40,7 +40,7 @@ final class E2ETest extends TestCase
         // Without overcommit this test fails with `proc_open(): fork failed - Cannot allocate memory`
         if (strpos(PHP_OS, 'Linux') === 0 &&
             is_readable('/proc/sys/vm/overcommit_memory') &&
-            file_get_contents('/proc/sys/vm/overcommit_memory') == 2) {
+            file_get_contents('/proc/sys/vm/overcommit_memory') === 2) {
             $this->markTestSkipped('This test needs copious amounts of virtual memory. It will fail unless it is allowed to overcommit memory.');
         }
 

--- a/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
+++ b/tests/Process/ExecutableFinder/PhpExecutableFinderTest.php
@@ -21,7 +21,7 @@ final class PhpExecutableFinderTest extends TestCase
     {
         $finder = new PhpExecutableFinder();
 
-        if ('phpdbg' == \PHP_SAPI) {
+        if ('phpdbg' === \PHP_SAPI) {
             $this->assertSame(['-qrr'], $finder->findArguments());
 
             return;


### PR DESCRIPTION
```
$ ./php-cs-fixer-v2.phar describe strict_comparison
Description of strict_comparison rule.
Comparisons should be strict.

Fixer applying this rule is risky.
Changing comparisons to strict might change code behavior.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,2 @@
    <?php
   -$a = 1== $b;
   +$a = 1=== $b;
   
   ----------- end diff -----------
```