### PR TITLE
Fix variable names in mutators

### DIFF
--- a/src/Mutator/Unwrap/AbstractUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractUnwrapMutator.php
@@ -61,7 +61,7 @@ abstract class AbstractUnwrapMutator extends Mutator
 
     final protected function mutatesNode(Node $node): bool
     {
-        if (!$node instanceof Node\Expr\FuncCall) {
+        if (!$node instanceof Node\Expr\FuncCall || !$node->name instanceof Node\Name) {
             return false;
         }
 

--- a/tests/Mutator/Unwrap/UnwrapArrayFilterTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayFilterTest.php
@@ -175,5 +175,16 @@ PHP
 $a = array_map('strtolower', ['A', 1, 'C']);
 PHP
         ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+<?php
+
+$a = 'array_filter';
+
+$b = $a([1,2,3], 'is_int');
+PHP
+            ,
+        ];
     }
 }

--- a/tests/Mutator/Unwrap/UnwrapArrayFlipTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayFlipTest.php
@@ -173,5 +173,16 @@ PHP
 $a = array_map('strtolower', ['A', 1, 'C']);
 PHP
         ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+<?php
+
+$a = 'array_flip';
+
+$b = $a([1,2,3]);
+PHP
+            ,
+        ];
     }
 }

--- a/tests/Mutator/Unwrap/UnwrapArrayIntersectTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayIntersectTest.php
@@ -280,5 +280,16 @@ function array_intersect($array, $array1, $array2)
 }
 PHP
         ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+<?php
+
+$a = 'array_intersect';
+
+$b = $a([1,2,3], [3,4,5]);
+PHP
+            ,
+        ];
     }
 }

--- a/tests/Mutator/Unwrap/UnwrapArrayMapTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayMapTest.php
@@ -175,5 +175,16 @@ PHP
 $a = array_filter(['A', 'B', 'C'], 'is_int');
 PHP
         ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+<?php
+
+$a = 'array_map';
+
+$b = $a('strtolower', [3,4,5]);
+PHP
+            ,
+        ];
     }
 }

--- a/tests/Mutator/Unwrap/UnwrapArrayMergeTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayMergeTest.php
@@ -280,5 +280,16 @@ function array_merge($array, $array1, $array2)
 }
 PHP
         ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+<?php
+
+$a = 'array_merge';
+
+$b = $a([1,2,3], [3,4,5]);
+PHP
+            ,
+        ];
     }
 }

--- a/tests/Mutator/Unwrap/UnwrapArrayReduceTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayReduceTest.php
@@ -225,5 +225,16 @@ function array_reduce($array, $callback, $initial = null)
 }
 PHP
         ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+<?php
+
+$a = 'array_reduce';
+
+$b = $a('strtolower', [3,4,5]);
+PHP
+            ,
+        ];
     }
 }

--- a/tests/Mutator/Unwrap/UnwrapArrayReplaceTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayReplaceTest.php
@@ -280,5 +280,16 @@ function array_replace($array, $array1, $array2)
 }
 PHP
         ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+<?php
+
+$a = 'array_replace';
+
+$b = $a([1,2,3], [3,4,5]);
+PHP
+            ,
+        ];
     }
 }

--- a/tests/Mutator/Unwrap/UnwrapArrayReverseTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayReverseTest.php
@@ -187,5 +187,16 @@ PHP
 $a = ['A', 1, 'C'];
 PHP
         ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+<?php
+
+$a = 'array_reverse';
+
+$b = $a([1,2,3]);
+PHP
+            ,
+        ];
     }
 }

--- a/tests/Mutator/Unwrap/UnwrapStrRepeatTest.php
+++ b/tests/Mutator/Unwrap/UnwrapStrRepeatTest.php
@@ -180,5 +180,16 @@ function str_repeat($input, $multiplier)
 }
 PHP
         ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+<?php
+
+$a = 'str_repeat';
+
+$b = $a('foo', 3);
+PHP
+            ,
+        ];
     }
 }

--- a/tests/Mutator/Unwrap/UnwrapStrToLowerTest.php
+++ b/tests/Mutator/Unwrap/UnwrapStrToLowerTest.php
@@ -177,5 +177,16 @@ function strtolower($string)
 }
 PHP
         ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+<?php
+
+$a = 'strtolower';
+
+$b = $a('FooBar');
+PHP
+            ,
+        ];
     }
 }


### PR DESCRIPTION
This PR:

- [x] Makes sure that variable function names don't break unwrap mutators
- [x] Covered by tests

CC @localheinz, once this gets merged could you update your open PRs to include this test case as well?