### PR TITLE
Replace usage of parameters from the container with the configuration

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -210,6 +210,7 @@ final class InfectionCommand extends BaseCommand
             return 1;
         }
 
+        /** @var InfectionConfig $config */
         $config = $container->get('infection.config');
 
         $this->includeUserBootstrap($config);
@@ -250,8 +251,8 @@ final class InfectionCommand extends BaseCommand
 
         $codeCoverageData = $this->getCodeCoverageData($testFrameworkKey);
         $mutationsGenerator = new MutationsGenerator(
-            $container->get('src.dirs'),
-            $container->get('exclude.paths'),
+            $config->getSourceDirs(),
+            $config->getSourceExcludePaths(),
             $codeCoverageData,
             $container->get('mutators'),
             $this->eventDispatcher,

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -215,7 +215,7 @@ final class InfectionCommand extends BaseCommand
 
         $this->includeUserBootstrap($config);
 
-        $testFrameworkKey = $input->getOption('test-framework') ?: $config->getTestFramework();
+        $testFrameworkKey = trim((string) $input->getOption('test-framework') ?: $config->getTestFramework());
         $adapter = $container->get('test.framework.factory')->create($testFrameworkKey, $this->skipCoverage);
 
         LogVerbosity::convertVerbosityLevel($input, $this->consoleOutput);
@@ -229,14 +229,11 @@ final class InfectionCommand extends BaseCommand
         $testFrameworkOptions = $this->getTestFrameworkExtraOptions($testFrameworkKey);
 
         $initialTestsRunner = new InitialTestsRunner($processBuilder, $this->eventDispatcher);
+        $initialTestsPhpOptions = trim((string) $input->getOption('initial-tests-php-options') ?: $config->getInitialTestsPhpOptions());
         $initialTestSuitProcess = $initialTestsRunner->run(
             $testFrameworkOptions->getForInitialProcess(),
             $this->skipCoverage,
-            explode(
-                ' ',
-                $input->getOption('initial-tests-php-options')
-                ?? $config->getInitialTestsPhpOptions()
-            )
+            explode(' ', $initialTestsPhpOptions)
         );
 
         if (!$initialTestSuitProcess->isSuccessful()) {

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -84,19 +84,7 @@ final class InfectionContainer extends Container
     {
         parent::__construct($values);
 
-        $this['src.dirs'] = function (): array {
-            return $this->getInfectionConfig()->getSourceDirs();
-        };
-
-        $this['exclude.paths'] = function (): array {
-            return $this->getInfectionConfig()->getSourceExcludePaths();
-        };
-
         $this['project.dir'] = getcwd();
-
-        $this['phpunit.config.dir'] = function (): string {
-            return $this->getInfectionConfig()->getPhpUnitConfigDir();
-        };
 
         $this['filesystem'] = static function (): Filesystem {
             return new Filesystem();
@@ -127,7 +115,7 @@ final class InfectionContainer extends Container
         };
 
         $this['path.replacer'] = function (): PathReplacer {
-            return new PathReplacer($this['filesystem'], $this['phpunit.config.dir']);
+            return new PathReplacer($this['filesystem'], $this['infection.config']->getPhpUnitConfigDir());
         };
 
         $this['test.framework.factory'] = function (): Factory {
@@ -143,7 +131,7 @@ final class InfectionContainer extends Container
         };
 
         $this['xml.configuration.helper'] = function (): XmlConfigurationHelper {
-            return new XmlConfigurationHelper($this['path.replacer'], $this['phpunit.config.dir']);
+            return new XmlConfigurationHelper($this['path.replacer'], $this['infection.config']->getPhpUnitConfigDir());
         };
 
         $this['mutant.creator'] = function (): MutantCreator {
@@ -170,7 +158,7 @@ final class InfectionContainer extends Container
 
         $this['testframework.config.locator'] = function (): TestFrameworkConfigLocator {
             return new TestFrameworkConfigLocator(
-                $this['phpunit.config.dir'] /*[phpunit.dir, phpspec.dir, ...]*/
+                $this['infection.config']->getPhpUnitConfigDir() /*[phpunit.dir, phpspec.dir, ...]*/
             );
         };
 


### PR DESCRIPTION
As per the description, in order to:

- reduce the number of parameters registered to the container
- avoid unnecessary redundancy