### PR TITLE
Update ProtectedVisibility/PublicVisibility to guard against missing reflection

### DIFF
--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -65,6 +65,11 @@ final class ProtectedVisibility extends Mutator
         /** @var \ReflectionClass $reflection */
         $reflection = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);
 
+        if (!$reflection instanceof \ReflectionClass) {
+            // assuming the worst where interface has the same method
+            return true;
+        }
+
         $parent = $reflection->getParentClass();
 
         while ($parent) {

--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -62,11 +62,11 @@ final class ProtectedVisibility extends Mutator
 
     private function hasSameProtectedParentMethod(Node $node): bool
     {
-        /** @var \ReflectionClass $reflection */
+        /** @var \ReflectionClass|null $reflection */
         $reflection = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);
 
         if (!$reflection instanceof \ReflectionClass) {
-            // assuming the worst where interface has the same method
+            // assuming the worst where a parent class has the same method
             return true;
         }
 

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -92,11 +92,11 @@ final class PublicVisibility extends Mutator
 
     private function hasSamePublicParentMethod(Node $node): bool
     {
-        /** @var \ReflectionClass $reflection */
+        /** @var \ReflectionClass|null $reflection */
         $reflection = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);
 
         if (!$reflection instanceof \ReflectionClass) {
-            // assuming the worst where interface has the same method
+            // assuming the worst where an interface has the same method
             return true;
         }
 

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -92,11 +92,6 @@ final class PublicVisibility extends Mutator
 
     private function hasSamePublicParentMethod(Node $node): bool
     {
-        return $this->hasSamePublicMethodInInterface($node) || $this->hasSamePublicMethodInParentClass($node);
-    }
-
-    private function hasSamePublicMethodInInterface(Node $node): bool
-    {
         /** @var \ReflectionClass $reflection */
         $reflection = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);
 
@@ -105,6 +100,11 @@ final class PublicVisibility extends Mutator
             return true;
         }
 
+        return $this->hasSamePublicMethodInInterface($node, $reflection) || $this->hasSamePublicMethodInParentClass($node, $reflection);
+    }
+
+    private function hasSamePublicMethodInInterface(Node $node, \ReflectionClass $reflection): bool
+    {
         foreach ($reflection->getInterfaces() as $reflectionInterface) {
             try {
                 $method = $reflectionInterface->getMethod($node->name->name);
@@ -121,16 +121,8 @@ final class PublicVisibility extends Mutator
         return false;
     }
 
-    private function hasSamePublicMethodInParentClass(Node $node): bool
+    private function hasSamePublicMethodInParentClass(Node $node, \ReflectionClass $reflection): bool
     {
-        /** @var \ReflectionClass $reflection */
-        $reflection = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);
-
-        if (!$reflection instanceof \ReflectionClass) {
-            // assuming the worst where interface has the same method
-            return true;
-        }
-
         $parent = $reflection->getParentClass();
 
         while ($parent) {

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -100,6 +100,11 @@ final class PublicVisibility extends Mutator
         /** @var \ReflectionClass $reflection */
         $reflection = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);
 
+        if (!$reflection instanceof \ReflectionClass) {
+            // assuming the worst where interface has the same method
+            return true;
+        }
+
         foreach ($reflection->getInterfaces() as $reflectionInterface) {
             try {
                 $method = $reflectionInterface->getMethod($node->name->name);
@@ -120,6 +125,11 @@ final class PublicVisibility extends Mutator
     {
         /** @var \ReflectionClass $reflection */
         $reflection = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);
+
+        if (!$reflection instanceof \ReflectionClass) {
+            // assuming the worst where interface has the same method
+            return true;
+        }
 
         $parent = $reflection->getParentClass();
 

--- a/tests/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -181,6 +181,22 @@ class Child extends ProtectedNonSameAbstract
 }
 PHP
         ];
+
+        yield 'it does not mutate an anonymous class because reflection is not avalable' => [
+            <<<'PHP'
+<?php
+
+function something()
+{
+    return new class() {
+        protected function anything()
+        {
+            return null;
+        }
+    };
+}
+PHP
+        ];
     }
 
     private function getFileContent(string $file): string

--- a/tests/Mutator/FunctionSignature/PublicVisibilityTest.php
+++ b/tests/Mutator/FunctionSignature/PublicVisibilityTest.php
@@ -236,6 +236,22 @@ class Child extends NonSameAbstract
 }
 PHP
         ];
+
+        yield 'it does not mutate an anonymous class because reflection is not avalable' => [
+            <<<'PHP'
+<?php
+
+function something()
+{
+    return new class() {
+        public function anything()
+        {
+            return null;
+        }
+    };
+}
+PHP
+        ];
     }
 
     private function getFileContent(string $file): string


### PR DESCRIPTION
This happens because `ReflectionVisitor` adds a class reflection only for non-anonymous, named, classes. For an anonymous class we need to create an actual instance of that class, which seems to be infeasible for now.

https://github.com/infection/infection/blob/c4ebe3eeb1f0e4f435b43131b799be025e217f6a/src/Visitor/ReflectionVisitor.php#L47-L49

PHP Parser has nothing to do with that issue.

This PR:

- [x] Fixes #501
- [x] Covered by tests
