### PR TITLE
Round MSI down to the smallest integer, instead of nearest

### DIFF
--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -134,7 +134,7 @@ class MetricsCalculator
         $defeatedTotal = $this->killedCount + $this->timedOutCount + $this->errorCount;
 
         if ($this->totalMutantsCount) {
-            $detectionRateAll = round(100 * ($defeatedTotal / $this->totalMutantsCount));
+            $detectionRateAll = floor(100 * ($defeatedTotal / $this->totalMutantsCount));
         }
 
         return $detectionRateAll;

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -134,7 +134,7 @@ class MetricsCalculator
         $defeatedTotal = $this->killedCount + $this->timedOutCount + $this->errorCount;
 
         if ($this->totalMutantsCount) {
-            $detectionRateAll = floor(100 * ($defeatedTotal / $this->totalMutantsCount));
+            $detectionRateAll = floor(100 * $defeatedTotal / $this->totalMutantsCount);
         }
 
         return $detectionRateAll;
@@ -151,7 +151,7 @@ class MetricsCalculator
         $coveredByTestsTotal = $this->totalMutantsCount - $this->notCoveredByTestsCount;
 
         if ($this->totalMutantsCount) {
-            $coveredRate = round(100 * ($coveredByTestsTotal / $this->totalMutantsCount));
+            $coveredRate = floor(100 * $coveredByTestsTotal / $this->totalMutantsCount);
         }
 
         return $coveredRate;
@@ -164,7 +164,7 @@ class MetricsCalculator
         $defeatedTotal = $this->killedCount + $this->timedOutCount + $this->errorCount;
 
         if ($coveredByTestsTotal) {
-            $detectionRateTested = round(100 * ($defeatedTotal / $coveredByTestsTotal));
+            $detectionRateTested = floor(100 * $defeatedTotal / $coveredByTestsTotal);
         }
 
         return $detectionRateTested;

--- a/tests/Logger/PerMutatorLoggerTest.php
+++ b/tests/Logger/PerMutatorLoggerTest.php
@@ -35,7 +35,7 @@ final class PerMutatorLoggerTest extends TestCase
                 "\n" .
                 "| Mutator | Mutations | Killed | Escaped | Errors | Timed Out | MSI | Covered MSI |\n" .
                 "| ------- | --------- | ------ | ------- |------- | --------- | --- | ----------- |\n" .
-                "| For_ | 15 | 10 | 0 | 0 | 0 | 67| 100|\n" .
+                "| For_ | 15 | 10 | 0 | 0 | 0 | 66| 100|\n" .
                 '| PregQuote | 5 | 0 | 0 | 0 | 0 | 0| 0|'
             );
 

--- a/tests/Mutant/MetricsCalculatorTest.php
+++ b/tests/Mutant/MetricsCalculatorTest.php
@@ -59,7 +59,7 @@ final class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
         $killedMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_KILLED);
 
         $errorMutantProcess = Mockery::mock(MutantProcessInterface::class);
-        $errorMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_ERROR);
+        $errorMutantProcess->shouldReceive('getResultCode')->times(2)->andReturn(MutantProcess::CODE_ERROR);
 
         $calculator = new MetricsCalculator();
 
@@ -78,5 +78,8 @@ final class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
         $this->assertSame(60.0, $calculator->getMutationScoreIndicator());
         $this->assertSame(80.0, $calculator->getCoverageRate());
         $this->assertSame(75.0, $calculator->getCoveredCodeMutationScoreIndicator());
+
+        $calculator->collect($errorMutantProcess);
+        $this->assertSame(66.0, $calculator->getMutationScoreIndicator()); // (1+1+2)/6 = 66.66%
     }
 }

--- a/tests/Mutant/MetricsCalculatorTest.php
+++ b/tests/Mutant/MetricsCalculatorTest.php
@@ -41,45 +41,40 @@ final class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
         $this->assertSame(0.0, $calculator->getCoveredCodeMutationScoreIndicator());
     }
 
+    private function addMutantProcess(MetricsCalculator $calculator, int $resultCode, int $count = 1): void
+    {
+        $mutantProcess = Mockery::mock(MutantProcessInterface::class);
+        $mutantProcess->shouldReceive('getResultCode')->times($count)->andReturn($resultCode);
+
+        while ($count--) {
+            $calculator->collect($mutantProcess);
+        }
+    }
+
     public function test_it_collects_all_values(): void
     {
         $process = Mockery::mock(Process::class);
         $process->shouldReceive('stop');
 
-        $notCoveredMutantProcess = Mockery::mock(MutantProcessInterface::class);
-        $notCoveredMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_NOT_COVERED);
-
-        $passMutantProcess = Mockery::mock(MutantProcessInterface::class);
-        $passMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_ESCAPED);
-
-        $timedOutMutantProcess = Mockery::mock(MutantProcessInterface::class);
-        $timedOutMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_TIMED_OUT);
-
-        $killedMutantProcess = Mockery::mock(MutantProcessInterface::class);
-        $killedMutantProcess->shouldReceive('getResultCode')->times(1)->andReturn(MutantProcess::CODE_KILLED);
-
-        $errorMutantProcess = Mockery::mock(MutantProcessInterface::class);
-        $errorMutantProcess->shouldReceive('getResultCode')->times(2)->andReturn(MutantProcess::CODE_ERROR);
-
         $calculator = new MetricsCalculator();
 
-        $calculator->collect($notCoveredMutantProcess);
-        $calculator->collect($passMutantProcess);
-        $calculator->collect($timedOutMutantProcess);
-        $calculator->collect($killedMutantProcess);
-        $calculator->collect($errorMutantProcess);
-
+        $this->addMutantProcess($calculator, MutantProcess::CODE_NOT_COVERED);
         $this->assertSame(1, $calculator->getNotCoveredByTestsCount());
-        $this->assertSame(1, $calculator->getEscapedCount());
-        $this->assertSame(1, $calculator->getTimedOutCount());
-        $this->assertSame(1, $calculator->getKilledCount());
-        $this->assertSame(1, $calculator->getErrorCount());
 
-        $this->assertSame(60.0, $calculator->getMutationScoreIndicator());
-        $this->assertSame(80.0, $calculator->getCoverageRate());
-        $this->assertSame(75.0, $calculator->getCoveredCodeMutationScoreIndicator());
+        $this->addMutantProcess($calculator, MutantProcess::CODE_ESCAPED, 2);
+        $this->assertSame(2, $calculator->getEscapedCount());
 
-        $calculator->collect($errorMutantProcess);
-        $this->assertSame(66.0, $calculator->getMutationScoreIndicator()); // (1+1+2)/6 = 66.66%
+        $this->addMutantProcess($calculator, MutantProcess::CODE_TIMED_OUT, 2);
+        $this->assertSame(2, $calculator->getTimedOutCount());
+
+        $this->addMutantProcess($calculator, MutantProcess::CODE_KILLED, 7);
+        $this->assertSame(7, $calculator->getKilledCount());
+
+        $this->addMutantProcess($calculator, MutantProcess::CODE_ERROR, 2);
+        $this->assertSame(2, $calculator->getErrorCount());
+
+        $this->assertSame(78.0, $calculator->getMutationScoreIndicator()); // 78.57
+        $this->assertSame(92.0, $calculator->getCoverageRate()); // 92.85
+        $this->assertSame(84.0, $calculator->getCoveredCodeMutationScoreIndicator()); // 84.61
     }
 }


### PR DESCRIPTION
Round metrics down to the smallest integer, instead of nearest, which is the worst case for a metric.

Fixes #426
