### PR TITLE
Use new config data when Infection has been executed at the first time

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -362,10 +362,9 @@ final class InfectionCommand extends BaseCommand
             $locator->locateOneOf(InfectionConfig::POSSIBLE_CONFIG_FILE_NAMES);
         } catch (\Exception $e) {
             $configureCommand = $this->getApplication()->find('configure');
-            $config = $this->getContainer()->get('infection.config');
 
             $args = [
-                '--test-framework' => $this->input->getOption('test-framework') ?: $config->getTestFramework(),
+                '--test-framework' => $this->input->getOption('test-framework') ?: TestFrameworkTypes::PHPUNIT,
             ];
 
             $newInput = new ArrayInput($args);

--- a/src/Config/InfectionConfig.php
+++ b/src/Config/InfectionConfig.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Config;
 
+use Infection\TestFramework\TestFrameworkTypes;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -152,7 +153,7 @@ class InfectionConfig
 
     public function getTestFramework(): string
     {
-        return $this->config->testFramework ?? 'phpunit';
+        return $this->config->testFramework ?? TestFrameworkTypes::PHPUNIT;
     }
 
     public function getInitialTestsPhpOptions(): string

--- a/src/Json/JsonFile.php
+++ b/src/Json/JsonFile.php
@@ -71,6 +71,10 @@ final class JsonFile
 
     private function parse(): void
     {
+        if (!is_file($this->path)) {
+            throw ParseException::invalidJson($this->path, 'file not found');
+        }
+
         $data = json_decode((string) file_get_contents($this->path));
 
         if (null === $data && JSON_ERROR_NONE !== json_last_error()) {

--- a/tests/Fixtures/e2e/Initial_Configuration/.gitignore
+++ b/tests/Fixtures/e2e/Initial_Configuration/.gitignore
@@ -1,0 +1,1 @@
+/infection.json*

--- a/tests/Fixtures/e2e/Initial_Configuration/Initial_Configuration/SourceClass.php
+++ b/tests/Fixtures/e2e/Initial_Configuration/Initial_Configuration/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Initial_Configuration;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/Initial_Configuration/composer.json
+++ b/tests/Fixtures/e2e/Initial_Configuration/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^6.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Initial_Configuration\\": "Initial_Configuration/"
+        }
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "Initial_Configuration": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Initial_Configuration/do_configure.expect
+++ b/tests/Fixtures/e2e/Initial_Configuration/do_configure.expect
@@ -1,0 +1,28 @@
+#!/usr/bin/env expect
+set timeout 20
+eval spawn $env(INFECTION)
+
+proc configure { input value } {
+    expect $input {
+        send $value
+    } timeout {
+        send_user "Test failed\n"
+        exit 1
+    }
+}
+
+configure "directories do you want to include" "1\r"
+configure "Any directories to exclude from" "\r"
+configure "timeout in seconds" "\r"
+configure "text log file?" "\r"
+
+expect {
+    "does not exist" {
+        close
+        exit 1
+    }
+    "Please note that some mutants will inevitably be harmless"
+}
+
+send_user "\nTest succeeded!\n"
+exit 0

--- a/tests/Fixtures/e2e/Initial_Configuration/phpunit.xml
+++ b/tests/Fixtures/e2e/Initial_Configuration/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">Initial_Configuration/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Initial_Configuration/run_tests.bash
+++ b/tests/Fixtures/e2e/Initial_Configuration/run_tests.bash
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+if test ! -f "$(which expect)"; then
+    test -x $(which tput) && tput setaf 1 # red
+    echo "Please install expect; it is readily available from apt and brew"
+    exit 1;
+fi
+
+cd $(dirname $0)
+rm -v -f infection.json.dist infection.log
+
+set -e
+
+if [ "$PHPDBG" = "1" ]
+then
+    INFECTION="phpdbg -qrr ../../../../bin/infection"
+else
+    INFECTION="php ../../../../bin/infection"
+fi
+export INFECTION
+
+./do_configure.expect
+
+trap 'echo Final check failed: $(tail -n+$LINENO $0 | head -n1)' ERR
+
+test -f infection.json.dist

--- a/tests/Fixtures/e2e/Initial_Configuration/tests/Initial_Configuration_Test.php
+++ b/tests/Fixtures/e2e/Initial_Configuration/tests/Initial_Configuration_Test.php
@@ -1,0 +1,13 @@
+<?php
+
+use Initial_Configuration\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class Initial_Configuration_Test extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/Json/JsonFileTest.php
+++ b/tests/Json/JsonFileTest.php
@@ -101,6 +101,16 @@ final class JsonFileTest extends TestCase
         (new JsonFile($jsonPath))->decode();
     }
 
+    public function test_it_throws_parse_exception_when_file_is_not_found(): void
+    {
+        $jsonPath = $this->tmpDir . '/missing-invalid.json';
+        self::assertFileNotExists($jsonPath);
+
+        self::expectException(ParseException::class);
+
+        (new JsonFile($jsonPath))->decode();
+    }
+
     public function test_it_throws_schema_validation_exception(): void
     {
         $jsonString = '{"timeout": 25}';


### PR DESCRIPTION
For one, `InfectionConfig` should be using known default values, but not access the configuration file that is non-existing at the time of configuration. For another, `JsonFile` should not continue as usual even if it is given a non-existing file.

Fixes #576

Kudos to @sidz for his effort in #577 (E2E test there is not exactly correct).