### PR TITLE
Fix: Remove cacheResultFile attribute from phpunit.xml

### DIFF
--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -107,6 +107,7 @@ class InitialConfigBuilder implements ConfigBuilder
         $this->xmlConfigurationHelper->replaceWithAbsolutePaths($xPath);
         $this->xmlConfigurationHelper->setStopOnFailure($xPath);
         $this->xmlConfigurationHelper->deactivateColours($xPath);
+        $this->xmlConfigurationHelper->removeCacheResultFile($dom, $xPath);
         $this->xmlConfigurationHelper->removeExistingLoggers($dom, $xPath);
         $this->xmlConfigurationHelper->removeExistingPrinters($dom, $xPath);
 

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -87,6 +87,7 @@ class MutationConfigBuilder extends ConfigBuilder
         $this->xmlConfigurationHelper->replaceWithAbsolutePaths($xPath);
         $this->xmlConfigurationHelper->setStopOnFailure($xPath);
         $this->xmlConfigurationHelper->deactivateColours($xPath);
+        $this->xmlConfigurationHelper->removeCacheResultFile($dom, $xPath);
         $this->xmlConfigurationHelper->removeExistingLoggers($dom, $xPath);
         $this->xmlConfigurationHelper->removeExistingPrinters($dom, $xPath);
         $this->xmlConfigurationHelper->removeDefaultTestSuite($dom, $xPath);

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -73,6 +73,15 @@ final class XmlConfigurationHelper
         }
     }
 
+    public function removeCacheResultFile(\DOMDocument $dom, \DOMXPath $xPath): void
+    {
+        $nodeList = $xPath->query('/phpunit/@cacheResultFile');
+
+        if ($nodeList->length) {
+            $dom->documentElement->removeAttribute('cacheResultFile');
+        }
+    }
+
     public function removeExistingLoggers(\DOMDocument $dom, \DOMXPath $xPath): void
     {
         foreach ($xPath->query('/phpunit/logging') as $node) {

--- a/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -231,6 +231,34 @@ XML
         );
     }
 
+    public function test_it_removes_cache_result_file(): void
+    {
+        $dom = new \DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+        $dom->loadXML(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" cacheResultFile="phpunit.cache" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false">
+</phpunit>
+
+XML
+        );
+        $xPath = new \DOMXPath($dom);
+
+        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
+
+        $xmlconfig->removeCacheResultFile($dom, $xPath);
+
+        $this->assertSame(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false">
+</phpunit>
+
+XML
+            , $dom->saveXML()
+        );
+    }
+
     public function test_it_removes_existing_printers(): void
     {
         $dom = new \DOMDocument();


### PR DESCRIPTION
This PR:

- [x] removes the `cacheResultFile` attribute from `phpunit.xml`

Fixes #572.