### PR TITLE
BadgeLogger now reports exact errors

### DIFF
--- a/src/Http/BadgeApiClient.php
+++ b/src/Http/BadgeApiClient.php
@@ -18,6 +18,8 @@ class BadgeApiClient
 {
     const STRYKER_DASHBOARD_API_URL = 'https://dashboard.stryker-mutator.io/api/reports';
 
+    const CREATED_RESPONSE_CODE = 201;
+
     /**
      * @var OutputInterface
      */
@@ -52,11 +54,14 @@ class BadgeApiClient
         curl_setopt($ch, CURLOPT_HEADER, true);
 
         $response = curl_exec($ch);
+        $responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
 
-        if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
-            $this->output->writeln($response);
+        if (self::CREATED_RESPONSE_CODE !== $responseCode) {
+            $this->output->writeln(sprintf('Stryker dashboard returned an unexpected response code: %s', $responseCode));
         }
 
-        curl_close($ch);
+        $this->output->writeln('Dashboard response:', OutputInterface::VERBOSITY_VERBOSE);
+        $this->output->writeln($response, OutputInterface::VERBOSITY_VERBOSE);
     }
 }


### PR DESCRIPTION
This PR:

- [x] Makes BadgeLogger report detailed explanation for an error
- [x] To avoid confusion, BadgeLogger now will also look for `STRYKER_DASHBOARD_API_KEY` since [that's what the official manual for the Stryker Dashboard calls for](https://stryker-mutator.io/blog/2018-02-08/get-your-mutation-score-badge-now.html).
- [x] BadgeApiClient now check for HTTP code on success
- [x] Covered by tests

