### PR TITLE
Add check for Node\Expr\Closure in MutationsCollectorVisitor

### DIFF
--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -85,7 +85,7 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
 
             if ($isOnFunctionSignature
                 && ($methodNode = $node->getAttribute(ReflectionVisitor::FUNCTION_SCOPE_KEY))
-                && $methodNode->isAbstract()
+                && (!$methodNode instanceof Node\Expr\Closure && $methodNode->isAbstract())
             ) {
                 continue;
             }


### PR DESCRIPTION
In one of my projects, I'm getting an error `PHP Fatal error:  Uncaught Error: Call to undefined method PhpParser\Node\Expr\Closure::isAbstract() in .../src/Visitor/MutationsCollectorVisitor.php:88`. This is with a simple function and test (no objects). This PR fixes the error, but I'm not completely sure how to add a test for it. Any guidance would be appreciated

#### Reproducer:

file.php

```php
<?php

function map($values, $callable): array
{
    return array_map(function ($value) use ($callable) {
        return $callable($value);
    }, $values);
}
```

test.php

```php
class MapTest extends TestCase
{
    public function testMap()
    {
        $square = function (int $n) {
            return $n * $n;
        };

        $this->assertSame([16, 64], map([4, 8], $square));
    }
}
```