### PR TITLE
Lower MSI requirement for PR builds

### DIFF
--- a/.ci/travis-functions.sh
+++ b/.ci/travis-functions.sh
@@ -28,11 +28,13 @@ function get-infection-pr-flags() {
         git fetch;
 
         CHANGED_FILES=$(git diff origin/$TRAVIS_BRANCH --diff-filter=AM --name-only | grep src/ | paste -sd "," -);
+        MIN_MSI=$(($(grep -o 'min-msi=[0-9]*' .travis.yml | head | cut -f2 -d=) + 1))
+        >&2 echo "Assumed minimal MSI: $MIN_MSI%"
 
         if [ -z "$CHANGED_FILES" ]; then
             INFECTION_PR_FLAGS="";
         else
-            INFECTION_PR_FLAGS="--filter=${CHANGED_FILES} --ignore-msi-with-no-mutations --only-covered --min-msi=90 --show-mutations";
+            INFECTION_PR_FLAGS="--filter=${CHANGED_FILES} --ignore-msi-with-no-mutations --only-covered --min-msi=$MIN_MSI --show-mutations";
         fi
     fi
 


### PR DESCRIPTION
Lower MSI requirement for PR builds, to match with a requirement for the whole project plus one point.

As discussed in #704