### PR TITLE
Fix exclude to excludes for generated config file

### DIFF
--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -141,7 +141,7 @@ final class ConfigureCommand extends BaseCommand
         }
 
         if ($excludedDirs) {
-            $configObject->source->exclude = $excludedDirs;
+            $configObject->source->excludes = $excludedDirs;
         }
 
         if ($phpUnitConfigPath) {


### PR DESCRIPTION
This PR:

- [x] changes the generated config to use `excludes` instead of `exclude`
- [x] Fixes #422 