### PR TITLE
According to PHP 7.4 changelog, `stream_set_option()` should always return false

### DIFF
--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -289,14 +289,20 @@ final class IncludeInterceptor
 
         switch ($option) {
             case STREAM_OPTION_BLOCKING:
-                return stream_set_blocking($this->fp, (bool) $arg1);
+                stream_set_blocking($this->fp, (bool) $arg1);
+                break;
             case STREAM_OPTION_READ_TIMEOUT:
-                return stream_set_timeout($this->fp, $arg1, $arg2);
+                stream_set_timeout($this->fp, $arg1, $arg2);
+                break;
             case STREAM_OPTION_WRITE_BUFFER:
-                return stream_set_write_buffer($this->fp, $arg1);
+                stream_set_write_buffer($this->fp, $arg1);
+                break;
             case STREAM_OPTION_READ_BUFFER:
-                return stream_set_read_buffer($this->fp, $arg1);
+                stream_set_read_buffer($this->fp, $arg1);
+                break;
         }
+
+        return false;
     }
 
     public function stream_stat()

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -290,15 +290,19 @@ final class IncludeInterceptor
         switch ($option) {
             case STREAM_OPTION_BLOCKING:
                 stream_set_blocking($this->fp, (bool) $arg1);
+
                 break;
             case STREAM_OPTION_READ_TIMEOUT:
                 stream_set_timeout($this->fp, $arg1, $arg2);
+
                 break;
             case STREAM_OPTION_WRITE_BUFFER:
                 stream_set_write_buffer($this->fp, $arg1);
+
                 break;
             case STREAM_OPTION_READ_BUFFER:
                 stream_set_read_buffer($this->fp, $arg1);
+
                 break;
         }
 


### PR DESCRIPTION
[The changelog says](https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.stream-wrappers) that `stream_set_option() ` must always return false, [where our implementation does not](https://github.com/infection/infection/blob/8b5fe199e222eff7a0fd5960815c91f825b0489f/src/StreamWrapper/IncludeInterceptor.php#L286).

_Originally posted by @sanmai in https://github.com/infection/infection/issues/774#issuecomment-554380486_
