### PR TITLE
Improve compatibility with framework based applications

### DIFF
--- a/tests/Fixtures/e2e/Config_Bootstrap/src/bootstrap.php
+++ b/tests/Fixtures/e2e/Config_Bootstrap/src/bootstrap.php
@@ -1,2 +1,7 @@
 <?php
+
+if (count(get_defined_vars()) > 1) {
+    throw new \Exception('Bootstrap file should be loaded in its separate scope, only $infectionBootstrapFile variable is allowed');
+}
+
 file_put_contents(__DIR__ . './../infection-file.txt', 'Hello World!');


### PR DESCRIPTION
When using a custom bootstrap/autoloader, this file is directly required by the InfectionCommand. Applications to be tested may also use the variable names $config and $container for their own configuration and dependency injection. This will cause either the application or Infection to use the wrong config/container. With a unique name, this collision is avoided.

This PR:

- [x] Renames config and container to avoid naming collisions.