### PR TITLE
Simplify the CS and Analyze Makefile commands

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,30 +2,26 @@
 
 Contributions are always welcome. Here are a few guidelines to be aware of:
  
- - Include unit or e2e tests for new behaviours introduced by PRs.
- - Fixed bugs MUST be covered by test(s) to avoid regression.
- - If you are on Unix-like system, run `./setup_environment.sh` to set up `pre-push` git hook.
- - All code must follow the `PSR-2` coding standard. Please see [PSR-2](https://www.php-fig.org/psr/psr-2/) for more details. 
-To make this as easy as possible, we use PHPCSFixer running two simple make commands: `make cs-check` and `make cs-fix`.
- - Before implementing a new big feature, consider creating a new Issue on Github. It will save your time when the core team is not going to accept it or has good recommendations about how to proceed.
+- Include tests for new behaviours introduced by PRs.
+- Fixed bugs MUST be covered by test(s) to avoid regression.
+- If you are on Unix-like system, you may run `./setup_environment.sh` to set up `pre-push` git 
+  hook.
+- All code must follow the project coding style standards which can be achieved by running `make cs`
+- Before implementing a new big feature, consider creating a new issue on Github. It will save your 
+  time when the core team is not going to accept it or has good recommendations about how to 
+  proceed.
  
+
 ## Tests
 
-The following commands can be ran to test on your local environment
+To run the tests locally, you can run `make test`. It however requires [Docker][docker]. For more
+granular tests, you can run `make` to see the available commands.
 
- - `./tests/e2e_tests` for end to end tests
- - `bin/infection` to run infection on itself.
- - `make analyze` to run PHPCSFixer and PHPStan.
 
-We also provide a way to run these commands in different environments, e.g. different php versions and debuggers.
+<br />
+<hr />
 
- - `make test` will run all types of tests, on all environments.
- - `make test-unit` will run all unit tests on different environments
- - `make test-infection-phpdbg` will run infection with `phpdbg` against different php versions
- - `make test-e2e-phpdbg` will run e2e tests with `phpdbg` against different php versions
- - `make test-infection-xdebug` will run infection with `xdebug` against different php versions
- - `make test-e2e-xdebug` will run e2e tests with `xdebug` against different php versions
- - For all test commands, except `make test` you can add `-70`, `-71`, or `-72` to run it agains php 7.0, 7.1 or 7.2
- So to run infection wtih phpdbg on php 7.1 you would run `make test-infection-phpdbg-71`
+« [Go back to the readme](README.md) »
 
-To use these command you need to have [Docker](https://www.docker.com/get-docker) installed.
+
+[docker]: https://www.docker.com/get-docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       install:
         - composer install
       script:
-        - make analyze-ci --keep-going
+        - make analyze --keep-going
 
     - &STANDARD_TEST_JOB
       stage: Test

--- a/Makefile
+++ b/Makefile
@@ -43,15 +43,10 @@ FLOCK=./devTools/flock
 compile:	## Bundles Infection into a PHAR
 compile: $(INFECTION)
 
-.PHONY: cs-fix
-cs-fix:	  	## Runs PHP-CS-Fixer
-cs-fix: $(PHP_CS_FIXER)
+.PHONY: cs
+cs:	  	## Runs PHP-CS-Fixer
+cs: $(PHP_CS_FIXER)
 	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE)
-
-.PHONY: cs-check
-cs-check:	## Runs PHP-CS-Fixer in dry mode
-cs-check: $(PHP_CS_FIXER)
-	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE) --dry-run --stop-on-violation
 
 .PHONY: phpstan
 phpstan:  	## Runs PHPStan
@@ -60,12 +55,8 @@ phpstan: vendor $(PHPSTAN)
 	$(PHPSTAN) analyse tests --level=4 --configuration ./devTools/phpstan-tests.neon --no-interaction --no-progress
 
 .PHONY: analyze
-analyze:	## Runs CS fixers, static analyzers and various other checks
-analyze: cs-check analyze-ci
-
-.PHONY: analyze-ci
-analyze-ci:	## Runs static analyzers and various other checks
-analyze-ci: phpstan validate
+analyze:	## Runs Static analyzers and various other checks
+analyze: phpstan validate
 
 .PHONY: validate
 validate:	## Checks that the composer.json file is valid

--- a/README.md
+++ b/README.md
@@ -8,18 +8,27 @@
 [![Slack channel: #infection on the Symfony slack](https://img.shields.io/badge/slack-%23infection-green.svg?style=flat-square)](https://symfony.com/slack-invite)
 
 
-Infection - Mutation Testing framework
-=========
+# Infection - Mutation Testing framework
 
-Please read documentation here: http://infection.github.io
+Please read documentation here: [infection.github.io][doc]
 
-Twitter: http://twitter.com/infection_php
+Twitter: [@infection_php][twitter]
+
 
 ### Contributing
 
-Infection is an open source project that welcomes pull requests and issues from anyone.
-Before opening pull requests, please read our short [Contribution Guide](https://github.com/infection/infection/blob/master/.github/CONTRIBUTING.md).
+Infection is an open source project that welcomes pull requests and issues from anyone. Before 
+pening pull requests, please consider reading our short [Contribution Guide][contribution guide].
+
 
 ### Credits
 
-This project is highly inspired from Pádraic Brady ([@padraic](https://github.com/padraic))'s [Humbug library](https://github.com/humbug/humbug). Humbug has since then been discountinued in favour of this project.
+This project is highly inspired from Pádraic Brady ([@padraic][padraic])'s [Humbug library][humbug]. 
+Humbug has since then been discontinued in favour of this project.
+
+
+[doc]: http://infection.github.io
+[contribution guide]: .github/CONTRIBUTING.md
+[humbug]: https://github.com/humbug/humbug
+[padraic]: https://github.com/padraic
+[twitter]: http://twitter.com/infection_php


### PR DESCRIPTION
This PR:

- Removes `make cs-fix` and `make cs-check` in favour of `make cs`
- Removes `make analyze-ci` in favour of the already existent `make analyze`

This should make the commands a bit easier to use (less commands to use/understand) and also reduce the friction of environment difference between local dev and CI which is always a source of pain.

I took the opportunity to slightly change the outdated contributing docs as well.