### PR TITLE
Fix/anonymous class

### DIFF
--- a/src/Visitor/CodeCoverageClassIgnoreVisitor.php
+++ b/src/Visitor/CodeCoverageClassIgnoreVisitor.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Visitor;
 
 use PhpParser\Node;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
@@ -61,6 +60,5 @@ final class CodeCoverageClassIgnoreVisitor extends NodeVisitorAbstract
         if (strpos($docComment->getText(), '@codeCoverageIgnore') !== false) {
             return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
         }
-
     }
 }

--- a/src/Visitor/CodeCoverageClassIgnoreVisitor.php
+++ b/src/Visitor/CodeCoverageClassIgnoreVisitor.php
@@ -46,31 +46,21 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class CodeCoverageClassIgnoreVisitor extends NodeVisitorAbstract
 {
-    private $namespace;
-
     public function enterNode(Node $node)
     {
-        if ($node instanceof Stmt\Namespace_) {
-            $this->namespace = $node->name;
-        } elseif ($node instanceof Stmt\ClassLike) {
-            if (!$node->name) {
-                return null;
-            }
-
-            /** @var Name $fullyQualifiedClassName */
-            $fullyQualifiedClassName = Name::concat($this->namespace, $node->name->name);
-
-            $reflectionClass = new \ReflectionClass($fullyQualifiedClassName->toString());
-
-            $docComment = $reflectionClass->getDocComment();
-
-            if ($docComment === false) {
-                return null;
-            }
-
-            if (strpos($docComment, '@codeCoverageIgnore') !== false) {
-                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
-            }
+        if (!$node instanceof Stmt\ClassLike) {
+            return null;
         }
+
+        $docComment = $node->getDocComment();
+
+        if ($docComment === null) {
+            return null;
+        }
+
+        if (strpos($docComment->getText(), '@codeCoverageIgnore') !== false) {
+            return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+        }
+
     }
 }

--- a/src/Visitor/CodeCoverageMethodIgnoreVisitor.php
+++ b/src/Visitor/CodeCoverageMethodIgnoreVisitor.php
@@ -50,18 +50,13 @@ final class CodeCoverageMethodIgnoreVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        /** @var \ReflectionClass $reflection */
-        $reflection = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);
+        $docComment = $node->getDocComment();
 
-        $method = $reflection->getMethod($node->name->toString());
-
-        $docComment = $method->getDocComment();
-
-        if ($docComment === false) {
+        if ($docComment === null) {
             return null;
         }
 
-        if (strpos($docComment, '@codeCoverageIgnore') !== false) {
+        if (strpos($docComment->getText(), '@codeCoverageIgnore') !== false) {
             return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
         }
 

--- a/src/Visitor/ReflectionVisitor.php
+++ b/src/Visitor/ReflectionVisitor.php
@@ -74,8 +74,8 @@ final class ReflectionVisitor extends NodeVisitorAbstract
 
     public function enterNode(Node $node)
     {
-        if ($node instanceof Node\Stmt\ClassLike){
-            if(isset($node->fullyQualifiedClassName)) {
+        if ($node instanceof Node\Stmt\ClassLike) {
+            if (isset($node->fullyQualifiedClassName)) {
                 $this->classScopeStack[] = new \ReflectionClass($node->fullyQualifiedClassName->toString());
             } else {
                 // Anonymous class
@@ -84,7 +84,7 @@ final class ReflectionVisitor extends NodeVisitorAbstract
         }
 
         // No need to traverse outside of classes
-        if (count($this->classScopeStack) === 0 ) {
+        if (\count($this->classScopeStack) === 0) {
             return null;
         }
 

--- a/src/Visitor/ReflectionVisitor.php
+++ b/src/Visitor/ReflectionVisitor.php
@@ -50,7 +50,7 @@ final class ReflectionVisitor extends NodeVisitorAbstract
     public const FUNCTION_SCOPE_KEY = 'functionScope';
     public const FUNCTION_NAME = 'functionName';
 
-    private $scopeStack = [];
+    private $functionScopeStack = [];
 
     /**
      * @var \ReflectionClass|null
@@ -64,7 +64,7 @@ final class ReflectionVisitor extends NodeVisitorAbstract
 
     public function beforeTraverse(array $nodes): void
     {
-        $this->scopeStack = [];
+        $this->functionScopeStack = [];
         $this->reflectionClass = null;
         $this->methodName = null;
     }
@@ -92,11 +92,11 @@ final class ReflectionVisitor extends NodeVisitorAbstract
         }
 
         if ($this->isFunctionLikeNode($node)) {
-            $this->scopeStack[] = $node;
+            $this->functionScopeStack[] = $node;
             $node->setAttribute(self::REFLECTION_CLASS_KEY, $this->reflectionClass);
             $node->setAttribute(self::FUNCTION_NAME, $this->methodName);
         } elseif ($isInsideFunction) {
-            $node->setAttribute(self::FUNCTION_SCOPE_KEY, $this->scopeStack[\count($this->scopeStack) - 1]);
+            $node->setAttribute(self::FUNCTION_SCOPE_KEY, $this->functionScopeStack[\count($this->functionScopeStack) - 1]);
             $node->setAttribute(self::REFLECTION_CLASS_KEY, $this->reflectionClass);
             $node->setAttribute(self::FUNCTION_NAME, $this->methodName);
         }
@@ -105,7 +105,7 @@ final class ReflectionVisitor extends NodeVisitorAbstract
     public function leaveNode(Node $node): void
     {
         if ($this->isFunctionLikeNode($node)) {
-            array_pop($this->scopeStack);
+            array_pop($this->functionScopeStack);
         }
     }
 

--- a/tests/Fixtures/Autoloaded/Coverage/code-coverage-class-not-ignored-with-comment.php
+++ b/tests/Fixtures/Autoloaded/Coverage/code-coverage-class-not-ignored-with-comment.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Infection\Tests\Fixtures\Coverage;
+
+/**
+ * This class does have a comment, but is not ignored
+ */
+class NotIgnoredClassWithComment
+{
+    public function getThree(): int
+    {
+        return 1 + 2;
+    }
+}

--- a/tests/Fixtures/Autoloaded/Coverage/code-coverage-method-not-ignored-with-comment.php
+++ b/tests/Fixtures/Autoloaded/Coverage/code-coverage-method-not-ignored-with-comment.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Infection\Tests\Fixtures\Coverage;
+
+class DoNotIgnoreMethodClassWithComment
+{
+    /**
+     * @return int
+     */
+    public function getThree(): int
+    {
+        return 1 + 2;
+    }
+}

--- a/tests/Fixtures/Autoloaded/Reflection/rv-anonymous-class-inside-class.php
+++ b/tests/Fixtures/Autoloaded/Reflection/rv-anonymous-class-inside-class.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace InfectionReflectionAnonymousClass;
+
+class Bug
+{
+    public function createAnonymousClass()
+    {
+        new class
+        {
+            public function foo()
+            {
+            }
+        };
+    }
+}

--- a/tests/Fixtures/Autoloaded/Reflection/rv-inside-closure.php
+++ b/tests/Fixtures/Autoloaded/Reflection/rv-inside-closure.php
@@ -2,6 +2,13 @@
 
 namespace InfectionReflectionClosure;
 
-$f = function() {
-    return 1;
-};
+class ClassWithAnonymousFunction
+{
+    public function bar()
+    {
+        return function() {
+            return 1;
+        };
+    }
+
+}

--- a/tests/Visitor/CodeCoverageClassIgnoreVisitorTest.php
+++ b/tests/Visitor/CodeCoverageClassIgnoreVisitorTest.php
@@ -70,6 +70,15 @@ final class CodeCoverageClassIgnoreVisitorTest extends AbstractBaseVisitorTest
         $this->assertTrue($this->spyVisitor->isNodeVisited(), 'ClassMethod node has not been visited');
     }
 
+    public function test_it_travers_nodes_when_coverage_is_not_ignored_but_has_a_comment(): void
+    {
+        $code = $this->getFileContent('Coverage/code-coverage-class-not-ignored-with-comment.php');
+
+        $this->parseAndTraverse($code);
+
+        $this->assertTrue($this->spyVisitor->isNodeVisited(), 'ClassMethod node has not been visited');
+    }
+
     protected function parseAndTraverse(string $code): void
     {
         $nodes = $this->getNodes($code);

--- a/tests/Visitor/CodeCoverageMethodIgnoreVisitorTest.php
+++ b/tests/Visitor/CodeCoverageMethodIgnoreVisitorTest.php
@@ -73,6 +73,15 @@ final class CodeCoverageMethodIgnoreVisitorTest extends AbstractBaseVisitorTest
         $this->assertTrue($this->spyVisitor->isNodeVisited(), 'Node\Stmt\Return_ node has not been visited');
     }
 
+    public function test_it_travers_nodes_when_coverage_is_not_ignored_but_has_a_comment(): void
+    {
+        $code = $this->getFileContent('Coverage/code-coverage-method-not-ignored-with-comment.php');
+
+        $this->parseAndTraverse($code);
+
+        $this->assertTrue($this->spyVisitor->isNodeVisited(), 'Node\Stmt\Return_ node has not been visited');
+    }
+
     private function parseAndTraverse(string $code): void
     {
         $nodes = $this->getNodes($code);


### PR DESCRIPTION
This PR:

- [x] Fixes #616 

This is fixed in two ways:

First of all, it no longer uses reflection for the doc comments, since those are available from the parser. Secondly, to stop this from coming back in the future, it now keeps a stack of the current class, which does make mutators using the `REFLECTION_CLASS_KEY` responsible for checking if it is a valid value. 

The current uses in the public and protected mutators already do this.