### PR TITLE
Extract the CoverageParser interface from the XML version

### DIFF
--- a/src/TestFramework/Coverage/XMLLineCodeCoverage.php
+++ b/src/TestFramework/Coverage/XMLLineCodeCoverage.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Coverage;
 
-use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
+use Infection\TestFramework\PhpUnit\Coverage\CoverageParser;
 use function Safe\file_get_contents;
 
 /**
@@ -58,7 +58,7 @@ final class XMLLineCodeCoverage implements LineCodeCoverage
     private $coverageDir;
 
     /**
-     * @var CoverageXmlParser
+     * @var CoverageParser
      */
     private $parser;
 
@@ -72,7 +72,7 @@ final class XMLLineCodeCoverage implements LineCodeCoverage
      */
     private $testFrameworkKey;
 
-    public function __construct(string $coverageDir, CoverageXmlParser $coverageXmlParser, string $testFrameworkKey, TestFileDataProvider $testFileDataProvider = null)
+    public function __construct(string $coverageDir, CoverageParser $coverageXmlParser, string $testFrameworkKey, TestFileDataProvider $testFileDataProvider = null)
     {
         $this->coverageDir = $coverageDir;
         $this->parser = $coverageXmlParser;

--- a/src/TestFramework/PhpUnit/Coverage/CoverageParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageParser.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\TestFramework\PhpUnit\Coverage;
+
+use Infection\TestFramework\Coverage\CoverageFileData;
+
+/**
+ * @internal
+ */
+interface CoverageParser
+{
+    /**
+     * @return CoverageFileData[]
+     *
+     * @throws \Exception
+     */
+    public function parse(string $coverageContent): array;
+}

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -46,7 +46,7 @@ use function Safe\realpath;
 /**
  * @internal
  */
-class CoverageXmlParser
+final class CoverageXmlParser implements CoverageParser
 {
     /**
      * @var string
@@ -63,10 +63,10 @@ class CoverageXmlParser
      *
      * @throws \Exception
      */
-    public function parse(string $coverageXmlContent): array
+    public function parse(string $coverageContent): array
     {
         $dom = new \DOMDocument();
-        $dom->loadXML($this->removeNamespace($coverageXmlContent));
+        $dom->loadXML($this->removeNamespace($coverageContent));
         $xPath = new \DOMXPath($dom);
 
         $this->assertHasCoverage($xPath);

--- a/tests/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -66,7 +66,6 @@ use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder as PhpSp
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder as PhpSpecMutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder as PhpUnitInitalConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder as PhpUnitMutationConfigBuilder;
-use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\TestFrameworkTypes;
 use function Infection\Tests\generator_to_phpunit_data_provider;
 use Infection\Utils\VersionParser;
@@ -119,7 +118,6 @@ final class ProjectCodeProvider
         PhpUnitInitalConfigBuilder::class,
         PhpSpecMutationConfigBuilder::class,
         PhpUnitMutationConfigBuilder::class,
-        CoverageXmlParser::class,
         VersionParser::class,
     ];
 

--- a/tests/TestFramework/Coverage/XMLLineCodeCoverageTest.php
+++ b/tests/TestFramework/Coverage/XMLLineCodeCoverageTest.php
@@ -43,7 +43,7 @@ use Infection\TestFramework\Coverage\NodeLineRangeData;
 use Infection\TestFramework\Coverage\TestFileDataProvider;
 use Infection\TestFramework\Coverage\TestFileTimeData;
 use Infection\TestFramework\Coverage\XMLLineCodeCoverage;
-use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
+use Infection\TestFramework\PhpUnit\Coverage\CoverageParser;
 use Infection\TestFramework\TestFrameworkTypes;
 use PHPUnit\Framework\TestCase;
 
@@ -236,7 +236,7 @@ final class XMLLineCodeCoverageTest extends TestCase
 
     public function test_it_throws_an_exception_when_no_coverage_found(): void
     {
-        $coverageXmlParserMock = $this->createMock(CoverageXmlParser::class);
+        $coverageXmlParserMock = $this->createMock(CoverageParser::class);
 
         $coverage = new XMLLineCodeCoverage('/abc/foo/bar', $coverageXmlParserMock, TestFrameworkTypes::PHPUNIT);
 
@@ -288,7 +288,7 @@ final class XMLLineCodeCoverageTest extends TestCase
 
     private function getCodeCoverageData(): XMLLineCodeCoverage
     {
-        $coverageXmlParserMock = $this->createMock(CoverageXmlParser::class);
+        $coverageXmlParserMock = $this->createMock(CoverageParser::class);
         $coverageXmlParserMock->expects($this->once())
             ->method('parse')
             ->willReturn($this->getParsedCodeCoverageData());


### PR DESCRIPTION
This PR:

- [x] Extracts the `CoverageParser` interface from its implementation.