### PR TITLE
allow to enable pcov with initial-tests-php-options

### DIFF
--- a/src/Process/Coverage/CoverageRequirementChecker.php
+++ b/src/Process/Coverage/CoverageRequirementChecker.php
@@ -65,13 +65,22 @@ final class CoverageRequirementChecker
             || \extension_loaded('xdebug')
             || \extension_loaded('pcov')
             || XdebugHandler::getSkippedVersion()
-            || $this->isXdebugIncludedInInitialTestPhpOptions();
+            || $this->isXdebugIncludedInInitialTestPhpOptions()
+            || $this->isPcovIncludedInInitialTestPhpOptions();
     }
 
     private function isXdebugIncludedInInitialTestPhpOptions(): bool
     {
         return (bool) preg_match(
             '/(zend_extension\s*=.*xdebug.*)/mi',
+            $this->initialTestPhpOptions
+        );
+    }
+
+    private function isPcovIncludedInInitialTestPhpOptions(): bool
+    {
+        return (bool) preg_match(
+            '/(extension\s*=.*pcov.*)/mi',
             $this->initialTestPhpOptions
         );
     }

--- a/tests/phpunit/Process/Coverage/CoverageRequirementCheckerTest.php
+++ b/tests/phpunit/Process/Coverage/CoverageRequirementCheckerTest.php
@@ -91,13 +91,24 @@ final class CoverageRequirementCheckerTest extends TestCase
         $this->assertTrue($coverageChecker->hasDebuggerOrCoverageOption());
     }
 
-    public function test_it_has_debug_or_coverage_option_when_provided_with_correct_initial_php_settings(): void
+    public function test_it_has_debug_or_coverage_option_when_provided_with_correct_xdebug_initial_php_settings(): void
     {
         $this->requireNoPhpDbg();
         $this->requireNoXdebug();
         $this->requireNoPcov();
 
         $coverageChecker = new CoverageRequirementChecker(false, '-d zend_extension=xdebug.so');
+
+        $this->assertTrue($coverageChecker->hasDebuggerOrCoverageOption());
+    }
+
+    public function test_it_has_debug_or_coverage_option_when_provided_with_correct_pcov_initial_php_settings(): void
+    {
+        $this->requireNoPhpDbg();
+        $this->requireNoXdebug();
+        $this->requireNoPcov();
+
+        $coverageChecker = new CoverageRequirementChecker(false, '-d extension=pcov.so');
 
         $this->assertTrue($coverageChecker->hasDebuggerOrCoverageOption());
     }


### PR DESCRIPTION
This PR allows to enable pcov using the `--initial-tests-php-options` option:

```
infection --initial-tests-php-options='-d extension=pcov.so'
```