### PR TITLE
Fix #672 and same problem for testFrameworkOptions

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -182,8 +182,7 @@ final class InfectionCommand extends BaseCommand
                 'initial-tests-php-options',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Extra php options for the initial test runner. Will be ignored if --coverage option presented.',
-                ''
+                'Extra php options for the initial test runner. Will be ignored if --coverage option presented.'
             )
             ->addOption(
                 'ignore-msi-with-no-mutations',
@@ -233,8 +232,8 @@ final class InfectionCommand extends BaseCommand
             $this->skipCoverage,
             explode(
                 ' ',
-                $input->hasOption('initial-tests-php-options') ? $input->getOption('initial-tests-php-options') :
-                    $config->getInitialTestsPhpOptions()
+                $input->getOption('initial-tests-php-options')
+                ?? $config->getInitialTestsPhpOptions()
             )
         );
 
@@ -348,8 +347,8 @@ final class InfectionCommand extends BaseCommand
 
     private function getTestFrameworkExtraOptions(string $testFrameworkKey): TestFrameworkExtraOptions
     {
-        $extraOptions = $this->input->hasOption('test-framework-options')
-            ? $this->input->getOption('test-framework-options') : $this->getContainer()->get('infection.config')->getTestFrameworkOptions();
+        $extraOptions = $this->input->getOption('test-framework-options')
+            ?? $this->getContainer()->get('infection.config')->getTestFrameworkOptions();
 
         return TestFrameworkTypes::PHPUNIT === $testFrameworkKey
             ? new PhpUnitExtraOptions($extraOptions)

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -257,7 +257,7 @@ final class InfectionContainer extends Container
         $this['coverage.checker'] = static function () use ($input): CoverageRequirementChecker {
             return new CoverageRequirementChecker(
                 \strlen(trim($input->getOption('coverage'))) > 0,
-                $input->getOption('initial-tests-php-options')
+                (string) $input->getOption('initial-tests-php-options') ?? ''
             );
         };
 

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -257,7 +257,7 @@ final class InfectionContainer extends Container
         $this['coverage.checker'] = static function () use ($input): CoverageRequirementChecker {
             return new CoverageRequirementChecker(
                 \strlen(trim($input->getOption('coverage'))) > 0,
-                (string) $input->getOption('initial-tests-php-options') ?? ''
+                (string) ($input->getOption('initial-tests-php-options') ?? '')
             );
         };
 

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -71,6 +71,7 @@ use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 use Pimple\Container;
 use SebastianBergmann\Diff\Differ as BaseDiffer;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -255,9 +256,20 @@ final class InfectionContainer extends Container
         };
 
         $this['coverage.checker'] = static function () use ($input): CoverageRequirementChecker {
+            $initialTestsPhpOptions = $input->getOption('initial-tests-php-options') ?? '';
+
+            if (!\is_string($initialTestsPhpOptions)) {
+                throw new InvalidArgumentException(
+                    \sprintf(
+                        'Expected initial-tests-php-options to be string, %s given',
+                        \gettype($initialTestsPhpOptions)
+                    )
+                );
+            }
+
             return new CoverageRequirementChecker(
                 \strlen(trim($input->getOption('coverage'))) > 0,
-                (string) ($input->getOption('initial-tests-php-options') ?? '')
+                $initialTestsPhpOptions
             );
         };
 

--- a/tests/Console/InfectionContainerTest.php
+++ b/tests/Console/InfectionContainerTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Console;
 use Infection\Console\InfectionContainer;
 use PHPUnit\Framework\TestCase;
 use Pimple\Container;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 
 /**
@@ -70,5 +71,27 @@ final class InfectionContainerTest extends TestCase
             $tmpDir,
             $container['coverage.path']
         );
+    }
+
+    public function test_it_throws_on_invalid_type(): void
+    {
+        $input = $this->createMock(InputInterface::class);
+        $input
+            ->method('hasOption')
+            ->with('coverage')
+            ->willReturn(false)
+        ;
+        $input
+            ->method('getOption')
+            ->with('initial-tests-php-options')
+            ->willReturn([])
+        ;
+
+        $container = new InfectionContainer();
+        $container->buildDynamicDependencies($input);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected initial-tests-php-options to be string, array given');
+        $this->assertNotNull($container['coverage.checker']);
     }
 }

--- a/tests/Fixtures/e2e/Test_Framework_Options_Config/README.md
+++ b/tests/Fixtures/e2e/Test_Framework_Options_Config/README.md
@@ -1,0 +1,9 @@
+# Title
+
+* Link to github ticket if relevant
+
+## Summary
+Short summary of the ticket
+
+## Full Ticket
+Full github ticket

--- a/tests/Fixtures/e2e/Test_Framework_Options_Config/README.md
+++ b/tests/Fixtures/e2e/Test_Framework_Options_Config/README.md
@@ -1,9 +1,37 @@
-# Title
+# Tests that testFrameworkOptions in infection.json correctly works
 
-* Link to github ticket if relevant
+* [Issue #673](https://github.com/infection/infection/issues/672)
 
 ## Summary
-Short summary of the ticket
+Parameter testFrameworkOptions in infection.json did nothing.
 
 ## Full Ticket
-Full github ticket
+Although I have put "initialTestsPhpOptions": "-d zend_extension=xdebug.so", inside infection.json[.dist], but I still need to use --initial-tests-php-options='-d zend_extension=xdebug.so' on the command line to get it working. Without the command line --initial-tests-php-options paraeter I get the following error:
+
+```
+Code Coverage does not exist. File /Users/admin/workspace/infection/reports/infection/temp/infection/coverage-xml/index.xml is not found. Check phpunit version Infection was run with and generated config files inside /Users/adin/workspace/infection/reports/infection/temp/infection.
+```
+
+I believe same goes true for other arguments such as testFrameworkOptions as well.
+
+I tried to dig into the issue myself and the culprit turned out to be this part:
+
+path: src/Command/InfectionCommand.php
+
+```php
+$input->hasOption('initial-tests-php-options') ? $input->getOption('initial-tests-php-options') : $config->getInitialTestsPhpOptions()
+```
+
+$input->hasOption('initial-tests-php-options') returns true and hence getOption gets called which returns an empty string.
+
+Also based on the documentations, initial-tests-php-options is optional but the following code (from the same file) says otherwise:
+
+```php
+->addOption(
+                'initial-tests-php-options',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Extra php options for the initial test runner. Will be ignored if --coverage option presented.',
+                ''
+            )
+```

--- a/tests/Fixtures/e2e/Test_Framework_Options_Config/composer.json
+++ b/tests/Fixtures/e2e/Test_Framework_Options_Config/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^6.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Test_Framework_Options_Config\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Test_Framework_Options_Config\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Test_Framework_Options_Config/expected-output.txt
+++ b/tests/Fixtures/e2e/Test_Framework_Options_Config/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/Test_Framework_Options_Config/infection.json
+++ b/tests/Fixtures/e2e/Test_Framework_Options_Config/infection.json
@@ -1,0 +1,13 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": ".",
+    "testFrameworkOptions": "--strict-global-state"
+}

--- a/tests/Fixtures/e2e/Test_Framework_Options_Config/phpunit.xml
+++ b/tests/Fixtures/e2e/Test_Framework_Options_Config/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Test_Framework_Options_Config/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Test_Framework_Options_Config/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test_Framework_Options_Config;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/Test_Framework_Options_Config/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Test_Framework_Options_Config/tests/SourceClassTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Test_Framework_Options_Config\Test;
+
+use Test_Framework_Options_Config\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        if (
+            !in_array('--strict-global-state', $GLOBALS['argv'], true)
+        ) {
+            var_dump($GLOBALS['argv']);
+            echo 'Failure to pass framework option';
+            die(1);
+        }
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/Fixtures/e2e/Test_Framework_Options_Config/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Test_Framework_Options_Config/tests/SourceClassTest.php
@@ -2,8 +2,8 @@
 
 namespace Test_Framework_Options_Config\Test;
 
-use Test_Framework_Options_Config\SourceClass;
 use PHPUnit\Framework\TestCase;
+use Test_Framework_Options_Config\SourceClass;
 
 class SourceClassTest extends TestCase
 {
@@ -12,10 +12,14 @@ class SourceClassTest extends TestCase
         if (
             !in_array('--strict-global-state', $GLOBALS['argv'], true)
         ) {
-            var_dump($GLOBALS['argv']);
-            echo 'Failure to pass framework option';
-            die(1);
+            $this->fail(
+                sprintf(
+                    'Failure to pass framework option (argv: %s)',
+                    implode(' ', $GLOBALS['argv'])
+                )
+            );
         }
+
         $sourceClass = new SourceClass();
         $this->assertSame('hello', $sourceClass->hello());
     }

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/README.md
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/README.md
@@ -1,0 +1,9 @@
+# Title
+
+* Link to github ticket if relevant
+
+## Summary
+Short summary of the ticket
+
+## Full Ticket
+Full github ticket

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/README.md
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/README.md
@@ -1,9 +1,37 @@
-# Title
+# Tests that initialTestsPhpOptions in infection.json correctly works
 
-* Link to github ticket if relevant
+* [Issue #673](https://github.com/infection/infection/issues/672)
 
 ## Summary
-Short summary of the ticket
+Parameter initialTestsPhpOptions in infection.json did nothing.
 
 ## Full Ticket
-Full github ticket
+Although I have put "initialTestsPhpOptions": "-d zend_extension=xdebug.so", inside infection.json[.dist], but I still need to use --initial-tests-php-options='-d zend_extension=xdebug.so' on the command line to get it working. Without the command line --initial-tests-php-options paraeter I get the following error:
+
+```
+Code Coverage does not exist. File /Users/admin/workspace/infection/reports/infection/temp/infection/coverage-xml/index.xml is not found. Check phpunit version Infection was run with and generated config files inside /Users/adin/workspace/infection/reports/infection/temp/infection.
+```
+
+I believe same goes true for other arguments such as testFrameworkOptions as well.
+
+I tried to dig into the issue myself and the culprit turned out to be this part:
+
+path: src/Command/InfectionCommand.php
+
+```php
+$input->hasOption('initial-tests-php-options') ? $input->getOption('initial-tests-php-options') : $config->getInitialTestsPhpOptions()
+```
+
+$input->hasOption('initial-tests-php-options') returns true and hence getOption gets called which returns an empty string.
+
+Also based on the documentations, initial-tests-php-options is optional but the following code (from the same file) says otherwise:
+
+```php
+->addOption(
+                'initial-tests-php-options',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Extra php options for the initial test runner. Will be ignored if --coverage option presented.',
+                ''
+            )
+```

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/composer.json
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^7.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Test_PHP_Options_Config\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Test_PHP_Options_Config\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/expected-output.txt
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/infection.json
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/infection.json
@@ -1,0 +1,13 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": ".",
+    "initialTestsPhpOptions": "-d short_open_tag=Test"
+}

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/infection.json
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/infection.json
@@ -9,5 +9,5 @@
         "summary": "infection.log"
     },
     "tmpDir": ".",
-    "initialTestsPhpOptions": "-d short_open_tag=Test"
+    "initialTestsPhpOptions": "-d memory_limit=123M"
 }

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/phpunit.xml
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test_PHP_Options_Config;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/tests/SourceClassTest.php
@@ -9,7 +9,7 @@ class SourceClassTest extends TestCase
 {
     public function test_hello()
     {
-        if (ini_get('memory_limit') !== 'Test') {
+        if (ini_get('memory_limit') !== '123M') {
             $this->fail(
                 sprintf(
                     "Failure to pass php option (ini memory_limit: '%s')",

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/tests/SourceClassTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Test_PHP_Options_Config\Test;
+
+use Test_PHP_Options_Config\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        if (ini_get('short_open_tag') !== 'Test') {
+            echo 'Failure to pass php option';
+            die(1);
+        }
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/tests/SourceClassTest.php
@@ -9,11 +9,11 @@ class SourceClassTest extends TestCase
 {
     public function test_hello()
     {
-        if (ini_get('short_open_tag') !== 'Test') {
+        if (ini_get('memory_limit') !== 'Test') {
             $this->fail(
                 sprintf(
-                    "Failure to pass php option (ini short_open_tag: '%s')",
-                    ini_get('short_open_tag')
+                    "Failure to pass php option (ini memory_limit: '%s')",
+                    ini_get('memory_limit')
                 )
             );
         }

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/tests/SourceClassTest.php
@@ -2,17 +2,22 @@
 
 namespace Test_PHP_Options_Config\Test;
 
-use Test_PHP_Options_Config\SourceClass;
 use PHPUnit\Framework\TestCase;
+use Test_PHP_Options_Config\SourceClass;
 
 class SourceClassTest extends TestCase
 {
     public function test_hello()
     {
         if (ini_get('short_open_tag') !== 'Test') {
-            echo 'Failure to pass php option';
-            die(1);
+            $this->fail(
+                sprintf(
+                    "Failure to pass php option (ini short_open_tag: '%s')",
+                    ini_get('short_open_tag')
+                )
+            );
         }
+
         $sourceClass = new SourceClass();
         $this->assertSame('hello', $sourceClass->hello());
     }


### PR DESCRIPTION
This PR:

- [x] Covered by tests
 
Fixes #672

Parameters testFrameworkOptions and initialTestsPhpOptions in infection.json did nothing.