### PR TITLE
Add Symfony PHPUnitBridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
     },
     "require-dev": {
         "helmich/phpunit-json-assert": "^3.0",
-        "phpunit/phpunit": "^8.2.4"
+        "phpunit/phpunit": "^8.2.4",
+        "symfony/phpunit-bridge": "^4.3"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24a7467739ed2d87a07fab3827e918ad",
+    "content-hash": "c85f01c0a53579013fa9d583a1cbf8ea",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -2564,6 +2564,71 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "573b5c4a36a171b94cf031d8dc6cc568082190f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/573b5c4a36a171b94cf031d8dc6cc568082190f1",
+                "reference": "573b5c4a36a171b94cf031d8dc6cc568082190f1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "suggest": {
+                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                },
+                "thanks": {
+                    "name": "phpunit/phpunit",
+                    "url": "https://github.com/sebastianbergmann/phpunit"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2019-06-26T12:14:14+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,10 @@
          verbose="true"
 >
 
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
+    </php>
+
     <testsuites>
         <testsuite name="Infection Test Suite">
             <directory>tests</directory>
@@ -28,5 +32,10 @@
             <group>large</group>
         </exclude>
     </groups>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+        <listener class="Symfony\Bridge\PhpUnit\CoverageListener" />
+    </listeners>
 
 </phpunit>

--- a/phpunit_autoreview.xml
+++ b/phpunit_autoreview.xml
@@ -8,6 +8,10 @@
          verbose="true"
 >
 
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
+    </php>
+
     <testsuites>
         <testsuite name="Auto-Review Test Suite">
             <directory>tests/AutoReview</directory>
@@ -19,5 +23,10 @@
             <directory>tests/AutoReview</directory>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+        <listener class="Symfony\Bridge\PhpUnit\CoverageListener" />
+    </listeners>
 
 </phpunit>

--- a/tests/AutoReview/Makefile/ParserTest.php
+++ b/tests/AutoReview/Makefile/ParserTest.php
@@ -40,8 +40,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
- *
- * @covers \Infection\Tests\AutoReview\Makefile\Parser
  */
 final class ParserTest extends TestCase
 {

--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -203,7 +203,7 @@ final class E2ETest extends TestCase
             try {
                 $process = new Process([
                     (new ComposerExecutableFinder())->find(),
-                    'install'
+                    'install',
                 ]);
                 $process->setTimeout(300);
                 $process->mustRun();

--- a/tests/Console/E2ETest.php
+++ b/tests/Console/E2ETest.php
@@ -201,7 +201,10 @@ final class E2ETest extends TestCase
             $this->assertNotEmpty(getenv('PATH') ?: getenv('Path'), 'E2E tests need a system composer installed, but it could not be found without a PATH set');
 
             try {
-                $process = new Process(sprintf('%s %s', (new ComposerExecutableFinder())->find(), 'install'));
+                $process = new Process([
+                    (new ComposerExecutableFinder())->find(),
+                    'install'
+                ]);
                 $process->setTimeout(300);
                 $process->mustRun();
             } catch (ProcessTimedOutException $e) {


### PR DESCRIPTION
This allows to:

- Fail hard if our code is using (direct) deprecated code
- Add a coverage listener which should improve how the coverage is measured