### PR TITLE
Remove Travis' phpunit binaries since they conflicts with vendor's phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
       install:
         - if [ "$DEPS" == "LOW" ]; then composer update --prefer-lowest $COMPOSER_FLAGS; else composer install $COMPOSER_FLAGS; fi
       before_script:
+          - rm /home/travis/.phpenv/versions/$TRAVIS_PHP_VERSION/bin/phpunit
           - |
               if [[ "$DRIVER" == "pcov" ]]; then
                 echo > $HOME/.phpenv/versions/$TRAVIS_PHP_VERSION/etc/conf.d/xdebug.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
       install:
         - if [ "$DEPS" == "LOW" ]; then composer update --prefer-lowest $COMPOSER_FLAGS; else composer install $COMPOSER_FLAGS; fi
       before_script:
+          - rm /home/travis/.phpenv/shims/phpunit || true
           - rm /home/travis/.phpenv/versions/$TRAVIS_PHP_VERSION/bin/phpunit
           - |
               if [[ "$DRIVER" == "pcov" ]]; then

--- a/tests/Fixtures/e2e/standard_script.bash
+++ b/tests/Fixtures/e2e/standard_script.bash
@@ -4,6 +4,12 @@ readonly INFECTION=../../../../${1}
 
 set -e pipefail
 
+if [ "$DRIVER" = "pcov" ]
+then
+    # `pcov` requires at least PHPUnit 8.0 (used by symfony/phpunit-bridge)
+    export SYMFONY_PHPUNIT_VERSION="8.0"
+fi
+
 if [ "$DRIVER" = "phpdbg" ]
 then
     phpdbg -qrr $INFECTION


### PR DESCRIPTION
The goal of this PR is to have green builds again. I'm fed up fighting with Travis' phpunit (see [this](https://github.com/infection/infection/issues/503), or [this](https://twitter.com/maks_rafalko/status/1082742792475107328?s=20)), so let's remove built in binaries once and for all.

By the way, this is exactly what guys from Travis suggest: https://twitter.com/travisci/status/1083116158205784065

Originally, found and reported here: https://github.com/infection/infection/pull/766#issuecomment-522059768

Fixes the build.

However, there is still one failed job for PHP 7.3 and `pcov`: https://travis-ci.org/infection/infection/jobs/577016266#L973

It tries to install PHPUnit 7.4.5 while `pcov` works with 8+ only. But this is for another free evening...