### PR TITLE
Don't allow unwraped variables to be unpacked

### DIFF
--- a/src/Mutator/Unwrap/AbstractUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractUnwrapMutator.php
@@ -71,7 +71,7 @@ abstract class AbstractUnwrapMutator extends Mutator
         }
 
         foreach ($this->getParameterIndexes($node) as $index) {
-            if (!\array_key_exists($index, $node->args)) {
+            if (!\array_key_exists($index, $node->args) || $node->args[$index]->unpack) {
                 return false;
             }
         }

--- a/src/Mutator/Unwrap/AbstractUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractUnwrapMutator.php
@@ -53,6 +53,10 @@ abstract class AbstractUnwrapMutator extends Mutator
     final public function mutate(Node $node)
     {
         foreach ($this->getParameterIndexes($node) as $index) {
+            if ($node->args[$index]->unpack) {
+                continue;
+            }
+
             yield $node->args[$index];
         }
     }
@@ -71,7 +75,7 @@ abstract class AbstractUnwrapMutator extends Mutator
         }
 
         foreach ($this->getParameterIndexes($node) as $index) {
-            if (!\array_key_exists($index, $node->args) || $node->args[$index]->unpack) {
+            if (!\array_key_exists($index, $node->args)) {
                 return false;
             }
         }

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeTest.php
@@ -297,5 +297,25 @@ $a = array_merge(...$classes);
 PHP
             ,
         ];
+
+        yield 'It does mutate the elements that are not unpacked' => [
+            <<<'PHP'
+<?php
+$first = [1, 2, 3, 4, 5];
+$other = [[6, 7], [8]];
+
+$result = array_merge($first, ...$other);
+PHP
+            ,
+            [
+                <<<'PHP'
+<?php
+
+$first = [1, 2, 3, 4, 5];
+$other = [[6, 7], [8]];
+$result = $first;
+PHP
+            ],
+        ];
     }
 }

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeTest.php
@@ -288,5 +288,14 @@ $b = $a([1,2,3], [3,4,5]);
 PHP
             ,
         ];
+
+        yield 'It does not mutate when the input array is unpacked' => [
+            <<<'PHP'
+<?php
+
+$a = array_merge(...$classes);
+PHP
+            ,
+        ];
     }
 }


### PR DESCRIPTION
This can generate syntax errors

This PR:

- [x] Fixed #801 
- [x] Covered by tests
