### PR TITLE
Dramatically reduce memory usage by using classes instead of object-like arrays

### DIFF
--- a/src/Mutant/Mutant.php
+++ b/src/Mutant/Mutant.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Mutant;
 
 use Infection\MutationInterface;
+use Infection\TestFramework\Coverage\CoverageLineData;
 
 /**
  * @internal
@@ -63,7 +64,7 @@ final class Mutant implements MutantInterface
     private $isCoveredByTest;
 
     /**
-     * @var array
+     * @var CoverageLineData[]
      */
     private $coverageTests;
 
@@ -96,6 +97,9 @@ final class Mutant implements MutantInterface
         return $this->isCoveredByTest;
     }
 
+    /**
+     * @return CoverageLineData[]
+     */
     public function getCoverageTests(): array
     {
         return $this->coverageTests;

--- a/src/TestFramework/Coverage/CoverageFileData.php
+++ b/src/TestFramework/Coverage/CoverageFileData.php
@@ -38,31 +38,25 @@ namespace Infection\TestFramework\Coverage;
 /**
  * @internal
  */
-final class CachedTestFileDataProvider implements TestFileDataProvider
+final class CoverageFileData
 {
     /**
-     * @var TestFileDataProvider
+     * @var array<int, array<int, CoverageLineData>>
      */
-    private $testFileDataProvider;
+    public $byLine = [];
 
     /**
-     * @var array<string, TestFileTimeData>
+     * @var CoverageMethodData[]
      */
-    private $testFileInfoCache = [];
+    public $byMethod = [];
 
-    public function __construct(TestFileDataProvider $testFileDataProvider)
+    public static function from(array $byLine, array $byMethod): self
     {
-        $this->testFileDataProvider = $testFileDataProvider;
-    }
+        $self = new self();
 
-    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData
-    {
-        if (\array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
-            return $this->testFileInfoCache[$fullyQualifiedClassName];
-        }
+        $self->byLine = $byLine;
+        $self->byMethod = $byMethod;
 
-        return $this->testFileInfoCache[$fullyQualifiedClassName] = $this->testFileDataProvider->getTestFileInfo(
-            $fullyQualifiedClassName
-        );
+        return $self;
     }
 }

--- a/src/TestFramework/Coverage/CoverageFileData.php
+++ b/src/TestFramework/Coverage/CoverageFileData.php
@@ -50,13 +50,13 @@ final class CoverageFileData
      */
     public $byMethod = [];
 
-    public static function from(array $byLine, array $byMethod): self
+    /**
+     * @param array<int, array<int, CoverageLineData>> $byLine
+     * @param CoverageMethodData[] $byMethod
+     */
+    public function __construct(array $byLine = [], array $byMethod = [])
     {
-        $self = new self();
-
-        $self->byLine = $byLine;
-        $self->byMethod = $byMethod;
-
-        return $self;
+        $this->byLine = $byLine;
+        $this->byMethod = $byMethod;
     }
 }

--- a/src/TestFramework/Coverage/CoverageLineData.php
+++ b/src/TestFramework/Coverage/CoverageLineData.php
@@ -38,31 +38,40 @@ namespace Infection\TestFramework\Coverage;
 /**
  * @internal
  */
-final class CachedTestFileDataProvider implements TestFileDataProvider
+final class CoverageLineData
 {
     /**
-     * @var TestFileDataProvider
+     * @var string
      */
-    private $testFileDataProvider;
+    public $testMethod;
 
     /**
-     * @var array<string, TestFileTimeData>
+     * @var ?string
      */
-    private $testFileInfoCache = [];
+    public $testFilePath;
 
-    public function __construct(TestFileDataProvider $testFileDataProvider)
+    /**
+     * @var ?float
+     */
+    public $time;
+
+    public static function withTestMethod(string $testMethod): self
     {
-        $this->testFileDataProvider = $testFileDataProvider;
+        $self = new self();
+
+        $self->testMethod = $testMethod;
+
+        return $self;
     }
 
-    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData
+    public static function with(string $testMethod, string $testFilePath, float $time): self
     {
-        if (\array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
-            return $this->testFileInfoCache[$fullyQualifiedClassName];
-        }
+        $self = new self();
 
-        return $this->testFileInfoCache[$fullyQualifiedClassName] = $this->testFileDataProvider->getTestFileInfo(
-            $fullyQualifiedClassName
-        );
+        $self->testMethod = $testMethod;
+        $self->testFilePath = $testFilePath;
+        $self->time = $time;
+
+        return $self;
     }
 }

--- a/src/TestFramework/Coverage/CoverageMethodData.php
+++ b/src/TestFramework/Coverage/CoverageMethodData.php
@@ -38,31 +38,37 @@ namespace Infection\TestFramework\Coverage;
 /**
  * @internal
  */
-final class CachedTestFileDataProvider implements TestFileDataProvider
+final class CoverageMethodData
 {
     /**
-     * @var TestFileDataProvider
+     * @var int
      */
-    private $testFileDataProvider;
+    public $startLine;
 
     /**
-     * @var array<string, TestFileTimeData>
+     * @var int
      */
-    private $testFileInfoCache = [];
+    public $endLine;
 
-    public function __construct(TestFileDataProvider $testFileDataProvider)
+    /**
+     * @var int
+     */
+    public $executed;
+
+    /**
+     * @var int
+     */
+    public $coverage;
+
+    public static function from(int $startLine, int $endLine, int $executed, int $coverage): self
     {
-        $this->testFileDataProvider = $testFileDataProvider;
-    }
+        $self = new self();
 
-    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData
-    {
-        if (\array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
-            return $this->testFileInfoCache[$fullyQualifiedClassName];
-        }
+        $self->startLine = $startLine;
+        $self->endLine = $endLine;
+        $self->executed = $executed;
+        $self->coverage = $coverage;
 
-        return $this->testFileInfoCache[$fullyQualifiedClassName] = $this->testFileDataProvider->getTestFileInfo(
-            $fullyQualifiedClassName
-        );
+        return $self;
     }
 }

--- a/src/TestFramework/Coverage/CoverageMethodData.php
+++ b/src/TestFramework/Coverage/CoverageMethodData.php
@@ -60,15 +60,11 @@ final class CoverageMethodData
      */
     public $coverage;
 
-    public static function from(int $startLine, int $endLine, int $executed, int $coverage): self
+    public function __construct(int $startLine, int $endLine, int $executed, int $coverage)
     {
-        $self = new self();
-
-        $self->startLine = $startLine;
-        $self->endLine = $endLine;
-        $self->executed = $executed;
-        $self->coverage = $coverage;
-
-        return $self;
+        $this->startLine = $startLine;
+        $this->endLine = $endLine;
+        $this->executed = $executed;
+        $this->coverage = $coverage;
     }
 }

--- a/src/TestFramework/Coverage/TestFileDataProvider.php
+++ b/src/TestFramework/Coverage/TestFileDataProvider.php
@@ -49,7 +49,7 @@ interface TestFileDataProvider
      *      return: '/path/to/NameSpace/Sub/TestClass.php'
      *
      *
-     * @return array file path and time
+     * @return TestFileTimeData file path and time
      */
-    public function getTestFileInfo(string $fullyQualifiedClassName): array;
+    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData;
 }

--- a/src/TestFramework/Coverage/TestFileTimeData.php
+++ b/src/TestFramework/Coverage/TestFileTimeData.php
@@ -38,31 +38,25 @@ namespace Infection\TestFramework\Coverage;
 /**
  * @internal
  */
-final class CachedTestFileDataProvider implements TestFileDataProvider
+final class TestFileTimeData
 {
     /**
-     * @var TestFileDataProvider
+     * @var string
      */
-    private $testFileDataProvider;
+    public $path;
 
     /**
-     * @var array<string, TestFileTimeData>
+     * @var float
      */
-    private $testFileInfoCache = [];
+    public $time;
 
-    public function __construct(TestFileDataProvider $testFileDataProvider)
+    public static function from(string $path, float $time): self
     {
-        $this->testFileDataProvider = $testFileDataProvider;
-    }
+        $self = new self();
 
-    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData
-    {
-        if (\array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
-            return $this->testFileInfoCache[$fullyQualifiedClassName];
-        }
+        $self->path = $path;
+        $self->time = $time;
 
-        return $this->testFileInfoCache[$fullyQualifiedClassName] = $this->testFileDataProvider->getTestFileInfo(
-            $fullyQualifiedClassName
-        );
+        return $self;
     }
 }

--- a/src/TestFramework/Coverage/TestFileTimeData.php
+++ b/src/TestFramework/Coverage/TestFileTimeData.php
@@ -50,13 +50,9 @@ final class TestFileTimeData
      */
     public $time;
 
-    public static function from(string $path, float $time): self
+    public function __construct(string $path, float $time)
     {
-        $self = new self();
-
-        $self->path = $path;
-        $self->time = $time;
-
-        return $self;
+        $this->path = $path;
+        $this->time = $time;
     }
 }

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -118,17 +118,15 @@ class CoverageXmlParser
         $linesNode = $xPath->query('/phpunit/file/totals/lines')[0];
         $percentage = (float) $linesNode->getAttribute('percent');
 
-        $coverageFileData = new CoverageFileData();
-
         if (!$percentage) {
-            return [$sourceFilePath => $coverageFileData];
+            return [$sourceFilePath => new CoverageFileData()];
         }
 
         /** @var \DOMNodeList $lineCoverageNodes */
         $lineCoverageNodes = $xPath->query('/phpunit/file/coverage/line');
 
         if (!$lineCoverageNodes->length) {
-            return [$sourceFilePath => $coverageFileData];
+            return [$sourceFilePath => new CoverageFileData()];
         }
 
         $methodsCoverageNodes = $xPath->query('/phpunit/file/class/method');
@@ -138,7 +136,7 @@ class CoverageXmlParser
         }
 
         return [
-            $sourceFilePath => CoverageFileData::from(
+            $sourceFilePath => new CoverageFileData(
                 $this->getCoveredLinesData($lineCoverageNodes),
                 $this->getMethodsCoverageData($methodsCoverageNodes)
             ),
@@ -215,7 +213,7 @@ class CoverageXmlParser
         foreach ($methodsCoverageNodes as $methodsCoverageNode) {
             $methodName = $methodsCoverageNode->getAttribute('name');
 
-            $methodsCoverage[$methodName] = CoverageMethodData::from(
+            $methodsCoverage[$methodName] = new CoverageMethodData(
                 (int) $methodsCoverageNode->getAttribute('start'),
                 (int) $methodsCoverageNode->getAttribute('end'),
                 (int) $methodsCoverageNode->getAttribute('executed'),

--- a/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
+++ b/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
@@ -70,7 +70,7 @@ final class PhpUnitTestFileDataProvider implements TestFileDataProvider
             throw TestFileNameNotFoundException::notFoundFromFQN($fullyQualifiedClassName);
         }
 
-        return TestFileTimeData::from(
+        return new TestFileTimeData(
             $nodes[0]->getAttribute('file'),
             (float) $nodes[0]->getAttribute('time')
         );

--- a/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
+++ b/src/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProvider.php
@@ -38,6 +38,7 @@ namespace Infection\TestFramework\PhpUnit\Coverage;
 use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
 use Infection\TestFramework\Coverage\TestFileDataProvider;
 use Infection\TestFramework\Coverage\TestFileNameNotFoundException;
+use Infection\TestFramework\Coverage\TestFileTimeData;
 
 /**
  * @internal
@@ -59,7 +60,7 @@ final class PhpUnitTestFileDataProvider implements TestFileDataProvider
         $this->jUnitFilePath = $jUnitFilePath;
     }
 
-    public function getTestFileInfo(string $fullyQualifiedClassName): array
+    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData
     {
         $xPath = $this->getXPath();
 
@@ -69,10 +70,10 @@ final class PhpUnitTestFileDataProvider implements TestFileDataProvider
             throw TestFileNameNotFoundException::notFoundFromFQN($fullyQualifiedClassName);
         }
 
-        return [
-            'path' => $nodes[0]->getAttribute('file'),
-            'time' => (float) $nodes[0]->getAttribute('time'),
-        ];
+        return TestFileTimeData::from(
+            $nodes[0]->getAttribute('file'),
+            (float) $nodes[0]->getAttribute('time')
+        );
     }
 
     private function getXPath(): \DOMXPath

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -58,6 +58,10 @@ use Infection\Process\Listener\MutationGeneratingConsoleLoggerSubscriber;
 use Infection\Process\Runner\MutationTestingRunner;
 use Infection\StreamWrapper\IncludeInterceptor;
 use Infection\TestFramework\Coverage\CodeCoverageData;
+use Infection\TestFramework\Coverage\CoverageFileData;
+use Infection\TestFramework\Coverage\CoverageLineData;
+use Infection\TestFramework\Coverage\CoverageMethodData;
+use Infection\TestFramework\Coverage\TestFileTimeData;
 use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder as PhpSpecInitalConfigBuilder;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder as PhpSpecMutationConfigBuilder;
 use Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException;
@@ -309,7 +313,7 @@ final class ProjectCodeTest extends TestCase
     }
 
     /**
-     * @dataProvider providesSourceClasses
+     * @dataProvider providesSourceClassesToCheckPublicProperties
      */
     public function test_src_classes_do_not_expose_public_properties(string $className): void
     {
@@ -410,6 +414,32 @@ final class ProjectCodeTest extends TestCase
                 return [$item];
             },
             $this->getSrcClasses()
+        );
+    }
+
+    public function providesSourceClassesToCheckPublicProperties()
+    {
+        $sourceClasses = array_filter(
+            $this->getSrcClasses(),
+            static function (string $className): bool {
+                return !\in_array(
+                    $className,
+                    [
+                        CoverageFileData::class,
+                        CoverageLineData::class,
+                        CoverageMethodData::class,
+                        TestFileTimeData::class,
+                    ],
+                true
+                );
+            }
+        );
+
+        return array_map(
+            static function ($item) {
+                return [$item];
+            },
+            $sourceClasses
         );
     }
 

--- a/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
+++ b/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
@@ -52,7 +52,7 @@ final class CachedTestFileDataProviderTest extends TestCase
         $providerMock->expects($this->once())
             ->method('getTestFileInfo')
             ->with($class)
-            ->willReturn(TestFileTimeData::from('path/to/Test.php', 4.567));
+            ->willReturn(new TestFileTimeData('path/to/Test.php', 4.567));
 
         $infoProvider = new CachedTestFileDataProvider($providerMock);
 

--- a/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
+++ b/tests/TestFramework/Coverage/CachedTestFileDataProviderTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\TestFramework\Coverage;
 
 use Infection\TestFramework\Coverage\CachedTestFileDataProvider;
 use Infection\TestFramework\Coverage\TestFileDataProvider;
+use Infection\TestFramework\Coverage\TestFileTimeData;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -51,7 +52,7 @@ final class CachedTestFileDataProviderTest extends TestCase
         $providerMock->expects($this->once())
             ->method('getTestFileInfo')
             ->with($class)
-            ->willReturn(['data']);
+            ->willReturn(TestFileTimeData::from('path/to/Test.php', 4.567));
 
         $infoProvider = new CachedTestFileDataProvider($providerMock);
 

--- a/tests/TestFramework/Coverage/CodeCoverageDataTest.php
+++ b/tests/TestFramework/Coverage/CodeCoverageDataTest.php
@@ -39,7 +39,11 @@ use Infection\Mutation;
 use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\Coverage\CodeCoverageData;
 use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
+use Infection\TestFramework\Coverage\CoverageFileData;
+use Infection\TestFramework\Coverage\CoverageLineData;
+use Infection\TestFramework\Coverage\CoverageMethodData;
 use Infection\TestFramework\Coverage\TestFileDataProvider;
+use Infection\TestFramework\Coverage\TestFileTimeData;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\TestFrameworkTypes;
 use PhpParser\Node\Scalar\LNumber;
@@ -178,8 +182,8 @@ final class CodeCoverageDataTest extends TestCase
         $tests = $codeCoverageData->getAllTestsFor($mutation);
 
         $this->assertCount(2, $tests);
-        $this->assertSame('path/to/testFile', $tests[0]['testFilePath']);
-        $this->assertSame(0.123, $tests[0]['time']);
+        $this->assertSame('path/to/testFile', $tests[0]->testFilePath);
+        $this->assertSame(0.123, $tests[0]->time);
     }
 
     public function test_it_returns_zero_tests_for_not_covered_function_signature_mutator(): void
@@ -241,47 +245,44 @@ final class CodeCoverageDataTest extends TestCase
     private function getParsedCodeCoverageData(): array
     {
         return [
-            '/tests/Fixtures/Files/phpunit/coverage-xml/FirstLevel/firstLevel.php' => [
-                'byLine' => [
+            '/tests/Fixtures/Files/phpunit/coverage-xml/FirstLevel/firstLevel.php' => CoverageFileData::from(
+                [
                     26 => [
-                            ['testMethod' => 'Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_mutate_plus_expression'],
-                            ['testMethod' => 'Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_not_mutate_plus_with_arrays'],
-                        ],
-                    30 => [
-                            ['testMethod' => 'Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_mutate_plus_expression'],
-                            ['testMethod' => 'Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_not_mutate_plus_with_arrays'],
-                        ],
-                    31 => [
-                            ['testMethod' => 'Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_not_mutate_plus_with_arrays'],
-                        ],
-                    34 => [
-                            ['testMethod' => 'Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_mutate_plus_expression'],
-                        ],
-                ],
-                'byMethod' => [
-                        'mutate' => [
-                            'startLine' => 19,
-                            'endLine' => 22,
-                            'executable' => 1,
-                            'executed' => 1,
-                            'coverage' => 0,
-                        ],
-                        'shouldMutate' => [
-                            'startLine' => 24,
-                            'endLine' => 35,
-                            'executable' => 5,
-                            'executed' => 4,
-                            'coverage' => 80,
-                        ],
-                        'notExecuted' => [
-                            'startLine' => 3,
-                            'endLine' => 5,
-                            'executable' => 5,
-                            'executed' => 0,
-                            'coverage' => 0, // not executed method can't be covered
-                        ],
+                        CoverageLineData::withTestMethod('Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_mutate_plus_expression'),
+                        CoverageLineData::withTestMethod('Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_not_mutate_plus_with_arrays'),
                     ],
-            ],
+                    30 => [
+                        CoverageLineData::withTestMethod('Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_mutate_plus_expression'),
+                        CoverageLineData::withTestMethod('Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_not_mutate_plus_with_arrays'),
+                    ],
+                    31 => [
+                        CoverageLineData::withTestMethod('Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_not_mutate_plus_with_arrays'),
+                    ],
+                    34 => [
+                        CoverageLineData::withTestMethod('Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_mutate_plus_expression'),
+                    ],
+                ],
+                [
+                    'mutate' => CoverageMethodData::from(
+                        19,
+                        22,
+                        1,
+                        0
+                    ),
+                    'shouldMutate' => CoverageMethodData::from(
+                        24,
+                        35,
+                        4,
+                        80
+                    ),
+                    'notExecuted' => CoverageMethodData::from(
+                        3,
+                        5,
+                        0,
+                        0 // not executed method can't be covered
+                    ),
+                ]
+            ),
         ];
     }
 
@@ -295,10 +296,12 @@ final class CodeCoverageDataTest extends TestCase
         $testFileDataProvider = $this->createMock(TestFileDataProvider::class);
         $testFileDataProvider->expects($this->any())
             ->method('getTestFileInfo')
-            ->willReturn([
-                'path' => 'path/to/testFile',
-                'time' => 0.123,
-            ]);
+            ->willReturn(
+                TestFileTimeData::from(
+                    'path/to/testFile',
+                    0.123
+                )
+            );
 
         return new CodeCoverageData(
             $this->coverageDir,

--- a/tests/TestFramework/Coverage/CodeCoverageDataTest.php
+++ b/tests/TestFramework/Coverage/CodeCoverageDataTest.php
@@ -245,7 +245,7 @@ final class CodeCoverageDataTest extends TestCase
     private function getParsedCodeCoverageData(): array
     {
         return [
-            '/tests/Fixtures/Files/phpunit/coverage-xml/FirstLevel/firstLevel.php' => CoverageFileData::from(
+            '/tests/Fixtures/Files/phpunit/coverage-xml/FirstLevel/firstLevel.php' => new CoverageFileData(
                 [
                     26 => [
                         CoverageLineData::withTestMethod('Infection\\Tests\\Mutator\\Arithmetic\\PlusTest::test_it_should_mutate_plus_expression'),
@@ -263,19 +263,19 @@ final class CodeCoverageDataTest extends TestCase
                     ],
                 ],
                 [
-                    'mutate' => CoverageMethodData::from(
+                    'mutate' => new CoverageMethodData(
                         19,
                         22,
                         1,
                         0
                     ),
-                    'shouldMutate' => CoverageMethodData::from(
+                    'shouldMutate' => new CoverageMethodData(
                         24,
                         35,
                         4,
                         80
                     ),
-                    'notExecuted' => CoverageMethodData::from(
+                    'notExecuted' => new CoverageMethodData(
                         3,
                         5,
                         0,
@@ -297,7 +297,7 @@ final class CodeCoverageDataTest extends TestCase
         $testFileDataProvider->expects($this->any())
             ->method('getTestFileInfo')
             ->willReturn(
-                TestFileTimeData::from(
+                new TestFileTimeData(
                     'path/to/testFile',
                     0.123
                 )

--- a/tests/TestFramework/Coverage/CoverageFileDataTest.php
+++ b/tests/TestFramework/Coverage/CoverageFileDataTest.php
@@ -33,36 +33,36 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\Coverage;
+namespace Infection\Tests\TestFramework\Coverage;
+
+use Infection\TestFramework\Coverage\CoverageFileData;
+use Infection\TestFramework\Coverage\CoverageLineData;
+use Infection\TestFramework\Coverage\CoverageMethodData;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class CachedTestFileDataProvider implements TestFileDataProvider
+final class CoverageFileDataTest extends TestCase
 {
-    /**
-     * @var TestFileDataProvider
-     */
-    private $testFileDataProvider;
-
-    /**
-     * @var array<string, TestFileTimeData>
-     */
-    private $testFileInfoCache = [];
-
-    public function __construct(TestFileDataProvider $testFileDataProvider)
+    public function test_it_has_default_values(): void
     {
-        $this->testFileDataProvider = $testFileDataProvider;
+        $coverageFileData = new CoverageFileData();
+
+        $this->assertSame([], $coverageFileData->byMethod);
+        $this->assertSame([], $coverageFileData->byLine);
     }
 
-    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData
+    public function test_it_creates_self_object_with_named_constructor(): void
     {
-        if (\array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
-            return $this->testFileInfoCache[$fullyQualifiedClassName];
-        }
+        $pathToTest = '/path/to/Test.php';
 
-        return $this->testFileInfoCache[$fullyQualifiedClassName] = $this->testFileDataProvider->getTestFileInfo(
-            $fullyQualifiedClassName
+        $coverageFileData = CoverageFileData::from(
+            [1 => [CoverageLineData::withTestMethod($pathToTest)]],
+            ['method' => CoverageMethodData::from(1, 3, 1, 100)]
         );
+
+        $this->assertSame($pathToTest, $coverageFileData->byLine[1][0]->testMethod);
+        $this->assertSame(100, $coverageFileData->byMethod['method']->coverage);
     }
 }

--- a/tests/TestFramework/Coverage/CoverageFileDataTest.php
+++ b/tests/TestFramework/Coverage/CoverageFileDataTest.php
@@ -57,9 +57,9 @@ final class CoverageFileDataTest extends TestCase
     {
         $pathToTest = '/path/to/Test.php';
 
-        $coverageFileData = CoverageFileData::from(
+        $coverageFileData = new CoverageFileData(
             [1 => [CoverageLineData::withTestMethod($pathToTest)]],
-            ['method' => CoverageMethodData::from(1, 3, 1, 100)]
+            ['method' => new CoverageMethodData(1, 3, 1, 100)]
         );
 
         $this->assertSame($pathToTest, $coverageFileData->byLine[1][0]->testMethod);

--- a/tests/TestFramework/Coverage/CoverageLineDataTest.php
+++ b/tests/TestFramework/Coverage/CoverageLineDataTest.php
@@ -33,36 +33,29 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\Coverage;
+namespace Infection\Tests\TestFramework\Coverage;
+
+use Infection\TestFramework\Coverage\CoverageLineData;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class CachedTestFileDataProvider implements TestFileDataProvider
+final class CoverageLineDataTest extends TestCase
 {
-    /**
-     * @var TestFileDataProvider
-     */
-    private $testFileDataProvider;
-
-    /**
-     * @var array<string, TestFileTimeData>
-     */
-    private $testFileInfoCache = [];
-
-    public function __construct(TestFileDataProvider $testFileDataProvider)
+    public function test_it_creates_self_with_named_constructor_for_test_method(): void
     {
-        $this->testFileDataProvider = $testFileDataProvider;
+        $coverageLineData = CoverageLineData::withTestMethod('mutatesNode');
+
+        $this->assertSame('mutatesNode', $coverageLineData->testMethod);
     }
 
-    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData
+    public function test_it_creates_self_with_named_constructor(): void
     {
-        if (\array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
-            return $this->testFileInfoCache[$fullyQualifiedClassName];
-        }
+        $coverageLineData = CoverageLineData::with('mutatesNode', 'path/to/Test.php', 0.123);
 
-        return $this->testFileInfoCache[$fullyQualifiedClassName] = $this->testFileDataProvider->getTestFileInfo(
-            $fullyQualifiedClassName
-        );
+        $this->assertSame('mutatesNode', $coverageLineData->testMethod);
+        $this->assertSame('path/to/Test.php', $coverageLineData->testFilePath);
+        $this->assertSame(0.123, $coverageLineData->time);
     }
 }

--- a/tests/TestFramework/Coverage/CoverageMethodDataTest.php
+++ b/tests/TestFramework/Coverage/CoverageMethodDataTest.php
@@ -33,36 +33,23 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\Coverage;
+namespace Infection\Tests\TestFramework\Coverage;
+
+use Infection\TestFramework\Coverage\CoverageMethodData;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class CachedTestFileDataProvider implements TestFileDataProvider
+final class CoverageMethodDataTest extends TestCase
 {
-    /**
-     * @var TestFileDataProvider
-     */
-    private $testFileDataProvider;
-
-    /**
-     * @var array<string, TestFileTimeData>
-     */
-    private $testFileInfoCache = [];
-
-    public function __construct(TestFileDataProvider $testFileDataProvider)
+    public function test_it_creates_self_with_named_constructor(): void
     {
-        $this->testFileDataProvider = $testFileDataProvider;
-    }
+        $coverageMethodData = CoverageMethodData::from(11, 22, 1, 100);
 
-    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData
-    {
-        if (\array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
-            return $this->testFileInfoCache[$fullyQualifiedClassName];
-        }
-
-        return $this->testFileInfoCache[$fullyQualifiedClassName] = $this->testFileDataProvider->getTestFileInfo(
-            $fullyQualifiedClassName
-        );
+        $this->assertSame(11, $coverageMethodData->startLine);
+        $this->assertSame(22, $coverageMethodData->endLine);
+        $this->assertSame(1, $coverageMethodData->executed);
+        $this->assertSame(100, $coverageMethodData->coverage);
     }
 }

--- a/tests/TestFramework/Coverage/CoverageMethodDataTest.php
+++ b/tests/TestFramework/Coverage/CoverageMethodDataTest.php
@@ -45,7 +45,7 @@ final class CoverageMethodDataTest extends TestCase
 {
     public function test_it_creates_self_with_named_constructor(): void
     {
-        $coverageMethodData = CoverageMethodData::from(11, 22, 1, 100);
+        $coverageMethodData = new CoverageMethodData(11, 22, 1, 100);
 
         $this->assertSame(11, $coverageMethodData->startLine);
         $this->assertSame(22, $coverageMethodData->endLine);

--- a/tests/TestFramework/Coverage/TestFileTimeDataTest.php
+++ b/tests/TestFramework/Coverage/TestFileTimeDataTest.php
@@ -45,7 +45,7 @@ final class TestFileTimeDataTest extends TestCase
 {
     public function test_it_creates_self_object_with_named_constructor(): void
     {
-        $testFileTimeData = TestFileTimeData::from(
+        $testFileTimeData = new TestFileTimeData(
             '/path/to/Test.php',
             2.345
         );

--- a/tests/TestFramework/Coverage/TestFileTimeDataTest.php
+++ b/tests/TestFramework/Coverage/TestFileTimeDataTest.php
@@ -33,36 +33,24 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\Coverage;
+namespace Infection\Tests\TestFramework\Coverage;
+
+use Infection\TestFramework\Coverage\TestFileTimeData;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class CachedTestFileDataProvider implements TestFileDataProvider
+final class TestFileTimeDataTest extends TestCase
 {
-    /**
-     * @var TestFileDataProvider
-     */
-    private $testFileDataProvider;
-
-    /**
-     * @var array<string, TestFileTimeData>
-     */
-    private $testFileInfoCache = [];
-
-    public function __construct(TestFileDataProvider $testFileDataProvider)
+    public function test_it_creates_self_object_with_named_constructor(): void
     {
-        $this->testFileDataProvider = $testFileDataProvider;
-    }
-
-    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData
-    {
-        if (\array_key_exists($fullyQualifiedClassName, $this->testFileInfoCache)) {
-            return $this->testFileInfoCache[$fullyQualifiedClassName];
-        }
-
-        return $this->testFileInfoCache[$fullyQualifiedClassName] = $this->testFileDataProvider->getTestFileInfo(
-            $fullyQualifiedClassName
+        $testFileTimeData = TestFileTimeData::from(
+            '/path/to/Test.php',
+            2.345
         );
+
+        $this->assertSame('/path/to/Test.php', $testFileTimeData->path);
+        $this->assertSame(2.345, $testFileTimeData->time);
     }
 }

--- a/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\TestFramework\PhpUnit\Config\Builder;
 
 use Infection\Mutant\MutantInterface;
 use Infection\MutationInterface;
+use Infection\TestFramework\Coverage\CoverageLineData;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
@@ -308,26 +309,26 @@ final class MutationConfigBuilderTest extends TestCase
         return [
             [
                 [
-                    [
-                        'testMethod' => 'SimpleHabits\\Domain\\Model\\Goal\\GoalTest::it_calculates_percentage with data set #5',
-                        'testFilePath' => '/path/to/siteSimpleHabits/Domain/Model/Goal/GoalTest.php',
-                        'time' => 0.086178,
-                    ],
-                    [
-                        'testMethod' => 'SimpleHabits\\Domain\\Model\\Goal\\GoalTest::it_calculates_percentage with data set #6',
-                        'testFilePath' => '/path/to/siteSimpleHabits/Domain/Model/Goal/GoalTest.php',
-                        'time' => 0.086178,
-                    ],
-                    [
-                        'testMethod' => 'SimpleHabits\\Domain\\Model\\Goal\\GoalStepTest::it_correctly_returns_id',
-                        'testFilePath' => '/path/to/siteSimpleHabits/Domain/Model/Goal/GoalStepTest.php',
-                        'time' => 0.035935,
-                    ],
-                    [
-                        'testMethod' => 'SimpleHabits\\Domain\\Model\\Goal\\GoalStepTest::it_correctly_returns_recorded_at_date',
-                        'testFilePath' => '/path/to/siteSimpleHabits/Domain/Model/Goal/GoalStepTest.php',
-                        'time' => 0.035935,
-                    ],
+                    CoverageLineData::with(
+                        'SimpleHabits\\Domain\\Model\\Goal\\GoalTest::it_calculates_percentage with data set #5',
+                        '/path/to/siteSimpleHabits/Domain/Model/Goal/GoalTest.php',
+                        0.086178
+                    ),
+                    CoverageLineData::with(
+                        'SimpleHabits\\Domain\\Model\\Goal\\GoalTest::it_calculates_percentage with data set #6',
+                        '/path/to/siteSimpleHabits/Domain/Model/Goal/GoalTest.php',
+                        0.086178
+                    ),
+                    CoverageLineData::with(
+                        'SimpleHabits\\Domain\\Model\\Goal\\GoalStepTest::it_correctly_returns_id',
+                        '/path/to/siteSimpleHabits/Domain/Model/Goal/GoalStepTest.php',
+                        0.035935
+                    ),
+                    CoverageLineData::with(
+                        'SimpleHabits\\Domain\\Model\\Goal\\GoalStepTest::it_correctly_returns_recorded_at_date',
+                        '/path/to/siteSimpleHabits/Domain/Model/Goal/GoalStepTest.php',
+                        0.035935
+                    ),
                 ],
                 [
                     '/path/to/siteSimpleHabits/Domain/Model/Goal/GoalStepTest.php',
@@ -336,21 +337,21 @@ final class MutationConfigBuilderTest extends TestCase
             ],
             [
                 [
-                    [
-                        'testMethod' => 'Path\\To\\A::test_a',
-                        'testFilePath' => '/path/to/A.php',
-                        'time' => 0.186178,
-                    ],
-                    [
-                        'testMethod' => 'Path\\To\\B::test_b',
-                        'testFilePath' => '/path/to/B.php',
-                        'time' => 0.086178,
-                    ],
-                    [
-                        'testMethod' => 'Path\\To\\C::test_c',
-                        'testFilePath' => '/path/to/C.php',
-                        'time' => 0.016178,
-                    ],
+                    CoverageLineData::with(
+                        'Path\\To\\A::test_a',
+                        '/path/to/A.php',
+                        0.186178
+                    ),
+                    CoverageLineData::with(
+                        'Path\\To\\B::test_b',
+                        '/path/to/B.php',
+                        0.086178
+                    ),
+                    CoverageLineData::with(
+                        'Path\\To\\C::test_c',
+                        '/path/to/C.php',
+                        0.016178
+                    ),
                 ],
                 [
                     '/path/to/C.php',

--- a/tests/TestFramework/PhpUnit/Coverage/CoverageXmlParserTest.php
+++ b/tests/TestFramework/PhpUnit/Coverage/CoverageXmlParserTest.php
@@ -79,13 +79,13 @@ final class CoverageXmlParserTest extends TestCase
         $this->assertArrayHasKey($firstLevelAbsolutePath, $coverage);
         $this->assertArrayHasKey($secondLevelAbsolutePath, $coverage);
 
-        $this->assertCount(0, $coverage[$zeroLevelAbsolutePath]['byLine']);
-        $this->assertCount(4, $coverage[$firstLevelAbsolutePath]['byLine']);
-        $this->assertCount(1, $coverage[$secondLevelAbsolutePath]['byLine']);
+        $this->assertCount(0, $coverage[$zeroLevelAbsolutePath]->byLine);
+        $this->assertCount(4, $coverage[$firstLevelAbsolutePath]->byLine);
+        $this->assertCount(1, $coverage[$secondLevelAbsolutePath]->byLine);
 
         $this->assertSame(
-            ['testMethod' => 'Infection\Tests\Mutator\Arithmetic\PlusTest::test_it_should_not_mutate_plus_with_arrays'],
-            $coverage[$firstLevelAbsolutePath]['byLine'][30][1]
+            'Infection\Tests\Mutator\Arithmetic\PlusTest::test_it_should_not_mutate_plus_with_arrays',
+            $coverage[$firstLevelAbsolutePath]->byLine[30][1]->testMethod
         );
     }
 
@@ -109,7 +109,9 @@ final class CoverageXmlParserTest extends TestCase
 
         $coverage = $this->parser->parse($this->getXml());
 
-        $this->assertSame($expectedByMethodArray, $coverage[$firstLevelAbsolutePath]['byMethod']);
+        $result = $this->convertObjectsToArray($coverage[$firstLevelAbsolutePath]->byMethod);
+
+        $this->assertSame($expectedByMethodArray, $result);
     }
 
     public function test_it_adds_by_method_coverage_data_for_traits(): void
@@ -133,7 +135,9 @@ final class CoverageXmlParserTest extends TestCase
 
         $coverage = $this->parser->parse($this->getXml());
 
-        $this->assertSame($expectedByMethodArray, $coverage[$pathToTrait]['byMethod']);
+        $result = $this->convertObjectsToArray($coverage[$pathToTrait]->byMethod);
+
+        $this->assertSame($expectedByMethodArray, $result);
     }
 
     /**
@@ -203,5 +207,21 @@ XML
             sprintf('$1%s$2', realpath($this->srcDir)),
             $xml
         );
+    }
+
+    private function convertObjectsToArray(array $coverageMethodsData): array
+    {
+        $result = [];
+
+        foreach ($coverageMethodsData as $method => $coverageMethodData) {
+            $result[$method] = [
+                'startLine' => $coverageMethodData->startLine,
+                'endLine' => $coverageMethodData->endLine,
+                'executed' => $coverageMethodData->executed,
+                'coverage' => $coverageMethodData->coverage,
+            ];
+        }
+
+        return $result;
     }
 }

--- a/tests/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProviderTest.php
+++ b/tests/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProviderTest.php
@@ -68,8 +68,8 @@ final class PhpUnitTestFileDataProviderTest extends TestCase
     {
         $info = $this->infoProvider->getTestFileInfo('Infection\Tests\Config\InfectionConfigTest');
 
-        $this->assertSame('/project/tests/Config/InfectionConfigTest.php', $info['path']);
-        $this->assertSame(0.021983, $info['time']);
+        $this->assertSame('/project/tests/Config/InfectionConfigTest.php', $info->path);
+        $this->assertSame(0.021983, $info->time);
     }
 
     public function test_consecutive_calls_with_the_same_class_return_the_same_result(): void
@@ -77,7 +77,8 @@ final class PhpUnitTestFileDataProviderTest extends TestCase
         $info1 = $this->infoProvider->getTestFileInfo('Infection\Tests\Config\InfectionConfigTest');
         $info2 = $this->infoProvider->getTestFileInfo('Infection\Tests\Config\InfectionConfigTest');
 
-        $this->assertSame($info1, $info2);
+        $this->assertSame($info1->path, $info2->path);
+        $this->assertSame($info1->time, $info2->time);
     }
 
     public function test_it_throws_a_coverage_does_not_exists_exception_when_junit_file_does_not_exist(): void


### PR DESCRIPTION
All proofs are here: https://steemit.com/php/@crell/php-use-associative-arrays-basically-never

* Objects of DTO classes takes less memory in PHP and as performant as arrays (or even better).
* Moreover, instead of `array` typehints we now have a real classes or typed collections, which is a big win IMO.
* No more passed variable by reference (`&$coverage`)

This PR follows https://github.com/infection/infection/pull/708 as @sanmai requested, I just extracted it to another PR for easier reviews.

Partially fixes issue https://github.com/infection/infection/issues/705

---

#### What is the memory benefit?

1. Originally, I wasn't able to run Infection for Psalm with `memory_limit=12G`
2. with #708, I was able to run Infection for Psalm with `memory_limit=12G`
3. With this PR, I'm able to run Infection for Psalm with `memory_limit=5G`

So it is `7Gb` or `58%` less memory usage for Psalm case.