### PR TITLE
escape % characters for sprintf.

### DIFF
--- a/src/TestFramework/Coverage/CoverageDoesNotExistException.php
+++ b/src/TestFramework/Coverage/CoverageDoesNotExistException.php
@@ -48,6 +48,7 @@ final class CoverageDoesNotExistException extends InfectionException
         $message = 'Code Coverage does not exist. File %s is not found. Check %s version Infection was run with and generated config files inside %s.';
 
         if ($processInfo) {
+            $processInfo = str_replace('%', '%%', $processInfo);
             $message .= $processInfo . PHP_EOL;
         }
 

--- a/tests/TestFramework/Coverage/CoverageDoesNotExistExceptionTest.php
+++ b/tests/TestFramework/Coverage/CoverageDoesNotExistExceptionTest.php
@@ -78,4 +78,13 @@ final class CoverageDoesNotExistExceptionTest extends TestCase
 
         $this->assertSame('Source file file.php was not found at /path/to/file', $exception->getMessage());
     }
+
+    public function test_for_correctly_escaped_output_of_subprocesses(): void
+    {
+        $exception = CoverageDoesNotExistException::with('foo.xml', 'bar', '/baz', 'string with a single % and placeholders %s %d %i.');
+
+        $this->assertInstanceOf(CoverageDoesNotExistException::class, $exception);
+
+        $this->assertStringStartsWith('Code Coverage does not exist. File foo.xml is not found. Check bar version Infection was run with and generated config files inside /baz.string with a single % and placeholders %s %d %i.', $exception->getMessage());
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/620

Output of subprocesses in CoverageDoesNotExistException is now escaped for sprintf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/infection/infection/621)
<!-- Reviewable:end -->
