### PR TITLE
Fix appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,10 @@ clone_folder: c:\projects\workspace
 environment:
   matrix:
   - dependencies: highest
-    php_ver_target: 7.2
+    php_ver_target: 7.3
     xdebug_ver: '2.6.0-7.2-vc15'
   - dependencies: current
-    php_ver_target: 7.2
+    php_ver_target: 7.3
     xdebug_ver: '2.6.0-7.2-vc15'
 
 cache: # cache is cleared when linked file is modified
@@ -29,8 +29,6 @@ install:
     # Enable Windows update service
     - ps: Set-Service wuauserv -StartupType Manual
     # Install PHP
-    - ps: choco search php --exact --all-versions -r
-    - choco search php --exact --all-versions -r
     - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
     - cd c:\tools\php
     - copy php.ini-production php.ini /Y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,10 @@ environment:
   matrix:
   - dependencies: highest
     php_ver_target: 7.3
-    xdebug_ver: '2.6.0-7.2-vc15'
+    xdebug_ver: '2.7.2-7.3-vc15'
   - dependencies: current
     php_ver_target: 7.3
-    xdebug_ver: '2.6.0-7.2-vc15'
+    xdebug_ver: '2.7.2-7.3-vc15'
 
 cache: # cache is cleared when linked file is modified
     - '%LOCALAPPDATA%\Composer\files -> composer.lock'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,11 @@ clone_folder: c:\projects\workspace
 environment:
   matrix:
   - dependencies: highest
-    php_ver_target: 7.3
-    xdebug_ver: '2.7.2-7.3-vc15'
+    php_ver_target: 7.2.20
+    xdebug_ver: '2.6.0-7.2-vc15'
   - dependencies: current
-    php_ver_target: 7.3
-    xdebug_ver: '2.7.2-7.3-vc15'
+    php_ver_target: 7.2.20
+    xdebug_ver: '2.6.0-7.2-vc15'
 
 cache: # cache is cleared when linked file is modified
     - '%LOCALAPPDATA%\Composer\files -> composer.lock'
@@ -29,7 +29,8 @@ install:
     # Enable Windows update service
     - ps: Set-Service wuauserv -StartupType Manual
     # Install PHP
-    - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+    - choco search php --exact --all-versions -r
+    - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version $env:php_ver_target
     - cd c:\tools\php
     - copy php.ini-production php.ini /Y
     - echo date.timezone="UTC" >> php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,8 @@ install:
     # Enable Windows update service
     - ps: Set-Service wuauserv -StartupType Manual
     # Install PHP
+    - ps: choco search php --exact --all-versions -r
+    - choco search php --exact --all-versions -r
     - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
     - cd c:\tools\php
     - copy php.ini-production php.ini /Y


### PR DESCRIPTION
AppVeyor is no longer lists PHP versions below `7.3.8`:

```bash
choco search php --exact --all-versions -r
php|7.3.8
```

It led to the following command fail when we pass `7.2`:

```
appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
```

This command is used to install the latest version of for example `7.2.*` when we pass `7.2`, but as you can see `choco search` no longer works as it was expected for this command.

Simple solution is to just install `7.2.20` at this moment.