### PR TITLE
Enhancement/simplify mutations collector

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
     <groups>
         <exclude>
             <group>large</group>
+            <group>e2e</group>
         </exclude>
     </groups>
 </phpunit>

--- a/src/Exception/InvalidMutatorException.php
+++ b/src/Exception/InvalidMutatorException.php
@@ -48,7 +48,7 @@ final class InvalidMutatorException extends \Exception
             sprintf(
                 'Encountered an error with the "%s" mutator in the "%s" file. ' .
                 'This is most likely a bug in Infection, so please report this in our issue tracker.',
-                $mutator::getName(),
+                $mutator->getName(),
                 $filePath
             ),
             0,

--- a/src/Exception/InvalidMutatorException.php
+++ b/src/Exception/InvalidMutatorException.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Exception;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 
 /**
  * @internal
  */
 final class InvalidMutatorException extends \Exception
 {
-    public static function create(string $filePath, Mutator $mutator, \Throwable $previous): self
+    public static function create(string $filePath, BaseMutator $mutator, \Throwable $previous): self
     {
         return new self(
             sprintf(

--- a/src/Exception/InvalidMutatorException.php
+++ b/src/Exception/InvalidMutatorException.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Exception;
 
-use Infection\Mutator\Util\BaseMutator;
+use Infection\Mutator\Util\Mutator;
 
 /**
  * @internal
  */
 final class InvalidMutatorException extends \Exception
 {
-    public static function create(string $filePath, BaseMutator $mutator, \Throwable $previous): self
+    public static function create(string $filePath, Mutator $mutator, \Throwable $previous): self
     {
         return new self(
             sprintf(

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -86,7 +86,7 @@ final class DebugFileLogger extends FileLogger
 
         foreach ($processes as $mutantProcess) {
             $logParts[] = '';
-            $logParts[] = 'Mutator: ' . $mutantProcess->getMutator()::getName();
+            $logParts[] = 'Mutator: ' . $mutantProcess->getMutator()->getName();
             $logParts[] = 'Line ' . $mutantProcess->getOriginalStartingLine();
         }
 

--- a/src/Logger/PerMutatorLogger.php
+++ b/src/Logger/PerMutatorLogger.php
@@ -79,7 +79,7 @@ final class PerMutatorLogger extends FileLogger
         $processPerMutator = [];
 
         foreach ($processes as $process) {
-            $mutatorName = $process->getMutator()::getName();
+            $mutatorName = $process->getMutator()->getName();
             $processPerMutator[$mutatorName][] = $process;
         }
 

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -103,7 +103,7 @@ final class TextFileLogger extends FileLogger
             $index + 1,
             $mutantProcess->getOriginalFilePath(),
             $mutantProcess->getOriginalStartingLine(),
-            $mutantProcess->getMutator()::getName()
+            $mutantProcess->getMutator()->getName()
         );
     }
 }

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -42,7 +42,7 @@ use Infection\Events\MutationGeneratingStarted;
 use Infection\Finder\SourceFilesFinder;
 use Infection\Mutant\Exception\ParserException;
 use Infection\Mutation;
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\Traverser\PriorityNodeTraverser;
 use Infection\Visitor\FullyQualifiedClassNameVisitor;
@@ -76,7 +76,7 @@ final class MutationsGenerator
     private $excludeDirsOrFiles;
 
     /**
-     * @var Mutator[]
+     * @var BaseMutator[]
      */
     private $mutators;
 

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -45,6 +45,7 @@ use Infection\Mutation;
 use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\Traverser\PriorityNodeTraverser;
+use Infection\Visitor\FilePathVisitor;
 use Infection\Visitor\FullyQualifiedClassNameVisitor;
 use Infection\Visitor\MutationsCollectorVisitor;
 use Infection\Visitor\NotMutableIgnoreVisitor;
@@ -159,7 +160,7 @@ final class MutationsGenerator
             $this->codeCoverageData,
             $onlyCovered
         );
-
+        $traverser->addVisitor(new FilePathVisitor($filePath), 60);
         $traverser->addVisitor(new NotMutableIgnoreVisitor(), 50);
         $traverser->addVisitor(new ParentConnectorVisitor(), 40);
         $traverser->addVisitor(new FullyQualifiedClassNameVisitor(), 30);

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -42,7 +42,7 @@ use Infection\Events\MutationGeneratingStarted;
 use Infection\Finder\SourceFilesFinder;
 use Infection\Mutant\Exception\ParserException;
 use Infection\Mutation;
-use Infection\Mutator\Util\BaseMutator;
+use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\Traverser\PriorityNodeTraverser;
 use Infection\Visitor\FullyQualifiedClassNameVisitor;
@@ -76,7 +76,7 @@ final class MutationsGenerator
     private $excludeDirsOrFiles;
 
     /**
-     * @var BaseMutator[]
+     * @var Mutator[]
      */
     private $mutators;
 

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -155,7 +155,6 @@ final class MutationsGenerator
 
         $mutationsCollectorVisitor = new MutationsCollectorVisitor(
             $this->mutators,
-            $filePath,
             $initialStatements,
             $this->codeCoverageData,
             $onlyCovered

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection;
 
-use Infection\Mutator\Util\BaseMutator;
+use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
 /**
@@ -44,7 +44,7 @@ use PhpParser\Node;
 final class Mutation implements MutationInterface
 {
     /**
-     * @var BaseMutator
+     * @var Mutator
      */
     private $mutator;
 
@@ -101,7 +101,7 @@ final class Mutation implements MutationInterface
     public function __construct(
         string $originalFilePath,
         array $originalFileAst,
-        BaseMutator $mutator,
+        Mutator $mutator,
         array $attributes,
         string $mutatedNodeClass,
         bool $isOnFunctionSignature,
@@ -122,7 +122,7 @@ final class Mutation implements MutationInterface
         $this->lineRange = $lineRange;
     }
 
-    public function getMutator(): BaseMutator
+    public function getMutator(): Mutator
     {
         return $this->mutator;
     }

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
@@ -44,7 +44,7 @@ use PhpParser\Node;
 final class Mutation implements MutationInterface
 {
     /**
-     * @var Mutator
+     * @var BaseMutator
      */
     private $mutator;
 
@@ -101,7 +101,7 @@ final class Mutation implements MutationInterface
     public function __construct(
         string $originalFilePath,
         array $originalFileAst,
-        Mutator $mutator,
+        BaseMutator $mutator,
         array $attributes,
         string $mutatedNodeClass,
         bool $isOnFunctionSignature,
@@ -122,7 +122,7 @@ final class Mutation implements MutationInterface
         $this->lineRange = $lineRange;
     }
 
-    public function getMutator(): Mutator
+    public function getMutator(): BaseMutator
     {
         return $this->mutator;
     }

--- a/src/MutationInterface.php
+++ b/src/MutationInterface.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection;
 
-use Infection\Mutator\Util\BaseMutator;
+use Infection\Mutator\Util\Mutator;
 use PhpParser\Node;
 
 /**
@@ -45,7 +45,7 @@ use PhpParser\Node;
  */
 interface MutationInterface
 {
-    public function getMutator(): BaseMutator;
+    public function getMutator(): Mutator;
 
     public function getAttributes(): array;
 

--- a/src/MutationInterface.php
+++ b/src/MutationInterface.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
@@ -45,7 +45,7 @@ use PhpParser\Node;
  */
 interface MutationInterface
 {
-    public function getMutator(): Mutator;
+    public function getMutator(): BaseMutator;
 
     public function getAttributes(): array;
 

--- a/src/Mutator/Arithmetic/Assignment.php
+++ b/src/Mutator/Arithmetic/Assignment.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Assignment extends Mutator
+final class Assignment extends BaseMutator
 {
     /**
      * Replaces "+=", "*=", ".=", and similar with a plain "="

--- a/src/Mutator/Arithmetic/AssignmentEqual.php
+++ b/src/Mutator/Arithmetic/AssignmentEqual.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class AssignmentEqual extends Mutator
+final class AssignmentEqual extends BaseMutator
 {
     /**
      * Replaces "==" with "="

--- a/src/Mutator/Arithmetic/BitwiseAnd.php
+++ b/src/Mutator/Arithmetic/BitwiseAnd.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class BitwiseAnd extends Mutator
+final class BitwiseAnd extends BaseMutator
 {
     /**
      * Replaces "&" with "|"

--- a/src/Mutator/Arithmetic/BitwiseNot.php
+++ b/src/Mutator/Arithmetic/BitwiseNot.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class BitwiseNot extends Mutator
+final class BitwiseNot extends BaseMutator
 {
     /**
      * Replaces "~" with "" (removed)

--- a/src/Mutator/Arithmetic/BitwiseOr.php
+++ b/src/Mutator/Arithmetic/BitwiseOr.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class BitwiseOr extends Mutator
+final class BitwiseOr extends BaseMutator
 {
     /**
      * Replaces "|" with "&"

--- a/src/Mutator/Arithmetic/BitwiseXor.php
+++ b/src/Mutator/Arithmetic/BitwiseXor.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class BitwiseXor extends Mutator
+final class BitwiseXor extends BaseMutator
 {
     /**
      * Replaces "^" with "&"

--- a/src/Mutator/Arithmetic/Decrement.php
+++ b/src/Mutator/Arithmetic/Decrement.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 use PhpParser\Node\Expr\PostDec;
 use PhpParser\Node\Expr\PostInc;
@@ -45,7 +45,7 @@ use PhpParser\Node\Expr\PreInc;
 /**
  * @internal
  */
-final class Decrement extends Mutator
+final class Decrement extends BaseMutator
 {
     /**
      * Replaces "--" with "++"

--- a/src/Mutator/Arithmetic/DivEqual.php
+++ b/src/Mutator/Arithmetic/DivEqual.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class DivEqual extends Mutator
+final class DivEqual extends BaseMutator
 {
     /**
      * Replaces "/=" with "*="

--- a/src/Mutator/Arithmetic/Division.php
+++ b/src/Mutator/Arithmetic/Division.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Division extends Mutator
+final class Division extends BaseMutator
 {
     /**
      * Replaces "/" with "*"

--- a/src/Mutator/Arithmetic/Exponentiation.php
+++ b/src/Mutator/Arithmetic/Exponentiation.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Exponentiation extends Mutator
+final class Exponentiation extends BaseMutator
 {
     /**
      * Replaces "**" with "/"

--- a/src/Mutator/Arithmetic/Increment.php
+++ b/src/Mutator/Arithmetic/Increment.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 use PhpParser\Node\Expr\PostDec;
 use PhpParser\Node\Expr\PostInc;
@@ -45,7 +45,7 @@ use PhpParser\Node\Expr\PreInc;
 /**
  * @internal
  */
-final class Increment extends Mutator
+final class Increment extends BaseMutator
 {
     /**
      * Replaces "++" with "--"

--- a/src/Mutator/Arithmetic/Minus.php
+++ b/src/Mutator/Arithmetic/Minus.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Minus extends Mutator
+final class Minus extends BaseMutator
 {
     /**
      * Replaces "-" with "+"

--- a/src/Mutator/Arithmetic/MinusEqual.php
+++ b/src/Mutator/Arithmetic/MinusEqual.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class MinusEqual extends Mutator
+final class MinusEqual extends BaseMutator
 {
     /**
      * Replaces "-=" with "+="

--- a/src/Mutator/Arithmetic/ModEqual.php
+++ b/src/Mutator/Arithmetic/ModEqual.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class ModEqual extends Mutator
+final class ModEqual extends BaseMutator
 {
     /**
      * Replaces "%=" with "*="

--- a/src/Mutator/Arithmetic/Modulus.php
+++ b/src/Mutator/Arithmetic/Modulus.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Modulus extends Mutator
+final class Modulus extends BaseMutator
 {
     /**
      * Replaces "%" with "*"

--- a/src/Mutator/Arithmetic/MulEqual.php
+++ b/src/Mutator/Arithmetic/MulEqual.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class MulEqual extends Mutator
+final class MulEqual extends BaseMutator
 {
     /**
      * Replaces "*=" with "/="

--- a/src/Mutator/Arithmetic/Multiplication.php
+++ b/src/Mutator/Arithmetic/Multiplication.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Multiplication extends Mutator
+final class Multiplication extends BaseMutator
 {
     /**
      * Replaces "*" with "/"

--- a/src/Mutator/Arithmetic/Plus.php
+++ b/src/Mutator/Arithmetic/Plus.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 
 /**
  * @internal
  */
-final class Plus extends Mutator
+final class Plus extends BaseMutator
 {
     /**
      * Replaces "+" with "-"

--- a/src/Mutator/Arithmetic/PlusEqual.php
+++ b/src/Mutator/Arithmetic/PlusEqual.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class PlusEqual extends Mutator
+final class PlusEqual extends BaseMutator
 {
     /**
      * Replaces "+=" with "-="

--- a/src/Mutator/Arithmetic/PowEqual.php
+++ b/src/Mutator/Arithmetic/PowEqual.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class PowEqual extends Mutator
+final class PowEqual extends BaseMutator
 {
     /**
      * Replaces "**=" with "/="

--- a/src/Mutator/Arithmetic/RoundingFamily.php
+++ b/src/Mutator/Arithmetic/RoundingFamily.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class RoundingFamily extends Mutator
+final class RoundingFamily extends BaseMutator
 {
     private const MUTATORS_MAP = [
         'floor',

--- a/src/Mutator/Arithmetic/ShiftLeft.php
+++ b/src/Mutator/Arithmetic/ShiftLeft.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class ShiftLeft extends Mutator
+final class ShiftLeft extends BaseMutator
 {
     /**
      * Replaces "<<" with ">>"

--- a/src/Mutator/Arithmetic/ShiftRight.php
+++ b/src/Mutator/Arithmetic/ShiftRight.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class ShiftRight extends Mutator
+final class ShiftRight extends BaseMutator
 {
     /**
      * Replaces ">>" with "<<"

--- a/src/Mutator/Boolean/ArrayItem.php
+++ b/src/Mutator/Boolean/ArrayItem.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class ArrayItem extends Mutator
+final class ArrayItem extends BaseMutator
 {
     /**
      * Replaces "[$a->foo => $b->bar]" with "[$a->foo > $b->bar]"

--- a/src/Mutator/Boolean/EqualIdentical.php
+++ b/src/Mutator/Boolean/EqualIdentical.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class EqualIdentical extends Mutator
+final class EqualIdentical extends BaseMutator
 {
     /**
      * Replaces "==" with "==="

--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class FalseValue extends Mutator
+final class FalseValue extends BaseMutator
 {
     /**
      * Replaces "false" with "true"

--- a/src/Mutator/Boolean/IdenticalEqual.php
+++ b/src/Mutator/Boolean/IdenticalEqual.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class IdenticalEqual extends Mutator
+final class IdenticalEqual extends BaseMutator
 {
     /**
      * Replaces "===" with "=="

--- a/src/Mutator/Boolean/LogicalAnd.php
+++ b/src/Mutator/Boolean/LogicalAnd.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class LogicalAnd extends Mutator
+final class LogicalAnd extends BaseMutator
 {
     /**
      * Replaces "&&" with "||"

--- a/src/Mutator/Boolean/LogicalLowerAnd.php
+++ b/src/Mutator/Boolean/LogicalLowerAnd.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class LogicalLowerAnd extends Mutator
+final class LogicalLowerAnd extends BaseMutator
 {
     /**
      * Replaces "and" with "or"

--- a/src/Mutator/Boolean/LogicalLowerOr.php
+++ b/src/Mutator/Boolean/LogicalLowerOr.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class LogicalLowerOr extends Mutator
+final class LogicalLowerOr extends BaseMutator
 {
     /**
      * Replaces "or" with "and"

--- a/src/Mutator/Boolean/LogicalNot.php
+++ b/src/Mutator/Boolean/LogicalNot.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class LogicalNot extends Mutator
+final class LogicalNot extends BaseMutator
 {
     /**
      * Replaces "!something" with "something"

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class LogicalOr extends Mutator
+final class LogicalOr extends BaseMutator
 {
     /**
      * Replaces "||" with "&&"

--- a/src/Mutator/Boolean/NotEqualNotIdentical.php
+++ b/src/Mutator/Boolean/NotEqualNotIdentical.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class NotEqualNotIdentical extends Mutator
+final class NotEqualNotIdentical extends BaseMutator
 {
     /**
      * Replaces "!=" with "!=="

--- a/src/Mutator/Boolean/NotIdenticalNotEqual.php
+++ b/src/Mutator/Boolean/NotIdenticalNotEqual.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class NotIdenticalNotEqual extends Mutator
+final class NotIdenticalNotEqual extends BaseMutator
 {
     /**
      * Replaces "!==" with "!="

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Visitor\ParentConnectorVisitor;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class TrueValue extends Mutator
+final class TrueValue extends BaseMutator
 {
     private const DEFAULT_SETTINGS = [
         'array_search' => false,

--- a/src/Mutator/Boolean/Yield_.php
+++ b/src/Mutator/Boolean/Yield_.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Yield_ extends Mutator
+final class Yield_ extends BaseMutator
 {
     /**
      * Replaces "yield $a => $b;" with "yield $a > $b;"

--- a/src/Mutator/Cast/AbstractCastMutator.php
+++ b/src/Mutator/Cast/AbstractCastMutator.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Cast;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-abstract class AbstractCastMutator extends Mutator
+abstract class AbstractCastMutator extends BaseMutator
 {
     /**
      * Replaces "(cast) $foo;" with "$foo;"

--- a/src/Mutator/ConditionalBoundary/GreaterThan.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThan.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalBoundary;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class GreaterThan extends Mutator
+final class GreaterThan extends BaseMutator
 {
     /**
      * Replaces ">" with ">="

--- a/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalBoundary;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class GreaterThanOrEqualTo extends Mutator
+final class GreaterThanOrEqualTo extends BaseMutator
 {
     /**
      * Replaces ">=" with ">"

--- a/src/Mutator/ConditionalBoundary/LessThan.php
+++ b/src/Mutator/ConditionalBoundary/LessThan.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalBoundary;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class LessThan extends Mutator
+final class LessThan extends BaseMutator
 {
     /**
      * Replaces "<" with "<="

--- a/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalBoundary;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class LessThanOrEqualTo extends Mutator
+final class LessThanOrEqualTo extends BaseMutator
 {
     /**
      * Replaces "<=" with "<"

--- a/src/Mutator/ConditionalNegotiation/Equal.php
+++ b/src/Mutator/ConditionalNegotiation/Equal.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Equal extends Mutator
+final class Equal extends BaseMutator
 {
     /**
      * Replaces "==" with "!="

--- a/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class GreaterThanNegotiation extends Mutator
+final class GreaterThanNegotiation extends BaseMutator
 {
     /**
      * Replaces ">" with "<="

--- a/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class GreaterThanOrEqualToNegotiation extends Mutator
+final class GreaterThanOrEqualToNegotiation extends BaseMutator
 {
     /**
      * Replaces ">=" with "<"

--- a/src/Mutator/ConditionalNegotiation/Identical.php
+++ b/src/Mutator/ConditionalNegotiation/Identical.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Identical extends Mutator
+final class Identical extends BaseMutator
 {
     /**
      * Replaces "===" with "!=="

--- a/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class LessThanNegotiation extends Mutator
+final class LessThanNegotiation extends BaseMutator
 {
     /**
      * Replaces "<" with ">="

--- a/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class LessThanOrEqualToNegotiation extends Mutator
+final class LessThanOrEqualToNegotiation extends BaseMutator
 {
     /**
      * Replaces "<=" with ">"

--- a/src/Mutator/ConditionalNegotiation/NotEqual.php
+++ b/src/Mutator/ConditionalNegotiation/NotEqual.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class NotEqual extends Mutator
+final class NotEqual extends BaseMutator
 {
     /**
      * Replaces "!=" with "=="

--- a/src/Mutator/ConditionalNegotiation/NotIdentical.php
+++ b/src/Mutator/ConditionalNegotiation/NotIdentical.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class NotIdentical extends Mutator
+final class NotIdentical extends BaseMutator
 {
     /**
      * Replaces "!==" with "==="

--- a/src/Mutator/Extensions/BCMath.php
+++ b/src/Mutator/Extensions/BCMath.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Mutator\Extensions;
 
 use Generator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Mutator\Util\Mutator;
 use Infection\Mutator\Util\MutatorConfig;
 use PhpParser\Node;
@@ -43,7 +44,7 @@ use PhpParser\Node;
 /**
  * @internal
  */
-final class BCMath extends Mutator
+final class BCMath extends BaseMutator
 {
     private $converters;
 

--- a/src/Mutator/Extensions/BCMath.php
+++ b/src/Mutator/Extensions/BCMath.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Extensions;
 
 use Generator;
 use Infection\Mutator\Util\BaseMutator;
-use Infection\Mutator\Util\Mutator;
 use Infection\Mutator\Util\MutatorConfig;
 use PhpParser\Node;
 

--- a/src/Mutator/Extensions/MBString.php
+++ b/src/Mutator/Extensions/MBString.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Extensions;
 
 use Generator;
 use Infection\Mutator\Util\BaseMutator;
-use Infection\Mutator\Util\Mutator;
 use Infection\Mutator\Util\MutatorConfig;
 use PhpParser\Node;
 

--- a/src/Mutator/Extensions/MBString.php
+++ b/src/Mutator/Extensions/MBString.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Mutator\Extensions;
 
 use Generator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Mutator\Util\Mutator;
 use Infection\Mutator\Util\MutatorConfig;
 use PhpParser\Node;
@@ -43,7 +44,7 @@ use PhpParser\Node;
 /**
  * @internal
  */
-final class MBString extends Mutator
+final class MBString extends BaseMutator
 {
     private $converters;
 

--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\FunctionSignature;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Visitor\ReflectionVisitor;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
@@ -44,7 +44,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 /**
  * @internal
  */
-final class ProtectedVisibility extends Mutator
+final class ProtectedVisibility extends BaseMutator
 {
     /**
      * Replaces "protected function..." with "private function ..."

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\FunctionSignature;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Visitor\ReflectionVisitor;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
@@ -44,7 +44,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 /**
  * @internal
  */
-final class PublicVisibility extends Mutator
+final class PublicVisibility extends BaseMutator
 {
     /**
      * Replaces "public function..." with "protected function ..."

--- a/src/Mutator/Number/AbstractNumberMutator.php
+++ b/src/Mutator/Number/AbstractNumberMutator.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Number;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Visitor\ParentConnectorVisitor;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-abstract class AbstractNumberMutator extends Mutator
+abstract class AbstractNumberMutator extends BaseMutator
 {
     protected function isPartOfSizeComparison(Node $node): bool
     {

--- a/src/Mutator/Operator/AssignCoalesce.php
+++ b/src/Mutator/Operator/AssignCoalesce.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp\Coalesce;
@@ -43,7 +43,7 @@ use PhpParser\Node\Expr\AssignOp\Coalesce;
 /**
  * @internal
  */
-final class AssignCoalesce extends Mutator
+final class AssignCoalesce extends BaseMutator
 {
     /**
      * Replaces "$array['a'] ??= 'otherValue';" with "$array['a'] = 'otherValue'"

--- a/src/Mutator/Operator/Break_.php
+++ b/src/Mutator/Operator/Break_.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Visitor\ParentConnectorVisitor;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Break_ extends Mutator
+final class Break_ extends BaseMutator
 {
     /**
      * Replaces "break;" with "continue;"

--- a/src/Mutator/Operator/Coalesce.php
+++ b/src/Mutator/Operator/Coalesce.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Coalesce extends Mutator
+final class Coalesce extends BaseMutator
 {
     /**
      * Replaces "'someValue' ?? 'otherValue';" with "'otherValue'"

--- a/src/Mutator/Operator/Continue_.php
+++ b/src/Mutator/Operator/Continue_.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Visitor\ParentConnectorVisitor;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Continue_ extends Mutator
+final class Continue_ extends BaseMutator
 {
     /**
      * Replaces "continue;" with "break;"

--- a/src/Mutator/Operator/Finally_.php
+++ b/src/Mutator/Operator/Finally_.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Visitor\ParentConnectorVisitor;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Finally_ extends Mutator
+final class Finally_ extends BaseMutator
 {
     /**
      * Removes "finally{}" blocks

--- a/src/Mutator/Operator/Throw_.php
+++ b/src/Mutator/Operator/Throw_.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Throw_ extends Mutator
+final class Throw_ extends BaseMutator
 {
     /**
      * Replaces "throw new Exception();" with "new Exception();"

--- a/src/Mutator/Regex/PregMatchMatches.php
+++ b/src/Mutator/Regex/PregMatchMatches.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Regex;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class PregMatchMatches extends Mutator
+final class PregMatchMatches extends BaseMutator
 {
     /**
      * Replaces "preg_match('/a/', 'b', $foo);" with "(int) $foo = array();"

--- a/src/Mutator/Regex/PregQuote.php
+++ b/src/Mutator/Regex/PregQuote.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Regex;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class PregQuote extends Mutator
+final class PregQuote extends BaseMutator
 {
     /**
      * Replaces "$a = preg_quote($b);" with "$a = $b;"

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -37,14 +37,14 @@ namespace Infection\Mutator\Removal;
 
 use Generator;
 use Infection\Config\Exception\InvalidConfigException;
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Mutator\Util\MutatorConfig;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class ArrayItemRemoval extends Mutator
+final class ArrayItemRemoval extends BaseMutator
 {
     private const DEFAULT_SETTINGS = [
         'remove' => 'first',

--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Removal;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class FunctionCallRemoval extends Mutator
+final class FunctionCallRemoval extends BaseMutator
 {
     /**
      * Replaces "doSmth()" with ""

--- a/src/Mutator/Removal/MethodCallRemoval.php
+++ b/src/Mutator/Removal/MethodCallRemoval.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Removal;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class MethodCallRemoval extends Mutator
+final class MethodCallRemoval extends BaseMutator
 {
     /**
      * Replaces "$object->doSmth()" with ""

--- a/src/Mutator/ReturnValue/FloatNegation.php
+++ b/src/Mutator/ReturnValue/FloatNegation.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ReturnValue;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class FloatNegation extends Mutator
+final class FloatNegation extends BaseMutator
 {
     /**
      * Replaces any float with negated float

--- a/src/Mutator/ReturnValue/IntegerNegation.php
+++ b/src/Mutator/ReturnValue/IntegerNegation.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ReturnValue;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class IntegerNegation extends Mutator
+final class IntegerNegation extends BaseMutator
 {
     /**
      * Replaces any integer with negated integer value.

--- a/src/Mutator/Sort/Spaceship.php
+++ b/src/Mutator/Sort/Spaceship.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Sort;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Spaceship extends Mutator
+final class Spaceship extends BaseMutator
 {
     /**
      * Swaps the arguments in the Spaceship operator <=>

--- a/src/Mutator/Unwrap/AbstractUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractUnwrapMutator.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-abstract class AbstractUnwrapMutator extends Mutator
+abstract class AbstractUnwrapMutator extends BaseMutator
 {
     /**
      * Replaces "$a = function(arg1, arg2);" with "$a = arg1;"

--- a/src/Mutator/Util/AbstractValueToNullReturnValue.php
+++ b/src/Mutator/Util/AbstractValueToNullReturnValue.php
@@ -41,7 +41,7 @@ use PhpParser\Node;
 /**
  * @internal
  */
-abstract class AbstractValueToNullReturnValue extends Mutator
+abstract class AbstractValueToNullReturnValue extends BaseMutator
 {
     protected function isNullReturnValueAllowed(Node $node): bool
     {

--- a/src/Mutator/Util/BaseMutator.php
+++ b/src/Mutator/Util/BaseMutator.php
@@ -38,7 +38,7 @@ namespace Infection\Mutator\Util;
 use Infection\Visitor\ReflectionVisitor;
 use PhpParser\Node;
 
-abstract class Mutator
+abstract class BaseMutator
 {
     /**
      * @var MutatorConfig

--- a/src/Mutator/Util/Mutator.php
+++ b/src/Mutator/Util/Mutator.php
@@ -2,7 +2,7 @@
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
- * Copyright (c) 2017-2019, Maks Rafalko
+ * Copyright (c) 2017, Maks Rafalko
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,7 +43,7 @@ use PhpParser\Node;
 interface Mutator
 {
     /**
-     * @return Node|Node[]|\Generator
+     * @return Node|Node[]|\Generator|array
      */
     public function mutate(Node $node);
 

--- a/src/Mutator/Util/Mutator.php
+++ b/src/Mutator/Util/Mutator.php
@@ -74,7 +74,7 @@ abstract class Mutator
         );
     }
 
-    final public static function getName(): string
+    final public function getName(): string
     {
         $parts = explode('\\', static::class);
 

--- a/src/Mutator/Util/Mutator.php
+++ b/src/Mutator/Util/Mutator.php
@@ -2,7 +2,7 @@
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
- * Copyright (c) 2017, Maks Rafalko
+ * Copyright (c) 2017-2019, Maks Rafalko
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,56 +35,19 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Util;
 
-use Infection\Visitor\ReflectionVisitor;
 use PhpParser\Node;
 
-abstract class BaseMutator implements Mutator
+/**
+ * @internal
+ */
+interface Mutator
 {
     /**
-     * @var MutatorConfig
+     * @return Node|Node[]|\Generator
      */
-    private $config;
+    public function mutate(Node $node);
 
-    public function __construct(MutatorConfig $config)
-    {
-        $this->config = $config;
-    }
+    public function shouldMutate(Node $node): bool;
 
-    /**
-     * @return Node|Node[]|\Generator|array
-     */
-    abstract public function mutate(Node $node);
-
-    final public function shouldMutate(Node $node): bool
-    {
-        if (!$this->mutatesNode($node)) {
-            return false;
-        }
-
-        $reflectionClass = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY, false);
-
-        if (!$reflectionClass) {
-            return true;
-        }
-
-        return !$this->config->isIgnored(
-            $reflectionClass->getName(),
-            $node->getAttribute(ReflectionVisitor::FUNCTION_NAME, ''),
-            $node->getLine()
-        );
-    }
-
-    final public function getName(): string
-    {
-        $parts = explode('\\', static::class);
-
-        return (string) end($parts);
-    }
-
-    final protected function getSettings(): array
-    {
-        return $this->config->getMutatorSettings();
-    }
-
-    abstract protected function mutatesNode(Node $node): bool;
+    public function getName(): string;
 }

--- a/src/Mutator/Util/MutatorParser.php
+++ b/src/Mutator/Util/MutatorParser.php
@@ -48,7 +48,7 @@ final class MutatorParser
     private $inputMutators;
 
     /**
-     * @var array|Mutator[]
+     * @var array|BaseMutator[]
      */
     private $configMutators;
 
@@ -59,7 +59,7 @@ final class MutatorParser
     }
 
     /**
-     * @return array|Mutator[]
+     * @return array|BaseMutator[]
      */
     public function getMutators(): array
     {

--- a/src/Mutator/Util/MutatorParser.php
+++ b/src/Mutator/Util/MutatorParser.php
@@ -48,7 +48,7 @@ final class MutatorParser
     private $inputMutators;
 
     /**
-     * @var array|BaseMutator[]
+     * @var array|Mutator[]
      */
     private $configMutators;
 
@@ -59,7 +59,7 @@ final class MutatorParser
     }
 
     /**
-     * @return array|BaseMutator[]
+     * @return array|Mutator[]
      */
     public function getMutators(): array
     {

--- a/src/Mutator/Util/MutatorsGenerator.php
+++ b/src/Mutator/Util/MutatorsGenerator.php
@@ -158,7 +158,7 @@ final class MutatorsGenerator
         foreach ($mutators as $mutator => $setting) {
             if ($setting !== false) {
                 \assert(\is_string($mutator));
-                $mutatorInstance = new $mutator(new MutatorConfig($setting));
+                $mutatorInstance = new ThrowingMutator(new $mutator(new MutatorConfig($setting)));
                 $mutatorList[$mutatorInstance->getName()] = $mutatorInstance;
             }
         }

--- a/src/Mutator/Util/MutatorsGenerator.php
+++ b/src/Mutator/Util/MutatorsGenerator.php
@@ -62,7 +62,7 @@ final class MutatorsGenerator
      *
      * @throws InvalidConfigException
      *
-     * @return Mutator[]
+     * @return BaseMutator[]
      */
     public function generate(): array
     {
@@ -149,7 +149,7 @@ final class MutatorsGenerator
     }
 
     /**
-     * @return Mutator[]
+     * @return BaseMutator[]
      */
     private function createFromList(array $mutators): array
     {

--- a/src/Mutator/Util/MutatorsGenerator.php
+++ b/src/Mutator/Util/MutatorsGenerator.php
@@ -62,7 +62,7 @@ final class MutatorsGenerator
      *
      * @throws InvalidConfigException
      *
-     * @return BaseMutator[]
+     * @return Mutator[]
      */
     public function generate(): array
     {
@@ -149,7 +149,7 @@ final class MutatorsGenerator
     }
 
     /**
-     * @return BaseMutator[]
+     * @return Mutator[]
      */
     private function createFromList(array $mutators): array
     {

--- a/src/Mutator/Util/MutatorsGenerator.php
+++ b/src/Mutator/Util/MutatorsGenerator.php
@@ -158,9 +158,8 @@ final class MutatorsGenerator
         foreach ($mutators as $mutator => $setting) {
             if ($setting !== false) {
                 \assert(\is_string($mutator));
-                $mutatorList[$mutator::getName()] = new $mutator(
-                    new MutatorConfig($setting)
-                );
+                $mutatorInstance = new $mutator(new MutatorConfig($setting));
+                $mutatorList[$mutatorInstance->getName()] = $mutatorInstance;
             }
         }
 

--- a/src/Mutator/Util/ThrowingMutator.php
+++ b/src/Mutator/Util/ThrowingMutator.php
@@ -2,7 +2,7 @@
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
- * Copyright (c) 2017-2019, Maks Rafalko
+ * Copyright (c) 2017, Maks Rafalko
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,7 +55,7 @@ final class ThrowingMutator implements Mutator
     }
 
     /**
-     * @return Node|Node[]|\Generator
+     * @return Node|Node[]|\Generator|array
      */
     public function mutate(Node $node)
     {

--- a/src/Mutator/Util/ThrowingMutator.php
+++ b/src/Mutator/Util/ThrowingMutator.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017-2019, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Util;
+
+use Infection\Exception\InvalidMutatorException;
+use Infection\Visitor\FilePathVisitor;
+use PhpParser\Node;
+
+/**
+ * @internal
+ */
+final class ThrowingMutator implements Mutator
+{
+    /**
+     * @var Mutator
+     */
+    private $innerMutator;
+
+    public function __construct(Mutator $innerMutator)
+    {
+        $this->innerMutator = $innerMutator;
+    }
+
+    /**
+     * @return Node|Node[]|\Generator
+     */
+    public function mutate(Node $node)
+    {
+        return $this->innerMutator->mutate($node);
+    }
+
+    public function shouldMutate(Node $node): bool
+    {
+        try {
+            return $this->innerMutator->shouldMutate($node);
+        } catch (\Throwable $t) {
+            throw InvalidMutatorException::create($node->getAttribute(FilePathVisitor::FILE_PATH), $this, $t);
+        }
+    }
+
+    public function getName(): string
+    {
+        return $this->innerMutator->getName();
+    }
+}

--- a/src/Mutator/ZeroIteration/For_.php
+++ b/src/Mutator/ZeroIteration/For_.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ZeroIteration;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class For_ extends Mutator
+final class For_ extends BaseMutator
 {
     /**
      * Replaces "for($i=0; $i<10; $i++)" with "for($i=0; false; $i++)"

--- a/src/Mutator/ZeroIteration/Foreach_.php
+++ b/src/Mutator/ZeroIteration/Foreach_.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ZeroIteration;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 /**
  * @internal
  */
-final class Foreach_ extends Mutator
+final class Foreach_ extends BaseMutator
 {
     /**
      * Replaces "foreach($a as $b)" with "foreach(array() as $b)"

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -164,7 +164,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInt
                     $index + 1,
                     $mutation->getOriginalFilePath(),
                     (int) $mutation->getAttributes()['startLine'],
-                    $mutation->getMutator()::getName()
+                    $mutation->getMutator()->getName()
                 ),
             ]);
 

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -37,7 +37,7 @@ namespace Infection\Process;
 
 use Infection\Mutant\MutantInterface;
 use Infection\MutationInterface;
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Symfony\Component\Process\Process;
 
@@ -125,7 +125,7 @@ final class MutantProcess implements MutantProcessInterface
         return self::CODE_KILLED;
     }
 
-    public function getMutator(): Mutator
+    public function getMutator(): BaseMutator
     {
         return $this->getMutation()->getMutator();
     }

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -37,7 +37,7 @@ namespace Infection\Process;
 
 use Infection\Mutant\MutantInterface;
 use Infection\MutationInterface;
-use Infection\Mutator\Util\BaseMutator;
+use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Symfony\Component\Process\Process;
 
@@ -125,7 +125,7 @@ final class MutantProcess implements MutantProcessInterface
         return self::CODE_KILLED;
     }
 
-    public function getMutator(): BaseMutator
+    public function getMutator(): Mutator
     {
         return $this->getMutation()->getMutator();
     }

--- a/src/Process/MutantProcessInterface.php
+++ b/src/Process/MutantProcessInterface.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Process;
 
 use Infection\Mutant\MutantInterface;
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Symfony\Component\Process\Process;
 
 /**
@@ -54,7 +54,7 @@ interface MutantProcessInterface
 
     public function getResultCode(): int;
 
-    public function getMutator(): Mutator;
+    public function getMutator(): BaseMutator;
 
     public function getOriginalFilePath(): string;
 

--- a/src/Process/MutantProcessInterface.php
+++ b/src/Process/MutantProcessInterface.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Process;
 
 use Infection\Mutant\MutantInterface;
-use Infection\Mutator\Util\BaseMutator;
+use Infection\Mutator\Util\Mutator;
 use Symfony\Component\Process\Process;
 
 /**
@@ -54,7 +54,7 @@ interface MutantProcessInterface
 
     public function getResultCode(): int;
 
-    public function getMutator(): BaseMutator;
+    public function getMutator(): Mutator;
 
     public function getOriginalFilePath(): string;
 

--- a/src/Visitor/FilePathVisitor.php
+++ b/src/Visitor/FilePathVisitor.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017-2019, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Visitor;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * @internal
+ */
+final class FilePathVisitor extends NodeVisitorAbstract
+{
+    public const FILE_PATH = 'file-path';
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    public function enterNode(Node $node): void
+    {
+        $node->setAttribute(self::FILE_PATH, $this->path);
+    }
+}

--- a/src/Visitor/FilePathVisitor.php
+++ b/src/Visitor/FilePathVisitor.php
@@ -2,7 +2,7 @@
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
- * Copyright (c) 2017-2019, Maks Rafalko
+ * Copyright (c) 2017, Maks Rafalko
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,8 +55,10 @@ final class FilePathVisitor extends NodeVisitorAbstract
         $this->path = $path;
     }
 
-    public function enterNode(Node $node): void
+    public function enterNode(Node $node): ?Node
     {
         $node->setAttribute(self::FILE_PATH, $this->path);
+
+        return null;
     }
 }

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -37,7 +37,7 @@ namespace Infection\Visitor;
 
 use Infection\Exception\InvalidMutatorException;
 use Infection\Mutation;
-use Infection\Mutator\Util\BaseMutator;
+use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
@@ -48,7 +48,7 @@ use PhpParser\NodeVisitorAbstract;
 final class MutationsCollectorVisitor extends NodeVisitorAbstract
 {
     /**
-     * @var BaseMutator[]
+     * @var Mutator[]
      */
     private $mutators;
 

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -98,6 +98,7 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
             }
 
             $path = $node->getAttribute(FilePathVisitor::FILE_PATH);
+
             if ($isOnFunctionSignature) {
                 // hasExecutedMethodOnLine checks for all lines of a given method,
                 // therefore it isn't making any sense to check any other line but first

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -37,7 +37,7 @@ namespace Infection\Visitor;
 
 use Infection\Exception\InvalidMutatorException;
 use Infection\Mutation;
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
@@ -48,7 +48,7 @@ use PhpParser\NodeVisitorAbstract;
 final class MutationsCollectorVisitor extends NodeVisitorAbstract
 {
     /**
-     * @var Mutator[]
+     * @var BaseMutator[]
      */
     private $mutators;
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -51,7 +51,7 @@ use Infection\Finder\TestFrameworkFinder;
 use Infection\Http\BadgeApiClient;
 use Infection\Logger\ResultsLoggerTypes;
 use Infection\Mutant\MetricsCalculator;
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Process\Builder\ProcessBuilder;
 use Infection\Process\Listener\MutantCreatingConsoleLoggerSubscriber;
 use Infection\Process\Listener\MutationGeneratingConsoleLoggerSubscriber;
@@ -95,7 +95,7 @@ final class ProjectCodeTest extends TestCase
      * @var string[]
      */
     private static $extensionPoints = [
-        Mutator::class,
+        BaseMutator::class,
         OutputFormatter::class,
     ];
 

--- a/tests/Fixtures/Autoloaded/Mutator/ErrorMutator.php
+++ b/tests/Fixtures/Autoloaded/Mutator/ErrorMutator.php
@@ -3,10 +3,10 @@
 namespace Infection\WrongMutator;
 
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
-class ErrorMutator extends Mutator
+class ErrorMutator extends BaseMutator
 {
     public function mutate(Node $node)
     {

--- a/tests/Fixtures/SimpleMutation.php
+++ b/tests/Fixtures/SimpleMutation.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
 class SimpleMutation
 {
     /**
-     * @var Mutator
+     * @var BaseMutator
      */
     private $mutator;
 
@@ -24,14 +24,14 @@ class SimpleMutation
      */
     private $mutatedNode;
 
-    public function __construct(array $originalFileAst, Mutator $mutator, $mutatedNode)
+    public function __construct(array $originalFileAst, BaseMutator $mutator, $mutatedNode)
     {
         $this->originalFileAst = $originalFileAst;
         $this->mutator = $mutator;
         $this->mutatedNode = $mutatedNode;
     }
 
-    public function getMutator(): Mutator
+    public function getMutator(): BaseMutator
     {
         return $this->mutator;
     }

--- a/tests/Fixtures/SimpleMutationsCollectorVisitor.php
+++ b/tests/Fixtures/SimpleMutationsCollectorVisitor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
@@ -14,7 +14,7 @@ use PhpParser\NodeVisitorAbstract;
 final class SimpleMutationsCollectorVisitor extends NodeVisitorAbstract
 {
     /**
-     * @var Mutator[]
+     * @var BaseMutator[]
      */
     private $mutator;
 
@@ -28,7 +28,7 @@ final class SimpleMutationsCollectorVisitor extends NodeVisitorAbstract
      */
     private $fileAst;
 
-    public function __construct(Mutator $mutator, array $fileAst)
+    public function __construct(BaseMutator $mutator, array $fileAst)
     {
         $this->mutator = $mutator;
         $this->fileAst = $fileAst;

--- a/tests/Fixtures/SimpleMutatorVisitor.php
+++ b/tests/Fixtures/SimpleMutatorVisitor.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 

--- a/tests/Fixtures/StubMutator.php
+++ b/tests/Fixtures/StubMutator.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use PhpParser\Node;
 
-class StubMutator extends Mutator
+class StubMutator extends BaseMutator
 {
     public function mutate(Node $node)
     {

--- a/tests/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/Mutant/Generator/MutationsGeneratorTest.php
@@ -45,6 +45,7 @@ use Infection\Mutator\Boolean\TrueValue;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
 use Infection\Mutator\Number\DecrementInteger;
 use Infection\Mutator\Util\MutatorConfig;
+use Infection\Mutator\Util\ThrowingMutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\Tests\Fixtures\Files\Mutation\OneFile\OneFile;
 use Infection\WrongMutator\ErrorMutator;
@@ -230,19 +231,19 @@ final class MutationsGeneratorTest extends TestCase
         $mutatorConfig = $mutatorConfig ?? new MutatorConfig([]);
 
         $container[Plus::class] = static function () use ($mutatorConfig) {
-            return new Plus($mutatorConfig);
+            return new ThrowingMutator(new Plus($mutatorConfig));
         };
 
         $container[PublicVisibility::class] = static function () use ($mutatorConfig) {
-            return new PublicVisibility($mutatorConfig);
+            return new ThrowingMutator(new PublicVisibility($mutatorConfig));
         };
 
         $container[TrueValue::class] = static function () use ($mutatorConfig) {
-            return new TrueValue($mutatorConfig);
+            return new ThrowingMutator(new TrueValue($mutatorConfig));
         };
 
         $container[DecrementInteger::class] = static function (Container $c) use ($mutatorConfig) {
-            return new DecrementInteger($mutatorConfig);
+            return new ThrowingMutator(new DecrementInteger($mutatorConfig));
         };
 
         $defaultMutators = [
@@ -252,7 +253,7 @@ final class MutationsGeneratorTest extends TestCase
             $container[DecrementInteger::class],
         ];
 
-        $mutators = $whitelistedMutatorName ? [new $whitelistedMutatorName($mutatorConfig)] : $defaultMutators;
+        $mutators = $whitelistedMutatorName ? [new ThrowingMutator(new $whitelistedMutatorName($mutatorConfig))] : $defaultMutators;
 
         $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcherMock->expects($this->any())->method('dispatch');

--- a/tests/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/Mutant/Generator/MutationsGeneratorTest.php
@@ -73,7 +73,7 @@ final class MutationsGeneratorTest extends TestCase
 
         $mutations = $this->createMutationGenerator($codeCoverageDataMock)->generate(false);
 
-        $this->assertInstanceOf(Plus::class, $mutations[3]->getMutator());
+        $this->assertSame('Plus', $mutations[3]->getMutator()->getName());
     }
 
     public function test_it_collects_public_visibility_mutation(): void
@@ -90,8 +90,8 @@ final class MutationsGeneratorTest extends TestCase
 
         $mutations = $this->createMutationGenerator($codeCoverageDataMock)->generate(false);
 
-        $this->assertInstanceOf(Plus::class, $mutations[3]->getMutator());
-        $this->assertInstanceOf(PublicVisibility::class, $mutations[4]->getMutator());
+        $this->assertSame('Plus', $mutations[3]->getMutator()->getName());
+        $this->assertSame('PublicVisibility', $mutations[4]->getMutator()->getName());
     }
 
     public function test_it_can_skip_not_covered_on_file_level(): void
@@ -126,8 +126,8 @@ final class MutationsGeneratorTest extends TestCase
         $mutations = $this->createMutationGenerator($codeCoverageDataMock)->generate(true);
 
         $this->assertCount(3, $mutations);
-        $this->assertInstanceOf(TrueValue::class, $mutations[0]->getMutator());
-        $this->assertInstanceOf(PublicVisibility::class, $mutations[2]->getMutator());
+        $this->assertSame('TrueValue', $mutations[0]->getMutator()->getName());
+        $this->assertSame('PublicVisibility', $mutations[2]->getMutator()->getName());
     }
 
     public function test_it_can_skip_not_covered_on_file_line_for_visibility(): void

--- a/tests/Mutator/AbstractMutatorTestCase.php
+++ b/tests/Mutator/AbstractMutatorTestCase.php
@@ -173,7 +173,7 @@ abstract class AbstractMutatorTestCase extends TestCase
             $returnCode,
             sprintf(
                 'Mutator %s produces invalid code',
-                $this->getMutator()::getName()
+                $this->getMutator()->getName()
             )
         );
     }

--- a/tests/Mutator/AbstractMutatorTestCase.php
+++ b/tests/Mutator/AbstractMutatorTestCase.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator;
 
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\Mutator\Util\MutatorConfig;
 use Infection\Tests\Fixtures\SimpleMutation;
 use Infection\Tests\Fixtures\SimpleMutationsCollectorVisitor;
@@ -58,7 +58,7 @@ use PHPUnit\Framework\TestCase;
 abstract class AbstractMutatorTestCase extends TestCase
 {
     /**
-     * @var Mutator
+     * @var BaseMutator
      */
     protected $mutator;
 
@@ -99,7 +99,7 @@ abstract class AbstractMutatorTestCase extends TestCase
         }
     }
 
-    protected function getMutator(array $settings = []): Mutator
+    protected function getMutator(array $settings = []): BaseMutator
     {
         $class = \get_class($this);
         $mutator = substr(str_replace('\Tests', '', $class), 0, -4);

--- a/tests/Mutator/AllMutatorTest.php
+++ b/tests/Mutator/AllMutatorTest.php
@@ -80,7 +80,7 @@ final class AllMutatorTest extends TestCase
         } catch (Throwable $t) {
             $this->fail(sprintf(
                'Ran into an error on the "%s" mutator, while parsing the file "%s". The original error was "%s"',
-               $mutator::getName(),
+               $mutator->getName(),
                $fileName,
                $t->getMessage()
             ));

--- a/tests/Mutator/Sort/SpaceshipTest.php
+++ b/tests/Mutator/Sort/SpaceshipTest.php
@@ -44,7 +44,7 @@ final class SpaceshipTest extends AbstractMutatorTestCase
 {
     public function test_get_name(): void
     {
-        $this->assertSame('Spaceship', $this->getMutator()::getName());
+        $this->assertSame('Spaceship', $this->getMutator()->getName());
     }
 
     /**

--- a/tests/Mutator/Util/MutatorParserTest.php
+++ b/tests/Mutator/Util/MutatorParserTest.php
@@ -35,8 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Util;
 
-use Infection\Mutator\Boolean\FalseValue;
-use Infection\Mutator\Boolean\TrueValue;
 use Infection\Mutator\Util\MutatorParser;
 use PHPUnit\Framework\TestCase;
 
@@ -69,7 +67,7 @@ final class MutatorParserTest extends TestCase
         $mutatorList = $parser->getMutators();
 
         $this->assertCount(1, $mutatorList);
-        $this->assertInstanceOf(TrueValue::class, array_shift($mutatorList));
+        $this->assertSame('TrueValue', array_shift($mutatorList)->getName());
     }
 
     public function test_it_generates_multiple_mutators_from_the_input_string(): void
@@ -79,7 +77,7 @@ final class MutatorParserTest extends TestCase
         $mutatorList = $parser->getMutators();
 
         $this->assertCount(2, $mutatorList);
-        $this->assertInstanceOf(TrueValue::class, array_shift($mutatorList));
-        $this->assertInstanceOf(FalseValue::class, array_shift($mutatorList));
+        $this->assertSame('TrueValue', array_shift($mutatorList)->getName());
+        $this->assertSame('FalseValue', array_shift($mutatorList)->getName());
     }
 }

--- a/tests/Mutator/Util/MutatorProfileTest.php
+++ b/tests/Mutator/Util/MutatorProfileTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Util;
 
+use Infection\Mutator\Util\MutatorConfig;
 use Infection\Mutator\Util\MutatorProfile;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
@@ -47,14 +48,15 @@ final class MutatorProfileTest extends TestCase
     public function test_all_mutators_have_the_correct_name_in_the_full_mutator_list(): void
     {
         foreach (MutatorProfile::FULL_MUTATOR_LIST as $name => $class) {
+            $className = (new $class(new MutatorConfig([])))->getName();
             $this->assertSame(
                 $name,
-                $class::getName(),
+                $className,
                 sprintf(
                     'Invalid name "%s" provided for the class "%s", expected "%s" as key',
                     $name,
                     $class,
-                    $class::getName()
+                    $className
                 )
             );
         }

--- a/tests/Mutator/Util/MutatorsGeneratorTest.php
+++ b/tests/Mutator/Util/MutatorsGeneratorTest.php
@@ -39,7 +39,6 @@ use Infection\Config\Exception\InvalidConfigException;
 use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\Util\MutatorProfile;
 use Infection\Mutator\Util\MutatorsGenerator;
-use Infection\Tests\Fixtures\StubMutator;
 use Infection\Visitor\ReflectionVisitor;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Plus as PlusNode;
@@ -139,7 +138,7 @@ final class MutatorsGeneratorTest extends TestCase
 
         $this->assertCount(self::$countDefaultMutators, $mutators);
 
-        $this->assertInstanceOf(Plus::class, $mutators['Plus']);
+        $this->assertSame('Plus', $mutators['Plus']->getName());
 
         $this->assertFalse($mutators['Plus']->shouldMutate($plusNode));
     }
@@ -164,7 +163,7 @@ final class MutatorsGeneratorTest extends TestCase
 
         $this->assertCount(self::$countDefaultMutators, $mutators);
 
-        $this->assertInstanceOf(Plus::class, $mutators['Plus']);
+        $this->assertSame('Plus', $mutators['Plus']->getName());
 
         $this->assertFalse($mutators['TrueValue']->shouldMutate($trueNode));
         $this->assertFalse($mutators['FalseValue']->shouldMutate($falseNode));
@@ -180,7 +179,7 @@ final class MutatorsGeneratorTest extends TestCase
         $mutators = $mutatorGenerator->generate();
 
         $this->assertArrayHasKey('StubMutator', $mutators);
-        $this->assertInstanceOf(StubMutator::class, $mutators['StubMutator']);
+        $this->assertSame('StubMutator', $mutators['StubMutator']->getName());
     }
 
     public function test_it_combines_custom_mutators_with_the_other_mutators(): void

--- a/tests/Mutator/Util/MutatorsGeneratorTest.php
+++ b/tests/Mutator/Util/MutatorsGeneratorTest.php
@@ -37,8 +37,6 @@ namespace Infection\Tests\Mutator\Util;
 
 use Infection\Config\Exception\InvalidConfigException;
 use Infection\Mutator\Arithmetic\Plus;
-use Infection\Mutator\Boolean\FalseValue;
-use Infection\Mutator\Boolean\TrueValue;
 use Infection\Mutator\Util\MutatorProfile;
 use Infection\Mutator\Util\MutatorsGenerator;
 use Infection\Tests\Fixtures\StubMutator;
@@ -106,7 +104,7 @@ final class MutatorsGeneratorTest extends TestCase
     {
         $mutatorGenerator = new MutatorsGenerator([
             '@default' => true,
-            Plus::getName() => false,
+            'Plus' => false,
         ]);
         $mutators = $mutatorGenerator->generate();
 
@@ -135,15 +133,15 @@ final class MutatorsGeneratorTest extends TestCase
 
         $mutatorGenerator = new MutatorsGenerator([
             '@default' => true,
-            Plus::getName() => ['ignore' => ['A::B']],
+            'Plus' => ['ignore' => ['A::B']],
         ]);
         $mutators = $mutatorGenerator->generate();
 
         $this->assertCount(self::$countDefaultMutators, $mutators);
 
-        $this->assertInstanceOf(Plus::class, $mutators[Plus::getName()]);
+        $this->assertInstanceOf(Plus::class, $mutators['Plus']);
 
-        $this->assertFalse($mutators[Plus::getName()]->shouldMutate($plusNode));
+        $this->assertFalse($mutators['Plus']->shouldMutate($plusNode));
     }
 
     public function test_it_keeps_settings_when_applied_to_profiles(): void
@@ -166,12 +164,12 @@ final class MutatorsGeneratorTest extends TestCase
 
         $this->assertCount(self::$countDefaultMutators, $mutators);
 
-        $this->assertInstanceOf(Plus::class, $mutators[Plus::getName()]);
+        $this->assertInstanceOf(Plus::class, $mutators['Plus']);
 
-        $this->assertFalse($mutators[TrueValue::getName()]->shouldMutate($trueNode));
-        $this->assertFalse($mutators[FalseValue::getName()]->shouldMutate($falseNode));
+        $this->assertFalse($mutators['TrueValue']->shouldMutate($trueNode));
+        $this->assertFalse($mutators['FalseValue']->shouldMutate($falseNode));
 
-        $this->assertTrue($mutators[Plus::getName()]->shouldMutate($plusNode));
+        $this->assertTrue($mutators['Plus']->shouldMutate($plusNode));
     }
 
     public function test_it_accepts_custom_mutators(): void
@@ -215,10 +213,10 @@ final class MutatorsGeneratorTest extends TestCase
 
         $this->assertCount(\count(MutatorProfile::BOOLEAN), $mutators);
 
-        $this->assertArrayNotHasKey(Plus::getName(), $mutators);
+        $this->assertArrayNotHasKey('Plus', $mutators);
 
-        $this->assertFalse($mutators[TrueValue::getName()]->shouldMutate($trueNode));
-        $this->assertFalse($mutators[FalseValue::getName()]->shouldMutate($falseNode));
+        $this->assertFalse($mutators['TrueValue']->shouldMutate($trueNode));
+        $this->assertFalse($mutators['FalseValue']->shouldMutate($falseNode));
     }
 
     public function test_an_empty_setting_is_allowed(): void
@@ -230,7 +228,7 @@ final class MutatorsGeneratorTest extends TestCase
 
         $this->assertCount(\count(MutatorProfile::BOOLEAN), $mutators);
 
-        $this->assertArrayNotHasKey(Plus::getName(), $mutators);
+        $this->assertArrayNotHasKey('Plus', $mutators);
     }
 
     /**

--- a/tests/Mutator/Util/ThrowingMutatorTest.php
+++ b/tests/Mutator/Util/ThrowingMutatorTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017-2019, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Util;
+
+use Infection\Exception\InvalidMutatorException;
+use Infection\Mutator\Operator\Coalesce;
+use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\MutatorConfig;
+use Infection\Mutator\Util\ThrowingMutator;
+use Infection\Visitor\FilePathVisitor;
+use PhpParser\Node;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class ThrowingMutatorTest extends TestCase
+{
+    public function test_it_sends_calls_to_inner_mutator(): void
+    {
+        $inputNode = $this->createMock(Node::class);
+        $innerMutator = $this->createMock(Mutator::class);
+        $innerMutator->expects($this->once())->method('mutate')->willReturn($inputNode);
+
+        $throwingMutator = new ThrowingMutator($innerMutator);
+        $throwingMutator->mutate($inputNode);
+    }
+
+    public function test_it_sends_get_name_call_to_inner_mutator(): void
+    {
+        $inputMutator = new Coalesce(new MutatorConfig([]));
+        $throwingMutator = new ThrowingMutator($inputMutator);
+
+        $this->assertSame($inputMutator->getName(), $throwingMutator->getName());
+    }
+
+    public function test_it_sends_call_to_inner_mutator_for_should_mutate(): void
+    {
+        $inputNode = $this->createMock(Node::class);
+        $innerMutator = $this->createMock(Mutator::class);
+        $innerMutator->expects($this->once())->method('shouldMutate')->willReturn(false);
+
+        $throwingMutator = new ThrowingMutator($innerMutator);
+        $throwingMutator->shouldMutate($inputNode);
+    }
+
+    public function test_it_throws_correct_error_when_inner_mutator_errors(): void
+    {
+        $e = new \BadMethodCallException('Oopsie');
+
+        $inputNode = $this->createMock(Node::class);
+        $inputNode->expects($this->once())
+            ->method('getAttribute')
+            ->with(FilePathVisitor::FILE_PATH)
+            ->willReturn('full/path/to/file.php');
+
+        $innerMutator = $this->createMock(Mutator::class);
+        $innerMutator->expects($this->once())->method('shouldMutate')->willThrowException($e);
+
+        $throwingMutator = new ThrowingMutator($innerMutator);
+
+        $this->expectException(InvalidMutatorException::class);
+        $throwingMutator->shouldMutate($inputNode);
+    }
+}

--- a/tests/Mutator/Util/ThrowingMutatorTest.php
+++ b/tests/Mutator/Util/ThrowingMutatorTest.php
@@ -2,7 +2,7 @@
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
- * Copyright (c) 2017-2019, Maks Rafalko
+ * Copyright (c) 2017, Maks Rafalko
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/TestFramework/Coverage/CodeCoverageDataTest.php
+++ b/tests/TestFramework/Coverage/CodeCoverageDataTest.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage;
 
 use Infection\Mutation;
-use Infection\Mutator\Util\Mutator;
+use Infection\Mutator\Util\BaseMutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
 use Infection\TestFramework\Coverage\CoverageFileData;
@@ -148,7 +148,7 @@ final class CodeCoverageDataTest extends TestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            $this->createMock(Mutator::class),
+            $this->createMock(BaseMutator::class),
             ['startLine' => 1, 'endLine' => 1],
             'PHPParser\Node\Expr\BinaryOp\Plus',
             false,
@@ -169,7 +169,7 @@ final class CodeCoverageDataTest extends TestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            $this->createMock(Mutator::class),
+            $this->createMock(BaseMutator::class),
             ['startLine' => 26, 'endLine' => 26],
             'PHPParser\Node\Expr\BinaryOp\Plus',
             false,
@@ -194,7 +194,7 @@ final class CodeCoverageDataTest extends TestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            $this->createMock(Mutator::class),
+            $this->createMock(BaseMutator::class),
             ['startLine' => 1, 'endLine' => 1],
             'PHPParser\Node\Stmt\ClassMethod',
             true,
@@ -215,7 +215,7 @@ final class CodeCoverageDataTest extends TestCase
         $mutation = new Mutation(
             $filePath,
             [],
-            $this->createMock(Mutator::class),
+            $this->createMock(BaseMutator::class),
             ['startLine' => 24, 'endLine' => 24],
             'PHPParser\Node\Stmt\ClassMethod',
             true,

--- a/tests/Visitor/FilePathVisitorTest.php
+++ b/tests/Visitor/FilePathVisitorTest.php
@@ -2,7 +2,7 @@
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
- * Copyright (c) 2017-2019, Maks Rafalko
+ * Copyright (c) 2017, Maks Rafalko
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/Visitor/FilePathVisitorTest.php
+++ b/tests/Visitor/FilePathVisitorTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017-2019, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Visitor;
+
+use Infection\Visitor\FilePathVisitor;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * @internal
+ */
+final class FilePathVisitorTest extends AbstractBaseVisitorTest
+{
+    public function test_it_sets_all_nodes_file_path(): void
+    {
+        $path = 'foo/bar/bar.php';
+        $nodes = $this->getNodes(<<<PHP
+<?php
+
+class Foo
+{
+    public function bar(): int
+    {
+        return 721;
+    }
+}
+PHP
+);
+
+        $traverser = new NodeTraverser();
+        $spy = $this->getSpyVisitor($path);
+        $traverser->addVisitor(new FilePathVisitor($path));
+        $traverser->addVisitor($spy);
+        $traverser->traverse($nodes);
+        $this->assertFalse($spy->foundWrongPath);
+    }
+
+    private function getSpyVisitor(string $path)
+    {
+        return new class($path) extends NodeVisitorAbstract {
+            private $path;
+
+            public $foundWrongPath = false;
+
+            public function __construct($path)
+            {
+                $this->path = $path;
+            }
+
+            public function leaveNode(Node $node): void
+            {
+                if ($node->getAttribute(FilePathVisitor::FILE_PATH) !== $this->path) {
+                    $this->foundWrongPath = true;
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Extracts functionality out of the `MutationsCollectorVisitor`
- [x] Allows Mutators to be decorated
- [x] Covered by tests

The main goal of this PR was to extract a bit more functionality out of the `MutationsCollectorVisitor`. The decoration of the mutators is simply a byproduct of that.

I'm not too happy about the `FilePathVisitor`, as its output is really only needed if a mutator is 'broken'. Otherwise all it does is eat up space. So another way to get the file path to the exception for error reporting would be preferred.

I tried to keep the commits as atomic as possible, so it may be easier to reviewer per commit, due to the size of the `Rename Mutator to BaseMutator` commit