### PR TITLE
Do not require dev packages on Deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ jobs:
     - stage: Deploy
       php: 7.2
       install:
-        - composer install
+        - composer install --no-dev
       script:
         make build/bin/infection.phar;
       before_deploy:


### PR DESCRIPTION
Seems like `humbug/box` removes dev dependencies automatically because I don't see them in the built PHAR, however, I see no reason to install dev dependencies on Deploy stage.

