### PR TITLE
Run cs-fixer

### DIFF
--- a/src/Console/LogVerbosity.php
+++ b/src/Console/LogVerbosity.php
@@ -75,7 +75,7 @@ final class LogVerbosity
             return;
         }
 
-        if (array_key_exists((int) $verbosityLevel, self::ALLOWED_OPTIONS)) {
+        if (\array_key_exists((int) $verbosityLevel, self::ALLOWED_OPTIONS)) {
             $input->setOption('log-verbosity', self::ALLOWED_OPTIONS[$verbosityLevel]);
             $io->logVerbosityDeprecationNotice(self::ALLOWED_OPTIONS[$verbosityLevel]);
 

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -81,6 +81,6 @@ final class TrueValue extends Mutator
 
         $functionName = $grandParentNode->name->toLowerString();
 
-        return array_key_exists($functionName, $resultSettings) && $resultSettings[$functionName] !== false;
+        return \array_key_exists($functionName, $resultSettings) && $resultSettings[$functionName] !== false;
     }
 }

--- a/src/Mutator/Unwrap/AbstractUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractUnwrapMutator.php
@@ -66,7 +66,7 @@ abstract class AbstractUnwrapMutator extends Mutator
         }
 
         foreach ($this->getParameterIndexes($node) as $index) {
-            if (!array_key_exists($index, $node->args)) {
+            if (!\array_key_exists($index, $node->args)) {
                 return false;
             }
         }

--- a/src/Mutator/Util/MutatorsGenerator.php
+++ b/src/Mutator/Util/MutatorsGenerator.php
@@ -74,7 +74,7 @@ final class MutatorsGenerator
         $this->mutatorList = [];
 
         foreach ($this->mutatorSettings as $mutatorOrProfile => $setting) {
-            if (array_key_exists($mutatorOrProfile, MutatorProfile::MUTATOR_PROFILE_LIST)) {
+            if (\array_key_exists($mutatorOrProfile, MutatorProfile::MUTATOR_PROFILE_LIST)) {
                 $this->registerFromProfile($mutatorOrProfile, $setting);
 
                 continue;
@@ -102,7 +102,7 @@ final class MutatorsGenerator
         $mutators = MutatorProfile::MUTATOR_PROFILE_LIST[$profile];
 
         foreach ($mutators as $mutatorOrProfile) {
-            if (array_key_exists($mutatorOrProfile, MutatorProfile::MUTATOR_PROFILE_LIST)) {
+            if (\array_key_exists($mutatorOrProfile, MutatorProfile::MUTATOR_PROFILE_LIST)) {
                 $this->registerFromProfile($mutatorOrProfile, $setting);
 
                 continue;
@@ -126,10 +126,10 @@ final class MutatorsGenerator
         if ($setting === false) {
             $this->mutatorList[$mutator] = false;
         } elseif ($setting === true) {
-            if (!array_key_exists($mutator, $this->mutatorList)) {
+            if (!\array_key_exists($mutator, $this->mutatorList)) {
                 $this->mutatorList[$mutator] = [];
             }
-        } elseif (!array_key_exists($mutator, $this->mutatorList) || !$this->mutatorList[$mutator]) {
+        } elseif (!\array_key_exists($mutator, $this->mutatorList) || !$this->mutatorList[$mutator]) {
             $this->mutatorList[$mutator] = (array) $setting;
         }
     }
@@ -141,7 +141,7 @@ final class MutatorsGenerator
      */
     private function registerFromName(string $mutator, $setting): void
     {
-        if (!array_key_exists($mutator, MutatorProfile::FULL_MUTATOR_LIST)) {
+        if (!\array_key_exists($mutator, MutatorProfile::FULL_MUTATOR_LIST)) {
             throw InvalidConfigException::invalidMutator($mutator);
         }
 

--- a/src/TestFramework/Coverage/CachedTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/CachedTestFileDataProvider.php
@@ -57,7 +57,7 @@ final class CachedTestFileDataProvider implements TestFileDataProvider
 
     public function getTestFileInfo(string $fullyQualifiedClassName): array
     {
-        if (array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
+        if (\array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
             return $this->testFileInfoCache[$fullyQualifiedClassName];
         }
 

--- a/src/TestFramework/Coverage/CodeCoverageData.php
+++ b/src/TestFramework/Coverage/CodeCoverageData.php
@@ -117,7 +117,7 @@ class CodeCoverageData
     {
         $coverage = $this->getCoverage();
 
-        if (!array_key_exists($filePath, $coverage)) {
+        if (!\array_key_exists($filePath, $coverage)) {
             return false;
         }
 
@@ -261,7 +261,7 @@ class CodeCoverageData
                 $allLines = range($coverageInfo['startLine'], $coverageInfo['endLine']);
 
                 foreach ($allLines as $lineInExecutedMethod) {
-                    if (array_key_exists($lineInExecutedMethod, $this->getCoverage()[$filePath]['byLine'])) {
+                    if (\array_key_exists($lineInExecutedMethod, $this->getCoverage()[$filePath]['byLine'])) {
                         $tests[] = $this->getCoverage()[$filePath]['byLine'][$lineInExecutedMethod];
                     }
                 }

--- a/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
@@ -65,7 +65,7 @@ abstract class AbstractYamlConfiguration
 
     protected function hasCodeCoverageExtension(array $parsedYaml): bool
     {
-        if (!array_key_exists('extensions', $parsedYaml)) {
+        if (!\array_key_exists('extensions', $parsedYaml)) {
             return false;
         }
 

--- a/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
@@ -129,7 +129,7 @@ AUTOLOAD;
      */
     private function getOriginalBootstrapFilePath(array $parsedYaml)
     {
-        if (!array_key_exists('bootstrap', $parsedYaml)) {
+        if (!\array_key_exists('bootstrap', $parsedYaml)) {
             return null;
         }
 

--- a/src/Visitor/MutatorVisitor.php
+++ b/src/Visitor/MutatorVisitor.php
@@ -59,7 +59,7 @@ final class MutatorVisitor extends NodeVisitorAbstract
     {
         $attributes = $node->getAttributes();
 
-        if (!array_key_exists('startTokenPos', $attributes)) {
+        if (!\array_key_exists('startTokenPos', $attributes)) {
             return null;
         }
 


### PR DESCRIPTION
`array_key_exists` got some optimizations in 7.4(?) so it
is now included in the settings for the `native_function_invocation` fixer
