### PR TITLE
Adding Line Numbers To Mutator Ignore List

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -10,5 +10,12 @@
         "badge": {
             "branch": "master"
         }
+    },
+    "mutators": {
+        "MethodCallRemoval": {
+            "ignore": [
+                "Infection\\Finder\\SourceFilesFinder::__construct::63"
+            ]
+        }
     }
 }

--- a/src/Mutator/Util/Mutator.php
+++ b/src/Mutator/Util/Mutator.php
@@ -67,7 +67,11 @@ abstract class Mutator
             return true;
         }
 
-        return !$this->config->isIgnored($reflectionClass->getName(), $node->getAttribute(ReflectionVisitor::FUNCTION_NAME, ''));
+        return !$this->config->isIgnored(
+            $reflectionClass->getName(),
+            $node->getAttribute(ReflectionVisitor::FUNCTION_NAME, ''),
+            $node->getLine()
+        );
     }
 
     final public static function getName(): string

--- a/src/Mutator/Util/MutatorConfig.php
+++ b/src/Mutator/Util/MutatorConfig.php
@@ -56,7 +56,7 @@ final class MutatorConfig
         $this->mutatorSettings = $config['settings'] ?? [];
     }
 
-    public function isIgnored(string $class, string $method): bool
+    public function isIgnored(string $class, string $method, int $lineNumber = null): bool
     {
         if (\in_array($class, $this->ignoreConfig)) {
             return true;
@@ -67,7 +67,10 @@ final class MutatorConfig
         }
 
         foreach ($this->ignoreConfig as $ignorePattern) {
-            if (fnmatch($ignorePattern, $class, FNM_NOESCAPE) || fnmatch($ignorePattern, $class . '::' . $method, FNM_NOESCAPE)) {
+            if (fnmatch($ignorePattern, $class, FNM_NOESCAPE)
+                || fnmatch($ignorePattern, $class . '::' . $method, FNM_NOESCAPE)
+                || ($lineNumber !== null && fnmatch($ignorePattern, $class . '::' . $method . '::' . $lineNumber, FNM_NOESCAPE))
+            ) {
                 return true;
             }
         }

--- a/tests/Mutator/Util/MutatorConfigTest.php
+++ b/tests/Mutator/Util/MutatorConfigTest.php
@@ -46,11 +46,11 @@ final class MutatorConfigTest extends TestCase
     /**
      * @dataProvider providesIgnoredValues
      */
-    public function test_is_ignored_returns_true_if_there_is_a_match(array $ignored, string $class, string $method): void
+    public function test_is_ignored_returns_true_if_there_is_a_match(array $ignored, string $class, string $method, int $lineNumber = null): void
     {
         $config = new MutatorConfig(['ignore' => $ignored]);
 
-        $this->assertTrue($config->isIgnored($class, $method));
+        $this->assertTrue($config->isIgnored($class, $method, $lineNumber));
     }
 
     public function providesIgnoredValues(): \Generator
@@ -89,6 +89,13 @@ final class MutatorConfigTest extends TestCase
             ['Foo\Bar\Test::m?th?d'],
             'Foo\Bar\Test',
             'method',
+        ];
+
+        yield 'It ignores a specific line number' => [
+            ['Foo\Bar\Test::method::63'],
+            'Foo\Bar\Test',
+            'method',
+            63
         ];
     }
 

--- a/tests/Mutator/Util/MutatorConfigTest.php
+++ b/tests/Mutator/Util/MutatorConfigTest.php
@@ -95,7 +95,7 @@ final class MutatorConfigTest extends TestCase
             ['Foo\Bar\Test::method::63'],
             'Foo\Bar\Test',
             'method',
-            63
+            63,
         ];
     }
 


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/121

This started off as adding a 'falsePositives' feature to the config, but then I saw the ignore stuff in the json schema. Good to know. The only shortcoming I see is that there wasn't the ability to specify line numbers specifically. IE: Ignore this call in this function on line 123 but process call in the same function on line 456. This PR alters the logic to allow for line numbers in the search string as well.

IE:
```json
    "mutators": {
        "MethodCallRemoval": {
            "ignore": [
                "Infection\\Finder\\SourceFilesFinder::__construct::63"
            ]
        }
    }
```

Note: The config change to infection.json.dist will fix the testing in PR #660. 