### PR TITLE
Explicitly require the DOM extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
     },
     "require": {
         "php": "^7.0",
+        "ext-dom": "*",
         "composer/xdebug-handler": "^1.1",
         "nikic/php-parser": "^4.0",
         "ocramius/package-versions": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f25dd0618f66a862c47b14b33d56d571",
+    "content-hash": "4609129e7936cb0821e12aa0f05cf4fc",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2499,7 +2499,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0"
+        "php": "^7.0",
+        "ext-dom": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
This PR:

* Explicitly requires the dom extension

A few things to note:

* We only require this when running phpunit, we don't use any DOM related things for phpspec as far as i know.
* We also require the curl extension, but only when dealing with the badge api.

