### PR TITLE
Add `ignore` property for each Mutator in JSON schema.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "symfony/process": "3.4.2"
     },
     "require-dev": {
+        "helmich/phpunit-json-assert": "^2.1",
         "phpunit/phpunit": "^7.5"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "symfony/process": "3.4.2"
     },
     "require-dev": {
-        "helmich/phpunit-json-assert": "^2.1",
+        "helmich/phpunit-json-assert": "^2.1 || ^3.0",
         "phpunit/phpunit": "^7.5"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8af1f24b91068bfac1ba46b2a0fd55f8",
+    "content-hash": "6c3c04621824d33ac2f3efe5e2aacead",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1166,6 +1166,91 @@
                 "instantiate"
             ],
             "time": "2017-07-22T11:58:36+00:00"
+        },
+        {
+            "name": "flow/jsonpath",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FlowCommunications/JSONPath.git",
+                "reference": "f0222818d5c938e4ab668ab2e2c079bd51a27112"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FlowCommunications/JSONPath/zipball/f0222818d5c938e4ab668ab2e2c079bd51a27112",
+                "reference": "f0222818d5c938e4ab668ab2e2c079bd51a27112",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "peekmo/jsonpath": "dev-master",
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Flow\\JSONPath": "src/",
+                    "Flow\\JSONPath\\Test": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stephen Frank",
+                    "email": "stephen@flowsa.com"
+                }
+            ],
+            "description": "JSONPath implementation for parsing, searching and flattening arrays",
+            "time": "2018-03-04T16:39:47+00:00"
+        },
+        {
+            "name": "helmich/phpunit-json-assert",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/martin-helmich/phpunit-json-assert.git",
+                "reference": "8ec83fc433ac60b99b51615fdfb5e061b1371a5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/martin-helmich/phpunit-json-assert/zipball/8ec83fc433ac60b99b51615fdfb5e061b1371a5c",
+                "reference": "8ec83fc433ac60b99b51615fdfb5e061b1371a5c",
+                "shasum": ""
+            },
+            "require": {
+                "flow/jsonpath": "^0.4.0",
+                "justinrainbow/json-schema": "^5.0",
+                "php": ">=7.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<6.0 || >= 8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0 | ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Helmich\\JsonAssert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Helmich",
+                    "email": "m.helmich@mittwald.de"
+                }
+            ],
+            "description": "PHPUnit assertions for JSON documents",
+            "time": "2019-03-22T17:40:25+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c3c04621824d33ac2f3efe5e2aacead",
+    "content-hash": "b5bf5ffe67bd534e92a20960f54b2f09",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -126,6 +126,7 @@
                                 "type": "object",
                                 "additionalProperties": false,
                                 "properties": {
+                                    "ignore": {"type": "array", "items": {"type": "string"}},
                                     "settings": {
                                         "type": "object",
                                         "additionalProperties": false,
@@ -155,6 +156,7 @@
                                 "type": "object",
                                 "additionalProperties": false,
                                 "properties": {
+                                    "ignore": {"type": "array", "items": {"type": "string"}},
                                     "settings": {
                                         "type": "object",
                                         "additionalProperties": false,
@@ -203,6 +205,7 @@
                                 "type": "object",
                                 "additionalProperties": false,
                                 "properties": {
+                                    "ignore": {"type": "array", "items": {"type": "string"}},
                                     "settings": {
                                         "type": "object",
                                         "additionalProperties": false,

--- a/tests/resources/InfectionConfigJsonSchemaTest.php
+++ b/tests/resources/InfectionConfigJsonSchemaTest.php
@@ -41,7 +41,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @internal
  */
-class InfectionConfigJsonSchemaTest extends TestCase
+final class InfectionConfigJsonSchemaTest extends TestCase
 {
     use JsonAssertions;
 

--- a/tests/resources/InfectionConfigJsonSchemaTest.php
+++ b/tests/resources/InfectionConfigJsonSchemaTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017-2019, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\resources;
+
+use Helmich\JsonAssert\JsonAssertions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class InfectionConfigJsonSchemaTest extends TestCase
+{
+    use JsonAssertions;
+
+    private const SCHEMA_FILE = __DIR__ . '/../../resources/schema.json';
+
+    /**
+     * @var array|null
+     */
+    private static $schema;
+
+    /**
+     * @dataProvider mutatorsProvider
+     */
+    public function test_all_mutators_support_ignore_key(string $mutator): void
+    {
+        $infectionJson = <<<"JSON"
+{
+    "timeout": 1,
+    "source": {"directories": ["src"]},
+    "mutators": {
+        "$mutator": {
+            "ignore": ["Foo\\\\Bar::baz"]
+        }
+    }
+}
+JSON;
+
+        self::assertJsonDocumentMatchesSchema($infectionJson, self::getSchema());
+    }
+
+    public function mutatorsProvider(): \Generator
+    {
+        foreach (array_keys(self::getSchema()['properties']['mutators']['properties']) as $mutator) {
+            yield $mutator => [$mutator];
+        }
+    }
+
+    private static function getSchema()
+    {
+        if (self::$schema !== null) {
+            return self::$schema;
+        }
+
+        return self::$schema = json_decode(file_get_contents(self::SCHEMA_FILE), true);
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Fixes #698
- [x] Add tests to prevent such issues in the future for any new mutators.
- [x] Add `helmich/phpunit-json-assert` for convenient JSON schema testing in PHPUnit

There were the same bugs for `MBString` and `BCMath` mutators.

Targeted to `0.13` to release as `0.13.2`