### PR TITLE
Move the registration of the built-in services in a factory function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /tests/Fixtures/e2e/Configure/infection.json.dist
 /tests/Fixtures/e2e/SymfonyFlex/bin/.phpunit/
 /vendor/
+phpunit.xml

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -111,7 +111,7 @@ return Config::create()
         'phpdoc_align' => false,
         'phpdoc_summary' => false,
         'php_unit_set_up_tear_down_visibility' => true,
-        'php_unit_strict' => false,
+        'php_unit_strict' => true,
         'php_unit_test_annotation' => [
             'style' => 'prefix',
             'case' => 'snake',

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -111,7 +111,7 @@ return Config::create()
         'phpdoc_align' => false,
         'phpdoc_summary' => false,
         'php_unit_set_up_tear_down_visibility' => true,
-        'php_unit_strict' => true,
+        'php_unit_strict' => false,
         'php_unit_test_annotation' => [
             'style' => 'prefix',
             'case' => 'snake',

--- a/bin/infection
+++ b/bin/infection
@@ -74,6 +74,7 @@ if (\PHP_SAPI !== 'cli' && \PHP_SAPI !== 'phpdbg') {
 }
 
 use Infection\Console\Application;
+use Infection\Console\InfectionContainer;
 
-$application = new Application(new \Infection\Console\InfectionContainer());
+$application = new Application(InfectionContainer::create());
 $application->run();

--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -307,7 +307,7 @@ final class E2ETest extends TestCase
             $this->markTestSkipped("Infection from within PHPUnit won't run without xdebug or phpdbg");
         }
 
-        $container = new InfectionContainer();
+        $container = InfectionContainer::create();
         $input = new ArgvInput(array_merge([
             'bin/infection',
             'run',

--- a/tests/Console/InfectionContainerTest.php
+++ b/tests/Console/InfectionContainerTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Console;
 
 use Infection\Console\InfectionContainer;
 use PHPUnit\Framework\TestCase;
-use Pimple\Container;
+use stdClass;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -46,12 +46,49 @@ use Symfony\Component\Console\Input\InputInterface;
  */
 final class InfectionContainerTest extends TestCase
 {
-    public function test_it_is_a_usable_container(): void
+    public function test_it_can_be_instantiated_without_any_services(): void
     {
         $container = new InfectionContainer();
 
-        $this->assertArrayHasKey('project.dir', $container);
-        $this->assertInstanceOf(Container::class, $container);
+        $this->assertSame([], $container->keys());
+    }
+
+    public function test_it_can_be_instantiated_with_services(): void
+    {
+        $syntheticService = (object) ['synthetic' => true];
+        $regularService = static function (): stdClass {
+            return (object) [
+                'regular' => true,
+            ];
+        };
+
+        $container = new InfectionContainer([
+            'synthetic service' => $syntheticService,
+            'regular service' => $regularService,
+        ]);
+
+        $this->assertSame(
+            [
+                'synthetic service',
+                'regular service',
+            ],
+            $container->keys()
+        );
+
+        $this->assertSame($syntheticService, $container['synthetic service']);
+        $this->assertSame(
+            (object) [
+                'regular' => true,
+            ],
+            $container['regular service']
+        );
+    }
+
+    public function test_it_can_be_instantiated_with_the_project_services(): void
+    {
+        $container = InfectionContainer::create();
+
+        $this->assertNotSame([], $container->keys());
     }
 
     public function test_it_can_build_dynamic_dependencies(): void

--- a/tests/Console/InfectionContainerTest.php
+++ b/tests/Console/InfectionContainerTest.php
@@ -76,12 +76,7 @@ final class InfectionContainerTest extends TestCase
         );
 
         $this->assertSame($syntheticService, $container['synthetic service']);
-        $this->assertEquals(
-            (object) [
-                'regular' => true,
-            ],
-            $container['regular service']
-        );
+        $this->assertTrue($container['regular service']->regular);
     }
 
     public function test_it_can_be_instantiated_with_the_project_services(): void

--- a/tests/Console/InfectionContainerTest.php
+++ b/tests/Console/InfectionContainerTest.php
@@ -76,7 +76,7 @@ final class InfectionContainerTest extends TestCase
         );
 
         $this->assertSame($syntheticService, $container['synthetic service']);
-        $this->assertSame(
+        $this->assertEquals(
             (object) [
                 'regular' => true,
             ],


### PR DESCRIPTION
This is the first step of the container refactoring, what I would like to do next is:

- Replace the service names by their FQCN
- Expose the services by typehinted getters instead of the PSR11 container interface
- Make the container readonly - I think by decorating the pimple container

Note that **no service definition has been changed in this PR**.