### PR TITLE
Fix: Use consistent naming for parameters

### DIFF
--- a/tests/Mutator/Unwrap/UnwrapArrayChunkTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayChunkTest.php
@@ -106,7 +106,7 @@ PHP
             <<<'PHP'
 <?php
 
-function array_chunk($array, $size, $preserve_keys)
+function array_chunk($array, $size, $preserveKeys)
 {
 }
 PHP
@@ -174,11 +174,11 @@ $a = array_map('strtolower', ['A', 1, 'C']);
 PHP
         ];
 
-        yield 'It mutates correctly when the $preserve_keys parameter is present' => [
+        yield 'It mutates correctly when the $preserveKeys parameter is present' => [
             <<<'PHP'
 <?php
 
-$a = array_chunk(['A', 1, 'C'], 2, $preserve_keys);
+$a = array_chunk(['A', 1, 'C'], 2, $preserveKeys);
 PHP
             ,
             <<<'PHP'

--- a/tests/Mutator/Unwrap/UnwrapArrayColumnTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayColumnTest.php
@@ -106,7 +106,7 @@ PHP
             <<<'PHP'
 <?php
 
-function array_column($array, $column_key, $index_key = null)
+function array_column($array, $columnKey, $indexKey = null)
 {
 }
 PHP
@@ -174,11 +174,11 @@ $a = array_map('strtolower', [['foo' => 'bar']]);
 PHP
         ];
 
-        yield 'It mutates correctly when the $index_key parameter is present' => [
+        yield 'It mutates correctly when the $indexKey parameter is present' => [
             <<<'PHP'
 <?php
 
-$a = array_column([['foo' => 'bar']], 'foo', $index_key);
+$a = array_column([['foo' => 'bar']], 'foo', $indexKey);
 PHP
             ,
             <<<'PHP'

--- a/tests/Mutator/Unwrap/UnwrapArrayDiffUassocTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayDiffUassocTest.php
@@ -56,7 +56,7 @@ final class UnwrapArrayDiffUassocTest extends AbstractMutatorTestCase
             <<<'PHP'
 <?php
 
-$a = array_diff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = array_diff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -70,7 +70,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_diff_uassoc(\Class_With_Const::Const, ['baz' => 'bar'], $callback);
+$a = array_diff_uassoc(\Class_With_Const::Const, ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -84,7 +84,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = \array_diff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = \array_diff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -99,7 +99,7 @@ PHP
 <?php
 
 $a = ['foo' => 'bar'];
-if (array_diff_uassoc($a, ['baz' => 'bar'], $callback) === $a) {
+if (array_diff_uassoc($a, ['baz' => 'bar'], $keyCompareFunc) === $a) {
     return true;
 }
 PHP
@@ -118,7 +118,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = aRraY_dIfF_uAsSoC(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = aRraY_dIfF_uAsSoC(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -132,7 +132,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_diff_uassoc($foo->bar(), $foo->baz(), $callback);
+$a = array_diff_uassoc($foo->bar(), $foo->baz(), $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -146,7 +146,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_map('strtolower', array_diff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $callback));
+$a = array_map('strtolower', array_diff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc));
 PHP
             ,
             <<<'PHP'
@@ -160,7 +160,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_diff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $callback);
+$a = array_diff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -194,7 +194,7 @@ PHP
 
 $a = 'array_diff_uassoc';
 
-$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
         ];
     }

--- a/tests/Mutator/Unwrap/UnwrapArrayDiffUkeyTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayDiffUkeyTest.php
@@ -56,7 +56,7 @@ final class UnwrapArrayDiffUkeyTest extends AbstractMutatorTestCase
             <<<'PHP'
 <?php
 
-$a = array_diff_ukey(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = array_diff_ukey(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -70,7 +70,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_diff_ukey(\Class_With_Const::Const, ['baz' => 'bar'], $callback);
+$a = array_diff_ukey(\Class_With_Const::Const, ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -84,7 +84,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = \array_diff_ukey(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = \array_diff_ukey(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -99,7 +99,7 @@ PHP
 <?php
 
 $a = ['foo' => 'bar'];
-if (array_diff_ukey($a, ['baz' => 'bar'], $callback) === $a) {
+if (array_diff_ukey($a, ['baz' => 'bar'], $keyCompareFunc) === $a) {
     return true;
 }
 PHP
@@ -118,7 +118,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = aRrAy_DiFf_UkEy(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = aRrAy_DiFf_UkEy(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -132,7 +132,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_diff_ukey($foo->bar(), $foo->baz(), $callback);
+$a = array_diff_ukey($foo->bar(), $foo->baz(), $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -146,7 +146,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_map('strtolower', array_diff_ukey(['foo' => 'bar'], ['baz' => 'bar'], $callback));
+$a = array_map('strtolower', array_diff_ukey(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc));
 PHP
             ,
             <<<'PHP'
@@ -160,7 +160,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_diff_ukey(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $callback);
+$a = array_diff_ukey(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -194,7 +194,7 @@ PHP
 
 $a = 'array_diff_ukey';
 
-$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
         ];
     }

--- a/tests/Mutator/Unwrap/UnwrapArrayIntersectUassocTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayIntersectUassocTest.php
@@ -56,7 +56,7 @@ final class UnwrapArrayIntersectUassocTest extends AbstractMutatorTestCase
             <<<'PHP'
 <?php
 
-$a = array_intersect_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = array_intersect_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             [
@@ -78,7 +78,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_intersect_uassoc(\Class_With_Const::Const, ['baz' => 'bar'], $callback);
+$a = array_intersect_uassoc(\Class_With_Const::Const, ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             [
@@ -101,7 +101,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = \array_intersect_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = \array_intersect_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             [
@@ -125,7 +125,7 @@ PHP
 <?php
 
 $a = ['foo' => 'bar'];
-if (array_intersect_uassoc($a, ['baz' => 'bar'], $callback) === $a) {
+if (array_intersect_uassoc($a, ['baz' => 'bar'], $keyCompareFunc) === $a) {
     return true;
 }
 PHP
@@ -156,7 +156,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = aRrAy_InTeRsEcT_uAsSoc(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = aRrAy_InTeRsEcT_uAsSoc(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             [
@@ -179,7 +179,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_intersect_uassoc($foo->bar(), $foo->baz(), $callback);
+$a = array_intersect_uassoc($foo->bar(), $foo->baz(), $keyCompareFunc);
 PHP
             ,
             [
@@ -202,7 +202,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_map('strtolower', array_intersect_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $callback));
+$a = array_map('strtolower', array_intersect_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc));
 PHP
             ,
             [
@@ -225,7 +225,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_intersect_uassoc(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $callback);
+$a = array_intersect_uassoc(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $keyCompareFunc);
 PHP
             ,
             [
@@ -262,7 +262,7 @@ PHP
             <<<'PHP'
 <?php
 
-function array_intersect_uassoc($array, $array1, $key_compare_func)
+function array_intersect_uassoc($array, $array1, $keyCompareFunc)
 {
 }
 PHP
@@ -274,7 +274,7 @@ PHP
 
 $a = 'array_intersect_uassoc';
 
-$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
         ];
     }

--- a/tests/Mutator/Unwrap/UnwrapArrayIntersectUkeyTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayIntersectUkeyTest.php
@@ -56,7 +56,7 @@ final class UnwrapArrayIntersectUkeyTest extends AbstractMutatorTestCase
             <<<'PHP'
 <?php
 
-$a = array_intersect_ukey(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = array_intersect_ukey(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             [
@@ -78,7 +78,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_intersect_ukey(\Class_With_Const::Const, ['baz' => 'bar'], $callback);
+$a = array_intersect_ukey(\Class_With_Const::Const, ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             [
@@ -101,7 +101,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = \array_intersect_ukey(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = \array_intersect_ukey(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             [
@@ -125,7 +125,7 @@ PHP
 <?php
 
 $a = ['foo' => 'bar'];
-if (array_intersect_ukey($a, ['baz' => 'bar'], $callback) === $a) {
+if (array_intersect_ukey($a, ['baz' => 'bar'], $keyCompareFunc) === $a) {
     return true;
 }
 PHP
@@ -156,7 +156,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = aRrAy_InTeRsEcT_uKeY(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = aRrAy_InTeRsEcT_uKeY(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
             ,
             [
@@ -179,7 +179,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_intersect_ukey($foo->bar(), $foo->baz(), $callback);
+$a = array_intersect_ukey($foo->bar(), $foo->baz(), $keyCompareFunc);
 PHP
             ,
             [
@@ -202,7 +202,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_map('strtolower', array_intersect_ukey(['foo' => 'bar'], ['baz' => 'bar'], $callback));
+$a = array_map('strtolower', array_intersect_ukey(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc));
 PHP
             ,
             [
@@ -225,7 +225,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_intersect_ukey(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $callback);
+$a = array_intersect_ukey(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $keyCompareFunc);
 PHP
             ,
             [
@@ -262,7 +262,7 @@ PHP
             <<<'PHP'
 <?php
 
-function array_intersect_ukey($array, $array1, $key_compare_func)
+function array_intersect_ukey($array, $array1, $keyCompareFunc)
 {
 }
 PHP
@@ -274,7 +274,7 @@ PHP
 
 $a = 'array_intersect_ukey';
 
-$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $keyCompareFunc);
 PHP
         ];
     }

--- a/tests/Mutator/Unwrap/UnwrapArrayReverseTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayReverseTest.php
@@ -174,11 +174,11 @@ $a = array_map('strtolower', ['A', 1, 'C']);
 PHP
         ];
 
-        yield 'It mutates correctly when the $preserve_keys parameter is present' => [
+        yield 'It mutates correctly when the $preserveKeys parameter is present' => [
             <<<'PHP'
 <?php
 
-$a = array_reverse(['A', 1, 'C'], $preserve_keys);
+$a = array_reverse(['A', 1, 'C'], $preserveKeys);
 PHP
             ,
             <<<'PHP'

--- a/tests/Mutator/Unwrap/UnwrapArraySliceTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArraySliceTest.php
@@ -106,7 +106,7 @@ PHP
             <<<'PHP'
 <?php
 
-function array_slice($array, $offset, $length = null, $preserve_keys = null)
+function array_slice($array, $offset, $length = null, $preserveKeys = null)
 {
 }
 PHP
@@ -188,7 +188,7 @@ $a = ['foo', 'bar', 'baz'];
 PHP
         ];
 
-        yield 'It mutates correctly when the $preserve_keys parameter is present' => [
+        yield 'It mutates correctly when the $preserveKeys parameter is present' => [
             <<<'PHP'
 <?php
 

--- a/tests/Mutator/Unwrap/UnwrapArraySpliceTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArraySpliceTest.php
@@ -106,7 +106,7 @@ PHP
             <<<'PHP'
 <?php
 
-function array_splice($array, $offset, $length = null, $preserve_keys = null)
+function array_splice($array, $offset, $length = null, $preserveKeys = null)
 {
 }
 PHP

--- a/tests/Mutator/Unwrap/UnwrapArrayUdiffAssocTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayUdiffAssocTest.php
@@ -56,7 +56,7 @@ final class UnwrapArrayUdiffAssocTest extends AbstractMutatorTestCase
             <<<'PHP'
 <?php
 
-$a = array_udiff_assoc(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = array_udiff_assoc(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -70,7 +70,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff_assoc(\Class_With_Const::Const, ['baz' => 'bar'], $callback);
+$a = array_udiff_assoc(\Class_With_Const::Const, ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -84,7 +84,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = \array_udiff_assoc(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = \array_udiff_assoc(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -99,7 +99,7 @@ PHP
 <?php
 
 $a = ['foo' => 'bar'];
-if (array_udiff_assoc($a, ['baz' => 'bar'], $callback) === $a) {
+if (array_udiff_assoc($a, ['baz' => 'bar'], $valueCompareFunc) === $a) {
     return true;
 }
 PHP
@@ -118,7 +118,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = aRrAy_UdIfF_aSsOc(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = aRrAy_UdIfF_aSsOc(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -132,7 +132,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff_assoc($foo->bar(), $foo->baz(), $callback);
+$a = array_udiff_assoc($foo->bar(), $foo->baz(), $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -146,7 +146,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_map('strtolower', array_udiff_assoc(['foo' => 'bar'], ['baz' => 'bar'], $callback));
+$a = array_map('strtolower', array_udiff_assoc(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc));
 PHP
             ,
             <<<'PHP'
@@ -160,7 +160,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff_assoc(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $callback);
+$a = array_udiff_assoc(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -194,7 +194,7 @@ PHP
 
 $a = 'array_udiff_assoc';
 
-$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
         ];
     }

--- a/tests/Mutator/Unwrap/UnwrapArrayUdiffTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayUdiffTest.php
@@ -56,7 +56,7 @@ final class UnwrapArrayUdiffTest extends AbstractMutatorTestCase
             <<<'PHP'
 <?php
 
-$a = array_udiff(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = array_udiff(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -70,7 +70,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff(\Class_With_Const::Const, ['baz' => 'bar'], $callback);
+$a = array_udiff(\Class_With_Const::Const, ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -84,7 +84,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = \array_udiff(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = \array_udiff(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -99,7 +99,7 @@ PHP
 <?php
 
 $a = ['foo' => 'bar'];
-if (array_udiff($a, ['baz' => 'bar'], $callback) === $a) {
+if (array_udiff($a, ['baz' => 'bar'], $valueCompareFunc) === $a) {
     return true;
 }
 PHP
@@ -118,7 +118,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = aRrAy_UdIfF(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = aRrAy_UdIfF(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -132,7 +132,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff($foo->bar(), $foo->baz(), $callback);
+$a = array_udiff($foo->bar(), $foo->baz(), $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -146,7 +146,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_map('strtolower', array_udiff(['foo' => 'bar'], ['baz' => 'bar'], $callback));
+$a = array_map('strtolower', array_udiff(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc));
 PHP
             ,
             <<<'PHP'
@@ -160,7 +160,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $callback);
+$a = array_udiff(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $valueCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -194,7 +194,7 @@ PHP
 
 $a = 'array_udiff';
 
-$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
         ];
     }

--- a/tests/Mutator/Unwrap/UnwrapArrayUdiffUassocTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayUdiffUassocTest.php
@@ -56,7 +56,7 @@ final class UnwrapArrayUdiffUassocTest extends AbstractMutatorTestCase
             <<<'PHP'
 <?php
 
-$a = array_udiff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $value_compare_func, $key_compare_func);
+$a = array_udiff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc, $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -70,7 +70,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff_uassoc(\Class_With_Const::Const, ['baz' => 'bar'], $value_compare_func, $key_compare_func);
+$a = array_udiff_uassoc(\Class_With_Const::Const, ['baz' => 'bar'], $valueCompareFunc, $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -84,7 +84,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = \array_udiff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $value_compare_func, $key_compare_func);
+$a = \array_udiff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc, $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -99,7 +99,7 @@ PHP
 <?php
 
 $a = ['foo' => 'bar'];
-if (array_udiff_uassoc($a, ['baz' => 'bar'], $value_compare_func, $key_compare_func) === $a) {
+if (array_udiff_uassoc($a, ['baz' => 'bar'], $valueCompareFunc, $keyCompareFunc) === $a) {
     return true;
 }
 PHP
@@ -118,7 +118,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = aRrAy_UdIfF_UaSsOc(['foo' => 'bar'], ['baz' => 'bar'], $value_compare_func, $key_compare_func);
+$a = aRrAy_UdIfF_UaSsOc(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc, $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -132,7 +132,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff_uassoc($foo->bar(), $foo->baz(), $value_compare_func, $key_compare_func);
+$a = array_udiff_uassoc($foo->bar(), $foo->baz(), $valueCompareFunc, $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -146,7 +146,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_map('strtolower', array_udiff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $value_compare_func, $key_compare_func));
+$a = array_map('strtolower', array_udiff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc, $keyCompareFunc));
 PHP
             ,
             <<<'PHP'
@@ -160,7 +160,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_udiff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $value_compare_func, $key_compare_func);
+$a = array_udiff_uassoc(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $valueCompareFunc, $keyCompareFunc);
 PHP
             ,
             <<<'PHP'
@@ -194,7 +194,7 @@ PHP
 
 $a = 'array_udiff_uassoc';
 
-$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $value_compare_func, $key_compare_func);
+$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc, $keyCompareFunc);
 PHP
         ];
     }

--- a/tests/Mutator/Unwrap/UnwrapArrayUintersectAssocTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayUintersectAssocTest.php
@@ -56,7 +56,7 @@ final class UnwrapArrayUintersectAssocTest extends AbstractMutatorTestCase
             <<<'PHP'
 <?php
 
-$a = array_uintersect_assoc(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = array_uintersect_assoc(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             [
@@ -78,7 +78,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_uintersect_assoc(\Class_With_Const::Const, ['baz' => 'bar'], $callback);
+$a = array_uintersect_assoc(\Class_With_Const::Const, ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             [
@@ -101,7 +101,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = \array_uintersect_assoc(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = \array_uintersect_assoc(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             [
@@ -125,7 +125,7 @@ PHP
 <?php
 
 $a = ['foo' => 'bar'];
-if (array_uintersect_assoc($a, ['baz' => 'bar'], $callback) === $a) {
+if (array_uintersect_assoc($a, ['baz' => 'bar'], $valueCompareFunc) === $a) {
     return true;
 }
 PHP
@@ -156,7 +156,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = aRrAy_UiNtErSeCt_AsSoC(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$a = aRrAy_UiNtErSeCt_AsSoC(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
             ,
             [
@@ -179,7 +179,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_uintersect_assoc($foo->bar(), $foo->baz(), $callback);
+$a = array_uintersect_assoc($foo->bar(), $foo->baz(), $valueCompareFunc);
 PHP
             ,
             [
@@ -202,7 +202,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_map('strtolower', array_uintersect_assoc(['foo' => 'bar'], ['baz' => 'bar'], $callback));
+$a = array_map('strtolower', array_uintersect_assoc(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc));
 PHP
             ,
             [
@@ -225,7 +225,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = array_uintersect_assoc(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $callback);
+$a = array_uintersect_assoc(['foo' => 'bar'], ['baz' => 'bar'], ['qux' => 'bar'], $valueCompareFunc);
 PHP
             ,
             [
@@ -274,7 +274,7 @@ PHP
 
 $a = 'array_uintersect_assoc';
 
-$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $callback);
+$b = $a(['foo' => 'bar'], ['baz' => 'bar'], $valueCompareFunc);
 PHP
         ];
     }

--- a/tests/Mutator/Unwrap/UnwrapArrayUniqueTest.php
+++ b/tests/Mutator/Unwrap/UnwrapArrayUniqueTest.php
@@ -174,11 +174,11 @@ $a = array_map('strtolower', ['foo', 'bar', 'bar']);
 PHP
         ];
 
-        yield 'It mutates correctly when the $sort_flags parameter is present' => [
+        yield 'It mutates correctly when the $sortFlags parameter is present' => [
             <<<'PHP'
 <?php
 
-$a = array_unique(['foo', 'bar', 'bar'], $sort_flags);
+$a = array_unique(['foo', 'bar', 'bar'], $sortFlags);
 PHP
             ,
             <<<'PHP'


### PR DESCRIPTION
This PR

* [x] uses consistent naming for function parameters in `UnwrapArray*Test`s

💁‍♂️ Also see https://github.com/infection/site/pull/113.