### PR TITLE
Fix: Use plural for method name as it returns a generator

### DIFF
--- a/src/Mutator/Unwrap/AbstractUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractUnwrapMutator.php
@@ -50,14 +50,14 @@ abstract class AbstractUnwrapMutator extends Mutator
      */
     final public function mutate(Node $node)
     {
-        foreach ($this->getParameterIndex($node) as $index) {
+        foreach ($this->getParameterIndexes($node) as $index) {
             yield $node->args[$index];
         }
     }
 
     abstract protected function getFunctionName(): string;
 
-    abstract protected function getParameterIndex(Node $node): \Generator;
+    abstract protected function getParameterIndexes(Node $node): \Generator;
 
     final protected function mutatesNode(Node $node): bool
     {
@@ -65,7 +65,7 @@ abstract class AbstractUnwrapMutator extends Mutator
             return false;
         }
 
-        foreach ($this->getParameterIndex($node) as $index) {
+        foreach ($this->getParameterIndexes($node) as $index) {
             if (!array_key_exists($index, $node->args)) {
                 return false;
             }

--- a/src/Mutator/Unwrap/UnwrapArrayFilter.php
+++ b/src/Mutator/Unwrap/UnwrapArrayFilter.php
@@ -47,7 +47,7 @@ final class UnwrapArrayFilter extends AbstractUnwrapMutator
         return 'array_filter';
     }
 
-    protected function getParameterIndex(Node $node): \Generator
+    protected function getParameterIndexes(Node $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayFlip.php
+++ b/src/Mutator/Unwrap/UnwrapArrayFlip.php
@@ -47,7 +47,7 @@ final class UnwrapArrayFlip extends AbstractUnwrapMutator
         return 'array_flip';
     }
 
-    protected function getParameterIndex(Node $node): \Generator
+    protected function getParameterIndexes(Node $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayIntersect.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersect.php
@@ -47,7 +47,7 @@ final class UnwrapArrayIntersect extends AbstractUnwrapMutator
         return 'array_intersect';
     }
 
-    protected function getParameterIndex(Node $node): \Generator
+    protected function getParameterIndexes(Node $node): \Generator
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayMap.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMap.php
@@ -47,7 +47,7 @@ final class UnwrapArrayMap extends AbstractUnwrapMutator
         return 'array_map';
     }
 
-    protected function getParameterIndex(Node $node): \Generator
+    protected function getParameterIndexes(Node $node): \Generator
     {
         yield 1;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayMerge.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMerge.php
@@ -47,7 +47,7 @@ final class UnwrapArrayMerge extends AbstractUnwrapMutator
         return 'array_merge';
     }
 
-    protected function getParameterIndex(Node $node): \Generator
+    protected function getParameterIndexes(Node $node): \Generator
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayReduce.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReduce.php
@@ -47,7 +47,7 @@ final class UnwrapArrayReduce extends AbstractUnwrapMutator
         return 'array_reduce';
     }
 
-    protected function getParameterIndex(Node $node): \Generator
+    protected function getParameterIndexes(Node $node): \Generator
     {
         yield 2;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayReplace.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReplace.php
@@ -47,7 +47,7 @@ final class UnwrapArrayReplace extends AbstractUnwrapMutator
         return 'array_replace';
     }
 
-    protected function getParameterIndex(Node $node): \Generator
+    protected function getParameterIndexes(Node $node): \Generator
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayReverse.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReverse.php
@@ -47,7 +47,7 @@ final class UnwrapArrayReverse extends AbstractUnwrapMutator
         return 'array_reverse';
     }
 
-    protected function getParameterIndex(Node $node): \Generator
+    protected function getParameterIndexes(Node $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapStrRepeat.php
+++ b/src/Mutator/Unwrap/UnwrapStrRepeat.php
@@ -47,7 +47,7 @@ final class UnwrapStrRepeat extends AbstractUnwrapMutator
         return 'str_repeat';
     }
 
-    protected function getParameterIndex(Node $node): \Generator
+    protected function getParameterIndexes(Node $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapStrToLower.php
+++ b/src/Mutator/Unwrap/UnwrapStrToLower.php
@@ -47,7 +47,7 @@ final class UnwrapStrToLower extends AbstractUnwrapMutator
         return 'strtolower';
     }
 
-    protected function getParameterIndex(Node $node): \Generator
+    protected function getParameterIndexes(Node $node): \Generator
     {
         yield 0;
     }


### PR DESCRIPTION
This PR

- [x] renames a method returning a generator

💁‍♂️ I think it makes sense as the generator potentially yields more than one index.