### PR TITLE
[RFC] Mutator: Spread operator in Array Expression - leave only the first element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,9 @@
 /infection-cache
 /infection.json
 /infection.log
+/phpunit.xml
 /tests/Fixtures/e2e/*/coverage/
 /tests/Fixtures/e2e/*/infection/
 /tests/Fixtures/e2e/Configure/infection.json.dist
 /tests/Fixtures/e2e/SymfonyFlex/bin/.phpunit/
 /vendor/
-/phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,9 @@
 /infection-cache
 /infection.json
 /infection.log
-/phpunit.xml
 /tests/Fixtures/e2e/*/coverage/
 /tests/Fixtures/e2e/*/infection/
 /tests/Fixtures/e2e/Configure/infection.json.dist
 /tests/Fixtures/e2e/SymfonyFlex/bin/.phpunit/
 /vendor/
+/phpunit.xml

--- a/src/Mutator/Operator/Spread.php
+++ b/src/Mutator/Operator/Spread.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Operator;
+
+use Infection\Mutator\Util\Mutator;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayItem;
+
+/**
+ * @internal
+ */
+final class Spread extends Mutator
+{
+    /**
+     * Replaces "[...[1, 2, 3], 4];" with "[[1, 2, 3][0], 4]"
+     * Replaces "[...$array, 2, 3];" with "[$array[0], 2, 3]"
+     * Replaces "[...getCollection(), 2, 3];" with "[getCollection[0], 2, 3]"
+     *
+     * @param ArrayItem $node
+     *
+     * @return ArrayItem
+     */
+    public function mutate(Node $node)
+    {
+        $newValue = new Node\Expr\ArrayDimFetch(
+            $node->value,
+            new Node\Scalar\LNumber(0),
+            $node->value->getAttributes()
+        );
+
+        $node->unpack = false;
+        $node->value = $newValue;
+
+        return $node;
+    }
+
+    protected function mutatesNode(Node $node): bool
+    {
+        return $node instanceof Node\Expr\ArrayItem
+            && $node->unpack
+            && $this->isSupportedValueType($node->value);
+    }
+
+    private function isSupportedValueType(Node\Expr $value): bool
+    {
+        return $value instanceof Node\Expr\Array_
+            || $value instanceof Node\Expr\Variable
+            || $value instanceof Node\Expr\MethodCall
+            || $value instanceof Node\Expr\FuncCall;
+    }
+}

--- a/src/Mutator/Operator/Spread.php
+++ b/src/Mutator/Operator/Spread.php
@@ -94,6 +94,7 @@ final class Spread extends Mutator
     {
         return $value instanceof Node\Expr\Array_
             || $value instanceof Node\Expr\Variable
+            || $value instanceof Node\Expr\MethodCall
             || $value instanceof Node\Expr\FuncCall;
     }
 }

--- a/src/Mutator/Operator/Spread.php
+++ b/src/Mutator/Operator/Spread.php
@@ -45,8 +45,7 @@ use PhpParser\Node\Expr\ArrayItem;
 final class Spread extends Mutator
 {
     /**
-     * Replaces "[...[1, 2, 3], 4];" with "[[1, 2, 3][0], 4]"
-     * Replaces "[...getCollection(), 2, 3];" with "[is_array($object->getCollection()) ? $object->getCollection()[0] : iterator_to_array($object->getCollection())[0], 2, 3]"
+     * Replaces "[...[1, 2, 3], 4];" with "[array_slice([1, 2, 3], 0, 1)[0], 4]"
      *
      * @param ArrayItem $node
      *

--- a/src/Mutator/Operator/Spread.php
+++ b/src/Mutator/Operator/Spread.php
@@ -94,7 +94,6 @@ final class Spread extends Mutator
     {
         return $value instanceof Node\Expr\Array_
             || $value instanceof Node\Expr\Variable
-            || $value instanceof Node\Expr\MethodCall
             || $value instanceof Node\Expr\FuncCall;
     }
 }

--- a/src/Mutator/Operator/Spread.php
+++ b/src/Mutator/Operator/Spread.php
@@ -65,14 +65,14 @@ final class Spread extends Mutator
         } else {
             $newValue = new Node\Expr\Ternary(
                 new Node\Expr\FuncCall(new Node\Name('is_array'), [new Node\Arg($node->value)]),
-                new Node\Expr\ArrayDimFetch(
-                    $node->value,
-                    new Node\Scalar\LNumber(0),
+                new Node\Expr\FuncCall(
+                    new Node\Name('reset'),
+                    [new Node\Arg($node->value)],
                     $node->value->getAttributes()
                 ),
-                new Node\Expr\ArrayDimFetch(
-                    new Node\Expr\FuncCall(new Node\Name('iterator_to_array'), [new Node\Arg($node->value)]),
-                    new Node\Scalar\LNumber(0),
+                new Node\Expr\FuncCall(
+                    new Node\Name('reset'),
+                    [new Node\Arg(new Node\Expr\FuncCall(new Node\Name('iterator_to_array'), [new Node\Arg($node->value)]))],
                     $node->value->getAttributes()
                 )
             );

--- a/src/Mutator/Util/MutatorProfile.php
+++ b/src/Mutator/Util/MutatorProfile.php
@@ -150,6 +150,7 @@ final class MutatorProfile
         Mutator\Operator\Coalesce::class,
         Mutator\Operator\Continue_::class,
         Mutator\Operator\Finally_::class,
+        Mutator\Operator\Spread::class,
         Mutator\Operator\Throw_::class,
     ];
 
@@ -333,6 +334,7 @@ final class MutatorProfile
         'Throw_' => Mutator\Operator\Throw_::class,
         'Finally_' => Mutator\Operator\Finally_::class,
         'Coalesce' => Mutator\Operator\Coalesce::class,
+        'Spread' => Mutator\Operator\Spread::class,
 
         //Regex
         'PregQuote' => Mutator\Regex\PregQuote::class,

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -94,21 +94,6 @@ PHP
             ,
         ];
 
-        yield 'Spread for a method call' => [
-            <<<'PHP'
-<?php
-
-$a = [...$object->getCollection(), 4];
-PHP
-            ,
-            <<<'PHP'
-<?php
-
-$a = [is_array($object->getCollection()) ? $object->getCollection()[0] : iterator_to_array($object->getCollection())[0], 4];
-PHP
-            ,
-        ];
-
         yield 'It does not mutate argument unpacking' => [
             <<<'PHP'
 <?php

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -94,6 +94,21 @@ PHP
             ,
         ];
 
+        yield 'Spread for a method call' => [
+            <<<'PHP'
+<?php
+
+$a = [...$object->getCollection(), 4];
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$a = [is_array($object->getCollection()) ? $object->getCollection()[0] : iterator_to_array($object->getCollection())[0], 4];
+PHP
+            ,
+        ];
+
         yield 'It does not mutate argument unpacking' => [
             <<<'PHP'
 <?php

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -45,7 +45,7 @@ final class SpreadTest extends AbstractMutatorTestCase
     public function test_mutator($input, $expected = null): void
     {
         if (version_compare(PHP_VERSION, '7.4.0') < 0) {
-            $this->markTestSkipped('Spread operator in Array Expression requires PHP 7.4+');
+//            $this->markTestSkipped('Spread operator in Array Expression requires PHP 7.4+');
         }
 
         $this->doTest($input, $expected);
@@ -63,7 +63,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [[1, 2, 3][0], 4];
+$a = [array_slice([1, 2, 3], 0, 1)[0], 4];
 PHP
             ,
         ];
@@ -78,7 +78,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [is_array($collection) ? reset($collection) : reset(iterator_to_array($collection)), 4];
+$a = [array_slice(is_array($collection) ? $collection : iterator_to_array($collection), 0, 1)[0], 4];
 PHP
             ,
         ];
@@ -93,7 +93,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [is_array(getCollection()) ? reset(getCollection()) : reset(iterator_to_array(getCollection())), 4];
+$a = [array_slice(is_array(getCollection()) ? getCollection() : iterator_to_array(getCollection()), 0, 1)[0], 4];
 PHP
             ,
         ];
@@ -108,7 +108,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [is_array($object->getCollection()) ? reset($object->getCollection()) : reset(iterator_to_array($object->getCollection())), 4];
+$a = [array_slice(is_array($object->getCollection()) ? $object->getCollection() : iterator_to_array($object->getCollection()), 0, 1)[0], 4];
 PHP
             ,
         ];

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -44,6 +44,10 @@ final class SpreadTest extends AbstractMutatorTestCase
      */
     public function test_mutator($input, $expected = null): void
     {
+        if (version_compare(PHP_VERSION, '7.4.0') < 0) {
+            $this->markTestSkipped('Spread operator in Array Expression requires PHP 7.4+');
+        }
+
         $this->doTest($input, $expected);
     }
 

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Operator;
+
+use Infection\Tests\Mutator\AbstractMutatorTestCase;
+
+final class SpreadTest extends AbstractMutatorTestCase
+{
+    /**
+     * @dataProvider provideMutationCases
+     */
+    public function test_mutator($input, $expected = null): void
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function provideMutationCases(): \Generator
+    {
+        yield 'Spread for a raw array' => [
+            <<<'PHP'
+<?php
+
+$a = [...[1, 2, 3], 4];
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$a = [[1, 2, 3][0], 4];
+PHP
+            ,
+        ];
+
+        yield 'Spread for a variable' => [
+            <<<'PHP'
+<?php
+
+$a = [...$collection, 4];
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$a = [$collection[0], 4];
+PHP
+            ,
+        ];
+
+        yield 'Spread for a function call' => [
+            <<<'PHP'
+<?php
+
+$a = [...getCollection(), 4];
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$a = [getCollection()[0], 4];
+PHP
+            ,
+        ];
+
+        yield 'Spread for a method call' => [
+            <<<'PHP'
+<?php
+
+$a = [...$object->getCollection(), 4];
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$a = [$object->getCollection()[0], 4];
+PHP
+            ,
+        ];
+
+        yield 'It works for an old array syntax' => [
+            <<<'PHP'
+<?php
+
+$a = array(...$object->getCollection(), 4);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$a = array($object->getCollection()[0], 4);
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate argument unpacking' => [
+            <<<'PHP'
+<?php
+
+function foo(...$array) {}
+PHP
+            ,
+        ];
+    }
+}

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -40,14 +40,11 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class SpreadTest extends AbstractMutatorTestCase
 {
     /**
+     * @requires PHP >= 7.4
      * @dataProvider provideMutationCases
      */
     public function test_mutator($input, $expected = null): void
     {
-        if (version_compare(PHP_VERSION, '7.4.0') < 0) {
-//            $this->markTestSkipped('Spread operator in Array Expression requires PHP 7.4+');
-        }
-
         $this->doTest($input, $expected);
     }
 

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -74,7 +74,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [$collection[0], 4];
+$a = [is_array($collection) ? $collection[0] : iterator_to_array($collection)[0], 4];
 PHP
             ,
         ];
@@ -89,7 +89,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [getCollection()[0], 4];
+$a = [is_array(getCollection()) ? getCollection()[0] : iterator_to_array(getCollection())[0], 4];
 PHP
             ,
         ];
@@ -104,22 +104,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [$object->getCollection()[0], 4];
-PHP
-            ,
-        ];
-
-        yield 'It works for an old array syntax' => [
-            <<<'PHP'
-<?php
-
-$a = array(...$object->getCollection(), 4);
-PHP
-            ,
-            <<<'PHP'
-<?php
-
-$a = array($object->getCollection()[0], 4);
+$a = [is_array($object->getCollection()) ? $object->getCollection()[0] : iterator_to_array($object->getCollection())[0], 4];
 PHP
             ,
         ];

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -78,7 +78,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [is_array($collection) ? $collection[0] : iterator_to_array($collection)[0], 4];
+$a = [is_array($collection) ? reset($collection) : reset(iterator_to_array($collection)), 4];
 PHP
             ,
         ];
@@ -93,7 +93,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [is_array(getCollection()) ? getCollection()[0] : iterator_to_array(getCollection())[0], 4];
+$a = [is_array(getCollection()) ? reset(getCollection()) : reset(iterator_to_array(getCollection())), 4];
 PHP
             ,
         ];
@@ -108,7 +108,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [is_array($object->getCollection()) ? $object->getCollection()[0] : iterator_to_array($object->getCollection())[0], 4];
+$a = [is_array($object->getCollection()) ? reset($object->getCollection()) : reset(iterator_to_array($object->getCollection())), 4];
 PHP
             ,
         ];

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -60,7 +60,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [array_slice([1, 2, 3], 0, 1)[0], 4];
+$a = [[...[1, 2, 3]][0], 4];
 PHP
             ,
         ];
@@ -75,7 +75,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [array_slice(is_array($collection) ? $collection : iterator_to_array($collection), 0, 1)[0], 4];
+$a = [[...$collection][0], 4];
 PHP
             ,
         ];
@@ -90,7 +90,7 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [array_slice(is_array(getCollection()) ? getCollection() : iterator_to_array(getCollection()), 0, 1)[0], 4];
+$a = [[...getCollection()][0], 4];
 PHP
             ,
         ];
@@ -105,7 +105,22 @@ PHP
             <<<'PHP'
 <?php
 
-$a = [array_slice(is_array($object->getCollection()) ? $object->getCollection() : iterator_to_array($object->getCollection()), 0, 1)[0], 4];
+$a = [[...$object->getCollection()][0], 4];
+PHP
+            ,
+        ];
+
+        yield 'Spread for a new iterator object' => [
+            <<<'PHP'
+<?php
+
+$a = [...new ArrayIterator(['a', 'b', 'c'])];
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$a = [[...new ArrayIterator(['a', 'b', 'c'])][0]];
 PHP
             ,
         ];


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/spread_operator_for_array
PHP 7.4+

- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/134

This mutator does the following mutations:

```diff
- $a = [...[1, 2, 3], 4];
+ $a = [[1, 2, 3][0], 4];

- $a = [...$collection, 4];
+ $a = [$collection[0], 4];

- $a = [...getCollection(), 4];
+ $a = [getCollection()[0], 4];
```

The only one issue I think will be with this mutator, is that it can work with any `\Traversable`, including `\Generator`, and the following mutation will be self-killed:

```diff
function arrGen() {
    for($i = 11; $i < 15; $i++) {
        yield $i;
    }
}

- $arr = [...arrGen()];
+ $arr = [arrGen()[0]];
```

Produces an error:

```php
Fatal error: Uncaught Error: Cannot use object of type Generator as array in ...
```

#### What can we do?

1. The first and the best solution is to exactly know what is the return type hint of `arrGen()` function and knowing that, do either `arrGen()[0]` for array or `iterator_to_array(arrGen())[0]` for iterator. However, unfortunately, Infection is not able to guess types at the moment (as for example PHPStan/Psalm do it)

2. The second option is to always do such mutation

```diff
- $arr = [...arrGen()];
+ $_traversable = arrGen();
+ $arr = [is_array($_traversable) ? $_traversable[0] : iterator_to_array($_traversable))[0];
```

3. Do not mutate variables and functions and methods, only raw arrays (the very first diff above)

Thoughts?