### PR TITLE
Update PHP-CS-Fixer configuration, apply rules (for version 2.16.0)

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -120,6 +120,7 @@ return Config::create()
         'static_lambda' => true,
         'strict_comparison' => true,
         'yoda_style' => false,
+        'single_line_throw' => false,
     ])
     ->setFinder($finder)
 ;

--- a/.prettyci.composer.json
+++ b/.prettyci.composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.16"
+    }
+}

--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -46,7 +46,6 @@ final class FalseValue extends Mutator
     /**
      * Replaces "false" with "true"
      *
-     *
      * @return Node\Expr\ConstFetch
      */
     public function mutate(Node $node)

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -52,7 +52,6 @@ final class TrueValue extends Mutator
     /**
      * Replaces "true" with "false"
      *
-     *
      * @return Node\Expr\ConstFetch
      */
     public function mutate(Node $node)

--- a/src/Mutator/Operator/Break_.php
+++ b/src/Mutator/Operator/Break_.php
@@ -47,7 +47,6 @@ final class Break_ extends Mutator
     /**
      * Replaces "break;" with "continue;"
      *
-     *
      * @return Node\Stmt\Continue_
      */
     public function mutate(Node $node)

--- a/src/Mutator/Operator/Continue_.php
+++ b/src/Mutator/Operator/Continue_.php
@@ -47,7 +47,6 @@ final class Continue_ extends Mutator
     /**
      * Replaces "continue;" with "break;"
      *
-     *
      * @return Node\Stmt\Break_
      */
     public function mutate(Node $node)

--- a/src/Mutator/Operator/Finally_.php
+++ b/src/Mutator/Operator/Finally_.php
@@ -47,7 +47,6 @@ final class Finally_ extends Mutator
     /**
      * Removes "finally{}" blocks
      *
-     *
      * @return Node\Stmt\Nop
      */
     public function mutate(Node $node)

--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -46,7 +46,6 @@ final class FunctionCallRemoval extends Mutator
     /**
      * Replaces "doSmth()" with ""
      *
-     *
      * @return Node\Stmt\Nop()
      */
     public function mutate(Node $node)

--- a/src/Mutator/Removal/MethodCallRemoval.php
+++ b/src/Mutator/Removal/MethodCallRemoval.php
@@ -46,7 +46,6 @@ final class MethodCallRemoval extends Mutator
     /**
      * Replaces "$object->doSmth()" with ""
      *
-     *
      * @return Node\Stmt\Nop()
      */
     public function mutate(Node $node)

--- a/src/Mutator/ReturnValue/This.php
+++ b/src/Mutator/ReturnValue/This.php
@@ -46,7 +46,6 @@ final class This extends AbstractValueToNullReturnValue
     /**
      * Replaces "return $this;" with "return null;"
      *
-     *
      * @return Node\Stmt\Return_
      */
     public function mutate(Node $node)

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -105,7 +105,6 @@ abstract class AbstractTestFrameworkAdapter
     /**
      * Returns array of arguments to pass them into the Initial Run Symfony Process
      *
-     *
      * @return string[]
      */
     public function getInitialTestRunCommandLine(
@@ -218,7 +217,6 @@ abstract class AbstractTestFrameworkAdapter
 
     /**
      * Need to return string for cases when user run phpdbg with -qrr argument.s
-     *
      *
      * @return string[]
      */

--- a/src/TestFramework/Coverage/TestFileDataProvider.php
+++ b/src/TestFramework/Coverage/TestFileDataProvider.php
@@ -48,7 +48,6 @@ interface TestFileDataProvider
      *      param:  '\NameSpace\Sub\TestClass'
      *      return: '/path/to/NameSpace/Sub/TestClass.php'
      *
-     *
      * @return TestFileTimeData file path and time
      */
     public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData;


### PR DESCRIPTION
This PR:

- [x] PHP-CS-Fixer 2.16 comes with `single_line_throw` enabled for our default profiles, which breaks the carefully crafted multi-line exception statements. Disable that rule.
- [x] Apply changes from `phpdoc_trim_consecutive_blank_line_separation`

PrettyCI uses PHP CS Fixer 2.14, but we use 2.16, which is a bummer. Is there a switch somewhere to let the CS Fixer ignore rules it does not understand yet?..