### PR TITLE
Find php script from .bat file on Windows

### DIFF
--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -43,10 +43,14 @@ class TestFrameworkFinder extends AbstractExecutableFinder
     {
         if (!isset($this->cachedPath)) {
             if (!$this->shouldUseCustomPath()) {
-                $this->addVendorFolderToPath();
+                $this->addVendorBinToPath();
             }
 
             $this->cachedPath = (string) realpath($this->findTestFramework());
+
+            if ('.bat' === substr($this->cachedPath, -4)) {
+                $this->cachedPath = $this->findFromBatchFile($this->cachedPath);
+            }
         }
 
         return $this->cachedPath;
@@ -65,7 +69,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
         throw FinderException::testCustomPathDoesNotExist($this->testFrameworkName, $this->customPath);
     }
 
-    private function addVendorFolderToPath(): void
+    private function addVendorBinToPath(): void
     {
         $vendorPath = null;
 
@@ -135,5 +139,26 @@ class TestFrameworkFinder extends AbstractExecutableFinder
         }
 
         throw FinderException::testFrameworkNotFound($this->testFrameworkName);
+    }
+
+    private function findFromBatchFile(string $path): string
+    {
+        /* Check the proxy code (%~dp0 is the script path with a backslash),
+         * then trim it and remove any leading directory slash and any trailing
+         * components. This will extract the relative path from lines like:
+         *
+         *   SET BIN_TARGET=%~dp0/../path
+         *   php %~dp0/path %*
+         */
+        if (preg_match('/%~dp0(.+$)/mi', (string) file_get_contents($path), $match)) {
+            $target = ltrim(rtrim(trim($match[1]), '" %*'), '\\/');
+            $script = (string) realpath(\dirname($path) . '/' . $target);
+
+            if (file_exists($script)) {
+                $path = $script;
+            }
+        }
+
+        return $path;
     }
 }

--- a/tests/Finder/MockVendor.php
+++ b/tests/Finder/MockVendor.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Finder;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class MockVendor
+{
+    public const VENDOR = 'phptester';
+    public const PACKAGE = 'awesome-php-tester';
+
+    /**
+     * @var string
+     */
+    private $tmpDir;
+
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem;
+
+    /**
+     * @var string
+     */
+    private $packageScript;
+
+    /**
+     * @var string
+     */
+    private $scriptPath;
+
+    /**
+     * @var string
+     */
+    private $vendorBinDir;
+
+    /**
+     * @var string
+     */
+    private $vendorBinLink;
+
+    /**
+     * @var string
+     */
+    private $vendorBinBat;
+
+    public function __construct(string $tmpDir, Filesystem $fileSystem)
+    {
+        $this->tmpDir = $tmpDir;
+        $this->fileSystem = $fileSystem;
+
+        $vendorDir = $this->tmpDir . '/vendor';
+        $this->vendorBinDir = $vendorDir . '/bin';
+
+        $binaryPath = self::VENDOR . '/' . self::PACKAGE . '/bin';
+        $scriptDir = $vendorDir . '/' . $binaryPath;
+
+        $this->fileSystem->mkdir([
+            $this->vendorBinDir,
+            $scriptDir,
+        ]);
+
+        // The package main script
+        $this->packageScript = $scriptDir . '/' . self::PACKAGE;
+        file_put_contents($this->packageScript, "#!/usr/bin/env php\n<?php\n");
+
+        // The relative path to the main script
+        $this->scriptPath = $binaryPath . '/' . self::PACKAGE;
+
+        $this->vendorBinLink = $this->vendorBinDir . '/' . self::PACKAGE;
+        $this->vendorBinBat = $this->vendorBinLink . '.bat';
+    }
+
+    public function setUpPlatformTest(): void
+    {
+        $this->emptyVendorBin();
+
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            // Use an empty batch script to disable finding the main script
+            file_put_contents($this->vendorBinBat, '@ECHO OFF');
+        } else {
+            // Mimic a symlink
+            file_put_contents($this->vendorBinLink, "#!/usr/bin/env php\n<?php\n");
+        }
+    }
+
+    public function setUpComposerBatchTest(): void
+    {
+        $this->emptyVendorBin();
+
+        // Use a valid batch script to test finding main script
+        $code = $this->getComposerBatProxy($this->scriptPath);
+        file_put_contents($this->vendorBinBat, $code);
+    }
+
+    public function setUpProjectBatchTest(): void
+    {
+        $this->emptyVendorBin();
+
+        // Use a valid batch script to test finding main script
+        $code = $this->getProjectBatProxy($this->scriptPath);
+        file_put_contents($this->vendorBinBat, $code);
+    }
+
+    public function getVendorBinDir(): string
+    {
+        return $this->vendorBinDir;
+    }
+
+    public function getPackageScript(): string
+    {
+        return $this->packageScript;
+    }
+
+    public function getVendorBinBat(): string
+    {
+        return $this->vendorBinBat;
+    }
+
+    public function getVendorBinLink(): string
+    {
+        return $this->vendorBinLink;
+    }
+
+    private function emptyVendorBin(): void
+    {
+        $files = array_filter(
+            [$this->vendorBinLink, $this->vendorBinBat],
+            'file_exists'
+        );
+
+        $this->fileSystem->remove($files);
+    }
+
+    private function getComposerBatProxy($binaryPath)
+    {
+        // As per Composer proxy code (BinaryInstaller::generateWindowsProxyCode)
+        $code = [
+            '@ECHO OFF',
+            'setlocal DISABLEDELAYEDEXPANSION',
+            'SET BIN_TARGET=%~dp0../' . $binaryPath,
+            'php "%BIN_TARGET%" %*',
+        ];
+
+        return implode(PHP_EOL, $code) . PHP_EOL;
+    }
+
+    private function getProjectBatProxy($binaryPath)
+    {
+        // Basic proxy
+        $code = [
+            '@ECHO OFF',
+            'php "%~dp0../' . $binaryPath . '" %*',
+        ];
+
+        return implode(PHP_EOL, $code) . PHP_EOL;
+    }
+}

--- a/tests/Finder/TestFrameworkFinderTest.php
+++ b/tests/Finder/TestFrameworkFinderTest.php
@@ -23,6 +23,21 @@ use function Infection\Tests\normalizePath;
 final class TestFrameworkFinderTest extends TestCase
 {
     /**
+     * @var string
+     */
+    private static $pathName;
+
+    /**
+     * @var array
+     */
+    private static $env;
+
+    /**
+     * @var array
+     */
+    private static $names;
+
+    /**
      * @var Filesystem
      */
     private $fileSystem;
@@ -37,8 +52,23 @@ final class TestFrameworkFinderTest extends TestCase
      */
     private $tmpDir;
 
+    /**
+     * Saves the current environment
+     */
+    public static function setUpBeforeClass(): void
+    {
+        self::$pathName = getenv('PATH') ? 'PATH' : 'Path';
+        self::$env = [];
+        self::$names = [self::$pathName, 'PATHEXT'];
+
+        foreach (self::$names as $name) {
+            self::$env[$name] = getenv($name);
+        }
+    }
+
     protected function setUp(): void
     {
+        self::restorePathEnvironment();
         $this->workspace = sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'infection-test' . \microtime(true) . \random_int(100, 999);
 
         $this->fileSystem = new Filesystem();
@@ -68,23 +98,32 @@ final class TestFrameworkFinderTest extends TestCase
         $frameworkFinder->find();
     }
 
-    public function test_it_adds_vendor_folder_to_path_if_needed(): void
+    public function test_it_adds_vendor_bin_to_path_if_needed(): void
     {
-        $pathName = getenv('PATH') ? 'PATH' : 'Path';
-        $path = getenv($pathName);
+        $path = getenv(self::$pathName);
 
         $frameworkFinder = new TestFrameworkFinder(TestFrameworkTypes::PHPUNIT);
 
-        $this->assertContains(
-            normalizePath(realpath('vendor/bin/phpunit')),
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            // The main script must be found from the .bat file
+            $expected = realpath('vendor/phpunit/phpunit/phpunit');
+        } else {
+            $expected = realpath('vendor/bin/phpunit');
+        }
+
+        $this->assertSame(
+            normalizePath($expected),
             normalizePath($frameworkFinder->find()),
-            'Should return the custom path'
+            'Should return the phpunit path'
         );
 
-        $pathAfterTest = getenv($pathName);
+        $pathAfterTest = getenv(self::$pathName);
+
+        // Vendor bin should be the first item
+        $pathList = explode(PATH_SEPARATOR, $pathAfterTest);
+        $this->assertContains('vendor', $pathList[0]);
 
         $this->assertNotSame($path, $pathAfterTest);
-        $this->assertContains('vendor', $pathAfterTest);
 
         $this->assertGreaterThan(
             \strlen($path),
@@ -93,8 +132,78 @@ final class TestFrameworkFinderTest extends TestCase
         );
     }
 
+    public function test_it_finds_framework_executable(): void
+    {
+        $mock = new MockVendor($this->tmpDir, $this->fileSystem);
+        $mock->setUpPlatformTest();
+
+        // Set the path to a single directory (vendor/bin)
+        putenv(sprintf('%s=%s', self::$pathName, $mock->getVendorBinDir()));
+        putenv('PATHEXT=');
+
+        $frameworkFinder = new TestFrameworkFinder($mock::PACKAGE);
+
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            // This .bat has no code, so main script will not be found
+            $expected = $mock->getVendorBinBat();
+        } else {
+            $expected = $mock->getVendorBinLink();
+        }
+
+        $this->assertSame(
+            normalizePath($expected),
+            normalizePath($frameworkFinder->find()),
+            'should return the vendor bin link or .bat'
+        );
+    }
+
+    /**
+     * @dataProvider providesMockSetup
+     */
+    public function test_it_finds_framework_script_from_bat(string $methodName): void
+    {
+        $mock = new MockVendor($this->tmpDir, $this->fileSystem);
+        $mock->{$methodName}();
+
+        // Set the path to a single directory (vendor/bin)
+        putenv(sprintf('%s=%s', self::$pathName, $mock->getVendorBinDir()));
+        putenv('PATHEXT=');
+
+        $frameworkFinder = new TestFrameworkFinder($mock::PACKAGE);
+
+        $this->assertSame(
+            normalizePath($mock->getPackageScript()),
+            normalizePath($frameworkFinder->find()),
+            'should return the package script from .bat'
+        );
+    }
+
+    public function providesMockSetup(): array
+    {
+        return [
+            'composer-bat' => ['setUpComposerBatchTest'],
+            'project-bat' => ['setUpProjectBatchTest'],
+        ];
+    }
+
+    private static function restorePathEnvironment(): void
+    {
+        foreach (self::$env as $name => $value) {
+            if (false !== $value) {
+                putenv($name . '=' . $value);
+            } else {
+                putenv($name);
+            }
+        }
+    }
+
     protected function tearDown(): void
     {
         $this->fileSystem->remove($this->workspace);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::restorePathEnvironment();
     }
 }


### PR DESCRIPTION
This PR:

- [ ] Enables the use of `--initial-tests-php-options` on Windows, without having to set a custom path
- [ ] Covered by tests

Fixes https://github.com/infection/infection/issues/471

If the test framework is invoked through a .bat proxy, `--initial-tests-php-options` cannot be used. This fix parses the batch file to find the location of the test framework script.

Composer generates Windows proxy scripts when installing `vendor/bin` requirements (a .bat file for cmd and a shell script for unixy tools). For example:

```bat
#phpunit.bat

@ECHO OFF
setlocal DISABLEDELAYEDEXPANSION
SET BIN_TARGET=%~dp0/../phpunit/phpunit/phpunit
php "%BIN_TARGET%" %*


#phpspec.bat

@ECHO OFF
setlocal DISABLEDELAYEDEXPANSION
SET BIN_TARGET=%~dp0/../phpspec/phpspec/bin/phpspec
php "%BIN_TARGET%" %*
```

This proxy will pass-through options, but not command-line options for php itself.

For example: `--initial-tests-php-options=-d zend_extension=xdebug.dll` is used to create the following  command-line:

```
php -d zend_extension=xdebug.dll phpunit ...
```
But this cannot be done in a .bat proxy because it invokes php without any command-line arguments:

```
php "%BIN_TARGET%" %*
```