### PR TITLE
Do not call deprecated/removed method for new versions of `symfony/process`

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -65,6 +65,7 @@ use Infection\TestFramework\PhpUnit\PhpUnitExtraOptions;
 use Infection\TestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\TestFrameworkExtraOptions;
 use Infection\TestFramework\TestFrameworkTypes;
+use Infection\Utils\VersionParser;
 use function is_numeric;
 use function Safe\sprintf;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
@@ -110,6 +111,11 @@ final class InfectionCommand extends BaseCommand
      * @var TestFrameworkExtraOptions
      */
     private $testFrameworkOptions;
+
+    /**
+     * @var VersionParser
+     */
+    private $versionParser;
 
     protected function configure(): void
     {
@@ -260,6 +266,7 @@ final class InfectionCommand extends BaseCommand
         $this->consoleOutput = $this->getApplication()->getConsoleOutput();
         $this->skipCoverage = trim((string) $input->getOption('coverage')) !== '';
         $this->eventDispatcher = $this->container['dispatcher'];
+        $this->versionParser = $this->container[VersionParser::class];
     }
 
     private function startUp(): TestFrameworkAdapter
@@ -293,7 +300,7 @@ final class InfectionCommand extends BaseCommand
         /** @var Configuration $config */
         $config = $this->container[Configuration::class];
 
-        $processBuilder = new InitialTestRunProcessBuilder($adapter);
+        $processBuilder = new InitialTestRunProcessBuilder($adapter, $this->versionParser);
 
         $initialTestsRunner = new InitialTestsRunner($processBuilder, $this->eventDispatcher);
 
@@ -317,7 +324,7 @@ final class InfectionCommand extends BaseCommand
         /** @var Configuration $config */
         $config = $this->container[Configuration::class];
 
-        $processBuilder = new MutantProcessBuilder($adapter, $config->getProcessTimeout());
+        $processBuilder = new MutantProcessBuilder($adapter, $this->versionParser, $config->getProcessTimeout());
 
         $codeCoverageData = $this->getCodeCoverageData($this->testFrameworkKey);
 

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -144,7 +144,7 @@ final class InfectionContainer extends Container
                     $container['xml.configuration.helper'],
                     $container['phpunit.junit.file.path'],
                     $container[Configuration::class],
-                    $container['version.parser']
+                    $container[VersionParser::class]
                 );
             },
             'xml.configuration.helper' => static function (self $container): XmlConfigurationHelper {
@@ -190,7 +190,7 @@ final class InfectionContainer extends Container
                     new PhpUnitTestFileDataProvider($container['phpunit.junit.file.path'])
                 );
             },
-            'version.parser' => static function (): VersionParser {
+            VersionParser::class => static function (): VersionParser {
                 return new VersionParser();
             },
             'lexer' => static function (): Lexer {

--- a/src/Process/Builder/InitialTestRunProcessBuilder.php
+++ b/src/Process/Builder/InitialTestRunProcessBuilder.php
@@ -37,6 +37,8 @@ namespace Infection\Process\Builder;
 
 use Infection\Console\Util\PhpProcess;
 use Infection\TestFramework\TestFrameworkAdapter;
+use Infection\Utils\VersionParser;
+use PackageVersions\Versions;
 use Symfony\Component\Process\Process;
 
 /**
@@ -49,9 +51,15 @@ class InitialTestRunProcessBuilder
      */
     private $testFrameworkAdapter;
 
-    public function __construct(TestFrameworkAdapter $testFrameworkAdapter)
+    /**
+     * @var VersionParser
+     */
+    private $versionParser;
+
+    public function __construct(TestFrameworkAdapter $testFrameworkAdapter, VersionParser $versionParser)
     {
         $this->testFrameworkAdapter = $testFrameworkAdapter;
+        $this->versionParser = $versionParser;
     }
 
     /**
@@ -75,7 +83,13 @@ class InitialTestRunProcessBuilder
         );
 
         $process->setTimeout(null); // ignore the default timeout of 60 seconds
-        $process->inheritEnvironmentVariables();
+
+        $symfonyProcessVersion = $this->versionParser->parse(Versions::getVersion('symfony/process'));
+
+        if (version_compare($symfonyProcessVersion, '4.4.0', '<')) {
+            // in version 4.4.0 this method is deprecated and removed in 5.0.0
+            $process->inheritEnvironmentVariables();
+        }
 
         return $process;
     }

--- a/tests/phpunit/Process/Builder/InitialTestRunProcessBuilderTest.php
+++ b/tests/phpunit/Process/Builder/InitialTestRunProcessBuilderTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\Process\Builder;
 
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\Utils\VersionParser;
 use PHPUnit\Framework\TestCase;
 
 final class InitialTestRunProcessBuilderTest extends TestCase
@@ -49,7 +50,7 @@ final class InitialTestRunProcessBuilderTest extends TestCase
         $fwAdapter->method('buildInitialConfigFile')
             ->willReturn('buildInitialConfigFile');
 
-        $builder = new InitialTestRunProcessBuilder($fwAdapter);
+        $builder = new InitialTestRunProcessBuilder($fwAdapter, new VersionParser());
 
         $process = $builder->createProcess('', false);
 

--- a/tests/phpunit/Process/Builder/MutantProcessBuilderTest.php
+++ b/tests/phpunit/Process/Builder/MutantProcessBuilderTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Process\Builder;
 use Infection\Mutant\MutantInterface;
 use Infection\Process\Builder\MutantProcessBuilder;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\Utils\VersionParser;
 use PHPUnit\Framework\TestCase;
 
 final class MutantProcessBuilderTest extends TestCase
@@ -50,7 +51,7 @@ final class MutantProcessBuilderTest extends TestCase
         $fwAdapter->method('buildMutationConfigFile')
             ->willReturn('buildMutationConfigFile');
 
-        $builder = new MutantProcessBuilder($fwAdapter, 100);
+        $builder = new MutantProcessBuilder($fwAdapter, new VersionParser(), 100);
 
         $process = $builder->createProcessForMutant($this->createMock(MutantInterface::class))->getProcess();
 


### PR DESCRIPTION
Also, see https://github.com/infection/infection/pull/842

Should fix AppVeyor builds and allow people using Infection with `symfony/process` `^4.4.0 | 5.0.0`