### PR TITLE
Do not mutate * to / and vice versa if one of the operands is numeric ±1.0

### DIFF
--- a/src/Mutator/Arithmetic/Division.php
+++ b/src/Mutator/Arithmetic/Division.php
@@ -56,6 +56,31 @@ final class Division extends Mutator
 
     protected function mutatesNode(Node $node): bool
     {
-        return $node instanceof Node\Expr\BinaryOp\Div;
+        if (!$node instanceof Node\Expr\BinaryOp\Div) {
+            return false;
+        }
+
+        if ($this->isNumericOne($node->left) || $this->isNumericOne($node->right)) {
+            return false;
+        }
+
+        if ($node->left instanceof Node\Expr\UnaryMinus && $this->isNumericOne($node->left->expr)) {
+            return false;
+        }
+
+        if ($node->right instanceof Node\Expr\UnaryMinus && $this->isNumericOne($node->right->expr)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isNumericOne(Node $node): bool
+    {
+        if ($node instanceof Node\Scalar\LNumber && $node->value === 1) {
+            return true;
+        }
+
+        return $node instanceof Node\Scalar\DNumber && $node->value === 1.0;
     }
 }

--- a/src/Mutator/Arithmetic/Multiplication.php
+++ b/src/Mutator/Arithmetic/Multiplication.php
@@ -56,6 +56,31 @@ final class Multiplication extends Mutator
 
     protected function mutatesNode(Node $node): bool
     {
-        return $node instanceof Node\Expr\BinaryOp\Mul;
+        if (!$node instanceof Node\Expr\BinaryOp\Mul) {
+            return false;
+        }
+
+        if ($this->isNumericOne($node->left) || $this->isNumericOne($node->right)) {
+            return false;
+        }
+
+        if ($node->left instanceof Node\Expr\UnaryMinus && $this->isNumericOne($node->left->expr)) {
+            return false;
+        }
+
+        if ($node->right instanceof Node\Expr\UnaryMinus && $this->isNumericOne($node->right->expr)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isNumericOne(Node $node): bool
+    {
+        if ($node instanceof Node\Scalar\LNumber && $node->value === 1) {
+            return true;
+        }
+
+        return $node instanceof Node\Scalar\DNumber && $node->value === 1.0;
     }
 }

--- a/tests/Mutator/Arithmetic/DivisionTest.php
+++ b/tests/Mutator/Arithmetic/DivisionTest.php
@@ -50,10 +50,9 @@ final class DivisionTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function provideMutationCases(): \Generator
     {
-        return [
-            'It changes regular divison' => [
+        yield 'It changes regular divison' => [
                 <<<'PHP'
 <?php
 
@@ -65,31 +64,79 @@ PHP
 
 $a = 10 * 2;
 PHP
-                ,
-            ],
-            'It does not change division equals' => [
+        ];
+
+        yield 'It does not change division equals' => [
                 <<<'PHP'
 <?php
 
 $a = 10;
 $a /= 5;
 PHP
-                ,
-            ],
         ];
-    }
 
-    public function test_replaces_division_with_multiplication(): void
-    {
-        $code = '<?php 1 / 2;';
-        $mutations = $this->mutate($code);
-
-        $expectedMutatedCode = <<<'PHP'
+        yield 'It does not mutate when the left side is 1 to avoid an equivalent mutation' => [
+            <<<'PHP'
 <?php
 
-1 * 2;
-PHP;
+$a = 1 / $b;
+PHP
+        ];
 
-        $this->assertSame($expectedMutatedCode, $mutations[0]);
+        yield 'It does not mutate when the right side is 1 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = $b / 1;
+PHP
+        ];
+
+        yield 'It does not mutate when the left side is -1 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = -1 / $b;
+PHP
+        ];
+
+        yield 'It does not mutate when the right side is -1 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = $b / -1;
+PHP
+        ];
+
+        yield 'It does not mutate when the left side is 1.0 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = 1.0 / $b;
+PHP
+        ];
+
+        yield 'It does not mutate when the right side is 1.0 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = $b / 1.0;
+PHP
+        ];
+
+        yield 'It does not mutate when the left side is -1.0 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = -1.0 / $b;
+PHP
+        ];
+
+        yield 'It does not mutate when the right side is -1.0 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = $b / -1.0;
+PHP
+        ];
     }
 }

--- a/tests/Mutator/Arithmetic/MultiplicationTest.php
+++ b/tests/Mutator/Arithmetic/MultiplicationTest.php
@@ -50,10 +50,9 @@ final class MultiplicationTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function provideMutationCases(): \Generator
     {
-        return [
-            'It mutates normal multiplication' => [
+        yield 'It mutates normal multiplication' => [
                 <<<'PHP'
 <?php
 
@@ -65,17 +64,79 @@ PHP
 
 $a = 10 / 3;
 PHP
-                ,
-            ],
-            'It does not mutate multiplication equals' => [
+        ];
+
+        yield 'It does not mutate multiplication equals' => [
                 <<<'PHP'
 <?php
 
 $a = 1;
 $a *= 2;
 PHP
-                ,
-            ],
+        ];
+
+        yield 'It does not mutate when the left side is 1 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = 1 * $b;
+PHP
+        ];
+
+        yield 'It does not mutate when the right side is 1 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = $b * 1;
+PHP
+        ];
+
+        yield 'It does not mutate when the left side is -1 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = -1 * $b;
+PHP
+        ];
+
+        yield 'It does not mutate when the right side is -1 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = $b * -1;
+PHP
+        ];
+
+        yield 'It does not mutate when the left side is 1.0 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = 1.0 * $b;
+PHP
+        ];
+
+        yield 'It does not mutate when the right side is 1.0 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = $b * 1.0;
+PHP
+        ];
+
+        yield 'It does not mutate when the left side is -1.0 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = -1.0 * $b;
+PHP
+        ];
+
+        yield 'It does not mutate when the right side is -1.0 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = $b * -1.0;
+PHP
         ];
     }
 }


### PR DESCRIPTION
Do not mutation `*` to `/` and vice versa if one of the operands is `1` or `-1` or `1.0` or `-1.0` to avoid equivalent mutations.

Fixes the issue mentioned by Badoo in their [talk about Mutation Testing](https://www.youtube.com/watch?v=EPU47QqtMiU):

```diff
- $a = $b * 1;
+ $a = $b / 1;
```

^ this is an equivalent mutant that can not be killed.