### PR TITLE
Run Infection only for changed files in PRs

### DIFF
--- a/.ci/travis-functions.sh
+++ b/.ci/travis-functions.sh
@@ -19,3 +19,17 @@ function xdebug-enable() {
         phpenv config-add /tmp/xdebug.ini
     fi
 }
+
+function get-infection-pr-flags() {
+    if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
+        INFECTION_PR_FLAGS="";
+    else
+        git remote set-branches --add origin $TRAVIS_BRANCH;
+        git fetch;
+
+        CHANGED_FILES=$(git diff origin/$TRAVIS_BRANCH --diff-filter=AM --name-only | grep src/ | paste -sd "," -);
+        INFECTION_PR_FLAGS="--filter=${CHANGED_FILES} --ignore-msi-with-no-mutations --only-covered --min-msi=90";
+    fi
+
+    echo $INFECTION_PR_FLAGS;
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
       - expect
 
 before_install:
-  - source .ci/xdebug.sh
+  - source .ci/travis-functions.sh
   - xdebug-disable
 
 jobs:
@@ -58,10 +58,13 @@ jobs:
           fi
         - if [[ $NO_DEBUGGER == 1 ]]; then xdebug-disable; fi
         - |
+          INFECTION_PR_FLAGS=$(get-infection-pr-flags);
+          echo "INFECTION_PR_FLAGS=$INFECTION_PR_FLAGS";
+
           if [[ $PHPDBG != 1 ]]; then
-            bin/infection $INFECTION_FLAGS;
+            bin/infection $INFECTION_FLAGS $INFECTION_PR_FLAGS;
           else
-            phpdbg -qrr bin/infection $INFECTION_FLAGS;
+            phpdbg -qrr bin/infection $INFECTION_FLAGS $INFECTION_PR_FLAGS;
           fi
 
       after_success:
@@ -126,7 +129,9 @@ jobs:
         - make build/bin/infection.phar;
         - ./tests/e2e_tests build/bin/infection.phar;
         - phpdbg -qrr $PHPUNIT_BIN
-        - phpdbg -qrr bin/infection $INFECTION_FLAGS
+        - |
+          INFECTION_PR_FLAGS=$(get-infection-pr-flags);
+          phpdbg -qrr bin/infection $INFECTION_FLAGS $INFECTION_PR_FLAGS;
 
     - stage: Deploy
       php: 7.2

--- a/src/Mutator/Arithmetic/Minus.php
+++ b/src/Mutator/Arithmetic/Minus.php
@@ -46,7 +46,6 @@ final class Minus extends Mutator
     /**
      * Replaces "-" with "+"
      *
-     *
      * @return Node\Expr\BinaryOp\Plus
      */
     public function mutate(Node $node)

--- a/src/Mutator/Arithmetic/Plus.php
+++ b/src/Mutator/Arithmetic/Plus.php
@@ -47,7 +47,6 @@ final class Plus extends Mutator
     /**
      * Replaces "+" with "-"
      *
-     *
      * @return Node\Expr\BinaryOp\Minus
      */
     public function mutate(Node $node)


### PR DESCRIPTION
During working on [the first how-to article](https://infection.github.io/guide/how-to.html#How-to-run-Infection-only-for-changed-files) in our docs, I realized that we can run Infection only for the changed files in this repository as well.

This PR brings at least the following benefits:

1. Firstly, all the new code will have the minimum MSI of `90%` (we can change this number up to `100%`). While increasing MSI for the whole project is [quite tricky](https://github.com/infection/infection/issues/344), we can easily control MSI for the changed files only. 

    When PR will contain only new files, the author will must write the proper tests without any exceptions.

    When PR will contain updated file, the author will have to update current tests in order to achieve `90%`. But, in comparison to current situation, the author of PR will have to do it only for the limited set of files that they has changed.

2. Secondly, this PR significantly reduces the build time on Travis. Let's compare the build from this branch with the recently executed build from #574:

    | Build  | Real Build Time  | Machine Build Time  |
    |---|---|---|
    |  [This branch](https://travis-ci.org/infection/infection/builds/457120502) | 20 min 56 sec  | 1 hr 11 min 57 sec  |
    |  [remove-mockery-as-dev-dependency](https://travis-ci.org/infection/infection/builds/457087662?utm_source=github_status&utm_medium=notification) | 53 min 37 sec  | 2 hrs 55 min 50 sec  |

    So its **~2.5x** faster. Each jobs takes 5-7 minutes.

3. Killing the Mutants becomes much easier just because the number of them:

    ```bash
    .: killed, M: escaped, S: uncovered, E: fatal error, T: timed out
    .......                                              (7 / 7)
    7 mutations were generated:
           7 mutants were killed
           0 mutants were not covered by tests
           0 covered mutants were not detected
           0 errors were encountered
           0 time outs were encountered
    ```
    
    Only 7 Mutants for the changed files in this PR. This will definitely help contributors killing Mutants more efficiently without reading the log file with hundreds (or thousands in our case) of mutations.

