### PR TITLE
Fix: Use assertXmlStringEqualsXmlString() instead of assertSame()

### DIFF
--- a/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -55,7 +55,7 @@ final class XmlConfigurationHelperTest extends TestCase
 
         $xmlconfig->replaceWithAbsolutePaths($xPath);
 
-        $this->assertSame(<<<XML
+        $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="/app/autoload2.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class">
   <testsuites>
@@ -88,7 +88,7 @@ XML
 
         $xmlconfig->removeExistingLoggers($dom, $xPath);
 
-        $this->assertSame(<<<XML
+        $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class">
   <testsuites>
@@ -118,7 +118,7 @@ XML
 
         $xmlconfig->setStopOnFailure($xPath);
 
-        $this->assertSame(<<<XML
+        $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="true">
   <testsuites>
@@ -160,7 +160,7 @@ XML
 
         $xmlconfig->setStopOnFailure($xPath);
 
-        $this->assertSame(<<<XML
+        $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="true">
 </phpunit>
@@ -179,7 +179,7 @@ XML
 
         $xmlconfig->deactivateColours($xPath);
 
-        $this->assertSame(<<<XML
+        $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" colors="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class">
   <testsuites>
@@ -221,7 +221,7 @@ XML
 
         $xmlconfig->deactivateColours($xPath);
 
-        $this->assertSame(<<<XML
+        $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false" colors="false">
 </phpunit>
@@ -249,7 +249,7 @@ XML
 
         $xmlconfig->removeCacheResultFile($dom, $xPath);
 
-        $this->assertSame(<<<XML
+        $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false">
 </phpunit>
@@ -277,7 +277,7 @@ XML
 
         $xmlconfig->removeExistingPrinters($dom, $xPath);
 
-        $this->assertSame(<<<XML
+        $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" stopOnFailure="false">
 </phpunit>
@@ -373,7 +373,7 @@ XML
 
         $xmlconfig->removeDefaultTestSuite($dom, new \DOMXPath($dom));
 
-        $this->assertSame(<<<XML
+        $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false">
 </phpunit>

--- a/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -57,23 +57,33 @@ final class XmlConfigurationHelperTest extends TestCase
 
         $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="/app/autoload2.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class">
-  <testsuites>
-    <testsuite name="Application Test Suite">
-      <directory>/*Bundle</directory>
-      <exclude>/*Bundle/Fixtures</exclude>
-    </testsuite>
-  </testsuites>
-  <filter>
-    <whitelist>
-      <directory>/src/</directory>
-    </whitelist>
-  </filter>
-  <logging>
-    <log type="coverage-html" target="/path/to/tmp"/>
-  </logging>
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="/app/autoload2.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>/*Bundle</directory>
+            <exclude>/*Bundle/Fixtures</exclude>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>/src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-html" target="/path/to/tmp"/>
+    </logging>
 </phpunit>
-
 XML
             , $dom->saveXML()
         );
@@ -90,20 +100,30 @@ XML
 
         $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class">
-  <testsuites>
-    <testsuite name="Application Test Suite">
-      <directory>./*Bundle</directory>
-      <exclude>./*Bundle/Fixtures</exclude>
-    </testsuite>
-  </testsuites>
-  <filter>
-    <whitelist>
-      <directory>src/</directory>
-    </whitelist>
-  </filter>
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>./*Bundle</directory>
+            <exclude>./*Bundle/Fixtures</exclude>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>
-
 XML
             , $dom->saveXML()
         );
@@ -120,23 +140,34 @@ XML
 
         $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="true">
-  <testsuites>
-    <testsuite name="Application Test Suite">
-      <directory>./*Bundle</directory>
-      <exclude>./*Bundle/Fixtures</exclude>
-    </testsuite>
-  </testsuites>
-  <filter>
-    <whitelist>
-      <directory>src/</directory>
-    </whitelist>
-  </filter>
-  <logging>
-    <log type="coverage-html" target="/path/to/tmp"/>
-  </logging>
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    stopOnFailure="true"
+    syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>./*Bundle</directory>
+            <exclude>./*Bundle/Fixtures</exclude>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-html" target="/path/to/tmp"/>
+    </logging>
 </phpunit>
-
 XML
             , $dom->saveXML()
         );
@@ -149,9 +180,20 @@ XML
         $dom->formatOutput = true;
         $dom->loadXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false">
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
+>
 </phpunit>
-
 XML
         );
         $xPath = new \DOMXPath($dom);
@@ -162,9 +204,20 @@ XML
 
         $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="true">
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    stopOnFailure="true"
+    syntaxCheck="false"
+>
 </phpunit>
-
 XML
             , $dom->saveXML()
         );
@@ -181,23 +234,33 @@ XML
 
         $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" colors="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class">
-  <testsuites>
-    <testsuite name="Application Test Suite">
-      <directory>./*Bundle</directory>
-      <exclude>./*Bundle/Fixtures</exclude>
-    </testsuite>
-  </testsuites>
-  <filter>
-    <whitelist>
-      <directory>src/</directory>
-    </whitelist>
-  </filter>
-  <logging>
-    <log type="coverage-html" target="/path/to/tmp"/>
-  </logging>
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    colors="false"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>./*Bundle</directory>
+            <exclude>./*Bundle/Fixtures</exclude>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-html" target="/path/to/tmp"/>
+    </logging>
 </phpunit>
-
 XML
             , $dom->saveXML()
         );
@@ -210,9 +273,19 @@ XML
         $dom->formatOutput = true;
         $dom->loadXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false">
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
+>
 </phpunit>
-
 XML
         );
         $xPath = new \DOMXPath($dom);
@@ -223,9 +296,20 @@ XML
 
         $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false" colors="false">
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    colors="false"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
+>
 </phpunit>
-
 XML
             , $dom->saveXML()
         );
@@ -238,9 +322,20 @@ XML
         $dom->formatOutput = true;
         $dom->loadXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" cacheResultFile="phpunit.cache" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false">
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    cacheResultFile="phpunit.cache"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
+>
 </phpunit>
-
 XML
         );
         $xPath = new \DOMXPath($dom);
@@ -251,9 +346,19 @@ XML
 
         $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false">
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
+>
 </phpunit>
-
 XML
             , $dom->saveXML()
         );
@@ -266,9 +371,19 @@ XML
         $dom->formatOutput = true;
         $dom->loadXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false">
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
+>
 </phpunit>
-
 XML
         );
         $xPath = new \DOMXPath($dom);
@@ -279,9 +394,18 @@ XML
 
         $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" stopOnFailure="false">
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
+>
 </phpunit>
-
 XML
             , $dom->saveXML()
         );
@@ -312,10 +436,12 @@ XML
         $dom->formatOutput = true;
         $dom->loadXML(<<<"XML"
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xsi:noNamespaceSchemaLocation="$xsdSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<phpunit
+    xsi:noNamespaceSchemaLocation="$xsdSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
     <invalid></invalid>
 </phpunit>
-
 XML
         );
         $xPath = new \DOMXPath($dom);
@@ -344,9 +470,11 @@ XML
         $dom->formatOutput = true;
         $dom->loadXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xsi:noNamespaceSchemaLocation="$xsdSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<phpunit
+    xsi:noNamespaceSchemaLocation="$xsdSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
 </phpunit>
-
 XML
         );
         $xPath = new \DOMXPath($dom);
@@ -363,9 +491,13 @@ XML
         $dom->formatOutput = true;
         $dom->loadXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false" defaultTestSuite="unit">
+<phpunit
+    defaultTestSuite="unit"
+    printerClass="Fake\Printer\Class"
+    stopOnFailure="false"
+    syntaxCheck="false"
+>
 </phpunit>
-
 XML
         );
 
@@ -375,9 +507,12 @@ XML
 
         $this->assertXmlStringEqualsXmlString(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit syntaxCheck="false" printerClass="Fake\Printer\Class" stopOnFailure="false">
+<phpunit
+    printerClass="Fake\Printer\Class"
+    stopOnFailure="false"
+    syntaxCheck="false"
+>
 </phpunit>
-
 XML
             , $dom->saveXML()
         );
@@ -402,7 +537,18 @@ XML
     {
         return <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="app/autoload2.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" printerClass="Fake\Printer\Class">
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="app/autoload2.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    syntaxCheck="false"
+>
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./*Bundle</directory>
@@ -420,7 +566,6 @@ XML
         <log type="coverage-html" target="/path/to/tmp"/>
     </logging>
 </phpunit>
-
 XML;
     }
 }


### PR DESCRIPTION
This PR

- [x] uses `assertXmlStringEqualsXmlString()` instead of `assertSame()`
- [x] formats XML strings in tests so they are easier to maintain