### PR TITLE
Guess test framework when symfony/phpunit-bridge is used

### DIFF
--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Finder;
 
 use Infection\Finder\Exception\FinderException;
+use Infection\TestFramework\TestFrameworkTypes;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -144,15 +145,22 @@ class TestFrameworkFinder extends AbstractExecutableFinder
             $this->testFrameworkName . '.phar',
         ];
 
+        if ($this->testFrameworkName === TestFrameworkTypes::PHPUNIT) {
+            $candidates[] = 'simple-phpunit.bat';
+            $candidates[] = 'simple-phpunit';
+            $candidates[] = 'simple-phpunit.phar';
+        }
+
         $finder = new ExecutableFinder();
 
+        $cwd = getcwd();
         foreach ($candidates as $name) {
-            if ($path = $finder->find($name, null, [getcwd()])) {
+            if ($path = $finder->find($name, null, [$cwd, $cwd . '/bin'])) {
                 return $path;
             }
         }
 
-        $path = $this->searchNonExecutables($candidates, [getcwd()]);
+        $path = $this->searchNonExecutables($candidates, [$cwd, $cwd . '/bin']);
 
         if (null !== $path) {
             return $path;

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -139,17 +139,17 @@ class TestFrameworkFinder extends AbstractExecutableFinder
          * file on Windows, even if there's a proper executable .bat by its side.
          * Therefore we have to explicitly look for a .bat first.
          */
-        $candidates = [
-            $this->testFrameworkName . '.bat',
-            $this->testFrameworkName,
-            $this->testFrameworkName . '.phar',
-        ];
-
         if ($this->testFrameworkName === TestFrameworkTypes::PHPUNIT) {
             $candidates[] = 'simple-phpunit.bat';
             $candidates[] = 'simple-phpunit';
             $candidates[] = 'simple-phpunit.phar';
         }
+
+        $candidates = [
+            $this->testFrameworkName . '.bat',
+            $this->testFrameworkName,
+            $this->testFrameworkName . '.phar',
+        ];
 
         $finder = new ExecutableFinder();
 

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -139,17 +139,17 @@ class TestFrameworkFinder extends AbstractExecutableFinder
          * file on Windows, even if there's a proper executable .bat by its side.
          * Therefore we have to explicitly look for a .bat first.
          */
-        if ($this->testFrameworkName === TestFrameworkTypes::PHPUNIT) {
-            $candidates[] = 'simple-phpunit.bat';
-            $candidates[] = 'simple-phpunit';
-            $candidates[] = 'simple-phpunit.phar';
-        }
-
         $candidates = [
             $this->testFrameworkName . '.bat',
             $this->testFrameworkName,
             $this->testFrameworkName . '.phar',
         ];
+
+        if ($this->testFrameworkName === TestFrameworkTypes::PHPUNIT) {
+            $candidates[] = 'simple-phpunit.bat';
+            $candidates[] = 'simple-phpunit';
+            $candidates[] = 'simple-phpunit.phar';
+        }
 
         $finder = new ExecutableFinder();
 

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -154,14 +154,15 @@ class TestFrameworkFinder extends AbstractExecutableFinder
         $finder = new ExecutableFinder();
 
         $cwd = getcwd();
+        $extraDirs = [$cwd, $cwd . '/bin'];
 
         foreach ($candidates as $name) {
-            if ($path = $finder->find($name, null, [$cwd, $cwd . '/bin'])) {
+            if ($path = $finder->find($name, null, $extraDirs)) {
                 return $path;
             }
         }
 
-        $path = $this->searchNonExecutables($candidates, [$cwd, $cwd . '/bin']);
+        $path = $this->searchNonExecutables($candidates, $extraDirs);
 
         if (null !== $path) {
             return $path;

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -154,6 +154,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
         $finder = new ExecutableFinder();
 
         $cwd = getcwd();
+
         foreach ($candidates as $name) {
             if ($path = $finder->find($name, null, [$cwd, $cwd . '/bin'])) {
                 return $path;

--- a/tests/Fixtures/e2e/SymfonyBridge/README.md
+++ b/tests/Fixtures/e2e/SymfonyBridge/README.md
@@ -1,0 +1,16 @@
+# Title
+
+https://github.com/infection/infection/issues/588
+
+## Summary
+symfony/phpunit-bridge isn't supported
+
+## Full Ticket
+A lot of symfony projects use the symfony/phpunit-bridge package instead
+of phpunit directly. This exposes simple-phpunit instead of phpunit as
+an executable in vendor/bin. When adding infection to a project it
+doesn't detect the correct executable during the config generation step.
+
+This is a common enough use case that we should either detect this
+during runtime, or help the user with a guesser during the initial
+set up.

--- a/tests/Fixtures/e2e/SymfonyBridge/README.md
+++ b/tests/Fixtures/e2e/SymfonyBridge/README.md
@@ -1,6 +1,6 @@
 # Title
 
-https://github.com/infection/infection/issues/588
+* https://github.com/infection/infection/issues/588
 
 ## Summary
 symfony/phpunit-bridge isn't supported

--- a/tests/Fixtures/e2e/SymfonyBridge/composer.json
+++ b/tests/Fixtures/e2e/SymfonyBridge/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "symfony/phpunit-bridge": "^4.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "SymfonyBridge\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SymfonyBridge\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/SymfonyBridge/expected-output.txt
+++ b/tests/Fixtures/e2e/SymfonyBridge/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/SymfonyBridge/infection.json
+++ b/tests/Fixtures/e2e/SymfonyBridge/infection.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/Fixtures/e2e/SymfonyBridge/phpunit.xml
+++ b/tests/Fixtures/e2e/SymfonyBridge/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/SymfonyBridge/phpunit.xml
+++ b/tests/Fixtures/e2e/SymfonyBridge/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.0/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
          colors="true"
 >

--- a/tests/Fixtures/e2e/SymfonyBridge/src/SourceClass.php
+++ b/tests/Fixtures/e2e/SymfonyBridge/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SymfonyBridge;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/SymfonyBridge/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/SymfonyBridge/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SymfonyBridge\Test;
+
+use SymfonyBridge\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/Fixtures/e2e/SymfonyFlex/README.md
+++ b/tests/Fixtures/e2e/SymfonyFlex/README.md
@@ -1,0 +1,9 @@
+# Title
+
+* Link to github ticket if relevant
+
+## Summary
+Short summary of the ticket
+
+## Full Ticket
+Full github ticket

--- a/tests/Fixtures/e2e/SymfonyFlex/README.md
+++ b/tests/Fixtures/e2e/SymfonyFlex/README.md
@@ -1,9 +1,15 @@
 # Title
 
-* Link to github ticket if relevant
+* https://github.com/infection/infection/issues/493
 
 ## Summary
-Short summary of the ticket
+Symfony flex should correctly detect phpunit executable
 
 ## Full Ticket
-Full github ticket
+Symfony flex has a phpunit executable located under bin/phpunit.
+Infection does not detect this yet, and will not be able to find
+the executable.
+
+This is a common enough use case that we should either detect this
+during runtime, or help the user with a guesser during the initial
+set up.

--- a/tests/Fixtures/e2e/SymfonyFlex/composer.json
+++ b/tests/Fixtures/e2e/SymfonyFlex/composer.json
@@ -1,6 +1,7 @@
 {
     "require-dev": {
-        "symfony/flex": "^1.1"
+        "symfony/flex": "^1.1",
+        "symfony/phpunit-bridge": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/SymfonyFlex/composer.json
+++ b/tests/Fixtures/e2e/SymfonyFlex/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "symfony-flex-demo/flex": "dev-master"
+    },
+    "autoload": {
+        "psr-4": {
+            "SymfonyFlex\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SymfonyFlex\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/SymfonyFlex/composer.json
+++ b/tests/Fixtures/e2e/SymfonyFlex/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "symfony-flex-demo/flex": "dev-master"
+        "symfony/flex": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/SymfonyFlex/expected-output.txt
+++ b/tests/Fixtures/e2e/SymfonyFlex/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/SymfonyFlex/infection.json
+++ b/tests/Fixtures/e2e/SymfonyFlex/infection.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/Fixtures/e2e/SymfonyFlex/phpunit.xml
+++ b/tests/Fixtures/e2e/SymfonyFlex/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/SymfonyFlex/phpunit.xml
+++ b/tests/Fixtures/e2e/SymfonyFlex/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.0/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
          colors="true"
 >

--- a/tests/Fixtures/e2e/SymfonyFlex/src/SourceClass.php
+++ b/tests/Fixtures/e2e/SymfonyFlex/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SymfonyFlex;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/SymfonyFlex/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/SymfonyFlex/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SymfonyFlex\Test;
+
+use SymfonyFlex\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds new feature Support of `symfony/phpunit-bridge` and `symfony/flex` projects.
- [x] Covered by tests
- [X] Doc PR: https://github.com/infection/site/pull/XXX

Fixes https://github.com/infection/infection/issues/493
Fixes https://github.com/infection/infection/issues/588

* find test framework for `simple-phpunit` from `symfony/phpunit-bridge` 
* added `bin/` to path, which is related to symfony flex. 