### PR TITLE
Mutator: AssignCoalesce. Upgrade PHPParser to 4.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ext-libxml": "*",
         "composer/xdebug-handler": "^1.3",
         "justinrainbow/json-schema": "^5.2",
-        "nikic/php-parser": "^4.2",
+        "nikic/php-parser": "^4.2.1",
         "ocramius/package-versions": "^1.2",
         "padraic/phar-updater": "^1.0.4",
         "pimple/pimple": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ext-libxml": "*",
         "composer/xdebug-handler": "^1.3",
         "justinrainbow/json-schema": "^5.2",
-        "nikic/php-parser": "^4.1",
+        "nikic/php-parser": "^4.2",
         "ocramius/package-versions": "^1.2",
         "padraic/phar-updater": "^1.0.4",
         "pimple/pimple": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "190efad535e3cf5eed049bcb1794f7ad",
+    "content-hash": "8af1f24b91068bfac1ba46b2a0fd55f8",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0460d05acd2ab2a660492a273f482df",
+    "content-hash": "190efad535e3cf5eed049bcb1794f7ad",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -104,7 +104,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-08-31T19:20:00+00:00"
+            "time": "2018-08-31T19:07:57+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -174,16 +174,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.1.0",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "d0230c5c77a7e3cfa69446febf340978540958c0"
+                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/d0230c5c77a7e3cfa69446febf340978540958c0",
-                "reference": "d0230c5c77a7e3cfa69446febf340978540958c0",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/5221f49a608808c1e4d436df32884cbc1b821ac0",
+                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0",
                 "shasum": ""
             },
             "require": {
@@ -199,7 +199,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -221,7 +221,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2018-10-10T09:24:14+00:00"
+            "time": "2019-02-16T20:54:15+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -325,7 +325,7 @@
                     "homepage": "http://blog.astrumfutura.com"
                 },
                 {
-                    "name": "Théo Fidry",
+                    "name": "Théo FIDRY",
                     "email": "theo.fidry@gmail.com"
                 }
             ],

--- a/src/Mutator/Operator/AssignCoalesce.php
+++ b/src/Mutator/Operator/AssignCoalesce.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017-2019, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Operator;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp\Coalesce;
+
+/**
+ * @internal
+ */
+final class AssignCoalesce extends Mutator
+{
+    /**
+     * Replaces "$array['a'] ??= 'otherValue';" with "$array['a'] = 'otherValue'"
+     *
+     * @param Coalesce $node
+     *
+     * @return Assign
+     */
+    public function mutate(Node $node)
+    {
+        return new Assign($node->var, $node->expr, $node->getAttributes());
+    }
+
+    protected function mutatesNode(Node $node): bool
+    {
+        return $node instanceof Coalesce;
+    }
+}

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -144,6 +144,7 @@ final class MutatorProfile
     ];
 
     public const OPERATOR = [
+        Mutator\Operator\AssignCoalesce::class,
         Mutator\Operator\Break_::class,
         Mutator\Operator\Coalesce::class,
         Mutator\Operator\Continue_::class,
@@ -310,6 +311,7 @@ final class MutatorProfile
         'OneZeroFloat' => Mutator\Number\OneZeroFloat::class,
 
         //Operator
+        'AssignCoalesce' => Mutator\Operator\AssignCoalesce::class,
         'Break_' => Mutator\Operator\Break_::class,
         'Continue_' => Mutator\Operator\Continue_::class,
         'Throw_' => Mutator\Operator\Throw_::class,

--- a/tests/Mutator/Operator/AssignCoalesceTest.php
+++ b/tests/Mutator/Operator/AssignCoalesceTest.php
@@ -93,5 +93,14 @@ PHP
 $a['value'] = $var;
 PHP
         ];
+
+        yield 'Does not mutate coalesce binary operator' => [
+            <<<'PHP'
+<?php
+
+$a['value'] = $foo ?? $bar;
+PHP
+            ,
+        ];
     }
 }

--- a/tests/Mutator/Operator/AssignCoalesceTest.php
+++ b/tests/Mutator/Operator/AssignCoalesceTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017-2019, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Operator;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+/**
+ * @internal
+ */
+final class AssignCoalesceTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null): void
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): \Generator
+    {
+        yield 'Mutate coalesce when right part is a scalar value' => [
+            <<<'PHP'
+<?php
+
+$a['value'] ??= 'otherValue';
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$a['value'] = 'otherValue';
+PHP
+        ];
+
+        yield 'Mutate coalesce when right part is an expression' => [
+            <<<'PHP'
+<?php
+
+$a['value'] ??= 'other' . ' Value';
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$a['value'] = 'other' . ' Value';
+PHP
+        ];
+
+        yield 'Mutate coalesce when right part is a variable' => [
+            <<<'PHP'
+<?php
+
+$a['value'] ??= $var;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$a['value'] = $var;
+PHP
+        ];
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds new mutator `AssignCoalesce`
- [x] Ugrades PHPParser to [4.2.1](https://github.com/nikic/PHP-Parser/releases/tag/v4.2.1)
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/117

See https://wiki.php.net/rfc/null_coalesce_equal_operator

Produces the following mutation:

```diff
- $this->request->data['comments']['user_id'] ??= 'value';
+ $this->request->data['comments']['user_id'] = 'value';
```