### PR TITLE
PhpProcess: Reset $_ENV if it is in use

### DIFF
--- a/src/Console/Util/PhpProcess.php
+++ b/src/Console/Util/PhpProcess.php
@@ -67,7 +67,7 @@ final class PhpProcess extends Process
         // As of 1.3.2 xdebug-handler won't update $_ENV if it is in use.
         // But Symfony's Process will happily import everything from $_ENV,
         // hence we need to reset it just as xdebug-handler does
-        $updateEnv = false !== strpos((string) ini_get('variables_order'), 'E');
+        $updateEnv = false !== stripos((string) ini_get('variables_order'), 'E');
 
         if ($updateEnv) {
             unset($_ENV['PHPRC']);

--- a/src/Console/Util/PhpProcess.php
+++ b/src/Console/Util/PhpProcess.php
@@ -63,7 +63,23 @@ final class PhpProcess extends Process
         $phpConfig = new PhpConfig();
 
         $phpConfig->useOriginal();
+
+        // As of 1.3.2 xdebug-handler won't update $_ENV if it is in use.
+        // But Symfony's Process will happily import everything from $_ENV,
+        // hence we need to reset it just as xdebug-handler does
+        $updateEnv = false !== strpos((string) ini_get('variables_order'), 'E');
+
+        if ($updateEnv) {
+            unset($_ENV['PHPRC']);
+            unset($_ENV['PHP_INI_SCAN_DIR']);
+        }
+
         parent::start($callback, $env ?? []);
         $phpConfig->usePersistent();
+
+        if ($updateEnv) {
+            $_ENV['PHPRC'] = $_SERVER['PHPRC'];
+            $_ENV['PHP_INI_SCAN_DIR'] = $_SERVER['PHP_INI_SCAN_DIR'];
+        }
     }
 }

--- a/tests/Fixtures/e2e/Variables_Order_EGPCS/README.md
+++ b/tests/Fixtures/e2e/Variables_Order_EGPCS/README.md
@@ -1,0 +1,7 @@
+# Ensure Infection runs with non-empty `$_ENV`
+
+When `variables_order` set to constain an `E`, Infection should just work.
+
+https://github.com/infection/infection/issues/692
+
+https://github.com/infection/infection/pull/693

--- a/tests/Fixtures/e2e/Variables_Order_EGPCS/composer.json
+++ b/tests/Fixtures/e2e/Variables_Order_EGPCS/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^7.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Variables_Order_EGPCS\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Variables_Order_EGPCS\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/Fixtures/e2e/Variables_Order_EGPCS/expected-output.txt
+++ b/tests/Fixtures/e2e/Variables_Order_EGPCS/expected-output.txt
@@ -1,0 +1,6 @@
+Total: 1
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/Fixtures/e2e/Variables_Order_EGPCS/infection.json
+++ b/tests/Fixtures/e2e/Variables_Order_EGPCS/infection.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/Fixtures/e2e/Variables_Order_EGPCS/phpunit.xml.dist
+++ b/tests/Fixtures/e2e/Variables_Order_EGPCS/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Fixtures/e2e/Variables_Order_EGPCS/run_tests.bash
+++ b/tests/Fixtures/e2e/Variables_Order_EGPCS/run_tests.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+readonly INFECTION=../../../../bin/infection
+
+set -e pipefail
+
+if [ "$PHPDBG" = "1" ]
+then
+    phpdbg -d variables_order=EGPCS -qrr $INFECTION
+else
+    php -d variables_order=EGPCS $INFECTION
+fi
+
+diff -w expected-output.txt infection.log

--- a/tests/Fixtures/e2e/Variables_Order_EGPCS/src/SourceClass.php
+++ b/tests/Fixtures/e2e/Variables_Order_EGPCS/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Variables_Order_EGPCS;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/Fixtures/e2e/Variables_Order_EGPCS/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/Variables_Order_EGPCS/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Variables_Order_EGPCS\Test;
+
+use Variables_Order_EGPCS\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}


### PR DESCRIPTION
As of 1.3.2 xdebug-handler won't update $_ENV if it is in use. But Symfony's Process will happily import everything from $_ENV, hence we need to reset it just as xdebug-handler does.

- [x] An E2E test probably needed.

Fixes #692

Related: https://github.com/composer/xdebug-handler/pull/95