### PR TITLE
Prevent using symfony/console with broken exit code handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "sort-packages": true
     },
     "conflict": {
+        "symfony/console": "3.4.16,4.1.5",
         "symfony/process": "3.4.2"
     },
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07ac6eb17366576ae5ce9758f0421c17",
+    "content-hash": "6138f69ed34077ab4485a8d1781e44f4",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -527,16 +527,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.10",
+            "version": "v3.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "36f83f642443c46f3cf751d4d2ee5d047d757a27"
+                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/36f83f642443c46f3cf751d4d2ee5d047d757a27",
-                "reference": "36f83f642443c46f3cf751d4d2ee5d047d757a27",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
+                "reference": "3b2b415d4c48fbefca7dc742aa0a0171bfae4e0b",
                 "shasum": ""
             },
             "require": {
@@ -592,7 +592,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T08:49:21+00:00"
+            "time": "2018-10-02T16:33:53+00:00"
         },
         {
             "name": "symfony/debug",


### PR DESCRIPTION
There's a [bug](https://github.com/symfony/symfony/issues/28666) in symfony/console 3.4.16 and 4.1.5 where the exit code is reported as success if it failed.

This obviously affects this tool in a major way rendering it useless in a CI environment, so this PR ensures this bug cannot be installed.