### PR TITLE
Reduce ammount of mutators generated by changing numbers

### DIFF
--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -35,14 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Number;
 
-use Infection\Mutator\Util\Mutator;
 use Infection\Visitor\ParentConnectorVisitor;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class DecrementInteger extends Mutator
+final class DecrementInteger extends AbstractNumberMutator
 {
     private const COUNT_NAMES = ['count', 'sizeof'];
 
@@ -60,6 +59,10 @@ final class DecrementInteger extends Mutator
     protected function mutatesNode(Node $node): bool
     {
         if (!$node instanceof Node\Scalar\LNumber || $node->value === 1) {
+            return false;
+        }
+
+        if ($this->isPartOfSizeComparison($node)) {
             return false;
         }
 

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -35,13 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Number;
 
-use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class IncrementInteger extends Mutator
+final class IncrementInteger extends AbstractNumberMutator
 {
     /**
      * Increments an integer by 1
@@ -56,6 +55,8 @@ final class IncrementInteger extends Mutator
 
     protected function mutatesNode(Node $node): bool
     {
-        return $node instanceof Node\Scalar\LNumber && $node->value !== 0;
+        return $node instanceof Node\Scalar\LNumber
+            && $node->value !== 0
+            && !$this->isPartOfSizeComparison($node);
     }
 }

--- a/src/Mutator/Number/OneZeroFloat.php
+++ b/src/Mutator/Number/OneZeroFloat.php
@@ -35,13 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Number;
 
-use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class OneZeroFloat extends Mutator
+final class OneZeroFloat extends AbstractNumberMutator
 {
     /**
      * Replaces "0.0" with "1.0" or "1.0" with "0.0"
@@ -60,6 +59,9 @@ final class OneZeroFloat extends Mutator
 
     protected function mutatesNode(Node $node): bool
     {
-        return $node instanceof Node\Scalar\DNumber && ($node->value === 0.0 || $node->value === 1.0);
+        return
+            $node instanceof Node\Scalar\DNumber
+            && ($node->value === 0.0 || $node->value === 1.0)
+            && !$this->isPartOfSizeComparison($node);
     }
 }

--- a/tests/Fixtures/e2e/Exec_Path/expected-output.txt
+++ b/tests/Fixtures/e2e/Exec_Path/expected-output.txt
@@ -1,6 +1,6 @@
-Total: 9
-Killed: 7
+Total: 7
+Killed: 6
 Errored: 0
-Escaped: 1
+Escaped: 0
 Timed Out: 0
 Not Covered: 1

--- a/tests/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/Mutator/Number/DecrementIntegerTest.php
@@ -53,19 +53,11 @@ final class DecrementIntegerTest extends AbstractMutatorTestCase
     public function provideMutationCases(): array
     {
         return [
-            'It decrements an integer' => [
+            'It does not decrement an integer in a comparison' => [
                 <<<'PHP'
 <?php
 
 if ($foo < 10) {
-    echo 'bar';
-}
-PHP
-                ,
-                <<<'PHP'
-<?php
-
-if ($foo < 9) {
     echo 'bar';
 }
 PHP
@@ -75,9 +67,7 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < 1) {
-    echo 'bar';
-}
+$a = 1;
 PHP
                 ,
             ],
@@ -225,7 +215,7 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < 0) {
+if ($foo === 0) {
     echo 'bar';
 }
 PHP
@@ -233,7 +223,7 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < -1) {
+if ($foo === -1) {
     echo 'bar';
 }
 PHP
@@ -271,17 +261,13 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < 0) {
-    echo 'bar';
-}
+$a = 0;
 PHP
                 ,
                 <<<'PHP'
 <?php
 
-if ($foo < -1) {
-    echo 'bar';
-}
+$a = -1;
 PHP
                 ,
             ],
@@ -289,7 +275,7 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < -10) {
+if ($foo === -10) {
     echo 'bar';
 }
 PHP
@@ -297,7 +283,7 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < -9) {
+if ($foo === -9) {
     echo 'bar';
 }
 PHP

--- a/tests/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/Mutator/Number/IncrementIntegerTest.php
@@ -57,7 +57,7 @@ final class IncrementIntegerTest extends AbstractMutatorTestCase
                 <<<'PHP'
 <?php
 
-if ($foo < 10) {
+if ($foo === 10) {
     echo 'bar';
 }
 PHP
@@ -65,7 +65,7 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < 11) {
+if ($foo === 11) {
     echo 'bar';
 }
 PHP
@@ -85,7 +85,7 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < 1) {
+if ($foo === 1) {
     echo 'bar';
 }
 PHP
@@ -93,7 +93,7 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < 2) {
+if ($foo === 2) {
     echo 'bar';
 }
 PHP
@@ -103,7 +103,7 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < 1.0) {
+if ($foo === 1.0) {
     echo 'bar';
 }
 PHP
@@ -112,7 +112,7 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < -10) {
+if ($foo === -10) {
     echo 'bar';
 }
 PHP
@@ -120,7 +120,7 @@ PHP
                 <<<'PHP'
 <?php
 
-if ($foo < -11) {
+if ($foo === -11) {
     echo 'bar';
 }
 PHP

--- a/tests/Mutator/Number/OneZeroFloatTest.php
+++ b/tests/Mutator/Number/OneZeroFloatTest.php
@@ -114,6 +114,15 @@ PHP
 PHP
                 ,
             ],
+            'It does not mutate in a comparison' => [
+                <<<'PHP'
+<?php
+
+if ($a < 0.0) {
+    echo "small";
+}
+PHP
+            ],
         ];
     }
 }

--- a/tests/Mutator/Number/OneZeroIntegerTest.php
+++ b/tests/Mutator/Number/OneZeroIntegerTest.php
@@ -89,7 +89,7 @@ PHP
 PHP
                 ,
             ],
-            'It does not mutate float one to zer0' => [
+            'It does not mutate float one to zero' => [
                 <<<'PHP'
 <?php
 
@@ -102,6 +102,15 @@ PHP
 <?php
 
 'a' . '0';
+PHP
+            ],
+            'It does not mutate in a comparison' => [
+                <<<'PHP'
+<?php
+
+if ($a < 0) {
+    echo "small";
+}
 PHP
             ],
         ];


### PR DESCRIPTION
This PR:

- [x] Reduce ammount of mutators generated by changing numbers
- [x] Covered by tests

For infection this only reduces the amount of mutators by 5. But for applications which do a lot of comparison against numbers, this will greatly reduce the amount of duplicate mutators. Since changing the number by one is basically the same as changing the comparison operator.
