### PR TITLE
Use codingmachine/safe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         "symfony/finder": "^3.4 || ^4.0",
         "symfony/process": "^3.4 || ^4.0",
         "symfony/yaml": "^3.4 || ^4.0",
+        "thecodingmachine/safe": "^0.1.16",
         "webmozart/assert": "^1.3"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "355f615204d440b6f3dc6d4b338687a1",
+    "content-hash": "7cd988515954431436112c840defb7e4",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -933,6 +933,138 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2019-04-06T14:04:46+00:00"
+        },
+        {
+            "name": "thecodingmachine/safe",
+            "version": "v0.1.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "4e8f840f0a0a2ea167813c3994a7fc527c3c2182"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/4e8f840f0a0a2ea167813c3994a7fc527c3c2182",
+                "reference": "4e8f840f0a0a2ea167813c3994a7fc527c3c2182",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.10.3",
+                "squizlabs/php_codesniffer": "^3.2",
+                "thecodingmachine/phpstan-strict-rules": "^0.10.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Safe\\": [
+                        "lib/",
+                        "generated/"
+                    ]
+                },
+                "files": [
+                    "generated/apache.php",
+                    "generated/apc.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/ingres-ii.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libevent.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/msql.php",
+                    "generated/mssql.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/mysqlndMs.php",
+                    "generated/mysqlndQc.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/password.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pdf.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/simplexml.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stats.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php",
+                    "lib/special_cases.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "time": "2019-06-25T08:45:33+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -47,6 +47,9 @@ use Infection\Config\ValueProvider\TimeoutProvider;
 use Infection\Finder\TestFrameworkFinder;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use Infection\TestFramework\TestFrameworkTypes;
+use function Safe\file_get_contents;
+use function Safe\glob;
+use function Safe\json_decode;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -94,13 +97,7 @@ final class ConfigureCommand extends BaseCommand
         $questionHelper = $this->getHelper('question');
 
         if (file_exists('composer.json')) {
-            $content = file_get_contents('composer.json');
-            \assert(\is_string($content));
-            $content = json_decode($content);
-
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                throw new \LogicException('composer.json does not contain valid JSON');
-            }
+            $content = json_decode(file_get_contents('composer.json'));
 
             $sourceDirGuesser = new SourceDirGuesser($content);
         } else {

--- a/src/Config/ConfigCreatorFacade.php
+++ b/src/Config/ConfigCreatorFacade.php
@@ -39,6 +39,7 @@ use Infection\Config\Validator as ConfigValidator;
 use Infection\Finder\Exception\LocatorException;
 use Infection\Finder\LocatorInterface;
 use Infection\Json\JsonFile;
+use function Safe\getcwd;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -83,9 +84,6 @@ final class ConfigCreatorFacade
 
             $configLocation = getcwd();
         }
-
-        // getcwd() may return false in rare circumstances
-        \assert(\is_string($configLocation));
 
         $infectionConfig = new InfectionConfig($content, $this->filesystem, $configLocation);
 

--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -37,6 +37,7 @@ namespace Infection\Config\ValueProvider;
 
 use Infection\Config\ConsoleHelper;
 use Infection\Finder\Locator;
+use function Safe\glob;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -39,6 +39,8 @@ use Infection\Config\ConsoleHelper;
 use Infection\Config\Guesser\PhpUnitPathGuesser;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\TestFrameworkTypes;
+use function Safe\file_get_contents;
+use function Safe\json_decode;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -86,7 +88,6 @@ final class TestFrameworkConfigPathProvider
             }
 
             $composerJsonText = file_get_contents('composer.json');
-            \assert(\is_string($composerJsonText));
 
             $phpUnitPathGuesser = new PhpUnitPathGuesser(json_decode($composerJsonText));
             $defaultValue = $phpUnitPathGuesser->guess();

--- a/src/Finder/Locator.php
+++ b/src/Finder/Locator.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Finder;
 
 use Infection\Finder\Exception\LocatorException;
+use function Safe\realpath;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -63,7 +64,7 @@ final class Locator implements LocatorInterface
     {
         if ($this->filesystem->isAbsolutePath($name)) {
             if ($this->filesystem->exists($name)) {
-                return (string) realpath($name);
+                return realpath($name);
             }
 
             throw LocatorException::fileOrDirectoryDoesNotExist($name);
@@ -73,7 +74,7 @@ final class Locator implements LocatorInterface
             $file = $path . \DIRECTORY_SEPARATOR . $name;
 
             if ($this->filesystem->exists($file)) {
-                return (string) realpath($file);
+                return realpath($file);
             }
         }
 

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -37,6 +37,8 @@ namespace Infection\Finder;
 
 use Infection\Finder\Exception\FinderException;
 use Infection\TestFramework\TestFrameworkTypes;
+use function Safe\file_get_contents;
+use function Safe\realpath;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -73,7 +75,7 @@ class TestFrameworkFinder extends AbstractExecutableFinder
                 $this->addVendorBinToPath();
             }
 
-            $this->cachedPath = (string) realpath($this->findTestFramework());
+            $this->cachedPath = realpath($this->findTestFramework());
 
             if ('.bat' === substr($this->cachedPath, -4)) {
                 $this->cachedPath = $this->findFromBatchFile($this->cachedPath);
@@ -180,9 +182,9 @@ class TestFrameworkFinder extends AbstractExecutableFinder
          *   SET BIN_TARGET=%~dp0/../path
          *   php %~dp0/path %*
          */
-        if (preg_match('/%~dp0(.+$)/mi', (string) file_get_contents($path), $match)) {
+        if (preg_match('/%~dp0(.+$)/mi', file_get_contents($path), $match)) {
             $target = ltrim(rtrim(trim($match[1]), '" %*'), '\\/');
-            $script = (string) realpath(\dirname($path) . '/' . $target);
+            $script = realpath(\dirname($path) . '/' . $target);
 
             if (file_exists($script)) {
                 $path = $script;

--- a/src/Http/BadgeApiClient.php
+++ b/src/Http/BadgeApiClient.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Http;
 
+use function Safe\curl_init;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -70,8 +71,6 @@ class BadgeApiClient
         ]);
 
         $ch = curl_init();
-
-        \assert(\is_resource($ch));
 
         curl_setopt($ch, CURLOPT_URL, self::STRYKER_DASHBOARD_API_URL);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/src/Json/JsonFile.php
+++ b/src/Json/JsonFile.php
@@ -38,6 +38,7 @@ namespace Infection\Json;
 use Infection\Json\Exception\JsonValidationException;
 use Infection\Json\Exception\ParseException;
 use JsonSchema\Validator;
+use function Safe\file_get_contents;
 
 /**
  * @internal
@@ -75,7 +76,7 @@ final class JsonFile
             throw ParseException::invalidJson($this->path, 'file not found');
         }
 
-        $data = json_decode((string) file_get_contents($this->path));
+        $data = json_decode(file_get_contents($this->path));
 
         if (null === $data && JSON_ERROR_NONE !== json_last_error()) {
             throw ParseException::invalidJson($this->path, json_last_error_msg());

--- a/src/Mutant/MutantCreator.php
+++ b/src/Mutant/MutantCreator.php
@@ -42,6 +42,7 @@ use Infection\Visitor\CloneVisitor;
 use Infection\Visitor\MutatorVisitor;
 use PhpParser\NodeTraverser;
 use PhpParser\PrettyPrinter\Standard;
+use function Safe\file_get_contents;
 
 /**
  * @internal
@@ -98,7 +99,6 @@ final class MutantCreator
     {
         if (is_readable($mutatedFilePath)) {
             $mutatedCode = file_get_contents($mutatedFilePath);
-            \assert(\is_string($mutatedCode));
 
             return $mutatedCode;
         }

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\TestFramework\Config;
 
 use Infection\Finder\Exception\LocatorException;
+use function Safe\realpath;
 
 /**
  * @internal
@@ -70,10 +71,7 @@ final class TestFrameworkConfigLocator implements TestFrameworkConfigLocatorInte
             $conf = sprintf('%s/%s.%s', $dir, $testFrameworkName, $extension);
 
             if (file_exists($conf)) {
-                $realpath = realpath($conf);
-                \assert(\is_string($realpath));
-
-                return $realpath;
+                return realpath($conf);
             }
 
             $triedFiles[] = sprintf('%s.%s', $testFrameworkName, $extension);

--- a/src/TestFramework/Coverage/CodeCoverageData.php
+++ b/src/TestFramework/Coverage/CodeCoverageData.php
@@ -37,6 +37,7 @@ namespace Infection\TestFramework\Coverage;
 
 use Infection\MutationInterface;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
+use function Safe\file_get_contents;
 
 /**
  * @internal
@@ -204,7 +205,6 @@ class CodeCoverageData
             }
 
             $coverageIndexFileContent = file_get_contents($coverageIndexFilePath);
-            \assert(\is_string($coverageIndexFileContent));
 
             $coverage = $this->parser->parse($coverageIndexFileContent);
 

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -48,6 +48,7 @@ use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use Infection\Utils\VersionParser;
+use function Safe\file_get_contents;
 
 /**
  * @internal
@@ -112,7 +113,6 @@ final class Factory
         if ($adapterName === TestFrameworkTypes::PHPUNIT) {
             $phpUnitConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPUNIT);
             $phpUnitConfigContent = file_get_contents($phpUnitConfigPath);
-            \assert(\is_string($phpUnitConfigContent));
 
             return new PhpUnitAdapter(
                 new TestFrameworkFinder(TestFrameworkTypes::PHPUNIT, $this->infectionConfig->getPhpUnitCustomPath()),

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -40,6 +40,8 @@ use Infection\TestFramework\Coverage\CoverageFileData;
 use Infection\TestFramework\Coverage\CoverageLineData;
 use Infection\TestFramework\Coverage\CoverageMethodData;
 use Infection\TestFramework\PhpUnit\Coverage\Exception\NoLinesExecutedException;
+use function Safe\file_get_contents;
+use function Safe\realpath;
 
 /**
  * @internal
@@ -104,10 +106,7 @@ class CoverageXmlParser
     private function processXmlFileCoverage(string $relativeCoverageFilePath, string $projectSource): array
     {
         $absolutePath = realpath($this->coverageDir . '/' . $relativeCoverageFilePath);
-        \assert(\is_string($absolutePath));
-
         $coverageFileXml = file_get_contents($absolutePath);
-        \assert(\is_string($coverageFileXml));
 
         $dom = new \DOMDocument();
         $dom->loadXML($this->removeNamespace($coverageFileXml));


### PR DESCRIPTION
This PR:

- [x] Adds [`thecodingmachine/safe`](https://github.com/thecodingmachine/safe) as a dependency
- [x] Fixes `assert` calls and (mostly) useless casts.

I can't fix everything at this moment, for example `preg_replace` has different return types bases on its parameters, and PHPStan can't understand that from the safe function. So i've opted to keep those as is right now.
