### PR TITLE
Deal with object settings

### DIFF
--- a/src/Mutator/Util/MutatorConfig.php
+++ b/src/Mutator/Util/MutatorConfig.php
@@ -53,7 +53,7 @@ final class MutatorConfig
     public function __construct(array $config)
     {
         $this->ignoreConfig = $config['ignore'] ?? [];
-        $this->mutatorSettings = $config['settings'] ?? [];
+        $this->mutatorSettings = (array) ($config['settings'] ?? []);
     }
 
     public function isIgnored(string $class, string $method, int $lineNumber = null): bool

--- a/tests/Mutator/Util/MutatorConfigTest.php
+++ b/tests/Mutator/Util/MutatorConfigTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\Mutator\Util;
 
 use Infection\Mutator\Util\MutatorConfig;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 /**
  * @internal
@@ -134,5 +135,19 @@ final class MutatorConfigTest extends TestCase
             'Bar\Foo\Test',
             'method',
         ];
+    }
+
+    public function test_it_correctly_converts_settings(): void
+    {
+        $settings = new stdClass();
+        $settings->foo = 'bar';
+        $config = new MutatorConfig(['settings' => $settings]);
+        $this->assertSame(['foo' => 'bar'], $config->getMutatorSettings());
+    }
+
+    public function test_it_can_deal_with_empty_settings(): void
+    {
+        $config = new MutatorConfig([]);
+        $this->assertSame([], $config->getMutatorSettings());
     }
 }


### PR DESCRIPTION
This PR:

- [x] Makes sure the mutator config can deal with objects of settings.
- [x] Covered by tests

Fixes #666