### PR TITLE
Fix Infection config builder: make sure it always creates an array for exluded dirs but not object

### DIFF
--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -120,7 +120,7 @@ final class ExcludeDirsProvider
             }
         }
 
-        return array_unique($excludedDirs);
+        return array_values(array_unique($excludedDirs));
     }
 
     private function getValidator(Locator $locator)

--- a/tests/Config/ValueProvider/ExcludeDirsProviderTest.php
+++ b/tests/Config/ValueProvider/ExcludeDirsProviderTest.php
@@ -131,6 +131,30 @@ final class ExcludeDirsProviderTest extends AbstractBaseProviderTest
         $this->assertContains('foo', $excludeDirs);
     }
 
+    public function test_returns_an_array_with_incremented_keys_started_from_zero(): void
+    {
+        if (!$this->hasSttyAvailable()) {
+            $this->markTestSkipped('Stty is not available');
+        }
+
+        $dirA = $this->workspace . \DIRECTORY_SEPARATOR . 'a' . \DIRECTORY_SEPARATOR;
+        $dirB = $this->workspace . \DIRECTORY_SEPARATOR . 'b' . \DIRECTORY_SEPARATOR;
+        $dirC = $this->workspace . \DIRECTORY_SEPARATOR . 'c' . \DIRECTORY_SEPARATOR;
+
+        \mkdir($dirA);
+        \mkdir($dirB);
+        \mkdir($dirC);
+
+        $excludeDirs = $this->provider->get(
+            $this->createStreamableInputInterfaceMock($this->getInputStream("$dirA\n$dirA\n$dirC\n")),
+            $this->createOutputInterface(),
+            [$dirA, $dirB, $dirC],
+            ['.']
+        );
+
+        $this->assertSame([0 => $dirA, 1 => $dirC], $excludeDirs);
+    }
+
     public function excludeDirsProvider()
     {
         return array_map(


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/580

`array_unique([['a', 'a', 'b'])` returns `[0 => 'a', 2 => 'b']` which in its turn breaks `infection.json` because now we have an object

```json
{
    "excludeDirs": {
        "0": "a",
        "2": "b",
    }
}
```

instead of array

```json
{
    "excludeDirs": [
        "a",
        "b",
    ]
}
```