### PR TITLE
Do not mutate interfaces

### DIFF
--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -109,11 +109,15 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
                 continue;
             }
 
-            if ($isOnFunctionSignature) {
-                $methodNode = $node->getAttribute(ReflectionVisitor::FUNCTION_SCOPE_KEY);
-
+            if ($isOnFunctionSignature
+                && $methodNode = $node->getAttribute(ReflectionVisitor::FUNCTION_SCOPE_KEY)
+            ) {
                 /** @var Node\Stmt\ClassMethod|Node\Expr\Closure $methodNode */
                 if ($methodNode instanceof Node\Stmt\ClassMethod && $methodNode->isAbstract()) {
+                    continue;
+                }
+
+                if ($methodNode instanceof Node\Stmt\ClassMethod && $methodNode->getAttribute(ParentConnectorVisitor::PARENT_KEY) instanceof Node\Stmt\Interface_) {
                     continue;
                 }
             }

--- a/tests/Fixtures/e2e/UncoveredInterfaces/README.md
+++ b/tests/Fixtures/e2e/UncoveredInterfaces/README.md
@@ -1,0 +1,9 @@
+# Do not mutate interfaces
+
+[#547](https://github.com/infection/infection/issues/547)
+
+## Summary
+
+Interfaces are always uncovered, therefore it makes no sense to mutate anything on them.
+
+That, unless we somehow know what test covers which interface, a feature is not possible yet.

--- a/tests/Fixtures/e2e/UncoveredInterfaces/composer.json
+++ b/tests/Fixtures/e2e/UncoveredInterfaces/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^6.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "UncoveredInterfaces\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "UncoveredInterfaces\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/UncoveredInterfaces/expected-output.txt
+++ b/tests/Fixtures/e2e/UncoveredInterfaces/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 4
+Killed: 4
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/UncoveredInterfaces/infection.json
+++ b/tests/Fixtures/e2e/UncoveredInterfaces/infection.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/Fixtures/e2e/UncoveredInterfaces/phpunit.xml.dist
+++ b/tests/Fixtures/e2e/UncoveredInterfaces/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/UncoveredInterfaces/src/SourceClass.php
+++ b/tests/Fixtures/e2e/UncoveredInterfaces/src/SourceClass.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UncoveredInterfaces;
+
+class SourceClass implements SourceInterface
+{
+    private $hello = 'hello';
+
+    public function hello(): string
+    {
+        return $this->hello;
+    }
+
+    public function doSomething(int $value = 301): SourceInterface
+    {
+        $this->hello = (string) $value;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/e2e/UncoveredInterfaces/src/SourceInterface.php
+++ b/tests/Fixtures/e2e/UncoveredInterfaces/src/SourceInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace UncoveredInterfaces;
+
+interface SourceInterface
+{
+    public function doSomething(int $value = 301): SourceInterface;
+}

--- a/tests/Fixtures/e2e/UncoveredInterfaces/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/UncoveredInterfaces/tests/SourceClassTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace UncoveredInterfaces\Test;
+
+use UncoveredInterfaces\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+
+    public function test_code()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('301', $sourceClass->doSomething()->hello());
+        $this->assertSame('200', $sourceClass->doSomething(200)->hello());
+    }
+}


### PR DESCRIPTION
Interfaces are always uncovered, therefore it makes no sense to mutate anything on them.

(For example, [interfaces not even included on CodeCov](https://codecov.io/gh/infection/infection/src/master/src/MutationInterface.php), and [not in the list of files either](https://codecov.io/gh/infection/infection/tree/master/src). Simple `phpunit --coverage-html=coverage && open coverage/index.html` will show the same blank coverage.)

This PR:

- [x] Fixes #547
- [x] Covered by tests
