### PR TITLE
Use parent array for coverage

### DIFF
--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -93,6 +93,11 @@ final class Mutation implements MutationInterface
      */
     private $mutationByMutatorIndex;
 
+    /**
+     * @var array|int[]
+     */
+    private $lineRange;
+
     public function __construct(
         string $originalFilePath,
         array $originalFileAst,
@@ -102,7 +107,8 @@ final class Mutation implements MutationInterface
         bool $isOnFunctionSignature,
         bool $isCoveredByTest,
         $mutatedNode,
-        int $mutationByMutatorIndex
+        int $mutationByMutatorIndex,
+        array $lineRange
     ) {
         $this->originalFilePath = $originalFilePath;
         $this->originalFileAst = $originalFileAst;
@@ -113,6 +119,7 @@ final class Mutation implements MutationInterface
         $this->isCoveredByTest = $isCoveredByTest;
         $this->mutatedNode = $mutatedNode;
         $this->mutationByMutatorIndex = $mutationByMutatorIndex;
+        $this->lineRange = $lineRange;
     }
 
     public function getMutator(): Mutator
@@ -182,5 +189,10 @@ final class Mutation implements MutationInterface
     public function getMutatedNode()
     {
         return $this->mutatedNode;
+    }
+
+    public function getLineRange(): array
+    {
+        return $this->lineRange;
     }
 }

--- a/src/MutationInterface.php
+++ b/src/MutationInterface.php
@@ -65,4 +65,6 @@ interface MutationInterface
      * @return Node|Node[] Node, array of Nodes
      */
     public function getMutatedNode();
+
+    public function getLineRange(): array;
 }

--- a/src/TestFramework/Coverage/CodeCoverageData.php
+++ b/src/TestFramework/Coverage/CodeCoverageData.php
@@ -147,7 +147,7 @@ class CodeCoverageData
     {
         $filePath = $mutation->getOriginalFilePath();
 
-        foreach ($this->linesForMutation($mutation) as $line) {
+        foreach ($mutation->getLineRange() as $line) {
             if ($this->hasExecutedMethodOnLine($filePath, $line)) {
                 yield from $this->getTestsForExecutedMethodOnLine($filePath, $line);
             }
@@ -158,24 +158,10 @@ class CodeCoverageData
     {
         $filePath = $mutation->getOriginalFilePath();
 
-        foreach ($this->linesForMutation($mutation) as $line) {
+        foreach ($mutation->getLineRange() as $line) {
             if ($this->hasTestsOnLine($filePath, $line)) {
                 yield from $this->getCoverage()[$filePath]['byLine'][$line];
             }
-        }
-    }
-
-    private function linesForMutation(MutationInterface $mutation): \Generator
-    {
-        /*
-         * If we only look for tests that cover only the very first line of our
-         * mutation, we may naturally miss other tests that may actually also
-         * cover this mutation, this all leading to false positives.
-         *
-         * Therefore we have to consider all lines of a mutation.
-         */
-        for ($line = $mutation->getAttributes()['startLine']; $line <= $mutation->getAttributes()['endLine']; ++$line) {
-            yield $line;
         }
     }
 

--- a/tests/MutationTest.php
+++ b/tests/MutationTest.php
@@ -67,7 +67,8 @@ final class MutationTest extends TestCase
             false,
             true,
             new Node\Scalar\LNumber(1),
-            0
+            0,
+            [1, 2, 3]
         );
 
         $this->assertSame('2930c05082a35248987760a81b9f9a08', $mutation->getHash());
@@ -94,7 +95,8 @@ final class MutationTest extends TestCase
             false,
             true,
             new Node\Scalar\LNumber(1),
-            0
+            0,
+            [1, 2, 3]
         );
 
         $this->assertFalse($mutation->isOnFunctionSignature());
@@ -122,9 +124,39 @@ final class MutationTest extends TestCase
             false,
             true,
             new Node\Scalar\LNumber(1),
-            0
+            0,
+            [1, 2, 3]
         );
 
         $this->assertSame($fileAst, $mutation->getOriginalFileAst());
+    }
+
+    public function test_it_correctly_sets_line_range(): void
+    {
+        $mutator = new Plus(new MutatorConfig([]));
+        $attributes = [
+            'startLine' => 3,
+            'endLine' => 5,
+            'startTokenPos' => 21,
+            'endTokenPos' => 31,
+            'startFilePos' => 43,
+            'endFilePos' => 53,
+        ];
+        $range = [21, 22, 23, 24];
+
+        $mutation = new Mutation(
+            '/abc.php',
+            ['file' => 'ast'],
+            $mutator,
+            $attributes,
+            'Interface_',
+            false,
+            true,
+            new Node\Scalar\LNumber(1),
+            0,
+            $range
+        );
+
+        $this->assertSame($range, $mutation->getLineRange());
     }
 }

--- a/tests/TestFramework/Coverage/CodeCoverageDataTest.php
+++ b/tests/TestFramework/Coverage/CodeCoverageDataTest.php
@@ -149,7 +149,8 @@ final class CodeCoverageDataTest extends TestCase
             false,
             true,
             new LNumber(1),
-            0
+            0,
+            [1]
         );
 
         $this->assertCount(0, $codeCoverageData->getAllTestsFor($mutation));
@@ -169,7 +170,8 @@ final class CodeCoverageDataTest extends TestCase
             false,
             true,
             new LNumber(1),
-            0
+            0,
+            [26]
         );
 
         $this->assertCount(2, $codeCoverageData->getAllTestsFor($mutation));
@@ -189,7 +191,8 @@ final class CodeCoverageDataTest extends TestCase
             true,
             true,
             new LNumber(1),
-            0
+            0,
+            [1]
         );
 
         $this->assertCount(0, $codeCoverageData->getAllTestsFor($mutation));
@@ -209,7 +212,8 @@ final class CodeCoverageDataTest extends TestCase
             true,
             true,
             new LNumber(1),
-            0
+            0,
+            [24]
         );
 
         $this->assertCount(6, $codeCoverageData->getAllTestsFor($mutation));

--- a/tests/Visitor/MutatorVisitorTest.php
+++ b/tests/Visitor/MutatorVisitorTest.php
@@ -121,7 +121,8 @@ PHP
                 true,
                 true,
                 new Nop(),
-                0
+                0,
+                range(29, 48)
             ),
         ];
 
@@ -170,7 +171,8 @@ PHP
                 true,
                 true,
                 new Nop(),
-                0
+                0,
+                range(29, 50)
             ),
         ];
         $badLexer = new Lexer\Emulative([
@@ -226,7 +228,8 @@ PHP
                 true,
                 true,
                 new Nop(),
-                0
+                0,
+                range(29, 48)
             ),
         ];
     }


### PR DESCRIPTION
This PR:

- [x] Handles array coverage a bit better
- [ ] Covered by tests

As shown here, array coverage is a bit wonky, and not all items are considered covered, except if function/methods are called as part of the array. 
This PR should make sure that any array is properly covered.
![image](https://user-images.githubusercontent.com/14289961/54029107-a24fe680-41a7-11e9-99c2-a141ecd2b28c.png)

It isn't properly tested, as the MutationsCollectorVisitor is a bit complex. I'll create a separate PR, to fix that up later.

Fixes https://github.com/infection/infection/issues/652