### PR TITLE
Remove default value from the coverage option

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -159,8 +159,7 @@ final class InfectionCommand extends BaseCommand
                 'coverage',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Path to existing coverage (`xml` and `junit` reports are required)',
-                ''
+                'Path to existing coverage (`xml` and `junit` reports are required)'
             )
             ->addOption(
                 'mutators',
@@ -255,7 +254,7 @@ final class InfectionCommand extends BaseCommand
         }
 
         $this->consoleOutput = $this->getApplication()->getConsoleOutput();
-        $this->skipCoverage = \strlen(trim($input->getOption('coverage'))) > 0;
+        $this->skipCoverage = trim((string) $input->getOption('coverage')) !== '';
         $this->eventDispatcher = $this->container['dispatcher'];
     }
 


### PR DESCRIPTION
Remove the default value (`''`) from the coverage option and simplify the normalization of that value later on in the command.

I think it's easier to keep `null` over `''` as a default value (or putted another way: I don't see the benefit of changing it) and the line changed for the comparison does not change the behaviour, it just makes it faster & more readable (IMO)