### PR TITLE
Chore/phpstan upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ INFECTION=build/bin/infection.phar
 # URLs to download all tools
 BOX_URL="https://github.com/humbug/box/releases/download/3.1.0/box.phar"
 PHP-CS-FIXER_URL="https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar"
-PHPSTAN_URL="https://github.com/phpstan/phpstan/releases/download/0.10.3/phpstan.phar"
+PHPSTAN_URL="https://github.com/phpstan/phpstan/releases/download/0.11.5/phpstan.phar"
 
 FLOCK=./devTools/flock
 

--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -1,7 +1,5 @@
 parameters:
     ignoreErrors:
-        - '#Access to an undefined property PhpParser\\Node(.*?)#'
-        - '#Call to an undefined method PhpParser\\Node(.*?)#'
         - '#expects .*, array<string>\|bool\|string\|null given#'
         - '#cast array<string>\|bool\|string\|null to#'
         - '#Return type \(void\) of method Infection\\Visitor\\.*::.*\(\) should be compatible with return type .* of method PhpParser\\Node.*::.*\(\)#'

--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -4,5 +4,5 @@ parameters:
         - '#cast array<string>\|bool\|string\|null to#'
         -
             path: '%currentWorkingDirectory%/src/Process/Runner/Parallel/ParallelProcessRunner.php'
-            message: '#Left side of [\||\&]{2} is always true#'
+            message: '#Left side of [\&]{2} is always true#'
 

--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -4,6 +4,8 @@ parameters:
         - '#Call to an undefined method PhpParser\\Node(.*?)#'
         - '#expects .*, array<string>\|bool\|string\|null given#'
         - '#cast array<string>\|bool\|string\|null to#'
-        - '#Offset array<string>\|bool\|string\|null does not#'
-        - '#Possibly invalid array key type array<string>\|bool\|string\|null#'
-        - '#Access to undefined constant PhpParser\\NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN#'
+        - '#Return type \(void\) of method Infection\\Visitor\\.*::.*\(\) should be compatible with return type .* of method PhpParser\\Node.*::.*\(\)#'
+        -
+            path: '%currentWorkingDirectory%/src/Process/Runner/Parallel/ParallelProcessRunner.php'
+            message: '#Left side of [\||\&]{2} is always true#'
+

--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -2,7 +2,6 @@ parameters:
     ignoreErrors:
         - '#expects .*, array<string>\|bool\|string\|null given#'
         - '#cast array<string>\|bool\|string\|null to#'
-        - '#Return type \(void\) of method Infection\\Visitor\\.*::.*\(\) should be compatible with return type .* of method PhpParser\\Node.*::.*\(\)#'
         -
             path: '%currentWorkingDirectory%/src/Process/Runner/Parallel/ParallelProcessRunner.php'
             message: '#Left side of [\||\&]{2} is always true#'

--- a/devTools/phpstan-tests.neon
+++ b/devTools/phpstan-tests.neon
@@ -1,3 +1,5 @@
 parameters:
     excludes_analyse:
         - %currentWorkingDirectory%/tests/Fixtures/*
+    ignoreErrors:
+        - '#Return type \(void\) of method .*[Visitor|Traverser].* should be compatible with return type .* of method PhpParser\\Node.*#'

--- a/src/Finder/SourceFilesFinder.php
+++ b/src/Finder/SourceFilesFinder.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Finder;
 
 use Infection\Finder\Iterator\RealPathFilterIterator;
+use Iterator;
 use Symfony\Component\Finder\Finder;
 
 /**
@@ -89,6 +90,9 @@ final class SourceFilesFinder extends Finder
         return $this;
     }
 
+    /**
+     * @return RealPathFilterIterator|(iterable<\Symfony\Component\Finder\SplFileInfo>&Iterator)
+     */
     public function getIterator()
     {
         $iterator = parent::getIterator();

--- a/src/Mutator/Arithmetic/Assignment.php
+++ b/src/Mutator/Arithmetic/Assignment.php
@@ -46,6 +46,7 @@ final class Assignment extends Mutator
     /**
      * Replaces "+=", "*=", ".=", and similar with a plain "="
      *
+     * @param Node&Node\Expr\AssignOp $node
      *
      * @return Node\Expr\Assign
      */

--- a/src/Mutator/Arithmetic/AssignmentEqual.php
+++ b/src/Mutator/Arithmetic/AssignmentEqual.php
@@ -46,6 +46,7 @@ final class AssignmentEqual extends Mutator
     /**
      * Replaces "==" with "="
      *
+     * @param Node&Node\Expr\BinaryOp\Equal $node
      *
      * @return Node\Expr\Assign
      */

--- a/src/Mutator/Arithmetic/BitwiseAnd.php
+++ b/src/Mutator/Arithmetic/BitwiseAnd.php
@@ -46,6 +46,7 @@ final class BitwiseAnd extends Mutator
     /**
      * Replaces "&" with "|"
      *
+     * @param Node&Node\Expr\BinaryOp\BooleanAnd $node
      *
      * @return Node\Expr\BinaryOp\BitwiseOr
      */

--- a/src/Mutator/Arithmetic/BitwiseNot.php
+++ b/src/Mutator/Arithmetic/BitwiseNot.php
@@ -45,6 +45,8 @@ final class BitwiseNot extends Mutator
 {
     /**
      * Replaces "~" with "" (removed)
+     *
+     * @param Node&Node\Expr\BitwiseNot $node
      */
     public function mutate(Node $node)
     {

--- a/src/Mutator/Arithmetic/BitwiseOr.php
+++ b/src/Mutator/Arithmetic/BitwiseOr.php
@@ -46,6 +46,7 @@ final class BitwiseOr extends Mutator
     /**
      * Replaces "|" with "&"
      *
+     * @param Node&Node\Expr\BinaryOp\BitwiseOr $node
      *
      * @return Node\Expr\BinaryOp\BitwiseAnd
      */

--- a/src/Mutator/Arithmetic/BitwiseXor.php
+++ b/src/Mutator/Arithmetic/BitwiseXor.php
@@ -46,6 +46,7 @@ final class BitwiseXor extends Mutator
     /**
      * Replaces "^" with "&"
      *
+     * @param Node&Node\Expr\BinaryOp\BitwiseXor $node
      *
      * @return Node\Expr\BinaryOp\BitwiseAnd
      */

--- a/src/Mutator/Arithmetic/Decrement.php
+++ b/src/Mutator/Arithmetic/Decrement.php
@@ -50,6 +50,7 @@ final class Decrement extends Mutator
     /**
      * Replaces "--" with "++"
      *
+     * @param Node&(PreDec|PostDec) $node
      *
      * @return PreInc|PostInc
      */

--- a/src/Mutator/Arithmetic/DivEqual.php
+++ b/src/Mutator/Arithmetic/DivEqual.php
@@ -46,6 +46,7 @@ final class DivEqual extends Mutator
     /**
      * Replaces "/=" with "*="
      *
+     * @param Node&Node\Expr\AssignOp\Div $node
      *
      * @return Node\Expr\AssignOp\Mul
      */

--- a/src/Mutator/Arithmetic/Division.php
+++ b/src/Mutator/Arithmetic/Division.php
@@ -46,6 +46,7 @@ final class Division extends Mutator
     /**
      * Replaces "/" with "*"
      *
+     * @param Node&Node\Expr\BinaryOp\Div $node
      *
      * @return Node\Expr\BinaryOp\Mul
      */

--- a/src/Mutator/Arithmetic/Exponentiation.php
+++ b/src/Mutator/Arithmetic/Exponentiation.php
@@ -46,6 +46,7 @@ final class Exponentiation extends Mutator
     /**
      * Replaces "**" with "/"
      *
+     * @param Node&Node\Expr\BinaryOp\Pow $node
      *
      * @return Node\Expr\BinaryOp\Div
      */

--- a/src/Mutator/Arithmetic/Increment.php
+++ b/src/Mutator/Arithmetic/Increment.php
@@ -50,6 +50,7 @@ final class Increment extends Mutator
     /**
      * Replaces "++" with "--"
      *
+     * @param Node&(PostInc|PreInc) $node
      *
      * @return PostDec|PreDec
      */

--- a/src/Mutator/Arithmetic/Minus.php
+++ b/src/Mutator/Arithmetic/Minus.php
@@ -46,6 +46,8 @@ final class Minus extends Mutator
     /**
      * Replaces "-" with "+"
      *
+     * @param Node&Node\Expr\BinaryOp\Minus $node
+     *
      * @return Node\Expr\BinaryOp\Plus
      */
     public function mutate(Node $node)

--- a/src/Mutator/Arithmetic/MinusEqual.php
+++ b/src/Mutator/Arithmetic/MinusEqual.php
@@ -46,6 +46,7 @@ final class MinusEqual extends Mutator
     /**
      * Replaces "-=" with "+="
      *
+     * @param Node&Node\Expr\AssignOp\Minus $node
      *
      * @return Node\Expr\AssignOp\Plus
      */

--- a/src/Mutator/Arithmetic/ModEqual.php
+++ b/src/Mutator/Arithmetic/ModEqual.php
@@ -46,6 +46,7 @@ final class ModEqual extends Mutator
     /**
      * Replaces "%=" with "*="
      *
+     * @param Node&Node\Expr\AssignOp\Mod $node
      *
      * @return Node\Expr\AssignOp\Mul
      */

--- a/src/Mutator/Arithmetic/Modulus.php
+++ b/src/Mutator/Arithmetic/Modulus.php
@@ -46,6 +46,7 @@ final class Modulus extends Mutator
     /**
      * Replaces "%" with "*"
      *
+     * @param Node&Node\Expr\BinaryOp\Mod $node
      *
      * @return Node\Expr\BinaryOp\Mul
      */

--- a/src/Mutator/Arithmetic/MulEqual.php
+++ b/src/Mutator/Arithmetic/MulEqual.php
@@ -46,6 +46,7 @@ final class MulEqual extends Mutator
     /**
      * Replaces "*=" with "/="
      *
+     * @param Node&Node\Expr\AssignOp\Mul $node
      *
      * @return Node\Expr\AssignOp\Div
      */

--- a/src/Mutator/Arithmetic/Multiplication.php
+++ b/src/Mutator/Arithmetic/Multiplication.php
@@ -46,6 +46,7 @@ final class Multiplication extends Mutator
     /**
      * Replaces "*" with "/"
      *
+     * @param Node&Node\Expr\BinaryOp\Mul $node
      *
      * @return Node\Expr\BinaryOp\Div
      */

--- a/src/Mutator/Arithmetic/Plus.php
+++ b/src/Mutator/Arithmetic/Plus.php
@@ -47,6 +47,8 @@ final class Plus extends Mutator
     /**
      * Replaces "+" with "-"
      *
+     * @param Node&Node\Expr\BinaryOp\Plus $node
+     *
      * @return Node\Expr\BinaryOp\Minus
      */
     public function mutate(Node $node)

--- a/src/Mutator/Arithmetic/PlusEqual.php
+++ b/src/Mutator/Arithmetic/PlusEqual.php
@@ -46,6 +46,7 @@ final class PlusEqual extends Mutator
     /**
      * Replaces "+=" with "-="
      *
+     * @param Node&Node\Expr\AssignOp\Plus $node
      *
      * @return Node\Expr\AssignOp\Minus
      */

--- a/src/Mutator/Arithmetic/PowEqual.php
+++ b/src/Mutator/Arithmetic/PowEqual.php
@@ -46,6 +46,7 @@ final class PowEqual extends Mutator
     /**
      * Replaces "**=" with "/="
      *
+     * @param Node&Node\Expr\AssignOp\Pow $node
      *
      * @return Node\Expr\AssignOp\Div
      */

--- a/src/Mutator/Arithmetic/RoundingFamily.php
+++ b/src/Mutator/Arithmetic/RoundingFamily.php
@@ -55,13 +55,15 @@ final class RoundingFamily extends Mutator
      *     2. ceil() to floor() and round()
      *     3. round() to ceil() and floor()
      *
-     * @param Node\Expr\FuncCall|Node $node
+     * @param Node&Node\Expr\FuncCall $node
      *
      * @return \Generator
      */
     public function mutate(Node $node)
     {
-        $currentFunctionName = $this->getNormalizedFunctionName($node->name);
+        /** @var Node\Name $name */
+        $name = $node->name;
+        $currentFunctionName = $name->toLowerString();
 
         $mutateToFunctions = array_diff(self::MUTATORS_MAP, [$currentFunctionName]);
 
@@ -81,16 +83,11 @@ final class RoundingFamily extends Mutator
         }
 
         if (!$node->name instanceof Node\Name ||
-            !\in_array($this->getNormalizedFunctionName($node->name), self::MUTATORS_MAP, true)
+            !\in_array($node->name->toLowerString(), self::MUTATORS_MAP, true)
         ) {
             return false;
         }
 
         return true;
-    }
-
-    private function getNormalizedFunctionName(Node\Name $name): string
-    {
-        return strtolower((string) $name);
     }
 }

--- a/src/Mutator/Arithmetic/ShiftLeft.php
+++ b/src/Mutator/Arithmetic/ShiftLeft.php
@@ -46,6 +46,7 @@ final class ShiftLeft extends Mutator
     /**
      * Replaces "<<" with ">>"
      *
+     * @param Node&Node\Expr\BinaryOp\ShiftLeft $node
      *
      * @return Node\Expr\BinaryOp\ShiftRight
      */

--- a/src/Mutator/Arithmetic/ShiftRight.php
+++ b/src/Mutator/Arithmetic/ShiftRight.php
@@ -46,6 +46,7 @@ final class ShiftRight extends Mutator
     /**
      * Replaces ">>" with "<<"
      *
+     * @param Node&Node\Expr\BinaryOp\ShiftRight $node
      *
      * @return Node\Expr\BinaryOp\ShiftLeft
      */

--- a/src/Mutator/Boolean/ArrayItem.php
+++ b/src/Mutator/Boolean/ArrayItem.php
@@ -46,12 +46,18 @@ final class ArrayItem extends Mutator
     /**
      * Replaces "[$a->foo => $b->bar]" with "[$a->foo > $b->bar]"
      *
+     * @param Node&Node\Expr\ArrayItem $node
      *
      * @return Node\Expr\BinaryOp\Greater
      */
     public function mutate(Node $node)
     {
-        return new Node\Expr\BinaryOp\Greater($node->key, $node->value, $node->getAttributes());
+        /** @var Node\Expr $key */
+        $key = $node->key;
+        /** @var Node\Expr $value */
+        $value = $node->value;
+
+        return new Node\Expr\BinaryOp\Greater($key, $value, $node->getAttributes());
     }
 
     protected function mutatesNode(Node $node): bool
@@ -59,7 +65,7 @@ final class ArrayItem extends Mutator
         return $node instanceof Node\Expr\ArrayItem && $node->key && ($this->isNodeWithSideEffects($node->value) || $this->isNodeWithSideEffects($node->key));
     }
 
-    private function isNodeWithSideEffects(Node $node)
+    private function isNodeWithSideEffects(Node $node): bool
     {
         return
             // __get() can have side-effects

--- a/src/Mutator/Boolean/EqualIdentical.php
+++ b/src/Mutator/Boolean/EqualIdentical.php
@@ -46,6 +46,7 @@ final class EqualIdentical extends Mutator
     /**
      * Replaces "==" with "==="
      *
+     * @param Node&Node\Expr\BinaryOp\Equal $node
      *
      * @return Node\Expr\BinaryOp\Identical
      */

--- a/src/Mutator/Boolean/IdenticalEqual.php
+++ b/src/Mutator/Boolean/IdenticalEqual.php
@@ -46,6 +46,7 @@ final class IdenticalEqual extends Mutator
     /**
      * Replaces "===" with "=="
      *
+     * @param Node&Node\Expr\BinaryOp\Identical $node
      *
      * @return Node\Expr\BinaryOp\Equal
      */

--- a/src/Mutator/Boolean/LogicalAnd.php
+++ b/src/Mutator/Boolean/LogicalAnd.php
@@ -46,6 +46,7 @@ final class LogicalAnd extends Mutator
     /**
      * Replaces "&&" with "||"
      *
+     * @param Node&Node\Expr\BinaryOp\LogicalOr $node
      *
      * @return Node\Expr\BinaryOp\BooleanOr
      */

--- a/src/Mutator/Boolean/LogicalLowerAnd.php
+++ b/src/Mutator/Boolean/LogicalLowerAnd.php
@@ -46,6 +46,7 @@ final class LogicalLowerAnd extends Mutator
     /**
      * Replaces "and" with "or"
      *
+     * @param Node&Node\Expr\BinaryOp\LogicalAnd $node
      *
      * @return Node\Expr\BinaryOp\LogicalOr
      */

--- a/src/Mutator/Boolean/LogicalLowerOr.php
+++ b/src/Mutator/Boolean/LogicalLowerOr.php
@@ -46,6 +46,7 @@ final class LogicalLowerOr extends Mutator
     /**
      * Replaces "or" with "and"
      *
+     * @param Node&Node\Expr\BinaryOp\LogicalOr $node
      *
      * @return Node\Expr\BinaryOp\LogicalAnd
      */

--- a/src/Mutator/Boolean/LogicalNot.php
+++ b/src/Mutator/Boolean/LogicalNot.php
@@ -45,6 +45,8 @@ final class LogicalNot extends Mutator
 {
     /**
      * Replaces "!something" with "something"
+     *
+     * @param Node&Node\Expr\BooleanNot $node
      */
     public function mutate(Node $node)
     {

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -46,6 +46,7 @@ final class LogicalOr extends Mutator
     /**
      * Replaces "||" with "&&"
      *
+     * @param Node&Node\Expr\BinaryOp\BooleanOr $node
      *
      * @return Node\Expr\BinaryOp\BooleanAnd
      */

--- a/src/Mutator/Boolean/NotEqualNotIdentical.php
+++ b/src/Mutator/Boolean/NotEqualNotIdentical.php
@@ -46,6 +46,7 @@ final class NotEqualNotIdentical extends Mutator
     /**
      * Replaces "!=" with "!=="
      *
+     * @param Node&Node\Expr\BinaryOp\NotEqual $node
      *
      * @return Node\Expr\BinaryOp\NotIdentical
      */

--- a/src/Mutator/Boolean/NotIdenticalNotEqual.php
+++ b/src/Mutator/Boolean/NotIdenticalNotEqual.php
@@ -46,6 +46,7 @@ final class NotIdenticalNotEqual extends Mutator
     /**
      * Replaces "!==" with "!="
      *
+     * @param Node&Node\Expr\BinaryOp\NotIdentical $node
      *
      * @return Node\Expr\BinaryOp\NotEqual
      */

--- a/src/Mutator/Boolean/Yield_.php
+++ b/src/Mutator/Boolean/Yield_.php
@@ -46,12 +46,17 @@ final class Yield_ extends Mutator
     /**
      * Replaces "yield $a => $b;" with "yield $a > $b;"
      *
+     * @param Node&Node\Expr\Yield_ $node
      *
      * @return Node|Node\Expr\Yield_
      */
     public function mutate(Node $node)
     {
-        $node->value = new Node\Expr\BinaryOp\Greater($node->key, $node->value, $node->getAttributes());
+        /** @var Node\Expr $key */
+        $key = $node->key;
+        /** @var Node\Expr $value */
+        $value = $node->value;
+        $node->value = new Node\Expr\BinaryOp\Greater($key, $value, $node->getAttributes());
         $node->key = null;
 
         return $node;

--- a/src/Mutator/Cast/AbstractCastMutator.php
+++ b/src/Mutator/Cast/AbstractCastMutator.php
@@ -46,6 +46,7 @@ abstract class AbstractCastMutator extends Mutator
     /**
      * Replaces "(cast) $foo;" with "$foo;"
      *
+     * @param Node&Node\Expr\Cast $node
      *
      * @return Node
      */

--- a/src/Mutator/ConditionalBoundary/GreaterThan.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThan.php
@@ -46,6 +46,7 @@ final class GreaterThan extends Mutator
     /**
      * Replaces ">" with ">="
      *
+     * @param Node&Node\Expr\BinaryOp\Greater $node
      *
      * @return Node\Expr\BinaryOp\GreaterOrEqual
      */

--- a/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
@@ -46,6 +46,7 @@ final class GreaterThanOrEqualTo extends Mutator
     /**
      * Replaces ">=" with ">"
      *
+     * @param Node&Node\Expr\BinaryOp\GreaterOrEqual $node
      *
      * @return Node\Expr\BinaryOp\Greater
      */

--- a/src/Mutator/ConditionalBoundary/LessThan.php
+++ b/src/Mutator/ConditionalBoundary/LessThan.php
@@ -46,6 +46,7 @@ final class LessThan extends Mutator
     /**
      * Replaces "<" with "<="
      *
+     * @param Node&Node\Expr\BinaryOp\Smaller $node
      *
      * @return Node\Expr\BinaryOp\SmallerOrEqual
      */

--- a/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
@@ -46,6 +46,7 @@ final class LessThanOrEqualTo extends Mutator
     /**
      * Replaces "<=" with "<"
      *
+     * @param Node&Node\Expr\BinaryOp\SmallerOrEqual $node
      *
      * @return Node\Expr\BinaryOp\Smaller
      */

--- a/src/Mutator/ConditionalNegotiation/Equal.php
+++ b/src/Mutator/ConditionalNegotiation/Equal.php
@@ -46,6 +46,7 @@ final class Equal extends Mutator
     /**
      * Replaces "==" with "!="
      *
+     * @param Node&Node\Expr\BinaryOp\Equal $node
      *
      * @return Node\Expr\BinaryOp\NotEqual
      */

--- a/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
@@ -46,6 +46,7 @@ final class GreaterThanNegotiation extends Mutator
     /**
      * Replaces ">" with "<="
      *
+     * @param Node&Node\Expr\BinaryOp\Greater $node
      *
      * @return Node\Expr\BinaryOp\SmallerOrEqual
      */

--- a/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
@@ -46,6 +46,7 @@ final class GreaterThanOrEqualToNegotiation extends Mutator
     /**
      * Replaces ">=" with "<"
      *
+     * @param Node&Node\Expr\BinaryOp\GreaterOrEqual $node
      *
      * @return Node\Expr\BinaryOp\Smaller
      */

--- a/src/Mutator/ConditionalNegotiation/Identical.php
+++ b/src/Mutator/ConditionalNegotiation/Identical.php
@@ -46,6 +46,7 @@ final class Identical extends Mutator
     /**
      * Replaces "===" with "!=="
      *
+     * @param Node&Node\Expr\BinaryOp\Identical $node
      *
      * @return Node\Expr\BinaryOp\NotIdentical
      */

--- a/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
@@ -46,6 +46,7 @@ final class LessThanNegotiation extends Mutator
     /**
      * Replaces "<" with ">="
      *
+     * @param Node&Node\Expr\BinaryOp\Smaller $node
      *
      * @return Node\Expr\BinaryOp\GreaterOrEqual
      */

--- a/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
@@ -46,6 +46,7 @@ final class LessThanOrEqualToNegotiation extends Mutator
     /**
      * Replaces "<=" with ">"
      *
+     * @param Node&Node\Expr\BinaryOp\SmallerOrEqual $node
      *
      * @return Node\Expr\BinaryOp\Greater
      */

--- a/src/Mutator/ConditionalNegotiation/NotEqual.php
+++ b/src/Mutator/ConditionalNegotiation/NotEqual.php
@@ -46,6 +46,7 @@ final class NotEqual extends Mutator
     /**
      * Replaces "!=" with "=="
      *
+     * @param Node&Node\Expr\BinaryOp\NotEqual $node
      *
      * @return Node\Expr\BinaryOp\Equal
      */

--- a/src/Mutator/ConditionalNegotiation/NotIdentical.php
+++ b/src/Mutator/ConditionalNegotiation/NotIdentical.php
@@ -46,6 +46,7 @@ final class NotIdentical extends Mutator
     /**
      * Replaces "!==" with "==="
      *
+     * @param Node&Node\Expr\BinaryOp\NotIdentical $node
      *
      * @return Node\Expr\BinaryOp\Identical
      */

--- a/src/Mutator/Extensions/BCMath.php
+++ b/src/Mutator/Extensions/BCMath.php
@@ -57,13 +57,16 @@ final class BCMath extends Mutator
     }
 
     /**
-     * @param Node|Node\Expr\FuncCall $node
+     * @param Node&Node\Expr\FuncCall $node
      *
      * @return Node|Node[]|Generator
      */
     public function mutate(Node $node)
     {
-        yield from $this->converters[$node->name->toLowerString()]($node);
+        /** @var Node\Name $name */
+        $name = $node->name;
+
+        yield from $this->converters[$name->toLowerString()]($node);
     }
 
     protected function mutatesNode(Node $node): bool

--- a/src/Mutator/Extensions/MBString.php
+++ b/src/Mutator/Extensions/MBString.php
@@ -57,13 +57,15 @@ final class MBString extends Mutator
     }
 
     /**
-     * @param Node\Expr\FuncCall $node
+     * @param Node&Node\Expr\FuncCall $node
      *
-     * @return Node|Node[]|Generator
+     * @return Node[]|Generator
      */
     public function mutate(Node $node)
     {
-        yield from $this->converters[$node->name->toLowerString()]($node);
+        /** @var Node\Name $name */
+        $name = $node->name;
+        yield from $this->converters[$name->toLowerString()]($node);
     }
 
     protected function mutatesNode(Node $node): bool

--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -49,6 +49,7 @@ final class ProtectedVisibility extends Mutator
     /**
      * Replaces "protected function..." with "private function ..."
      *
+     * @param Node&ClassMethod $node
      *
      * @return ClassMethod
      */
@@ -85,7 +86,7 @@ final class ProtectedVisibility extends Mutator
         return !$this->hasSameProtectedParentMethod($node);
     }
 
-    private function hasSameProtectedParentMethod(Node $node): bool
+    private function hasSameProtectedParentMethod(ClassMethod $node): bool
     {
         /** @var \ReflectionClass|null $reflection */
         $reflection = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -49,6 +49,7 @@ final class PublicVisibility extends Mutator
     /**
      * Replaces "public function..." with "protected function ..."
      *
+     * @param Node&ClassMethod $node
      *
      * @return ClassMethod
      */
@@ -85,7 +86,7 @@ final class PublicVisibility extends Mutator
         return !$this->hasSamePublicParentMethod($node);
     }
 
-    private function hasSamePublicParentMethod(Node $node): bool
+    private function hasSamePublicParentMethod(ClassMethod $node): bool
     {
         /** @var \ReflectionClass|null $reflection */
         $reflection = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -55,6 +55,7 @@ final class DecrementInteger extends AbstractNumberMutator
     /**
      * Decrements an integer by 1
      *
+     * @param Node&Node\Scalar\LNumber $node
      *
      * @return Node\Scalar\LNumber
      */

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -45,6 +45,7 @@ final class IncrementInteger extends AbstractNumberMutator
     /**
      * Increments an integer by 1
      *
+     * @param Node&Node\Scalar\LNumber $node
      *
      * @return Node\Scalar\LNumber
      */

--- a/src/Mutator/Number/OneZeroFloat.php
+++ b/src/Mutator/Number/OneZeroFloat.php
@@ -45,6 +45,7 @@ final class OneZeroFloat extends AbstractNumberMutator
     /**
      * Replaces "0.0" with "1.0" or "1.0" with "0.0"
      *
+     * @param Node&Node\Scalar\DNumber $node
      *
      * @return Node\Scalar\DNumber
      */

--- a/src/Mutator/Number/OneZeroInteger.php
+++ b/src/Mutator/Number/OneZeroInteger.php
@@ -45,6 +45,7 @@ final class OneZeroInteger extends AbstractNumberMutator
     /**
      * Replaces "0" with "1" or "1" with "0"
      *
+     * @param Node&Node\Scalar\LNumber $node
      *
      * @return Node\Scalar\LNumber
      */

--- a/src/Mutator/Operator/Coalesce.php
+++ b/src/Mutator/Operator/Coalesce.php
@@ -46,8 +46,9 @@ final class Coalesce extends Mutator
     /**
      * Replaces "'someValue' ?? 'otherValue';" with "'otherValue'"
      *
+     * @param Node&Node\Expr\BinaryOp\Coalesce $node
      *
-     * @return Node\Expr\BinaryOp\Coalesce
+     * @return Node\Expr
      */
     public function mutate(Node $node)
     {

--- a/src/Mutator/Operator/Throw_.php
+++ b/src/Mutator/Operator/Throw_.php
@@ -46,6 +46,7 @@ final class Throw_ extends Mutator
     /**
      * Replaces "throw new Exception();" with "new Exception();"
      *
+     * @param Node&Node\Stmt\Throw_ $node
      *
      * @return Node\Stmt\Expression
      */

--- a/src/Mutator/Regex/PregMatchMatches.php
+++ b/src/Mutator/Regex/PregMatchMatches.php
@@ -46,7 +46,7 @@ final class PregMatchMatches extends Mutator
     /**
      * Replaces "preg_match('/a/', 'b', $foo);" with "(int) $foo = array();"
      *
-     * @param Node|Node\Expr\FuncCall $node
+     * @param Node&Node\Expr\FuncCall $node
      *
      * @return Node\Expr\Cast\Int_
      */

--- a/src/Mutator/Regex/PregQuote.php
+++ b/src/Mutator/Regex/PregQuote.php
@@ -45,6 +45,8 @@ final class PregQuote extends Mutator
 {
     /**
      * Replaces "$a = preg_quote($b);" with "$a = $b;"
+     *
+     * @param Node&Node\Expr\FuncCall $node
      */
     public function mutate(Node $node)
     {

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -67,7 +67,7 @@ final class ArrayItemRemoval extends Mutator
     }
 
     /**
-     * @param Node|Node\Expr\Array_  $arrayNode
+     * @param Node&Node\Expr\Array_  $arrayNode
      */
     public function mutate(Node $arrayNode): Generator
     {

--- a/src/Mutator/ReturnValue/FloatNegation.php
+++ b/src/Mutator/ReturnValue/FloatNegation.php
@@ -47,17 +47,14 @@ final class FloatNegation extends Mutator
      * Replaces any float with negated float
      * Replaces "-33.4" with "33.4"
      *
+     * @param Node&Node\Stmt\Return_ $node
      *
      * @return Node\Stmt\Return_
      */
     public function mutate(Node $node)
     {
-        $floatValue = $node->expr instanceof Node\Expr\UnaryMinus
-            ? -$node->expr->expr->value
-            : $node->expr->value;
-
         return new Node\Stmt\Return_(
-            new Node\Scalar\DNumber(-1 * $floatValue, $node->getAttributes())
+            new Node\Scalar\DNumber(-1 * $this->getFloatValueOfNode($node), $node->getAttributes())
         );
     }
 
@@ -82,5 +79,23 @@ final class FloatNegation extends Mutator
         }
 
         return true;
+    }
+
+    /**
+     * @param Node&Node\Stmt\Return_ $node
+     */
+    private function getFloatValueOfNode(Node $node): float
+    {
+        /** @var Node\Expr\UnaryMinus|Node\Scalar\DNumber $expression */
+        $expression = $node->expr;
+
+        if ($expression instanceof Node\Expr\UnaryMinus) {
+            /** @var Node\Scalar\LNumber $innerExpression */
+            $innerExpression = $expression->expr;
+
+            return -$innerExpression->value;
+        }
+
+        return $expression->value;
     }
 }

--- a/src/Mutator/ReturnValue/FunctionCall.php
+++ b/src/Mutator/ReturnValue/FunctionCall.php
@@ -46,13 +46,17 @@ final class FunctionCall extends AbstractValueToNullReturnValue
     /**
      * Replaces "return func();" with "func(); return null;"
      *
+     * @param Node&Node\Stmt\Return_ $node
      *
      * @return Node[]
      */
     public function mutate(Node $node)
     {
+        /** @var Node\Expr\New_ $expr */
+        $expr = $node->expr;
+
         return [
-            new Node\Stmt\Expression($node->expr),
+            new Node\Stmt\Expression($expr),
             new Node\Stmt\Return_(
                 new Node\Expr\ConstFetch(new Node\Name('null'))
             ),

--- a/src/Mutator/ReturnValue/IntegerNegation.php
+++ b/src/Mutator/ReturnValue/IntegerNegation.php
@@ -47,17 +47,14 @@ final class IntegerNegation extends Mutator
      * Replaces any integer with negated integer value.
      * Replaces "-5" with "5"
      *
+     * @param Node&Node\Stmt\Return_ $node
      *
      * @return Node\Stmt\Return_
      */
     public function mutate(Node $node)
     {
-        $integerValue = $node->expr instanceof Node\Expr\UnaryMinus
-            ? -$node->expr->expr->value
-            : $node->expr->value;
-
         return new Node\Stmt\Return_(
-            new Node\Scalar\LNumber(-1 * $integerValue, $node->getAttributes())
+            new Node\Scalar\LNumber(-1 * $this->getIntegerValueOfNode($node), $node->getAttributes())
         );
     }
 
@@ -82,5 +79,23 @@ final class IntegerNegation extends Mutator
         }
 
         return true;
+    }
+
+    /**
+     * @param Node&Node\Stmt\Return_ $node
+     */
+    private function getIntegerValueOfNode(Node $node): int
+    {
+        /** @var Node\Expr\UnaryMinus|Node\Scalar\LNumber $expression */
+        $expression = $node->expr;
+
+        if ($expression instanceof Node\Expr\UnaryMinus) {
+            /** @var Node\Scalar\LNumber $innerExpression */
+            $innerExpression = $expression->expr;
+
+            return -$innerExpression->value;
+        }
+
+        return $expression->value;
     }
 }

--- a/src/Mutator/ReturnValue/NewObject.php
+++ b/src/Mutator/ReturnValue/NewObject.php
@@ -46,13 +46,17 @@ final class NewObject extends AbstractValueToNullReturnValue
     /**
      * Replaces "return new Something(anything);" with "new Something(anything); return null;"
      *
+     * @param Node&Node\Stmt\Return_ $node
      *
      * @return Node[]
      */
     public function mutate(Node $node)
     {
+        /** @var Node\Expr\New_ $expr */
+        $expr = $node->expr;
+
         return [
-            new Node\Stmt\Expression($node->expr),
+            new Node\Stmt\Expression($expr),
             new Node\Stmt\Return_(
                 new Node\Expr\ConstFetch(new Node\Name('null'))
             ),

--- a/src/Mutator/Sort/Spaceship.php
+++ b/src/Mutator/Sort/Spaceship.php
@@ -47,6 +47,7 @@ final class Spaceship extends Mutator
      * Swaps the arguments in the Spaceship operator <=>
      * Replaces "$a <=> $b" with "$b <=> $a"
      *
+     * @param Node&Node\Expr\BinaryOp\Spaceship $node
      *
      * @return Node\Expr\BinaryOp\Spaceship
      */

--- a/src/Mutator/Unwrap/AbstractUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractUnwrapMutator.php
@@ -46,7 +46,9 @@ abstract class AbstractUnwrapMutator extends Mutator
     /**
      * Replaces "$a = function(arg1, arg2);" with "$a = arg1;"
      *
-     * @return Node\Param;
+     * @param Node&Node\Expr\FuncCall $node
+     *
+     * @return Node\Param[]|\Generator;
      */
     final public function mutate(Node $node)
     {
@@ -57,7 +59,10 @@ abstract class AbstractUnwrapMutator extends Mutator
 
     abstract protected function getFunctionName(): string;
 
-    abstract protected function getParameterIndexes(Node $node): \Generator;
+    /**
+     * @return int[]|\Generator
+     */
+    abstract protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator;
 
     final protected function mutatesNode(Node $node): bool
     {

--- a/src/Mutator/Unwrap/UnwrapArrayChangeKeyCase.php
+++ b/src/Mutator/Unwrap/UnwrapArrayChangeKeyCase.php
@@ -47,7 +47,7 @@ final class UnwrapArrayChangeKeyCase extends AbstractUnwrapMutator
         return 'array_change_key_case';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayChunk.php
+++ b/src/Mutator/Unwrap/UnwrapArrayChunk.php
@@ -47,7 +47,7 @@ final class UnwrapArrayChunk extends AbstractUnwrapMutator
         return 'array_chunk';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayColumn.php
+++ b/src/Mutator/Unwrap/UnwrapArrayColumn.php
@@ -47,7 +47,7 @@ final class UnwrapArrayColumn extends AbstractUnwrapMutator
         return 'array_column';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayCombine.php
+++ b/src/Mutator/Unwrap/UnwrapArrayCombine.php
@@ -47,7 +47,7 @@ final class UnwrapArrayCombine extends AbstractUnwrapMutator
         return 'array_combine';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
 

--- a/src/Mutator/Unwrap/UnwrapArrayDiff.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiff.php
@@ -47,7 +47,7 @@ final class UnwrapArrayDiff extends AbstractUnwrapMutator
         return 'array_diff';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffAssoc.php
@@ -47,7 +47,7 @@ final class UnwrapArrayDiffAssoc extends AbstractUnwrapMutator
         return 'array_diff_assoc';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffKey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffKey.php
@@ -47,7 +47,7 @@ final class UnwrapArrayDiffKey extends AbstractUnwrapMutator
         return 'array_diff_key';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffUassoc.php
@@ -47,7 +47,7 @@ final class UnwrapArrayDiffUassoc extends AbstractUnwrapMutator
         return 'array_diff_uassoc';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffUkey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffUkey.php
@@ -47,7 +47,7 @@ final class UnwrapArrayDiffUkey extends AbstractUnwrapMutator
         return 'array_diff_ukey';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayFilter.php
+++ b/src/Mutator/Unwrap/UnwrapArrayFilter.php
@@ -47,7 +47,7 @@ final class UnwrapArrayFilter extends AbstractUnwrapMutator
         return 'array_filter';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayFlip.php
+++ b/src/Mutator/Unwrap/UnwrapArrayFlip.php
@@ -47,7 +47,7 @@ final class UnwrapArrayFlip extends AbstractUnwrapMutator
         return 'array_flip';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayIntersect.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersect.php
@@ -47,7 +47,7 @@ final class UnwrapArrayIntersect extends AbstractUnwrapMutator
         return 'array_intersect';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectAssoc.php
@@ -47,7 +47,7 @@ final class UnwrapArrayIntersectAssoc extends AbstractUnwrapMutator
         return 'array_intersect_assoc';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectKey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectKey.php
@@ -47,7 +47,7 @@ final class UnwrapArrayIntersectKey extends AbstractUnwrapMutator
         return 'array_intersect_key';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectUassoc.php
@@ -47,7 +47,7 @@ final class UnwrapArrayIntersectUassoc extends AbstractUnwrapMutator
         return 'array_intersect_uassoc';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from \array_slice(
             array_keys($node->args),

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectUkey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectUkey.php
@@ -47,7 +47,7 @@ final class UnwrapArrayIntersectUkey extends AbstractUnwrapMutator
         return 'array_intersect_ukey';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from \array_slice(
             array_keys($node->args),

--- a/src/Mutator/Unwrap/UnwrapArrayKeys.php
+++ b/src/Mutator/Unwrap/UnwrapArrayKeys.php
@@ -47,7 +47,7 @@ final class UnwrapArrayKeys extends AbstractUnwrapMutator
         return 'array_keys';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayMap.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMap.php
@@ -47,7 +47,7 @@ final class UnwrapArrayMap extends AbstractUnwrapMutator
         return 'array_map';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from range(1, \count($node->args) - 1);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayMerge.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMerge.php
@@ -47,7 +47,7 @@ final class UnwrapArrayMerge extends AbstractUnwrapMutator
         return 'array_merge';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayMergeRecursive.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMergeRecursive.php
@@ -47,7 +47,7 @@ final class UnwrapArrayMergeRecursive extends AbstractUnwrapMutator
         return 'array_merge_recursive';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayPad.php
+++ b/src/Mutator/Unwrap/UnwrapArrayPad.php
@@ -47,7 +47,7 @@ final class UnwrapArrayPad extends AbstractUnwrapMutator
         return 'array_pad';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayReduce.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReduce.php
@@ -47,7 +47,7 @@ final class UnwrapArrayReduce extends AbstractUnwrapMutator
         return 'array_reduce';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 2;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayReplace.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReplace.php
@@ -47,7 +47,7 @@ final class UnwrapArrayReplace extends AbstractUnwrapMutator
         return 'array_replace';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayReplaceRecursive.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReplaceRecursive.php
@@ -47,7 +47,7 @@ final class UnwrapArrayReplaceRecursive extends AbstractUnwrapMutator
         return 'array_replace_recursive';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayReverse.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReverse.php
@@ -47,7 +47,7 @@ final class UnwrapArrayReverse extends AbstractUnwrapMutator
         return 'array_reverse';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArraySlice.php
+++ b/src/Mutator/Unwrap/UnwrapArraySlice.php
@@ -47,7 +47,7 @@ final class UnwrapArraySlice extends AbstractUnwrapMutator
         return 'array_slice';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArraySplice.php
+++ b/src/Mutator/Unwrap/UnwrapArraySplice.php
@@ -47,7 +47,7 @@ final class UnwrapArraySplice extends AbstractUnwrapMutator
         return 'array_splice';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayUdiff.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUdiff.php
@@ -47,7 +47,7 @@ final class UnwrapArrayUdiff extends AbstractUnwrapMutator
         return 'array_udiff';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayUdiffAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUdiffAssoc.php
@@ -47,7 +47,7 @@ final class UnwrapArrayUdiffAssoc extends AbstractUnwrapMutator
         return 'array_udiff_assoc';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayUdiffUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUdiffUassoc.php
@@ -47,7 +47,7 @@ final class UnwrapArrayUdiffUassoc extends AbstractUnwrapMutator
         return 'array_udiff_uassoc';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayUintersect.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUintersect.php
@@ -47,7 +47,7 @@ final class UnwrapArrayUintersect extends AbstractUnwrapMutator
         return 'array_uintersect';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from \array_slice(
             array_keys($node->args),

--- a/src/Mutator/Unwrap/UnwrapArrayUintersectAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUintersectAssoc.php
@@ -47,7 +47,7 @@ final class UnwrapArrayUintersectAssoc extends AbstractUnwrapMutator
         return 'array_uintersect_assoc';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from \array_slice(
             array_keys($node->args),

--- a/src/Mutator/Unwrap/UnwrapArrayUintersectUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUintersectUassoc.php
@@ -47,7 +47,7 @@ final class UnwrapArrayUintersectUassoc extends AbstractUnwrapMutator
         return 'array_uintersect_uassoc';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield from \array_slice(
             array_keys($node->args),

--- a/src/Mutator/Unwrap/UnwrapArrayUnique.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUnique.php
@@ -47,7 +47,7 @@ final class UnwrapArrayUnique extends AbstractUnwrapMutator
         return 'array_unique';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayValues.php
+++ b/src/Mutator/Unwrap/UnwrapArrayValues.php
@@ -47,7 +47,7 @@ final class UnwrapArrayValues extends AbstractUnwrapMutator
         return 'array_values';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapLcFirst.php
+++ b/src/Mutator/Unwrap/UnwrapLcFirst.php
@@ -47,7 +47,7 @@ final class UnwrapLcFirst extends AbstractUnwrapMutator
         return 'lcfirst';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapStrRepeat.php
+++ b/src/Mutator/Unwrap/UnwrapStrRepeat.php
@@ -47,7 +47,7 @@ final class UnwrapStrRepeat extends AbstractUnwrapMutator
         return 'str_repeat';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapStrToLower.php
+++ b/src/Mutator/Unwrap/UnwrapStrToLower.php
@@ -47,7 +47,7 @@ final class UnwrapStrToLower extends AbstractUnwrapMutator
         return 'strtolower';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapStrToUpper.php
+++ b/src/Mutator/Unwrap/UnwrapStrToUpper.php
@@ -47,7 +47,7 @@ final class UnwrapStrToUpper extends AbstractUnwrapMutator
         return 'strtoupper';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapTrim.php
+++ b/src/Mutator/Unwrap/UnwrapTrim.php
@@ -47,7 +47,7 @@ final class UnwrapTrim extends AbstractUnwrapMutator
         return 'trim';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapUcFirst.php
+++ b/src/Mutator/Unwrap/UnwrapUcFirst.php
@@ -47,7 +47,7 @@ final class UnwrapUcFirst extends AbstractUnwrapMutator
         return 'ucfirst';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapUcWords.php
+++ b/src/Mutator/Unwrap/UnwrapUcWords.php
@@ -47,7 +47,7 @@ final class UnwrapUcWords extends AbstractUnwrapMutator
         return 'ucwords';
     }
 
-    protected function getParameterIndexes(Node $node): \Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): \Generator
     {
         yield 0;
     }

--- a/src/Mutator/Util/Mutator.php
+++ b/src/Mutator/Util/Mutator.php
@@ -51,7 +51,7 @@ abstract class Mutator
     }
 
     /**
-     * @return Node|Node[]|\Generator
+     * @return Node|Node[]|\Generator|array
      */
     abstract public function mutate(Node $node);
 
@@ -78,7 +78,7 @@ abstract class Mutator
     {
         $parts = explode('\\', static::class);
 
-        return end($parts);
+        return (string) end($parts);
     }
 
     final protected function getSettings(): array

--- a/src/Mutator/ZeroIteration/For_.php
+++ b/src/Mutator/ZeroIteration/For_.php
@@ -46,6 +46,7 @@ final class For_ extends Mutator
     /**
      * Replaces "for($i=0; $i<10; $i++)" with "for($i=0; false; $i++)"
      *
+     * @param Node&Node\Stmt\For_ $node
      *
      * @return Node\Stmt\For_
      */

--- a/src/Mutator/ZeroIteration/Foreach_.php
+++ b/src/Mutator/ZeroIteration/Foreach_.php
@@ -46,8 +46,9 @@ final class Foreach_ extends Mutator
     /**
      * Replaces "foreach($a as $b)" with "foreach(array() as $b)"
      *
+     * @param Node&Node\Stmt\Foreach_ $node
      *
-     * @return Node\Stmt\Foreach_
+     * @return Node&Node\Stmt\Foreach_
      */
     public function mutate(Node $node)
     {

--- a/src/Process/Runner/Parallel/ParallelProcessRunner.php
+++ b/src/Process/Runner/Parallel/ParallelProcessRunner.php
@@ -119,7 +119,7 @@ final class ParallelProcessRunner
                 }
             }
             // continue loop while there are processes being executed or waiting for execution
-        } while ($this->processesQueue || $this->currentProcesses);
+        } while ($this->currentProcesses);
     }
 
     private function startProcess(): bool

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -123,7 +123,7 @@ class CoverageXmlParser
      */
     private function removeNamespace(string $xml): string
     {
-        return preg_replace('/xmlns=\".*?\"/', '', $xml);
+        return (string) preg_replace('/xmlns=\".*?\"/', '', $xml);
     }
 
     /**

--- a/src/TestFramework/TestFrameworkExtraOptions.php
+++ b/src/TestFramework/TestFrameworkExtraOptions.php
@@ -60,10 +60,11 @@ abstract class TestFrameworkExtraOptions
         $extraOptions = $this->extraOptions;
 
         foreach ($this->getInitialRunOnlyOptions() as $initialRunOnlyOption) {
+            /** @var string $extraOptions */
             $extraOptions = preg_replace(sprintf('/%s[\=| ](?:\"[^\"]*\"|\'[^\']*\'|[^\ ]*)/', $initialRunOnlyOption), '', $extraOptions);
         }
 
-        return preg_replace('/\s+/', ' ', trim($extraOptions));
+        return (string) preg_replace('/\s+/', ' ', trim($extraOptions));
     }
 
     abstract protected function getInitialRunOnlyOptions(): array;

--- a/src/Visitor/FullyQualifiedClassNameVisitor.php
+++ b/src/Visitor/FullyQualifiedClassNameVisitor.php
@@ -49,6 +49,7 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class FullyQualifiedClassNameVisitor extends NodeVisitorAbstract
 {
+    public const FQN_KEY = 'fullyQualifiedClassName';
     private $namespace;
 
     public function enterNode(Node $node): void
@@ -56,7 +57,7 @@ final class FullyQualifiedClassNameVisitor extends NodeVisitorAbstract
         if ($node instanceof Stmt\Namespace_) {
             $this->namespace = $node->name;
         } elseif ($node instanceof Stmt\ClassLike) {
-            $node->fullyQualifiedClassName = $node->name ? Name::concat($this->namespace, $node->name->name) : null;
+            $node->setAttribute(self::FQN_KEY, $node->name ? Name::concat($this->namespace, $node->name->name) : null);
         }
     }
 }

--- a/src/Visitor/FullyQualifiedClassNameVisitor.php
+++ b/src/Visitor/FullyQualifiedClassNameVisitor.php
@@ -50,6 +50,7 @@ use PhpParser\NodeVisitorAbstract;
 final class FullyQualifiedClassNameVisitor extends NodeVisitorAbstract
 {
     public const FQN_KEY = 'fullyQualifiedClassName';
+
     private $namespace;
 
     public function enterNode(Node $node): void

--- a/src/Visitor/FullyQualifiedClassNameVisitor.php
+++ b/src/Visitor/FullyQualifiedClassNameVisitor.php
@@ -53,12 +53,14 @@ final class FullyQualifiedClassNameVisitor extends NodeVisitorAbstract
 
     private $namespace;
 
-    public function enterNode(Node $node): void
+    public function enterNode(Node $node): ?Node
     {
         if ($node instanceof Stmt\Namespace_) {
             $this->namespace = $node->name;
         } elseif ($node instanceof Stmt\ClassLike) {
             $node->setAttribute(self::FQN_KEY, $node->name ? Name::concat($this->namespace, $node->name->name) : null);
         }
+
+        return null;
     }
 }

--- a/src/Visitor/FullyQualifiedClassNameVisitor.php
+++ b/src/Visitor/FullyQualifiedClassNameVisitor.php
@@ -44,13 +44,16 @@ use PhpParser\NodeVisitorAbstract;
  * @internal
  *
  * Adds FullyQualifiedClassName (FQCN) string to class node:
- *      $node->name                    // Plus
- *      $node->fullyQualifiedClassName // Infection\Mutator\Plus
+ *      $node->name                                                  // Plus
+ *      $node->getAttribute(FullyQualifiedClassNameVisitor::FQN_KEY) // Infection\Mutator\Plus
  */
 final class FullyQualifiedClassNameVisitor extends NodeVisitorAbstract
 {
     public const FQN_KEY = 'fullyQualifiedClassName';
 
+    /**
+     * @var Node\Name|null
+     */
     private $namespace;
 
     public function enterNode(Node $node): ?Node

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -90,7 +90,7 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
         $this->onlyCovered = $onlyCovered;
     }
 
-    public function leaveNode(Node $node): void
+    public function leaveNode(Node $node): ?Node
     {
         foreach ($this->mutators as $mutator) {
             try {
@@ -151,6 +151,8 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
                 );
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Visitor/ParentConnectorVisitor.php
+++ b/src/Visitor/ParentConnectorVisitor.php
@@ -47,22 +47,28 @@ final class ParentConnectorVisitor extends NodeVisitorAbstract
 
     private $stack;
 
-    public function beforeTraverse(array $nodes): void
+    public function beforeTraverse(array $nodes): ?array
     {
         $this->stack = [];
+
+        return null;
     }
 
-    public function enterNode(Node $node): void
+    public function enterNode(Node $node): ?Node
     {
         if (!empty($this->stack)) {
             $node->setAttribute(self::PARENT_KEY, $this->stack[\count($this->stack) - 1]);
         }
 
         $this->stack[] = $node;
+
+        return null;
     }
 
-    public function leaveNode(Node $node): void
+    public function leaveNode(Node $node): ?Node
     {
         array_pop($this->stack);
+
+        return null;
     }
 }

--- a/src/Visitor/ReflectionVisitor.php
+++ b/src/Visitor/ReflectionVisitor.php
@@ -76,7 +76,7 @@ final class ReflectionVisitor extends NodeVisitorAbstract
     {
         if ($node instanceof Node\Stmt\ClassLike) {
             if ($attribute = $node->getAttribute(FullyQualifiedClassNameVisitor::FQN_KEY)) {
-                $this->classScopeStack[] = new \ReflectionClass($attribute);
+                $this->classScopeStack[] = new \ReflectionClass($attribute->toString());
             } else {
                 // Anonymous class
                 $this->classScopeStack[] = null;

--- a/src/Visitor/ReflectionVisitor.php
+++ b/src/Visitor/ReflectionVisitor.php
@@ -75,8 +75,8 @@ final class ReflectionVisitor extends NodeVisitorAbstract
     public function enterNode(Node $node)
     {
         if ($node instanceof Node\Stmt\ClassLike) {
-            if (isset($node->fullyQualifiedClassName)) {
-                $this->classScopeStack[] = new \ReflectionClass($node->fullyQualifiedClassName->toString());
+            if ($attribute = $node->getAttribute(FullyQualifiedClassNameVisitor::FQN_KEY)) {
+                $this->classScopeStack[] = new \ReflectionClass($attribute);
             } else {
                 // Anonymous class
                 $this->classScopeStack[] = null;

--- a/src/Visitor/ReflectionVisitor.php
+++ b/src/Visitor/ReflectionVisitor.php
@@ -65,11 +65,13 @@ final class ReflectionVisitor extends NodeVisitorAbstract
      */
     private $methodName;
 
-    public function beforeTraverse(array $nodes): void
+    public function beforeTraverse(array $nodes): ?array
     {
         $this->functionScopeStack = [];
         $this->classScopeStack = [];
         $this->methodName = null;
+
+        return null;
     }
 
     public function enterNode(Node $node)
@@ -115,7 +117,7 @@ final class ReflectionVisitor extends NodeVisitorAbstract
         }
     }
 
-    public function leaveNode(Node $node): void
+    public function leaveNode(Node $node): ?Node
     {
         if ($this->isFunctionLikeNode($node)) {
             array_pop($this->functionScopeStack);
@@ -124,6 +126,8 @@ final class ReflectionVisitor extends NodeVisitorAbstract
         if ($node instanceof  Node\Stmt\ClassLike) {
             array_pop($this->classScopeStack);
         }
+
+        return null;
     }
 
     private function isPartOfFunctionSignature(Node $node): bool

--- a/tests/Visitor/FullyQualifiedClassNameVisitorTest.php
+++ b/tests/Visitor/FullyQualifiedClassNameVisitorTest.php
@@ -61,7 +61,7 @@ final class FullyQualifiedClassNameVisitorTest extends AbstractBaseVisitorTest
         $this->assertCount(1, $this->spyVisitor->processedNodes);
         $this->assertSame(
             'FqcnEmptyClass\EmptyClass',
-            $this->spyVisitor->processedNodes[0]->fullyQualifiedClassName->toString()
+            $this->spyVisitor->processedNodes[0]->getAttribute(FullyQualifiedClassNameVisitor::FQN_KEY)->toString()
         );
     }
 
@@ -74,7 +74,7 @@ final class FullyQualifiedClassNameVisitorTest extends AbstractBaseVisitorTest
         $this->assertCount(1, $this->spyVisitor->processedNodes);
         $this->assertSame(
             'FqcnClassInterface\Ci',
-            $this->spyVisitor->processedNodes[0]->fullyQualifiedClassName->toString()
+            $this->spyVisitor->processedNodes[0]->getAttribute(FullyQualifiedClassNameVisitor::FQN_KEY)->toString()
         );
     }
 
@@ -87,7 +87,7 @@ final class FullyQualifiedClassNameVisitorTest extends AbstractBaseVisitorTest
         $this->assertCount(1, $this->spyVisitor->processedNodes);
         $this->assertSame(
             'FqcnClassAnonymous\Ci',
-            $this->spyVisitor->processedNodes[0]->fullyQualifiedClassName->toString()
+            $this->spyVisitor->processedNodes[0]->getAttribute(FullyQualifiedClassNameVisitor::FQN_KEY)->toString()
         );
     }
 
@@ -98,7 +98,7 @@ final class FullyQualifiedClassNameVisitorTest extends AbstractBaseVisitorTest
 
             public function enterNode(Node $node): void
             {
-                if (isset($node->fullyQualifiedClassName)) {
+                if ($node->getAttribute(FullyQualifiedClassNameVisitor::FQN_KEY)) {
                     $this->processedNodes[] = $node;
                 }
             }


### PR DESCRIPTION
This PR:

- [x] Upgrades PHPStan to 0.11.5
- [x] Fixes new errors found by PHPStan
- [x] Removes the two rules about the `Node` class missing properties or methods

Blocked by #685 Since that fixes issues surrounding names on nodes for decrement integer

That last one is the biggest change here. In most cases it means updating the doc comment to accurately reflect what is actually going into the method. 
In some other cases it means assigning a property to a value, and then telling PHPStan what it is through `/** @var */` notation.

The big upside of no longer ignoring these issues is that we now are notified of errors with `$node->name` during development. Like the ones found in:
* #685  
* #384
* #549

What do you think, should we stop ignoring these errors, and have a bit more code, like in this PR? 
Or should we ignore the errors like previously?
Or should we add rules for specific files, stating for exactly which files these rules can be ignored?