### PR TITLE
Enhancement: Use default rules of ordered_class_elements fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -55,13 +55,7 @@ return \PhpCsFixer\Config::create()
             'include' => ['@compiler_optimized']
         ],
         'no_useless_else'=> true,
-        'ordered_class_elements' => [
-            'order' => [
-                'use_trait',
-                'constant_public',
-                'property_public',
-            ],
-        ],
+        'ordered_class_elements' => true,
         'ordered_imports' => true,
         'phpdoc_align' => false,
         'phpdoc_summary' => false,

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -23,11 +23,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class BaseCommand extends Command
 {
     /**
-     * @var Container
-     */
-    private $container;
-
-    /**
      * @var InputInterface
      */
     protected $input;
@@ -36,6 +31,10 @@ abstract class BaseCommand extends Command
      * @var OutputInterface
      */
     protected $output;
+    /**
+     * @var Container
+     */
+    private $container;
 
     public function getContainer(): Container
     {

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -31,6 +31,7 @@ abstract class BaseCommand extends Command
      * @var OutputInterface
      */
     protected $output;
+
     /**
      * @var Container
      */

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -261,6 +261,31 @@ final class InfectionCommand extends BaseCommand
         return $statusCode;
     }
 
+    /**
+     * Run configuration command if config does not exist
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @throws InfectionException
+     */
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        parent::initialize($input, $output);
+
+        $locator = $this->getContainer()->get('locator');
+
+        if ($customConfigPath = $input->getOption('configuration')) {
+            $locator->locate($customConfigPath);
+        } else {
+            $this->runConfigurationCommand($locator);
+        }
+
+        $this->consoleOutput = $this->getApplication()->getConsoleOutput();
+        $this->skipCoverage = \strlen(trim($input->getOption('coverage'))) > 0;
+        $this->eventDispatcher = $this->getContainer()->get('dispatcher');
+    }
+
     private function includeUserBootstrap(InfectionConfig $config): void
     {
         $bootstrap = $config->getBootstrap();
@@ -295,31 +320,6 @@ final class InfectionCommand extends BaseCommand
         return TestFrameworkTypes::PHPUNIT === $testFrameworkKey
             ? new PhpUnitExtraOptions($extraOptions)
             : new PhpSpecExtraOptions($extraOptions);
-    }
-
-    /**
-     * Run configuration command if config does not exist
-     *
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     *
-     * @throws InfectionException
-     */
-    protected function initialize(InputInterface $input, OutputInterface $output): void
-    {
-        parent::initialize($input, $output);
-
-        $locator = $this->getContainer()->get('locator');
-
-        if ($customConfigPath = $input->getOption('configuration')) {
-            $locator->locate($customConfigPath);
-        } else {
-            $this->runConfigurationCommand($locator);
-        }
-
-        $this->consoleOutput = $this->getApplication()->getConsoleOutput();
-        $this->skipCoverage = \strlen(trim($input->getOption('coverage'))) > 0;
-        $this->eventDispatcher = $this->getContainer()->get('dispatcher');
     }
 
     private function runConfigurationCommand(Locator $locator): void

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -94,48 +94,9 @@ class InfectionConfig
         return $excludedPaths;
     }
 
-    private function getExcludes(): array
-    {
-        if (isset($this->config->source->excludes) && \is_array($this->config->source->excludes)) {
-            return $this->config->source->excludes;
-        }
-
-        return self::DEFAULT_EXCLUDE_DIRS;
-    }
-
     public function getLogsTypes(): array
     {
         return (array) ($this->config->logs ?? []);
-    }
-
-    private function getExcludedDirsByPattern(string $originalExcludedDir)
-    {
-        $excludedDirs = [];
-        $srcDirs = $this->getSourceDirs();
-
-        foreach ($srcDirs as $srcDir) {
-            $unpackedPaths = glob(
-                sprintf('%s/%s', $srcDir, $originalExcludedDir),
-                GLOB_ONLYDIR
-            );
-
-            if ($unpackedPaths) {
-                $excludedDirs = array_merge(
-                    $excludedDirs,
-                    array_map(
-                        function ($excludeDir) use ($srcDir) {
-                            return ltrim(
-                                substr_replace($excludeDir, '', 0, \strlen($srcDir)),
-                                \DIRECTORY_SEPARATOR
-                            );
-                        },
-                        $unpackedPaths
-                    )
-                );
-            }
-        }
-
-        return $excludedDirs;
     }
 
     public function getTmpDir(): string
@@ -176,5 +137,44 @@ class InfectionConfig
     public function getTestFrameworkOptions(): string
     {
         return $this->config->testFrameworkOptions ?? '';
+    }
+
+    private function getExcludes(): array
+    {
+        if (isset($this->config->source->excludes) && \is_array($this->config->source->excludes)) {
+            return $this->config->source->excludes;
+        }
+
+        return self::DEFAULT_EXCLUDE_DIRS;
+    }
+
+    private function getExcludedDirsByPattern(string $originalExcludedDir)
+    {
+        $excludedDirs = [];
+        $srcDirs = $this->getSourceDirs();
+
+        foreach ($srcDirs as $srcDir) {
+            $unpackedPaths = glob(
+                sprintf('%s/%s', $srcDir, $originalExcludedDir),
+                GLOB_ONLYDIR
+            );
+
+            if ($unpackedPaths) {
+                $excludedDirs = array_merge(
+                    $excludedDirs,
+                    array_map(
+                        function ($excludeDir) use ($srcDir) {
+                            return ltrim(
+                                substr_replace($excludeDir, '', 0, \strlen($srcDir)),
+                                \DIRECTORY_SEPARATOR
+                            );
+                        },
+                        $unpackedPaths
+                    )
+                );
+            }
+        }
+
+        return $excludedDirs;
     }
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -93,15 +93,6 @@ ASCII;
         return parent::run($input, $output);
     }
 
-    private function logRunningWithDebugger(): void
-    {
-        if (\PHP_SAPI === 'phpdbg') {
-            $this->consoleOutput->logRunningWithDebugger(\PHP_SAPI);
-        } elseif (\extension_loaded('xdebug')) {
-            $this->consoleOutput->logRunningWithDebugger('xdebug');
-        }
-    }
-
     public function doRun(InputInterface $input, OutputInterface $output)
     {
         $this->getContainer()->buildDynamicDependencies($input);
@@ -120,6 +111,16 @@ ASCII;
         }
 
         return parent::getLongVersion();
+    }
+
+    public function getContainer(): InfectionContainer
+    {
+        return $this->container;
+    }
+
+    public function getConsoleOutput(): InfectionConsoleOutput
+    {
+        return $this->consoleOutput;
     }
 
     protected function getDefaultCommands()
@@ -155,13 +156,12 @@ ASCII;
         $output->getFormatter()->setStyle('high', new OutputFormatterStyle('green', null, ['bold']));
     }
 
-    public function getContainer(): InfectionContainer
+    private function logRunningWithDebugger(): void
     {
-        return $this->container;
-    }
-
-    public function getConsoleOutput(): InfectionConsoleOutput
-    {
-        return $this->consoleOutput;
+        if (\PHP_SAPI === 'phpdbg') {
+            $this->consoleOutput->logRunningWithDebugger(\PHP_SAPI);
+        } elseif (\extension_loaded('xdebug')) {
+            $this->consoleOutput->logRunningWithDebugger('xdebug');
+        }
     }
 }

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -209,11 +209,6 @@ final class InfectionContainer extends Container
         };
     }
 
-    private function getInfectionConfig(): InfectionConfig
-    {
-        return $this['infection.config'];
-    }
-
     public function buildDynamicDependencies(InputInterface $input): void
     {
         $this['infection.config'] = function () use ($input): InfectionConfig {
@@ -311,5 +306,10 @@ final class InfectionContainer extends Container
 
             return $parser->getMutators();
         };
+    }
+
+    private function getInfectionConfig(): InfectionConfig
+    {
+        return $this['infection.config'];
     }
 }

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -34,6 +34,7 @@ abstract class FileLogger implements MutationTestingResultsLogger
      * @var bool
      */
     protected $isDebugMode;
+
     /**
      * @var string
      */

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -21,19 +21,9 @@ use Symfony\Component\Filesystem\Filesystem;
 abstract class FileLogger implements MutationTestingResultsLogger
 {
     /**
-     * @var string
-     */
-    private $logFilePath;
-
-    /**
      * @var MetricsCalculator
      */
     protected $metricsCalculator;
-
-    /**
-     * @var Filesystem
-     */
-    private $fs;
 
     /**
      * @var bool
@@ -44,6 +34,15 @@ abstract class FileLogger implements MutationTestingResultsLogger
      * @var bool
      */
     protected $isDebugMode;
+    /**
+     * @var string
+     */
+    private $logFilePath;
+
+    /**
+     * @var Filesystem
+     */
+    private $fs;
 
     /**
      * @var OutputInterface

--- a/src/Mutator/Unwrap/AbstractUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractUnwrapMutator.php
@@ -17,10 +17,6 @@ use PhpParser\Node;
  */
 abstract class AbstractUnwrapMutator extends Mutator
 {
-    abstract protected function getFunctionName(): string;
-
-    abstract protected function getParameterIndex(): int;
-
     /**
      * Replaces "$a = function(arg1, arg2);" with "$a = arg1;"
      *
@@ -30,6 +26,10 @@ abstract class AbstractUnwrapMutator extends Mutator
     {
         return $node->args[$this->getParameterIndex()];
     }
+
+    abstract protected function getFunctionName(): string;
+
+    abstract protected function getParameterIndex(): int;
 
     final protected function mutatesNode(Node $node): bool
     {

--- a/src/Mutator/Util/Mutator.php
+++ b/src/Mutator/Util/Mutator.php
@@ -31,8 +31,6 @@ abstract class Mutator
      */
     abstract public function mutate(Node $node);
 
-    abstract protected function mutatesNode(Node $node): bool;
-
     final public function shouldMutate(Node $node): bool
     {
         if (!$this->mutatesNode($node)) {
@@ -54,4 +52,6 @@ abstract class Mutator
 
         return end($parts);
     }
+
+    abstract protected function mutatesNode(Node $node): bool;
 }

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -63,11 +63,6 @@ final class MutantProcess implements MutantProcessInterface
         $this->testFrameworkAdapter = $testFrameworkAdapter;
     }
 
-    private function isTimedOut(): bool
-    {
-        return $this->isTimedOut;
-    }
-
     public function getProcess(): Process
     {
         return $this->process;
@@ -117,6 +112,11 @@ final class MutantProcess implements MutantProcessInterface
     public function getOriginalStartingLine(): int
     {
         return (int) $this->getMutation()->getAttributes()['startLine'];
+    }
+
+    private function isTimedOut(): bool
+    {
+        return $this->isTimedOut;
     }
 
     private function getMutation(): MutationInterface

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -14,11 +14,11 @@ namespace Infection\StreamWrapper;
  */
 final class IncludeInterceptor
 {
+    private const STREAM_OPEN_FOR_INCLUDE = 0x00000080;
     /**
      * @var resource
      */
     public $context;
-    private const STREAM_OPEN_FOR_INCLUDE = 0x00000080;
 
     /**
      * @var bool|resource

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -15,6 +15,7 @@ namespace Infection\StreamWrapper;
 final class IncludeInterceptor
 {
     private const STREAM_OPEN_FOR_INCLUDE = 0x00000080;
+
     /**
      * @var resource
      */

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -127,29 +127,6 @@ abstract class AbstractTestFrameworkAdapter
         return array_filter($commandLineArgs);
     }
 
-    /**
-     * Need to return string for cases when user run phpdbg with -qrr argument.s
-     *
-     * @param bool $includeArgs
-     *
-     * @return string[]
-     */
-    private function findPhp(bool $includeArgs = true): array
-    {
-        if ($this->cachedPhpPath === null || $this->cachedIncludedArgs !== $includeArgs) {
-            $this->cachedIncludedArgs = $includeArgs;
-            $phpPath = (new PhpExecutableFinder())->find($includeArgs);
-
-            if ($phpPath === false) {
-                throw FinderException::phpExecutableNotFound();
-            }
-
-            $this->cachedPhpPath = explode(' ', $phpPath);
-        }
-
-        return $this->cachedPhpPath;
-    }
-
     public function buildInitialConfigFile(): string
     {
         return $this->initialConfigBuilder->build();
@@ -176,6 +153,29 @@ abstract class AbstractTestFrameworkAdapter
         $process->mustRun();
 
         return $this->versionParser->parse($process->getOutput());
+    }
+
+    /**
+     * Need to return string for cases when user run phpdbg with -qrr argument.s
+     *
+     * @param bool $includeArgs
+     *
+     * @return string[]
+     */
+    private function findPhp(bool $includeArgs = true): array
+    {
+        if ($this->cachedPhpPath === null || $this->cachedIncludedArgs !== $includeArgs) {
+            $this->cachedIncludedArgs = $includeArgs;
+            $phpPath = (new PhpExecutableFinder())->find($includeArgs);
+
+            if ($phpPath === false) {
+                throw FinderException::phpExecutableNotFound();
+            }
+
+            $this->cachedPhpPath = explode(' ', $phpPath);
+        }
+
+        return $this->cachedPhpPath;
     }
 
     private function isBatchFile(string $path): bool

--- a/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
@@ -21,6 +21,7 @@ final class InitialYamlConfiguration extends AbstractYamlConfiguration
      * @var string
      */
     protected $originalYamlConfigPath;
+
     /**
      * @var bool
      */

--- a/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
@@ -18,6 +18,10 @@ use Symfony\Component\Yaml\Yaml;
 final class InitialYamlConfiguration extends AbstractYamlConfiguration
 {
     /**
+     * @var string
+     */
+    protected $originalYamlConfigPath;
+    /**
      * @var bool
      */
     private $skipCoverage;
@@ -28,11 +32,6 @@ final class InitialYamlConfiguration extends AbstractYamlConfiguration
 
         $this->skipCoverage = $skipCoverage;
     }
-
-    /**
-     * @var string
-     */
-    protected $originalYamlConfigPath;
 
     public function getYaml(): string
     {

--- a/src/TestFramework/TestFrameworkExtraOptions.php
+++ b/src/TestFramework/TestFrameworkExtraOptions.php
@@ -19,8 +19,6 @@ abstract class TestFrameworkExtraOptions
      */
     private $extraOptions;
 
-    abstract protected function getInitialRunOnlyOptions(): array;
-
     public function __construct(string $extraOptions = null)
     {
         $this->extraOptions = $extraOptions ?: '';
@@ -41,4 +39,6 @@ abstract class TestFrameworkExtraOptions
 
         return preg_replace('/\s+/', ' ', trim($extraOptions));
     }
+
+    abstract protected function getInitialRunOnlyOptions(): array;
 }

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -118,6 +118,14 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
         }
     }
 
+    /**
+     * @return Mutation[]
+     */
+    public function getMutations(): array
+    {
+        return $this->mutations;
+    }
+
     private function isCoveredByTest(bool $isOnFunctionSignature, Node $node): bool
     {
         if ($isOnFunctionSignature) {
@@ -133,13 +141,5 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
         }
 
         return false;
-    }
-
-    /**
-     * @return Mutation[]
-     */
-    public function getMutations(): array
-    {
-        return $this->mutations;
     }
 }

--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -49,6 +49,15 @@ final class E2ETest extends TestCase
         $this->cwd = getcwd();
     }
 
+    protected function tearDown(): void
+    {
+        if ($this->previousLoader) {
+            $this->previousLoader->unregister();
+        }
+
+        chdir($this->cwd);
+    }
+
     /**
      * Longest test: runs under about 160-200 sec
      *
@@ -114,15 +123,6 @@ final class E2ETest extends TestCase
 
             yield basename((string) $dirName) => [$dirName];
         }
-    }
-
-    protected function tearDown(): void
-    {
-        if ($this->previousLoader) {
-            $this->previousLoader->unregister();
-        }
-
-        chdir($this->cwd);
     }
 
     private function runOnE2EFixture($path): string

--- a/tests/Finder/TestFrameworkFinderTest.php
+++ b/tests/Finder/TestFrameworkFinderTest.php
@@ -66,6 +66,11 @@ final class TestFrameworkFinderTest extends TestCase
         }
     }
 
+    public static function tearDownAfterClass(): void
+    {
+        self::restorePathEnvironment();
+    }
+
     protected function setUp(): void
     {
         self::restorePathEnvironment();
@@ -73,6 +78,11 @@ final class TestFrameworkFinderTest extends TestCase
 
         $this->fileSystem = new Filesystem();
         $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fileSystem->remove($this->workspace);
     }
 
     public function test_it_can_load_a_custom_path(): void
@@ -195,15 +205,5 @@ final class TestFrameworkFinderTest extends TestCase
                 putenv($name);
             }
         }
-    }
-
-    protected function tearDown(): void
-    {
-        $this->fileSystem->remove($this->workspace);
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        self::restorePathEnvironment();
     }
 }

--- a/tests/Mutant/MetricsCalculatorTest.php
+++ b/tests/Mutant/MetricsCalculatorTest.php
@@ -41,16 +41,6 @@ final class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
         $this->assertSame(0.0, $calculator->getCoveredCodeMutationScoreIndicator());
     }
 
-    private function addMutantProcess(MetricsCalculator $calculator, int $resultCode, int $count = 1): void
-    {
-        $mutantProcess = Mockery::mock(MutantProcessInterface::class);
-        $mutantProcess->shouldReceive('getResultCode')->times($count)->andReturn($resultCode);
-
-        while ($count--) {
-            $calculator->collect($mutantProcess);
-        }
-    }
-
     public function test_it_collects_all_values(): void
     {
         $process = Mockery::mock(Process::class);
@@ -76,5 +66,15 @@ final class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
         $this->assertSame(78.0, $calculator->getMutationScoreIndicator()); // 78.57
         $this->assertSame(92.0, $calculator->getCoverageRate()); // 92.85
         $this->assertSame(84.0, $calculator->getCoveredCodeMutationScoreIndicator()); // 84.61
+    }
+
+    private function addMutantProcess(MetricsCalculator $calculator, int $resultCode, int $count = 1): void
+    {
+        $mutantProcess = Mockery::mock(MutantProcessInterface::class);
+        $mutantProcess->shouldReceive('getResultCode')->times($count)->andReturn($resultCode);
+
+        while ($count--) {
+            $calculator->collect($mutantProcess);
+        }
     }
 }

--- a/tests/Mutator/AbstractMutatorTestCase.php
+++ b/tests/Mutator/AbstractMutatorTestCase.php
@@ -35,6 +35,11 @@ abstract class AbstractMutatorTestCase extends TestCase
      */
     protected $mutator;
 
+    protected function setUp(): void
+    {
+        $this->mutator = $this->getMutator();
+    }
+
     public function doTest(string $inputCode, $expectedCode = null): void
     {
         $expectedCodeSamples = (array) $expectedCode;
@@ -69,11 +74,6 @@ abstract class AbstractMutatorTestCase extends TestCase
         $mutator = substr(str_replace('\Tests', '', $class), 0, -4);
 
         return new $mutator(new MutatorConfig([]));
-    }
-
-    protected function setUp(): void
-    {
-        $this->mutator = $this->getMutator();
     }
 
     protected function getNodes(string $code): array

--- a/tests/Mutator/Util/AbstractValueToNullReturnValueTest.php
+++ b/tests/Mutator/Util/AbstractValueToNullReturnValueTest.php
@@ -29,42 +29,6 @@ final class AbstractValueToNullReturnValueTest extends TestCase
             ->getMockForAbstractClass();
     }
 
-    private function mockNode($returnValue): Node
-    {
-        /** @var Node|MockObject $mockNode */
-        $mockNode = $this->getMockBuilder(Node::class)
-                         ->disableOriginalConstructor()
-                         ->setMethods(['getAttribute'])
-                         ->getMockForAbstractClass();
-
-        $mockNode->method('getAttribute')
-                 ->willReturn($returnValue);
-
-        return $mockNode;
-    }
-
-    private function mockFunction($returnValue): Function_
-    {
-        /** @var Function_|MockObject $mockFunction */
-        $mockFunction = $this->getMockBuilder(Function_::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getReturnType'])
-            ->getMock();
-
-        $mockFunction->method('getReturnType')
-            ->willReturn($returnValue);
-
-        return $mockFunction;
-    }
-
-    private function invokeMethod(Node $mockNode)
-    {
-        $reflectionMethod = new \ReflectionMethod(AbstractValueToNullReturnValue::class, 'isNullReturnValueAllowed');
-        $reflectionMethod->setAccessible(true);
-
-        return $reflectionMethod->invoke($this->testSubject, $mockNode);
-    }
-
     public function test_attribute_not_found(): void
     {
         $this->assertTrue($this->invokeMethod($this->mockNode(null)));
@@ -132,5 +96,41 @@ final class AbstractValueToNullReturnValueTest extends TestCase
                 )
             )
         );
+    }
+
+    private function mockNode($returnValue): Node
+    {
+        /** @var Node|MockObject $mockNode */
+        $mockNode = $this->getMockBuilder(Node::class)
+                         ->disableOriginalConstructor()
+                         ->setMethods(['getAttribute'])
+                         ->getMockForAbstractClass();
+
+        $mockNode->method('getAttribute')
+                 ->willReturn($returnValue);
+
+        return $mockNode;
+    }
+
+    private function mockFunction($returnValue): Function_
+    {
+        /** @var Function_|MockObject $mockFunction */
+        $mockFunction = $this->getMockBuilder(Function_::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getReturnType'])
+            ->getMock();
+
+        $mockFunction->method('getReturnType')
+            ->willReturn($returnValue);
+
+        return $mockFunction;
+    }
+
+    private function invokeMethod(Node $mockNode)
+    {
+        $reflectionMethod = new \ReflectionMethod(AbstractValueToNullReturnValue::class, 'isNullReturnValueAllowed');
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod->invoke($this->testSubject, $mockNode);
     }
 }

--- a/tests/Performance/Limiter/MemoryLimiterTest.php
+++ b/tests/Performance/Limiter/MemoryLimiterTest.php
@@ -30,6 +30,17 @@ final class MemoryLimiterTest extends TestCase
         $fs->mkdir(self::TEST_DIR_LOCATION);
     }
 
+    public static function tearDownAfterClass(): void
+    {
+        $fs = new Filesystem();
+        $fs->remove(self::TEST_DIR_LOCATION);
+
+        $xdebug = new \ReflectionClass(XdebugHandler::class);
+        $skipped = $xdebug->getProperty('skipped');
+        $skipped->setAccessible(true);
+        $skipped->setValue(null);
+    }
+
     protected function setUp(): void
     {
         if (ini_get('memory_limit') !== '-1') {
@@ -52,17 +63,6 @@ final class MemoryLimiterTest extends TestCase
         if (XdebugHandler::getSkippedVersion() !== 'infection-fake') {
             throw new \LogicException('Xdebug handler is active during tests, which it should not be.');
         }
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        $fs = new Filesystem();
-        $fs->remove(self::TEST_DIR_LOCATION);
-
-        $xdebug = new \ReflectionClass(XdebugHandler::class);
-        $skipped = $xdebug->getProperty('skipped');
-        $skipped->setAccessible(true);
-        $skipped->setValue(null);
     }
 
     public function test_it_does_nothing_when_adapter_is_not_memory_limit_aware(): void

--- a/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
+++ b/tests/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
@@ -36,11 +36,6 @@ final class InitialYamlConfigurationTest extends TestCase
         'bootstrap' => '/path/to/adc',
     ];
 
-    protected function getConfigurationObject(array $configArray = [], bool $skipCoverage = false)
-    {
-        return new InitialYamlConfiguration($this->tempDir, $configArray ?: $this->defaultConfig, $skipCoverage);
-    }
-
     public function test_it_throws_exception_when_extensions_array_is_empty(): void
     {
         $configuration = $this->getConfigurationObject(['extensions' => []]);
@@ -94,5 +89,10 @@ final class InitialYamlConfigurationTest extends TestCase
         $parsedYaml = Yaml::parse($configuration->getYaml());
 
         $this->assertSame(['.'], $parsedYaml['extensions']['PhpSpecCodeCoverageExtension']['whitelist']);
+    }
+
+    protected function getConfigurationObject(array $configArray = [], bool $skipCoverage = false)
+    {
+        return new InitialYamlConfiguration($this->tempDir, $configArray ?: $this->defaultConfig, $skipCoverage);
     }
 }

--- a/tests/TestFramework/PhpSpec/Config/MutationYamlConfigurationTest.php
+++ b/tests/TestFramework/PhpSpec/Config/MutationYamlConfigurationTest.php
@@ -36,15 +36,6 @@ final class MutationYamlConfigurationTest extends TestCase
         'bootstrap' => '/path/to/adc',
     ];
 
-    protected function getConfigurationObject(array $configArray = [])
-    {
-        return new MutationYamlConfiguration(
-            $this->tempDir,
-            $configArray ?: $this->defaultConfig,
-            $this->customAutoloadFilePath
-        );
-    }
-
     public function test_it_removes_code_coverage_extension(): void
     {
         $configuration = $this->getConfigurationObject();
@@ -72,5 +63,14 @@ final class MutationYamlConfigurationTest extends TestCase
         $parsedYaml = Yaml::parse($configuration->getYaml());
 
         $this->assertSame($this->customAutoloadFilePath, $parsedYaml['bootstrap']);
+    }
+
+    protected function getConfigurationObject(array $configArray = [])
+    {
+        return new MutationYamlConfiguration(
+            $this->tempDir,
+            $configArray ?: $this->defaultConfig,
+            $this->customAutoloadFilePath
+        );
     }
 }

--- a/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -66,25 +66,6 @@ final class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTest
         $this->fileSystem->remove($this->workspace);
     }
 
-    private function createConfigBuilder(string $phpUnitXmlConfigPath = null, bool $skipCoverage = false): void
-    {
-        $phpunitXmlPath = $phpUnitXmlConfigPath ?: __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit.xml';
-
-        $jUnitFilePath = '/path/to/junit.xml';
-        $srcDirs = ['src', 'app'];
-
-        $replacer = new PathReplacer($this->fileSystem, $this->pathToProject);
-
-        $this->builder = new InitialConfigBuilder(
-            $this->tmpDir,
-            file_get_contents($phpunitXmlPath),
-            new XmlConfigurationHelper($replacer),
-            $jUnitFilePath,
-            $srcDirs,
-            $skipCoverage
-        );
-    }
-
     public function test_it_replaces_relative_path_to_absolute_path(): void
     {
         $configurationPath = $this->builder->build();
@@ -193,5 +174,24 @@ final class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTest
         $xPath = new \DOMXPath($dom);
 
         return $xPath->query($query);
+    }
+
+    private function createConfigBuilder(string $phpUnitXmlConfigPath = null, bool $skipCoverage = false): void
+    {
+        $phpunitXmlPath = $phpUnitXmlConfigPath ?: __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit.xml';
+
+        $jUnitFilePath = '/path/to/junit.xml';
+        $srcDirs = ['src', 'app'];
+
+        $replacer = new PathReplacer($this->fileSystem, $this->pathToProject);
+
+        $this->builder = new InitialConfigBuilder(
+            $this->tmpDir,
+            file_get_contents($phpunitXmlPath),
+            new XmlConfigurationHelper($replacer),
+            $jUnitFilePath,
+            $srcDirs,
+            $skipCoverage
+        );
     }
 }

--- a/tests/TestFramework/PhpUnit/Coverage/CoverageXmlParserTest.php
+++ b/tests/TestFramework/PhpUnit/Coverage/CoverageXmlParserTest.php
@@ -31,18 +31,6 @@ final class CoverageXmlParserTest extends TestCase
         $this->parser = new CoverageXmlParser($this->tempDir);
     }
 
-    protected function getXml()
-    {
-        $xml = file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpunit/coverage-xml/index.xml');
-
-        // replace dummy source path with the real path
-        return preg_replace(
-            '/(source=\").*?(\")/',
-            sprintf('$1%s$2', realpath($this->srcDir)),
-            $xml
-        );
-    }
-
     public function test_it_collects_data_recursively_for_all_files(): void
     {
         $coverage = $this->parser->parse($this->getXml());
@@ -122,5 +110,17 @@ final class CoverageXmlParserTest extends TestCase
         $coverage = $this->parser->parse($this->getXml());
 
         $this->assertSame($expectedByMethodArray, $coverage[$pathToTrait]['byMethod']);
+    }
+
+    protected function getXml()
+    {
+        $xml = file_get_contents(__DIR__ . '/../../../Fixtures/Files/phpunit/coverage-xml/index.xml');
+
+        // replace dummy source path with the real path
+        return preg_replace(
+            '/(source=\").*?(\")/',
+            sprintf('$1%s$2', realpath($this->srcDir)),
+            $xml
+        );
     }
 }


### PR DESCRIPTION
This PR

* [x] uses the default rules of the `ordered_class_elements` fixer
* [x] runs `php-cs-fixer`
* [x] manually adds empty lines where it makes sense

Related to https://github.com/infection/infection/pull/524#discussion_r229454351.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.9#usage:

>**ordered_class_elements**
>
>Orders the elements of classes/interfaces/traits.
>
>Configuration options:
>
>* `order` (a subset of `['use_trait', 'public', 'protected', 'private', 'constant', 'constant_public', 'constant_protected', 'constant_private', 'property', 'property_static', 'property_public', 'property_protected', 'property_private', 'property_public_static', 'property_protected_static', 'property_private_static', 'method', 'method_static', 'method_public', 'method_protected', 'method_private', 'method_public_static', 'method_protected_static', 'method_private_static', 'construct', 'destruct', 'magic', 'phpunit']`): list of strings defining order of elements; defaults to `['use_trait', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'destruct', 'magic', 'phpunit', 'method_public', 'method_protected', 'method_private']`
>* `sortAlgorithm` (`'alpha'`, `'none'`): how multiple occurrences of same type statements should be sorted; defaults to `'none'`