### PR TITLE
Ensure only unit tests are run with `make test-unit`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,11 +76,11 @@ test-unit: test-unit-72 test-unit-73
 
 .PHONY: test-unit-72
 test-unit-72: $(DOCKER_RUN_72_IMAGE) $(PHPUNIT)
-	$(DOCKER_RUN_72) $(PHPUNIT)
+	$(DOCKER_RUN_72) $(PHPUNIT) --group default
 
 .PHONY: test-unit-73
 test-unit-73: $(DOCKER_RUN_73_IMAGE) $(PHPUNIT)
-	$(DOCKER_RUN_73) $(PHPUNIT)
+	$(DOCKER_RUN_73) $(PHPUNIT) --group default
 
 .PHONY: test-e2e
 test-e2e: 	 ## Runs the end-to-end tests
@@ -91,10 +91,12 @@ test-e2e-phpdbg: test-e2e-phpdbg-72 test-e2e-phpdbg-73
 
 .PHONY: test-e2e-phpdbg-72
 test-e2e-phpdbg-72: $(DOCKER_RUN_72_IMAGE) $(INFECTION)
+	$(DOCKER_RUN_72) $(PHPUNIT) --group integration,e2e
 	$(DOCKER_RUN_72) env PHPDBG=1 ./tests/e2e_tests $(INFECTION)
 
 .PHONY: test-e2e-phpdbg-73
 test-e2e-phpdbg-73: $(DOCKER_RUN_73_IMAGE) $(INFECTION)
+	$(DOCKER_RUN_73) $(PHPUNIT) --group integration,e2e
 	$(DOCKER_RUN_73) env PHPDBG=1 ./tests/e2e_tests $(INFECTION)
 
 .PHONY: test-e2e-xdebug
@@ -102,10 +104,12 @@ test-e2e-xdebug: test-e2e-xdebug-72 test-e2e-xdebug-73
 
 .PHONY: test-e2e-xdebug-72
 test-e2e-xdebug-72: $(DOCKER_RUN_72_IMAGE) $(INFECTION)
+	$(DOCKER_RUN_72) $(PHPUNIT) --group integration,e2e
 	$(DOCKER_RUN_72) ./tests/e2e_tests $(INFECTION)
 
 .PHONY: test-e2e-xdebug-73
 test-e2e-xdebug-73: $(DOCKER_RUN_73_IMAGE) $(INFECTION)
+	$(DOCKER_RUN_73) $(PHPUNIT) --group integration,e2e
 	$(DOCKER_RUN_73) ./tests/e2e_tests $(INFECTION)
 
 .PHONY: test-infection

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -48,6 +48,9 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
+/**
+ * @group e2e
+ */
 final class E2ETest extends TestCase
 {
     private const MAX_FAILING_COMPOSER_INSTALL = 5;


### PR DESCRIPTION
We currently have 3 PHPUnit groups: `default`, `integration` and `e2e` (which could be seen as a
sub-part of integration tests but we can't have any form of taxonomy with PHPUnit groups).

All those 3 groups were actually run when running `make test-unit` which is confusing. The following
changes ensure the `e2e` and `integration` PHPUnit groups are run only with `make test-e2e`.
