### PR TITLE
Test against php 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,11 @@ jobs:
       <<: *STANDARD_TEST_JOB
       php: 7.3
       env: PHPDBG=1
+    
+    -
+      <<: *STANDARD_TEST_JOB
+      php: 7.4snapshot
+      env: PHPDBG=1
 
     -
       <<: *STANDARD_TEST_JOB
@@ -148,4 +153,6 @@ jobs:
 
   allow_failures:
     - php: nightly
+      env: PHPDBG=1
+    - php: 7.4snapshot
       env: PHPDBG=1


### PR DESCRIPTION
This PR:

- [x] Runs tests on php 7.4

Master is now PHP 8.0, and we also want to test against php 7.4.

PHPDBG is used because xdebug doesn't yet support the newer versions as far as i know.

Sources: 
* https://twitter.com/nikita_ppv/status/1094897743594770433
* https://externals.io/message/103862
* https://travis-ci.community/t/add-php-7-4-branch-to-test-against/2179/3