### PR TITLE
Add a test for NoCodeCoverageException

### DIFF
--- a/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
@@ -66,7 +66,7 @@ final class InitialYamlConfiguration extends AbstractYamlConfiguration
             $this->removeCoverageExtension($this->parsedYaml);
         } else {
             if (!$this->hasCodeCoverageExtension($this->parsedYaml)) {
-                throw new NoCodeCoverageException("No code coverage Extension detected for PhpSpec. \nWithout code coverage, running Infection is not useful.");
+                throw NoCodeCoverageException::fromTestFramework('PhpSpec');
             }
 
             $this->updateCodeCoveragePath($this->parsedYaml);

--- a/tests/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -64,7 +64,6 @@ use Infection\TestFramework\Coverage\CoverageMethodData;
 use Infection\TestFramework\Coverage\TestFileTimeData;
 use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder as PhpSpecInitalConfigBuilder;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder as PhpSpecMutationConfigBuilder;
-use Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException;
 use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder as PhpUnitInitalConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder as PhpUnitMutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
@@ -97,7 +96,6 @@ final class ProjectCodeProvider
         MutantCreatingConsoleLoggerSubscriber::class,
         MutationGeneratingConsoleLoggerSubscriber::class,
         MutationTestingRunner::class,
-        NoCodeCoverageException::class,
         TestFrameworkTypes::class,
         MutationsCollectorVisitor::class,
         ParentConnectorVisitor::class,

--- a/tests/TestFramework/PhpSpec/Config/NoCodeCoverageExceptionTest.php
+++ b/tests/TestFramework/PhpSpec/Config/NoCodeCoverageExceptionTest.php
@@ -33,19 +33,23 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\PhpSpec\Config;
+namespace Infection\Tests\TestFramework\PhpSpec\Config;
+
+use Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-final class NoCodeCoverageException extends \Exception
+final class NoCodeCoverageExceptionTest extends TestCase
 {
-    public static function fromTestFramework(string $framework): self
+    public function test_from_test_framework(): void
     {
-        return new self(sprintf(
-            'No code coverage Extension detected for %s. %sWithout code coverage, running Infection is not useful.',
-            $framework,
-            "\n"
-        ));
+        $exception = NoCodeCoverageException::fromTestFramework('Foo');
+
+        $this->assertSame(
+            "No code coverage Extension detected for Foo. \nWithout code coverage, running Infection is not useful.",
+            $exception->getMessage()
+        );
     }
 }


### PR DESCRIPTION
This PR:
- [x] Adds a test for the `NoCodeCoverageException` class and reworks it to use a named constructor.