### PR TITLE
Add config for automatic tap release

### DIFF
--- a/.github/tap-release.yml
+++ b/.github/tap-release.yml
@@ -1,0 +1,20 @@
+asset: infection.phar
+tap: infection/homebrew-infection/Formula/infection.rb
+template: >
+  class Infection < Formula
+    desc     "$REPO_DESCRIPTION"
+    homepage "$REPO_WEBITE"
+    version  "$STABLE_VERSION"
+    url      "$STABLE_ASSET_URL"
+    sha256   "$STABLE_ASSET_SHA256"
+
+    depends_on "php71-xdebug" if Formula["php71"].linked_keg.exist?
+
+    def install
+      bin.install "infection.phar" => "infection"
+    end
+
+    test do
+        shell_output("#{bin}/infection --version").include?(version)
+    end
+  end


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [ ] Covered by tests
- [x] Doc PR: N/A

Add configuration file to automatically create homebrew tap on new releases (Ref: infection/homebrew-infection#2).
Note: This won't publish the GPG key as the tap-release bot doesn't [support publishing multiple assets](https://github.com/toolmantim/tap-release/issues/50) yet.

This PR is dependant on the [tap-release bot](https://github.com/apps/tap-release) to be installed in the repo

Fixes https://github.com/infection/homebrew-infection/issues/2