### PR TITLE
Move PHP-CS-Fixer from `analyze` to PrettyCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       install:
         - composer install
       script:
-        - make analyze --keep-going
+        - make analyze-ci --keep-going
 
     - &STANDARD_TEST_JOB
       stage: Test

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,10 @@ devTools/Dockerfile-php72-xdebug.json: devTools/Dockerfile-php72-xdebug
 .PHONY: analyze cs-fix cs-check phpstan validate auto-review
 analyze: cs-check phpstan validate
 
+# PHP-CS-Fixer is checked by PrettyCI
+.PHONY: analyze-ci
+analyze-ci: phpstan validate
+
 cs-fix: build/cache $(PHP-CS-FIXER)
 	$(PHP-CS-FIXER) fix -v --cache-file=build/cache/.php_cs.cache
 


### PR DESCRIPTION
Move PHP-CS-Fixer from `analyze` to PrettyCI for CI. 

It will speed up feedback about broken builds a little bit, read more here https://prettyci.com/