### PR TITLE
Ignore target MSI on Travis with empty --filter

### DIFF
--- a/.ci/travis-functions.sh
+++ b/.ci/travis-functions.sh
@@ -28,7 +28,12 @@ function get-infection-pr-flags() {
         git fetch;
 
         CHANGED_FILES=$(git diff origin/$TRAVIS_BRANCH --diff-filter=AM --name-only | grep src/ | paste -sd "," -);
-        INFECTION_PR_FLAGS="--filter=${CHANGED_FILES} --ignore-msi-with-no-mutations --only-covered --min-msi=90";
+
+        if [ -z "$CHANGED_FILES" ]; then
+            INFECTION_PR_FLAGS="";
+        else
+            INFECTION_PR_FLAGS="--filter=${CHANGED_FILES} --ignore-msi-with-no-mutations --only-covered --min-msi=90";
+        fi
     fi
 
     echo $INFECTION_PR_FLAGS;

--- a/.ci/travis-functions.sh
+++ b/.ci/travis-functions.sh
@@ -32,7 +32,7 @@ function get-infection-pr-flags() {
         if [ -z "$CHANGED_FILES" ]; then
             INFECTION_PR_FLAGS="";
         else
-            INFECTION_PR_FLAGS="--filter=${CHANGED_FILES} --ignore-msi-with-no-mutations --only-covered --min-msi=90";
+            INFECTION_PR_FLAGS="--filter=${CHANGED_FILES} --ignore-msi-with-no-mutations --only-covered --min-msi=90 --show-mutations";
         fi
     fi
 


### PR DESCRIPTION
Fixes #631

That's only a part of issue. Infection will still be annoying by requiring 90% MSI for things like bugfixes. Really this requirement must stand only for feature requests, what do you think? I'm not sure though how can it know these from others. 

Other option would to lower that 90% requirement down to the existing project-wide requirement.