### PR TITLE
Sort logs

### DIFF
--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -54,12 +54,12 @@ final class DebugFileLogger extends FileLogger
     private function convertProcess(array $processes, string $headlinePrefix): string
     {
         $logParts = $this->getHeadlineParts($headlinePrefix);
+        $this->sortProcesses($processes);
 
-        foreach ($processes as $index => $mutantProcess) {
+        foreach ($processes as $mutantProcess) {
             $logParts[] = '';
-            $mutation = $mutantProcess->getMutant()->getMutation();
-            $logParts[] = 'Mutator: ' . $mutation->getMutator()::getName();
-            $logParts[] = 'Line ' . $mutation->getAttributes()['startLine'];
+            $logParts[] = 'Mutator: ' . $mutantProcess->getMutator()::getName();
+            $logParts[] = 'Line ' . $mutantProcess->getOriginalStartingLine();
         }
 
         return implode($logParts, "\n") . "\n";

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Logger;
 
 use Infection\Mutant\MetricsCalculator;
+use Infection\Process\MutantProcessInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -62,4 +63,18 @@ abstract class FileLogger implements MutationTestingResultsLogger
     }
 
     abstract protected function getLogLines(): array;
+
+    /**
+     * @param MutantProcessInterface[] $processes
+     */
+    final protected function sortProcesses(array &$processes): void
+    {
+        usort($processes, function (MutantProcessInterface $a, MutantProcessInterface $b): int {
+            if ($a->getOriginalFilePath() === $b->getOriginalFilePath()) {
+                return $a->getOriginalStartingLine() <=> $b->getOriginalStartingLine();
+            }
+
+            return $a->getOriginalFilePath() <=> $b->getOriginalFilePath();
+        });
+    }
 }

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -19,14 +19,14 @@ final class TextFileLogger extends FileLogger
     protected function getLogLines(): array
     {
         $logs[] = $this->getLogParts($this->metricsCalculator->getEscapedMutantProcesses(), 'Escaped');
-        $logs[] = $this->getLogParts($this->metricsCalculator->getTimedOutProcesses(), 'Timeout');
+        $logs[] = $this->getLogParts($this->metricsCalculator->getTimedOutProcesses(), 'Timed Out');
 
         if ($this->isDebugVerbosity) {
             $logs[] = $this->getLogParts($this->metricsCalculator->getKilledMutantProcesses(), 'Killed');
             $logs[] = $this->getLogParts($this->metricsCalculator->getErrorProcesses(), 'Errors');
         }
 
-        $logs[] = $this->getLogParts($this->metricsCalculator->getNotCoveredMutantProcesses(), 'Not covered');
+        $logs[] = $this->getLogParts($this->metricsCalculator->getNotCoveredMutantProcesses(), 'Not Covered');
 
         return $logs;
     }
@@ -40,6 +40,7 @@ final class TextFileLogger extends FileLogger
     private function getLogParts(array $processes, string $headlinePrefix): string
     {
         $logParts = $this->getHeadlineParts($headlinePrefix);
+        $this->sortProcesses($processes);
 
         foreach ($processes as $index => $mutantProcess) {
             $isShowFullFormat = $this->isDebugVerbosity && $mutantProcess->getProcess()->isStarted();
@@ -72,14 +73,12 @@ final class TextFileLogger extends FileLogger
 
     private function getMutatorFirstLine(int $index, MutantProcessInterface $mutantProcess): string
     {
-        $mutation = $mutantProcess->getMutant()->getMutation();
-
         return sprintf(
             '%d) %s:%d    [M] %s',
             $index + 1,
-            $mutation->getOriginalFilePath(),
-            (int) $mutation->getAttributes()['startLine'],
-            $mutation->getMutator()::getName()
+            $mutantProcess->getOriginalFilePath(),
+            $mutantProcess->getOriginalStartingLine(),
+            $mutantProcess->getMutator()::getName()
         );
     }
 }

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Process;
 
 use Infection\Mutant\MutantInterface;
+use Infection\MutationInterface;
 use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Symfony\Component\Process\Process;
@@ -105,6 +106,21 @@ final class MutantProcess implements MutantProcessInterface
 
     public function getMutator(): Mutator
     {
-        return $this->getMutant()->getMutation()->getMutator();
+        return $this->getMutation()->getMutator();
+    }
+
+    public function getOriginalFilePath(): string
+    {
+        return $this->getMutation()->getOriginalFilePath();
+    }
+
+    public function getOriginalStartingLine(): int
+    {
+        return (int) $this->getMutation()->getAttributes()['startLine'];
+    }
+
+    private function getMutation(): MutationInterface
+    {
+        return $this->getMutant()->getMutation();
     }
 }

--- a/src/Process/MutantProcessInterface.php
+++ b/src/Process/MutantProcessInterface.php
@@ -29,4 +29,8 @@ interface MutantProcessInterface
     public function getResultCode(): int;
 
     public function getMutator(): Mutator;
+
+    public function getOriginalFilePath(): string;
+
+    public function getOriginalStartingLine(): int;
 }

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -24,10 +24,7 @@ use Infection\Differ\Differ;
 use Infection\Finder\ComposerExecutableFinder;
 use Infection\Finder\TestFrameworkFinder;
 use Infection\Http\BadgeApiClient;
-use Infection\Logger\DebugFileLogger;
 use Infection\Logger\ResultsLoggerTypes;
-use Infection\Logger\SummaryFileLogger;
-use Infection\Logger\TextFileLogger;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutator\Util\Mutator;
 use Infection\Process\Builder\ProcessBuilder;
@@ -115,10 +112,7 @@ final class ProjectCodeTest extends TestCase
         PhpProcess::class,
         ComposerExecutableFinder::class,
         BadgeApiClient::class,
-        DebugFileLogger::class,
         ResultsLoggerTypes::class,
-        SummaryFileLogger::class,
-        TextFileLogger::class,
         MutantCreatingConsoleLoggerSubscriber::class,
         MutationGeneratingConsoleLoggerSubscriber::class,
         MutationTestingRunner::class,

--- a/tests/Fixtures/e2e/Config_Framework/expected-output.txt
+++ b/tests/Fixtures/e2e/Config_Framework/expected-output.txt
@@ -3,13 +3,16 @@ Killed mutants:
 ===============
 
 
-Mutator: Plus
-Line 9
-
 Mutator: PublicVisibility
 Line 7
 
+Mutator: Plus
+Line 9
+
 Mutator: TrueValue
+Line 12
+
+Mutator: PublicVisibility
 Line 12
 
 Mutator: FalseValue
@@ -20,9 +23,6 @@ Line 14
 
 Mutator: TrueValue
 Line 15
-
-Mutator: PublicVisibility
-Line 12
 
 Errors mutants:
 ===============

--- a/tests/Fixtures/e2e/Multiline_Statement/expected-output.txt
+++ b/tests/Fixtures/e2e/Multiline_Statement/expected-output.txt
@@ -1,8 +1,8 @@
 Escaped mutants:
 ================
 
-Timeout mutants:
-================
+Timed Out mutants:
+==================
 
-Not covered mutants:
+Not Covered mutants:
 ====================

--- a/tests/Fixtures/e2e/Trait_Coverage/expected-output.txt
+++ b/tests/Fixtures/e2e/Trait_Coverage/expected-output.txt
@@ -12,11 +12,11 @@ Line 7
 Mutator: TrueValue
 Line 12
 
-Mutator: Plus
-Line 15
-
 Mutator: PublicVisibility
 Line 12
+
+Mutator: Plus
+Line 15
 
 Errors mutants:
 ===============

--- a/tests/Logger/DebugFileLoggerTest.php
+++ b/tests/Logger/DebugFileLoggerTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Logger;
+
+use Infection\Logger\DebugFileLogger;
+use Infection\Mutant\MetricsCalculator;
+use Infection\Mutator\Boolean\TrueValue;
+use Infection\Mutator\Util\MutatorConfig;
+use Infection\Mutator\ZeroIteration\For_;
+use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class DebugFileLoggerTest extends TestCase
+{
+    public function test_it_logs_correctly_with_no_mutations(): void
+    {
+        $logFilePath = sys_get_temp_dir() . '/foo.txt';
+        $calculator = new MetricsCalculator();
+        $fs = $this->createMock(Filesystem::class);
+        $fs->expects($this->once())->method('dumpFile')->with(
+            $logFilePath,
+            <<<'TXT'
+Total: 0
+Killed mutants:
+===============
+
+
+Errors mutants:
+===============
+
+
+Escaped mutants:
+================
+
+
+Timed Out mutants:
+==================
+
+
+Not Covered mutants:
+====================
+
+
+TXT
+        );
+
+        $debugFileLogger = new DebugFileLogger($logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger->log();
+    }
+
+    public function test_it_log_correctly_with_mutations(): void
+    {
+        $logFilePath = sys_get_temp_dir() . '/foo.txt';
+        $calculator = $this->createFilledMetricsCalculator();
+        $fs = $this->createMock(Filesystem::class);
+        $fs->expects($this->once())->method('dumpFile')->with(
+            $logFilePath,
+            <<<'TXT'
+Total: 12
+Killed mutants:
+===============
+
+
+Mutator: TrueValue
+Line 16
+
+Mutator: TrueValue
+Line 17
+
+Mutator: TrueValue
+Line 18
+
+Mutator: TrueValue
+Line 19
+
+Mutator: TrueValue
+Line 20
+
+Mutator: For_
+Line 6
+
+Mutator: For_
+Line 7
+
+Mutator: For_
+Line 8
+
+Mutator: For_
+Line 9
+
+Mutator: For_
+Line 10
+
+Errors mutants:
+===============
+
+
+Escaped mutants:
+================
+
+
+Mutator: For_
+Line 9
+
+Mutator: For_
+Line 10
+
+Timed Out mutants:
+==================
+
+
+Not Covered mutants:
+====================
+
+
+TXT
+        );
+
+        $debugFileLogger = new DebugFileLogger($logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger->log();
+    }
+
+    private function createFilledMetricsCalculator(): MetricsCalculator
+    {
+        $processes = [];
+
+        for ($i = 0; $i < 5; ++$i) {
+            $process = $this->createMock(MutantProcessInterface::class);
+            $process->expects($this->once())->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
+            $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
+            $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
+            $processes[] = $process;
+        }
+
+        for ($i = 0; $i < 5; ++$i) {
+            $process = $this->createMock(MutantProcessInterface::class);
+            $process->expects($this->once())->method('getMutator')->willReturn(new TrueValue(new MutatorConfig([])));
+            $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
+            $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(20 - $i);
+            $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('bar/bar');
+
+            $processes[] = $process;
+        }
+
+        for ($i = 0; $i < 2; ++$i) {
+            $process = $this->createMock(MutantProcessInterface::class);
+            $process->expects($this->once())->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
+            $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
+            $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
+            $processes[] = $process;
+        }
+
+        return MetricsCalculator::createFromArray($processes);
+    }
+}

--- a/tests/Logger/SummaryFileLoggerTest.php
+++ b/tests/Logger/SummaryFileLoggerTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Logger;
+
+use Infection\Logger\SummaryFileLogger;
+use Infection\Mutant\MetricsCalculator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class SummaryFileLoggerTest extends TestCase
+{
+    public function test_it_logs_the_correct_lines_with_no_mutations(): void
+    {
+        $logFilePath = sys_get_temp_dir() . '/foo.txt';
+        $calculator = new MetricsCalculator();
+        $fs = $this->createMock(Filesystem::class);
+        $fs->expects($this->once())->method('dumpFile')->with(
+            $logFilePath,
+            <<<'TXT'
+Total: 0
+Killed: 0
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0
+TXT
+        );
+
+        $debugFileLogger = new SummaryFileLogger($logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger->log();
+    }
+
+    public function test_it_logs_the_correct_lines_with_mutations(): void
+    {
+        $logFilePath = sys_get_temp_dir() . '/foo.txt';
+        $calculator = $this->createMock(MetricsCalculator::class);
+        $calculator->expects($this->once())->method('getTotalMutantsCount')->willReturn(6);
+        $calculator->expects($this->once())->method('getKilledCount')->willReturn(8);
+        $calculator->expects($this->once())->method('getErrorCount')->willReturn(7);
+        $calculator->expects($this->once())->method('getEscapedCount')->willReturn(30216);
+        $calculator->expects($this->once())->method('getTimedOutCount')->willReturn(2);
+        $calculator->expects($this->once())->method('getNotCoveredByTestsCount')->willReturn(0);
+        $fs = $this->createMock(Filesystem::class);
+        $fs->expects($this->once())->method('dumpFile')->with(
+            $logFilePath,
+            <<<'TXT'
+Total: 6
+Killed: 8
+Errored: 7
+Escaped: 30216
+Timed Out: 2
+Not Covered: 0
+TXT
+        );
+
+        $debugFileLogger = new SummaryFileLogger($logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger->log();
+    }
+}

--- a/tests/Logger/TextFileLoggerTest.php
+++ b/tests/Logger/TextFileLoggerTest.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Logger;
+
+use Infection\Logger\TextFileLogger;
+use Infection\Mutant\MetricsCalculator;
+use Infection\Mutant\MutantInterface;
+use Infection\Mutator\Boolean\TrueValue;
+use Infection\Mutator\Util\MutatorConfig;
+use Infection\Mutator\ZeroIteration\For_;
+use Infection\Process\MutantProcess;
+use Infection\Process\MutantProcessInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+
+/**
+ * @internal
+ */
+final class TextFileLoggerTest extends TestCase
+{
+    public function test_it_logs_correctly_with_no_mutations_and_no_debug_verbosity(): void
+    {
+        $logFilePath = sys_get_temp_dir() . '/foo.txt';
+        $calculator = new MetricsCalculator();
+        $fs = $this->createMock(Filesystem::class);
+        $fs->expects($this->once())->method('dumpFile')->with(
+            $logFilePath,
+            <<<'TXT'
+Escaped mutants:
+================
+
+Timed Out mutants:
+==================
+
+Not Covered mutants:
+====================
+
+TXT
+        );
+
+        $debugFileLogger = new TextFileLogger($logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger->log();
+    }
+
+    public function test_it_logs_correctly_with_no_mutations_and_debug_verbosity(): void
+    {
+        $logFilePath = sys_get_temp_dir() . '/foo.txt';
+        $calculator = new MetricsCalculator();
+        $fs = $this->createMock(Filesystem::class);
+        $fs->expects($this->once())->method('dumpFile')->with(
+            $logFilePath,
+            <<<'TXT'
+Escaped mutants:
+================
+
+Timed Out mutants:
+==================
+
+Killed mutants:
+===============
+
+Errors mutants:
+===============
+
+Not Covered mutants:
+====================
+
+TXT
+        );
+
+        $debugFileLogger = new TextFileLogger($logFilePath, $calculator, $fs, true, false);
+        $debugFileLogger->log();
+    }
+
+    public function test_it_logs_correctly_with_mutations_and_no_debug_verbosity_and_with_debug(): void
+    {
+        $logFilePath = sys_get_temp_dir() . '/foo.txt';
+        $calculator = $this->createFilledMetricsCalculator();
+        $fs = $this->createMock(Filesystem::class);
+        $fs->expects($this->atMost(10))->method('dumpFile')->with(
+            $logFilePath,
+            <<<'TXT'
+Escaped mutants:
+================
+
+
+1) bar/bar:16    [M] TrueValue
+bin/foo/bar -c conf
+Diff Diff Diff
+
+2) bar/bar:17    [M] TrueValue
+bin/foo/bar -c conf
+Diff Diff Diff
+
+3) bar/bar:18    [M] TrueValue
+bin/foo/bar -c conf
+Diff Diff Diff
+
+4) bar/bar:19    [M] TrueValue
+bin/foo/bar -c conf
+Diff Diff Diff
+
+5) bar/bar:20    [M] TrueValue
+bin/foo/bar -c conf
+Diff Diff Diff
+
+6) foo/bar:6    [M] For_
+bin/foo/bar -c conf
+Diff Diff
+
+7) foo/bar:7    [M] For_
+bin/foo/bar -c conf
+Diff Diff
+
+8) foo/bar:8    [M] For_
+bin/foo/bar -c conf
+Diff Diff
+
+9) foo/bar:9    [M] For_
+bin/foo/bar -c conf
+Diff Diff
+
+10) foo/bar:10    [M] For_
+bin/foo/bar -c conf
+Diff Diff
+Timed Out mutants:
+==================
+
+Not Covered mutants:
+====================
+
+
+1) foo/bar:9    [M] For_
+bin/foo/bar -c conf
+Diff Diff
+
+2) foo/bar:10    [M] For_
+bin/foo/bar -c conf
+Diff Diff
+TXT
+        );
+
+        $debugFileLogger = new TextFileLogger($logFilePath, $calculator, $fs, false, true);
+        $debugFileLogger->log();
+    }
+
+    public function test_it_logs_correctly_with_mutations_and_debug_verbosity_and_no_debug_mode(): void
+    {
+        $logFilePath = sys_get_temp_dir() . '/foo.txt';
+        $calculator = $this->createFilledMetricsCalculator();
+        $fs = $this->createMock(Filesystem::class);
+        $fs->expects($this->atMost(10))->method('dumpFile')->with(
+            $logFilePath,
+            <<<'TXT'
+Escaped mutants:
+================
+
+
+1) bar/bar:16    [M] TrueValue
+
+Diff Diff Diff
+
+
+2) bar/bar:17    [M] TrueValue
+
+Diff Diff Diff
+
+
+3) bar/bar:18    [M] TrueValue
+
+Diff Diff Diff
+
+
+4) bar/bar:19    [M] TrueValue
+
+Diff Diff Diff
+
+
+5) bar/bar:20    [M] TrueValue
+
+Diff Diff Diff
+
+
+6) foo/bar:6    [M] For_
+
+Diff Diff
+
+
+7) foo/bar:7    [M] For_
+
+Diff Diff
+
+
+8) foo/bar:8    [M] For_
+
+Diff Diff
+
+
+9) foo/bar:9    [M] For_
+
+Diff Diff
+
+
+10) foo/bar:10    [M] For_
+
+Diff Diff
+
+Timed Out mutants:
+==================
+
+Killed mutants:
+===============
+
+
+1) foo/bar:9    [M] For_
+
+Diff Diff
+
+
+2) foo/bar:10    [M] For_
+
+Diff Diff
+
+Errors mutants:
+===============
+
+Not Covered mutants:
+====================
+
+
+1) foo/bar:9    [M] For_
+
+Diff Diff
+
+
+2) foo/bar:10    [M] For_
+
+Diff Diff
+
+TXT
+        );
+
+        $debugFileLogger = new TextFileLogger($logFilePath, $calculator, $fs, true, false);
+        $debugFileLogger->log();
+    }
+
+    private function createFilledMetricsCalculator(): MetricsCalculator
+    {
+        $processes = [];
+
+        for ($i = 0; $i < 5; ++$i) {
+            $phpProcess = $this->createMock(Process::class);
+            $phpProcess->expects($this->atMost(1))->method('getCommandLine')->willReturn('bin/foo/bar -c conf');
+            $phpProcess->expects($this->atMost(1))->method('isStarted')->willReturn(true);
+
+            $mutant = $this->createMock(MutantInterface::class);
+            $mutant->expects($this->once())->method('getDiff')->willReturn('Diff Diff');
+
+            $process = $this->createMock(MutantProcessInterface::class);
+            $process->method('getProcess')->willReturn($phpProcess);
+            $process->expects($this->once())->method('getMutant')->willReturn($mutant);
+
+            $process->expects($this->once())->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
+            $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
+            $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
+            $processes[] = $process;
+        }
+
+        for ($i = 0; $i < 5; ++$i) {
+            $phpProcess = $this->createMock(Process::class);
+
+            $phpProcess->expects($this->atMost(1))->method('getCommandLine')->willReturn('bin/foo/bar -c conf');
+            $phpProcess->expects($this->atMost(1))->method('isStarted')->willReturn(true);
+
+            $mutant = $this->createMock(MutantInterface::class);
+            $mutant->expects($this->once())->method('getDiff')->willReturn('Diff Diff Diff');
+
+            $process = $this->createMock(MutantProcessInterface::class);
+            $process->method('getProcess')->willReturn($phpProcess);
+            $process->expects($this->once())->method('getMutant')->willReturn($mutant);
+
+            $process->expects($this->once())->method('getMutator')->willReturn(new TrueValue(new MutatorConfig([])));
+            $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
+            $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(20 - $i);
+            $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('bar/bar');
+
+            $processes[] = $process;
+        }
+
+        for ($i = 0; $i < 2; ++$i) {
+            $phpProcess = $this->createMock(Process::class);
+
+            $phpProcess->expects($this->atMost(1))->method('getCommandLine')->willReturn('bin/foo/bar -c conf');
+            $phpProcess->expects($this->atMost(1))->method('isStarted')->willReturn(true);
+
+            $mutant = $this->createMock(MutantInterface::class);
+            $mutant->expects($this->once())->method('getDiff')->willReturn('Diff Diff');
+
+            $process = $this->createMock(MutantProcessInterface::class);
+            $process->method('getProcess')->willReturn($phpProcess);
+            $process->expects($this->once())->method('getMutant')->willReturn($mutant);
+
+            $process->expects($this->once())->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_NOT_COVERED);
+            $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
+            $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
+            $processes[] = $process;
+        }
+
+        for ($i = 0; $i < 2; ++$i) {
+            $phpProcess = $this->createMock(Process::class);
+
+            $phpProcess->expects($this->atMost(1))->method('getCommandLine')->willReturn('bin/foo/bar -c conf');
+            $phpProcess->expects($this->atMost(1))->method('isStarted')->willReturn(true);
+
+            $mutant = $this->createMock(MutantInterface::class);
+            $mutant->expects($this->atMost(1))->method('getDiff')->willReturn('Diff Diff');
+
+            $process = $this->createMock(MutantProcessInterface::class);
+            $process->method('getProcess')->willReturn($phpProcess);
+            $process->expects($this->atMost(1))->method('getMutant')->willReturn($mutant);
+
+            $process->expects($this->atMost(1))->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $process->expects($this->atMost(1))->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
+            $process->method('getOriginalStartingLine')->willReturn(10 - $i);
+            $process->method('getOriginalFilePath')->willReturn('foo/bar');
+            $processes[] = $process;
+        }
+
+        return MetricsCalculator::createFromArray($processes);
+    }
+}

--- a/tests/Process/MutantProcessTest.php
+++ b/tests/Process/MutantProcessTest.php
@@ -115,4 +115,44 @@ final class MutantProcessTest extends MockeryTestCase
 
         $this->assertSame($mutator, $mutantProcess->getMutator());
     }
+
+    public function test_it_knows_its_original_path(): void
+    {
+        $process = $this->createMOck(Process::class);
+        $process->expects($this->never())->method($this->anything());
+
+        $adapter = $this->createMock(AbstractTestFrameworkAdapter::class);
+        $adapter->expects($this->never())->method($this->anything());
+
+        $mutation = $this->createMock(MutationInterface::class);
+        $mutation->expects($this->once())->method('getOriginalFilePath')->willReturn('foo/bar');
+        $mutant = $this->createMock(MutantInterface::class);
+        $mutant->expects($this->once())->method('getMutation')->willReturn($mutation);
+
+        $mutantProcess = new MutantProcess($process, $mutant, $adapter);
+
+        $path = $mutantProcess->getOriginalFilePath();
+
+        $this->assertSame('foo/bar', $path);
+    }
+
+    public function test_it_knows_its_original_starting_line(): void
+    {
+        $process = $this->createMOck(Process::class);
+        $process->expects($this->never())->method($this->anything());
+
+        $adapter = $this->createMock(AbstractTestFrameworkAdapter::class);
+        $adapter->expects($this->never())->method($this->anything());
+
+        $mutation = $this->createMock(MutationInterface::class);
+        $mutation->expects($this->once())->method('getAttributes')->willReturn(['startLine' => '3']);
+        $mutant = $this->createMock(MutantInterface::class);
+        $mutant->expects($this->once())->method('getMutation')->willReturn($mutation);
+
+        $mutantProcess = new MutantProcess($process, $mutant, $adapter);
+
+        $line = $mutantProcess->getOriginalStartingLine();
+
+        $this->assertSame(3, $line);
+    }
 }


### PR DESCRIPTION
Sort by filename, with a fall back to line number.
Also add tests for that.
This PR:

- [x] Sorts the logs based on filename, and then by line number.
- [x] Covered by tests
- [x] Fixes #421 
