### PR TITLE
Allow text logs to be written to a PHP stream

### DIFF
--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -101,8 +101,17 @@ abstract class FileLogger implements MutationTestingResultsLogger
 
     public function log(): void
     {
+        $content = implode(PHP_EOL, $this->getLogLines());
+
+        // If the output should be written to a stream then just write it directly
+        if (0 === strpos($this->logFilePath, 'php://')) {
+            file_put_contents($this->logFilePath, $content);
+
+            return;
+        }
+
         try {
-            $this->fs->dumpFile($this->logFilePath, implode(PHP_EOL, $this->getLogLines()));
+            $this->fs->dumpFile($this->logFilePath, $content);
         } catch (IOException $e) {
             $this->output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
         }

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -105,7 +105,12 @@ abstract class FileLogger implements MutationTestingResultsLogger
 
         // If the output should be written to a stream then just write it directly
         if (0 === strpos($this->logFilePath, 'php://')) {
-            file_put_contents($this->logFilePath, $content);
+            if (\in_array($this->logFilePath, ['php://stdout', 'php://stderr'], true)) {
+                file_put_contents($this->logFilePath, $content);
+            } else {
+                // The Symfony filesystem component doesn't support using streams so provide a sensible error message
+                $this->output->writeln(sprintf('<error>%s</error>', 'The only streams supported are php://stdout and php://stderr'));
+            }
 
             return;
         }

--- a/tests/e2e/Output_Stream/README.md
+++ b/tests/e2e/Output_Stream/README.md
@@ -1,0 +1,9 @@
+# Output streams
+
+## Discussion
+
+When running in a CI context it's useful to display the log file contents, to avoid the time wasted running it again locally to access infection.log  
+
+The simple option of just dumping `infection.log` to the console after the tests complete is not that simple, because most CI will stop once the infection command exits with non-zero status.
+
+So to avoid complex and error prone scripts in CI, this test ensures that the text log can be configured to be written to a PHP stream.

--- a/tests/e2e/Output_Stream/composer.json
+++ b/tests/e2e/Output_Stream/composer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.2.9"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8"
+    },
+    "autoload": {
+        "psr-4": {
+            "OutputStream\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "OutputStream\\": "tests/"
+        }
+    }
+}

--- a/tests/e2e/Output_Stream/expected-output.txt
+++ b/tests/e2e/Output_Stream/expected-output.txt
@@ -1,0 +1,26 @@
+Total: 2
+Killed mutants:
+===============
+
+
+Mutator: PublicVisibility
+Line 7
+
+Mutator: TrueValue
+Line 9
+
+Errors mutants:
+===============
+
+
+Escaped mutants:
+================
+
+
+Timed Out mutants:
+==================
+
+
+Not Covered mutants:
+====================
+

--- a/tests/e2e/Output_Stream/infection.json.dist
+++ b/tests/e2e/Output_Stream/infection.json.dist
@@ -1,0 +1,12 @@
+{
+    "timeout": 10,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "debug": "php://stderr"
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/Output_Stream/phpunit.xml
+++ b/tests/e2e/Output_Stream/phpunit.xml
@@ -1,0 +1,5 @@
+<phpunit>
+    <testsuite name="tests">
+        <directory suffix="Test.php">tests</directory>
+    </testsuite>
+</phpunit>

--- a/tests/e2e/Output_Stream/run_tests.bash
+++ b/tests/e2e/Output_Stream/run_tests.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e pipefail
+
+readonly INFECTION="../../../bin/infection --no-progress"
+
+rm -f infection.log
+
+if [ "$DRIVER" = "phpdbg" ]
+then
+    phpdbg -qrr $INFECTION 2> infection.log
+else
+    php $INFECTION 2> infection.log
+fi
+
+diff expected-output.txt infection.log

--- a/tests/e2e/Output_Stream/src/Example.php
+++ b/tests/e2e/Output_Stream/src/Example.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OutputStream;
+
+class Example
+{
+    public function run(): bool
+    {
+        return true;
+    }
+}

--- a/tests/e2e/Output_Stream/tests/ExampleTest.php
+++ b/tests/e2e/Output_Stream/tests/ExampleTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OutputStream;
+
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
+{
+    public function test1(): void
+    {
+        $example = new Example();
+        $result = $example->run();
+        $this->assertTrue($result);
+    }
+}

--- a/tests/phpunit/Logger/TextFileLoggerTest.php
+++ b/tests/phpunit/Logger/TextFileLoggerTest.php
@@ -292,6 +292,18 @@ TXT;
         $debugFileLogger->log();
     }
 
+    public function test_it_rejects_invalid_streams_with_a_clear_error_message(): void
+    {
+        $logFilePath = 'php://memory';
+        $calculator = new MetricsCalculator();
+        $fs = $this->createMock(Filesystem::class);
+        $output = $this->createMock(OutputInterface::class);
+        $output->expects($this->once())->method('writeln')->with('<error>The only streams supported are php://stdout and php://stderr</error>');
+
+        $debugFileLogger = new TextFileLogger($output, $logFilePath, $calculator, $fs, false, false);
+        $debugFileLogger->log();
+    }
+
     private function createFilledMetricsCalculator(): MetricsCalculator
     {
         $processes = [];


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/145

When running in a CI context it's useful to display the log file contents, to avoid the time wasted running it again locally to access the details of the escaped mutants.

The simple option of just dumping `infection.log` to the console after the tests complete is not that simple, because most CI will stop once the infection command exits with non-zero status.

So to avoid complex and error prone scripts being duplicated in every project's CI, this test ensures that the text log can be configured to be written to a PHP stream.