### PR TITLE
Fix: Debugger is called Xdebug

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -187,7 +187,7 @@ ASCII;
         if (\PHP_SAPI === 'phpdbg') {
             $this->consoleOutput->logRunningWithDebugger(\PHP_SAPI);
         } elseif (\extension_loaded('xdebug')) {
-            $this->consoleOutput->logRunningWithDebugger('xdebug');
+            $this->consoleOutput->logRunningWithDebugger('Xdebug');
         }
     }
 }


### PR DESCRIPTION
This PR

- [x] fixes a small spelling issue

💁‍♂️ For reference, https://xdebug.org:

> This release only updates **Xdebug** to support PHP 7.3. There are a few known issues that still need to be addressed, such as a problem with Code Coverage and multiple catches. These will be addressed in a future beta or Release Candidate.