### PR TITLE
Replace ExampleTest namespace with unique one, same as E2E dirname

### DIFF
--- a/tests/add_new_e2e
+++ b/tests/add_new_e2e
@@ -21,6 +21,9 @@ cp  Example_Test/infection.json $dirname/infection.json
 cp  Example_Test/phpunit.xml $dirname/phpunit.xml
 cp  Example_Test/README.md $dirname/README.md
 
+cd $dirname
+find ./ -type f -exec sed -i -e "s/ExampleTest/$dirname/g" {} \;
+
 echo "Created the base for a new end-to-end test in directory $dirname"
 
 


### PR DESCRIPTION
Since many namespaces under e2e tests are not unique, build started to fail after I added `\ReflectionMethod` in one of the visitor.

https://travis-ci.org/infection/infection/jobs/432793693#L697-L700

This is because of class names collision.

This PR replaces an `ExampleTest` namespace with a dir name, which is unique.

Could somebody please check it on Linux? because I'm on MacOS.