### PR TITLE
Fix: Add missing callback parameter in tests

### DIFF
--- a/tests/Mutator/Unwrap/UnwrapArrayDiffUassocTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayDiffUassocTest.php
@@ -132,7 +132,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_diff_uassoc($foo->bar(), $foo->baz());
+$a = array_diff_uassoc($foo->bar(), $foo->baz(), $callback);
 PHP
             ,
             <<<'PHP'

--- a/tests/Mutator/Unwrap/UnwrapArrayDiffUkeyTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayDiffUkeyTest.php
@@ -132,7 +132,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_diff_ukey($foo->bar(), $foo->baz());
+$a = array_diff_ukey($foo->bar(), $foo->baz(), $callback);
 PHP
             ,
             <<<'PHP'

--- a/tests/Mutator/Unwrap/UnwrapArrayUdiffAssocTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayUdiffAssocTest.php
@@ -132,7 +132,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff_assoc($foo->bar(), $foo->baz());
+$a = array_udiff_assoc($foo->bar(), $foo->baz(), $callback);
 PHP
             ,
             <<<'PHP'

--- a/tests/Mutator/Unwrap/UnwrapArrayUdiffTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayUdiffTest.php
@@ -132,7 +132,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff($foo->bar(), $foo->baz());
+$a = array_udiff($foo->bar(), $foo->baz(), $callback);
 PHP
             ,
             <<<'PHP'

--- a/tests/Mutator/Unwrap/UnwrapArrayUdiffUassocTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayUdiffUassocTest.php
@@ -132,7 +132,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff_uassoc($foo->bar(), $foo->baz());
+$a = array_udiff_uassoc($foo->bar(), $foo->baz(), $value_compare_func, $key_compare_func);
 PHP
             ,
             <<<'PHP'


### PR DESCRIPTION
This PR

* [x] adds otherwise missing `$callback` parameters in tests

Follows #568.
Follows #583.
Follows #614.
Follows #623.
Follows #624.