### PR TITLE
Remove empty option from test framework arguments

### DIFF
--- a/src/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -18,7 +18,7 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
 {
     public function build(string $configPath, string $extraOptions): array
     {
-        return [
+        return array_filter([
             'run',
             '--config',
             $configPath,
@@ -26,6 +26,6 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
             '--format=tap',
             '--stop-on-failure',
             $extraOptions,
-        ];
+        ]);
     }
 }

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -18,11 +18,11 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
 {
     public function build(string $configPath, string $extraOptions): array
     {
-        return [
+        return array_filter([
             '--configuration',
             $configPath,
             '--stop-on-failure',
             $extraOptions,
-        ];
+        ]);
     }
 }

--- a/tests/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -35,4 +35,22 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
             $builder->build($configPath, '--verbose')
         );
     }
+
+    public function test_it_removes_empty_extra_options(): void
+    {
+        $configPath = '/config/path';
+        $builder = new ArgumentsAndOptionsBuilder();
+
+        $this->assertSame(
+            [
+                'run',
+                '--config',
+                $configPath,
+                '--no-ansi',
+                '--format=tap',
+                '--stop-on-failure',
+            ],
+            $builder->build($configPath, '')
+        );
+    }
 }

--- a/tests/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -32,4 +32,19 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
             $builder->build($configPath, '--verbose')
         );
     }
+
+    public function test_it_removes_empty_extra_options(): void
+    {
+        $configPath = '/config/path';
+        $builder = new ArgumentsAndOptionsBuilder();
+
+        $this->assertSame(
+            [
+                '--configuration',
+                $configPath,
+                '--stop-on-failure',
+            ],
+            $builder->build($configPath, '')
+        );
+    }
 }


### PR DESCRIPTION
This PR:

- [x] Modifies ArgumentsAndOptionsBuilder::build methods to filter empty values
- [x] Covered by tests

Fixes https://github.com/infection/infection/issues/467

This is the most robust way to stop empty command-line parameters being sent to the new process.

Alternatively, `AbstractTestFrameworkAdapter::getCommandLine` could do it, except that this method is currently the source of the problem, in that it does filter all the arguments, but not for every value that it returns.
