### PR TITLE
Do not travers plain functions unless they are in the method or closures

### DIFF
--- a/src/Visitor/ReflectionVisitor.php
+++ b/src/Visitor/ReflectionVisitor.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Infection\Visitor;
 
 use PhpParser\Node;
+use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
 /**
@@ -42,7 +43,7 @@ final class ReflectionVisitor extends NodeVisitorAbstract
         $this->methodName = null;
     }
 
-    public function enterNode(Node $node): void
+    public function enterNode(Node $node)
     {
         if ($node instanceof Node\Stmt\ClassLike && isset($node->fullyQualifiedClassName)) {
             $this->reflectionClass = new \ReflectionClass($node->fullyQualifiedClassName->toString());
@@ -56,6 +57,8 @@ final class ReflectionVisitor extends NodeVisitorAbstract
 
         if ($isInsideFunction) {
             $node->setAttribute(self::IS_INSIDE_FUNCTION_KEY, true);
+        } elseif ($node instanceof Node\Stmt\Function_) {
+            return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
         }
 
         if ($this->isPartOfFunctionSignature($node)) {

--- a/tests/Fixtures/Autoloaded/Reflection/rv-inside-function.php
+++ b/tests/Fixtures/Autoloaded/Reflection/rv-inside-function.php
@@ -4,5 +4,7 @@ namespace InfectionReflectionFunction;
 
 function test()
 {
-    return 1;
+    return function ($a) {
+        return 1;
+    };
 }

--- a/tests/Fixtures/Autoloaded/Reflection/rv-inside-plain-function-in-class.php
+++ b/tests/Fixtures/Autoloaded/Reflection/rv-inside-plain-function-in-class.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace InfectionReflectionPlainFunctionInClass;
+
+class Test
+{
+    public function foo()
+    {
+        function bar() {
+            count([]);
+        }
+    }
+}

--- a/tests/Fixtures/Autoloaded/Reflection/rv-inside-plain-function-in-closure.php
+++ b/tests/Fixtures/Autoloaded/Reflection/rv-inside-plain-function-in-closure.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace InfectionReflectionPlainFunctionInClosure;
+
+$a = function (int $b) {
+    function bar() {
+        count([]);
+    }
+};

--- a/tests/Mutator/Boolean/Yield_Test.php
+++ b/tests/Mutator/Boolean/Yield_Test.php
@@ -30,19 +30,17 @@ final class Yield_Test extends AbstractMutatorTestCase
             <<<'PHP'
 <?php
 
-function test()
-{
+$a = function () {
     (yield $a => $b);
-}
+};
 PHP
             ,
             <<<'PHP'
 <?php
 
-function test()
-{
+$a = function () {
     (yield $a > $b);
-}
+};
 PHP
             ,
         ];
@@ -51,10 +49,9 @@ PHP
             <<<'PHP'
 <?php
 
-function test()
-{
+$a = function () {
     (yield $b);
-}
+};
 PHP
             ,
         ];

--- a/tests/Mutator/Regex/PregQuoteTest.php
+++ b/tests/Mutator/Regex/PregQuoteTest.php
@@ -169,23 +169,21 @@ PHP
             <<<'PHP'
 <?php
 
-function bar($input)
-{
+$bar = function ($input) {
     return array_map(function ($key, $value) {
         return strtolower(preg_quote($key . (ctype_alnum($value) ? '' : $value), '/'));
     }, $input);
-}
+};
 PHP
             ,
             <<<'PHP'
 <?php
 
-function bar($input)
-{
+$bar = function ($input) {
     return array_map(function ($key, $value) {
         return strtolower($key . (ctype_alnum($value) ? '' : $value));
     }, $input);
-}
+};
 PHP
         ];
 

--- a/tests/Mutator/ReturnValue/FunctionCallTest.php
+++ b/tests/Mutator/ReturnValue/FunctionCallTest.php
@@ -57,22 +57,6 @@ PHP
         ];
     }
 
-    public function test_it_does_not_mutate_a_function_outside_a_class(): void
-    {
-        $code = <<<"PHP"
-<?php
-
-function test()
-{
-    return 1;
-}
-PHP;
-
-        $mutations = $this->mutate($code);
-
-        $this->assertCount(0, $mutations);
-    }
-
     public function test_it_does_not_mutate_when_function_contains_another_function_but_return_null_is_not_allowed(): void
     {
         $code = $this->getFileContent('fc-contains-another-func-and-null-is-not-allowed.php');


### PR DESCRIPTION
This PR prevents Infection from mutating any code inside plain function, unless function is in the method or closure.

- [x] Fixes #466
- [x] Covered by tests

https://github.com/infection/infection/issues/466#issuecomment-419304479

> On the other hand, we should definitely mutate functions that do not exist in the global scope at the time of a mutation. E.g. if function_exists($functionName) returns false, then our mutations will affect tests, and will be useful. Although I'm not entirely sure that is going to happen any often.

I'm not sure about this, because Infection can be unaware of project's bootstrap file that can be used to load functions. I would rather not traverse plain function at all, simpler and less confusing. However, feel free to discuss it.