### PR TITLE
Update E2E tests to use PHPUnit 8

### DIFF
--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -40,6 +40,7 @@ use Infection\Command\ConfigureCommand;
 use Infection\Console\Application;
 use Infection\Console\InfectionContainer;
 use Infection\Finder\ComposerExecutableFinder;
+use Infection\Finder\Exception\FinderException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -211,6 +212,13 @@ final class E2ETest extends TestCase
 
                 ++self::$countFailingComposerInstall;
                 $this->markTestSkipped($e->getMessage());
+            } catch (FinderException $e) {
+                if (\DIRECTORY_SEPARATOR !== '\\') {
+                    throw $e;
+                }
+
+                // It is not our call to work around ComposerExecutableFinder's misbehavior on Windows
+                $this->markTestIncomplete($e->getMessage());
             }
         }
 

--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -78,10 +78,6 @@ final class E2ETest extends TestCase
             $this->markTestSkipped('This test needs copious amounts of virtual memory. It will fail unless it is allowed to overcommit memory.');
         }
 
-        if (\version_compare(\PHPUnit\Runner\Version::id(), '8', '>=')) {
-            $this->markTestSkipped('Most E2E tests use an earlier version of PHPUnit, which is incompatible with PHPUnit 8 and later');
-        }
-
         // E2E tests usually require to chdir to their location
         // Hence we would need to go back to this dir
         $this->cwd = getcwd();

--- a/tests/Fixtures/e2e/Code_Coverage_Ignore/composer.json
+++ b/tests/Fixtures/e2e/Code_Coverage_Ignore/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Config_Bootstrap/composer.json
+++ b/tests/Fixtures/e2e/Config_Bootstrap/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Configure/composer.json
+++ b/tests/Fixtures/e2e/Configure/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Custom_tmp_dir/composer.json
+++ b/tests/Fixtures/e2e/Custom_tmp_dir/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Empty_Path/composer.json
+++ b/tests/Fixtures/e2e/Empty_Path/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Example_Test/composer.json
+++ b/tests/Fixtures/e2e/Example_Test/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Exec_Path/composer.json
+++ b/tests/Fixtures/e2e/Exec_Path/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Identical_Mutator_Example/composer.json
+++ b/tests/Fixtures/e2e/Identical_Mutator_Example/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/composer.json
+++ b/tests/Fixtures/e2e/Ignore_MSI_Zero_Mutations/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Initial_Configuration/composer.json
+++ b/tests/Fixtures/e2e/Initial_Configuration/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Memory_Limit/composer.json
+++ b/tests/Fixtures/e2e/Memory_Limit/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Multiline_Statement/composer.json
+++ b/tests/Fixtures/e2e/Multiline_Statement/composer.json
@@ -2,11 +2,11 @@
     "license": "MIT",
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Multiline_Statement/tests/CalculatorTest.php
+++ b/tests/Fixtures/e2e/Multiline_Statement/tests/CalculatorTest.php
@@ -9,7 +9,7 @@ class CalculatorTest extends TestCase
     /** @var Calculator */
     private $calculator;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->calculator = new Calculator();

--- a/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/composer.json
+++ b/tests/Fixtures/e2e/PHPUnit_Custom_Config_Dir/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/PHPUnit_Hidden_Dependency/composer.json
+++ b/tests/Fixtures/e2e/PHPUnit_Hidden_Dependency/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^7.2"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/PHPUnit_XSD_Validation/composer.json
+++ b/tests/Fixtures/e2e/PHPUnit_XSD_Validation/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/PSR_0_Autoloader/composer.json
+++ b/tests/Fixtures/e2e/PSR_0_Autoloader/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-0": {

--- a/tests/Fixtures/e2e/Parameters_Coverage/composer.json
+++ b/tests/Fixtures/e2e/Parameters_Coverage/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {
@@ -14,7 +14,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.0.8"
+            "php": "7.2.9"
         },
         "sort-packages": true
     }

--- a/tests/Fixtures/e2e/PhpUnit_Depends_Order/composer.json
+++ b/tests/Fixtures/e2e/PhpUnit_Depends_Order/composer.json
@@ -10,6 +10,8 @@
         }
     },
     "require": {
-        "phpunit/phpunit": "7.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8"
     }
 }

--- a/tests/Fixtures/e2e/PhpUnit_Depends_Order/expected-output.txt
+++ b/tests/Fixtures/e2e/PhpUnit_Depends_Order/expected-output.txt
@@ -1,6 +1,6 @@
 Total: 1
-Killed: 0
-Errored: 1
+Killed: 1
+Errored: 0
 Escaped: 0
 Timed Out: 0
 Not Covered: 0

--- a/tests/Fixtures/e2e/PhpUnit_Depends_Order/tests/SourceClassTest.php
+++ b/tests/Fixtures/e2e/PhpUnit_Depends_Order/tests/SourceClassTest.php
@@ -19,7 +19,7 @@ class SourceClassTest extends TestCase
      * Expected result: random order of these tests should respect `@depends` annotation and do not
      * produce skipped tests, thanks to `resolveDependencies="true"`flag (or `--resolve-dependencies` option)
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
 

--- a/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/composer.json
+++ b/tests/Fixtures/e2e/Phpunit_Bat_Wrapper/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Profiles_Ignore_Combination/composer.json
+++ b/tests/Fixtures/e2e/Profiles_Ignore_Combination/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Provide_Existing_Coverage/composer.json
+++ b/tests/Fixtures/e2e/Provide_Existing_Coverage/composer.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {

--- a/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/composer.json
+++ b/tests/Fixtures/e2e/Save_PHPUnit_Bootstrap_File/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.1"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Test_Framework_Options_Config/composer.json
+++ b/tests/Fixtures/e2e/Test_Framework_Options_Config/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Test_Frameworks/composer.json
+++ b/tests/Fixtures/e2e/Test_Frameworks/composer.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "autoload": {

--- a/tests/Fixtures/e2e/Test_PHP_Options_Config/composer.json
+++ b/tests/Fixtures/e2e/Test_PHP_Options_Config/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Trait_Coverage/composer.json
+++ b/tests/Fixtures/e2e/Trait_Coverage/composer.json
@@ -1,11 +1,11 @@
 {
     "config": {
         "platform": {
-            "php": "7.0"
+            "php": "7.2.9"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/UncoveredInterfaces/composer.json
+++ b/tests/Fixtures/e2e/UncoveredInterfaces/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/e2e/Variables_Order_EGPCS/composer.json
+++ b/tests/Fixtures/e2e/Variables_Order_EGPCS/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR:

- [x] Updates E2E tests to use PHPUnit 8
