### PR TITLE
Test more versions on php 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,26 @@ jobs:
     -
       <<: *STANDARD_TEST_JOB
       php: 7.3
+
+    -
+      <<: *STANDARD_TEST_JOB
+      php: 7.3
+      env: NO_DEBUGGER=1
+
+    -
+      <<: *STANDARD_TEST_JOB
+      php: 7.3
       env: PHPDBG=1
+
+    -
+      <<: *STANDARD_TEST_JOB
+      php: 7.3
+      env: DEPS="LOW"
+
+    -
+      <<: *STANDARD_TEST_JOB
+      php: 7.3
+      env: DEPS="LOW" PHPDBG=1
     
     -
       <<: *STANDARD_TEST_JOB


### PR DESCRIPTION
This PR:

- [x] Adds extra CI runs for php 7.3.

We didn't have these initially because php 7.3 didn't have Xdebug yet.