### PR TITLE
Multiple extra test framework options escape in the wrong way

### DIFF
--- a/src/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -44,14 +44,18 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
 {
     public function build(string $configPath, string $extraOptions): array
     {
-        return array_filter([
-            'run',
-            '--config',
-            $configPath,
-            '--no-ansi',
-            '--format=tap',
-            '--stop-on-failure',
-            $extraOptions,
-        ]);
+        $options = array_merge(
+            [
+                'run',
+                '--config',
+                $configPath,
+                '--no-ansi',
+                '--format=tap',
+                '--stop-on-failure',
+            ],
+            explode(' ', $extraOptions)
+        );
+
+        return array_filter($options);
     }
 }

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -44,10 +44,14 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
 {
     public function build(string $configPath, string $extraOptions): array
     {
-        return array_filter([
-            '--configuration',
-            $configPath,
-            $extraOptions,
-        ]);
+        $options = array_merge(
+            [
+                '--configuration',
+                $configPath,
+            ],
+            explode(' ', $extraOptions)
+        );
+
+        return array_filter($options);
     }
 }

--- a/tests/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -57,8 +57,9 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 '--format=tap',
                 '--stop-on-failure',
                 '--verbose',
+                '--debug',
             ],
-            $builder->build($configPath, '--verbose')
+            $builder->build($configPath, '--verbose --debug')
         );
     }
 

--- a/tests/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -53,8 +53,9 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 '--configuration',
                 $configPath,
                 '--verbose',
+                '--debug',
             ],
-            $builder->build($configPath, '--verbose')
+            $builder->build($configPath, '--verbose --debug')
         );
     }
 


### PR DESCRIPTION
This PR:
Fixes https://github.com/infection/infection/issues/615

p.s. Probably need to write an e2e test to avoid such issues in the future.