### PR TITLE
Permit for occasional skipped E2E test due to Composer's failure to install dependencies

### DIFF
--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -44,6 +44,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 /**
@@ -51,6 +52,7 @@ use Symfony\Component\Process\Process;
  */
 final class E2ETest extends TestCase
 {
+    private const MAX_FAILING_COMPOSER_INSTALL = 5;
     private const EXPECT_ERROR = 1;
     private const EXPECT_SUCCESS = 0;
 
@@ -60,6 +62,8 @@ final class E2ETest extends TestCase
      * @var \Composer\Autoload\ClassLoader|null
      */
     private $previousLoader;
+
+    private static $countFailingComposerInstall = 0;
 
     protected function setUp(): void
     {
@@ -184,8 +188,23 @@ final class E2ETest extends TestCase
             // Install deps only if there's none
             $this->assertNotEmpty(getenv('PATH') ?: getenv('Path'), 'E2E tests need a system composer installed, but it could not be found without a PATH set');
 
-            $process = new Process(sprintf('%s %s', (new ComposerExecutableFinder())->find(), 'install'));
-            $process->mustRun();
+            try {
+                $process = new Process(sprintf('%s %s', (new ComposerExecutableFinder())->find(), 'install'));
+                $process->setTimeout(300);
+                $process->mustRun();
+            } catch (ProcessTimedOutException $e) {
+                /*
+                 * Packagist is a free service and is not 100% reliable as one may guess, but
+                 * since we run multiple same tests at once in different environments, if we
+                 * occasionally skip a test for reasons we can't control, it should do no harm.
+                 */
+                if (self::$countFailingComposerInstall >= self::MAX_FAILING_COMPOSER_INSTALL) {
+                    throw $e;
+                }
+
+                ++self::$countFailingComposerInstall;
+                $this->markTestSkipped($e->getMessage());
+            }
         }
 
         /*


### PR DESCRIPTION
Packagist is a free service and is not 100% reliable as one may guess, but since we run multiple same tests at once in different environments, if we occasionally skip a test for reasons we can't control, it should do no harm. [E.g. in case of this kind of failures.](https://ci.appveyor.com/project/borNfreee/infection/builds/20071579/job/benm8m46h7d8mbwb#L215)

- [x] Also raise the process timeout up to 5 minutes.