### PR TITLE
@codeCoverageIgnore annotations support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "composer/xdebug-handler": "^1.3",
-        "nikic/php-parser": "^4.0",
+        "nikic/php-parser": "^4.1",
         "ocramius/package-versions": "^1.2",
         "padraic/phar-updater": "^1.0.4",
         "pimple/pimple": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6dee8fc78cb77f37da4ec73ec45e4186",
+    "content-hash": "07ac6eb17366576ae5ce9758f0421c17",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -108,16 +108,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.0.1",
+            "version": "v4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "e4a54fa90a5cd8e8dd3fb4099942681731c5cdd3"
+                "reference": "d0230c5c77a7e3cfa69446febf340978540958c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/e4a54fa90a5cd8e8dd3fb4099942681731c5cdd3",
-                "reference": "e4a54fa90a5cd8e8dd3fb4099942681731c5cdd3",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/d0230c5c77a7e3cfa69446febf340978540958c0",
+                "reference": "d0230c5c77a7e3cfa69446febf340978540958c0",
                 "shasum": ""
             },
             "require": {
@@ -133,7 +133,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -155,7 +155,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2018-03-25T17:35:16+00:00"
+            "time": "2018-10-10T09:24:14+00:00"
         },
         {
             "name": "ocramius/package-versions",

--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -2,3 +2,4 @@ parameters:
     ignoreErrors:
         - '#Access to an undefined property PhpParser\\Node(.*?)#'
         - '#Call to an undefined method PhpParser\\Node(.*?)#'
+        - '#Access to undefined constant PhpParser\\NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN#'

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -25,6 +25,7 @@ use Infection\Process\Runner\InitialTestsRunner;
 use Infection\Process\Runner\MutationTestingRunner;
 use Infection\Process\Runner\TestRunConstraintChecker;
 use Infection\TestFramework\Coverage\CodeCoverageData;
+use Infection\TestFramework\HasExtraNodeVisitors;
 use Infection\TestFramework\PhpSpec\PhpSpecExtraOptions;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\PhpUnit\PhpUnitExtraOptions;
@@ -221,7 +222,11 @@ final class InfectionCommand extends BaseCommand
             $container->get('parser')
         );
 
-        $mutations = $mutationsGenerator->generate($input->getOption('only-covered'), $input->getOption('filter'));
+        $mutations = $mutationsGenerator->generate(
+            $input->getOption('only-covered'),
+            $input->getOption('filter'),
+            $adapter instanceof HasExtraNodeVisitors ? $adapter->getMutationsCollectionNodeVisitors() : []
+        );
 
         $mutationTestingRunner = new MutationTestingRunner(
             $processBuilder,

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -18,6 +18,8 @@ use Infection\Mutant\Exception\ParserException;
 use Infection\Mutation;
 use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
+use Infection\Visitor\CodeCoverageClassIgnoreVisitor;
+use Infection\Visitor\CodeCoverageMethodIgnoreVisitor;
 use Infection\Visitor\FullyQualifiedClassNameVisitor;
 use Infection\Visitor\MutationsCollectorVisitor;
 use Infection\Visitor\ParentConnectorVisitor;
@@ -133,9 +135,11 @@ final class MutationsGenerator
             $onlyCovered
         );
 
+        $traverser->addVisitor(new CodeCoverageClassIgnoreVisitor());
         $traverser->addVisitor(new ParentConnectorVisitor());
         $traverser->addVisitor(new FullyQualifiedClassNameVisitor());
         $traverser->addVisitor(new ReflectionVisitor());
+        $traverser->addVisitor(new CodeCoverageMethodIgnoreVisitor());
         $traverser->addVisitor($mutationsCollectorVisitor);
 
         $traverser->traverse($initialStatements);

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -18,8 +18,6 @@ use Infection\Mutant\Exception\ParserException;
 use Infection\Mutation;
 use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
-use Infection\Visitor\CodeCoverageClassIgnoreVisitor;
-use Infection\Visitor\CodeCoverageMethodIgnoreVisitor;
 use Infection\Visitor\FullyQualifiedClassNameVisitor;
 use Infection\Visitor\MutationsCollectorVisitor;
 use Infection\Visitor\ParentConnectorVisitor;

--- a/src/TestFramework/HasExtraNodeVisitors.php
+++ b/src/TestFramework/HasExtraNodeVisitors.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: maksrafalko
- * Date: 9/24/18
- * Time: 12:07 AM
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Infection\TestFramework;
 

--- a/src/TestFramework/HasExtraNodeVisitors.php
+++ b/src/TestFramework/HasExtraNodeVisitors.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: maksrafalko
+ * Date: 9/24/18
+ * Time: 12:07 AM
+ */
+
+namespace Infection\TestFramework;
+
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * @internal
+ */
+interface HasExtraNodeVisitors
+{
+    /**
+     * @return NodeVisitorAbstract[]
+     */
+    public function getMutationsCollectionNodeVisitors(): array;
+}

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -14,7 +14,6 @@ use Infection\TestFramework\HasExtraNodeVisitors;
 use Infection\TestFramework\MemoryUsageAware;
 use Infection\Visitor\CodeCoverageClassIgnoreVisitor;
 use Infection\Visitor\CodeCoverageMethodIgnoreVisitor;
-use PhpParser\NodeVisitorAbstract;
 
 /**
  * @internal

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -57,7 +57,7 @@ final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements Memor
     {
         return [
             100 => new CodeCoverageClassIgnoreVisitor(),
-            0 => new CodeCoverageMethodIgnoreVisitor(),
+            15 => new CodeCoverageMethodIgnoreVisitor(),
         ];
     }
 

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -10,12 +10,16 @@ declare(strict_types=1);
 namespace Infection\TestFramework\PhpUnit\Adapter;
 
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\TestFramework\HasExtraNodeVisitors;
 use Infection\TestFramework\MemoryUsageAware;
+use Infection\Visitor\CodeCoverageClassIgnoreVisitor;
+use Infection\Visitor\CodeCoverageMethodIgnoreVisitor;
+use PhpParser\NodeVisitorAbstract;
 
 /**
  * @internal
  */
-final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements MemoryUsageAware
+final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements MemoryUsageAware, HasExtraNodeVisitors
 {
     public const JUNIT_FILE_NAME = 'phpunit.junit.xml';
 
@@ -48,6 +52,14 @@ final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements Memor
         }
 
         return -1;
+    }
+
+    public function getMutationsCollectionNodeVisitors(): array
+    {
+        return [
+            100 => new CodeCoverageClassIgnoreVisitor(),
+            0 => new CodeCoverageMethodIgnoreVisitor(),
+        ];
     }
 
     public function getName(): string

--- a/src/Traverser/PriorityNodeTraverser.php
+++ b/src/Traverser/PriorityNodeTraverser.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Traverser;
+
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+use Webmozart\Assert\Assert;
+
+/**
+ * @internal
+ */
+final class PriorityNodeTraverser extends NodeTraverser
+{
+    public function addVisitor(NodeVisitor $visitor, int $priority = 1): void
+    {
+        Assert::keyNotExists($this->visitors, $priority, sprintf('Priority %d is already used', $priority));
+
+        $this->visitors[$priority] = $visitor;
+
+        krsort($this->visitors);
+    }
+}

--- a/src/Visitor/CodeCoverageClassIgnoreVisitor.php
+++ b/src/Visitor/CodeCoverageClassIgnoreVisitor.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
 
 declare(strict_types=1);
 
@@ -10,7 +15,10 @@ use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
-class CodeCoverageClassIgnoreVisitor extends NodeVisitorAbstract
+/**
+ * @internal
+ */
+final class CodeCoverageClassIgnoreVisitor extends NodeVisitorAbstract
 {
     private $namespace;
 
@@ -19,7 +27,12 @@ class CodeCoverageClassIgnoreVisitor extends NodeVisitorAbstract
         if ($node instanceof Stmt\Namespace_) {
             $this->namespace = $node->name;
         } elseif ($node instanceof Stmt\ClassLike) {
-            $fullyQualifiedClassName = $node->name ? Name::concat($this->namespace, $node->name->name) : null;
+            if (!$node->name) {
+                return null;
+            }
+
+            /** @var Name $fullyQualifiedClassName */
+            $fullyQualifiedClassName = Name::concat($this->namespace, $node->name->name);
 
             $reflectionClass = new \ReflectionClass($fullyQualifiedClassName->toString());
 

--- a/src/Visitor/CodeCoverageClassIgnoreVisitor.php
+++ b/src/Visitor/CodeCoverageClassIgnoreVisitor.php
@@ -43,7 +43,7 @@ final class CodeCoverageClassIgnoreVisitor extends NodeVisitorAbstract
             }
 
             if (strpos($docComment, '@codeCoverageIgnore') !== false) {
-                return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
         }
     }

--- a/src/Visitor/CodeCoverageClassIgnoreVisitor.php
+++ b/src/Visitor/CodeCoverageClassIgnoreVisitor.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Visitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+class CodeCoverageClassIgnoreVisitor extends NodeVisitorAbstract
+{
+    private $namespace;
+
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Stmt\Namespace_) {
+            $this->namespace = $node->name;
+        } elseif ($node instanceof Stmt\ClassLike) {
+            $fullyQualifiedClassName = $node->name ? Name::concat($this->namespace, $node->name->name) : null;
+
+            $reflectionClass = new \ReflectionClass($fullyQualifiedClassName->toString());
+
+            $docComment = $reflectionClass->getDocComment();
+
+            if ($docComment === false) {
+                return null;
+            }
+
+            if (strpos($docComment, '@codeCoverageIgnore') !== false) {
+                return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+            }
+        }
+    }
+}

--- a/src/Visitor/CodeCoverageMethodIgnoreVisitor.php
+++ b/src/Visitor/CodeCoverageMethodIgnoreVisitor.php
@@ -36,17 +36,7 @@ final class CodeCoverageMethodIgnoreVisitor extends NodeVisitorAbstract
         }
 
         if (strpos($docComment, '@codeCoverageIgnore') !== false) {
-            /*
-             * This is a workaround to "disable" this Node from mutation.
-             *
-             * When PHP-Parser's NodeTraverser::DONT_TRAVERSE_CHILDREN is returned, subsequent Visitors still process
-             * current Node (enterNode(), leaveNode()), but without its children. This lead to class method to be
-             * mutated, while it shouldn't be.
-             */
-            $node->setAttribute(ReflectionVisitor::IS_ON_FUNCTION_SIGNATURE, false);
-            $node->setAttribute(ReflectionVisitor::IS_INSIDE_FUNCTION_KEY, false);
-
-            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+            return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
         }
 
         return null;

--- a/src/Visitor/CodeCoverageMethodIgnoreVisitor.php
+++ b/src/Visitor/CodeCoverageMethodIgnoreVisitor.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Visitor;
+
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+class CodeCoverageMethodIgnoreVisitor extends NodeVisitorAbstract
+{
+    public function enterNode(Node $node)
+    {
+        if (!$node instanceof Node\Stmt\ClassMethod) {
+            return null;
+        }
+
+        /** @var \ReflectionClass $reflection */
+        $reflection = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);
+
+        $method = $reflection->getMethod($node->name->toString());
+
+        $docComment = $method->getDocComment();
+
+        if ($docComment === false) {
+            return null;
+        }
+
+        if (strpos($docComment, '@codeCoverageIgnore') !== false) {
+            /*
+             * This is a workaround to "disable" this Node from mutation.
+             *
+             * When PHP-Parser's NodeTraverser::DONT_TRAVERSE_CHILDREN is returned, subsequent Visitors still process
+             * current Node (enterNode(), leaveNode()), but without its children. This lead to class method to be
+             * mutated, while it shouldn't be.
+             */
+            $node->setAttribute(ReflectionVisitor::IS_ON_FUNCTION_SIGNATURE, false);
+            $node->setAttribute(ReflectionVisitor::IS_INSIDE_FUNCTION_KEY, false);
+
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+
+        return null;
+    }
+}

--- a/src/Visitor/CodeCoverageMethodIgnoreVisitor.php
+++ b/src/Visitor/CodeCoverageMethodIgnoreVisitor.php
@@ -1,15 +1,22 @@
 <?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
 
 declare(strict_types=1);
 
 namespace Infection\Visitor;
 
-
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
-class CodeCoverageMethodIgnoreVisitor extends NodeVisitorAbstract
+/**
+ * @internal
+ */
+final class CodeCoverageMethodIgnoreVisitor extends NodeVisitorAbstract
 {
     public function enterNode(Node $node)
     {

--- a/tests/Fixtures/Autoloaded/Coverage/code-coverage-class-ignore.php
+++ b/tests/Fixtures/Autoloaded/Coverage/code-coverage-class-ignore.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CodeCoverageIgnore;
+namespace Infection\Tests\Fixtures\Coverage;
 
 /**
  * @codeCoverageIgnore

--- a/tests/Fixtures/Autoloaded/Coverage/code-coverage-class-not-ignored.php
+++ b/tests/Fixtures/Autoloaded/Coverage/code-coverage-class-not-ignored.php
@@ -1,11 +1,8 @@
 <?php
 
-namespace CodeCoverageIgnore;
+namespace Infection\Tests\Fixtures\Coverage;
 
-/**
- * @codeCoverageIgnore
- */
-class IgnoreClass
+class NotIgnoredClass
 {
     public function getThree(): int
     {

--- a/tests/Fixtures/Autoloaded/Coverage/code-coverage-method-ignore.php
+++ b/tests/Fixtures/Autoloaded/Coverage/code-coverage-method-ignore.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Infection\Tests\Fixtures\Coverage;
+
+class IgnoreMethodClass
+{
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getThree(): int
+    {
+        return 1 + 2;
+    }
+}

--- a/tests/Fixtures/Autoloaded/Coverage/code-coverage-method-not-ignored.php
+++ b/tests/Fixtures/Autoloaded/Coverage/code-coverage-method-not-ignored.php
@@ -1,11 +1,8 @@
 <?php
 
-namespace CodeCoverageIgnore;
+namespace Infection\Tests\Fixtures\Coverage;
 
-/**
- * @codeCoverageIgnore
- */
-class IgnoreClass
+class DoNotIgnoreMethodClass
 {
     public function getThree(): int
     {

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/README.md
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/README.md
@@ -1,0 +1,9 @@
+# Title
+
+* Link to github ticket if relevant
+
+## Summary
+Short summary of the ticket
+
+## Full Ticket
+Full github ticket

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/README.md
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/README.md
@@ -1,9 +1,7 @@
-# Title
+# @CodeCoverageIgnore
 
-* Link to github ticket if relevant
+* https://github.com/infection/infection/issues/407
 
 ## Summary
-Short summary of the ticket
 
-## Full Ticket
-Full github ticket
+Code that is ignored from code coverage (@codeCoverageIgnore annotation on a class or method;) should not be mutated.

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/composer.json
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.0"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Namespace_\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Namespace_\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/composer.json
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "CodeCoverageIgnore\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "CodeCoverageIgnore\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/expected-output.txt
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 0
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 1

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/infection.json
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/infection.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/phpunit.xml
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.1/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/src/IgnoreClass.php
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/src/IgnoreClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Namespace_;
+
+/**
+ * @codeCoverageIgnore
+ */
+class IgnoreClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/src/IgnoreClass.php
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/src/IgnoreClass.php
@@ -7,8 +7,8 @@ namespace Namespace_;
  */
 class IgnoreClass
 {
-    public function hello(): string
+    public function getThree(): int
     {
-        return 'hello';
+        return 1 + 2;
     }
 }

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/src/IgnoreMethod.php
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/src/IgnoreMethod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace CodeCoverageIgnore;
 
 class IgnoreMethod
 {

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/src/IgnoreMethod.php
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/src/IgnoreMethod.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Namespace_;
+
+class IgnoreMethod
+{
+    /**
+     * @codeCoverageIgnore
+     */
+    public function hello(): string
+    {
+        return 1 + 2;
+    }
+
+    public function foo(): string
+    {
+        return 'foo';
+    }
+}

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/src/IgnoreMethod.php
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/src/IgnoreMethod.php
@@ -7,7 +7,7 @@ class IgnoreMethod
     /**
      * @codeCoverageIgnore
      */
-    public function hello(): string
+    public function getThree(): string
     {
         return 1 + 2;
     }

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Namespace_\Test;
+
+use Namespace_\IgnoreClass;
+use PHPUnit\Framework\TestCase;
+
+class IgnoreClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $ignoreClass = new IgnoreClass();
+        $this->assertSame('hello', $ignoreClass->hello());
+    }
+}

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/tests/SourceClassTest.php
@@ -10,6 +10,6 @@ class IgnoreClassTest extends TestCase
     public function test_hello()
     {
         $ignoreClass = new IgnoreClass();
-        $this->assertSame('hello', $ignoreClass->hello());
+        $this->assertSame(3, $ignoreClass->getThree());
     }
 }

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/tests/SourceClassTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Namespace_\Test;
+namespace CodeCoverageIgnore\Test;
 
-use Namespace_\IgnoreClass;
+use CodeCoverageIgnore\IgnoreClass;
 use PHPUnit\Framework\TestCase;
 
 class IgnoreClassTest extends TestCase

--- a/tests/Fixtures/e2e/Config_Bootstrap/composer.json
+++ b/tests/Fixtures/e2e/Config_Bootstrap/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "ConfigBoostrap\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "ConfigBoostrap\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Config_Bootstrap/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Config_Bootstrap/src/SourceClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace ConfigBoostrap;
 
 class SourceClass
 {

--- a/tests/Fixtures/e2e/Config_Bootstrap/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Config_Bootstrap/tests/SourceClassTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Namespace_\Test;
+namespace ConfigBoostrap\Test;
 
-use Namespace_\SourceClass;
+use ConfigBoostrap\SourceClass;
 use PHPUnit\Framework\TestCase;
 
 class SourceClassTest extends TestCase

--- a/tests/Fixtures/e2e/Config_Framework/composer.json
+++ b/tests/Fixtures/e2e/Config_Framework/composer.json
@@ -6,7 +6,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "ConfigFramework\\": "src/"
         }
     },
     "autoload-dev": {

--- a/tests/Fixtures/e2e/Config_Framework/phpspec.yml
+++ b/tests/Fixtures/e2e/Config_Framework/phpspec.yml
@@ -1,7 +1,7 @@
 suites:
   source_suite:
-    namespace: Namespace_
-    psr4_prefix: Namespace_
+    namespace: ConfigFramework
+    psr4_prefix: ConfigFramework
 
 extensions:
   LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension: ~

--- a/tests/Fixtures/e2e/Config_Framework/spec/SourceClassSpec.php
+++ b/tests/Fixtures/e2e/Config_Framework/spec/SourceClassSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Namespace_;
+namespace spec\ConfigFramework;
 
 use PhpSpec\ObjectBehavior;
 

--- a/tests/Fixtures/e2e/Config_Framework/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Config_Framework/src/SourceClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace ConfigFramework;
 
 class SourceClass
 {

--- a/tests/Fixtures/e2e/Empty_Path/composer.json
+++ b/tests/Fixtures/e2e/Empty_Path/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "EmptyPass\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "EmptyPass\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Empty_Path/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Empty_Path/src/SourceClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace EmptyPass;
 
 class SourceClass
 {

--- a/tests/Fixtures/e2e/Empty_Path/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Empty_Path/tests/SourceClassTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Namespace_\Test;
+namespace EmptyPass\Test;
 
-use Namespace_\SourceClass;
+use EmptyPass\SourceClass;
 use PHPUnit\Framework\TestCase;
 
 class SourceClassTest extends TestCase

--- a/tests/Fixtures/e2e/Example_Test/composer.json
+++ b/tests/Fixtures/e2e/Example_Test/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "ExampleTest\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "ExampleTest\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Example_Test/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Example_Test/src/SourceClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace ExampleTest;
 
 class SourceClass
 {

--- a/tests/Fixtures/e2e/Example_Test/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Example_Test/tests/SourceClassTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Namespace_\Test;
+namespace ExampleTest\Test;
 
-use Namespace_\SourceClass;
+use ExampleTest\SourceClass;
 use PHPUnit\Framework\TestCase;
 
 class SourceClassTest extends TestCase

--- a/tests/Fixtures/e2e/Exec_Path/composer.json
+++ b/tests/Fixtures/e2e/Exec_Path/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "ExecPath\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "ExecPath\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Exec_Path/src/RunShellScript.php
+++ b/tests/Fixtures/e2e/Exec_Path/src/RunShellScript.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace ExecPath;
 
 class RunShellScript
 {

--- a/tests/Fixtures/e2e/Exec_Path/tests/RunShellScriptTest.php
+++ b/tests/Fixtures/e2e/Exec_Path/tests/RunShellScriptTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Namespace_\Test;
+namespace ExecPath\Test;
 
-use Namespace_\RunShellScript;
+use ExecPath\RunShellScript;
 use PHPUnit\Framework\TestCase;
 
 class RunShellScriptTest extends TestCase

--- a/tests/Fixtures/e2e/Identical_Mutator_Example/composer.json
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "IdenticalMutatorExample\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "IdenticalMutatorExample\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Identical_Mutator_Example/src/StringEnvelope.php
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/src/StringEnvelope.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace IdenticalMutatorExample;
 
 class StringEnvelope
 {

--- a/tests/Fixtures/e2e/Identical_Mutator_Example/tests/StringEnvelopeTest.php
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/tests/StringEnvelopeTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Namespace_\Test;
+namespace IdenticalMutatorExample\Test;
 
 use PHPUnit\Framework\TestCase;
-use Namespace_\StringEnvelope;
+use IdenticalMutatorExample\StringEnvelope;
 
 class StringEnvelopeTest extends TestCase
 {

--- a/tests/Fixtures/e2e/Memory_Limit/composer.json
+++ b/tests/Fixtures/e2e/Memory_Limit/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "MemoryLimit\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "MemoryLimit\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Memory_Limit/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Memory_Limit/src/SourceClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace MemoryLimit;
 
 class SourceClass
 {

--- a/tests/Fixtures/e2e/Memory_Limit/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Memory_Limit/tests/SourceClassTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Namespace_\Test;
+namespace MemoryLimit\Test;
 
-use Namespace_\SourceClass;
+use MemoryLimit\SourceClass;
 use PHPUnit\Framework\TestCase;
 
 class SourceClassTest extends TestCase

--- a/tests/Fixtures/e2e/Multiline_Statement/composer.json
+++ b/tests/Fixtures/e2e/Multiline_Statement/composer.json
@@ -10,12 +10,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "MultilineStatement\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "MultilineStatement\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Multiline_Statement/src/Calculator.php
+++ b/tests/Fixtures/e2e/Multiline_Statement/src/Calculator.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Namespace_;
+namespace MultilineStatement;
 
 class Calculator
 {

--- a/tests/Fixtures/e2e/Multiline_Statement/tests/CalculatorTest.php
+++ b/tests/Fixtures/e2e/Multiline_Statement/tests/CalculatorTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Namespace_;
+namespace MultilineStatement;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/composer.json
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "PhpUnitCustomConfigDir\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "PhpUnitCustomConfigDir\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/src/SourceClass.php
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/src/SourceClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace PhpUnitCustomConfigDir;
 
 class SourceClass
 {

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/tests/SourceClassTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Namespace_\Test;
+namespace PhpUnitCustomConfigDir\Test;
 
-use Namespace_\SourceClass;
+use PhpUnitCustomConfigDir\SourceClass;
 use PHPUnit\Framework\TestCase;
 
 class SourceClassTest extends TestCase

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/composer.json
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "PhpUnitBatWrapper\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "PhpUnitBatWrapper\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/src/SourceClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace PhpUnitBatWrapper;
 
 class SourceClass
 {

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/tests/SourceClassTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Namespace_\Test;
+namespace PhpUnitBatWrapper\Test;
 
-use Namespace_\SourceClass;
+use PhpUnitBatWrapper\SourceClass;
 use PHPUnit\Framework\TestCase;
 
 class SourceClassTest extends TestCase

--- a/tests/Fixtures/e2e/Profiles_Ignore_Combination/composer.json
+++ b/tests/Fixtures/e2e/Profiles_Ignore_Combination/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "TmpNamespace_\\": "src/"
+            "ProfileIgnoreCombination\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "TmpNamespace_\\Test\\": "tests/"
+            "ProfileIgnoreCombination\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Profiles_Ignore_Combination/src/OtherClass.php
+++ b/tests/Fixtures/e2e/Profiles_Ignore_Combination/src/OtherClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TmpNamespace_;
+namespace ProfileIgnoreCombination;
 
 class OtherClass
 {

--- a/tests/Fixtures/e2e/Profiles_Ignore_Combination/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Profiles_Ignore_Combination/src/SourceClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TmpNamespace_;
+namespace ProfileIgnoreCombination;
 
 class SourceClass
 {

--- a/tests/Fixtures/e2e/Profiles_Ignore_Combination/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Profiles_Ignore_Combination/tests/SourceClassTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace TmpNamespace_\Test;
+namespace ProfileIgnoreCombination\Test;
 
-use TmpNamespace_\SourceClass;
+use ProfileIgnoreCombination\SourceClass;
 use PHPUnit\Framework\TestCase;
 
 class SourceClassTest extends TestCase

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/composer.json
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/composer.json
@@ -12,12 +12,12 @@
     "autoload": {
         "psr-4": {
             "spec\\": "spec/",
-            "Namespace_\\": "src/"
+            "ProvideExistingCoverage\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "ProvideExistingCoverage\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/phpspec.yml
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/phpspec.yml
@@ -1,7 +1,7 @@
 suites:
   source_suite:
-    namespace: Namespace_
-    psr4_prefix: Namespace_
+    namespace: ProvideExistingCoverage
+    psr4_prefix: ProvideExistingCoverage
 
 extensions:
   LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension: ~

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/spec/SourceClassSpec.php
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/spec/SourceClassSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Namespace_;
+namespace spec\ProvideExistingCoverage;
 
 use PhpSpec\ObjectBehavior;
 

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/src/SourceClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace ProvideExistingCoverage;
 
 class SourceClass
 {

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/tests/SourceClassTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Namespace_\Test;
+namespace ProvideExistingCoverage\Test;
 
-use Namespace_\SourceClass;
+use ProvideExistingCoverage\SourceClass;
 use PHPUnit\Framework\TestCase;
 
 class SourceClassTest extends TestCase

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/composer.json
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/composer.json
@@ -9,12 +9,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "SavePhpUnitBoostrapFile\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Namespace_\\Test\\": "tests/"
+            "SavePhpUnitBoostrapFile\\Test\\": "tests/"
         }
     }
 }

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/src/CustomAutoloadedClass.php
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/src/CustomAutoloadedClass.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SavePhpUnitBoostrapFile;
+
 class CustomAutoloadedClass
 {
     public function hello(): string

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/tests/SourceClassTest.php
@@ -1,14 +1,15 @@
 <?php
 
-namespace Namespace_\Test;
+namespace SavePhpUnitBoostrapFile\Test;
 
 use PHPUnit\Framework\TestCase;
+use SavePhpUnitBoostrapFile\CustomAutoloadedClass;
 
 class SourceClassTest extends TestCase
 {
     public function test_hello()
     {
-        $sourceClass = new \CustomAutoloadedClass();
+        $sourceClass = new CustomAutoloadedClass();
         $this->assertSame('hello', $sourceClass->hello());
     }
 }

--- a/tests/Fixtures/e2e/Test_Frameworks/composer.json
+++ b/tests/Fixtures/e2e/Test_Frameworks/composer.json
@@ -6,13 +6,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Namespace_\\": "src/"
+            "TestFrameworks\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "spec\\": "spec/",
-            "Namespace\\Test\\": "tests/"
+            "TestFrameworks\\Test\\": "tests/"
         }
     },
     "require-dev": {

--- a/tests/Fixtures/e2e/Test_Frameworks/phpspec.yml
+++ b/tests/Fixtures/e2e/Test_Frameworks/phpspec.yml
@@ -1,7 +1,7 @@
 suites:
   source_suite:
-    namespace: Namespace_
-    psr4_prefix: Namespace_
+    namespace: TestFrameworks
+    psr4_prefix: TestFrameworks
 
 extensions:
   LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension: ~

--- a/tests/Fixtures/e2e/Test_Frameworks/spec/SourceClassSpec.php
+++ b/tests/Fixtures/e2e/Test_Frameworks/spec/SourceClassSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Namespace_;
+namespace spec\TestFrameworks;
 
 use PhpSpec\ObjectBehavior;
 

--- a/tests/Fixtures/e2e/Test_Frameworks/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Test_Frameworks/src/SourceClass.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Namespace_;
+namespace TestFrameworks;
 
 class SourceClass
 {

--- a/tests/Fixtures/e2e/Test_Frameworks/tests/SoucreClassTest.php
+++ b/tests/Fixtures/e2e/Test_Frameworks/tests/SoucreClassTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Namespace_\Test;
+namespace TestFrameworks\Test;
 
-use Namespace_\SourceClass;
+use TestFrameworks\SourceClass;
 use PHPUnit\Framework\TestCase;
 
 class SourceClassTest extends TestCase

--- a/tests/Traverser/PriorityNodeTraverserTest.php
+++ b/tests/Traverser/PriorityNodeTraverserTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Traverser;
+
+use Infection\Traverser\PriorityNodeTraverser;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitorAbstract;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class PriorityNodeTraverserTest extends TestCase
+{
+    public function test_it_sorts_visitors_by_priorites(): void
+    {
+        $traverser = new PriorityNodeTraverser();
+
+        $callOrder = [];
+
+        $traverser->addVisitor($this->createVisitor($callOrder, 20), 20);
+        $traverser->addVisitor($this->createVisitor($callOrder, 30), 30);
+        $traverser->addVisitor($this->createVisitor($callOrder, 5), 5);
+        $traverser->addVisitor($this->createVisitor($callOrder, 10), 10);
+
+        $traverser->traverse([]);
+
+        $this->assertSame([30, 20, 10, 5], $callOrder);
+    }
+
+    public function test_it_does_not_allow_duplicater_priorities(): void
+    {
+        $traverser = new PriorityNodeTraverser();
+
+        $callOrder = [];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Priority 20 is already used');
+
+        $traverser->addVisitor($this->createVisitor($callOrder, 20), 20);
+        $traverser->addVisitor($this->createVisitor($callOrder, 20), 20);
+    }
+
+    private function createVisitor(array &$callOrder, int $priority): NodeVisitor
+    {
+        return new class($callOrder, $priority) extends NodeVisitorAbstract {
+            public $callOrder;
+            public $priority;
+
+            public function __construct(array &$callOrder, int $priority)
+            {
+                $this->callOrder = &$callOrder;
+                $this->priority = $priority;
+            }
+
+            public function beforeTraverse(array $nodes): void
+            {
+                $this->callOrder[] = $this->priority;
+            }
+        };
+    }
+}

--- a/tests/Visitor/AbstractBaseVisitorTest.php
+++ b/tests/Visitor/AbstractBaseVisitorTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Visitor;
+
+use PhpParser\Lexer;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+abstract class AbstractBaseVisitorTest extends TestCase
+{
+    protected function getNodes(string $code): array
+    {
+        $lexer = new Lexer\Emulative();
+        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);
+
+        return $parser->parse($code);
+    }
+
+    protected function getFileContent(string $file): string
+    {
+        return file_get_contents(sprintf(__DIR__ . '/../Fixtures/Autoloaded/%s', $file));
+    }
+}

--- a/tests/Visitor/CloneVisitorTest.php
+++ b/tests/Visitor/CloneVisitorTest.php
@@ -13,19 +13,26 @@ use Infection\Visitor\CloneVisitor;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
-use PhpParser\ParserFactory;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class CloneVisitorTest extends TestCase
+final class CloneVisitorTest extends AbstractBaseVisitorTest
 {
+    private const CODE = <<<'PHP'
+<?php
+
+function hello() 
+{
+    return 'hello';
+}
+PHP;
+
     public function test_it_does_not_save_the_old_nodes_without_the_clone_visitor(): void
     {
         $traverser = new NodeTraverser();
         $traverser->addVisitor($this->getChangingVisitor());
-        $oldNodes = $this->getNodes();
+        $oldNodes = $this->getNodes(self::CODE);
 
         $newNodes = $traverser->traverse($oldNodes);
         $this->assertSame($oldNodes, $newNodes);
@@ -36,25 +43,10 @@ final class CloneVisitorTest extends TestCase
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new CloneVisitor());
         $traverser->addVisitor($this->getChangingVisitor());
-        $oldNodes = $this->getNodes();
+        $oldNodes = $this->getNodes(self::CODE);
 
         $newNodes = $traverser->traverse($oldNodes);
         $this->assertNotSame($oldNodes, $newNodes);
-    }
-
-    private function getNodes(): array
-    {
-        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
-
-        return $parser->parse(<<<'PHP'
-<?php
-
-function hello() 
-{
-    return 'hello';
-}
-PHP
-        );
     }
 
     private function getChangingVisitor()

--- a/tests/Visitor/CodeCoverageClassIgnoreVisitorTest.php
+++ b/tests/Visitor/CodeCoverageClassIgnoreVisitorTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Visitor;
+
+use Infection\Visitor\CodeCoverageClassIgnoreVisitor;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * @internal
+ */
+final class CodeCoverageClassIgnoreVisitorTest extends AbstractBaseVisitorTest
+{
+    private $spyVisitor;
+
+    protected function setUp(): void
+    {
+        $this->spyVisitor = $this->getSpyVisitor();
+    }
+
+    public function test_it_do_not_travers_when_coverage_is_ignored(): void
+    {
+        $code = $this->getFileContent('Coverage/code-coverage-class-ignore.php');
+
+        $this->parseAndTraverse($code);
+
+        $this->assertFalse($this->spyVisitor->isNodeVisited(), 'ClassMethod node has been visited');
+    }
+
+    public function test_it_travers_nodes_when_coverage_is_not_ignored(): void
+    {
+        $code = $this->getFileContent('Coverage/code-coverage-class-not-ignored.php');
+
+        $this->parseAndTraverse($code);
+
+        $this->assertTrue($this->spyVisitor->isNodeVisited(), 'ClassMethod node has not been visited');
+    }
+
+    protected function parseAndTraverse(string $code): void
+    {
+        $nodes = $this->getNodes($code);
+
+        $traverser = new NodeTraverser();
+
+        $traverser->addVisitor(new CodeCoverageClassIgnoreVisitor());
+        $traverser->addVisitor($this->spyVisitor);
+
+        $traverser->traverse($nodes);
+    }
+
+    private function getSpyVisitor()
+    {
+        return new class() extends NodeVisitorAbstract {
+            private $nodeVisited = false;
+
+            public function leaveNode(Node $node): void
+            {
+                if ($node instanceof Node\Stmt\ClassMethod) {
+                    $this->nodeVisited = true;
+                }
+            }
+
+            public function isNodeVisited(): bool
+            {
+                return $this->nodeVisited;
+            }
+        };
+    }
+}

--- a/tests/Visitor/CodeCoverageMethodIgnoreVisitorTest.php
+++ b/tests/Visitor/CodeCoverageMethodIgnoreVisitorTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright © 2017-2018 Maks Rafalko
+ *
+ * License: https://opensource.org/licenses/BSD-3-Clause New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Visitor;
+
+use Infection\Visitor\CodeCoverageMethodIgnoreVisitor;
+use Infection\Visitor\FullyQualifiedClassNameVisitor;
+use Infection\Visitor\ParentConnectorVisitor;
+use Infection\Visitor\ReflectionVisitor;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * @internal
+ */
+final class CodeCoverageMethodIgnoreVisitorTest extends AbstractBaseVisitorTest
+{
+    private $spyVisitor;
+
+    protected function setUp(): void
+    {
+        $this->spyVisitor = $this->getSpyVisitor();
+    }
+
+    public function test_it_do_not_travers_when_coverage_is_ignored(): void
+    {
+        $code = $this->getFileContent('Coverage/code-coverage-method-ignore.php');
+
+        $this->parseAndTraverse($code);
+
+        $this->assertFalse($this->spyVisitor->isNodeVisited(), 'Node\Stmt\Return_ node has been visited');
+    }
+
+    public function test_it_travers_nodes_when_coverage_is_not_ignored(): void
+    {
+        $code = $this->getFileContent('Coverage/code-coverage-method-not-ignored.php');
+
+        $this->parseAndTraverse($code);
+
+        $this->assertTrue($this->spyVisitor->isNodeVisited(), 'Node\Stmt\Return_ node has not been visited');
+    }
+
+    private function parseAndTraverse(string $code): void
+    {
+        $nodes = $this->getNodes($code);
+
+        $traverser = new NodeTraverser();
+
+        $traverser->addVisitor(new ParentConnectorVisitor());
+        $traverser->addVisitor(new FullyQualifiedClassNameVisitor());
+        $traverser->addVisitor(new ReflectionVisitor());
+        $traverser->addVisitor(new CodeCoverageMethodIgnoreVisitor());
+        $traverser->addVisitor($this->spyVisitor);
+
+        $traverser->traverse($nodes);
+    }
+
+    private function getSpyVisitor()
+    {
+        return new class() extends NodeVisitorAbstract {
+            private $nodeVisited = false;
+
+            public function leaveNode(Node $node): void
+            {
+                if ($node instanceof Node\Stmt\Return_) {
+                    $this->nodeVisited = true;
+                }
+            }
+
+            public function isNodeVisited(): bool
+            {
+                return $this->nodeVisited;
+            }
+        };
+    }
+}

--- a/tests/Visitor/FullyQualifiedClassNameVisitorTest.php
+++ b/tests/Visitor/FullyQualifiedClassNameVisitorTest.php
@@ -10,17 +10,14 @@ declare(strict_types=1);
 namespace Infection\Tests\Visitor;
 
 use Infection\Visitor\FullyQualifiedClassNameVisitor;
-use PhpParser\Lexer;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
-use PhpParser\ParserFactory;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class FullyQualifiedClassNameVisitorTest extends TestCase
+final class FullyQualifiedClassNameVisitorTest extends AbstractBaseVisitorTest
 {
     private $spyVisitor;
 
@@ -31,7 +28,7 @@ final class FullyQualifiedClassNameVisitorTest extends TestCase
 
     public function test_it_adds_fqcl_to_class_node(): void
     {
-        $code = $this->getFileContent('fqcn-empty-class.php');
+        $code = $this->getFileContent('Fqcn/fqcn-empty-class.php');
 
         $this->parseAndTraverse($code);
 
@@ -44,7 +41,7 @@ final class FullyQualifiedClassNameVisitorTest extends TestCase
 
     public function test_it_adds_fqcl_to_class_with_interface(): void
     {
-        $code = $this->getFileContent('fqcn-class-interface.php');
+        $code = $this->getFileContent('Fqcn/fqcn-class-interface.php');
 
         $this->parseAndTraverse($code);
 
@@ -57,7 +54,7 @@ final class FullyQualifiedClassNameVisitorTest extends TestCase
 
     public function test_it_adds_fqcl_to_class_with_anonymous_class(): void
     {
-        $code = $this->getFileContent('fqcn-anonymous-class.php');
+        $code = $this->getFileContent('Fqcn/fqcn-anonymous-class.php');
 
         $this->parseAndTraverse($code);
 
@@ -66,14 +63,6 @@ final class FullyQualifiedClassNameVisitorTest extends TestCase
             'FqcnClassAnonymous\Ci',
             $this->spyVisitor->processedNodes[0]->fullyQualifiedClassName->toString()
         );
-    }
-
-    private function getNodes(string $code): array
-    {
-        $lexer = new Lexer\Emulative();
-        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);
-
-        return $parser->parse($code);
     }
 
     private function getSpyVisitor()
@@ -100,10 +89,5 @@ final class FullyQualifiedClassNameVisitorTest extends TestCase
         $traverser->addVisitor($this->spyVisitor);
 
         $traverser->traverse($nodes);
-    }
-
-    private function getFileContent(string $file): string
-    {
-        return file_get_contents(sprintf(__DIR__ . '/../Fixtures/Autoloaded/Fqcn/%s', $file));
     }
 }

--- a/tests/Visitor/ReflectionVisitorTest.php
+++ b/tests/Visitor/ReflectionVisitorTest.php
@@ -19,12 +19,11 @@ use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class ReflectionVisitorTest extends TestCase
+final class ReflectionVisitorTest extends AbstractBaseVisitorTest
 {
     private $spyVisitor;
 
@@ -49,7 +48,7 @@ final class ReflectionVisitorTest extends TestCase
         ]);
 
         $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);
-        $this->code = $this->getFileContent('rv-part-of-signature-flag.php');
+        $this->code = $this->getFileContent('Reflection/rv-part-of-signature-flag.php');
     }
 
     /**
@@ -74,7 +73,7 @@ final class ReflectionVisitorTest extends TestCase
 
     public function test_it_detects_if_traversed_inside_class_method(): void
     {
-        $code = $this->getFileContent('rv-inside-class-method.php');
+        $code = $this->getFileContent('Reflection/rv-inside-class-method.php');
 
         $this->parseAndTraverse($code);
 
@@ -83,7 +82,7 @@ final class ReflectionVisitorTest extends TestCase
 
     public function test_it_detects_if_traversed_inside_function(): void
     {
-        $code = $this->getFileContent('rv-inside-function.php');
+        $code = $this->getFileContent('Reflection/rv-inside-function.php');
 
         $this->parseAndTraverse($code);
 
@@ -92,7 +91,7 @@ final class ReflectionVisitorTest extends TestCase
 
     public function test_it_detects_if_traversed_inside_closure(): void
     {
-        $code = $this->getFileContent('rv-inside-closure.php');
+        $code = $this->getFileContent('Reflection/rv-inside-closure.php');
 
         $this->parseAndTraverse($code);
 
@@ -101,7 +100,7 @@ final class ReflectionVisitorTest extends TestCase
 
     public function test_it_does_not_add_inside_function_flag_if_not_needed(): void
     {
-        $code = $this->getFileContent('rv-without-function.php');
+        $code = $this->getFileContent('Reflection/rv-without-function.php');
 
         $this->parseAndTraverse($code);
 
@@ -110,7 +109,7 @@ final class ReflectionVisitorTest extends TestCase
 
     public function test_it_correctly_works_with_anonymous_classes(): void
     {
-        $code = $this->getFileContent('rv-anonymous-class.php');
+        $code = $this->getFileContent('Reflection/rv-anonymous-class.php');
 
         $this->parseAndTraverse($code);
 
@@ -119,7 +118,7 @@ final class ReflectionVisitorTest extends TestCase
 
     public function test_it_sets_reflection_class_to_nodes(): void
     {
-        $code = $this->getFileContent('rv-inside-class-method.php');
+        $code = $this->getFileContent('Reflection/rv-inside-class-method.php');
         $reflectionSpyVisitor = $this->getReflectionClassSpyVisitor();
 
         $this->parseAndTraverse($code, $reflectionSpyVisitor);
@@ -168,14 +167,6 @@ final class ReflectionVisitorTest extends TestCase
         };
     }
 
-    private function getNodes(string $code): array
-    {
-        $lexer = new Lexer\Emulative();
-        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);
-
-        return $parser->parse($code);
-    }
-
     private function getInsideFunctionSpyVisitor()
     {
         return new class() extends NodeVisitorAbstract {
@@ -221,10 +212,5 @@ final class ReflectionVisitorTest extends TestCase
         $traverser->addVisitor($nodeVisitor ?: $this->spyVisitor);
 
         $traverser->traverse($nodes);
-    }
-
-    private function getFileContent(string $file): string
-    {
-        return file_get_contents(sprintf(__DIR__ . '/../Fixtures/Autoloaded/Reflection/%s', $file));
     }
 }

--- a/tests/add_new_e2e
+++ b/tests/add_new_e2e
@@ -21,6 +21,9 @@ cp  Example_Test/infection.json $dirname/infection.json
 cp  Example_Test/phpunit.xml $dirname/phpunit.xml
 cp  Example_Test/README.md $dirname/README.md
 
+cd $dirname
+find ./ -type f -exec sed -i -e "s/ExampleTest/$dirname/g" {} \;
+
 echo "Created the base for a new end-to-end test in directory $dirname"
 
 


### PR DESCRIPTION
This PR Fixes https://github.com/infection/infection/issues/407:

- [x] Covered by tests

There were requested 4 cases regarding PHPUnit's annotation:

- [x] `@codeCoverageIgnore` on the class level
- [x] `@codeCoverageIgnore` on the method level
- [ ] `@codeCoverageIgnore` on the line level
- [ ] `@codeCoverageIgnoreStart` and `codeCoverageIgnoreEnd` to ignore any lines of code.

This PR considers only the first two cases. Here is an explanation of why didn't I implement 3rd and 4th:

## `@codeCoverageIgnore` on the line level

There are 2 reasons why I think we should not support this case:

1. It's very tricky to implement with PHP-Parser. Look at this simple code:

```php
# test.php file
<?php

exit; // @codeCoverageIgnore
```

And this is what the AST looks like:

```php
./vendor/bin/php-parse test.php

4: Stmt_Expression[3:1 - 3:5](
    expr: Expr_Exit[3:1 - 3:4](
        expr: null
    )
)
5: Stmt_Nop[4:1 - 3:5](
    comments: array(
        0: // @codeCoverageIgnore
    )
)
```

The comment is not assigned to the `Expr_Exit` node, instead, it is assigned to the `Stmt_Nop` node that is completely another node in the tree.

And here is a `--var-dump` output of the `Stmt_Nop`:

```php
object(PhpParser\Node\Stmt\Nop)#1084 (1) {
    ["attributes":protected]=>
    array(5) {
      ["startLine"]=>
      int(4)
      ["startFilePos"]=>
      int(35)
      ["comments"]=>
      array(1) {
        [0]=>
        object(PhpParser\Comment)#1083 (4) {
          ["text":protected]=>
          string(23) "// @codeCoverageIgnore"
          ["line":protected]=>
          int(3)
          ["filePos":protected]=>
          int(12)
          ["tokenPos":protected]=>
          int(4)
        }
      }
      ["endLine"]=>
      int(3)
      ["endFilePos"]=>
      int(11)
    }
  }
```

Note that this method has `startLine`=4, `endLine`=3, and has comment which also starts on the line 3, which is a mess or PHP-Parser's bug.

2. Second reason is I don't think it's worth to write some not stable code to support this little feature. I have literally never seen a piece of code that uses `@codeCoverageIgnore` on the line level to ignore just one particular line of code.

## `@codeCoverageIgnoreStart` and `codeCoverageIgnoreEnd` 

This case is more difficult than the previous one. 

For such code:

```php
<?php

$a = 1;

// @coverageIgnoreStart
$b = 2;
$c = 3;

// @coverageIgnoreEnd

1;
```

We have the following AST:

<details>
<summary>AST dump (click me)</summary>

```php
array(
    0: Stmt_Expression[3:1 - 3:7](
        expr: Expr_Assign[3:1 - 3:6](
            var: Expr_Variable[3:1 - 3:2](
                name: a
            )
            expr: Scalar_LNumber[3:6 - 3:6](
                value: 1
            )
        )
    )
    1: Stmt_Expression[6:1 - 6:7](
        expr: Expr_Assign[6:1 - 6:6](
            var: Expr_Variable[6:1 - 6:2](
                name: b
                comments: array(
                    0: // @coverageIgnoreStart
                )
            )
            expr: Scalar_LNumber[6:6 - 6:6](
                value: 2
            )
            comments: array(
                0: // @coverageIgnoreStart
            )
        )
        comments: array(
            0: // @coverageIgnoreStart
        )
    )
    2: Stmt_Expression[7:1 - 7:7](
        expr: Expr_Assign[7:1 - 7:6](
            var: Expr_Variable[7:1 - 7:2](
                name: c
            )
            expr: Scalar_LNumber[7:6 - 7:6](
                value: 3
            )
        )
    )
    3: Stmt_Expression[11:1 - 11:2](
        expr: Scalar_LNumber[11:1 - 11:1](
            value: 1
            comments: array(
                0: // @coverageIgnoreEnd
            )
        )
        comments: array(
            0: // @coverageIgnoreEnd
        )
    )
)
```

</details>

Note that `@coverageIgnoreEnd` is assign to the `1;` line of code, and the number of code comment is 9 while the number of the `1;` is 11, which is again a little bit confusing.

Of course, we can collect all comments of all nodes when each node is visited, and then somehow understand where `@coverageIgnoreStart` and `@coverageIgnoreEnd` were placed, but this looks for me too difficult with the little value.

If you think we still should implement last two cases, I would do it as a separate PR to not make this one overcomplicated.