### PR TITLE
Can't find Composer's bin-dir if SSL/TLS protection is disabled

### DIFF
--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -126,7 +126,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
             }
         }
 
-        $path = $this->searchNonExecutables($candidates, [getcwd()]);
+        $path = $this->searchNonExecutables($candidates, [getcwd(), getcwd() . '/vendor/bin']);
 
         if (null !== $path) {
             return $path;


### PR DESCRIPTION
... otherwise I always see this message.

-> In FinderException.php line 33:
                                                                                                          
Unable to locate a phpunit executable on local system. Ensure that phpunit is installed and available.
