### PR TITLE
Preventing Issue Where Extra Commas Caused Infection To Ignore Filter

### DIFF
--- a/src/Finder/SourceFilesFinder.php
+++ b/src/Finder/SourceFilesFinder.php
@@ -80,7 +80,7 @@ final class SourceFilesFinder extends Finder
             return $this;
         }
 
-        $filters = explode(',', $filter);
+        $filters = array_filter(explode(',', $filter));
 
         foreach ($filters as $filter) {
             $this->filters[] = $filter;

--- a/tests/Finder/SourceFilesFinderTest.php
+++ b/tests/Finder/SourceFilesFinderTest.php
@@ -109,6 +109,32 @@ final class SourceFilesFinderTest extends TestCase
         }
     }
 
+    /**
+     * IE: --filter=1,,2,3,
+     */
+    public function test_extra_commas_in_filters(): void
+    {
+        $sourceFilesFinder = new SourceFilesFinder(['tests/Fixtures/Files/Finder'], []);
+
+        $filter = 'tests/Fixtures/Files/Finder/FirstFile.php,,tests/Fixtures/Files/Finder/SecondFile.php,';
+        $files = $sourceFilesFinder->getSourceFiles($filter);
+
+        $iterator = $files->getIterator();
+        $iterator->rewind();
+        $firstFile = $iterator->current();
+        $iterator->next();
+        $secondFile = $iterator->current();
+
+        $this->assertInstanceOf(Finder::class, $files);
+        $this->assertSame(2, $files->count());
+
+        $expectedFilenames = ['FirstFile.php', 'SecondFile.php'];
+
+        foreach ([$firstFile, $secondFile] as $file) {
+            $this->assertTrue(\in_array($file->getFilename(), $expectedFilenames, true));
+        }
+    }
+
     public function test_it_can_filter_a_list_of_files_by_filename(): void
     {
         $sourceFilesFinder = new SourceFilesFinder(['tests/Fixtures/Files/Finder'], []);


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [x] Covered by tests

While working on another PR, I came across an issue where if there extra commas (IE: Trailing) in the filter option, it would completely negate the filter and run all files. 

    infection --filter=src/Service/Mailer.php,,src/Entity/Foobar.php

This resolves that issue by filtering out any empty elements in the array.



