### PR TITLE
Rename infection-log.txt -> infection.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.idea
 /vendor
-/infection-log.txt
+/infection.log
 /build/*
 !/build/.gitkeep
 /.php_cs.cache

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "text": "infection-log.txt",
+        "text": "infection.log",
         "badge": {
             "branch": "master"
         }

--- a/src/Config/ValueProvider/TextLogFileProvider.php
+++ b/src/Config/ValueProvider/TextLogFileProvider.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Question\Question;
  */
 final class TextLogFileProvider
 {
-    public const TEXT_LOG_FILE_NAME = 'infection-log.txt';
+    public const TEXT_LOG_FILE_NAME = 'infection.log';
 
     /**
      * @var ConsoleHelper

--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -138,11 +138,11 @@ final class E2ETest extends TestCase
         $this->assertRegExp('/\d+ mutants were killed/', $output);
 
         if (isset($_SERVER['GOLDEN'])) {
-            copy('infection-log.txt', 'expected-output.txt');
+            copy('infection.log', 'expected-output.txt');
             $this->markTestSkipped('Saved golden output');
         }
 
-        $this->assertFileEquals('expected-output.txt', 'infection-log.txt', sprintf('%s/expected-output.txt is not same as infection-log.txt (if that is OK, run GOLDEN=1 vendor/bin/phpunit)', getcwd()));
+        $this->assertFileEquals('expected-output.txt', 'infection.log', sprintf('%s/expected-output.txt is not same as infection.log (if that is OK, run GOLDEN=1 vendor/bin/phpunit)', getcwd()));
 
         return $output;
     }

--- a/tests/Fixtures/e2e/.gitignore
+++ b/tests/Fixtures/e2e/.gitignore
@@ -1,5 +1,5 @@
 vendor/
-infection-log.txt
+infection.log
 infection-cache/
 composer.lock
 error.log

--- a/tests/Fixtures/e2e/Config_Bootstrap/infection.json
+++ b/tests/Fixtures/e2e/Config_Bootstrap/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "bootstrap": "src/bootstrap.php",
     "tmpDir": "."

--- a/tests/Fixtures/e2e/Config_Bootstrap/run_tests.bash
+++ b/tests/Fixtures/e2e/Config_Bootstrap/run_tests.bash
@@ -13,5 +13,5 @@ else
     php $INFECTION
 fi
 
-diff -w expected-output.txt infection-log.txt
+diff -w expected-output.txt infection.log
 diff -w expected-file.txt infection-file.txt

--- a/tests/Fixtures/e2e/Config_Framework/infection.json
+++ b/tests/Fixtures/e2e/Config_Framework/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "debug": "infection-log.txt"
+        "debug": "infection.log"
     },
     "testFramework" : "phpspec",
     "tmpDir": "."

--- a/tests/Fixtures/e2e/Configure/infection.json.test
+++ b/tests/Fixtures/e2e/Configure/infection.json.test
@@ -6,6 +6,6 @@
         ]
     },
     "logs": {
-        "text": "infection-log.txt"
+        "text": "infection.log"
     }
 }

--- a/tests/Fixtures/e2e/Custom_tmp_dir/infection.json
+++ b/tests/Fixtures/e2e/Custom_tmp_dir/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Empty_Path/infection.json
+++ b/tests/Fixtures/e2e/Empty_Path/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Empty_Path/run_tests.bash
+++ b/tests/Fixtures/e2e/Empty_Path/run_tests.bash
@@ -11,4 +11,4 @@ else
     $(which php) $INFECTION
 fi
 
-diff expected-output.txt infection-log.txt
+diff expected-output.txt infection.log

--- a/tests/Fixtures/e2e/Example_Test/infection.json
+++ b/tests/Fixtures/e2e/Example_Test/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Exec_Path/infection.json
+++ b/tests/Fixtures/e2e/Exec_Path/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Exec_Path/run_tests.bash
+++ b/tests/Fixtures/e2e/Exec_Path/run_tests.bash
@@ -48,7 +48,7 @@ echo "Pre-generated coverage..."
 tputx sgr0
 
 PATH=$PATH:bin run "../../../../bin/infection --coverage=coverage --quiet"
-diff -uw expected-output.txt infection-log.txt
+diff -uw expected-output.txt infection.log
 
 tputx bold
 echo "Internal coverage..."
@@ -56,6 +56,6 @@ tputx sgr0
 
 PATH=$PATH:bin run "../../../../bin/infection --quiet"
 
-diff -w expected-output.txt infection-log.txt
+diff -w expected-output.txt infection.log
 
 rm -vfr coverage

--- a/tests/Fixtures/e2e/Identical_Mutator_Example/infection.json
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/infection.json
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/run_tests.bash
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/run_tests.bash
@@ -11,4 +11,4 @@ else
     php $INFECTION
 fi
 
-diff expected-output.txt infection-log.txt
+diff expected-output.txt infection.log

--- a/tests/Fixtures/e2e/Memory_Limit/infection.json
+++ b/tests/Fixtures/e2e/Memory_Limit/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Memory_Limit/run_tests.bash
+++ b/tests/Fixtures/e2e/Memory_Limit/run_tests.bash
@@ -20,7 +20,7 @@ run () {
         php $PHPARGS $INFECTION
     fi
 
-    diff -u -w expected-output.txt infection-log.txt
+    diff -u -w expected-output.txt infection.log
 }
 
 

--- a/tests/Fixtures/e2e/Multiline_Statement/infection.json.dist
+++ b/tests/Fixtures/e2e/Multiline_Statement/infection.json.dist
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "text": "infection-log.txt"
+        "text": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/infection.json
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "phpUnit": {
         "configDir": "build"

--- a/tests/Fixtures/e2e/Parameters_Coverage/infection.json
+++ b/tests/Fixtures/e2e/Parameters_Coverage/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "debug": "infection-log.txt"
+        "debug": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/infection.json
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/run_tests.bash
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/run_tests.bash
@@ -38,7 +38,7 @@ fi
 rm -f phpunit.bat.canary
 
 run "../../../../bin/infection --quiet"
-diff -w expected-output.txt infection-log.txt
+diff -w expected-output.txt infection.log
 
 test -f phpunit.bat.canary && rm phpunit.bat.canary
 

--- a/tests/Fixtures/e2e/Profiles_Ignore_Combination/infection.json
+++ b/tests/Fixtures/e2e/Profiles_Ignore_Combination/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "mutators": {
         "@function_signature": {

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/infection.json
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/infection.json
@@ -7,6 +7,6 @@
         ]
     },
     "logs": {
-        "debug": "infection-log.txt"
+        "debug": "infection.log"
     }
 }

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/run_tests.bash
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/run_tests.bash
@@ -11,7 +11,7 @@ else
     php $INFECTION
 fi
 
-diff expected-output_phpunit.txt infection-log.txt
+diff expected-output_phpunit.txt infection.log
 
 if [ -f "infection-cache/infection/phpunit.junit.xml" ]
 then
@@ -32,7 +32,7 @@ else
     php $INFECTION --test-framework=phpspec
 fi
 
-diff expected-output_phpspec.txt infection-log.txt
+diff expected-output_phpspec.txt infection.log
 
 if [ -d "infection-cache/infection/phpspec-coverage-xml" ]
 then

--- a/tests/Fixtures/e2e/README.md
+++ b/tests/Fixtures/e2e/README.md
@@ -1,7 +1,7 @@
 #How-to
 
 Every sub-folder should contain an e2e test case for `infection`. For each of these folders `standard_script.bash` is ran.
-This runs infection, and checks the difference between `expected-output.txt` and `infection-log.txt`.
+This runs infection, and checks the difference between `expected-output.txt` and `infection.log`.
 
 If your test-case needs more sophisticated checks you can provide a `run_test.bash` file in the sub-folder which should
 contain all needed checks.

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/infection.json
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection-log.txt"
+        "summary": "infection.log"
     },
     "bootstrap": "./custom-autoload.php",
     "tmpDir": "."

--- a/tests/Fixtures/e2e/Test_Frameworks/infection.json
+++ b/tests/Fixtures/e2e/Test_Frameworks/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "debug": "infection-log.txt"
+        "debug": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/Test_Frameworks/run_tests.bash
+++ b/tests/Fixtures/e2e/Test_Frameworks/run_tests.bash
@@ -11,7 +11,7 @@ else
     php $INFECTION
 fi
 
-diff expected-output.txt infection-log.txt
+diff expected-output.txt infection.log
 
 
 
@@ -22,4 +22,4 @@ else
     php $INFECTION --test-framework=phpspec
 fi
 
-diff expected-output.txt infection-log.txt
+diff expected-output.txt infection.log

--- a/tests/Fixtures/e2e/Trait_Coverage/infection.json
+++ b/tests/Fixtures/e2e/Trait_Coverage/infection.json
@@ -6,7 +6,7 @@
         ]
     },
     "logs": {
-        "debug": "infection-log.txt"
+        "debug": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/Fixtures/e2e/standard_script.bash
+++ b/tests/Fixtures/e2e/standard_script.bash
@@ -11,4 +11,4 @@ else
     php $INFECTION
 fi
 
-diff -w expected-output.txt infection-log.txt
+diff -w expected-output.txt infection.log

--- a/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
+++ b/tests/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
@@ -83,7 +83,7 @@ final class MutationTestingResultsLoggerSubscriberTest extends TestCase
 
     public function test_it_reacts_on_mutation_testing_finished(): void
     {
-        $logTypes = ['text' => sys_get_temp_dir() . '/infection-log.txt'];
+        $logTypes = ['text' => sys_get_temp_dir() . '/infection.log'];
 
         $this->infectionConfig->expects($this->once())
             ->method('getLogsTypes')
@@ -127,7 +127,7 @@ final class MutationTestingResultsLoggerSubscriberTest extends TestCase
 
     public function test_it_reacts_on_mutation_testing_finished_and_debug_mode_off(): void
     {
-        $logTypes = ['text' => sys_get_temp_dir() . '/infection-log.txt'];
+        $logTypes = ['text' => sys_get_temp_dir() . '/infection.log'];
 
         $this->infectionConfig->expects($this->once())
             ->method('getLogsTypes')
@@ -169,7 +169,7 @@ final class MutationTestingResultsLoggerSubscriberTest extends TestCase
 
     public function test_it_reacts_on_mutation_testing_finished_and_no_file_logging(): void
     {
-        $logTypes = ['text' => sys_get_temp_dir() . '/infection-log.txt'];
+        $logTypes = ['text' => sys_get_temp_dir() . '/infection.log'];
 
         $this->infectionConfig->expects($this->once())
             ->method('getLogsTypes')


### PR DESCRIPTION
This PR:

- [x] Renames `infection-log.txt` -> `infection.log`
- [x] Doc PR: https://github.com/infection/site/pull/58

#### Why?

Because this is how other frameworks, tools, etc. name their log files (symfony, nginx, apache and so on).

There is no BC break because each project should have already existing `infection.json` with the name of the config file. Only new users are affected.