### PR TITLE
Adjusting Makefile To Allow Running Similar To Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PHPSTAN_URL="https://github.com/phpstan/phpstan/releases/download/0.10.3/phpstan
 TEST_TRAVIS_OPTIONS ?= false
 ifeq ($(TEST_TRAVIS_OPTIONS),false)
 else
-	FILTER_OPTIONS := --filter=$(shell git whatchanged HEAD^! --name-only | grep \.php | tr '\n' ',')
+	FILTER_OPTIONS := --filter=$(shell git diff master --name-only | grep \.php | tr '\n' ',')
 	INFECTION_TRAVIS_OPTIONS := --ignore-msi-with-no-mutations --only-covered --min-msi=90 --threads=4 --min-covered-msi=75 --log-verbosity=none $(FILTER_OPTIONS)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,16 @@ BOX_URL="https://github.com/humbug/box/releases/download/3.1.0/box.phar"
 PHP-CS-FIXER_URL="https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar"
 PHPSTAN_URL="https://github.com/phpstan/phpstan/releases/download/0.10.3/phpstan.phar"
 
+TEST_TRAVIS_OPTIONS ?= false
+ifeq ($(TEST_TRAVIS_OPTIONS),false)
+else
+	FILTER_OPTIONS := --filter=$(shell git whatchanged HEAD^! --name-only | grep \.php | tr '\n' ',')
+	INFECTION_TRAVIS_OPTIONS := --ignore-msi-with-no-mutations --only-covered --min-msi=90 --threads=4 --min-covered-msi=75 --log-verbosity=none $(FILTER_OPTIONS)
+endif
+
+INFECTION_EXTRA_OPTIONS ?= --threads=4
+INFECTION_OPTIONS ?= $(INFECTION_EXTRA_OPTIONS) $(INFECTION_TRAVIS_OPTIONS)
+
 FLOCK=./devTools/flock
 
 DOCKER_RUN=docker run -t --rm -v "$$PWD":/opt/infection -w /opt/infection
@@ -58,13 +68,13 @@ test-unit-73: build-xdebug-73
 test-infection-phpdbg: test-infection-phpdbg-71 test-infection-phpdbg-72 test-infection-phpdbg-73
 
 test-infection-phpdbg-71: build-xdebug-71
-	$(DOCKER_RUN_71) phpdbg -qrr bin/infection --threads=4
+	$(DOCKER_RUN_71) phpdbg $(PHP_OPTIONS) -qrr bin/infection $(INFECTION_OPTIONS)
 
 test-infection-phpdbg-72: build-xdebug-72
-	$(DOCKER_RUN_72) phpdbg -qrr bin/infection --threads=4
+	$(DOCKER_RUN_72) phpdbg $(PHP_OPTIONS) -qrr bin/infection $(INFECTION_OPTIONS)
 
 test-infection-phpdbg-73: build-xdebug-73
-	$(DOCKER_RUN_73) phpdbg -qrr bin/infection --threads=4
+	$(DOCKER_RUN_73) phpdbg $(PHP_OPTIONS) -qrr bin/infection $(INFECTION_OPTIONS)
 
 
 .PHONY: test-e2e-phpdbg test-e2e-phpdbg-71 test-e2e-phpdbg-72 test-e2e-phpdbg-73
@@ -86,13 +96,13 @@ test-e2e-phpdbg-73: build-xdebug-73 $(INFECTION)
 test-infection-xdebug: test-infection-xdebug-71 test-infection-xdebug-72 test-infection-xdebug-73
 
 test-infection-xdebug-71: build-xdebug-71
-	$(DOCKER_RUN_71) php bin/infection --threads=4
+	$(DOCKER_RUN_71) php $(PHP_OPTIONS) bin/infection $(INFECTION_OPTIONS)
 
 test-infection-xdebug-72: build-xdebug-72
-	$(DOCKER_RUN_72) php bin/infection --threads=4
+	$(DOCKER_RUN_72) php $(PHP_OPTIONS) bin/infection $(INFECTION_OPTIONS)
 
 test-infection-xdebug-73: build-xdebug-73
-	$(DOCKER_RUN_73) php bin/infection --threads=4
+	$(DOCKER_RUN_73) php $(PHP_OPTIONS) bin/infection $(INFECTION_OPTIONS)
 
 .PHONY: test-e2e-xdebug test-e2e-xdebug-71 test-e2e-xdebug-72 test-e2e-xdebug-73
 #e2e tests with xdebug

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TEST_TRAVIS_OPTIONS ?= false
 ifeq ($(TEST_TRAVIS_OPTIONS),false)
 else
 	FILTER_OPTIONS := --filter=$(shell git diff master --name-only | grep \.php | tr '\n' ',')
-	INFECTION_TRAVIS_OPTIONS := --ignore-msi-with-no-mutations --only-covered --min-msi=90 --threads=4 --min-covered-msi=75 --log-verbosity=none $(FILTER_OPTIONS)
+	INFECTION_TRAVIS_OPTIONS := --ignore-msi-with-no-mutations --only-covered --min-msi=90 --threads=4 --min-covered-msi=75 $(FILTER_OPTIONS)
 endif
 
 INFECTION_EXTRA_OPTIONS ?= --threads=4


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [ ] Covered by tests

While working on another MR, I was getting errors in travis and couldn't figure out the issues. Once I realized it was because of extra parameters used to run in travis, I wanted to replicate them locally so I wouldn't have to fix/push/fix/push etc, as well as get an output of the issues.

This PR adds additional options to the Makefile to allow simple access to travis mode. By running `TEST_TRAVIS_OPTIONS=true make test` (Or another other run command), make will automatically append additional options that are pretty much the same as travis would run. I also added in the PHP_OPTIONS flag to pass options to php when running. For example, I kept getting a few memory limit issues, so I can now run `PHP_OPTIONS="-d memory_limit=-1" make test` (Yes, I know about the infection config option as well, but this came in hand for other items too).