### PR TITLE
Update xdebug-handler to simplify sub-processes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "php": "^7.1",
         "ext-dom": "*",
         "ext-json": "*",
-        "composer/xdebug-handler": "^1.1",
+        "composer/xdebug-handler": "^1.3",
         "nikic/php-parser": "^4.0",
         "ocramius/package-versions": "^1.2",
         "padraic/phar-updater": "^1.0.4",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "984a11e13776404fad03341ad52ec6dd",
+    "content-hash": "21bf5d2eee9ee7886728b8d230531cca",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -64,16 +64,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "c919dc6c62e221fc6406f861ea13433c0aa24f08"
+                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/c919dc6c62e221fc6406f861ea13433c0aa24f08",
-                "reference": "c919dc6c62e221fc6406f861ea13433c0aa24f08",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/b8e9745fb9b06ea6664d8872c4505fb16df4611c",
+                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c",
                 "shasum": ""
             },
             "require": {
@@ -104,7 +104,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-04-11T15:42:36+00:00"
+            "time": "2018-08-31T19:20:00+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -12,7 +12,6 @@ namespace Infection\Console;
 use Composer\XdebugHandler\XdebugHandler;
 use Infection\Command;
 use Infection\Console\ConsoleOutput as InfectionConsoleOutput;
-use Infection\Console\Util\PhpProcess;
 use PackageVersions\Versions;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
@@ -34,11 +33,11 @@ final class Application extends BaseApplication
 
     private const LOGO = <<<'ASCII'
     ____      ____          __  _
-   /  _/___  / __/__  _____/ /_(_)___  ____ 
+   /  _/___  / __/__  _____/ /_(_)___  ____
    / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \
  _/ // / / / __/  __/ /__/ /_/ / /_/ / / / /
 /___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/
- 
+
 ASCII;
 
     /**
@@ -87,15 +86,9 @@ ASCII;
             return parent::run($input, $output);
         }
 
-        $xdebug = new XdebugHandler(self::INFECTION_PREFIX, '--ansi');
-        $xdebug->check();
-
-        /*
-         * If we're skipping Xdebug, setup a default Xdebug-free environment for all subprocesses
-         */
-        if ('' !== XdebugHandler::getSkippedVersion()) {
-            PhpProcess::setupXdebugFreeEnvironment();
-        }
+        (new XdebugHandler(self::INFECTION_PREFIX, '--ansi'))
+            ->setPersistent()
+            ->check();
 
         return parent::run($input, $output);
     }

--- a/src/Console/Util/PhpProcess.php
+++ b/src/Console/Util/PhpProcess.php
@@ -26,6 +26,10 @@ final class PhpProcess extends Process
      * This method allows a sub-process to run with xdebug enabled (if it was
      * originally loaded), then restores the xdebug-free environment.
      *
+     * This means that we can use xdebug when it is required and not have to
+     * worry about it for the bulk of other processes, which do not need it and
+     * work better without it.
+     *
      * {@inheritdoc}
      */
     public function start(callable $callback = null, array $env = null): void

--- a/src/Console/Util/PhpProcess.php
+++ b/src/Console/Util/PhpProcess.php
@@ -9,85 +9,31 @@ declare(strict_types=1);
 
 namespace Infection\Console\Util;
 
-use Composer\XdebugHandler\XdebugHandler;
+use Composer\XdebugHandler\PhpConfig;
 use Symfony\Component\Process\Process;
 
 /**
- * Vanilla PHP process and utility functions
- *
  * @internal
  */
 final class PhpProcess extends Process
 {
     /**
-     * @var string|bool
-     */
-    private static $phprc;
-
-    /**
-     * Setups a default Xdebug-free environment for all subprocesses:
+     * Runs a PHP process with xdebug loaded
      *
-     * - PHPRC should point to our temporary php.ini (we need to save a previous value)
+     * If xdebug was loaded in the main process, it will have been restarted
+     * without xdebug and configured to keep xdebug out of PHP sub-processes.
      *
-     * - PHP_INI_SCAN_DIR should be made blank because our php.ini has all we need
-     *   (a previous value can be found in XdebugHandler::getRestartSettings()["scanDir"])
+     * This method allows a sub-process to run with xdebug enabled (if it was
+     * originally loaded), then restores the xdebug-free environment.
+     *
+     * {@inheritdoc}
      */
-    public static function setupXdebugFreeEnvironment(): void
-    {
-        if (!isset(self::$phprc)) {
-            self::$phprc = getenv('PHPRC');
-        }
-
-        self::putenv('PHPRC', XdebugHandler::getRestartSettings()['tmpIni']);
-        self::putenv('PHP_INI_SCAN_DIR', '');
-    }
-
     public function start(callable $callback = null, array $env = null): void
     {
-        // Xdebug wasn't skipped, running as is
-        if ('' === XdebugHandler::getSkippedVersion()) {
-            parent::start($callback, $env ?? []);
+        $phpConfig = new PhpConfig();
 
-            return;
-        }
-
-        /*
-         * Vanilla processes are expected to run in a vanilla, or the most original, environment.
-         *
-         * For that, we need to remove or reset all environment variables we set to setup our custom
-         * xdebug-free environment, later setting them back so we won't have to think again about it
-         * for the bulk of other processes, which not require xdebug to function, and work better
-         * without it.
-         */
-
-        self::restoreVanillaEnvironment();
-
+        $phpConfig->useOriginal();
         parent::start($callback, $env ?? []);
-
-        self::setupXdebugFreeEnvironment();
-    }
-
-    private static function restoreVanillaEnvironment(): void
-    {
-        self::putenv('PHPRC', self::$phprc);
-        self::putenv('PHP_INI_SCAN_DIR', XdebugHandler::getRestartSettings()['scanDir']);
-    }
-
-    /**
-     * @param string $name
-     * @param string|bool $value either string or false
-     */
-    private static function putenv(string $name, $value): void
-    {
-        // getenv returns false if there was no variable => we must delete it
-        putenv(false === $value ? $name : $name . '=' . $value);
-
-        // Our parent will read vars from $_SERVER
-        $_SERVER[$name] = $value;
-
-        // $_ENV is typically empty, but update it if not
-        if (!empty($_ENV)) {
-            $_ENV[$name] = $value;
-        }
+        $phpConfig->usePersistent();
     }
 }


### PR DESCRIPTION
This PR:

- [x] Updates xdebug-handler to [1.3.0](https://github.com/composer/xdebug-handler/releases/tag/1.3.0)

This simplifies setting up a default xdebug-free environment and running PHP sub-processes with xdebug loaded.