### PR TITLE
Preliminary support for PCOV

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -188,6 +188,8 @@ ASCII;
             $this->consoleOutput->logRunningWithDebugger(\PHP_SAPI);
         } elseif (\extension_loaded('xdebug')) {
             $this->consoleOutput->logRunningWithDebugger('Xdebug');
+        } elseif (\extension_loaded('pcov')) {
+            $this->consoleOutput->logRunningWithDebugger('PCOV');
         }
     }
 }

--- a/src/Process/Coverage/CoverageRequirementChecker.php
+++ b/src/Process/Coverage/CoverageRequirementChecker.php
@@ -63,6 +63,7 @@ final class CoverageRequirementChecker
         return $this->skipCoverage
             || \PHP_SAPI === 'phpdbg'
             || \extension_loaded('xdebug')
+            || \extension_loaded('pcov')
             || XdebugHandler::getSkippedVersion()
             || $this->isXdebugIncludedInInitialTestPhpOptions();
     }

--- a/tests/Fixtures/e2e/PCOV_PHPUnit8/README.md
+++ b/tests/Fixtures/e2e/PCOV_PHPUnit8/README.md
@@ -1,0 +1,9 @@
+# Title
+
+* Link to github ticket if relevant
+
+## Summary
+Short summary of the ticket
+
+## Full Ticket
+Full github ticket

--- a/tests/Fixtures/e2e/PCOV_PHPUnit8/README.md
+++ b/tests/Fixtures/e2e/PCOV_PHPUnit8/README.md
@@ -1,9 +1,8 @@
-# Title
+# Test Infection with PCOV and PHPUnit 8
 
-* Link to github ticket if relevant
+https://github.com/infection/infection/issues/665
 
 ## Summary
-Short summary of the ticket
 
-## Full Ticket
-Full github ticket
+...the issue boils down to Infection not being aware of PCOV as a coverage driver.
+

--- a/tests/Fixtures/e2e/PCOV_PHPUnit8/composer.json
+++ b/tests/Fixtures/e2e/PCOV_PHPUnit8/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^8"
+    },
+    "autoload": {
+        "psr-4": {
+            "PCOV_PHPUnit8\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PCOV_PHPUnit8\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/PCOV_PHPUnit8/expected-output.txt
+++ b/tests/Fixtures/e2e/PCOV_PHPUnit8/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/PCOV_PHPUnit8/infection.json
+++ b/tests/Fixtures/e2e/PCOV_PHPUnit8/infection.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/Fixtures/e2e/PCOV_PHPUnit8/phpunit.xml.dist
+++ b/tests/Fixtures/e2e/PCOV_PHPUnit8/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/PCOV_PHPUnit8/run_tests.bash
+++ b/tests/Fixtures/e2e/PCOV_PHPUnit8/run_tests.bash
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -e
+
+tputx () {
+	test -x $(which tput) && tput "$@"
+}
+
+run () {
+    local INFECTION=${1}
+    local PHPARGS=${2}
+
+    if [ "$PHPDBG" = "1" ]
+    then
+        phpdbg $PHPARGS -qrr $INFECTION
+    else
+        php $PHPARGS $INFECTION
+    fi
+}
+
+cd $(dirname "$0")
+
+if [ "$PHPDBG" = "1" ]
+then
+    exit 0
+fi
+
+if php -r "exit(version_compare(PHP_VERSION, '7.3.0'));"
+then
+    exit 0
+fi
+
+tputx bold
+echo "Checking for PCOV..."
+tputx sgr0
+
+
+if ! php --ri pcov
+then
+    tput setaf 1 # red
+    echo "PCOV not detected"
+    exit 0
+fi
+
+readonly INFECTION=../../../../${1}
+
+set -e pipefail
+
+php $INFECTION
+
+diff -w expected-output.txt infection.log
+

--- a/tests/Fixtures/e2e/PCOV_PHPUnit8/src/SourceClass.php
+++ b/tests/Fixtures/e2e/PCOV_PHPUnit8/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PCOV_PHPUnit8;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/PCOV_PHPUnit8/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/PCOV_PHPUnit8/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PCOV_PHPUnit8\Test;
+
+use PCOV_PHPUnit8\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Add support for running Infection with PCOV (this is as easy as 1-2-3)

Fixes #665

I can verify that Infection can indeed recognize PCOV and do not fail with an error. Looks like this:

```
tests/Fixtures/e2e/PCOV_PHPUnit8$ php ../../../../bin/infection
You are running Infection with PCOV enabled.
     ____      ____          __  _
    /  _/___  / __/__  _____/ /_(_)___  ____
    / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \
  _/ // / / / __/  __/ /__/ /_/ / /_/ / / / /
 /___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/

Running initial test suite...
... and so on
```

Getting this new changes tested on CI is a bit tricky, because even though PCOV is kind of exclusive with xdebug, they both can be loaded at the same time, and it is not like PHPUnit is willing to report exactly what it is using for coverage. Extra care should be taken to be sure that PCOV does its thing, like by disabling and/or not installing xdebug in the first place. In Debian this is done by:

    sudo phpdismod -v ALL xdebug
    sudo phpenmod -v ALL pcov

PCOV is supported only under PHPUnit 8, which only works under PHP 7.2 and later, therefore if we wish to test Infection under PHP 7.1, we can't upgrade to PHPUnit 8 yet. There's [an option of pcov/clobber](https://gist.github.com/krakjoe/8272c747ed247fedbed1c25a2831f09f), but that's kind of gross in my opinion. I'd rather have a single E2E test for PCOV for time being, than to resort to pcov/clobber with no clear benefit (and it is not our job to test PCOV).