### PR TITLE
Use default test framework if neither CLI nor config has the value for it

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -374,9 +374,10 @@ final class InfectionCommand extends BaseCommand
             $locator->locateAnyOf(InfectionConfig::POSSIBLE_CONFIG_FILE_NAMES);
         } catch (\Exception $e) {
             $configureCommand = $this->getApplication()->find('configure');
+            $config = $this->getContainer()->get('infection.config');
 
             $args = [
-                '--test-framework' => $this->input->getOption('test-framework'),
+                '--test-framework' => $this->input->getOption('test-framework') ?: $config->getTestFramework(),
             ];
 
             $newInput = new ArrayInput($args);

--- a/tests/Fixtures/e2e/Configure/do_configure.expect
+++ b/tests/Fixtures/e2e/Configure/do_configure.expect
@@ -13,7 +13,6 @@ proc configure {input} {
 
 configure "directories do you want to include"
 configure "Any directories to exclude from"
-configure "configuration located?"
 configure "timeout in seconds"
 configure "text log file?"
 


### PR DESCRIPTION
During the installation process of Infection for the new project, I noticed a wierd question from `ConfigureCommand`:

```
Where is your .(xml|yml)(.dist) configuration located?:
```

Note the absence of `phpunit` ot `phpspec` before `.(xml|yml)(.dist)` (sprintf pattern is `Where is your %s.(xml|yml)(.dist) configuration located?`

Previously, we had a default value for `--test-framework` option in `InfectionCommand`, but it was removed in https://github.com/infection/infection/pull/281

Now, the value of test framework can be set from `infection.json.dist` or cli option. So this update checks cli option as a priority and then checks config. If nothing is found, it defaults to `phpunit`.

After this update, no question is raised at all, infection automatically finds `phpunit.xml[.dist]`.