### PR TITLE
Enable preliminary testing on PHP 7.3 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,11 @@ jobs:
 
     -
       <<: *STANDARD_TEST_JOB
+      php: 7.3
+      env: PHPDBG=1
+
+    -
+      <<: *STANDARD_TEST_JOB
       php: nightly
       env: PHPDBG=1
 


### PR DESCRIPTION
For example, see this commit: https://github.com/composer/composer/commit/3c173702b5e45ba8180f991744ef947e863ece28
