### PR TITLE
Enhancement: Unwrap all available arguments to array_map()

### DIFF
--- a/src/Mutator/Unwrap/UnwrapArrayMap.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMap.php
@@ -49,6 +49,6 @@ final class UnwrapArrayMap extends AbstractUnwrapMutator
 
     protected function getParameterIndexes(Node $node): \Generator
     {
-        yield 1;
+        yield from range(1, \count($node->args) - 1);
     }
 }

--- a/tests/Mutator/Unwrap/UnwrapArrayMapTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayMapTest.php
@@ -176,6 +176,35 @@ $a = array_filter(['A', 'B', 'C'], 'is_int');
 PHP
         ];
 
+        yield 'It mutates correctly when provided with more than two parameters' => [
+            <<<'PHP'
+<?php
+
+$a = array_map('strtolower', ['A', 'B', 'C'], \Class_With_Const::Const, $foo->bar());
+PHP
+            ,
+            [
+                <<<'PHP'
+<?php
+
+$a = ['A', 'B', 'C'];
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$a = \Class_With_Const::Const;
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$a = $foo->bar();
+PHP
+                ,
+            ],
+        ];
+
         yield 'It does not break when provided with a variable function name' => [
             <<<'PHP'
 <?php


### PR DESCRIPTION
This PR

- [x] unwraps all additional arguments to `array_map()`

Follows #513.