### PR TITLE
Verify that MutationsCollectorVisitor can work around closures

### DIFF
--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -83,11 +83,13 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
                 continue;
             }
 
-            if ($isOnFunctionSignature
-                && ($methodNode = $node->getAttribute(ReflectionVisitor::FUNCTION_SCOPE_KEY))
-                && $methodNode->isAbstract()
-            ) {
-                continue;
+            if ($isOnFunctionSignature) {
+                $methodNode = $node->getAttribute(ReflectionVisitor::FUNCTION_SCOPE_KEY);
+
+                /** @var Node\Stmt\ClassMethod|Node\Expr\Closure $methodNode */
+                if ($methodNode instanceof Node\Stmt\ClassMethod && $methodNode->isAbstract()) {
+                    continue;
+                }
             }
 
             $isCoveredByTest = $this->isCoveredByTest($isOnFunctionSignature, $node);

--- a/src/Visitor/ReflectionVisitor.php
+++ b/src/Visitor/ReflectionVisitor.php
@@ -123,9 +123,14 @@ final class ReflectionVisitor extends NodeVisitorAbstract
 
     private function isFunctionLikeNode(Node $node): bool
     {
-        $isClassMethod = $node instanceof Node\Stmt\ClassMethod;
-        $isClosure = $node instanceof Node\Expr\Closure;
+        if ($node instanceof Node\Stmt\ClassMethod) {
+            return true;
+        }
 
-        return $isClassMethod || $isClosure;
+        if ($node instanceof Node\Expr\Closure) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Fixtures/Files/Mutation/OneFile/OneFile.php
+++ b/tests/Fixtures/Files/Mutation/OneFile/OneFile.php
@@ -15,6 +15,8 @@ class OneFile
 
     public function foo($value = true): int
     {
-        return 33 + 44;
+        return (function ($input = 33) {
+            return $input;
+        })() + 44;
     }
 }

--- a/tests/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/Mutant/Generator/MutationsGeneratorTest.php
@@ -18,6 +18,7 @@ use Infection\Mutator\Arithmetic\Decrement;
 use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\Boolean\TrueValue;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
+use Infection\Mutator\Number\DecrementInteger;
 use Infection\Mutator\Util\MutatorConfig;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\Tests\Fixtures\Files\Mutation\OneFile\OneFile;
@@ -36,28 +37,28 @@ final class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCa
     public function test_it_collects_plus_mutation(): void
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->once()->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->twice()->andReturn(false);
+        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->twice()->andReturn(true);
+        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->times(3)->andReturn(false);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
         $mutations = $generator->generate(false);
 
-        $this->assertInstanceOf(Plus::class, $mutations[1]->getMutator());
+        $this->assertInstanceOf(Plus::class, $mutations[3]->getMutator());
     }
 
     public function test_it_collects_public_visibility_mutation(): void
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->once()->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->twice()->andReturn(true);
+        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->twice()->andReturn(true);
+        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->times(3)->andReturn(true);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
         $mutations = $generator->generate(false);
 
-        $this->assertInstanceOf(Plus::class, $mutations[1]->getMutator());
-        $this->assertInstanceOf(PublicVisibility::class, $mutations[2]->getMutator());
+        $this->assertInstanceOf(Plus::class, $mutations[3]->getMutator());
+        $this->assertInstanceOf(PublicVisibility::class, $mutations[4]->getMutator());
     }
 
     public function test_it_can_skip_not_covered_on_file_level(): void
@@ -76,24 +77,24 @@ final class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCa
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
         $codeCoverageDataMock->shouldReceive('hasTests')->once()->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->once()->andReturn(false);
-        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->twice()->andReturn(true);
+        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->times(4)->andReturn(false);
+        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->times(3)->andReturn(true);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
         $mutations = $generator->generate(true);
 
-        $this->assertCount(2, $mutations);
+        $this->assertCount(3, $mutations);
         $this->assertInstanceOf(TrueValue::class, $mutations[0]->getMutator());
-        $this->assertInstanceOf(PublicVisibility::class, $mutations[1]->getMutator());
+        $this->assertInstanceOf(PublicVisibility::class, $mutations[2]->getMutator());
     }
 
     public function test_it_can_skip_not_covered_on_file_line_for_visibility(): void
     {
         $codeCoverageDataMock = Mockery::mock(CodeCoverageData::class);
         $codeCoverageDataMock->shouldReceive('hasTests')->once()->andReturn(true);
-        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->once()->andReturn(false);
-        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->twice()->andReturn(false);
+        $codeCoverageDataMock->shouldReceive('hasTestsOnLine')->times(4)->andReturn(false);
+        $codeCoverageDataMock->shouldReceive('hasExecutedMethodOnLine')->times(3)->andReturn(false);
 
         $generator = $this->createMutationGenerator($codeCoverageDataMock);
 
@@ -200,10 +201,15 @@ final class MutationsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCa
             return new TrueValue($mutatorConfig);
         };
 
+        $container[DecrementInteger::class] = function (Container $c) use ($mutatorConfig) {
+            return new DecrementInteger($mutatorConfig);
+        };
+
         $defaultMutators = [
             $container[Plus::class],
             $container[PublicVisibility::class],
             $container[TrueValue::class],
+            $container[DecrementInteger::class],
         ];
 
         $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);


### PR DESCRIPTION
ReflectionVisitor treats closures just like plain functions, where they're different objects. This isn't a problem for ReflectionVisitor, but MutationsCollectorVisitor should take a care of this. Sadly, we don't have a test suite for the latter, therefore a test for MutationsGenerator was used to cover this issue.

Fixes #452
