### PR TITLE
Fix: use initialTestsPhpOptions in InfectionContainer / CoverageRequirementChecker

### DIFF
--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -249,7 +249,13 @@ final class InfectionContainer extends Container
             ;
         };
 
-        $clone['coverage.checker'] = static function () use ($initialTestsPhpOptions, $existingCoveragePath): CoverageRequirementChecker {
+        $clone['coverage.checker'] = static function (self $container) use (
+            $initialTestsPhpOptions,
+            $existingCoveragePath
+        ): CoverageRequirementChecker {
+            $initialTestsPhpOptions = $initialTestsPhpOptions ?: $container['infection.config']
+                ->getInitialTestsPhpOptions();
+
             if (!\is_string($initialTestsPhpOptions)) {
                 throw new InvalidArgumentException(
                     \sprintf(


### PR DESCRIPTION
This PR:

- [x] Fixes missing fallback of `initialTestsPhpOptions` in `InfectionContainer` / `CoverageRequirementChecker`
- [x] Covered by tests

## Description

When xdebug is not installed by default in php.ini, it is possible to set this value by CLI option or in the `infection.json`. When both are not set you will get this error:

```
Neither phpdbg or xdebug has been found. One of those is required by Infection in order to generate coverage data. Either:
  - Enable xdebug and run infection again
  - Use phpdbg: phpdbg -qrr infection
  - Use --coverage option with path to the existing coverage report
  - Use --initial-tests-php-options option with `-d zend_extension=xdebug.so` and/or any extra php parameters
```

When either the CLI option or the option is set in `infection.json`, this error should not be thrown anymore, and infection should be run.

However, when this option `initialTestsPhpOptions` is set in `infection.json` and not as CLI option, the error is still thrown.

The `InfectionContainer` / `CoverageRequirementChecker` is checking the CLI input option `--initial-tests-php-options`, but it is not checking the infection.json option `initialTestsPhpOptions` when empty.

This PR fixes this, by checking the infection.json option `initialTestsPhpOptions` when `--initial-tests-php-options` is empty.

### Related to
- https://github.com/infection/infection/issues/672