### PR TITLE
Remove Mockery as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,6 @@
         "webmozart/assert": "^1.3"
     },
     "require-dev": {
-        "mockery/mockery": "^1.1",
         "phpunit/phpunit": "^6"
     },
     "bin": ["bin/infection"]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6136bf91d17bd67f560460694af046c0",
+    "content-hash": "f1e90f9b739e2ea6b8c0096d914fae17",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1145,119 +1145,6 @@
                 "instantiate"
             ],
             "time": "2017-07-22T11:58:36+00:00"
-        },
-        {
-            "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
-                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3|^7.0"
-            },
-            "replace": {
-                "cordoval/hamcrest-php": "*",
-                "davedevelopment/hamcrest-php": "*",
-                "kodova/hamcrest-php": "*"
-            },
-            "require-dev": {
-                "phpunit/php-file-iterator": "1.3.3",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "hamcrest"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD"
-            ],
-            "description": "This is the PHP port of Hamcrest Matchers",
-            "keywords": [
-                "test"
-            ],
-            "time": "2016-01-20T08:20:44+00:00"
-        },
-        {
-            "name": "mockery/mockery",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mockery/mockery.git",
-                "reference": "100633629bf76d57430b86b7098cd6beb996a35a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/100633629bf76d57430b86b7098cd6beb996a35a",
-                "reference": "100633629bf76d57430b86b7098cd6beb996a35a",
-                "shasum": ""
-            },
-            "require": {
-                "hamcrest/hamcrest-php": "~2.0",
-                "lib-pcre": ">=7.0",
-                "php": ">=5.6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5.7.10|~6.5|~7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Mockery": "library/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Pádraic Brady",
-                    "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
-                },
-                {
-                    "name": "Dave Marshall",
-                    "email": "dave.marshall@atstsolutions.co.uk",
-                    "homepage": "http://davedevelopment.co.uk"
-                }
-            ],
-            "description": "Mockery is a simple yet flexible PHP mock object framework",
-            "homepage": "https://github.com/mockery/mockery",
-            "keywords": [
-                "BDD",
-                "TDD",
-                "library",
-                "mock",
-                "mock objects",
-                "mockery",
-                "stub",
-                "test",
-                "test double",
-                "testing"
-            ],
-            "time": "2018-10-02T21:52:37+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/devTools/phpstan-tests.neon
+++ b/devTools/phpstan-tests.neon
@@ -1,5 +1,3 @@
 parameters:
     excludes_analyse:
         - %currentWorkingDirectory%/tests/Fixtures/*
-    ignoreErrors:
-        - '#Call to an undefined method Mockery#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,14 +18,9 @@
         </whitelist>
     </filter>
 
-    <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener"></listener>
-    </listeners>
-
     <groups>
         <exclude>
             <group>large</group>
         </exclude>
     </groups>
-
 </phpunit>

--- a/tests/Config/ValueProvider/AbstractBaseProviderTest.php
+++ b/tests/Config/ValueProvider/AbstractBaseProviderTest.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Config\ValueProvider;
 
-use Mockery;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\StreamableInputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
@@ -43,16 +43,16 @@ use Symfony\Component\Console\Output\StreamOutput;
 /**
  * @internal
  */
-abstract class AbstractBaseProviderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+abstract class AbstractBaseProviderTest extends TestCase
 {
     protected static $stty;
 
-    protected function getQuestionHelper()
+    protected function getQuestionHelper(): QuestionHelper
     {
         return new QuestionHelper();
     }
 
-    protected function getInputStream($input)
+    protected function getInputStream(string $input)
     {
         $stream = fopen('php://memory', 'r+b', false);
         fwrite($stream, $input);
@@ -61,7 +61,7 @@ abstract class AbstractBaseProviderTest extends Mockery\Adapter\Phpunit\MockeryT
         return $stream;
     }
 
-    protected function createOutputInterface()
+    protected function createOutputInterface(): StreamOutput
     {
         return new StreamOutput(fopen('php://memory', 'r+b', false));
     }
@@ -69,20 +69,18 @@ abstract class AbstractBaseProviderTest extends Mockery\Adapter\Phpunit\MockeryT
     protected function createStreamableInputInterfaceMock($stream = null, $interactive = true)
     {
         $mock = $this->createMock(StreamableInputInterface::class);
-        $mock->expects($this->any())
-            ->method('isInteractive')
+        $mock->method('isInteractive')
             ->will($this->returnValue($interactive));
 
         if ($stream) {
-            $mock->expects($this->any())
-                ->method('getStream')
+            $mock->method('getStream')
                 ->willReturn($stream);
         }
 
         return $mock;
     }
 
-    protected function hasSttyAvailable()
+    protected function hasSttyAvailable(): bool
     {
         if (null !== self::$stty) {
             return self::$stty;

--- a/tests/Config/ValueProvider/ExcludeDirsProviderTest.php
+++ b/tests/Config/ValueProvider/ExcludeDirsProviderTest.php
@@ -37,7 +37,6 @@ namespace Infection\Tests\Config\ValueProvider;
 
 use Infection\Config\ConsoleHelper;
 use Infection\Config\ValueProvider\ExcludeDirsProvider;
-use Mockery;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -55,12 +54,23 @@ final class ExcludeDirsProviderTest extends AbstractBaseProviderTest
      */
     private $fileSystem;
 
+    /**
+     * @var ExcludeDirsProvider
+     */
+    private $provider;
+
     protected function setUp(): void
     {
         $this->workspace = \sys_get_temp_dir() . '/exclude' . \microtime(true) . \random_int(100, 999);
         \mkdir($this->workspace, 0777, true);
 
         $this->fileSystem = new Filesystem();
+
+        $this->provider = new ExcludeDirsProvider(
+            $this->createMock(ConsoleHelper::class),
+            $this->getQuestionHelper(),
+            $this->fileSystem
+        );
     }
 
     protected function tearDown(): void
@@ -73,14 +83,7 @@ final class ExcludeDirsProviderTest extends AbstractBaseProviderTest
      */
     public function test_it_contains_vendors_when_sources_contains_current_dir(string $excludedRootDir, array $dirsInCurrentFolder): void
     {
-        $consoleMock = Mockery::mock(ConsoleHelper::class);
-        $consoleMock->shouldReceive('getQuestion')->once()->andReturn('?');
-
-        $dialog = $this->getQuestionHelper();
-
-        $provider = new ExcludeDirsProvider($consoleMock, $dialog, $this->fileSystem);
-
-        $excludedDirs = $provider->get(
+        $excludedDirs = $this->provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("\n")),
             $this->createOutputInterface(),
             $dirsInCurrentFolder,
@@ -96,14 +99,7 @@ final class ExcludeDirsProviderTest extends AbstractBaseProviderTest
             $this->markTestSkipped('Stty is not available');
         }
 
-        $consoleMock = Mockery::mock(ConsoleHelper::class);
-        $consoleMock->shouldReceive('getQuestion')->once()->andReturn('?');
-
-        $dialog = $this->getQuestionHelper();
-
-        $provider = new ExcludeDirsProvider($consoleMock, $dialog, $this->fileSystem);
-
-        $excludeDirs = $provider->get(
+        $excludeDirs = $this->provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("abc\n")),
             $this->createOutputInterface(),
             ['src'],
@@ -125,14 +121,7 @@ final class ExcludeDirsProviderTest extends AbstractBaseProviderTest
         \mkdir($dir1);
         \mkdir($dir2);
 
-        $consoleMock = Mockery::mock(ConsoleHelper::class);
-        $consoleMock->shouldReceive('getQuestion')->once()->andReturn('?');
-
-        $dialog = $this->getQuestionHelper();
-
-        $provider = new ExcludeDirsProvider($consoleMock, $dialog, $this->fileSystem);
-
-        $excludeDirs = $provider->get(
+        $excludeDirs = $this->provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("foo\n")),
             $this->createOutputInterface(),
             ['src'],

--- a/tests/Config/ValueProvider/TextLogFileProviderTest.php
+++ b/tests/Config/ValueProvider/TextLogFileProviderTest.php
@@ -37,23 +37,28 @@ namespace Infection\Tests\Config\ValueProvider;
 
 use Infection\Config\ConsoleHelper;
 use Infection\Config\ValueProvider\TextLogFileProvider;
-use Mockery;
 
 /**
  * @internal
  */
 final class TextLogFileProviderTest extends AbstractBaseProviderTest
 {
+    /**
+     * @var TextLogFileProvider
+     */
+    private $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = new TextLogFileProvider(
+            $this->createMock(ConsoleHelper::class),
+            $this->getQuestionHelper()
+        );
+    }
+
     public function test_it_uses_default_value(): void
     {
-        $consoleMock = Mockery::mock(ConsoleHelper::class);
-        $consoleMock->shouldReceive('getQuestion')->once()->andReturn('?');
-
-        $dialog = $this->getQuestionHelper();
-
-        $provider = new TextLogFileProvider($consoleMock, $dialog);
-
-        $textLogFilePath = $provider->get(
+        $textLogFilePath = $this->provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("\n")),
             $this->createOutputInterface(),
             []
@@ -65,14 +70,8 @@ final class TextLogFileProviderTest extends AbstractBaseProviderTest
     public function test_it_uses_typed_value(): void
     {
         $inputValue = 'test-log.txt';
-        $consoleMock = Mockery::mock(ConsoleHelper::class);
-        $consoleMock->shouldReceive('getQuestion')->once()->andReturn('?');
 
-        $dialog = $this->getQuestionHelper();
-
-        $provider = new TextLogFileProvider($consoleMock, $dialog);
-
-        $textLogFilePath = $provider->get(
+        $textLogFilePath = $this->provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("{$inputValue}\n")),
             $this->createOutputInterface(),
             []

--- a/tests/Config/ValueProvider/TimeoutProviderTest.php
+++ b/tests/Config/ValueProvider/TimeoutProviderTest.php
@@ -38,23 +38,28 @@ namespace Infection\Tests\Config\ValueProvider;
 use Infection\Config\ConsoleHelper;
 use Infection\Config\InfectionConfig;
 use Infection\Config\ValueProvider\TimeoutProvider;
-use Mockery;
 
 /**
  * @internal
  */
 final class TimeoutProviderTest extends AbstractBaseProviderTest
 {
+    /**
+     * @var TimeoutProvider
+     */
+    private $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = new TimeoutProvider(
+            $this->createMock(ConsoleHelper::class),
+            $this->getQuestionHelper()
+        );
+    }
+
     public function test_it_uses_default_value(): void
     {
-        $consoleMock = Mockery::mock(ConsoleHelper::class);
-        $consoleMock->shouldReceive('getQuestion')->once()->andReturn('?');
-
-        $dialog = $this->getQuestionHelper();
-
-        $provider = new TimeoutProvider($consoleMock, $dialog);
-
-        $timeout = $provider->get(
+        $timeout = $this->provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("\n")),
             $this->createOutputInterface()
         );
@@ -64,14 +69,7 @@ final class TimeoutProviderTest extends AbstractBaseProviderTest
 
     public function test_it_casts_any_value_to_integer(): void
     {
-        $consoleMock = Mockery::mock(ConsoleHelper::class);
-        $consoleMock->shouldReceive('getQuestion')->once()->andReturn('?');
-
-        $dialog = $this->getQuestionHelper();
-
-        $provider = new TimeoutProvider($consoleMock, $dialog);
-
-        $timeout = $provider->get(
+        $timeout = $this->provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("13\n")),
             $this->createOutputInterface()
         );
@@ -84,16 +82,9 @@ final class TimeoutProviderTest extends AbstractBaseProviderTest
      */
     public function test_it_does_not_allow_invalid_values($inputValue): void
     {
-        $consoleMock = Mockery::mock(ConsoleHelper::class);
-        $consoleMock->shouldReceive('getQuestion')->once()->andReturn('?');
-
-        $dialog = $this->getQuestionHelper();
-
-        $provider = new TimeoutProvider($consoleMock, $dialog);
-
         $this->expectException(\RuntimeException::class);
 
-        $timeout = $provider->get(
+        $timeout = $this->provider->get(
             $this->createStreamableInputInterfaceMock($this->getInputStream("{$inputValue}\n")),
             $this->createOutputInterface()
         );

--- a/tests/Console/LogVerbosityTest.php
+++ b/tests/Console/LogVerbosityTest.php
@@ -37,21 +37,21 @@ namespace Infection\Tests\Console;
 
 use Infection\Console\ConsoleOutput;
 use Infection\Console\LogVerbosity;
-use Mockery;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @internal
  */
-final class LogVerbosityTest extends MockeryTestCase
+final class LogVerbosityTest extends TestCase
 {
     public function test_it_works_if_verbosity_is_valid(): void
     {
         $input = $this->setInputExpectationsWhenItDoesNotChange(LogVerbosity::NORMAL);
 
-        LogVerbosity::convertVerbosityLevel($input, new ConsoleOutput(Mockery::mock(SymfonyStyle::class)));
+        LogVerbosity::convertVerbosityLevel($input, new ConsoleOutput($this->createMock(SymfonyStyle::class)));
     }
 
     /**
@@ -60,10 +60,10 @@ final class LogVerbosityTest extends MockeryTestCase
     public function test_it_converts_int_version_to_string_version_of_verbosity(int $input, string $output): void
     {
         $input = $this->setInputExpectationsWhenItDoesChange($input, $output);
-        $io = Mockery::mock(SymfonyStyle::class);
-        $io->shouldReceive('note')
-            ->withArgs(['Numeric versions of log-verbosity have been deprecated, please use, ' . $output . ' to keep the same result'])
-            ->once();
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects($this->once())
+            ->method('note')
+            ->with('Numeric versions of log-verbosity have been deprecated, please use, ' . $output . ' to keep the same result');
 
         LogVerbosity::convertVerbosityLevel($input, new ConsoleOutput($io));
     }
@@ -94,10 +94,10 @@ final class LogVerbosityTest extends MockeryTestCase
     public function test_it_converts_to_normal_and_writes_notice_when_invalid_verbosity(): void
     {
         $input = $this->setInputExpectationsWhenItDoesChange('asdf', LogVerbosity::NORMAL);
-        $io = Mockery::mock(SymfonyStyle::class);
-        $io->shouldReceive('note')
-            ->withArgs(['Running infection with an unknown log-verbosity option, falling back to default option'])
-            ->once();
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects($this->once())
+            ->method('note')
+            ->with('Running infection with an unknown log-verbosity option, falling back to default option');
 
         LogVerbosity::convertVerbosityLevel($input, new ConsoleOutput($io));
     }
@@ -105,15 +105,15 @@ final class LogVerbosityTest extends MockeryTestCase
     /**
      * @param string|int $inputVerbosity
      *
-     * @return InputInterface|Mockery\MockInterface
+     * @return InputInterface|MockObject
      */
     private function setInputExpectationsWhenItDoesNotChange($inputVerbosity)
     {
-        $input = Mockery::mock(InputInterface::class);
-        $input->shouldReceive('getOption')
-            ->withArgs(['log-verbosity'])
-            ->once()
-            ->andReturn($inputVerbosity);
+        $input = $this->createMock(InputInterface::class);
+        $input->expects($this->once())
+            ->method('getOption')
+            ->with('log-verbosity')
+            ->willReturn($inputVerbosity);
 
         return $input;
     }
@@ -121,14 +121,14 @@ final class LogVerbosityTest extends MockeryTestCase
     /**
      * @param string|int $input
      *
-     * @return InputInterface|Mockery\MockInterface
+     * @return InputInterface|MockObject
      */
     private function setInputExpectationsWhenItDoesChange($input, string $output)
     {
         $input = $this->setInputExpectationsWhenItDoesNotChange($input);
-        $input->shouldReceive('setOption')
-            ->withArgs(['log-verbosity', $output])
-            ->once();
+        $input->expects($this->once())
+            ->method('setOption')
+            ->with('log-verbosity', $output);
 
         return $input;
     }

--- a/tests/Mutant/MetricsCalculatorTest.php
+++ b/tests/Mutant/MetricsCalculatorTest.php
@@ -38,13 +38,13 @@ namespace Infection\Tests\Mutant;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessInterface;
-use Mockery;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
 /**
  * @internal
  */
-final class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+final class MetricsCalculatorTest extends TestCase
 {
     public function test_it_shows_zero_values_by_default(): void
     {
@@ -69,8 +69,8 @@ final class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
 
     public function test_it_collects_all_values(): void
     {
-        $process = Mockery::mock(Process::class);
-        $process->shouldReceive('stop');
+        $process = $this->createMock(Process::class);
+        $process->method('stop');
 
         $calculator = new MetricsCalculator();
 
@@ -96,8 +96,10 @@ final class MetricsCalculatorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
 
     private function addMutantProcess(MetricsCalculator $calculator, int $resultCode, int $count = 1): void
     {
-        $mutantProcess = Mockery::mock(MutantProcessInterface::class);
-        $mutantProcess->shouldReceive('getResultCode')->times($count)->andReturn($resultCode);
+        $mutantProcess = $this->createMock(MutantProcessInterface::class);
+        $mutantProcess->expects($this->exactly($count))
+            ->method('getResultCode')
+            ->willReturn($resultCode);
 
         while ($count--) {
             $calculator->collect($mutantProcess);

--- a/tests/Mutant/MutantCreatorTest.php
+++ b/tests/Mutant/MutantCreatorTest.php
@@ -39,13 +39,13 @@ use Infection\Differ\Differ;
 use Infection\Mutant\MutantCreator;
 use Infection\MutationInterface;
 use Infection\TestFramework\Coverage\CodeCoverageData;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use PhpParser\PrettyPrinter\Standard;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class MutantCreatorTest extends MockeryTestCase
+final class MutantCreatorTest extends TestCase
 {
     private const TEST_FILE_NAME = '/mutant.hash.infection.php';
 
@@ -56,7 +56,6 @@ final class MutantCreatorTest extends MockeryTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->directory = \sys_get_temp_dir() . '/infection/MutantCreator';
         mkdir($this->directory, 0777, true);
         touch($this->directory . self::TEST_FILE_NAME);
@@ -77,25 +76,26 @@ PHP
 
     public function test_it_uses_avaialable_file_if_hash_is_the_same(): void
     {
-        $standard = \Mockery::mock(Standard::class);
-        $standard->shouldReceive('prettyPrintFile')->andReturn('The Print');
+        $standard = $this->createMock(Standard::class);
+        $standard->method('prettyPrintFile')
+            ->willReturn('The Print');
 
-        $differ = \Mockery::mock(Differ::class);
-        $differ->shouldReceive('diff')
-            ->withArgs(['The Print', '<?php return \'This is a diff\';'])
-            ->andReturn('This is the Diff');
+        $differ = $this->createMock(Differ::class);
+        $differ->method('diff')
+            ->with('The Print', '<?php return \'This is a diff\';')
+            ->willReturn('This is the Diff');
 
-        $mutation = \Mockery::mock(MutationInterface::class);
-        $mutation->shouldReceive('getHash')->andReturn('hash');
-        $mutation->shouldReceive('getOriginalFilePath')->andReturn('original/path');
-        $mutation->shouldReceive('getOriginalFileAst')->andReturn(['ast']);
-        $mutation->shouldReceive('getAttributes')->andReturn(['startLine' => 1]);
-        $mutation->shouldReceive('isOnFunctionSignature')->andReturn(true);
-        $mutation->shouldReceive('isCoveredByTest')->once()->andReturn(true);
+        $mutation = $this->createMock(MutationInterface::class);
+        $mutation->method('getHash')->willReturn('hash');
+        $mutation->method('getOriginalFilePath')->willReturn('original/path');
+        $mutation->method('getOriginalFileAst')->willReturn(['ast']);
+        $mutation->method('getAttributes')->willReturn(['startLine' => 1]);
+        $mutation->method('isOnFunctionSignature')->willReturn(true);
+        $mutation->expects($this->once())->method('isCoveredByTest')->willReturn(true);
 
-        $coverage = \Mockery::mock(CodeCoverageData::class);
-        $coverage->shouldReceive('hasExecutedMethodOnLine')->andReturn(true);
-        $coverage->shouldReceive('getAllTestsFor')->andReturn(['test', 'list']);
+        $coverage = $this->createMock(CodeCoverageData::class);
+        $coverage->method('hasExecutedMethodOnLine')->willReturn(true);
+        $coverage->method('getAllTestsFor')->willReturn(['test', 'list']);
 
         $creator = new MutantCreator($this->directory, $differ, $standard);
         $mutant = $creator->create($mutation, $coverage);

--- a/tests/Mutator/Util/MutatorsGeneratorTest.php
+++ b/tests/Mutator/Util/MutatorsGeneratorTest.php
@@ -43,15 +43,16 @@ use Infection\Mutator\Util\MutatorProfile;
 use Infection\Mutator\Util\MutatorsGenerator;
 use Infection\Tests\Fixtures\StubMutator;
 use Infection\Visitor\ReflectionVisitor;
-use Mockery;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Plus as PlusNode;
 use PhpParser\Node\Scalar\DNumber;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class MutatorsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+final class MutatorsGeneratorTest extends TestCase
 {
     private static $countDefaultMutators = 0;
 
@@ -64,8 +65,7 @@ final class MutatorsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
 
     public function test_no_setting_returns_the_default_mutators(): void
     {
-        $mutatorGenerator = new MutatorsGenerator([]);
-        $mutators = $mutatorGenerator->generate();
+        $mutators = (new MutatorsGenerator([]))->generate();
 
         $this->assertCount(self::$countDefaultMutators, $mutators);
     }
@@ -125,9 +125,12 @@ final class MutatorsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
 
     public function test_it_keeps_settings(): void
     {
-        /** @var \Mockery\MockInterface|\ReflectionClass $reflectionMock */
-        $reflectionMock = Mockery::mock(\ReflectionClass::class);
-        $reflectionMock->shouldReceive('getName')->once()->andReturn('A');
+        /** @var MockObject|\ReflectionClass $reflectionMock */
+        $reflectionMock = $this->createMock(\ReflectionClass::class);
+        $reflectionMock->expects($this->once())
+            ->method('getName')
+            ->willReturn('A');
+
         $plusNode = $this->getPlusNode('B', $reflectionMock);
 
         $mutatorGenerator = new MutatorsGenerator([
@@ -145,9 +148,12 @@ final class MutatorsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
 
     public function test_it_keeps_settings_when_applied_to_profiles(): void
     {
-        /** @var \Mockery\MockInterface|\ReflectionClass $reflectionMock */
-        $reflectionMock = Mockery::mock(\ReflectionClass::class);
-        $reflectionMock->shouldReceive('getName')->times(3)->andReturn('A');
+        /** @var MockObject|\ReflectionClass $reflectionMock */
+        $reflectionMock = $this->createMock(\ReflectionClass::class);
+        $reflectionMock->expects($this->exactly(3))
+            ->method('getName')
+            ->willReturn('A');
+
         $plusNode = $this->getPlusNode('B', $reflectionMock);
         $falseNode = $this->getBoolNode('false', 'B', $reflectionMock);
         $trueNode = $this->getBoolNode('true', 'B', $reflectionMock);
@@ -193,8 +199,12 @@ final class MutatorsGeneratorTest extends Mockery\Adapter\Phpunit\MockeryTestCas
 
     public function test_it_can_set_a_single_item_with_a_setting(): void
     {
-        $reflectionMock = Mockery::mock(\ReflectionClass::class);
-        $reflectionMock->shouldReceive('getName')->times(2)->andReturn('A');
+        /** @var MockObject|\ReflectionClass $reflectionMock */
+        $reflectionMock = $this->createMock(\ReflectionClass::class);
+        $reflectionMock->expects($this->exactly(2))
+            ->method('getName')
+            ->willReturn('A');
+
         $falseNode = $this->getBoolNode('false', 'B', $reflectionMock);
         $trueNode = $this->getBoolNode('true', 'B', $reflectionMock);
 

--- a/tests/Process/Builder/ProcessBuilderTest.php
+++ b/tests/Process/Builder/ProcessBuilderTest.php
@@ -38,18 +38,20 @@ namespace Infection\Tests\Process\Builder;
 use Infection\Mutant\MutantInterface;
 use Infection\Process\Builder\ProcessBuilder;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
-use Mockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class ProcessBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+final class ProcessBuilderTest extends TestCase
 {
     public function test_getProcessForInitialTestRun_has_no_timeout(): void
     {
-        $fwAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
-        $fwAdapter->shouldReceive('getInitialTestRunCommandLine', ['buildInitialConfigFile'])->andReturn(['/usr/bin/php']);
-        $fwAdapter->shouldReceive('buildInitialConfigFile')->andReturn('buildInitialConfigFile');
+        $fwAdapter = $this->createMock(AbstractTestFrameworkAdapter::class);
+        $fwAdapter->method('getInitialTestRunCommandLine')
+            ->willReturn(['/usr/bin/php']);
+        $fwAdapter->method('buildInitialConfigFile')
+            ->willReturn('buildInitialConfigFile');
 
         $builder = new ProcessBuilder($fwAdapter, 100);
 
@@ -61,13 +63,15 @@ final class ProcessBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     public function test_getProcessForMutant_has_timeout(): void
     {
-        $fwAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
-        $fwAdapter->shouldReceive('getMutantCommandLine', ['buildMutationConfigFile'])->andReturn(['/usr/bin/php']);
-        $fwAdapter->shouldReceive('buildMutationConfigFile')->andReturn('buildMutationConfigFile');
+        $fwAdapter = $this->createMock(AbstractTestFrameworkAdapter::class);
+        $fwAdapter->method('getMutantCommandLine')
+            ->willReturn(['/usr/bin/php']);
+        $fwAdapter->method('buildMutationConfigFile')
+            ->willReturn('buildMutationConfigFile');
 
         $builder = new ProcessBuilder($fwAdapter, 100);
 
-        $process = $builder->getProcessForMutant(Mockery::mock(MutantInterface::class))->getProcess();
+        $process = $builder->getProcessForMutant($this->createMock(MutantInterface::class))->getProcess();
 
         $this->assertContains('/usr/bin/php', $process->getCommandLine());
         $this->assertSame(100.0, $process->getTimeout());

--- a/tests/Process/MutantProcessTest.php
+++ b/tests/Process/MutantProcessTest.php
@@ -41,86 +41,130 @@ use Infection\Mutator\Util\MutatorConfig;
 use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
-use Mockery;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
 /**
  * @internal
  */
-final class MutantProcessTest extends MockeryTestCase
+final class MutantProcessTest extends TestCase
 {
+    /**
+     * @var MutantProcess
+     */
+    private $mutantProcess;
+
+    /**
+     * @var MockObject|Process
+     */
+    private $process;
+
+    /**
+     * @var MockObject|MutantInterface
+     */
+    private $mutant;
+
+    /**
+     * @var MockObject|AbstractTestFrameworkAdapter
+     */
+    private $adapter;
+
+    protected function setUp(): void
+    {
+        $this->process = $this->createMock(Process::class);
+        $this->mutant = $this->createMock(MutantInterface::class);
+        $this->adapter = $this->createMock(AbstractTestFrameworkAdapter::class);
+
+        $this->mutantProcess = new MutantProcess($this->process, $this->mutant, $this->adapter);
+    }
+
     public function test_it_handles_not_covered_mutant(): void
     {
-        $process = Mockery::mock(Process::class);
-        $mutant = Mockery::mock(MutantInterface::class);
-        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(false);
-        $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
+        $this->mutant
+            ->expects($this->once())
+            ->method('isCoveredByTest')
+            ->willReturn(false);
 
-        $mutantProcess = new MutantProcess($process, $mutant, $testFrameworkAdapter);
-
-        $this->assertSame(MutantProcess::CODE_NOT_COVERED, $mutantProcess->getResultCode());
+        $this->assertSame(MutantProcess::CODE_NOT_COVERED, $this->mutantProcess->getResultCode());
     }
 
     public function test_it_handles_timeout(): void
     {
-        $process = Mockery::mock(Process::class);
-        $mutant = Mockery::mock(MutantInterface::class);
-        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
-        $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
+        $this->mutant
+            ->expects($this->once())
+            ->method('isCoveredByTest')
+            ->willReturn(true);
 
-        $mutantProcess = new MutantProcess($process, $mutant, $testFrameworkAdapter);
-        $mutantProcess->markTimeout();
+        $this->mutantProcess->markTimeout();
 
-        $this->assertSame(MutantProcess::CODE_TIMED_OUT, $mutantProcess->getResultCode());
+        $this->assertSame(MutantProcess::CODE_TIMED_OUT, $this->mutantProcess->getResultCode());
     }
 
     public function test_it_handles_error(): void
     {
-        $process = Mockery::mock(Process::class);
-        $process->shouldReceive('getExitCode')->once()->andReturn(126);
-        $mutant = Mockery::mock(MutantInterface::class);
-        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
-        $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
+        $this->mutant
+            ->expects($this->once())
+            ->method('isCoveredByTest')
+            ->willReturn(true);
 
-        $mutantProcess = new MutantProcess($process, $mutant, $testFrameworkAdapter);
+        $this->process
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(126);
 
-        $this->assertSame(MutantProcess::CODE_ERROR, $mutantProcess->getResultCode());
+        $this->assertSame(MutantProcess::CODE_ERROR, $this->mutantProcess->getResultCode());
     }
 
     public function test_it_handles_escaped_mutant(): void
     {
-        $process = Mockery::mock(Process::class);
-        $process->shouldReceive('getExitCode')->once()->andReturn(0);
-        $process->shouldReceive('getOutput')->once()->andReturn('...');
+        $this->mutant
+            ->expects($this->once())
+            ->method('isCoveredByTest')
+            ->willReturn(true);
 
-        $mutant = Mockery::mock(MutantInterface::class);
-        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
+        $this->process
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(0);
 
-        $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
-        $testFrameworkAdapter->shouldReceive('testsPass')->once()->andReturn(true);
+        $this->process
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('...');
 
-        $mutantProcess = new MutantProcess($process, $mutant, $testFrameworkAdapter);
+        $this->adapter
+            ->expects($this->once())
+            ->method('testsPass')
+            ->willReturn(true);
 
-        $this->assertSame(MutantProcess::CODE_ESCAPED, $mutantProcess->getResultCode());
+        $this->assertSame(MutantProcess::CODE_ESCAPED, $this->mutantProcess->getResultCode());
     }
 
     public function test_it_handles_killed_mutant(): void
     {
-        $process = Mockery::mock(Process::class);
-        $process->shouldReceive('getExitCode')->once()->andReturn(0);
-        $process->shouldReceive('getOutput')->once()->andReturn('...');
+        $this->mutant
+            ->expects($this->once())
+            ->method('isCoveredByTest')
+            ->willReturn(true);
 
-        $mutant = Mockery::mock(MutantInterface::class);
-        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
+        $this->process
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(0);
 
-        $testFrameworkAdapter = Mockery::mock(AbstractTestFrameworkAdapter::class);
-        $testFrameworkAdapter->shouldReceive('testsPass')->once()->andReturn(false);
+        $this->process
+            ->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('...');
 
-        $mutantProcess = new MutantProcess($process, $mutant, $testFrameworkAdapter);
+        $this->adapter
+            ->expects($this->once())
+            ->method('testsPass')
+            ->willReturn(false);
 
-        $this->assertSame(MutantProcess::CODE_KILLED, $mutantProcess->getResultCode());
-        $this->assertSame($mutant, $mutantProcess->getMutant());
+        $this->assertSame(MutantProcess::CODE_KILLED, $this->mutantProcess->getResultCode());
+        $this->assertSame($this->mutant, $this->mutantProcess->getMutant());
     }
 
     public function test_it_knows_its_mutator(): void
@@ -128,57 +172,61 @@ final class MutantProcessTest extends MockeryTestCase
         $mutator = new For_(new MutatorConfig([]));
 
         $mutation = $this->createMock(MutationInterface::class);
-        $mutation->expects($this->once())->method('getMutator')->willReturn($mutator);
+        $mutation->expects($this->once())
+            ->method('getMutator')
+            ->willReturn($mutator);
 
-        $mutant = $this->createMock(MutantInterface::class);
-        $mutant->expects($this->once())->method('getMutation')->willReturn($mutation);
+        $this->mutant
+            ->expects($this->once())
+            ->method('getMutation')
+            ->willReturn($mutation);
 
-        $adapter = $this->createMock(AbstractTestFrameworkAdapter::class);
-
-        $process = $this->createMock(Process::class);
-
-        $mutantProcess = new MutantProcess($process, $mutant, $adapter);
-
-        $this->assertSame($mutator, $mutantProcess->getMutator());
+        $this->assertSame($mutator, $this->mutantProcess->getMutator());
     }
 
     public function test_it_knows_its_original_path(): void
     {
-        $process = $this->createMOck(Process::class);
-        $process->expects($this->never())->method($this->anything());
+        $this->process
+            ->expects($this->never())
+            ->method($this->anything());
 
-        $adapter = $this->createMock(AbstractTestFrameworkAdapter::class);
-        $adapter->expects($this->never())->method($this->anything());
+        $this->adapter
+            ->expects($this->never())
+            ->method($this->anything());
 
         $mutation = $this->createMock(MutationInterface::class);
-        $mutation->expects($this->once())->method('getOriginalFilePath')->willReturn('foo/bar');
-        $mutant = $this->createMock(MutantInterface::class);
-        $mutant->expects($this->once())->method('getMutation')->willReturn($mutation);
+        $mutation->expects($this->once())
+            ->method('getOriginalFilePath')
+            ->willReturn('foo/bar');
 
-        $mutantProcess = new MutantProcess($process, $mutant, $adapter);
+        $this->mutant
+            ->expects($this->once())
+            ->method('getMutation')
+            ->willReturn($mutation);
 
-        $path = $mutantProcess->getOriginalFilePath();
-
-        $this->assertSame('foo/bar', $path);
+        $this->assertSame('foo/bar', $this->mutantProcess->getOriginalFilePath());
     }
 
     public function test_it_knows_its_original_starting_line(): void
     {
-        $process = $this->createMOck(Process::class);
-        $process->expects($this->never())->method($this->anything());
+        $this->process
+            ->expects($this->never())
+            ->method($this->anything());
 
-        $adapter = $this->createMock(AbstractTestFrameworkAdapter::class);
-        $adapter->expects($this->never())->method($this->anything());
+        $this->adapter
+            ->expects($this->never())
+            ->method($this->anything());
 
         $mutation = $this->createMock(MutationInterface::class);
-        $mutation->expects($this->once())->method('getAttributes')->willReturn(['startLine' => '3']);
-        $mutant = $this->createMock(MutantInterface::class);
-        $mutant->expects($this->once())->method('getMutation')->willReturn($mutation);
+        $mutation->expects($this->once())
+            ->method('getAttributes')
+            ->willReturn(['startLine' => '3']);
 
-        $mutantProcess = new MutantProcess($process, $mutant, $adapter);
+        $this->mutant
+            ->expects($this->once())
+            ->method('getMutation')
+            ->willReturn($mutation);
 
-        $line = $mutantProcess->getOriginalStartingLine();
-
-        $this->assertSame(3, $line);
+        $this->assertSame(3, $this->mutantProcess->getOriginalStartingLine());
     }
 }

--- a/tests/Process/Runner/InitialTestsRunnerTest.php
+++ b/tests/Process/Runner/InitialTestsRunnerTest.php
@@ -59,9 +59,8 @@ final class InitialTestsRunnerTest extends TestCase
     {
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
+        /** @var MockObject|Process $process */
         $process = $this->createMock(Process::class);
-        $process->expects($this->never())
-            ->method('stop');
 
         $process->expects($this->once())
             ->method('run')

--- a/tests/Process/Runner/InitialTestsRunnerTest.php
+++ b/tests/Process/Runner/InitialTestsRunnerTest.php
@@ -64,12 +64,14 @@ final class InitialTestsRunnerTest extends TestCase
 
         $process->expects($this->once())
             ->method('run')
-            ->will($this->returnCallback(function ($type) use ($process): void {
+            ->will($this->returnCallback(function ($type) use ($process) {
                 if (Process::ERR === $type) {
                     $process->stop();
                 }
 
                 $this->eventDispatcher->dispatch(new InitialTestCaseCompleted());
+
+                return 1;
             }));
 
         $processBuilder = $this->createMock(ProcessBuilder::class);

--- a/tests/Process/Runner/Parallel/ParallelProcessRunnerTest.php
+++ b/tests/Process/Runner/Parallel/ParallelProcessRunnerTest.php
@@ -40,15 +40,15 @@ use Infection\Events\MutantProcessFinished;
 use Infection\Mutant\MutantInterface;
 use Infection\Process\MutantProcessInterface;
 use Infection\Process\Runner\Parallel\ParallelProcessRunner;
-use Mockery;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 /**
  * @internal
  */
-final class ParallelProcessRunnerTest extends MockeryTestCase
+final class ParallelProcessRunnerTest extends TestCase
 {
     public function test_it_does_nothing_when_nothing_to_do(): void
     {
@@ -123,58 +123,84 @@ final class ParallelProcessRunnerTest extends MockeryTestCase
 
     private function buildEventDispatcherWithEventCount($eventCount): EventDispatcherInterface
     {
-        /** @var EventDispatcherInterface|Mockery\MockInterface $eventDispatcher */
-        $eventDispatcher = Mockery::mock(EventDispatcherInterface::class);
-        $eventDispatcher->shouldReceive('dispatch')->times($eventCount)->with(Mockery::type(MutantProcessFinished::class));
+        /** @var MockObject|EventDispatcherInterface $eventDispatcher */
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->exactly($eventCount))
+            ->method('dispatch')
+            ->with(new MutantProcessFinished($this->createMock(MutantProcessInterface::class)));
 
         return $eventDispatcher;
     }
 
     private function buildUncoveredMutantProcess(): MutantProcessInterface
     {
-        $mutant = Mockery::mock(MutantInterface::class);
-        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(false);
+        $mutant = $this->createMock(MutantInterface::class);
+        $mutant->expects($this->once())
+            ->method('isCoveredByTest')
+            ->willReturn(false);
 
-        /** @var MutantProcessFinished|Mockery\MockInterface $mutantProcess */
-        $mutantProcess = Mockery::mock(MutantProcessInterface::class);
-        $mutantProcess->shouldReceive('getMutant')->once()->andReturn($mutant);
+        /** @var MockObject|MutantProcessInterface $mutantProcess */
+        $mutantProcess = $this->createMock(MutantProcessInterface::class);
+        $mutantProcess->expects($this->once())
+            ->method('getMutant')
+            ->willReturn($mutant);
 
         return $mutantProcess;
     }
 
     private function buildCoveredMutantProcess(): MutantProcessInterface
     {
-        $process = Mockery::mock(Process::class);
-        $process->shouldReceive('start')->once();
-        $process->shouldReceive('checkTimeout')->once();
-        $process->shouldReceive('isRunning')->once()->andReturn(false);
+        $process = $this->createMock(Process::class);
+        $process->expects($this->once())
+            ->method('start');
+        $process->expects($this->once())
+            ->method('checkTimeout');
+        $process->expects($this->once())
+            ->method('isRunning')
+            ->willReturn(false);
 
-        $mutant = Mockery::mock(MutantInterface::class);
-        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
+        $mutant = $this->createMock(MutantInterface::class);
+        $mutant->expects($this->once())
+            ->method('isCoveredByTest')
+            ->willReturn(true);
 
-        /** @var MutantProcessFinished|Mockery\MockInterface $mutantProcess */
-        $mutantProcess = Mockery::mock(MutantProcessInterface::class);
-        $mutantProcess->shouldReceive('getProcess')->twice()->andReturn($process);
-        $mutantProcess->shouldReceive('getMutant')->once()->andReturn($mutant);
+        $mutantProcess = $this->createMock(MutantProcessInterface::class);
+        $mutantProcess->expects($this->exactly(2))
+            ->method('getProcess')
+            ->willReturn($process);
+        $mutantProcess->expects($this->once())
+            ->method('getMutant')
+            ->willReturn($mutant);
 
         return $mutantProcess;
     }
 
     private function buildCoveredMutantProcessWithTimeout(): MutantProcessInterface
     {
-        $process = Mockery::mock(Process::class);
-        $process->shouldReceive('start')->once();
-        $process->shouldReceive('checkTimeout')->once()->andThrow(Mockery::mock(ProcessTimedOutException::class));
-        $process->shouldReceive('isRunning')->once()->andReturn(false);
+        $process = $this->createMock(Process::class);
+        $process->expects($this->once())
+            ->method('start');
+        $process->expects($this->once())
+            ->method('checkTimeout')
+            ->will($this->throwException(new ProcessTimedOutException($process, 1)));
+        $process->expects($this->once())
+            ->method('isRunning')
+            ->willReturn(false);
 
-        $mutant = Mockery::mock(MutantInterface::class);
-        $mutant->shouldReceive('isCoveredByTest')->once()->andReturn(true);
+        $mutant = $this->createMock(MutantInterface::class);
+        $mutant->expects($this->once())
+            ->method('isCoveredByTest')
+            ->willReturn(true);
 
-        /** @var MutantProcessFinished|Mockery\MockInterface $mutantProcess */
-        $mutantProcess = Mockery::mock(MutantProcessInterface::class);
-        $mutantProcess->shouldReceive('getProcess')->twice()->andReturn($process);
-        $mutantProcess->shouldReceive('getMutant')->once()->andReturn($mutant);
-        $mutantProcess->shouldReceive('markTimeout')->once();
+        $mutantProcess = $this->createMock(MutantProcessInterface::class);
+        $mutantProcess->expects($this->exactly(2))
+            ->method('getProcess')
+            ->willReturn($process);
+        $mutantProcess->expects($this->once())
+            ->method('getMutant')
+            ->willReturn($mutant);
+        $mutantProcess->expects($this->once())
+            ->method('markTimeout');
 
         return $mutantProcess;
     }

--- a/tests/Process/Runner/Parallel/ParallelProcessRunnerTest.php
+++ b/tests/Process/Runner/Parallel/ParallelProcessRunnerTest.php
@@ -164,6 +164,7 @@ final class ParallelProcessRunnerTest extends TestCase
             ->method('isCoveredByTest')
             ->willReturn(true);
 
+        /** @var MockObject|MutantProcessInterface $mutantProcess */
         $mutantProcess = $this->createMock(MutantProcessInterface::class);
         $mutantProcess->expects($this->exactly(2))
             ->method('getProcess')
@@ -192,6 +193,7 @@ final class ParallelProcessRunnerTest extends TestCase
             ->method('isCoveredByTest')
             ->willReturn(true);
 
+        /** @var MockObject|MutantProcessInterface $mutantProcess */
         $mutantProcess = $this->createMock(MutantProcessInterface::class);
         $mutantProcess->expects($this->exactly(2))
             ->method('getProcess')

--- a/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
+++ b/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
@@ -37,21 +37,21 @@ namespace Infection\Tests\TestFramework\Coverage;
 
 use Infection\TestFramework\Coverage\CachedTestFileDataProvider;
 use Infection\TestFramework\Coverage\TestFileDataProvider;
-use Mockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class CachedTestFileDataProviderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+final class CachedTestFileDataProviderTest extends TestCase
 {
     public function test_the_second_call_returns_cached_result(): void
     {
         $class = 'Test\Class';
-        $providerMock = Mockery::mock(TestFileDataProvider::class);
-        $providerMock->shouldReceive('getTestFileInfo')
+        $providerMock = $this->createMock(TestFileDataProvider::class);
+        $providerMock->expects($this->once())
+            ->method('getTestFileInfo')
             ->with($class)
-            ->once()
-            ->andReturn(['data']);
+            ->willReturn(['data']);
 
         $infoProvider = new CachedTestFileDataProvider($providerMock);
 

--- a/tests/TestFramework/Coverage/CodeCoverageDataTest.php
+++ b/tests/TestFramework/Coverage/CodeCoverageDataTest.php
@@ -41,13 +41,13 @@ use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\TestFrameworkTypes;
-use Mockery;
 use PhpParser\Node\Scalar\LNumber;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+final class CodeCoverageDataTest extends TestCase
 {
     private $coverageDir = __DIR__ . '/../../Fixtures/Files/phpunit/coverage-xml';
 
@@ -143,7 +143,7 @@ final class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            Mockery::mock(Mutator::class),
+            $this->createMock(Mutator::class),
             ['startLine' => 1, 'endLine' => 1],
             'PHPParser\Node\Expr\BinaryOp\Plus',
             false,
@@ -163,7 +163,7 @@ final class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            Mockery::mock(Mutator::class),
+            $this->createMock(Mutator::class),
             ['startLine' => 26, 'endLine' => 26],
             'PHPParser\Node\Expr\BinaryOp\Plus',
             false,
@@ -183,7 +183,7 @@ final class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            Mockery::mock(Mutator::class),
+            $this->createMock(Mutator::class),
             ['startLine' => 1, 'endLine' => 1],
             'PHPParser\Node\Stmt\ClassMethod',
             true,
@@ -203,7 +203,7 @@ final class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            Mockery::mock(Mutator::class),
+            $this->createMock(Mutator::class),
             ['startLine' => 24, 'endLine' => 24],
             'PHPParser\Node\Stmt\ClassMethod',
             true,
@@ -217,7 +217,7 @@ final class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     public function test_it_throws_an_exception_when_no_coverage_found(): void
     {
-        $coverageXmlParserMock = Mockery::mock(CoverageXmlParser::class);
+        $coverageXmlParserMock = $this->createMock(CoverageXmlParser::class);
 
         $coverage = new CodeCoverageData('/abc/foo/bar', $coverageXmlParserMock, TestFrameworkTypes::PHPUNIT);
 
@@ -278,8 +278,10 @@ final class CodeCoverageDataTest extends Mockery\Adapter\Phpunit\MockeryTestCase
 
     private function getCodeCoverageData(): CodeCoverageData
     {
-        $coverageXmlParserMock = Mockery::mock(CoverageXmlParser::class);
-        $coverageXmlParserMock->shouldReceive('parse')->once()->andReturn($this->getParsedCodeCoverageData());
+        $coverageXmlParserMock = $this->createMock(CoverageXmlParser::class);
+        $coverageXmlParserMock->expects($this->once())
+            ->method('parse')
+            ->willReturn($this->getParsedCodeCoverageData());
 
         return new CodeCoverageData($this->coverageDir, $coverageXmlParserMock, TestFrameworkTypes::PHPUNIT);
     }

--- a/tests/TestFramework/FactoryTest.php
+++ b/tests/TestFramework/FactoryTest.php
@@ -41,24 +41,24 @@ use Infection\TestFramework\Factory;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use Infection\Utils\VersionParser;
-use Mockery;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
  */
-final class FactoryTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+final class FactoryTest extends TestCase
 {
     public function test_it_throws_an_exception_if_it_cant_find_the_testframework(): void
     {
         $factory = new Factory(
             '',
             '',
-            Mockery::mock(TestFrameworkConfigLocatorInterface::class),
+            $this->createMock(TestFrameworkConfigLocatorInterface::class),
             new XmlConfigurationHelper(new PathReplacer(new Filesystem()), ''),
             '',
             new InfectionConfig(new \stdClass(), new Filesystem(), ''),
-            Mockery::mock(VersionParser::class)
+            $this->createMock(VersionParser::class)
         );
 
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/TestFramework/PhpSpec/Adapter/PhpSpecAdapterTest.php
+++ b/tests/TestFramework/PhpSpec/Adapter/PhpSpecAdapterTest.php
@@ -41,12 +41,12 @@ use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapter;
 use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
 use Infection\Utils\VersionParser;
-use Mockery;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class PhpSpecAdapterTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+final class PhpSpecAdapterTest extends TestCase
 {
     public function test_it_has_a_name(): void
     {
@@ -127,12 +127,12 @@ OUTPUT;
 
     private function getAdapter(): PhpSpecAdapter
     {
-        $executableFined = Mockery::mock(AbstractExecutableFinder::class);
-        $initialConfigBuilder = Mockery::mock(InitialConfigBuilder::class);
-        $mutationConfigBuilder = Mockery::mock(MutationConfigBuilder::class);
-        $cliArgumentsBuilder = Mockery::mock(CommandLineArgumentsAndOptionsBuilder::class);
-        $versionParser = Mockery::mock(VersionParser::class);
-
-        return new PhpSpecAdapter($executableFined, $initialConfigBuilder, $mutationConfigBuilder, $cliArgumentsBuilder, $versionParser);
+        return new PhpSpecAdapter(
+            $this->createMock(AbstractExecutableFinder::class),
+            $this->createMock(InitialConfigBuilder::class),
+            $this->createMock(MutationConfigBuilder::class),
+            $this->createMock(CommandLineArgumentsAndOptionsBuilder::class),
+            $this->createMock(VersionParser::class)
+        );
     }
 }

--- a/tests/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
@@ -39,13 +39,13 @@ use Infection\Mutant\MutantInterface;
 use Infection\MutationInterface;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
 use Infection\Utils\TmpDirectoryCreator;
-use Mockery;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
  */
-final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+final class MutationConfigBuilderTest extends TestCase
 {
     private $tmpDir;
 
@@ -77,13 +77,17 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
         $projectDir = '/project/dir';
         $originalYamlConfigPath = __DIR__ . '/../../../../Fixtures/Files/phpspec/phpspec.yml';
 
-        $mutation = Mockery::mock(MutationInterface::class);
-        $mutation->shouldReceive('getHash')->andReturn('a1b2c3');
-        $mutation->shouldReceive('getOriginalFilePath')->andReturn('/original/file/path');
+        $mutation = $this->createMock(MutationInterface::class);
+        $mutation->method('getHash')
+            ->willReturn('a1b2c3');
+        $mutation->method('getOriginalFilePath')
+            ->willReturn('/original/file/path');
 
-        $mutant = Mockery::mock(MutantInterface::class);
-        $mutant->shouldReceive('getMutation')->andReturn($mutation);
-        $mutant->shouldReceive('getMutatedFilePath')->andReturn('/mutated/file/path');
+        $mutant = $this->createMock(MutantInterface::class);
+        $mutant->method('getMutation')
+            ->willReturn($mutation);
+        $mutant->method('getMutatedFilePath')
+            ->willReturn('/mutated/file/path');
 
         // TODO for PhpSpec pass file content as well
         // TODO test phpspec after that
@@ -97,13 +101,17 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
         $projectDir = '/project/dir';
         $originalYamlConfigPath = __DIR__ . '/../../../../Fixtures/Files/phpspec/phpspec.with.bootstrap.yml';
 
-        $mutation = Mockery::mock(MutationInterface::class);
-        $mutation->shouldReceive('getHash')->andReturn('a1b2c3');
-        $mutation->shouldReceive('getOriginalFilePath')->andReturn('/original/file/path');
+        $mutation = $this->createMock(MutationInterface::class);
+        $mutation->method('getHash')
+            ->willReturn('a1b2c3');
+        $mutation->method('getOriginalFilePath')
+            ->willReturn('/original/file/path');
 
-        $mutant = Mockery::mock(MutantInterface::class);
-        $mutant->shouldReceive('getMutation')->andReturn($mutation);
-        $mutant->shouldReceive('getMutatedFilePath')->andReturn('/mutated/file/path');
+        $mutant = $this->createMock(MutantInterface::class);
+        $mutant->method('getMutation')
+            ->willReturn($mutation);
+        $mutant->method('getMutatedFilePath')
+            ->willReturn('/mutated/file/path');
 
         $builder = new MutationConfigBuilder($this->tmpDir, $originalYamlConfigPath, $projectDir);
 

--- a/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -39,14 +39,14 @@ use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use Infection\Utils\TmpDirectoryCreator;
-use Mockery;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use function Infection\Tests\normalizePath as p;
 
 /**
  * @internal
  */
-final class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+final class InitialConfigBuilderTest extends TestCase
 {
     public const HASH = 'a1b2c3';
 
@@ -239,7 +239,7 @@ final class InitialConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTest
         yield 'PHPUnit 7.3.1 runs dependency resolver' => ['7.3.1', 'resolveDependencies', 1];
     }
 
-    protected function queryXpath(string $xml, string $query)
+    private function queryXpath(string $xml, string $query)
     {
         $dom = new \DOMDocument();
         $dom->loadXML($xml);

--- a/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -41,14 +41,14 @@ use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use Infection\Utils\TmpDirectoryCreator;
-use Mockery;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use function Infection\Tests\normalizePath as p;
 
 /**
  * @internal
  */
-final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTestCase
+final class MutationConfigBuilderTest extends TestCase
 {
     public const HASH = 'a1b2c3';
 
@@ -89,14 +89,21 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
         $projectDir = '/project/dir';
         $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit.xml';
 
-        $this->mutation = Mockery::mock(MutationInterface::class);
-        $this->mutation->shouldReceive('getHash')->andReturn(self::HASH);
-        $this->mutation->shouldReceive('getOriginalFilePath')->andReturn('/original/file/path');
+        $this->mutation = $this->createMock(MutationInterface::class);
+        $this->mutation
+            ->method('getHash')
+            ->willReturn(self::HASH);
+        $this->mutation
+            ->method('getOriginalFilePath')
+            ->willReturn('/original/file/path');
 
-        $this->mutant = Mockery::mock(MutantInterface::class);
-        $this->mutant->shouldReceive('getMutation')->andReturn($this->mutation);
-        $this->mutant->shouldReceive('getMutatedFilePath')->andReturn('/mutated/file/path');
-        $this->mutant->shouldReceive('getMutatedFileCode')->andReturn('<?php');
+        $this->mutant = $this->createMock(MutantInterface::class);
+        $this->mutant
+            ->method('getMutation')
+            ->willReturn($this->mutation);
+        $this->mutant
+            ->method('getMutatedFilePath')
+            ->willReturn('/mutated/file/path');
 
         $this->xmlConfigurationHelper = new XmlConfigurationHelper(new PathReplacer($this->fileSystem, $this->pathToProject), '');
 
@@ -115,7 +122,9 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
     public function test_it_builds_path_to_mutation_config_file(): void
     {
-        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+        $this->mutant
+            ->method('getCoverageTests')
+            ->willReturn([]);
 
         $this->assertSame(
             $this->tmpDir . '/phpunitConfiguration.a1b2c3.infection.xml',
@@ -125,7 +134,9 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
     public function test_it_sets_custom_autoloader(): void
     {
-        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+        $this->mutant
+            ->method('getCoverageTests')
+            ->willReturn([]);
 
         $configurationPath = $this->builder->build($this->mutant);
 
@@ -145,7 +156,10 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
     public function test_it_sets_custom_autoloader_when_attribute_is_absent(): void
     {
-        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+        $this->mutant
+            ->method('getCoverageTests')
+            ->willReturn([]);
+
         $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpuit_without_bootstrap.xml';
         $this->builder = new MutationConfigBuilder(
             $this->tmpDir,
@@ -172,7 +186,9 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
     public function test_it_sets_stop_on_failure_flag(): void
     {
-        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+        $this->mutant
+            ->method('getCoverageTests')
+            ->willReturn([]);
 
         $configurationPath = $this->builder->build($this->mutant);
 
@@ -185,7 +201,9 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
     public function test_it_sets_colors_flag(): void
     {
-        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+        $this->mutant
+            ->method('getCoverageTests')
+            ->willReturn([]);
 
         $configurationPath = $this->builder->build($this->mutant);
 
@@ -198,7 +216,9 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
     public function test_it_handles_root_test_suite(): void
     {
-        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+        $this->mutant
+            ->method('getCoverageTests')
+            ->willReturn([]);
 
         $phpunitXmlPath = __DIR__ . '/../../../../Fixtures/Files/phpunit/phpunit_root_test_suite.xml';
         $replacer = new PathReplacer($this->fileSystem, $this->pathToProject);
@@ -218,7 +238,9 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
     public function test_it_removes_original_loggers(): void
     {
-        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+        $this->mutant
+            ->method('getCoverageTests')
+            ->willReturn([]);
 
         $configurationPath = $this->builder->build($this->mutant);
 
@@ -230,7 +252,9 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
     public function test_it_removes_printer_class(): void
     {
-        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+        $this->mutant
+            ->method('getCoverageTests')
+            ->willReturn([]);
 
         $configurationPath = $this->builder->build($this->mutant);
 
@@ -246,7 +270,9 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
      */
     public function test_it_sets_sorted_list_of_test_files(array $coverageTests, array $expectedFiles): void
     {
-        $this->mutant->shouldReceive('getCoverageTests')->andReturn($coverageTests);
+        $this->mutant
+            ->method('getCoverageTests')
+            ->willReturn($coverageTests);
 
         $configurationPath = $this->builder->build($this->mutant);
 
@@ -264,7 +290,9 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
 
     public function test_it_removes_default_test_suite(): void
     {
-        $this->mutant->shouldReceive('getCoverageTests')->andReturn([]);
+        $this->mutant
+            ->method('getCoverageTests')
+            ->willReturn([]);
 
         $configurationPath = $this->builder->build($this->mutant);
 
@@ -333,7 +361,7 @@ final class MutationConfigBuilderTest extends Mockery\Adapter\Phpunit\MockeryTes
         ];
     }
 
-    protected function queryXpath(string $xml, string $query)
+    private function queryXpath(string $xml, string $query)
     {
         $dom = new \DOMDocument();
         $dom->loadXML($xml);


### PR DESCRIPTION
This PR removes Mockery from the dev dependencies and replaces on equivalent calls from phpunit