### PR TITLE
Fix Decrement integer

### DIFF
--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -35,6 +35,6 @@ final class FalseValue extends Mutator
             return false;
         }
 
-        return strtolower($node->name->getFirst()) === 'false';
+        return $node->name->toLowerString() === 'false';
     }
 }

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -35,6 +35,6 @@ final class TrueValue extends Mutator
             return false;
         }
 
-        return strtolower($node->name->getFirst()) === 'true';
+        return $node->name->toLowerString() === 'true';
     }
 }

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -18,7 +18,7 @@ use PhpParser\Node;
  */
 final class DecrementInteger extends Mutator
 {
-    private const COUNT_NAME = ['count', 'sizeof'];
+    private const COUNT_NAMEs = ['count', 'sizeof'];
 
     /**
      * Decrements an integer by 1
@@ -55,8 +55,8 @@ final class DecrementInteger extends Mutator
 
         if ($parentNode->left instanceof Node\Expr\FuncCall
             && \in_array(
-                $this->getLowercaseMethodName($parentNode, 'left'),
-                self::COUNT_NAME,
+                $parentNode->left->name->toLowerString(),
+                self::COUNT_NAMEs,
                 true)
         ) {
             return $this->isAllowedLeftSideCountComparison($parentNode);
@@ -64,8 +64,8 @@ final class DecrementInteger extends Mutator
 
         if ($parentNode->right instanceof Node\Expr\FuncCall
             && \in_array(
-                $this->getLowercaseMethodName($parentNode, 'right'),
-                self::COUNT_NAME,
+                $parentNode->right->name->toLowerString(),
+                self::COUNT_NAMEs,
                 true)
         ) {
             return $this->isAllowedRightSideCountComparison($parentNode);
@@ -104,10 +104,5 @@ final class DecrementInteger extends Mutator
     {
         return $parentNode instanceof Node\Expr\BinaryOp\Smaller
             || $parentNode instanceof Node\Expr\BinaryOp\SmallerOrEqual;
-    }
-
-    private function getLowercaseMethodName(Node $node, string $part): string
-    {
-        return $node->{$part}->name->toLowerString();
     }
 }

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -18,7 +18,7 @@ use PhpParser\Node;
  */
 final class DecrementInteger extends Mutator
 {
-    private const COUNT_NAMEs = ['count', 'sizeof'];
+    private const COUNT_NAMES = ['count', 'sizeof'];
 
     /**
      * Decrements an integer by 1
@@ -56,32 +56,22 @@ final class DecrementInteger extends Mutator
         if ($parentNode->left instanceof Node\Expr\FuncCall
             && \in_array(
                 $parentNode->left->name->toLowerString(),
-                self::COUNT_NAMEs,
+                self::COUNT_NAMES,
                 true)
         ) {
-            return $this->isAllowedLeftSideCountComparison($parentNode);
+            return false;
         }
 
         if ($parentNode->right instanceof Node\Expr\FuncCall
             && \in_array(
                 $parentNode->right->name->toLowerString(),
-                self::COUNT_NAMEs,
+                self::COUNT_NAMES,
                 true)
         ) {
-            return $this->isAllowedRightSideCountComparison($parentNode);
+            return false;
         }
 
         return true;
-    }
-
-    private function isAllowedLeftSideCountComparison(Node $node): bool
-    {
-        return $this->isSmallerThanComparison($node);
-    }
-
-    private function isAllowedRightSideCountComparison(Node $node): bool
-    {
-        return  $this->isGreaterThanComparison($node);
     }
 
     private function isComparison(Node $parentNode): bool
@@ -90,19 +80,9 @@ final class DecrementInteger extends Mutator
             || $parentNode instanceof Node\Expr\BinaryOp\NotIdentical
             || $parentNode instanceof Node\Expr\BinaryOp\Equal
             || $parentNode instanceof Node\Expr\BinaryOp\NotEqual
-            || $this->isGreaterThanComparison($parentNode)
-            || $this->isSmallerThanComparison($parentNode);
-    }
-
-    private function isGreaterThanComparison(Node $parentNode): bool
-    {
-        return $parentNode instanceof Node\Expr\BinaryOp\Greater
-            || $parentNode instanceof Node\Expr\BinaryOp\GreaterOrEqual;
-    }
-
-    private function isSmallerThanComparison(Node $parentNode): bool
-    {
-        return $parentNode instanceof Node\Expr\BinaryOp\Smaller
+            || $parentNode instanceof Node\Expr\BinaryOp\Greater
+            || $parentNode instanceof Node\Expr\BinaryOp\GreaterOrEqual
+            || $parentNode instanceof Node\Expr\BinaryOp\Smaller
             || $parentNode instanceof Node\Expr\BinaryOp\SmallerOrEqual;
     }
 }

--- a/src/Mutator/Regex/PregMatchMatches.php
+++ b/src/Mutator/Regex/PregMatchMatches.php
@@ -36,7 +36,7 @@ final class PregMatchMatches extends Mutator
         }
 
         if (!$node->name instanceof Node\Name ||
-            strtolower((string) $node->name) !== 'preg_match') {
+            $node->name->toLowerString() !== 'preg_match') {
             return false;
         }
 

--- a/src/Mutator/Regex/PregQuote.php
+++ b/src/Mutator/Regex/PregQuote.php
@@ -33,6 +33,6 @@ final class PregQuote extends Mutator
     {
         return $node instanceof Node\Expr\FuncCall &&
             $node->name instanceof Node\Name &&
-            strtolower((string) $node->name) === 'preg_quote';
+            $node->name->toLowerString() === 'preg_quote';
     }
 }

--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -45,12 +45,6 @@ final class FunctionCallRemoval extends Mutator
             return true;
         }
 
-        $string = strtolower((string) $name);
-
-        if ($string === 'assert') {
-            return false;
-        }
-
-        return true;
+        return $name->toLowerString() !== 'assert';
     }
 }

--- a/tests/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/Mutator/Number/DecrementIntegerTest.php
@@ -85,6 +85,16 @@ if (cOunT($a) === 0) {
 PHP
                 ,
             ],
+            'It does not decrement zero with when it is being compared as identical with result of sizeOf()' => [
+                <<<'PHP'
+<?php
+
+if (sizeOf($a) === 0) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
             'It does not decrement zero when it is being compared as not identical with result of count()' => [
                 <<<'PHP'
 <?php
@@ -125,6 +135,54 @@ if (count($a) > 0) {
 PHP
                 ,
             ],
+            'It does not decrement zero when it is compared as less than count() on the right side' => [
+                <<<'PHP'
+<?php
+
+if (0 < count($a)) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It does not decrement zero when it is compared as less than or equal to count() on the right side' => [
+                <<<'PHP'
+<?php
+
+if (0 <= count($a)) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It does not decrement zero when it is compared as equal to count() on the right side' => [
+                <<<'PHP'
+<?php
+
+if (0 == count($a)) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It does decrement zero when it is compared as greater than count() on the right side' => [
+                <<<'PHP'
+<?php
+
+if (0 > count($a)) {
+    echo 'bar';
+}
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+if (-1 > count($a)) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
             'It does not decrement zero when it is compared as more or equal than count()' => [
                 <<<'PHP'
 <?php
@@ -148,6 +206,24 @@ PHP
 <?php
 
 if (count($a) < -1) {
+    echo 'bar';
+}
+PHP
+                ,
+            ],
+            'It does decrement when compared against a variable function' => [
+                <<<'PHP'
+<?php
+
+if ($foo < 0) {
+    echo 'bar';
+}
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+if ($foo < -1) {
     echo 'bar';
 }
 PHP

--- a/tests/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/Mutator/Number/DecrementIntegerTest.php
@@ -165,6 +165,16 @@ if (0 == count($a)) {
 PHP
                 ,
             ],
+
+            'It does not decrement zero when it is compared as greater than count() on the right side' => [
+                <<<'PHP'
+<?php
+
+if (0 > count($a)) {
+    echo 'bar';
+}	
+PHP
+            ],
             'It does not decrement zero when it is compared as more or equal than count()' => [
                 <<<'PHP'
 <?php
@@ -175,19 +185,11 @@ if (count($a) >= 0) {
 PHP
                 ,
             ],
-            'It decrements zero when it is compared as less than count()' => [
+            'It doest not decrement zero when it is compared as less than count()' => [
                 <<<'PHP'
 <?php
 
 if (count($a) < 0) {
-    echo 'bar';
-}
-PHP
-                ,
-                <<<'PHP'
-<?php
-
-if (count($a) < -1) {
     echo 'bar';
 }
 PHP
@@ -234,14 +236,6 @@ PHP
 <?php
 
 if (count($a) <= 0) {
-    echo 'bar';
-}
-PHP
-                ,
-                <<<'PHP'
-<?php
-
-if (count($a) <= -1) {
     echo 'bar';
 }
 PHP

--- a/tests/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/Mutator/Number/DecrementIntegerTest.php
@@ -172,7 +172,7 @@ PHP
 
 if (0 > count($a)) {
     echo 'bar';
-}	
+}
 PHP
             ],
             'It does not decrement zero when it is compared as more or equal than count()' => [
@@ -231,7 +231,7 @@ if (abs($a) === -1) {
 PHP
                 ,
             ],
-            'It decrements zero when it is compared as less or equal than count()' => [
+            'It doest not decrements zero when it is compared as less or equal than count()' => [
                 <<<'PHP'
 <?php
 

--- a/tests/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/Mutator/Number/DecrementIntegerTest.php
@@ -85,7 +85,7 @@ if (cOunT($a) === 0) {
 PHP
                 ,
             ],
-            'It does not decrement zero with when it is being compared as identical with result of sizeOf()' => [
+            'It does not decrement zero when it is being compared as identical with result of sizeOf()' => [
                 <<<'PHP'
 <?php
 
@@ -160,24 +160,6 @@ PHP
 <?php
 
 if (0 == count($a)) {
-    echo 'bar';
-}
-PHP
-                ,
-            ],
-            'It does decrement zero when it is compared as greater than count() on the right side' => [
-                <<<'PHP'
-<?php
-
-if (0 > count($a)) {
-    echo 'bar';
-}
-PHP
-                ,
-                <<<'PHP'
-<?php
-
-if (-1 > count($a)) {
     echo 'bar';
 }
 PHP


### PR DESCRIPTION
This PR:

- [x] Fixes some issues surrounding DecrementInteger
- [x] Uses `toLowerString` for php-parser name nodes
- [x] Covered by tests

The checks for the decrement integer mutator did not consider the `sizeOf` function, which is an alias of `count`. It did not behave correctly if the count function was on the right side of the equation. Which needs to have greater than and lesser than flipped.

I also changed our own `strtolower` for node names to use php-parser's `toLowerString`. 