### PR TITLE
Fix pre-push hook after Makefile updates

### DIFF
--- a/devTools/pre-push
+++ b/devTools/pre-push
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make analyze && make test-unit-71
+make analyze && make test-autoreview && make test-unit


### PR DESCRIPTION
`make test-unit` no longer runs autoreview tests, so they are separated