### PR TITLE
Refactor XmlConfigurationHelper

### DIFF
--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -101,7 +101,7 @@ class InitialConfigBuilder implements ConfigBuilder
 
         $xPath = new \DOMXPath($dom);
 
-        $this->xmlConfigurationHelper->validate($dom, $xPath);
+        $this->xmlConfigurationHelper->validate($xPath);
 
         $this->addCoverageFilterWhitelistIfDoesNotExist($dom, $xPath);
         $this->addRandomTestsOrderAttributesIfNotSet($version, $xPath);
@@ -110,8 +110,8 @@ class InitialConfigBuilder implements ConfigBuilder
         $this->xmlConfigurationHelper->deactivateColours($xPath);
         $this->xmlConfigurationHelper->deactivateResultCaching($xPath);
         $this->xmlConfigurationHelper->deactivateStderrRedirection($xPath);
-        $this->xmlConfigurationHelper->removeExistingLoggers($dom, $xPath);
-        $this->xmlConfigurationHelper->removeExistingPrinters($dom, $xPath);
+        $this->xmlConfigurationHelper->removeExistingLoggers($xPath);
+        $this->xmlConfigurationHelper->removeExistingPrinters($xPath);
 
         if (!$this->skipCoverage) {
             $this->addCodeCoverageLogger($dom, $xPath);
@@ -130,7 +130,7 @@ class InitialConfigBuilder implements ConfigBuilder
 
     private function addJUnitLogger(\DOMDocument $dom, \DOMXPath $xPath): void
     {
-        $logging = $this->getOrCreateNode($dom, $xPath, 'logging');
+        $logging = $this->getOrCreateNode($xPath, 'logging');
 
         $junitLog = $dom->createElement('log');
         $junitLog->setAttribute('type', 'junit');
@@ -141,9 +141,9 @@ class InitialConfigBuilder implements ConfigBuilder
 
     private function addCodeCoverageLogger(\DOMDocument $dom, \DOMXPath $xPath): void
     {
-        $logging = $this->getOrCreateNode($dom, $xPath, 'logging');
+        $logging = $this->getOrCreateNode($xPath, 'logging');
 
-        $coverageXmlLog = $dom->createElement('log');
+        $coverageXmlLog = $xPath->document->createElement('log');
         $coverageXmlLog->setAttribute('type', 'coverage-xml');
         $coverageXmlLog->setAttribute('target', $this->tmpDir . '/' . XMLLineCodeCoverage::PHP_UNIT_COVERAGE_DIR);
 
@@ -172,12 +172,12 @@ class InitialConfigBuilder implements ConfigBuilder
         }
     }
 
-    private function getOrCreateNode(\DOMDocument $dom, \DOMXPath $xPath, string $nodeName): \DOMElement
+    private function getOrCreateNode(\DOMXPath $xPath, string $nodeName): \DOMElement
     {
         $node = $this->getNode($xPath, $nodeName);
 
         if (!$node) {
-            $node = $this->createNode($dom, $nodeName);
+            $node = $this->createNode($xPath->document, $nodeName);
         }
 
         return $node;

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -90,9 +90,9 @@ class MutationConfigBuilder extends ConfigBuilder
         $this->xmlConfigurationHelper->deactivateColours($xPath);
         $this->xmlConfigurationHelper->deactivateResultCaching($xPath);
         $this->xmlConfigurationHelper->deactivateStderrRedirection($xPath);
-        $this->xmlConfigurationHelper->removeExistingLoggers($dom, $xPath);
-        $this->xmlConfigurationHelper->removeExistingPrinters($dom, $xPath);
-        $this->xmlConfigurationHelper->removeDefaultTestSuite($dom, $xPath);
+        $this->xmlConfigurationHelper->removeExistingLoggers($xPath);
+        $this->xmlConfigurationHelper->removeExistingPrinters($xPath);
+        $this->xmlConfigurationHelper->removeDefaultTestSuite($xPath);
 
         $customAutoloadFilePath = sprintf(
             '%s/interceptor.autoload.%s.infection.php',

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -74,10 +74,10 @@ final class XmlConfigurationHelper
         }
     }
 
-    public function removeExistingLoggers(\DOMDocument $dom, \DOMXPath $xPath): void
+    public function removeExistingLoggers(\DOMXPath $xPath): void
     {
         foreach ($xPath->query('/phpunit/logging') as $node) {
-            $document = $dom->documentElement;
+            $document = $xPath->document->documentElement;
             \assert($document instanceof DOMElement);
             $document->removeChild($node);
         }
@@ -111,16 +111,15 @@ final class XmlConfigurationHelper
         );
     }
 
-    public function removeExistingPrinters(\DOMDocument $dom, \DOMXPath $xPath): void
+    public function removeExistingPrinters(\DOMXPath $xPath): void
     {
         $this->removeAttribute(
-            $dom,
             $xPath,
             'printerClass'
         );
     }
 
-    public function validate(\DOMDocument $dom, \DOMXPath $xPath): bool
+    public function validate(\DOMXPath $xPath): bool
     {
         if ($xPath->query('/phpunit')->length === 0) {
             throw InvalidPhpUnitXmlConfigException::byRootNode();
@@ -135,7 +134,7 @@ final class XmlConfigurationHelper
         $original = libxml_use_internal_errors(true);
         $schemaPath = $this->buildSchemaPath($schema[0]->nodeValue);
 
-        if ($schema->length && !$dom->schemaValidate($schemaPath)) {
+        if ($schema->length && !$xPath->document->schemaValidate($schemaPath)) {
             throw InvalidPhpUnitXmlConfigException::byXsdSchema($this->getXmlErrorsString());
         }
 
@@ -144,10 +143,9 @@ final class XmlConfigurationHelper
         return true;
     }
 
-    public function removeDefaultTestSuite(\DOMDocument $dom, \DOMXPath $xPath): void
+    public function removeDefaultTestSuite(\DOMXPath $xPath): void
     {
         $this->removeAttribute(
-            $dom,
             $xPath,
             'defaultTestSuite'
         );
@@ -181,7 +179,7 @@ final class XmlConfigurationHelper
         return sprintf('%s/%s', $this->phpUnitConfigDir, $nodeValue);
     }
 
-    private function removeAttribute(\DOMDocument $dom, \DOMXPath $xPath, string $name): void
+    private function removeAttribute(\DOMXPath $xPath, string $name): void
     {
         $nodeList = $xPath->query(sprintf(
             '/phpunit/@%s',
@@ -189,7 +187,7 @@ final class XmlConfigurationHelper
         ));
 
         if ($nodeList->length) {
-            $document = $dom->documentElement;
+            $document = $xPath->document->documentElement;
             \assert($document instanceof DOMElement);
             $document->removeAttribute($name);
         }

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -45,14 +45,9 @@ final class XmlConfigurationHelperTest extends TestCase
 {
     public function test_it_replaces_with_absolute_paths(): void
     {
-        $dom = $this->getDomDocument();
-        $xPath = new \DOMXPath($dom);
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->replaceWithAbsolutePaths($xPath);
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+        $this->assertItChangesStandardConfiguration(static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+            $xmlconfig->replaceWithAbsolutePaths($xPath);
+        }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -82,20 +77,14 @@ final class XmlConfigurationHelperTest extends TestCase
     </logging>
 </phpunit>
 XML
-            , $dom->saveXML()
         );
     }
 
     public function test_it_removes_existing_loggers(): void
     {
-        $dom = $this->getDomDocument();
-        $xPath = new \DOMXPath($dom);
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->removeExistingLoggers($dom, $xPath);
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+        $this->assertItChangesStandardConfiguration(static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+            $xmlconfig->removeExistingLoggers($xPath);
+        }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -122,20 +111,14 @@ XML
     </filter>
 </phpunit>
 XML
-            , $dom->saveXML()
         );
     }
 
     public function test_it_sets_set_stop_on_failure(): void
     {
-        $dom = $this->getDomDocument();
-        $xPath = new \DOMXPath($dom);
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->setStopOnFailure($xPath);
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+        $this->assertItChangesStandardConfiguration(static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+            $xmlconfig->setStopOnFailure($xPath);
+        }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -166,16 +149,12 @@ XML
     </logging>
 </phpunit>
 XML
-            , $dom->saveXML()
         );
     }
 
     public function test_it_sets_set_stop_on_failure_when_it_is_already_present(): void
     {
-        $dom = new \DOMDocument();
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML(<<<XML
+        $this->assertItChangesXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -192,14 +171,9 @@ XML
 >
 </phpunit>
 XML
-        );
-        $xPath = new \DOMXPath($dom);
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->setStopOnFailure($xPath);
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+        , static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+            $xmlconfig->setStopOnFailure($xPath);
+        }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -216,20 +190,14 @@ XML
 >
 </phpunit>
 XML
-            , $dom->saveXML()
         );
     }
 
     public function test_it_deactivates_colors(): void
     {
-        $dom = $this->getDomDocument();
-        $xPath = new \DOMXPath($dom);
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->deactivateColours($xPath);
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+        $this->assertItChangesStandardConfiguration(static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+            $xmlconfig->deactivateColours($xPath);
+        }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -259,16 +227,12 @@ XML
     </logging>
 </phpunit>
 XML
-            , $dom->saveXML()
         );
     }
 
     public function test_it_deactivates_colors_when_it_is_not_already_present(): void
     {
-        $dom = new \DOMDocument();
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML(<<<XML
+        $this->assertItChangesXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -284,14 +248,9 @@ XML
 >
 </phpunit>
 XML
-        );
-        $xPath = new \DOMXPath($dom);
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->deactivateColours($xPath);
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+            , static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+                $xmlconfig->deactivateColours($xPath);
+            }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -308,18 +267,12 @@ XML
 >
 </phpunit>
 XML
-            , $dom->saveXML()
         );
     }
 
     public function test_it_sets_cache_result_to_false_when_it_exists(): void
     {
-        $dom = new \DOMDocument();
-
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-
-        $dom->loadXML(<<<XML
+        $this->assertItChangesXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -335,14 +288,11 @@ XML
     syntaxCheck="false"
 >
 </phpunit>
+
 XML
-        );
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->deactivateResultCaching(new \DOMXPath($dom));
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+        , static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+            $xmlconfig->deactivateResultCaching($xPath);
+        }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -358,20 +308,13 @@ XML
     syntaxCheck="false"
 >
 </phpunit>
-
 XML
-            , $dom->saveXML()
         );
     }
 
     public function test_it_sets_cache_result_to_false_when_it_does_not_exist(): void
     {
-        $dom = new \DOMDocument();
-
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-
-        $dom->loadXML(<<<XML
+        $this->assertItChangesXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -386,15 +329,10 @@ XML
     syntaxCheck="false"
 >
 </phpunit>
-
 XML
-        );
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->deactivateResultCaching(new \DOMXPath($dom));
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+        , static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+            $xmlconfig->deactivateResultCaching($xPath);
+        }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -411,18 +349,12 @@ XML
 >
 </phpunit>
 XML
-            , $dom->saveXML()
         );
     }
 
     public function test_it_sets_stderr_to_false_when_it_exists(): void
     {
-        $dom = new \DOMDocument();
-
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-
-        $dom->loadXML(<<<XML
+        $this->assertItChangesXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     stderr="true"
@@ -430,13 +362,9 @@ XML
 >
 </phpunit>
 XML
-        );
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->deactivateStderrRedirection(new \DOMXPath($dom));
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+        , static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+            $xmlconfig->deactivateStderrRedirection($xPath);
+        }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     stderr="false"
@@ -444,31 +372,21 @@ XML
 >
 </phpunit>
 XML
-            , $dom->saveXML()
         );
     }
 
     public function test_it_sets_stderr_to_false_when_it_does_not_exist(): void
     {
-        $dom = new \DOMDocument();
-
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-
-        $dom->loadXML(<<<XML
+        $this->assertItChangesXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     syntaxCheck="false"
 >
 </phpunit>
 XML
-        );
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->deactivateStderrRedirection(new \DOMXPath($dom));
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+            , static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+                $xmlconfig->deactivateStderrRedirection($xPath);
+            }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     stderr="false"
@@ -476,16 +394,12 @@ XML
 >
 </phpunit>
 XML
-            , $dom->saveXML()
         );
     }
 
     public function test_it_removes_existing_printers(): void
     {
-        $dom = new \DOMDocument();
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML(<<<XML
+        $this->assertItChangesXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -501,14 +415,9 @@ XML
 >
 </phpunit>
 XML
-        );
-        $xPath = new \DOMXPath($dom);
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->removeExistingPrinters($dom, $xPath);
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+            , static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+                $xmlconfig->removeExistingPrinters($xPath);
+            }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -523,7 +432,6 @@ XML
 >
 </phpunit>
 XML
-            , $dom->saveXML()
         );
     }
 
@@ -539,7 +447,7 @@ XML
         $this->expectException(InvalidPhpUnitXmlConfigException::class);
         $this->expectExceptionMessage('phpunit.xml does not contain a valid PHPUnit configuration.');
 
-        $xmlHelper->validate($dom, $xPath);
+        $xmlHelper->validate($xPath);
     }
 
     /**
@@ -566,7 +474,7 @@ XML
         $this->expectException(InvalidPhpUnitXmlConfigException::class);
         $this->expectExceptionMessageRegExp('/Element \'invalid\'\: This element is not expected/');
 
-        $xmlHelper->validate($dom, $xPath);
+        $xmlHelper->validate($xPath);
     }
 
     public function schemaProvider(): \Generator
@@ -597,15 +505,12 @@ XML
 
         $xmlHelper = new XmlConfigurationHelper($this->getPathReplacer(), '');
 
-        $this->assertTrue($xmlHelper->validate($dom, $xPath));
+        $this->assertTrue($xmlHelper->validate($xPath));
     }
 
     public function test_it_removes_default_test_suite(): void
     {
-        $dom = new \DOMDocument();
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML(<<<XML
+        $this->assertItChangesXML(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     defaultTestSuite="unit"
@@ -614,14 +519,11 @@ XML
     syntaxCheck="false"
 >
 </phpunit>
+
 XML
-        );
-
-        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $xmlconfig->removeDefaultTestSuite($dom, new \DOMXPath($dom));
-
-        $this->assertXmlStringEqualsXmlString(<<<XML
+            , static function (XmlConfigurationHelper $xmlconfig, \DOMXPath $xPath, \DOMDocument $dom): void {
+                $xmlconfig->removeDefaultTestSuite($xPath);
+            }, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     printerClass="Fake\Printer\Class"
@@ -629,9 +531,36 @@ XML
     syntaxCheck="false"
 >
 </phpunit>
+
 XML
-            , $dom->saveXML()
         );
+    }
+
+    private function assertItChangesStandardConfiguration(\Closure $callback, string $resultXml): void
+    {
+        $dom = $this->getDomDocument();
+        $xPath = new \DOMXPath($dom);
+
+        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
+
+        $callback($xmlconfig, $xPath, $dom);
+
+        $this->assertXmlStringEqualsXmlString($resultXml, $dom->saveXML());
+    }
+
+    private function assertItChangesXML(string $inputXml, callable $callback, string $expectedXml): void
+    {
+        $dom = new \DOMDocument();
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+        $dom->loadXML($inputXml);
+        $xPath = new \DOMXPath($dom);
+
+        $xmlconfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
+
+        $callback($xmlconfig, $xPath, $dom);
+
+        $this->assertXmlStringEqualsXmlString($expectedXml, $dom->saveXML());
     }
 
     private function getDomDocument(): \DOMDocument


### PR DESCRIPTION
- [x]  Methods need no DOMDocument, \DOMXPath is enough
- [x]  Refactor tests
