### PR TITLE
Validate that infection.json contains valid (writable) file paths for loggers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
     "require": {
         "php": "^7.1",
         "ext-dom": "*",
+        "ext-json": "*",
         "composer/xdebug-handler": "^1.1",
         "nikic/php-parser": "^4.0",
         "ocramius/package-versions": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a718a3159d10583bab1c3bd9ea00d983",
+    "content-hash": "984a11e13776404fad03341ad52ec6dd",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2500,7 +2500,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.1",
-        "ext-dom": "*"
+        "ext-dom": "*",
+        "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/Config/Validator.php
+++ b/src/Config/Validator.php
@@ -29,17 +29,19 @@ final class Validator
         $logTypes = $config->getLogsTypes();
 
         foreach ($logTypes as $logType => $file) {
-            if ($logType !== ResultsLoggerTypes::BADGE) {
-                $dir = \dirname($file);
+            if ($logType === ResultsLoggerTypes::BADGE) {
+                continue;
+            }
 
-                if (is_dir($dir) && !is_writable($dir)) {
-                    throw new IOException(
-                        sprintf('Unable to write to the "%s" directory. Check "logs.%s" file path in infection.json.', $dir, $logType),
-                        0,
-                        null,
-                        $dir
-                    );
-                }
+            $dir = \dirname($file);
+
+            if (is_dir($dir) && !is_writable($dir)) {
+                throw new IOException(
+                    sprintf('Unable to write to the "%s" directory. Check "logs.%s" file path in infection.json.', $dir, $logType),
+                    0,
+                    null,
+                    $dir
+                );
             }
         }
     }

--- a/src/Config/Validator.php
+++ b/src/Config/Validator.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Config;
+
+use Infection\Logger\ResultsLoggerTypes;
+use Symfony\Component\Filesystem\Exception\IOException;
+
+/**
+ * @internal
+ */
+final class Validator
+{
+    public function validate(InfectionConfig $infectionConfig): bool
+    {
+        $this->validateLogFilePaths($infectionConfig);
+
+        return true;
+    }
+
+    private function validateLogFilePaths(InfectionConfig $config): void
+    {
+        $logTypes = $config->getLogsTypes();
+
+        foreach ($logTypes as $logType => $file) {
+            if ($logType !== ResultsLoggerTypes::BADGE) {
+                $dir = \dirname($file);
+
+                if (is_dir($dir) && !is_writable($dir)) {
+                    throw new IOException(
+                        sprintf('Unable to write to the "%s" directory. Check "logs.%s" file path in infection.json.', $dir, $logType),
+                        0,
+                        null,
+                        $dir
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -11,6 +11,7 @@ namespace Infection\Console;
 
 use Infection\Config\Exception\InvalidConfigException;
 use Infection\Config\InfectionConfig;
+use Infection\Config\Validator;
 use Infection\Differ\DiffColorizer;
 use Infection\Differ\Differ;
 use Infection\EventDispatcher\EventDispatcher;
@@ -199,6 +200,10 @@ final class InfectionContainer extends Container
             return new MemoryFormatter();
         };
 
+        $this['infection.config.validator'] = function (): Validator {
+            return new Validator();
+        };
+
         $this['memory.limit.applier'] = function (): MemoryLimiter {
             return new MemoryLimiter($this['filesystem'], \php_ini_loaded_file());
         };
@@ -247,7 +252,11 @@ final class InfectionContainer extends Container
             // getcwd() may return false in rare circumstances
             \assert(\is_string($configLocation));
 
-            return new InfectionConfig($config, $this['filesystem'], $configLocation);
+            $infectionConfig = new InfectionConfig($config, $this['filesystem'], $configLocation);
+
+            $this['infection.config.validator']->validate($infectionConfig);
+
+            return $infectionConfig;
         };
 
         $this['coverage.path'] = function () use ($input): string {

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -11,6 +11,8 @@ namespace Infection\Logger;
 
 use Infection\Mutant\MetricsCalculator;
 use Infection\Process\MutantProcessInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -43,7 +45,13 @@ abstract class FileLogger implements MutationTestingResultsLogger
      */
     protected $isDebugMode;
 
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
     public function __construct(
+        OutputInterface $output,
         string $logFilePath,
         MetricsCalculator $metricsCalculator,
         Filesystem $fs,
@@ -55,11 +63,16 @@ abstract class FileLogger implements MutationTestingResultsLogger
         $this->fs = $fs;
         $this->isDebugVerbosity = $isDebugVerbosity;
         $this->isDebugMode = $isDebugMode;
+        $this->output = $output;
     }
 
     public function log(): void
     {
-        $this->fs->dumpFile($this->logFilePath, implode("\n", $this->getLogLines()));
+        try {
+            $this->fs->dumpFile($this->logFilePath, implode("\n", $this->getLogLines()));
+        } catch (IOException $e) {
+            $this->output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+        }
     }
 
     abstract protected function getLogLines(): array;

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -123,6 +123,7 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
         switch ($logType) {
             case ResultsLoggerTypes::TEXT_FILE:
                 (new TextFileLogger(
+                    $this->output,
                     $config,
                     $this->metricsCalculator,
                     $this->fs,
@@ -133,6 +134,7 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
                 break;
             case ResultsLoggerTypes::SUMMARY_FILE:
                 (new SummaryFileLogger(
+                    $this->output,
                     $config,
                     $this->metricsCalculator,
                     $this->fs,
@@ -143,6 +145,7 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
                 break;
             case ResultsLoggerTypes::DEBUG_FILE:
                 (new DebugFileLogger(
+                    $this->output,
                     $config,
                     $this->metricsCalculator,
                     $this->fs,
@@ -162,6 +165,7 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInt
                 break;
             case ResultsLoggerTypes::PER_MUTATOR:
                 (new PerMutatorLogger(
+                    $this->output,
                     $config,
                     $this->metricsCalculator,
                     $this->fs,

--- a/tests/Config/ValidatorTest.php
+++ b/tests/Config/ValidatorTest.php
@@ -69,15 +69,7 @@ final class ValidatorTest extends TestCase
         // make it readonly
         $this->fileSystem->mkdir($readOnlyDirPath, 0400);
 
-        $configObject = json_decode(
-            <<<"JSON"
-{
-    "logs": {
-        "{$logType}": "{$readOnlyDirPath}\/infection.log"
-    }
-}
-JSON
-        );
+        $configObject = json_decode(sprintf('{"logs": {"%s": "%s/infection.log"}}', $logType, $readOnlyDirPath));
 
         $config = new InfectionConfig($configObject, $this->fileSystem, '');
         $validator = new Validator();

--- a/tests/Config/ValidatorTest.php
+++ b/tests/Config/ValidatorTest.php
@@ -60,6 +60,10 @@ final class ValidatorTest extends TestCase
      */
     public function test_it_validates_log_file_paths(string $logType): void
     {
+        if (\DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Can\' test file permission on Windows');
+        }
+
         $readOnlyDirPath = $this->tmpDir . '/invalid';
         $exceptionMessage = sprintf('Unable to write to the "%s" directory. Check "logs.%s" file path in infection.json.', $readOnlyDirPath, $logType);
 

--- a/tests/Config/ValidatorTest.php
+++ b/tests/Config/ValidatorTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Config;
+
+use Infection\Config\InfectionConfig;
+use Infection\Config\Validator;
+use Infection\Logger\ResultsLoggerTypes;
+use Infection\Utils\TmpDirectoryCreator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class ValidatorTest extends TestCase
+{
+    /**
+     * @var TmpDirectoryCreator
+     */
+    private $creator;
+
+    /**
+     * @var string
+     */
+    private $workspace;
+
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem;
+
+    /**
+     * @var string
+     */
+    private $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->fileSystem = new Filesystem();
+        $this->creator = new TmpDirectoryCreator($this->fileSystem);
+        $this->workspace = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fileSystem->remove($this->workspace);
+    }
+
+    /**
+     * @dataProvider invalidFilePaths
+     */
+    public function test_it_validates_log_file_paths(string $logType): void
+    {
+        $readOnlyDirPath = $this->tmpDir . '/invalid';
+        $exceptionMessage = sprintf('Unable to write to the "%s" directory. Check "logs.%s" file path in infection.json.', $readOnlyDirPath, $logType);
+
+        $this->expectException(IOException::class);
+        $this->expectExceptionMessage($exceptionMessage);
+
+        // make it readonly
+        $this->fileSystem->mkdir($readOnlyDirPath, 0400);
+
+        $configObject = json_decode(
+            <<<"JSON"
+{
+    "logs": {
+        "{$logType}": "{$readOnlyDirPath}\/infection.log"
+    }
+}
+JSON
+        );
+
+        $config = new InfectionConfig($configObject, $this->fileSystem, '');
+        $validator = new Validator();
+
+        $validator->validate($config);
+    }
+
+    public function invalidFilePaths(): \Generator
+    {
+        $logTypes = array_diff(ResultsLoggerTypes::ALL, [ResultsLoggerTypes::BADGE]);
+
+        foreach ($logTypes as $logType) {
+            yield "Throws exception when {$logType} logger has invalid path" => [$logType];
+        }
+    }
+}

--- a/tests/Logger/DebugFileLoggerTest.php
+++ b/tests/Logger/DebugFileLoggerTest.php
@@ -17,6 +17,7 @@ use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -28,6 +29,7 @@ final class DebugFileLoggerTest extends TestCase
     {
         $logFilePath = sys_get_temp_dir() . '/foo.txt';
         $calculator = new MetricsCalculator();
+        $output = $this->createMock(OutputInterface::class);
         $fs = $this->createMock(Filesystem::class);
         $fs->expects($this->once())->method('dumpFile')->with(
             $logFilePath,
@@ -56,7 +58,7 @@ Not Covered mutants:
 TXT
         );
 
-        $debugFileLogger = new DebugFileLogger($logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger = new DebugFileLogger($output, $logFilePath, $calculator, $fs, false, false);
         $debugFileLogger->log();
     }
 
@@ -64,6 +66,7 @@ TXT
     {
         $logFilePath = sys_get_temp_dir() . '/foo.txt';
         $calculator = $this->createFilledMetricsCalculator();
+        $output = $this->createMock(OutputInterface::class);
         $fs = $this->createMock(Filesystem::class);
         $fs->expects($this->once())->method('dumpFile')->with(
             $logFilePath,
@@ -128,7 +131,7 @@ Not Covered mutants:
 TXT
         );
 
-        $debugFileLogger = new DebugFileLogger($logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger = new DebugFileLogger($output, $logFilePath, $calculator, $fs, false, false);
         $debugFileLogger->log();
     }
 

--- a/tests/Logger/PerMutatorLoggerTest.php
+++ b/tests/Logger/PerMutatorLoggerTest.php
@@ -17,6 +17,7 @@ use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -26,6 +27,7 @@ final class PerMutatorLoggerTest extends TestCase
 {
     public function test_it_correctly_build_log_lines(): void
     {
+        $output = $this->createMock(OutputInterface::class);
         $fs = $this->createMock(Filesystem::class);
         $fs->expects($this->once())
             ->method('dumpFile')
@@ -40,6 +42,7 @@ final class PerMutatorLoggerTest extends TestCase
             );
 
         $perMutatorLogger = new PerMutatorLogger(
+            $output,
             sys_get_temp_dir() . '/fake-file.md',
             $this->createMetricsCalculator(),
             $fs,

--- a/tests/Logger/SummaryFileLoggerTest.php
+++ b/tests/Logger/SummaryFileLoggerTest.php
@@ -106,6 +106,10 @@ TXT
 
     public function test_it_outputs_an_error_when_dir_is_not_writable(): void
     {
+        if (\DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Can\' test file permission on Windows');
+        }
+
         $readOnlyDirPath = $this->tmpDir . '/invalid';
         $logFilePath = $readOnlyDirPath . '/foo.txt';
 

--- a/tests/Logger/SummaryFileLoggerTest.php
+++ b/tests/Logger/SummaryFileLoggerTest.php
@@ -11,7 +11,9 @@ namespace Infection\Tests\Logger;
 
 use Infection\Logger\SummaryFileLogger;
 use Infection\Mutant\MetricsCalculator;
+use Infection\Utils\TmpDirectoryCreator;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -19,10 +21,44 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class SummaryFileLoggerTest extends TestCase
 {
+    /**
+     * @var TmpDirectoryCreator
+     */
+    private $creator;
+
+    /**
+     * @var string
+     */
+    private $workspace;
+
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem;
+
+    /**
+     * @var string
+     */
+    private $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->fileSystem = new Filesystem();
+        $this->creator = new TmpDirectoryCreator($this->fileSystem);
+        $this->workspace = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
+        $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fileSystem->remove($this->workspace);
+    }
+
     public function test_it_logs_the_correct_lines_with_no_mutations(): void
     {
-        $logFilePath = sys_get_temp_dir() . '/foo.txt';
+        $logFilePath = $this->tmpDir . '/foo.txt';
         $calculator = new MetricsCalculator();
+        $output = $this->createMock(OutputInterface::class);
         $fs = $this->createMock(Filesystem::class);
         $fs->expects($this->once())->method('dumpFile')->with(
             $logFilePath,
@@ -36,13 +72,13 @@ Not Covered: 0
 TXT
         );
 
-        $debugFileLogger = new SummaryFileLogger($logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger = new SummaryFileLogger($output, $logFilePath, $calculator, $fs, false, false);
         $debugFileLogger->log();
     }
 
     public function test_it_logs_the_correct_lines_with_mutations(): void
     {
-        $logFilePath = sys_get_temp_dir() . '/foo.txt';
+        $logFilePath = $this->tmpDir . '/foo.txt';
         $calculator = $this->createMock(MetricsCalculator::class);
         $calculator->expects($this->once())->method('getTotalMutantsCount')->willReturn(6);
         $calculator->expects($this->once())->method('getKilledCount')->willReturn(8);
@@ -50,6 +86,7 @@ TXT
         $calculator->expects($this->once())->method('getEscapedCount')->willReturn(30216);
         $calculator->expects($this->once())->method('getTimedOutCount')->willReturn(2);
         $calculator->expects($this->once())->method('getNotCoveredByTestsCount')->willReturn(0);
+        $output = $this->createMock(OutputInterface::class);
         $fs = $this->createMock(Filesystem::class);
         $fs->expects($this->once())->method('dumpFile')->with(
             $logFilePath,
@@ -63,7 +100,37 @@ Not Covered: 0
 TXT
         );
 
-        $debugFileLogger = new SummaryFileLogger($logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger = new SummaryFileLogger($output, $logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger->log();
+    }
+
+    public function test_it_outputs_an_error_when_dir_is_not_writable(): void
+    {
+        $readOnlyDirPath = $this->tmpDir . '/invalid';
+        $logFilePath = $readOnlyDirPath . '/foo.txt';
+
+        // make it readonly
+        $this->fileSystem->mkdir($readOnlyDirPath, 0400);
+
+        $calculator = $this->createMock(MetricsCalculator::class);
+        $calculator->expects($this->once())->method('getTotalMutantsCount')->willReturn(6);
+        $calculator->expects($this->once())->method('getKilledCount')->willReturn(8);
+        $calculator->expects($this->once())->method('getErrorCount')->willReturn(7);
+        $calculator->expects($this->once())->method('getEscapedCount')->willReturn(30216);
+        $calculator->expects($this->once())->method('getTimedOutCount')->willReturn(2);
+        $calculator->expects($this->once())->method('getNotCoveredByTestsCount')->willReturn(0);
+
+        $output = $this->createMock(OutputInterface::class);
+        $output->expects($this->once())->method('writeln')->with(
+            sprintf(
+                '<error>Unable to write to the "%s" directory.</error>',
+                $readOnlyDirPath
+            )
+        );
+
+        $fs = new Filesystem();
+
+        $debugFileLogger = new SummaryFileLogger($output, $logFilePath, $calculator, $fs, false, false);
         $debugFileLogger->log();
     }
 }

--- a/tests/Logger/TextFileLoggerTest.php
+++ b/tests/Logger/TextFileLoggerTest.php
@@ -18,6 +18,7 @@ use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
@@ -30,6 +31,7 @@ final class TextFileLoggerTest extends TestCase
     {
         $logFilePath = sys_get_temp_dir() . '/foo.txt';
         $calculator = new MetricsCalculator();
+        $output = $this->createMock(OutputInterface::class);
         $fs = $this->createMock(Filesystem::class);
         $fs->expects($this->once())->method('dumpFile')->with(
             $logFilePath,
@@ -46,7 +48,7 @@ Not Covered mutants:
 TXT
         );
 
-        $debugFileLogger = new TextFileLogger($logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger = new TextFileLogger($output, $logFilePath, $calculator, $fs, false, false);
         $debugFileLogger->log();
     }
 
@@ -54,6 +56,7 @@ TXT
     {
         $logFilePath = sys_get_temp_dir() . '/foo.txt';
         $calculator = new MetricsCalculator();
+        $output = $this->createMock(OutputInterface::class);
         $fs = $this->createMock(Filesystem::class);
         $fs->expects($this->once())->method('dumpFile')->with(
             $logFilePath,
@@ -76,7 +79,7 @@ Not Covered mutants:
 TXT
         );
 
-        $debugFileLogger = new TextFileLogger($logFilePath, $calculator, $fs, true, false);
+        $debugFileLogger = new TextFileLogger($output, $logFilePath, $calculator, $fs, true, false);
         $debugFileLogger->log();
     }
 
@@ -84,6 +87,7 @@ TXT
     {
         $logFilePath = sys_get_temp_dir() . '/foo.txt';
         $calculator = $this->createFilledMetricsCalculator();
+        $output = $this->createMock(OutputInterface::class);
         $fs = $this->createMock(Filesystem::class);
         $fs->expects($this->atMost(10))->method('dumpFile')->with(
             $logFilePath,
@@ -148,7 +152,7 @@ Diff Diff
 TXT
         );
 
-        $debugFileLogger = new TextFileLogger($logFilePath, $calculator, $fs, false, true);
+        $debugFileLogger = new TextFileLogger($output, $logFilePath, $calculator, $fs, false, true);
         $debugFileLogger->log();
     }
 
@@ -156,6 +160,7 @@ TXT
     {
         $logFilePath = sys_get_temp_dir() . '/foo.txt';
         $calculator = $this->createFilledMetricsCalculator();
+        $output = $this->createMock(OutputInterface::class);
         $fs = $this->createMock(Filesystem::class);
         $fs->expects($this->atMost(10))->method('dumpFile')->with(
             $logFilePath,
@@ -248,7 +253,7 @@ Diff Diff
 TXT
         );
 
-        $debugFileLogger = new TextFileLogger($logFilePath, $calculator, $fs, true, false);
+        $debugFileLogger = new TextFileLogger($output, $logFilePath, $calculator, $fs, true, false);
         $debugFileLogger->log();
     }
 


### PR DESCRIPTION
When for example `logs.text` key in `infection.json` file contains not writable path, infection fails with a correct message, but does that only *after* mutation logic.

<img width="851" alt="not_writable_bug" src="https://user-images.githubusercontent.com/3725595/44427637-ca288580-a59a-11e8-897e-543076b55a6d.png">

This PR:

- [x] Validates logger file paths right after `InfectionConfig` is instantiated.
- [x] Covered by tests

With this update, user will get validation error immediately:

<img width="618" alt="fixed_bug" src="https://user-images.githubusercontent.com/3725595/44427732-0e1b8a80-a59b-11e8-89e6-a1a41f5ba873.png">
