### PR TITLE
Make interceptor resilient to file not found warnings

### DIFF
--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -110,7 +110,11 @@ final class IncludeInterceptor
                 }
             }
 
-            $this->fp = fopen($path, $mode, (bool) $options, $this->context);
+            if (isset($this->context)) {
+                $this->fp = fopen($path, $mode, (bool) $options, $this->context);
+            } else {
+                $this->fp = fopen($path, $mode, (bool) $options);
+            }
         } finally {
             self::enable();
         }
@@ -132,7 +136,11 @@ final class IncludeInterceptor
         self::disable();
 
         try {
-            $this->fp = opendir($path, $this->context);
+            if (isset($this->context)) {
+                $this->fp = opendir($path, $this->context);
+            } else {
+                $this->fp = opendir($path);
+            }
         } finally {
             self::enable();
         }
@@ -162,10 +170,16 @@ final class IncludeInterceptor
         $isRecursive = (bool) ($options & STREAM_MKDIR_RECURSIVE);
 
         try {
-            return mkdir($path, $mode, $isRecursive, $this->context);
+            if (isset($this->context)) {
+                $return = mkdir($path, $mode, $isRecursive, $this->context);
+            } else {
+                $return = mkdir($path, $mode, $isRecursive);
+            }
         } finally {
             self::enable();
         }
+
+        return $return;
     }
 
     public function rename($path_from, $path_to)
@@ -173,10 +187,16 @@ final class IncludeInterceptor
         self::disable();
 
         try {
-            return rename($path_from, $path_to, $this->context);
+            if (isset($this->context)) {
+                $return = rename($path_from, $path_to, $this->context);
+            } else {
+                $return = rename($path_from, $path_to);
+            }
         } finally {
             self::enable();
         }
+
+        return $return;
     }
 
     public function rmdir($path)
@@ -184,10 +204,16 @@ final class IncludeInterceptor
         self::disable();
 
         try {
-            return rmdir($path, $this->context);
+            if (isset($this->context)) {
+                $return = rmdir($path, $this->context);
+            } else {
+                $return = rmdir($path);
+            }
         } finally {
             self::enable();
         }
+
+        return $return;
     }
 
     public function stream_cast()
@@ -324,10 +350,16 @@ final class IncludeInterceptor
         self::disable();
 
         try {
-            return unlink($path, $this->context);
+            if (isset($this->context)) {
+                $return = unlink($path, $this->context);
+            } else {
+                $return = unlink($path);
+            }
         } finally {
             self::enable();
         }
+
+        return $return;
     }
 
     public function url_stat($path)

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -135,12 +135,15 @@ final class IncludeInterceptor
     {
         self::disable();
 
-        if (isset($this->context)) {
-            $this->fp = opendir($path, $this->context);
-        } else {
-            $this->fp = opendir($path);
+        try {
+            if (isset($this->context)) {
+                $this->fp = opendir($path, $this->context);
+            } else {
+                $this->fp = opendir($path);
+            }
+        } finally {
+            self::enable();
         }
-        self::enable();
 
         return $this->fp !== false;
     }

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -53,11 +53,6 @@ final class IncludeInterceptor
     private $fp;
 
     /**
-     * @var bool
-     */
-    private static $isEnabled = false;
-
-    /**
      * @var string
      */
     private static $intercept;
@@ -93,18 +88,11 @@ final class IncludeInterceptor
         }
         stream_wrapper_unregister('file');
         stream_wrapper_register('file', __CLASS__);
-        self::$isEnabled = true;
     }
 
     public static function disable(): void
     {
         stream_wrapper_restore('file');
-        self::$isEnabled = false;
-    }
-
-    public static function isEnabled(): bool
-    {
-        return self::$isEnabled;
     }
 
     public function stream_open($path, $mode, $options)

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -110,11 +110,7 @@ final class IncludeInterceptor
                 }
             }
 
-            if (isset($this->context)) {
-                $this->fp = fopen($path, $mode, (bool) $options, $this->context);
-            } else {
-                $this->fp = fopen($path, $mode, (bool) $options);
-            }
+            $this->fp = fopen($path, $mode, (bool) $options, $this->context);
         } finally {
             self::enable();
         }
@@ -136,11 +132,7 @@ final class IncludeInterceptor
         self::disable();
 
         try {
-            if (isset($this->context)) {
-                $this->fp = opendir($path, $this->context);
-            } else {
-                $this->fp = opendir($path);
-            }
+            $this->fp = opendir($path, $this->context);
         } finally {
             self::enable();
         }
@@ -169,11 +161,8 @@ final class IncludeInterceptor
 
         $isRecursive = (bool) ($options & STREAM_MKDIR_RECURSIVE);
 
-        if (isset($this->context)) {
-            $return = mkdir($path, $mode, $isRecursive, $this->context);
-        } else {
-            $return = mkdir($path, $mode, $isRecursive);
-        }
+        $return = mkdir($path, $mode, $isRecursive, $this->context);
+
         self::enable();
 
         return $return;
@@ -183,11 +172,8 @@ final class IncludeInterceptor
     {
         self::disable();
 
-        if (isset($this->context)) {
-            $return = rename($path_from, $path_to, $this->context);
-        } else {
-            $return = rename($path_from, $path_to);
-        }
+        $return = rename($path_from, $path_to, $this->context);
+
         self::enable();
 
         return $return;
@@ -197,11 +183,8 @@ final class IncludeInterceptor
     {
         self::disable();
 
-        if (isset($this->context)) {
-            $return = rmdir($path, $this->context);
-        } else {
-            $return = rmdir($path);
-        }
+        $return = rmdir($path, $this->context);
+
         self::enable();
 
         return $return;
@@ -337,11 +320,7 @@ final class IncludeInterceptor
     {
         self::disable();
 
-        if (isset($this->context)) {
-            $return = unlink($path, $this->context);
-        } else {
-            $return = unlink($path);
-        }
+        $return = unlink($path, $this->context);
         self::enable();
 
         return $return;

--- a/src/StreamWrapper/IncludeInterceptor.php
+++ b/src/StreamWrapper/IncludeInterceptor.php
@@ -161,33 +161,33 @@ final class IncludeInterceptor
 
         $isRecursive = (bool) ($options & STREAM_MKDIR_RECURSIVE);
 
-        $return = mkdir($path, $mode, $isRecursive, $this->context);
-
-        self::enable();
-
-        return $return;
+        try {
+            return mkdir($path, $mode, $isRecursive, $this->context);
+        } finally {
+            self::enable();
+        }
     }
 
     public function rename($path_from, $path_to)
     {
         self::disable();
 
-        $return = rename($path_from, $path_to, $this->context);
-
-        self::enable();
-
-        return $return;
+        try {
+            return rename($path_from, $path_to, $this->context);
+        } finally {
+            self::enable();
+        }
     }
 
     public function rmdir($path)
     {
         self::disable();
 
-        $return = rmdir($path, $this->context);
-
-        self::enable();
-
-        return $return;
+        try {
+            return rmdir($path, $this->context);
+        } finally {
+            self::enable();
+        }
     }
 
     public function stream_cast()
@@ -227,33 +227,36 @@ final class IncludeInterceptor
     {
         self::disable();
 
-        switch ($option) {
-            case STREAM_META_TOUCH:
-                if (empty($value)) {
-                    $return = touch($path);
-                } else {
-                    $return = touch($path, $value[0], $value[1]);
-                }
+        try {
+            switch ($option) {
+                case STREAM_META_TOUCH:
+                    if (empty($value)) {
+                        $return = touch($path);
+                    } else {
+                        $return = touch($path, $value[0], $value[1]);
+                    }
 
-                break;
-            case STREAM_META_OWNER_NAME:
-            case STREAM_META_OWNER:
-                $return = chown($path, $value);
+                    break;
+                case STREAM_META_OWNER_NAME:
+                case STREAM_META_OWNER:
+                    $return = chown($path, $value);
 
-                break;
-            case STREAM_META_GROUP_NAME:
-            case STREAM_META_GROUP:
-                $return = chgrp($path, $value);
+                    break;
+                case STREAM_META_GROUP_NAME:
+                case STREAM_META_GROUP:
+                    $return = chgrp($path, $value);
 
-                break;
-            case STREAM_META_ACCESS:
-                $return = chmod($path, $value);
+                    break;
+                case STREAM_META_ACCESS:
+                    $return = chmod($path, $value);
 
-                break;
-            default:
-                throw new \RuntimeException('Unknown stream_metadata option');
+                    break;
+                default:
+                    throw new \RuntimeException('Unknown stream_metadata option');
+            }
+        } finally {
+            self::enable();
         }
-        self::enable();
 
         return $return;
     }
@@ -320,18 +323,21 @@ final class IncludeInterceptor
     {
         self::disable();
 
-        $return = unlink($path, $this->context);
-        self::enable();
-
-        return $return;
+        try {
+            return unlink($path, $this->context);
+        } finally {
+            self::enable();
+        }
     }
 
     public function url_stat($path)
     {
         self::disable();
-        $return = is_readable($path) ? stat($path) : false;
-        self::enable();
 
-        return $return;
+        try {
+            return is_readable($path) ? stat($path) : false;
+        } finally {
+            self::enable();
+        }
     }
 }

--- a/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
@@ -67,11 +67,6 @@ final class IncludeInterceptorTest extends TestCase
         }
     }
 
-    protected function tearDown(): void
-    {
-        @IncludeInterceptor::disable();
-    }
-
     public static function tearDownAfterClass(): void
     {
         /*
@@ -84,6 +79,11 @@ final class IncludeInterceptorTest extends TestCase
         @IncludeInterceptor::disable();
 
         array_map('unlink', self::$files);
+    }
+
+    protected function tearDown(): void
+    {
+        @IncludeInterceptor::disable();
     }
 
     /**

--- a/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\StreamWrapper;
 
 use Infection\StreamWrapper\IncludeInterceptor;
 use PHPUnit\Framework\Error\Warning;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests IncludeInterceptor for correct operation.
@@ -53,7 +54,7 @@ use PHPUnit\Framework\Error\Warning;
  * Other methods are not essential for interception to work,
  * but still are required to be implemented by a full wrapper
  */
-final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
+final class IncludeInterceptorTest extends TestCase
 {
     private static $files = [];
 
@@ -64,6 +65,11 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
             file_put_contents($tempnam, "<?php return $number;");
             self::$files[$number] = $tempnam;
         }
+    }
+
+    protected function tearDown(): void
+    {
+        @IncludeInterceptor::disable();
     }
 
     public static function tearDownAfterClass(): void
@@ -353,7 +359,7 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
         IncludeInterceptor::enable();
 
         try {
-            chown('file-does-not-exist.txt', 'root');
+            touch('/');
         } catch (Warning $e) {
             $after = include self::$files[1];
 

--- a/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
@@ -244,4 +244,24 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
 
         $this->fail('Badly set up test, exception was not thrown');
     }
+
+    public function test_it_re_enables_interceptor_after_directory_not_found(): void
+    {
+        $expected = include self::$files[2];
+
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::enable();
+
+        try {
+            opendir('dir-does-not-exist');
+        } catch (Warning $e) {
+            $after = include self::$files[1];
+
+            $this->assertSame($after, $expected);
+
+            return;
+        }
+
+        $this->fail('Badly set up test, exception was not thrown');
+    }
 }

--- a/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
@@ -353,6 +353,10 @@ final class IncludeInterceptorTest extends TestCase
 
     public function test_it_re_enables_interceptor_after_file_not_found_with_stream_metadata(): void
     {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('This test cannot be run on Windows.');
+        }
+
         $expected = include self::$files[2];
 
         IncludeInterceptor::intercept(self::$files[1], self::$files[2]);

--- a/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\StreamWrapper;
 
 use Infection\StreamWrapper\IncludeInterceptor;
+use PHPUnit\Framework\Error\Warning;
 
 /**
  * Tests IncludeInterceptor for correct operation.
@@ -222,5 +223,21 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
         rmdir($newname);
 
         IncludeInterceptor::disable();
+    }
+
+    public function test_it_re_enables_interceptor_after_file_not_found(): void
+    {
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::enable();
+
+        try {
+            fopen('file-does-not-exist.txt', 'r');
+        } catch (Warning $e) {
+            $this->assertTrue(IncludeInterceptor::isEnabled());
+
+            return;
+        }
+
+        $this->fail('Badly set up test, exception was not thrown');
     }
 }

--- a/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
@@ -227,13 +227,17 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
 
     public function test_it_re_enables_interceptor_after_file_not_found(): void
     {
+        $expected = include self::$files[2];
+
         IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
         IncludeInterceptor::enable();
 
         try {
             fopen('file-does-not-exist.txt', 'r');
         } catch (Warning $e) {
-            $this->assertTrue(IncludeInterceptor::isEnabled());
+            $after = include self::$files[1];
+
+            $this->assertSame($after, $expected);
 
             return;
         }

--- a/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
@@ -351,12 +351,12 @@ final class IncludeInterceptorTest extends TestCase
         $this->fail('Badly set up test, exception was not thrown');
     }
 
+    /**
+     * @requires OSFAMILY Linux
+     * @requires OSFAMILY Darwin
+     */
     public function test_it_re_enables_interceptor_after_file_not_found_with_stream_metadata(): void
     {
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('This test cannot be run on Windows.');
-        }
-
         $expected = include self::$files[2];
 
         IncludeInterceptor::intercept(self::$files[1], self::$files[2]);

--- a/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
@@ -225,7 +225,7 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
         IncludeInterceptor::disable();
     }
 
-    public function test_it_re_enables_interceptor_after_file_not_found(): void
+    public function test_it_re_enables_interceptor_after_file_not_found_with_fopen(): void
     {
         $expected = include self::$files[2];
 
@@ -245,7 +245,27 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
         $this->fail('Badly set up test, exception was not thrown');
     }
 
-    public function test_it_re_enables_interceptor_after_directory_not_found(): void
+    public function test_it_re_enables_interceptor_after_file_not_found_with_include(): void
+    {
+        $expected = include self::$files[2];
+
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::enable();
+
+        try {
+            include 'file-does-not-exist.txt';
+        } catch (Warning $e) {
+            $after = include self::$files[1];
+
+            $this->assertSame($after, $expected);
+
+            return;
+        }
+
+        $this->fail('Badly set up test, exception was not thrown');
+    }
+
+    public function test_it_re_enables_interceptor_after_directory_not_found_with_opendir(): void
     {
         $expected = include self::$files[2];
 
@@ -254,6 +274,126 @@ final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
 
         try {
             opendir('dir-does-not-exist');
+        } catch (Warning $e) {
+            $after = include self::$files[1];
+
+            $this->assertSame($after, $expected);
+
+            return;
+        }
+
+        $this->fail('Badly set up test, exception was not thrown');
+    }
+
+    public function test_it_re_enables_interceptor_after_directory_already_exist_with_mkdir(): void
+    {
+        $expected = include self::$files[2];
+
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::enable();
+
+        try {
+            mkdir(__DIR__);
+        } catch (Warning $e) {
+            $after = include self::$files[1];
+
+            $this->assertSame($after, $expected);
+
+            return;
+        }
+
+        $this->fail('Badly set up test, exception was not thrown');
+    }
+
+    public function test_it_re_enables_interceptor_after_file_not_found_with_rename(): void
+    {
+        $expected = include self::$files[2];
+
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::enable();
+
+        try {
+            rename('file-does-not-exist.txt', 'something-else.txt');
+        } catch (Warning $e) {
+            $after = include self::$files[1];
+
+            $this->assertSame($after, $expected);
+
+            return;
+        }
+
+        $this->fail('Badly set up test, exception was not thrown');
+    }
+
+    public function test_it_re_enables_interceptor_after_directory_not_found_with_rmdir(): void
+    {
+        $expected = include self::$files[2];
+
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::enable();
+
+        try {
+            rmdir('dir-does-not-exist');
+        } catch (Warning $e) {
+            $after = include self::$files[1];
+
+            $this->assertSame($after, $expected);
+
+            return;
+        }
+
+        $this->fail('Badly set up test, exception was not thrown');
+    }
+
+    public function test_it_re_enables_interceptor_after_file_not_found_with_stream_metadata(): void
+    {
+        $expected = include self::$files[2];
+
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::enable();
+
+        try {
+            chown('file-does-not-exist.txt', 'root');
+        } catch (Warning $e) {
+            $after = include self::$files[1];
+
+            $this->assertSame($after, $expected);
+
+            return;
+        }
+
+        $this->fail('Badly set up test, exception was not thrown');
+    }
+
+    public function test_it_re_enables_interceptor_after_file_not_found_with_unlink(): void
+    {
+        $expected = include self::$files[2];
+
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::enable();
+
+        try {
+            unlink('file-does-not-exist.txt');
+        } catch (Warning $e) {
+            $after = include self::$files[1];
+
+            $this->assertSame($after, $expected);
+
+            return;
+        }
+
+        $this->fail('Badly set up test, exception was not thrown');
+    }
+
+    public function test_it_re_enables_interceptor_after_file_not_found_with_url_stat(): void
+    {
+        $expected = include self::$files[2];
+
+        IncludeInterceptor::intercept(self::$files[1], self::$files[2]);
+        IncludeInterceptor::enable();
+
+        try {
+            copy('file-does-not-exist.txt', 'somewhere-else.txt');
         } catch (Warning $e) {
             $after = include self::$files[1];
 


### PR DESCRIPTION
This PR:

- [x] Covered by tests

Fixes https://github.com/infection/infection/issues/836

Warnings are converted to Errors while running tests under PHPUnit. But due to the fact the interceptor wrapper disables itself before calling fopen, and re-enables itself just after, if an error is thrown in between, the interceptor is never re-enabled.

This is actually the issue we experienced with @Bilge. Because we use Symfony, and one of the cache components attempts to read files in `./var/cache/test/pools` to determine hits and misses as part of the Kernel initialisation. Which means that very early on the interceptor gets disabled, and then mutations are never really applied to the code, so all mutants *appear* to be escaping.

--I've only added the try/finally in the `stream_open` function because I didn't have any example for the other functions, but tell me if you'd rather do the same for all functions on principle.--

I have added a try/finally to all functions disabling and re-enabling the interceptor around a system call, and added specific tests for all of them.