### PR TITLE
Remove duplicated job in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,11 @@ jobs:
     -
       <<: *STANDARD_TEST_JOB
       php: 7.2
+      env: SYMFONY_VERSION="^4.0"
+
+    -
+      <<: *STANDARD_TEST_JOB
+      php: 7.2
       env: SYMFONY_VERSION="^4.0" PHPDBG=1
 
     -

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,11 +103,6 @@ jobs:
 
     -
       <<: *STANDARD_TEST_JOB
-      php: 7.1
-      env: SYMFONY_VERSION="^4.0"
-
-    -
-      <<: *STANDARD_TEST_JOB
       php: 7.2
       env: SYMFONY_VERSION="^4.0" PHPDBG=1
 


### PR DESCRIPTION
While worked with the previous PR I realized that we run the same job for php 7.1 + symfony 4.0 components twice. Looks like it should be 7.2 + symfony 4.0 (with xdebug).