### PR TITLE
Introduce TestFrameworkAdapter interface

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -55,7 +55,6 @@ use Infection\Process\Runner\InitialTestsFailed;
 use Infection\Process\Runner\InitialTestsRunner;
 use Infection\Process\Runner\MutationTestingRunner;
 use Infection\Process\Runner\TestRunConstraintChecker;
-use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
 use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Infection\TestFramework\Coverage\XMLLineCodeCoverage;
@@ -63,6 +62,7 @@ use Infection\TestFramework\HasExtraNodeVisitors;
 use Infection\TestFramework\PhpSpec\PhpSpecExtraOptions;
 use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\PhpUnit\PhpUnitExtraOptions;
+use Infection\TestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\TestFrameworkExtraOptions;
 use Infection\TestFramework\TestFrameworkTypes;
 use function is_numeric;
@@ -262,7 +262,7 @@ final class InfectionCommand extends BaseCommand
         $this->eventDispatcher = $this->container['dispatcher'];
     }
 
-    private function startUp(): AbstractTestFrameworkAdapter
+    private function startUp(): TestFrameworkAdapter
     {
         Assert::notNull($this->container);
 
@@ -288,7 +288,7 @@ final class InfectionCommand extends BaseCommand
         return $adapter;
     }
 
-    private function runInitialTestSuite(AbstractTestFrameworkAdapter $adapter): void
+    private function runInitialTestSuite(TestFrameworkAdapter $adapter): void
     {
         /** @var Configuration $config */
         $config = $this->container[Configuration::class];
@@ -312,7 +312,7 @@ final class InfectionCommand extends BaseCommand
         $this->container['memory.limit.applier']->applyMemoryLimitFromProcess($initialTestSuitProcess, $adapter);
     }
 
-    private function runMutationTesting(AbstractTestFrameworkAdapter $adapter): void
+    private function runMutationTesting(TestFrameworkAdapter $adapter): void
     {
         /** @var Configuration $config */
         $config = $this->container[Configuration::class];

--- a/src/Performance/Limiter/MemoryLimiter.php
+++ b/src/Performance/Limiter/MemoryLimiter.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Performance\Limiter;
 
 use Composer\XdebugHandler\XdebugHandler;
-use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Infection\TestFramework\MemoryUsageAware;
+use Infection\TestFramework\TestFrameworkAdapter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
@@ -62,7 +62,7 @@ final class MemoryLimiter
         $this->iniLocation = $iniLocation;
     }
 
-    public function applyMemoryLimitFromProcess(Process $process, AbstractTestFrameworkAdapter $adapter): void
+    public function applyMemoryLimitFromProcess(Process $process, TestFrameworkAdapter $adapter): void
     {
         if (!$adapter instanceof MemoryUsageAware || $this->hasMemoryLimitSet() || $this->isUsingSystemIni()) {
             return;

--- a/src/Process/Builder/InitialTestRunProcessBuilder.php
+++ b/src/Process/Builder/InitialTestRunProcessBuilder.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Process\Builder;
 
 use Infection\Console\Util\PhpProcess;
-use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\TestFramework\TestFrameworkAdapter;
 use Symfony\Component\Process\Process;
 
 /**
@@ -45,11 +45,11 @@ use Symfony\Component\Process\Process;
 class InitialTestRunProcessBuilder
 {
     /**
-     * @var AbstractTestFrameworkAdapter
+     * @var TestFrameworkAdapter
      */
     private $testFrameworkAdapter;
 
-    public function __construct(AbstractTestFrameworkAdapter $testFrameworkAdapter)
+    public function __construct(TestFrameworkAdapter $testFrameworkAdapter)
     {
         $this->testFrameworkAdapter = $testFrameworkAdapter;
     }

--- a/src/Process/Builder/SubscriberBuilder.php
+++ b/src/Process/Builder/SubscriberBuilder.php
@@ -56,7 +56,7 @@ use Infection\Process\Listener\MutantCreatingConsoleLoggerSubscriber;
 use Infection\Process\Listener\MutationGeneratingConsoleLoggerSubscriber;
 use Infection\Process\Listener\MutationTestingConsoleLoggerSubscriber;
 use Infection\Process\Listener\MutationTestingResultsLoggerSubscriber;
-use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\TestFramework\TestFrameworkAdapter;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -176,7 +176,7 @@ final class SubscriberBuilder
     }
 
     public function registerSubscribers(
-        AbstractTestFrameworkAdapter $testFrameworkAdapter,
+        TestFrameworkAdapter $testFrameworkAdapter,
         OutputInterface $output
     ): void {
         foreach ($this->getSubscribers($testFrameworkAdapter, $output) as $subscriber) {
@@ -185,7 +185,7 @@ final class SubscriberBuilder
     }
 
     private function getSubscribers(
-        AbstractTestFrameworkAdapter $testFrameworkAdapter,
+        TestFrameworkAdapter $testFrameworkAdapter,
         OutputInterface $output
     ): array {
         $subscribers = [
@@ -257,7 +257,7 @@ final class SubscriberBuilder
         return new MutationGeneratingConsoleLoggerSubscriber($output);
     }
 
-    private function getInitialTestsConsoleLoggerSubscriber(AbstractTestFrameworkAdapter $testFrameworkAdapter, OutputInterface $output): EventSubscriberInterface
+    private function getInitialTestsConsoleLoggerSubscriber(TestFrameworkAdapter $testFrameworkAdapter, OutputInterface $output): EventSubscriberInterface
     {
         if ($this->shouldSkipProgressBars()) {
             return new CiInitialTestsConsoleLoggerSubscriber($output, $testFrameworkAdapter);

--- a/src/Process/Listener/CiInitialTestsConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/CiInitialTestsConsoleLoggerSubscriber.php
@@ -37,7 +37,7 @@ namespace Infection\Process\Listener;
 
 use Infection\EventDispatcher\EventSubscriberInterface;
 use Infection\Events\InitialTestSuiteStarted;
-use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\TestFramework\TestFrameworkAdapter;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -51,11 +51,11 @@ final class CiInitialTestsConsoleLoggerSubscriber implements EventSubscriberInte
     private $output;
 
     /**
-     * @var AbstractTestFrameworkAdapter
+     * @var TestFrameworkAdapter
      */
     private $testFrameworkAdapter;
 
-    public function __construct(OutputInterface $output, AbstractTestFrameworkAdapter $testFrameworkAdapter)
+    public function __construct(OutputInterface $output, TestFrameworkAdapter $testFrameworkAdapter)
     {
         $this->output = $output;
         $this->testFrameworkAdapter = $testFrameworkAdapter;

--- a/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
@@ -39,7 +39,7 @@ use Infection\EventDispatcher\EventSubscriberInterface;
 use Infection\Events\InitialTestCaseCompleted;
 use Infection\Events\InitialTestSuiteFinished;
 use Infection\Events\InitialTestSuiteStarted;
-use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\TestFramework\TestFrameworkAdapter;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -59,7 +59,7 @@ final class InitialTestsConsoleLoggerSubscriber implements EventSubscriberInterf
     private $progressBar;
 
     /**
-     * @var AbstractTestFrameworkAdapter
+     * @var TestFrameworkAdapter
      */
     private $testFrameworkAdapter;
 
@@ -68,7 +68,7 @@ final class InitialTestsConsoleLoggerSubscriber implements EventSubscriberInterf
      */
     private $debug;
 
-    public function __construct(OutputInterface $output, AbstractTestFrameworkAdapter $testFrameworkAdapter, bool $debug)
+    public function __construct(OutputInterface $output, TestFrameworkAdapter $testFrameworkAdapter, bool $debug)
     {
         $this->output = $output;
         $this->testFrameworkAdapter = $testFrameworkAdapter;

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -38,7 +38,7 @@ namespace Infection\Process;
 use Infection\Mutant\MutantInterface;
 use Infection\MutationInterface;
 use Infection\Mutator\Util\Mutator;
-use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\TestFramework\TestFrameworkAdapter;
 use Symfony\Component\Process\Process;
 
 /**
@@ -78,11 +78,11 @@ final class MutantProcess implements MutantProcessInterface
     private $isTimedOut = false;
 
     /**
-     * @var AbstractTestFrameworkAdapter
+     * @var TestFrameworkAdapter
      */
     private $testFrameworkAdapter;
 
-    public function __construct(Process $process, MutantInterface $mutant, AbstractTestFrameworkAdapter $testFrameworkAdapter)
+    public function __construct(Process $process, MutantInterface $mutant, TestFrameworkAdapter $testFrameworkAdapter)
     {
         $this->process = $process;
         $this->mutant = $mutant;

--- a/src/Process/Runner/InitialTestsFailed.php
+++ b/src/Process/Runner/InitialTestsFailed.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Process\Runner;
 
 use Exception;
-use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\TestFramework\TestFrameworkAdapter;
 use Symfony\Component\Process\Process;
 
 /**
@@ -46,7 +46,7 @@ final class InitialTestsFailed extends Exception
 {
     public static function fromProcessAndAdapter(
         Process $initialTestSuitProcess,
-        AbstractTestFrameworkAdapter $testFrameworkAdapter
+        TestFrameworkAdapter $testFrameworkAdapter
     ): self {
         $testFrameworkKey = $testFrameworkAdapter->getName();
 

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -47,7 +47,7 @@ use Symfony\Component\Process\Process;
 /**
  * @internal
  */
-abstract class AbstractTestFrameworkAdapter
+abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
 {
     /**
      * @var AbstractExecutableFinder

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -108,7 +108,7 @@ final class Factory
         $this->versionParser = $versionParser;
     }
 
-    public function create(string $adapterName, bool $skipCoverage): AbstractTestFrameworkAdapter
+    public function create(string $adapterName, bool $skipCoverage): TestFrameworkAdapter
     {
         if ($adapterName === TestFrameworkTypes::PHPUNIT) {
             $phpUnitConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPUNIT);

--- a/src/TestFramework/TestFrameworkAdapter.php
+++ b/src/TestFramework/TestFrameworkAdapter.php
@@ -33,46 +33,38 @@
 
 declare(strict_types=1);
 
-namespace Infection\Process\Builder;
+namespace Infection\TestFramework;
 
 use Infection\Mutant\MutantInterface;
-use Infection\Process\MutantProcess;
-use Infection\TestFramework\TestFrameworkAdapter;
-use Symfony\Component\Process\Process;
 
 /**
  * @internal
  */
-final class MutantProcessBuilder
+interface TestFrameworkAdapter
 {
-    /**
-     * @var TestFrameworkAdapter
-     */
-    private $testFrameworkAdapter;
+    public const JUNIT_FILE_NAME = 'junit.xml';
+
+    public function getName(): string;
+
+    public function testsPass(string $output): bool;
 
     /**
-     * @var int
+     * @param string[] $phpExtraArgs
+     *
+     * @return string[]
      */
-    private $timeout;
+    public function getInitialTestRunCommandLine(string $configPath, string $extraOptions, array $phpExtraArgs): array;
 
-    public function __construct(TestFrameworkAdapter $testFrameworkAdapter, int $timeout)
-    {
-        $this->testFrameworkAdapter = $testFrameworkAdapter;
-        $this->timeout = $timeout;
-    }
+    /**
+     * @return string[]
+     */
+    public function getMutantCommandLine(string $configPath, string $extraOptions): array;
 
-    public function createProcessForMutant(MutantInterface $mutant, string $testFrameworkExtraOptions = ''): MutantProcess
-    {
-        $process = new Process(
-            $this->testFrameworkAdapter->getMutantCommandLine(
-                $this->testFrameworkAdapter->buildMutationConfigFile($mutant),
-                $testFrameworkExtraOptions
-            )
-        );
+    public function getVersion(): string;
 
-        $process->setTimeout($this->timeout);
-        $process->inheritEnvironmentVariables();
+    public function getInitialTestsFailRecommendations(string $commandLine): string;
 
-        return new MutantProcess($process, $mutant, $this->testFrameworkAdapter);
-    }
+    public function buildInitialConfigFile();
+
+    public function buildMutationConfigFile(MutantInterface $mutant);
 }


### PR DESCRIPTION
Extracted from https://github.com/infection/infection/pull/800 to reduce the size of the PR.

This is needed because `CodeceptionAdapter` does not extend our `AbstractTestFramework` abstract class and works differently.

More improvements in https://github.com/infection/infection/pull/800