### PR TITLE
 PHPUnit 8 future-proofing on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,6 +147,17 @@ jobs:
           INFECTION_PR_FLAGS=$(get-infection-pr-flags);
           phpdbg -qrr bin/infection $INFECTION_FLAGS $INFECTION_PR_FLAGS;
 
+    - stage: PHPUnit 8 future-proofing
+      php: 7.2
+      env: PHPUNIT_BIN='vendor/bin/phpunit'
+      install:
+        - composer config --unset platform.php
+        - composer require --dev phpunit/phpunit:^8 --no-update
+        - composer update
+      script:
+        - if [[ $PHPDBG != 1 ]]; then xdebug-enable; fi
+        - if [[ $PHPDBG != 1 ]]; then $PHPUNIT_BIN; else phpdbg -qrr $PHPUNIT_BIN; fi
+
     - stage: Deploy
       php: 7.2
       install:

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -246,7 +246,7 @@ final class ProjectCodeTest extends TestCase
                     )
                 );
             }
-            $this->assertNotContains(
+            $this->assertStringNotContainsString(
                 '@internal',
                 $docBlock,
                 sprintf(
@@ -258,15 +258,14 @@ final class ProjectCodeTest extends TestCase
             return;
         }
 
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $docBlock,
             sprintf(
                 'The "%s" class is not an extension point, and should be marked as internal.',
                 $className
             )
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '@internal',
             $docBlock,
             sprintf(
@@ -389,15 +388,14 @@ final class ProjectCodeTest extends TestCase
         $rc = new \ReflectionClass($className);
         $docBlock = $rc->getDocComment();
 
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $docBlock,
             sprintf(
                 'Test class  "%s" must be marked internal.',
                 $className
             )
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '@internal',
             $rc->getDocComment(),
             sprintf(

--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -78,6 +78,10 @@ final class E2ETest extends TestCase
             $this->markTestSkipped('This test needs copious amounts of virtual memory. It will fail unless it is allowed to overcommit memory.');
         }
 
+        if (\version_compare(\PHPUnit\Runner\Version::id(), '8', '>=')) {
+            $this->markTestSkipped('Most E2E tests use an earlier version of PHPUnit, which is incompatible with PHPUnit 8 and later');
+        }
+
         // E2E tests usually require to chdir to their location
         // Hence we would need to go back to this dir
         $this->cwd = getcwd();
@@ -129,7 +133,7 @@ final class E2ETest extends TestCase
 
         $output = $this->runInfection(self::EXPECT_ERROR);
 
-        $this->assertContains(ConfigureCommand::NONINTERACTIVE_MODE_ERROR, $output);
+        $this->assertStringContainsString(ConfigureCommand::NONINTERACTIVE_MODE_ERROR, $output);
     }
 
     /**
@@ -155,7 +159,7 @@ final class E2ETest extends TestCase
                 continue;
             }
 
-            yield basename((string) $dirName) => [$dirName];
+            yield basename((string) $dirName) => [(string) $dirName];
         }
     }
 

--- a/tests/Console/LogVerbosityTest.php
+++ b/tests/Console/LogVerbosityTest.php
@@ -57,7 +57,7 @@ final class LogVerbosityTest extends TestCase
     /**
      * @dataProvider provideConvertedLogVerbosity
      */
-    public function test_it_converts_int_version_to_string_version_of_verbosity(int $input, string $output): void
+    public function test_it_converts_int_version_to_string_version_of_verbosity($input, string $output): void
     {
         $input = $this->setInputExpectationsWhenItDoesChange($input, $output);
         $io = $this->createMock(SymfonyStyle::class);

--- a/tests/Finder/Exception/FinderExceptionTest.php
+++ b/tests/Finder/Exception/FinderExceptionTest.php
@@ -48,7 +48,7 @@ final class FinderExceptionTest extends TestCase
         $exception = FinderException::composerNotFound();
 
         $this->assertInstanceOf(FinderException::class, $exception);
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Unable to locate a Composer executable on local system',
             $exception->getMessage()
         );
@@ -59,7 +59,7 @@ final class FinderExceptionTest extends TestCase
         $exception = FinderException::phpExecutableNotFound();
 
         $this->assertInstanceOf(FinderException::class, $exception);
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Unable to locate the PHP executable on the local system',
             $exception->getMessage()
         );
@@ -70,11 +70,11 @@ final class FinderExceptionTest extends TestCase
         $exception = FinderException::testFrameworkNotFound('framework');
 
         $this->assertInstanceOf(FinderException::class, $exception);
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Unable to locate a framework executable on local system.',
             $exception->getMessage()
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Ensure that framework is installed and available.',
             $exception->getMessage()
         );
@@ -85,7 +85,7 @@ final class FinderExceptionTest extends TestCase
         $exception = FinderException::testCustomPathDoesNotExist('framework', 'foo/bar/abc');
 
         $this->assertInstanceOf(FinderException::class, $exception);
-        $this->assertContains(
+        $this->assertStringContainsString(
             'The custom path to framework was set as "foo/bar/abc"',
             $exception->getMessage()
         );

--- a/tests/Finder/TestFrameworkFinderTest.php
+++ b/tests/Finder/TestFrameworkFinderTest.php
@@ -157,7 +157,7 @@ final class TestFrameworkFinderTest extends TestCase
 
         // Vendor bin should be the first item
         $pathList = explode(PATH_SEPARATOR, $pathAfterTest);
-        $this->assertContains('vendor', $pathList[0]);
+        $this->assertStringContainsString('vendor', $pathList[0]);
 
         $this->assertNotSame($path, $pathAfterTest);
 

--- a/tests/Mutator/Operator/CoalesceTest.php
+++ b/tests/Mutator/Operator/CoalesceTest.php
@@ -126,7 +126,7 @@ $foo;
 PHP
         ];
 
-        yield 'Mutate coalesce with variable as second argument' => [
+        yield 'Mutate coalesce with constants in a conditional' => [
             <<<'PHP'
 <?php
 

--- a/tests/Performance/Time/TimerTest.php
+++ b/tests/Performance/Time/TimerTest.php
@@ -58,7 +58,7 @@ final class TimerTest extends TestCase
         $this->timer->start();
         $timeInSeconds = $this->timer->stop();
 
-        $this->assertInternalType('float', $timeInSeconds);
+        $this->assertIsFloat($timeInSeconds);
         $this->assertGreaterThanOrEqual(0, $timeInSeconds);
     }
 

--- a/tests/Process/Builder/ProcessBuilderTest.php
+++ b/tests/Process/Builder/ProcessBuilderTest.php
@@ -57,7 +57,7 @@ final class ProcessBuilderTest extends TestCase
 
         $process = $builder->getProcessForInitialTestRun('', false);
 
-        $this->assertContains('/usr/bin/php', $process->getCommandLine());
+        $this->assertStringContainsString('/usr/bin/php', $process->getCommandLine());
         $this->assertNull($process->getTimeout());
     }
 
@@ -73,7 +73,7 @@ final class ProcessBuilderTest extends TestCase
 
         $process = $builder->getProcessForMutant($this->createMock(MutantInterface::class))->getProcess();
 
-        $this->assertContains('/usr/bin/php', $process->getCommandLine());
+        $this->assertStringContainsString('/usr/bin/php', $process->getCommandLine());
         $this->assertSame(100.0, $process->getTimeout());
     }
 }

--- a/tests/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/StreamWrapper/IncludeInterceptorTest.php
@@ -107,7 +107,7 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
     {
         $before = file_get_contents(self::$files[1]);
         // Sanity check
-        $this->assertContains('1', $before);
+        $this->assertStringContainsString('1', $before);
 
         IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
         IncludeInterceptor::enable();

--- a/tests/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
@@ -116,7 +116,7 @@ final class MutationConfigBuilderTest extends TestCase
         $builder = new MutationConfigBuilder($this->tmpDir, $originalYamlConfigPath, $projectDir);
 
         $this->assertSame($this->tmpDir . '/phpspecConfiguration.a1b2c3.infection.yml', $builder->build($mutant));
-        $this->assertContains(
+        $this->assertStringContainsString(
             "require_once '/project/dir/bootstrap.php';",
             file_get_contents($this->tmpDir . '/interceptor.phpspec.autoload.a1b2c3.infection.php')
         );

--- a/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -151,7 +151,7 @@ final class MutationConfigBuilderTest extends TestCase
         );
 
         $this->assertSame($expectedCustomAutoloadFilePath, $resultAutoLoaderFilePath);
-        $this->assertContains('app/autoload2.php', file_get_contents($expectedCustomAutoloadFilePath));
+        $this->assertStringContainsString('app/autoload2.php', file_get_contents($expectedCustomAutoloadFilePath));
     }
 
     public function test_it_sets_custom_autoloader_when_attribute_is_absent(): void
@@ -181,7 +181,7 @@ final class MutationConfigBuilderTest extends TestCase
         );
 
         $this->assertSame($expectedCustomAutoloadFilePath, $resultAutoLoaderFilePath);
-        $this->assertContains('vendor/autoload.php', file_get_contents($expectedCustomAutoloadFilePath));
+        $this->assertStringContainsString('vendor/autoload.php', file_get_contents($expectedCustomAutoloadFilePath));
     }
 
     public function test_it_sets_stop_on_failure_flag(): void

--- a/tests/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
@@ -58,6 +58,6 @@ final class InvalidPhpUnitXmlConfigExceptionTest extends TestCase
 
         $this->assertInstanceOf(InvalidPhpUnitXmlConfigException::class, $exception);
 
-        $this->assertContains('phpunit.xml file does not pass XSD schema validation.', $exception->getMessage());
+        $this->assertStringContainsString('phpunit.xml file does not pass XSD schema validation.', $exception->getMessage());
     }
 }


### PR DESCRIPTION
This PR addresses the following issues arising from an upgrade to PHPUnit 8:

- Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.

- assertInternalType() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertIsArray(), assertIsBool(), assertIsFloat(), assertIsInt(), assertIsNumeric(), assertIsObject(), assertIsResource(), assertIsString(), assertIsScalar(), assertIsCallable(), or assertIsIterable() instead.

- TypeError: Argument 1 passed to Infection\Tests\Console\LogVerbosityTest::test_it_converts_int_version_to_string_version_of_verbosity() must be of the type integer, string given

- The data provider specified for Infection\Tests\Mutator\Operator\CoalesceTest::test_mutator is invalid. The key "Mutate coalesce with variable as second argument" has already been defined in the data provider "provideMutationCases".

- TypeError: Argument 1 passed to Infection\Tests\Console\E2ETest::test_it_runs_an_e2e_test_with_success() must be of the type string, object given

Lastly, running E2E tests using PHPUnit 7 from within PHPUnit 8 is impossible, they have been disabled for time being for PHPUnit 8. (Autoloaded classes from PHPUnit 7 from E2E tests are not compatible, e.g.  as in *'PHP Fatal error:  Declaration of PHPUnit\Framework\Constraint\RegularExpression::matches($other) must be compatible with PHPUnit\Framework\Constraint\Constraint::matches($other): bool'*)
