### PR TITLE
Consume directly the InfectionContainer instead of a generic PSR-11

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Command;
 
 use Infection\Console\Application;
-use Pimple\Psr11\Container;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -57,20 +56,6 @@ abstract class BaseCommand extends Command
      * @var OutputInterface
      */
     protected $output;
-
-    /**
-     * @var Container
-     */
-    private $container;
-
-    public function getContainer(): Container
-    {
-        if ($this->container === null) {
-            $this->container = new Container($this->getApplication()->getContainer());
-        }
-
-        return $this->container;
-    }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -116,7 +116,7 @@ final class ConfigureCommand extends BaseCommand
         $excludeDirsProvider = new ExcludeDirsProvider(
             $consoleHelper,
             $questionHelper,
-            $this->getContainer()->get('filesystem')
+            $this->getApplication()->getContainer()['filesystem']
         );
 
         $excludedDirs = $excludeDirsProvider->get($input, $output, $dirsInCurrentDir, $sourceDirs);


### PR DESCRIPTION
After @maks-rafalko comments, here is an attempt to try to reduce the scope of #759.

The idea here is that in our application, namely the console commands `InfectionCommand`  and `ConfigureCommand` (for now), we now consume `InfectionContainer` instead of a generic PSR11 one. This will later allow us to:

- Use typehinted getters
- Use more specifics functions e.g. `withInput()` introduced in #759