### PR TITLE
Enable Symfony 5 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,11 +53,11 @@
         "pimple/pimple": "^3.2",
         "sebastian/diff": "^3.0.2",
         "seld/jsonlint": "^1.7",
-        "symfony/console": "^3.4.29 || ^4.0",
-        "symfony/filesystem": "^3.4.29 || ^4.0",
-        "symfony/finder": "^3.4.29 || ^4.0",
-        "symfony/process": "^3.4.29 || ^4.0",
-        "symfony/yaml": "^3.4.29 || ^4.0",
+        "symfony/console": "^3.4.29 || ^4.0 || ^5.0",
+        "symfony/filesystem": "^3.4.29 || ^4.0 || ^5.0",
+        "symfony/finder": "^3.4.29 || ^4.0 || ^5.0",
+        "symfony/process": "^3.4.29 || ^4.0 || ^5.0",
+        "symfony/yaml": "^3.4.29 || ^4.0 || ^5.0",
         "thecodingmachine/safe": "^0.1.16",
         "webmozart/assert": "^1.3",
         "webmozart/path-util": "^2.3"
@@ -68,7 +68,7 @@
     "require-dev": {
         "helmich/phpunit-json-assert": "^3.0",
         "phpunit/phpunit": "^8.2.5 <8.4",
-        "symfony/phpunit-bridge": "^4.3.4"
+        "symfony/phpunit-bridge": "^4.3.4 || ^5.0"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d36a4d6b73557c1b052eeb047f98cc12",
+    "content-hash": "98423204937767a434ea921240eae192",
     "packages": [
         {
             "name": "composer/xdebug-handler",


### PR DESCRIPTION
This PR:

- [x] Adds support of new Symfony 5 Components.  #SymfonyHackday
- Not covered by tests. Let's see what CI shows

There 2 classes using deprecated (and removed in Symfony5) feature like [`Process::inheritEnvironmentVariables()`](https://github.com/symfony/process/blob/master/CHANGELOG.md)

* Infection\Process\Builder\MutantProcessBuilder
* Infection\Process\Builder\InitialTestRunProcessBuilder

That could be tricky to get rid of and support earlier versions of `symfony/process`. Here is the [source code for 4.4](https://github.com/symfony/process/blob/4.4/Process.php#L1222)