### PR TITLE
Add missing `UnwrapStrReplace` to the schema.json 

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -298,6 +298,7 @@
                 "UnwrapArrayValues": { "$ref": "#/definitions/default-mutator-config" },
                 "UnwrapLcFirst": { "$ref": "#/definitions/default-mutator-config" },
                 "UnwrapStrRepeat": { "$ref": "#/definitions/default-mutator-config" },
+                "UnwrapStrReplace": { "$ref": "#/definitions/default-mutator-config" },
                 "UnwrapStrToLower": { "$ref": "#/definitions/default-mutator-config" },
                 "UnwrapStrToUpper": { "$ref": "#/definitions/default-mutator-config" },
                 "UnwrapTrim": { "$ref": "#/definitions/default-mutator-config" },


### PR DESCRIPTION
This bug went unnoticed in #831 since there was no end-to-end test for it. 

Note that this kind of bug will be caught by #750. Hence I'm not going an extra mile in this PR to attempt to add a test case to capture this failure