### PR TITLE
Improve min ci score accuracy with the option to pass float values as well

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -100,6 +100,24 @@ ASCII;
             $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
         }
 
+        if ($input->hasOption('min-msi')) {
+            $minMsi = \trim($input->getOption('min-msi'));
+            $dotPos = \strpos($minMsi, '.');
+
+            if ($dotPos !== false) {
+                $this->consoleOutput->setMsiDecimalAccuracy(\strlen($minMsi) - $dotPos + 1);
+            }
+        }
+
+        if ($input->hasOption('min-covered-msi')) {
+            $minCoveredMsi = \trim($input->getOption('min-covered-msi'));
+            $dotPos = \strpos($minCoveredMsi, '.');
+
+            if ($dotPos !== false) {
+                $this->consoleOutput->setCoverageDecimalAccuracy(\strlen($minCoveredMsi) - $dotPos + 1);
+            }
+        }
+
         $this->logRunningWithDebugger();
 
         if (!$this->isAutoExitEnabled()) {

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -60,6 +60,16 @@ final class ConsoleOutput
      */
     private $io;
 
+    /**
+     * @var int
+     */
+    private $msiDecimalAccuracy = 0;
+
+    /**
+     * @var int
+     */
+    private $coverageDecimalAccuracy = 0;
+
     public function __construct(SymfonyStyle $io)
     {
         $this->io = $io;
@@ -112,17 +122,21 @@ final class ConsoleOutput
             throw MsiCalculationException::create('min-msi');
         }
 
-        $this->io->error(
+        $errorMessage = $type === TestRunConstraintChecker::MSI_FAILURE ?
             sprintf(
                 self::CI_FLAG_ERROR,
-                ($type === TestRunConstraintChecker::MSI_FAILURE ? 'MSI' : 'Covered Code MSI'),
-                $minMsi,
-                ($type === TestRunConstraintChecker::MSI_FAILURE ?
-                    $metricsCalculator->getMutationScoreIndicator() :
-                    $metricsCalculator->getCoveredCodeMutationScoreIndicator()
-                )
-            )
-        );
+                'MSI',
+                number_format($minMsi, $this->getMsiDecimalAccuracy()),
+                number_format($metricsCalculator->getMutationScoreIndicator(), $this->getMsiDecimalAccuracy())
+            ) :
+            sprintf(
+                self::CI_FLAG_ERROR,
+                'Covered Code MSI',
+                number_format($minMsi, $this->getCoverageDecimalAccuracy()),
+                number_format($metricsCalculator->getCoveredCodeMutationScoreIndicator(), $this->getCoverageDecimalAccuracy())
+            );
+
+        $this->io->error($errorMessage);
     }
 
     public function logMissedDebuggerOrCoverageOption(): void
@@ -144,5 +158,25 @@ final class ConsoleOutput
             'Infection cannot control exit codes and unable to relaunch itself.' . PHP_EOL .
             'It is your responsibility to disable xdebug/phpdbg unless needed.',
         ]);
+    }
+
+    public function getMsiDecimalAccuracy(): int
+    {
+        return $this->msiDecimalAccuracy;
+    }
+
+    public function setMsiDecimalAccuracy(int $msiDecimalAccuracy): void
+    {
+        $this->msiDecimalAccuracy = $msiDecimalAccuracy;
+    }
+
+    public function getCoverageDecimalAccuracy(): int
+    {
+        return $this->coverageDecimalAccuracy;
+    }
+
+    public function setCoverageDecimalAccuracy(int $coverageDecimalAccuracy): void
+    {
+        $this->coverageDecimalAccuracy = $coverageDecimalAccuracy;
     }
 }

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -158,7 +158,7 @@ class MetricsCalculator
         $defeatedTotal = $this->killedCount + $this->timedOutCount + $this->errorCount;
 
         if ($this->totalMutantsCount) {
-            $detectionRateAll = floor(100 * $defeatedTotal / $this->totalMutantsCount);
+            $detectionRateAll = 100.0 * $defeatedTotal / $this->totalMutantsCount;
         }
 
         return $detectionRateAll;
@@ -173,7 +173,7 @@ class MetricsCalculator
         $coveredByTestsTotal = $this->totalMutantsCount - $this->notCoveredByTestsCount;
 
         if ($this->totalMutantsCount) {
-            $coveredRate = floor(100 * $coveredByTestsTotal / $this->totalMutantsCount);
+            $coveredRate = 100.0 * $coveredByTestsTotal / $this->totalMutantsCount;
         }
 
         return $coveredRate;
@@ -186,7 +186,7 @@ class MetricsCalculator
         $defeatedTotal = $this->killedCount + $this->timedOutCount + $this->errorCount;
 
         if ($coveredByTestsTotal) {
-            $detectionRateTested = floor(100 * $defeatedTotal / $coveredByTestsTotal);
+            $detectionRateTested = 100.0 * $defeatedTotal / $coveredByTestsTotal;
         }
 
         return $detectionRateTested;

--- a/tests/Config/ValueProvider/AbstractBaseProviderTest.php
+++ b/tests/Config/ValueProvider/AbstractBaseProviderTest.php
@@ -70,7 +70,7 @@ abstract class AbstractBaseProviderTest extends TestCase
     {
         $mock = $this->createMock(StreamableInputInterface::class);
         $mock->method('isInteractive')
-            ->will($this->returnValue($interactive));
+            ->willReturn($interactive);
 
         if ($stream) {
             $mock->method('getStream')

--- a/tests/Console/ConsoleOutputTest.php
+++ b/tests/Console/ConsoleOutputTest.php
@@ -118,6 +118,21 @@ final class ConsoleOutputTest extends TestCase
         $console->logBadMsiErrorMessage($metrics, 25.0, 'min-msi');
     }
 
+    public function test_log_bad_msi_error_message_with_accuracy(): void
+    {
+        $metrics = $this->createMock(MetricsCalculator::class);
+        $metrics->expects($this->once())->method('getMutationScoreIndicator')->willReturn(75.00123987);
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects($this->once())->method('error')->with(
+            'The minimum required MSI percentage should be 25.0043%, but actual is 75.0012%. Improve your tests!'
+        );
+
+        $console = new ConsoleOutput($io);
+        $console->setMsiDecimalAccuracy(4);
+
+        $console->logBadMsiErrorMessage($metrics, 25.00429942, 'min-msi');
+    }
+
     public function test_log_bad_msi_error_message_throws_error_on_faulty_msi(): void
     {
         $io = $this->createMock(SymfonyStyle::class);
@@ -138,6 +153,21 @@ final class ConsoleOutputTest extends TestCase
         );
 
         $console = new ConsoleOutput($io);
+
+        $console->logBadMsiErrorMessage($metrics, 25.0, 'min-covered-msi');
+    }
+
+    public function test_log_bad_covered_msi_error_message_with_accuracy(): void
+    {
+        $metrics = $this->createMock(MetricsCalculator::class);
+        $metrics->expects($this->once())->method('getCoveredCodeMutationScoreIndicator')->willReturn(75.00123987);
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects($this->once())->method('error')->with(
+            'The minimum required Covered Code MSI percentage should be 25.00000%, but actual is 75.00124%. Improve your tests!'
+        );
+
+        $console = new ConsoleOutput($io);
+        $console->setCoverageDecimalAccuracy(5);
 
         $console->logBadMsiErrorMessage($metrics, 25.0, 'min-covered-msi');
     }

--- a/tests/Logger/PerMutatorLoggerTest.php
+++ b/tests/Logger/PerMutatorLoggerTest.php
@@ -58,7 +58,7 @@ final class PerMutatorLoggerTest extends TestCase
 
 | Mutator | Mutations | Killed | Escaped | Errors | Timed Out | MSI | Covered MSI |
 | ------- | --------- | ------ | ------- |------- | --------- | --- | ----------- |
-| For_ | 15 | 10 | 0 | 0 | 0 | 66| 100|
+| For_ | 15 | 10 | 0 | 0 | 0 | 66.666666666667| 100|
 | PregQuote | 5 | 0 | 0 | 0 | 0 | 0| 0|
 TXT;
         $content = str_replace("\n", PHP_EOL, $content);

--- a/tests/Mutant/MetricsCalculatorTest.php
+++ b/tests/Mutant/MetricsCalculatorTest.php
@@ -89,9 +89,9 @@ final class MetricsCalculatorTest extends TestCase
         $this->addMutantProcess($calculator, MutantProcess::CODE_ERROR, 2);
         $this->assertSame(2, $calculator->getErrorCount());
 
-        $this->assertSame(78.0, $calculator->getMutationScoreIndicator()); // 78.57
-        $this->assertSame(92.0, $calculator->getCoverageRate()); // 92.85
-        $this->assertSame(84.0, $calculator->getCoveredCodeMutationScoreIndicator()); // 84.61
+        $this->assertSame(78.571428571429, $calculator->getMutationScoreIndicator());
+        $this->assertSame(92.857142857143, $calculator->getCoverageRate());
+        $this->assertSame(84.615384615385, $calculator->getCoveredCodeMutationScoreIndicator());
     }
 
     private function addMutantProcess(MetricsCalculator $calculator, int $resultCode, int $count = 1): void

--- a/tests/Process/Builder/SubscriberBuilderTest.php
+++ b/tests/Process/Builder/SubscriberBuilderTest.php
@@ -63,7 +63,7 @@ final class SubscriberBuilderTest extends TestCase
         $input = $this->createMock(InputInterface::class);
         $input->expects($this->exactly(9))
             ->method('getOption')
-            ->will($this->returnValueMap(
+            ->willReturnMap(
                 [
                     ['no-progress', true],
                     ['formatter', 'progress'],
@@ -71,7 +71,7 @@ final class SubscriberBuilderTest extends TestCase
                     ['log-verbosity', 'all'],
                     ['debug', true],
                 ]
-            ));
+            );
         $calculator = new MetricsCalculator();
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($this->exactly(6))->method('addSubscriber');
@@ -101,7 +101,7 @@ final class SubscriberBuilderTest extends TestCase
         $input = $this->createMock(InputInterface::class);
         $input->expects($this->exactly(9))
             ->method('getOption')
-            ->will($this->returnValueMap(
+            ->willReturnMap(
                 [
                     ['no-progress', true],
                     ['formatter', 'progress'],
@@ -109,7 +109,7 @@ final class SubscriberBuilderTest extends TestCase
                     ['log-verbosity', 'all'],
                     ['debug', false],
                 ]
-            ));
+            );
         $calculator = new MetricsCalculator();
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($this->exactly(7))->method('addSubscriber');
@@ -139,14 +139,14 @@ final class SubscriberBuilderTest extends TestCase
         $input = $this->createMock(InputInterface::class);
         $input->expects($this->exactly(5))
             ->method('getOption')
-            ->will($this->returnValueMap(
+            ->willReturnMap(
                 [
                     ['no-progress', true],
                     ['formatter', 'foo'],
                     ['show-mutations', true],
                     ['debug', true],
                 ]
-            ));
+            );
         $calculator = new MetricsCalculator();
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($this->never())->method('addSubscriber');


### PR DESCRIPTION
This PR:

- [X] Covered by tests

Fixes https://github.com/infection/infection/issues/694

- Internally, values are compared as floats instead of floored integers.
- if min-msi or min-coverage-msi is set as integer, the comparison worked as before
- if min-msi or min-coverage-msi is set as a float, the comparison takes the higher accuracy into account, instead of comparing both as floored integer as before
- if the score is below min-*msi, the error message displays the values with their expected decimal accuracies, depending on the input. For example with `--min-msi=10.55` the error message displays the actual percentage up to two decimal points as well.
- in the console output summary, the metrics display the full float value. (Previously: `15%`, New: `15.774240231548%`)