### PR TITLE
Validate phpunit.xml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "php": "^7.1",
         "ext-dom": "*",
         "ext-json": "*",
+        "ext-libxml": "*",
         "composer/xdebug-handler": "^1.3",
         "nikic/php-parser": "^4.0",
         "ocramius/package-versions": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "21bf5d2eee9ee7886728b8d230531cca",
+    "content-hash": "6dee8fc78cb77f37da4ec73ec45e4186",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2501,7 +2501,8 @@
     "platform": {
         "php": "^7.1",
         "ext-dom": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-libxml": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -73,6 +73,8 @@ class InitialConfigBuilder implements ConfigBuilder
 
         $xPath = new \DOMXPath($dom);
 
+        $this->xmlConfigurationHelper->validate($dom, $xPath);
+
         $this->addCoverageFilterWhitelistIfDoesNotExist($dom, $xPath);
         $this->xmlConfigurationHelper->replaceWithAbsolutePaths($xPath);
         $this->xmlConfigurationHelper->setStopOnFailure($xPath);

--- a/src/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigException.php
+++ b/src/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigException.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\TestFramework\PhpUnit\Config\Exception;
+
+/**
+ * @internal
+ */
+final class InvalidPhpUnitXmlConfigException extends \RuntimeException
+{
+    public static function byRootNode(): self
+    {
+        return new self('phpunit.xml does not contain a valid PHPUit configuration.');
+    }
+
+    public static function byXsdSchema(string $libXmlErrorsString): self
+    {
+        return new self(sprintf('phpunit.xml file does not pass XSD schema validation. %s', $libXmlErrorsString));
+    }
+}

--- a/src/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigException.php
+++ b/src/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigException.php
@@ -16,7 +16,7 @@ final class InvalidPhpUnitXmlConfigException extends \RuntimeException
 {
     public static function byRootNode(): self
     {
-        return new self('phpunit.xml does not contain a valid PHPUit configuration.');
+        return new self('phpunit.xml does not contain a valid PHPUnit configuration.');
     }
 
     public static function byXsdSchema(string $libXmlErrorsString): self

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -93,11 +93,13 @@ final class XmlConfigurationHelper
 
         $schema = $xPath->query('/phpunit/@xsi:noNamespaceSchemaLocation');
 
-        libxml_use_internal_errors(true);
+        $original = libxml_use_internal_errors(true);
 
         if ($schema->length && !$dom->schemaValidate($schema[0]->nodeValue)) {
             throw InvalidPhpUnitXmlConfigException::byXsdSchema($this->getXmlErrorsString());
         }
+
+        libxml_use_internal_errors($original);
 
         return true;
     }

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpUnit\Config;
 
+use Infection\TestFramework\PhpUnit\Config\Exception\InvalidPhpUnitXmlConfigException;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 
 /**
@@ -78,5 +79,45 @@ final class XmlConfigurationHelper
         if ($nodeList->length) {
             $dom->documentElement->removeAttribute('printerClass');
         }
+    }
+
+    public function validate(\DOMDocument $dom, \DOMXPath $xPath): bool
+    {
+        if ($xPath->query('/phpunit')->length === 0) {
+            throw InvalidPhpUnitXmlConfigException::byRootNode();
+        }
+
+        if (!$xPath->query('namespace::xsi')->length) {
+            return true;
+        }
+
+        $schema = $xPath->query('/phpunit/@xsi:noNamespaceSchemaLocation');
+
+        libxml_use_internal_errors(true);
+
+        if ($schema->length && !$dom->schemaValidate($schema[0]->nodeValue)) {
+            throw InvalidPhpUnitXmlConfigException::byXsdSchema($this->getXmlErrorsString());
+        }
+
+        return true;
+    }
+
+    private function getXmlErrorsString(): string
+    {
+        $errorsString = '';
+        $errors = libxml_get_errors();
+
+        foreach ($errors as $key => $error) {
+            $level = $error->level === LIBXML_ERR_WARNING ? 'Warning' : $error->level === LIBXML_ERR_ERROR ? 'Error' : 'Fatal';
+            $errorsString .= sprintf('[%s] %s', $level, $error->message);
+
+            if ($error->file) {
+                $errorsString .= sprintf(' in %s (line %s, col %s)', $error->file, $error->line, $error->column);
+            }
+
+            $errorsString .= "\n";
+        }
+
+        return $errorsString;
     }
 }

--- a/tests/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
@@ -23,7 +23,7 @@ final class InvalidPhpUnitXmlConfigExceptionTest extends TestCase
 
         $this->assertInstanceOf(InvalidPhpUnitXmlConfigException::class, $exception);
 
-        $this->assertSame('phpunit.xml does not contain a valid PHPUit configuration.', $exception->getMessage());
+        $this->assertSame('phpunit.xml does not contain a valid PHPUnit configuration.', $exception->getMessage());
     }
 
     public function test_for_xsd_schema(): void

--- a/tests/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestFramework\PhpUnit\Config\Exception;
+
+use Infection\TestFramework\PhpUnit\Config\Exception\InvalidPhpUnitXmlConfigException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class InvalidPhpUnitXmlConfigExceptionTest extends TestCase
+{
+    public function test_for_root_node(): void
+    {
+        $exception = InvalidPhpUnitXmlConfigException::byRootNode();
+
+        $this->assertInstanceOf(InvalidPhpUnitXmlConfigException::class, $exception);
+
+        $this->assertSame('phpunit.xml does not contain a valid PHPUit configuration.', $exception->getMessage());
+    }
+
+    public function test_for_xsd_schema(): void
+    {
+        $exception = InvalidPhpUnitXmlConfigException::byXsdSchema('Invalid');
+
+        $this->assertInstanceOf(InvalidPhpUnitXmlConfigException::class, $exception);
+
+        $this->assertContains('phpunit.xml file does not pass XSD schema validation.', $exception->getMessage());
+    }
+}

--- a/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpUnit\Config;
 
+use Infection\TestFramework\PhpUnit\Config\Exception\InvalidPhpUnitXmlConfigException;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use PHPUnit\Framework\TestCase;
@@ -230,6 +231,77 @@ XML
 XML
             , $dom->saveXML()
         );
+    }
+
+    public function test_it_validates_xml_by_root_node(): void
+    {
+        $this->expectException(InvalidPhpUnitXmlConfigException::class);
+        $this->expectExceptionMessage('phpunit.xml does not contain a valid PHPUit configuration.');
+
+        $dom = new \DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+        $dom->loadXML('<invalid></invalid>');
+        $xPath = new \DOMXPath($dom);
+
+        $xmlHelper = new XmlConfigurationHelper($this->getPathReplacer());
+
+        $xmlHelper->validate($dom, $xPath);
+    }
+
+    /**
+     * @dataProvider schemaProvider
+     */
+    public function test_it_validates_xml_by_xsd(string $xsdSchema): void
+    {
+        $this->expectException(InvalidPhpUnitXmlConfigException::class);
+        $this->expectExceptionMessageRegExp('/Element \'invalid\'\: This element is not expected/');
+
+        $dom = new \DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+        $dom->loadXML(<<<"XML"
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xsi:noNamespaceSchemaLocation="$xsdSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <invalid></invalid>
+</phpunit>
+
+XML
+        );
+        $xPath = new \DOMXPath($dom);
+
+        $xmlHelper = new XmlConfigurationHelper($this->getPathReplacer());
+
+        $xmlHelper->validate($dom, $xPath);
+    }
+
+    public function schemaProvider(): \Generator
+    {
+        yield 'Remote XSD' => ['https://schema.phpunit.de/6.1/phpunit.xsd'];
+
+        yield 'Local XSD' => ['./vendor/phpunit/phpunit/phpunit.xsd'];
+    }
+
+    /**
+     * @dataProvider schemaProvider
+     */
+    public function test_it_passes_validation_by_xsd(string $xsdSchema): void
+    {
+        $dom = new \DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+        $dom->loadXML(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xsi:noNamespaceSchemaLocation="$xsdSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+</phpunit>
+
+XML
+        );
+        $xPath = new \DOMXPath($dom);
+
+        $xmlHelper = new XmlConfigurationHelper($this->getPathReplacer());
+
+        $this->assertTrue(true, $xmlHelper->validate($dom, $xPath));
     }
 
     private function getDomDocument(): \DOMDocument

--- a/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -236,7 +236,7 @@ XML
     public function test_it_validates_xml_by_root_node(): void
     {
         $this->expectException(InvalidPhpUnitXmlConfigException::class);
-        $this->expectExceptionMessage('phpunit.xml does not contain a valid PHPUit configuration.');
+        $this->expectExceptionMessage('phpunit.xml does not contain a valid PHPUnit configuration.');
 
         $dom = new \DOMDocument();
         $dom->preserveWhiteSpace = false;

--- a/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -235,16 +235,15 @@ XML
 
     public function test_it_validates_xml_by_root_node(): void
     {
-        $this->expectException(InvalidPhpUnitXmlConfigException::class);
-        $this->expectExceptionMessage('phpunit.xml does not contain a valid PHPUnit configuration.');
-
         $dom = new \DOMDocument();
         $dom->preserveWhiteSpace = false;
         $dom->formatOutput = true;
         $dom->loadXML('<invalid></invalid>');
         $xPath = new \DOMXPath($dom);
-
         $xmlHelper = new XmlConfigurationHelper($this->getPathReplacer());
+
+        $this->expectException(InvalidPhpUnitXmlConfigException::class);
+        $this->expectExceptionMessage('phpunit.xml does not contain a valid PHPUnit configuration.');
 
         $xmlHelper->validate($dom, $xPath);
     }
@@ -254,9 +253,6 @@ XML
      */
     public function test_it_validates_xml_by_xsd(string $xsdSchema): void
     {
-        $this->expectException(InvalidPhpUnitXmlConfigException::class);
-        $this->expectExceptionMessageRegExp('/Element \'invalid\'\: This element is not expected/');
-
         $dom = new \DOMDocument();
         $dom->preserveWhiteSpace = false;
         $dom->formatOutput = true;
@@ -269,8 +265,10 @@ XML
 XML
         );
         $xPath = new \DOMXPath($dom);
-
         $xmlHelper = new XmlConfigurationHelper($this->getPathReplacer());
+
+        $this->expectException(InvalidPhpUnitXmlConfigException::class);
+        $this->expectExceptionMessageRegExp('/Element \'invalid\'\: This element is not expected/');
 
         $xmlHelper->validate($dom, $xPath);
     }


### PR DESCRIPTION
This PR:

- [x] Fixes #409
- [x] Add `phpunit.xml` validation: by checking the root node and then by XSD schema if needed/possible. XSD can be validated with local and remote (http[s]) paths to files
- [x] Adds `ext-libxml` to the list of required extensions. This is *not a new requirement*, just made it explicit by adding to `composer.json`

