### PR TITLE
Ensure file permission is really set in tests

### DIFF
--- a/tests/Config/ValidatorTest.php
+++ b/tests/Config/ValidatorTest.php
@@ -61,7 +61,7 @@ final class ValidatorTest extends TestCase
     public function test_it_validates_log_file_paths(string $logType): void
     {
         if (\DIRECTORY_SEPARATOR === '\\') {
-            $this->markTestSkipped('Can\' test file permission on Windows');
+            $this->markTestSkipped('Can\'t test file permission on Windows');
         }
 
         $readOnlyDirPath = $this->tmpDir . '/invalid';
@@ -72,6 +72,10 @@ final class ValidatorTest extends TestCase
 
         // make it readonly
         $this->fileSystem->mkdir($readOnlyDirPath, 0400);
+
+        if (is_writable($readOnlyDirPath)) {
+            $this->markTestSkipped('Unable to change file permission to 0400');
+        }
 
         $configObject = json_decode(sprintf('{"logs": {"%s": "%s/infection.log"}}', $logType, $readOnlyDirPath));
 

--- a/tests/Logger/SummaryFileLoggerTest.php
+++ b/tests/Logger/SummaryFileLoggerTest.php
@@ -107,7 +107,7 @@ TXT
     public function test_it_outputs_an_error_when_dir_is_not_writable(): void
     {
         if (\DIRECTORY_SEPARATOR === '\\') {
-            $this->markTestSkipped('Can\' test file permission on Windows');
+            $this->markTestSkipped('Can\'t test file permission on Windows');
         }
 
         $readOnlyDirPath = $this->tmpDir . '/invalid';
@@ -115,6 +115,10 @@ TXT
 
         // make it readonly
         $this->fileSystem->mkdir($readOnlyDirPath, 0400);
+
+        if (is_writable($readOnlyDirPath)) {
+            $this->markTestSkipped('Unable to change file permission to 0400');
+        }
 
         $calculator = $this->createMock(MetricsCalculator::class);
         $calculator->expects($this->once())->method('getTotalMutantsCount')->willReturn(6);


### PR DESCRIPTION
This PR:

- [ ] Marks tests skipped if the required file permission cannot be set

Fixes https://github.com/infection/infection/issues/477

This is noticeable on Docker for Windows, where file permissions cannot be set due to the host (Windows) operating system.
