### PR TITLE
Mutate `mb_str_split` to `str_split`

### DIFF
--- a/src/Mutator/Extensions/MBString.php
+++ b/src/Mutator/Extensions/MBString.php
@@ -95,6 +95,7 @@ final class MBString extends Mutator
             'mb_strstr' => $this->makeFunctionAndRemoveExtraArgsMapper('strstr', 3),
             'mb_strtolower' => $this->makeFunctionAndRemoveExtraArgsMapper('strtolower', 1),
             'mb_strtoupper' => $this->makeFunctionAndRemoveExtraArgsMapper('strtoupper', 1),
+            'mb_str_split' => $this->makeFunctionAndRemoveExtraArgsMapper('str_split', 2),
             'mb_substr_count' => $this->makeFunctionAndRemoveExtraArgsMapper('substr_count', 2),
             'mb_substr' => $this->makeFunctionAndRemoveExtraArgsMapper('substr', 3),
             'mb_convert_case' => $this->makeConvertCaseMapper(),

--- a/tests/phpunit/Mutator/Extensions/MBStringTest.php
+++ b/tests/phpunit/Mutator/Extensions/MBStringTest.php
@@ -114,6 +114,8 @@ final class MBStringTest extends AbstractMutatorTestCase
         yield from $this->provideMutationCasesForStrRChr();
 
         yield from $this->provideMutationCasesForConvertCase();
+
+        yield from $this->provideMutationCasesForStrSplit();
     }
 
     private function provideMutationCasesForChr(): Generator
@@ -575,6 +577,28 @@ final class MBStringTest extends AbstractMutatorTestCase
 
         yield 'It does not mutate mb_convert_case called via variable' => [
             '<?php $a = "mb_convert_case"; $a("test");',
+        ];
+    }
+
+    private function provideMutationCasesForStrSplit()
+    {
+        yield 'It converts mb_str_split to str_split' => [
+            "<?php mb_str_split('test', 2);",
+            "<?php\n\nstr_split('test', 2);",
+        ];
+
+        yield 'It converts correctly when mb_str_split is wrongly capitalize' => [
+            "<?php MB_str_sPlit('test', 2);",
+            "<?php\n\nstr_split('test', 2);",
+        ];
+
+        yield 'It converts mb_str_split with encoding to str_split' => [
+            "<?php mb_str_split('test', 2, 'utf-8');",
+            "<?php\n\nstr_split('test', 2);",
+        ];
+
+        yield 'It does not mutate mb_str_split called via variable' => [
+            '<?php $a = "mb_str_split"; $a("test", 2);',
         ];
     }
 


### PR DESCRIPTION
This function was added for PHP 7.4.

RFC: https://wiki.php.net/rfc/mb_str_split

Follows https://github.com/infection/infection/pull/664

- [x] Mutates`mb_str_split` to `str_split`
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/133

