### PR TITLE
Tweaking Makefile For Easy Symfony Switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,3 +137,20 @@ build/bin/infection.phar: $(shell find bin/ src/ -type f) box.phar box.json.dist
 box.phar:
 	wget $(BOX_URL)
 	chmod a+x box.phar
+
+.PHONY: symfony-40 symfony-30
+symfony-40:
+	composer config --unset platform.php
+	composer require symfony/console:^4.0 \
+		symfony/filesystem:^4.0 \
+		symfony/process:^4.0 \
+		symfony/finder:^4.0 \
+		symfony/yaml:^4.0
+
+symfony-30:
+	composer config platform.php 7.1
+	composer require symfony/console:^3.0 \
+		symfony/filesystem:^3.0 \
+		symfony/process:^3.0 \
+		symfony/finder:^3.0 \
+		symfony/yaml:^3.0


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...

While working on PR #464 I was getting errors with the testing in travis for Symfony 4.0. It took me a bit of digging to figure out how to do the switch locally. After figuring it out, I went ahead and added some helper methods to the Makefile to switch between 3.0 and 4.0 more easily.