### PR TITLE
Build phar on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,8 @@ jobs:
       php: 7.2
       install:
         - composer install
+      script:
+        make build/bin/infection.phar;
       deploy:
         provider: releases
         api_key:


### PR DESCRIPTION
This PR:

- [x] Fixes the phar build on travis

This was due to me not adding the make build/bin/infection.phar to the deploy stage when i re arranged travis into build stages.