### PR TITLE
[Removal] Don't remove calls to assert()

### DIFF
--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -62,7 +62,7 @@ final class DebugFileLogger extends FileLogger
             $logParts[] = 'Line ' . $mutantProcess->getOriginalStartingLine();
         }
 
-        return implode($logParts, "\n") . "\n";
+        return implode("\n", $logParts) . "\n";
     }
 
     private function getHeadlineParts(string $headlinePrefix): array

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -59,7 +59,7 @@ abstract class FileLogger implements MutationTestingResultsLogger
 
     public function log(): void
     {
-        $this->fs->dumpFile($this->logFilePath, implode($this->getLogLines(), "\n"));
+        $this->fs->dumpFile($this->logFilePath, implode("\n", $this->getLogLines()));
     }
 
     abstract protected function getLogLines(): array;

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -57,7 +57,7 @@ final class TextFileLogger extends FileLogger
             }
         }
 
-        return implode($logParts, "\n");
+        return implode("\n", $logParts);
     }
 
     private function getHeadlineParts(string $headlinePrefix): array

--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -28,6 +28,22 @@ final class FunctionCallRemoval extends Mutator
             return false;
         }
 
-        return $node->expr instanceof Node\Expr\FuncCall;
+        if (!$node->expr instanceof Node\Expr\FuncCall) {
+            return false;
+        }
+
+        $name = $node->expr->name;
+
+        if (!$name instanceof Node\Name) {
+            return true;
+        }
+
+        $string = strtolower((string) $name);
+
+        if ($string === 'assert') {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -75,7 +75,7 @@ final class IncludeInterceptor
 
         if ($including) {
             if ($path === self::$intercept || realpath($path) === self::$intercept) {
-                $this->fp = fopen(self::$replacement, 'r');
+                $this->fp = fopen(self::$replacement, 'rb');
                 self::enable();
 
                 return true;

--- a/tests/Config/ValueProvider/AbstractBaseProviderTest.php
+++ b/tests/Config/ValueProvider/AbstractBaseProviderTest.php
@@ -28,7 +28,7 @@ abstract class AbstractBaseProviderTest extends Mockery\Adapter\Phpunit\MockeryT
 
     protected function getInputStream($input)
     {
-        $stream = fopen('php://memory', 'r+', false);
+        $stream = fopen('php://memory', 'r+b', false);
         fwrite($stream, $input);
         rewind($stream);
 
@@ -37,7 +37,7 @@ abstract class AbstractBaseProviderTest extends Mockery\Adapter\Phpunit\MockeryT
 
     protected function createOutputInterface()
     {
-        return new StreamOutput(fopen('php://memory', 'r+', false));
+        return new StreamOutput(fopen('php://memory', 'r+b', false));
     }
 
     protected function createStreamableInputInterfaceMock($stream = null, $interactive = true)

--- a/tests/Mutator/Removal/FunctionCallRemovalTest.php
+++ b/tests/Mutator/Removal/FunctionCallRemovalTest.php
@@ -43,6 +43,28 @@ PHP
             ,
         ];
 
+        yield 'It removes dynamic function calls' => [
+            <<<'PHP'
+<?php
+
+$start = true;
+$foo();
+('foo')();
+$end = true;
+
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$start = true;
+
+
+$end = true;
+PHP
+            ,
+        ];
+
         yield 'It does not remove a function call that is assigned to something' => [
             <<<'PHP'
 <?php
@@ -81,6 +103,17 @@ PHP
 <?php
 
 $this->foo();
+$a = 3;
+PHP
+        ];
+
+        yield 'It does not remove an assert() call' => [
+            <<<'PHP'
+<?php
+
+assert(true === true);
+aSsert(true === true);
+\assert(true === true);
 $a = 3;
 PHP
         ];

--- a/tests/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/StreamWrapper/IncludeInterceptorTest.php
@@ -26,7 +26,7 @@ use Infection\StreamWrapper\IncludeInterceptor;
  * url_stat
  *
  * Other methods are not essential for interception to work,
- * but still are required to be implemented by a full wrapper.
+ * but still are required to be implemented by a full wrapper
  */
 final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
 {
@@ -141,7 +141,7 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
 
         $tempnam = tempnam('', basename(__FILE__, 'php'));
 
-        $fp = fopen($tempnam, 'w+');
+        $fp = fopen($tempnam, 'w+b');
         flock($fp, LOCK_EX);
         fwrite($fp, 'test');
         fseek($fp, 0);


### PR DESCRIPTION
The new `FunctionCallRemoval` mutator is removing calls to `assert()` and expecting the tests to fail, but the `assert()` function is a special case that it doesn't make sense to remove.

This PR prevents calls to `assert()` from being removed, and adds a test to ensure they aren't removed