### PR TITLE
Log phpunit output to console when in debug mode

### DIFF
--- a/src/Events/InitialTestSuiteFinished.php
+++ b/src/Events/InitialTestSuiteFinished.php
@@ -40,4 +40,18 @@ namespace Infection\Events;
  */
 final class InitialTestSuiteFinished
 {
+    /**
+     * @var string
+     */
+    private $outputText;
+
+    public function __construct(string $outputText)
+    {
+        $this->outputText = $outputText;
+    }
+
+    public function getOutputText(): string
+    {
+        return $this->outputText;
+    }
 }

--- a/src/Process/Builder/SubscriberBuilder.php
+++ b/src/Process/Builder/SubscriberBuilder.php
@@ -228,7 +228,7 @@ final class SubscriberBuilder
             return new CiInitialTestsConsoleLoggerSubscriber($output, $testFrameworkAdapter);
         }
 
-        return new InitialTestsConsoleLoggerSubscriber($output, $testFrameworkAdapter);
+        return new InitialTestsConsoleLoggerSubscriber($output, $testFrameworkAdapter, $this->input->getOption('debug'));
     }
 
     private function shouldSkipProgressBars(): bool

--- a/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
@@ -63,10 +63,16 @@ final class InitialTestsConsoleLoggerSubscriber implements EventSubscriberInterf
      */
     private $testFrameworkAdapter;
 
-    public function __construct(OutputInterface $output, AbstractTestFrameworkAdapter $testFrameworkAdapter)
+    /**
+     * @var bool
+     */
+    private $debug;
+
+    public function __construct(OutputInterface $output, AbstractTestFrameworkAdapter $testFrameworkAdapter, bool $debug)
     {
         $this->output = $output;
         $this->testFrameworkAdapter = $testFrameworkAdapter;
+        $this->debug = $debug;
 
         $this->progressBar = new ProgressBar($this->output);
         $this->progressBar->setFormat('verbose');
@@ -105,6 +111,10 @@ final class InitialTestsConsoleLoggerSubscriber implements EventSubscriberInterf
     public function onInitialTestSuiteFinished(InitialTestSuiteFinished $event): void
     {
         $this->progressBar->finish();
+
+        if ($this->debug) {
+            $this->output->writeln(PHP_EOL . $event->getOutputText());
+        }
     }
 
     public function onInitialTestCaseCompleted(InitialTestCaseCompleted $event): void

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -81,7 +81,7 @@ final class InitialTestsRunner
             $this->eventDispatcher->dispatch(new InitialTestCaseCompleted());
         });
 
-        $this->eventDispatcher->dispatch(new InitialTestSuiteFinished());
+        $this->eventDispatcher->dispatch(new InitialTestSuiteFinished($process->getOutput()));
 
         return $process;
     }

--- a/tests/Events/InitialTestSuiteFinishedTest.php
+++ b/tests/Events/InitialTestSuiteFinishedTest.php
@@ -43,12 +43,12 @@ use PHPUnit\Framework\TestCase;
  */
 final class InitialTestSuiteFinishedTest extends TestCase
 {
-    /**
-     * This class is only used to fire events, and the only functionality it needs is being instantiated
-     */
-    public function test_it_can_be_initialzed(): void
+    public function test_it_passes_the_output_along(): void
     {
-        $class = new InitialTestSuiteFinished();
-        $this->assertInstanceOf(InitialTestSuiteFinished::class, $class);
+        $text = 'foo-bar-baz';
+
+        $class = new InitialTestSuiteFinished($text);
+
+        $this->assertSame($text, $class->getOutputText());
     }
 }

--- a/tests/Process/Builder/SubscriberBuilderTest.php
+++ b/tests/Process/Builder/SubscriberBuilderTest.php
@@ -57,7 +57,7 @@ final class SubscriberBuilderTest extends TestCase
     public function test_it_registers_the_subscribers_when_debugging(): void
     {
         $input = $this->createMock(InputInterface::class);
-        $input->expects($this->exactly(9))
+        $input->expects($this->exactly(10))
             ->method('getOption')
             ->will($this->returnValueMap(
                 [
@@ -95,7 +95,7 @@ final class SubscriberBuilderTest extends TestCase
     public function test_it_registers_the_subscribers_when_not_debugging(): void
     {
         $input = $this->createMock(InputInterface::class);
-        $input->expects($this->exactly(9))
+        $input->expects($this->exactly(10))
             ->method('getOption')
             ->will($this->returnValueMap(
                 [
@@ -133,13 +133,14 @@ final class SubscriberBuilderTest extends TestCase
     public function test_it_throws_an_exception_when_output_formatter_is_invalid(): void
     {
         $input = $this->createMock(InputInterface::class);
-        $input->expects($this->exactly(5))
+        $input->expects($this->exactly(6))
             ->method('getOption')
             ->will($this->returnValueMap(
                 [
                     ['ci-friendly', false],
                     ['formatter', 'foo'],
                     ['show-mutations', true],
+                    ['debug', true],
                 ]
             ));
         $calculator = new MetricsCalculator();

--- a/tests/Process/Builder/SubscriberBuilderTest.php
+++ b/tests/Process/Builder/SubscriberBuilderTest.php
@@ -51,17 +51,21 @@ use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
+ *
+ * NOTE:
+ * InputInterfaces should be mocked here so that the 'getOption' method with paramater 'no-progress'
+ * should return true. Otherwise you will see different results based on wheter its running in CI or not.
  */
 final class SubscriberBuilderTest extends TestCase
 {
     public function test_it_registers_the_subscribers_when_debugging(): void
     {
         $input = $this->createMock(InputInterface::class);
-        $input->expects($this->exactly(10))
+        $input->expects($this->exactly(9))
             ->method('getOption')
             ->will($this->returnValueMap(
                 [
-                    ['ci-friendly', false],
+                    ['no-progress', true],
                     ['formatter', 'progress'],
                     ['show-mutations', true],
                     ['log-verbosity', 'all'],
@@ -95,11 +99,11 @@ final class SubscriberBuilderTest extends TestCase
     public function test_it_registers_the_subscribers_when_not_debugging(): void
     {
         $input = $this->createMock(InputInterface::class);
-        $input->expects($this->exactly(10))
+        $input->expects($this->exactly(9))
             ->method('getOption')
             ->will($this->returnValueMap(
                 [
-                    ['ci-friendly', false],
+                    ['no-progress', true],
                     ['formatter', 'progress'],
                     ['show-mutations', true],
                     ['log-verbosity', 'all'],
@@ -133,11 +137,11 @@ final class SubscriberBuilderTest extends TestCase
     public function test_it_throws_an_exception_when_output_formatter_is_invalid(): void
     {
         $input = $this->createMock(InputInterface::class);
-        $input->expects($this->exactly(6))
+        $input->expects($this->exactly(5))
             ->method('getOption')
             ->will($this->returnValueMap(
                 [
-                    ['ci-friendly', false],
+                    ['no-progress', true],
                     ['formatter', 'foo'],
                     ['show-mutations', true],
                     ['debug', true],

--- a/tests/Process/Listener/InitialTestsConsoleLoggerSubscriberTest.php
+++ b/tests/Process/Listener/InitialTestsConsoleLoggerSubscriberTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Process\Listener;
 
 use Infection\EventDispatcher\EventDispatcher;
+use Infection\Events\InitialTestSuiteFinished;
 use Infection\Events\InitialTestSuiteStarted;
 use Infection\Process\Listener\InitialTestsConsoleLoggerSubscriber;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
@@ -58,7 +59,7 @@ final class InitialTestsConsoleLoggerSubscriberTest extends TestCase
             ->method('getVersion');
 
         $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber(new InitialTestsConsoleLoggerSubscriber($output, $testFramework));
+        $dispatcher->addSubscriber(new InitialTestsConsoleLoggerSubscriber($output, $testFramework, false));
 
         $dispatcher->dispatch(new InitialTestSuiteStarted());
     }
@@ -85,8 +86,27 @@ final class InitialTestsConsoleLoggerSubscriberTest extends TestCase
             ->will($this->throwException(new \InvalidArgumentException()));
 
         $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber(new InitialTestsConsoleLoggerSubscriber($output, $testFramework));
+        $dispatcher->addSubscriber(new InitialTestsConsoleLoggerSubscriber($output, $testFramework, false));
 
         $dispatcher->dispatch(new InitialTestSuiteStarted());
+    }
+
+    public function test_it_outputs_the_initial_process_text_if_in_debug_mode(): void
+    {
+        $processText = 'PHPUnit Test suite ...';
+        $output = $this->createMock(OutputInterface::class);
+        $output->expects($this->once())
+            ->method('writeln')
+            ->with(PHP_EOL . $processText);
+
+        $output->method('getVerbosity')
+            ->willReturn(OutputInterface::VERBOSITY_QUIET);
+
+        $testFramework = $this->createMock(AbstractTestFrameworkAdapter::class);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new InitialTestsConsoleLoggerSubscriber($output, $testFramework, true));
+
+        $dispatcher->dispatch(new InitialTestSuiteFinished($processText));
     }
 }

--- a/tests/Process/Runner/InitialTestsRunnerTest.php
+++ b/tests/Process/Runner/InitialTestsRunnerTest.php
@@ -62,6 +62,9 @@ final class InitialTestsRunnerTest extends TestCase
 
                 return true;
             }));
+        $process->expects($this->once())
+            ->method('getOutput')
+            ->willReturn('foo');
 
         $processBuilder = $this->createMock(ProcessBuilder::class);
         $processBuilder->method('getProcessForInitialTestRun')


### PR DESCRIPTION
This PR:

- [x] Logs PHPUnits output to the commandline when the `--debug` flag is used
- [x] Covered by tests

Fixes #520 