### PR TITLE
Add @unwrap mutator profile to the default list

### DIFF
--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -255,6 +255,7 @@ final class MutatorProfile
         '@sort',
         '@zero_iteration',
         '@extensions',
+        '@unwrap',
     ];
 
     public const FULL_MUTATOR_LIST = [


### PR DESCRIPTION
I'm pretty sure we wanted to add it to the default list, but for some reason, it's not there.