### PR TITLE
Remove type wrap of anyOf to fix invalid JSON schema

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -93,183 +93,175 @@
             "description": "Contains the settings for different mutations and profiles",
             "properties": {
                 "TrueValue": {
-                    "type": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "ignore": {"type": "array", "items": {"type": "string"}},
-                                    "settings": {
-                                        "type": "object",
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "in_array": {"type": "boolean"},
-                                            "array_search": {"type": "boolean"}
-                                        }
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ignore": {"type": "array", "items": {"type": "string"}},
+                                "settings": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "in_array": {"type": "boolean"},
+                                        "array_search": {"type": "boolean"}
                                     }
                                 }
                             }
-                        ]
-                    }
+                        }
+                    ]
                 },
                 "ArrayItemRemoval": {
-                    "type": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "ignore": {"type": "array", "items": {"type": "string"}},
-                                    "settings": {
-                                        "type": "object",
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "remove": {
-                                                "type": "string",
-                                                "enum": ["first", "last", "all"]
-                                            },
-                                            "limit": {
-                                                "type": "integer",
-                                                "minimum": 1
-                                            }
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ignore": {"type": "array", "items": {"type": "string"}},
+                                "settings": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "remove": {
+                                            "type": "string",
+                                            "enum": ["first", "last", "all"]
+                                        },
+                                        "limit": {
+                                            "type": "integer",
+                                            "minimum": 1
                                         }
                                     }
                                 }
                             }
-                        ]
-                    }
+                        }
+                    ]
                 },
                 "BCMath": {
-                    "type": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "ignore": {"type": "array", "items": {"type": "string"}},
-                                    "settings": {
-                                        "type": "object",
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "bcadd": {
-                                                "type": "boolean"
-                                            },
-                                            "bccomp": {
-                                                "type": "boolean"
-                                            },
-                                            "bcdiv": {
-                                                "type": "boolean"
-                                            },
-                                            "bcmod": {
-                                                "type": "boolean"
-                                            },
-                                            "bcmul": {
-                                                "type": "boolean"
-                                            },
-                                            "bcpow": {
-                                                "type": "boolean"
-                                            },
-                                            "bcsub": {
-                                                "type": "boolean"
-                                            },
-                                            "bcsqrt": {
-                                                "type": "boolean"
-                                            },
-                                            "bcpowmod": {
-                                                "type": "boolean"
-                                            }
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ignore": {"type": "array", "items": {"type": "string"}},
+                                "settings": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "bcadd": {
+                                            "type": "boolean"
+                                        },
+                                        "bccomp": {
+                                            "type": "boolean"
+                                        },
+                                        "bcdiv": {
+                                            "type": "boolean"
+                                        },
+                                        "bcmod": {
+                                            "type": "boolean"
+                                        },
+                                        "bcmul": {
+                                            "type": "boolean"
+                                        },
+                                        "bcpow": {
+                                            "type": "boolean"
+                                        },
+                                        "bcsub": {
+                                            "type": "boolean"
+                                        },
+                                        "bcsqrt": {
+                                            "type": "boolean"
+                                        },
+                                        "bcpowmod": {
+                                            "type": "boolean"
                                         }
                                     }
                                 }
                             }
-                        ]
-                    }
+                        }
+                    ]
                 },
                 "MBString": {
-                    "type": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "ignore": {"type": "array", "items": {"type": "string"}},
-                                    "settings": {
-                                        "type": "object",
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "mb_chr": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_ord": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_parse_str": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_send_mail": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_strcut": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_stripos": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_stristr": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_strlen": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_strpos": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_strrchr": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_strripos": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_strrpos": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_strstr": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_strtolower": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_strtoupper": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_substr_count": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_substr": {
-                                                "type": "boolean"
-                                            },
-                                            "mb_convert_case": {
-                                                "type": "boolean"
-                                            }
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ignore": {"type": "array", "items": {"type": "string"}},
+                                "settings": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "mb_chr": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_ord": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_parse_str": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_send_mail": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_strcut": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_stripos": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_stristr": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_strlen": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_strpos": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_strrchr": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_strripos": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_strrpos": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_strstr": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_strtolower": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_strtoupper": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_substr_count": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_substr": {
+                                            "type": "boolean"
+                                        },
+                                        "mb_convert_case": {
+                                            "type": "boolean"
                                         }
                                     }
                                 }
                             }
-                        ]
-                    }
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
This PR:

- [ ] Adds new feature ...
- [ ] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

This PR fixes broken JSON schema by removing invalid type constraints, according to JSON schema spec `type` can only have a string value or an array of string values. `type` is not allowed to be an `object`. 

<!--
Remove if not relevant
-->

Fixes https://github.com/infection/infection/issues/XXX

<!--
- Replace this comment by a detailed description of what your PR is solving.
- Use labels for different kinds of PR like `performance`, `feature`, etc.
- Use Milestone to show when this code is going to be released.

Deprecations? don't forget to update UPGRADE-*.md files
-->