### PR TITLE
Run e2e tests with `bin/infection` by default if parameter is skipped

### DIFF
--- a/tests/e2e_tests
+++ b/tests/e2e_tests
@@ -25,7 +25,7 @@ do
     then
         output="$(bash run_tests.bash)"
     else
-        output="$(bash ../standard_script.bash ${1:-build/bin/infection.phar})"
+        output="$(bash ../standard_script.bash ${1:-bin/infection})"
     fi
 
     if [ $? != 0 ]


### PR DESCRIPTION
2 issues are fixed here:

* there is no `build/bin/infection.phar` (incorrect path), it is now `build/infection.phar`
* when you run multiple times e2e tests locally, it is much more convenient to just run `tests/e2e_tests` and be sure that `bin/infection` (the latest changed code) is executed rather than compiled PHAR with the old code

This patch does not affect Travis, since we always pass arguments:

https://github.com/infection/infection/blob/d146b35f0d98d0b95b28f70dc9ffdc92e1fadd61/.travis.yml#L65-L69