### PR TITLE
Fix Docker builds for PHP 7.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,8 +184,8 @@ $(PHPSTAN): Makefile
 
 $(INFECTION): vendor $(shell find bin/ src/ -type f) $(BOX) box.json.dist .git/HEAD
 	$(BOX) validate
-	$(BOX) compile
-	touch $@
+	ulimit -n 4096 && $(BOX) compile
+	touch -c $@
 
 vendor: composer.lock
 	composer install
@@ -193,22 +193,22 @@ vendor: composer.lock
 
 composer.lock: composer.json
 	composer install
-	touch $@
+	touch -c $@
 
 $(PHPUNIT): vendor
-	touch $@
+	touch -c $@
 
 $(DOCKER_RUN_72_IMAGE): devTools/Dockerfile-php72-xdebug
 	docker build --tag infection_php72 --file devTools/Dockerfile-php72-xdebug .
-	docker image inspect infection_php72 >> $(DOCKER_RUN_72_IMAGE)
+	docker image inspect infection_php72 > $(DOCKER_RUN_72_IMAGE)
 	touch $@
 
 $(DOCKER_RUN_73_IMAGE): devTools/Dockerfile-php73-xdebug
 	docker build --tag infection_php73 --file devTools/Dockerfile-php73-xdebug .
-	docker image inspect infection_php73 >> $(DOCKER_RUN_73_IMAGE)
+	docker image inspect infection_php73 > $(DOCKER_RUN_73_IMAGE)
 	touch $@
 
 $(DOCKER_RUN_74_IMAGE): devTools/Dockerfile-php74-xdebug
 	docker build --tag infection_php74 --file devTools/Dockerfile-php74-xdebug .
-	docker image inspect infection_php74 >> $(DOCKER_RUN_74_IMAGE)
+	docker image inspect infection_php74 > $(DOCKER_RUN_74_IMAGE)
 	touch $@

--- a/devTools/Dockerfile-php72-xdebug
+++ b/devTools/Dockerfile-php72-xdebug
@@ -9,4 +9,6 @@ RUN curl --silent --show-error https://getcomposer.org/installer | php -- --inst
 
 RUN useradd --home-dir /opt/infection --shell /bin/bash infection
 
+COPY devTools/memory-limit.ini /usr/local/etc/php/conf.d/memory-limit.ini
+
 USER infection

--- a/devTools/Dockerfile-php73-xdebug
+++ b/devTools/Dockerfile-php73-xdebug
@@ -9,4 +9,6 @@ RUN curl --silent --show-error https://getcomposer.org/installer | php -- --inst
 
 RUN useradd --home-dir /opt/infection --shell /bin/bash infection
 
+COPY devTools/memory-limit.ini /usr/local/etc/php/conf.d/memory-limit.ini
+
 USER infection

--- a/devTools/Dockerfile-php74-xdebug
+++ b/devTools/Dockerfile-php74-xdebug
@@ -9,4 +9,6 @@ RUN curl --silent --show-error https://getcomposer.org/installer | php -- --inst
 
 RUN useradd --home-dir /opt/infection --shell /bin/bash infection
 
+COPY devTools/memory-limit.ini /usr/local/etc/php/conf.d/memory-limit.ini
+
 USER infection

--- a/devTools/memory-limit.ini
+++ b/devTools/memory-limit.ini
@@ -1,0 +1,2 @@
+memory_limit = 512M
+


### PR DESCRIPTION
This PR:

- [x] Fixes Makefile so that touch won't create empty files where a previous command failed without a correct exit code
- [x] Raises the open file limit for box to function correctly
- [x] Raises the PHP memory limit for the programs running inside Docker VMs

Overall this command should finish running with success, albeit after a long time:

```
make test-unit-74 test-e2e-phpdbg-74 test-infection-phpdbg-74 test-infection-xdebug-74
```

Related #774