### PR TITLE
Make test case classes non-final

### DIFF
--- a/tests/phpunit/AutoReview/BuildConfigYmlTest.php
+++ b/tests/phpunit/AutoReview/BuildConfigYmlTest.php
@@ -42,7 +42,7 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * @coversNothing
  */
-final class BuildConfigYmlTest extends TestCase
+class BuildConfigYmlTest extends TestCase
 {
     /**
      * @dataProvider providesYamlFilesForTesting

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -49,7 +49,7 @@ use function substr_count;
 /**
  * @coversNothing
  */
-final class MakefileTest extends TestCase
+class MakefileTest extends TestCase
 {
     private const MAKEFILE_PATH = __DIR__ . '/../../../../Makefile';
 

--- a/tests/phpunit/AutoReview/Makefile/Parser.php
+++ b/tests/phpunit/AutoReview/Makefile/Parser.php
@@ -48,7 +48,7 @@ use function strpos;
 use function substr;
 use function trim;
 
-final class Parser
+class Parser
 {
     /**
      * @return array<string[]&string[][]>

--- a/tests/phpunit/AutoReview/Makefile/ParserTest.php
+++ b/tests/phpunit/AutoReview/Makefile/ParserTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\AutoReview\Makefile;
 use Generator;
 use PHPUnit\Framework\TestCase;
 
-final class ParserTest extends TestCase
+class ParserTest extends TestCase
 {
     /**
      * @dataProvider makefileContentProvider

--- a/tests/phpunit/AutoReview/MutatorTest.php
+++ b/tests/phpunit/AutoReview/MutatorTest.php
@@ -45,7 +45,7 @@ use Symfony\Component\Finder\SplFileInfo;
  * This class is responsible for testing that all Mutator classes adhere to certain rules
  * e.g. 'Mutators shouldn't declare any public methods`
  */
-final class MutatorTest extends TestCase
+class MutatorTest extends TestCase
 {
     /**
      * @dataProvider providesMutatorClasses

--- a/tests/phpunit/AutoReview/ProjectCode/DocBlockParser.php
+++ b/tests/phpunit/AutoReview/ProjectCode/DocBlockParser.php
@@ -44,7 +44,7 @@ use function implode;
 use function substr;
 use function trim;
 
-final class DocBlockParser
+class DocBlockParser
 {
     public static function parse(string $docblock): string
     {

--- a/tests/phpunit/AutoReview/ProjectCode/DocBlockParserTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/DocBlockParserTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\AutoReview\ProjectCode;
 use Generator;
 use PHPUnit\Framework\TestCase;
 
-final class DocBlockParserTest extends TestCase
+class DocBlockParserTest extends TestCase
 {
     /**
      * @dataProvider docBlocksProvider

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -84,7 +84,7 @@ use const SORT_STRING;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-final class ProjectCodeProvider
+class ProjectCodeProvider
 {
     /**
      * This array contains all classes that don't have tests yet, due to legacy

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php
@@ -42,7 +42,7 @@ use function trait_exists;
 /**
  * @requires ProjectCodeProviderTest
  */
-final class ProjectCodeProviderTest extends TestCase
+class ProjectCodeProviderTest extends TestCase
 {
     /**
      * @dataProvider \Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider::sourceClassesProvider()

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
@@ -249,14 +249,13 @@ class ProjectCodeTest extends TestCase
     /**
      * @dataProvider \Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider::classesTestProvider
      */
-    public function test_all_test_classes_are_trait_abstract_or_not_final(string $className): void
+    public function test_all_test_classes_are_trait_abstract(string $className): void
     {
         $reflectionClass = new ReflectionClass($className);
 
         $this->assertTrue(
             $reflectionClass->isTrait()
-            || $reflectionClass->isAbstract()
-            || !$reflectionClass->isFinal(),
+            || $reflectionClass->isAbstract(),
             sprintf(
                 'The test class "%s" should be a trait, an abstract or final class.',
                 $className

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
@@ -53,7 +53,7 @@ use function Safe\sprintf;
  * The goal is to reduce pr reviews about style issues that can't be automatically fixed.
  * All test failures should be clear in meaning, to help new contributors.
  */
-final class ProjectCodeTest extends TestCase
+class ProjectCodeTest extends TestCase
 {
     public function test_infection_bin_is_executable(): void
     {
@@ -249,14 +249,14 @@ final class ProjectCodeTest extends TestCase
     /**
      * @dataProvider \Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider::classesTestProvider
      */
-    public function test_all_test_classes_are_trait_abstract_or_final(string $className): void
+    public function test_all_test_classes_are_trait_abstract_or_not_final(string $className): void
     {
         $reflectionClass = new ReflectionClass($className);
 
         $this->assertTrue(
             $reflectionClass->isTrait()
             || $reflectionClass->isAbstract()
-            || $reflectionClass->isFinal(),
+            || !$reflectionClass->isFinal(),
             sprintf(
                 'The test class "%s" should be a trait, an abstract or final class.',
                 $className

--- a/tests/phpunit/Config/ConsoleHelperTest.php
+++ b/tests/phpunit/Config/ConsoleHelperTest.php
@@ -40,7 +40,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class ConsoleHelperTest extends TestCase
+class ConsoleHelperTest extends TestCase
 {
     public function test_it_writes_to_section(): void
     {

--- a/tests/phpunit/Config/Exception/InvalidConfigExceptionTest.php
+++ b/tests/phpunit/Config/Exception/InvalidConfigExceptionTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Config\Exception;
 use Infection\Config\Exception\InvalidConfigException;
 use PHPUnit\Framework\TestCase;
 
-final class InvalidConfigExceptionTest extends TestCase
+class InvalidConfigExceptionTest extends TestCase
 {
     public function test_extends_runtime_exception(): void
     {

--- a/tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php
+++ b/tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Config\Guesser;
 use Infection\Config\Guesser\PhpUnitPathGuesser;
 use PHPUnit\Framework\TestCase;
 
-final class PhpUnitPathGuesserTest extends TestCase
+class PhpUnitPathGuesserTest extends TestCase
 {
     /**
      * @dataProvider providesJsonComposerAndLocations

--- a/tests/phpunit/Config/Guesser/SourceDirGuesserTest.php
+++ b/tests/phpunit/Config/Guesser/SourceDirGuesserTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Config\Guesser;
 use Infection\Config\Guesser\SourceDirGuesser;
 use PHPUnit\Framework\TestCase;
 
-final class SourceDirGuesserTest extends TestCase
+class SourceDirGuesserTest extends TestCase
 {
     public function test_it_parser_psr4(): void
     {

--- a/tests/phpunit/Config/InfectionConfigTest.php
+++ b/tests/phpunit/Config/InfectionConfigTest.php
@@ -41,7 +41,7 @@ use function Infection\Tests\normalizePath as p;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class InfectionConfigTest extends TestCase
+class InfectionConfigTest extends TestCase
 {
     /**
      * @var Filesystem

--- a/tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php
@@ -39,7 +39,7 @@ use Infection\Config\ConsoleHelper;
 use Infection\Config\ValueProvider\ExcludeDirsProvider;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class ExcludeDirsProviderTest extends AbstractBaseProviderTest
+class ExcludeDirsProviderTest extends AbstractBaseProviderTest
 {
     /**
      * @var string

--- a/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
@@ -43,7 +43,7 @@ use function Infection\Tests\normalizePath as p;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Exception\RuntimeException as SymfonyRuntimeException;
 
-final class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProviderTest
+class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProviderTest
 {
     /**
      * @var MockObject|TestFrameworkFinder

--- a/tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php
@@ -40,7 +40,7 @@ use Infection\Config\Guesser\SourceDirGuesser;
 use Infection\Config\ValueProvider\SourceDirsProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
-final class SourceDirsProviderTest extends AbstractBaseProviderTest
+class SourceDirsProviderTest extends AbstractBaseProviderTest
 {
     /**
      * @var SourceDirsProvider

--- a/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -42,7 +42,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
+class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
 {
     /**
      * @var TestFrameworkConfigPathProvider

--- a/tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Config\ValueProvider;
 use Infection\Config\ConsoleHelper;
 use Infection\Config\ValueProvider\TextLogFileProvider;
 
-final class TextLogFileProviderTest extends AbstractBaseProviderTest
+class TextLogFileProviderTest extends AbstractBaseProviderTest
 {
     /**
      * @var TextLogFileProvider

--- a/tests/phpunit/Config/ValueProvider/TimeoutProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TimeoutProviderTest.php
@@ -39,7 +39,7 @@ use Infection\Config\ConsoleHelper;
 use Infection\Config\InfectionConfig;
 use Infection\Config\ValueProvider\TimeoutProvider;
 
-final class TimeoutProviderTest extends AbstractBaseProviderTest
+class TimeoutProviderTest extends AbstractBaseProviderTest
 {
     /**
      * @var TimeoutProvider

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -45,7 +45,7 @@ use Infection\Configuration\Schema\SchemaConfiguration;
 use PHPUnit\Framework\TestCase;
 use function sys_get_temp_dir;
 
-final class ConfigurationFactoryTest extends TestCase
+class ConfigurationFactoryTest extends TestCase
 {
     use ConfigurationAssertions;
 

--- a/tests/phpunit/Configuration/ConfigurationTest.php
+++ b/tests/phpunit/Configuration/ConfigurationTest.php
@@ -43,7 +43,7 @@ use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Entry\Source;
 use PHPUnit\Framework\TestCase;
 
-final class ConfigurationTest extends TestCase
+class ConfigurationTest extends TestCase
 {
     use ConfigurationAssertions;
 

--- a/tests/phpunit/Configuration/Entry/BadgeTest.php
+++ b/tests/phpunit/Configuration/Entry/BadgeTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Configuration\Entry;
 use Infection\Configuration\Entry\Badge;
 use PHPUnit\Framework\TestCase;
 
-final class BadgeTest extends TestCase
+class BadgeTest extends TestCase
 {
     use BadgeAssertions;
 

--- a/tests/phpunit/Configuration/Entry/LogsTest.php
+++ b/tests/phpunit/Configuration/Entry/LogsTest.php
@@ -40,7 +40,7 @@ use Infection\Configuration\Entry\Badge;
 use Infection\Configuration\Entry\Logs;
 use PHPUnit\Framework\TestCase;
 
-final class LogsTest extends TestCase
+class LogsTest extends TestCase
 {
     use LogsAssertions;
 

--- a/tests/phpunit/Configuration/Entry/PhpUnitTest.php
+++ b/tests/phpunit/Configuration/Entry/PhpUnitTest.php
@@ -39,7 +39,7 @@ use Generator;
 use Infection\Configuration\Entry\PhpUnit;
 use PHPUnit\Framework\TestCase;
 
-final class PhpUnitTest extends TestCase
+class PhpUnitTest extends TestCase
 {
     use PhpUnitAssertions;
 

--- a/tests/phpunit/Configuration/Entry/SourceTest.php
+++ b/tests/phpunit/Configuration/Entry/SourceTest.php
@@ -39,7 +39,7 @@ use Generator;
 use Infection\Configuration\Entry\Source;
 use PHPUnit\Framework\TestCase;
 
-final class SourceTest extends TestCase
+class SourceTest extends TestCase
 {
     use SourceAssertions;
 

--- a/tests/phpunit/Configuration/Schema/InvalidFileTest.php
+++ b/tests/phpunit/Configuration/Schema/InvalidFileTest.php
@@ -42,7 +42,7 @@ use Infection\Configuration\Schema\SchemaConfigurationFile;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
-final class InvalidFileTest extends TestCase
+class InvalidFileTest extends TestCase
 {
     public function test_it_can_be_created_for_file_not_found(): void
     {

--- a/tests/phpunit/Configuration/Schema/InvalidSchemaTest.php
+++ b/tests/phpunit/Configuration/Schema/InvalidSchemaTest.php
@@ -41,7 +41,7 @@ use Infection\Configuration\Schema\SchemaConfigurationFile;
 use function Infection\Tests\normalizeLineReturn;
 use PHPUnit\Framework\TestCase;
 
-final class InvalidSchemaTest extends TestCase
+class InvalidSchemaTest extends TestCase
 {
     /**
      * @dataProvider configWithErrorsProvider

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -65,7 +65,7 @@ use function var_export;
  * @covers \Infection\Configuration\Entry\PhpUnit
  * @covers \Infection\Configuration\Entry\Source
  */
-final class SchemaConfigurationFactoryTest extends TestCase
+class SchemaConfigurationFactoryTest extends TestCase
 {
     private const SCHEMA_FILE = 'file://' . __DIR__ . '/../../../../resources/schema.json';
 

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
@@ -47,7 +47,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use function Safe\realpath;
 
-final class SchemaConfigurationFileLoaderTest extends TestCase
+class SchemaConfigurationFileLoaderTest extends TestCase
 {
     /**
      * @var SchemaValidator|MockObject

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
@@ -43,7 +43,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Seld\JsonLint\ParsingException;
 
-final class SchemaConfigurationFileTest extends TestCase
+class SchemaConfigurationFileTest extends TestCase
 {
     private const FIXTURES_DIR = __DIR__ . '/../../Fixtures/Configuration';
 

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php
@@ -44,7 +44,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
-final class SchemaConfigurationLoaderTest extends TestCase
+class SchemaConfigurationLoaderTest extends TestCase
 {
     /**
      * @var Locator|MockObject

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationTest.php
@@ -43,7 +43,7 @@ use Infection\Configuration\Entry\Source;
 use Infection\Configuration\Schema\SchemaConfiguration;
 use PHPUnit\Framework\TestCase;
 
-final class SchemaConfigurationTest extends TestCase
+class SchemaConfigurationTest extends TestCase
 {
     /**
      * @dataProvider valueProvider

--- a/tests/phpunit/Configuration/Schema/SchemaValidatorTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaValidatorTest.php
@@ -46,7 +46,7 @@ use ReflectionClass;
 use function Safe\json_last_error_msg;
 use Webmozart\Assert\Assert;
 
-final class SchemaValidatorTest extends TestCase
+class SchemaValidatorTest extends TestCase
 {
     /**
      * @dataProvider configProvider

--- a/tests/phpunit/Console/ConsoleOutputTest.php
+++ b/tests/phpunit/Console/ConsoleOutputTest.php
@@ -41,7 +41,7 @@ use Infection\Mutant\MetricsCalculator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-final class ConsoleOutputTest extends TestCase
+class ConsoleOutputTest extends TestCase
 {
     public function test_log_verbosity_deprecation_notice(): void
     {

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -51,7 +51,7 @@ use Symfony\Component\Process\Process;
 /**
  * @group e2e
  */
-final class E2ETest extends TestCase
+class E2ETest extends TestCase
 {
     private const MAX_FAILING_COMPOSER_INSTALL = 5;
     private const EXPECT_ERROR = 1;

--- a/tests/phpunit/Console/Exception/ConfigurationExceptionTest.php
+++ b/tests/phpunit/Console/Exception/ConfigurationExceptionTest.php
@@ -39,7 +39,7 @@ use Infection\Console\Exception\ConfigurationException;
 use Infection\Console\Exception\InfectionException;
 use PHPUnit\Framework\TestCase;
 
-final class ConfigurationExceptionTest extends TestCase
+class ConfigurationExceptionTest extends TestCase
 {
     public function test_configuration_aborted(): void
     {

--- a/tests/phpunit/Console/InfectionContainerTest.php
+++ b/tests/phpunit/Console/InfectionContainerTest.php
@@ -40,7 +40,7 @@ use Infection\Console\InfectionContainer;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-final class InfectionContainerTest extends TestCase
+class InfectionContainerTest extends TestCase
 {
     public function test_it_can_be_instantiated_without_any_services(): void
     {

--- a/tests/phpunit/Console/LogVerbosityTest.php
+++ b/tests/phpunit/Console/LogVerbosityTest.php
@@ -42,7 +42,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-final class LogVerbosityTest extends TestCase
+class LogVerbosityTest extends TestCase
 {
     public function test_it_works_if_verbosity_is_valid(): void
     {

--- a/tests/phpunit/Console/OutputFormatter/DotFormatterTest.php
+++ b/tests/phpunit/Console/OutputFormatter/DotFormatterTest.php
@@ -41,7 +41,7 @@ use Infection\Process\MutantProcessInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class DotFormatterTest extends TestCase
+class DotFormatterTest extends TestCase
 {
     public function test_start_logs_inital_starting_text(): void
     {

--- a/tests/phpunit/Differ/DiffColorizerTest.php
+++ b/tests/phpunit/Differ/DiffColorizerTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Differ;
 use Infection\Differ\DiffColorizer;
 use PHPUnit\Framework\TestCase;
 
-final class DiffColorizerTest extends TestCase
+class DiffColorizerTest extends TestCase
 {
     public function test_id_adds_colours(): void
     {

--- a/tests/phpunit/Differ/DifferTest.php
+++ b/tests/phpunit/Differ/DifferTest.php
@@ -39,7 +39,7 @@ use Infection\Differ\Differ;
 use PHPUnit\Framework\TestCase;
 use SebastianBergmann\Diff\Differ as BaseDiffer;
 
-final class DifferTest extends TestCase
+class DifferTest extends TestCase
 {
     public function test_show_diffs_with_max_lines(): void
     {

--- a/tests/phpunit/EventDispatcher/EventDispatcherTest.php
+++ b/tests/phpunit/EventDispatcher/EventDispatcherTest.php
@@ -40,7 +40,7 @@ use Infection\Tests\Fixtures\UserEventSubscriber;
 use Infection\Tests\Fixtures\UserWasCreated;
 use PHPUnit\Framework\TestCase;
 
-final class EventDispatcherTest extends TestCase
+class EventDispatcherTest extends TestCase
 {
     public function test_event_dispatcher_dispatches_events_correctly(): void
     {

--- a/tests/phpunit/Events/ApplicationExecutionFinishedTest.php
+++ b/tests/phpunit/Events/ApplicationExecutionFinishedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\ApplicationExecutionFinished;
 use PHPUnit\Framework\TestCase;
 
-final class ApplicationExecutionFinishedTest extends TestCase
+class ApplicationExecutionFinishedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated

--- a/tests/phpunit/Events/ApplicationExecutionStartedTest.php
+++ b/tests/phpunit/Events/ApplicationExecutionStartedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\ApplicationExecutionStarted;
 use PHPUnit\Framework\TestCase;
 
-final class ApplicationExecutionStartedTest extends TestCase
+class ApplicationExecutionStartedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated

--- a/tests/phpunit/Events/InitialTestCaseCompletedTest.php
+++ b/tests/phpunit/Events/InitialTestCaseCompletedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\InitialTestCaseCompleted;
 use PHPUnit\Framework\TestCase;
 
-final class InitialTestCaseCompletedTest extends TestCase
+class InitialTestCaseCompletedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated

--- a/tests/phpunit/Events/InitialTestSuiteFinishedTest.php
+++ b/tests/phpunit/Events/InitialTestSuiteFinishedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\InitialTestSuiteFinished;
 use PHPUnit\Framework\TestCase;
 
-final class InitialTestSuiteFinishedTest extends TestCase
+class InitialTestSuiteFinishedTest extends TestCase
 {
     public function test_it_passes_the_output_along(): void
     {

--- a/tests/phpunit/Events/InitialTestSuiteStartedTest.php
+++ b/tests/phpunit/Events/InitialTestSuiteStartedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\InitialTestSuiteStarted;
 use PHPUnit\Framework\TestCase;
 
-final class InitialTestSuiteStartedTest extends TestCase
+class InitialTestSuiteStartedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated

--- a/tests/phpunit/Events/MutableFileProcessedTest.php
+++ b/tests/phpunit/Events/MutableFileProcessedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\MutableFileProcessed;
 use PHPUnit\Framework\TestCase;
 
-final class MutableFileProcessedTest extends TestCase
+class MutableFileProcessedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated

--- a/tests/phpunit/Events/MutantCreatedTest.php
+++ b/tests/phpunit/Events/MutantCreatedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\MutantCreated;
 use PHPUnit\Framework\TestCase;
 
-final class MutantCreatedTest extends TestCase
+class MutantCreatedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated

--- a/tests/phpunit/Events/MutantProcessFinishedTest.php
+++ b/tests/phpunit/Events/MutantProcessFinishedTest.php
@@ -39,7 +39,7 @@ use Infection\Events\MutantProcessFinished;
 use Infection\Process\MutantProcessInterface;
 use PHPUnit\Framework\TestCase;
 
-final class MutantProcessFinishedTest extends TestCase
+class MutantProcessFinishedTest extends TestCase
 {
     public function test_it_passes_around_its_mutant_process_without_changing_it(): void
     {

--- a/tests/phpunit/Events/MutantsCreatingFinishedTest.php
+++ b/tests/phpunit/Events/MutantsCreatingFinishedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\MutantsCreatingFinished;
 use PHPUnit\Framework\TestCase;
 
-final class MutantsCreatingFinishedTest extends TestCase
+class MutantsCreatingFinishedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated

--- a/tests/phpunit/Events/MutantsCreatingStartedTest.php
+++ b/tests/phpunit/Events/MutantsCreatingStartedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\MutantsCreatingStarted;
 use PHPUnit\Framework\TestCase;
 
-final class MutantsCreatingStartedTest extends TestCase
+class MutantsCreatingStartedTest extends TestCase
 {
     public function test_it_passes_along_its_mutation_count_without_changing_it(): void
     {

--- a/tests/phpunit/Events/MutationGeneratingFinishedTest.php
+++ b/tests/phpunit/Events/MutationGeneratingFinishedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\MutationGeneratingFinished;
 use PHPUnit\Framework\TestCase;
 
-final class MutationGeneratingFinishedTest extends TestCase
+class MutationGeneratingFinishedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated

--- a/tests/phpunit/Events/MutationGeneratingStartedTest.php
+++ b/tests/phpunit/Events/MutationGeneratingStartedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\MutationGeneratingStarted;
 use PHPUnit\Framework\TestCase;
 
-final class MutationGeneratingStartedTest extends TestCase
+class MutationGeneratingStartedTest extends TestCase
 {
     public function test_it_passes_along_its_mutable_file_count_without_changing_it(): void
     {

--- a/tests/phpunit/Events/MutationTestingFinishedTest.php
+++ b/tests/phpunit/Events/MutationTestingFinishedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\MutationTestingFinished;
 use PHPUnit\Framework\TestCase;
 
-final class MutationTestingFinishedTest extends TestCase
+class MutationTestingFinishedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated

--- a/tests/phpunit/Events/MutationTestingStartedTest.php
+++ b/tests/phpunit/Events/MutationTestingStartedTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Events;
 use Infection\Events\MutationTestingStarted;
 use PHPUnit\Framework\TestCase;
 
-final class MutationTestingStartedTest extends TestCase
+class MutationTestingStartedTest extends TestCase
 {
     public function test_it_passes_along_its_mutation_count_without_changing_it(): void
     {

--- a/tests/phpunit/Exception/InvalidMutatorExceptionTest.php
+++ b/tests/phpunit/Exception/InvalidMutatorExceptionTest.php
@@ -40,7 +40,7 @@ use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\Util\MutatorConfig;
 use PHPUnit\Framework\TestCase;
 
-final class InvalidMutatorExceptionTest extends TestCase
+class InvalidMutatorExceptionTest extends TestCase
 {
     public function test_it_has_correct_user_facing_message(): void
     {

--- a/tests/phpunit/Finder/Exception/FinderExceptionTest.php
+++ b/tests/phpunit/Finder/Exception/FinderExceptionTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Finder\Exception;
 use Infection\Finder\Exception\FinderException;
 use PHPUnit\Framework\TestCase;
 
-final class FinderExceptionTest extends TestCase
+class FinderExceptionTest extends TestCase
 {
     public function test_composer_not_found_exception(): void
     {

--- a/tests/phpunit/Finder/Iterator/RealPathFilterIteratorTest.php
+++ b/tests/phpunit/Finder/Iterator/RealPathFilterIteratorTest.php
@@ -39,7 +39,7 @@ use Infection\Tests\Fixtures\Autoloaded\Finder\MockRelativePathFinder;
 use Infection\Tests\Fixtures\Finder\MockRealPathFinder;
 use PHPUnit\Framework\TestCase;
 
-final class RealPathFilterIteratorTest extends TestCase
+class RealPathFilterIteratorTest extends TestCase
 {
     /**
      * @dataProvider providesFinders

--- a/tests/phpunit/Finder/MockVendor.php
+++ b/tests/phpunit/Finder/MockVendor.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Finder;
 
 use Symfony\Component\Filesystem\Filesystem;
 
-final class MockVendor
+class MockVendor
 {
     public const VENDOR = 'phptester';
     public const PACKAGE = 'awesome-php-tester';

--- a/tests/phpunit/Finder/SourceFilesFinderTest.php
+++ b/tests/phpunit/Finder/SourceFilesFinderTest.php
@@ -39,7 +39,7 @@ use Infection\Finder\SourceFilesFinder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 
-final class SourceFilesFinderTest extends TestCase
+class SourceFilesFinderTest extends TestCase
 {
     public function test_it_lists_all_php_files_without_a_filter(): void
     {

--- a/tests/phpunit/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/Finder/TestFrameworkFinderTest.php
@@ -43,7 +43,7 @@ use Infection\Utils\TmpDirectoryCreator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class TestFrameworkFinderTest extends TestCase
+class TestFrameworkFinderTest extends TestCase
 {
     /**
      * @var string

--- a/tests/phpunit/Json/Exception/JsonValidationExceptionTest.php
+++ b/tests/phpunit/Json/Exception/JsonValidationExceptionTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Json\Exception;
 use Infection\Json\Exception\JsonValidationException;
 use PHPUnit\Framework\TestCase;
 
-final class JsonValidationExceptionTest extends TestCase
+class JsonValidationExceptionTest extends TestCase
 {
     public function test_does_not_match_schema_with_errors(): void
     {

--- a/tests/phpunit/Json/Exception/ParseExceptionTest.php
+++ b/tests/phpunit/Json/Exception/ParseExceptionTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Json\Exception;
 use Infection\Json\Exception\ParseException;
 use PHPUnit\Framework\TestCase;
 
-final class ParseExceptionTest extends TestCase
+class ParseExceptionTest extends TestCase
 {
     public function test_invalid_json(): void
     {

--- a/tests/phpunit/Json/JsonFileTest.php
+++ b/tests/phpunit/Json/JsonFileTest.php
@@ -42,7 +42,7 @@ use JsonSchema\Exception\ValidationException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class JsonFileTest extends TestCase
+class JsonFileTest extends TestCase
 {
     /**
      * @var Filesystem

--- a/tests/phpunit/Locator/FileNotFoundTest.php
+++ b/tests/phpunit/Locator/FileNotFoundTest.php
@@ -39,7 +39,7 @@ use Generator;
 use Infection\Locator\FileNotFound;
 use PHPUnit\Framework\TestCase;
 
-final class FileNotFoundTest extends TestCase
+class FileNotFoundTest extends TestCase
 {
     /**
      * @dataProvider nonExistentPathsProvider

--- a/tests/phpunit/Locator/FileOrDirectoryNotFoundTest.php
+++ b/tests/phpunit/Locator/FileOrDirectoryNotFoundTest.php
@@ -39,7 +39,7 @@ use Generator;
 use Infection\Locator\FileOrDirectoryNotFound;
 use PHPUnit\Framework\TestCase;
 
-final class FileOrDirectoryNotFoundTest extends TestCase
+class FileOrDirectoryNotFoundTest extends TestCase
 {
     /**
      * @dataProvider nonExistentPathsProvider

--- a/tests/phpunit/Locator/RootsFileLocatorTest.php
+++ b/tests/phpunit/Locator/RootsFileLocatorTest.php
@@ -48,7 +48,7 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * @group integration
  */
-final class RootsFileLocatorTest extends TestCase
+class RootsFileLocatorTest extends TestCase
 {
     private const FIXTURES_DIR = __DIR__ . '/../Fixtures/Locator';
 

--- a/tests/phpunit/Locator/RootsFileOrDirectoryLocatorTest.php
+++ b/tests/phpunit/Locator/RootsFileOrDirectoryLocatorTest.php
@@ -48,7 +48,7 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * @group integration
  */
-final class RootsFileOrDirectoryLocatorTest extends TestCase
+class RootsFileOrDirectoryLocatorTest extends TestCase
 {
     private const FIXTURES_DIR = __DIR__ . '/../Fixtures/Locator';
 

--- a/tests/phpunit/Logger/BadgeLoggerTest.php
+++ b/tests/phpunit/Logger/BadgeLoggerTest.php
@@ -42,7 +42,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class BadgeLoggerTest extends TestCase
+class BadgeLoggerTest extends TestCase
 {
     /**
      * @var OutputInterface|MockObject

--- a/tests/phpunit/Logger/DebugFileLoggerTest.php
+++ b/tests/phpunit/Logger/DebugFileLoggerTest.php
@@ -46,7 +46,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class DebugFileLoggerTest extends TestCase
+class DebugFileLoggerTest extends TestCase
 {
     public function test_it_logs_correctly_with_no_mutations(): void
     {

--- a/tests/phpunit/Logger/PerMutatorLoggerTest.php
+++ b/tests/phpunit/Logger/PerMutatorLoggerTest.php
@@ -46,7 +46,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class PerMutatorLoggerTest extends TestCase
+class PerMutatorLoggerTest extends TestCase
 {
     public function test_it_correctly_build_log_lines(): void
     {

--- a/tests/phpunit/Logger/SummaryFileLoggerTest.php
+++ b/tests/phpunit/Logger/SummaryFileLoggerTest.php
@@ -42,7 +42,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class SummaryFileLoggerTest extends TestCase
+class SummaryFileLoggerTest extends TestCase
 {
     /**
      * @var string

--- a/tests/phpunit/Logger/TextFileLoggerTest.php
+++ b/tests/phpunit/Logger/TextFileLoggerTest.php
@@ -48,7 +48,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
-final class TextFileLoggerTest extends TestCase
+class TextFileLoggerTest extends TestCase
 {
     public function test_it_logs_correctly_with_no_mutations_and_no_debug_verbosity(): void
     {

--- a/tests/phpunit/Mutant/Exception/MsiCalculationExceptionTest.php
+++ b/tests/phpunit/Mutant/Exception/MsiCalculationExceptionTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutant\Exception;
 
 use Infection\Mutant\Exception\MsiCalculationException;
 
-final class MsiCalculationExceptionTest extends \PHPUnit\Framework\TestCase
+class MsiCalculationExceptionTest extends \PHPUnit\Framework\TestCase
 {
     public function test_it_is_instance_of_logic_exception(): void
     {

--- a/tests/phpunit/Mutant/Exception/ParserExceptionTest.php
+++ b/tests/phpunit/Mutant/Exception/ParserExceptionTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Mutant\Exception;
 use Infection\Mutant\Exception\ParserException;
 use PHPUnit\Framework\TestCase;
 
-final class ParserExceptionTest extends TestCase
+class ParserExceptionTest extends TestCase
 {
     public function test_it_has_correct_error_message(): void
     {

--- a/tests/phpunit/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/phpunit/Mutant/Generator/MutationsGeneratorTest.php
@@ -57,7 +57,7 @@ use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 
-final class MutationsGeneratorTest extends TestCase
+class MutationsGeneratorTest extends TestCase
 {
     public function test_it_collects_plus_mutation(): void
     {

--- a/tests/phpunit/Mutant/MetricsCalculatorTest.php
+++ b/tests/phpunit/Mutant/MetricsCalculatorTest.php
@@ -41,7 +41,7 @@ use Infection\Process\MutantProcessInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
-final class MetricsCalculatorTest extends TestCase
+class MetricsCalculatorTest extends TestCase
 {
     public function test_it_shows_zero_values_by_default(): void
     {

--- a/tests/phpunit/Mutant/MutantCreatorTest.php
+++ b/tests/phpunit/Mutant/MutantCreatorTest.php
@@ -41,7 +41,7 @@ use Infection\MutationInterface;
 use PhpParser\PrettyPrinter\Standard;
 use PHPUnit\Framework\TestCase;
 
-final class MutantCreatorTest extends TestCase
+class MutantCreatorTest extends TestCase
 {
     private const TEST_FILE_NAME = '/mutant.hash.infection.php';
 

--- a/tests/phpunit/Mutant/MutantTest.php
+++ b/tests/phpunit/Mutant/MutantTest.php
@@ -39,7 +39,7 @@ use Infection\Mutant\Mutant;
 use Infection\MutationInterface;
 use PHPUnit\Framework\TestCase;
 
-final class MutantTest extends TestCase
+class MutantTest extends TestCase
 {
     public function test_it_passes_along_its_input_without_changing_it(): void
     {

--- a/tests/phpunit/MutationTest.php
+++ b/tests/phpunit/MutationTest.php
@@ -41,7 +41,7 @@ use Infection\Mutator\Util\MutatorConfig;
 use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
 
-final class MutationTest extends TestCase
+class MutationTest extends TestCase
 {
     public function test_it_correctly_generates_hash(): void
     {

--- a/tests/phpunit/Mutator/AllMutatorTest.php
+++ b/tests/phpunit/Mutator/AllMutatorTest.php
@@ -52,7 +52,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Throwable;
 
-final class AllMutatorTest extends TestCase
+class AllMutatorTest extends TestCase
 {
     /**
      * @var Parser

--- a/tests/phpunit/Mutator/Arithmetic/AssignmentEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/AssignmentEqualTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class AssignmentEqualTest extends AbstractMutatorTestCase
+class AssignmentEqualTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/AssignmentTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/AssignmentTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class AssignmentTest extends AbstractMutatorTestCase
+class AssignmentTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseAndTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseAndTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class BitwiseAndTest extends AbstractMutatorTestCase
+class BitwiseAndTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseNotTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseNotTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class BitwiseNotTest extends AbstractMutatorTestCase
+class BitwiseNotTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseOrTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseOrTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class BitwiseOrTest extends AbstractMutatorTestCase
+class BitwiseOrTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseXorTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseXorTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class BitwiseXorTest extends AbstractMutatorTestCase
+class BitwiseXorTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/DecrementTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/DecrementTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class DecrementTest extends AbstractMutatorTestCase
+class DecrementTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/DivEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/DivEqualTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class DivEqualTest extends AbstractMutatorTestCase
+class DivEqualTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/DivisionTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/DivisionTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class DivisionTest extends AbstractMutatorTestCase
+class DivisionTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/ExponentiationTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ExponentiationTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class ExponentiationTest extends AbstractMutatorTestCase
+class ExponentiationTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/IncrementTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/IncrementTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class IncrementTest extends AbstractMutatorTestCase
+class IncrementTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/MinusEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MinusEqualTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class MinusEqualTest extends AbstractMutatorTestCase
+class MinusEqualTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/MinusTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MinusTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class MinusTest extends AbstractMutatorTestCase
+class MinusTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/ModEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ModEqualTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class ModEqualTest extends AbstractMutatorTestCase
+class ModEqualTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/ModulusTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ModulusTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class ModulusTest extends AbstractMutatorTestCase
+class ModulusTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/MulEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MulEqualTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class MulEqualTest extends AbstractMutatorTestCase
+class MulEqualTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/MultiplicationTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MultiplicationTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class MultiplicationTest extends AbstractMutatorTestCase
+class MultiplicationTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/PlusEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/PlusEqualTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class PlusEqualTest extends AbstractMutatorTestCase
+class PlusEqualTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/PlusTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/PlusTest.php
@@ -40,7 +40,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Scalar\LNumber;
 
-final class PlusTest extends AbstractMutatorTestCase
+class PlusTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/PowEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/PowEqualTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class PowEqualTest extends AbstractMutatorTestCase
+class PowEqualTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/RoundingFamilyTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/RoundingFamilyTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class RoundingFamilyTest extends AbstractMutatorTestCase
+class RoundingFamilyTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/ShiftLeftTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ShiftLeftTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class ShiftLeftTest extends AbstractMutatorTestCase
+class ShiftLeftTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Arithmetic/ShiftRightTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ShiftRightTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Arithmetic;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class ShiftRightTest extends AbstractMutatorTestCase
+class ShiftRightTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/ArrayItemTest.php
+++ b/tests/phpunit/Mutator/Boolean/ArrayItemTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Boolean;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class ArrayItemTest extends AbstractMutatorTestCase
+class ArrayItemTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Boolean;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class EqualIdenticalTest extends AbstractMutatorTestCase
+class EqualIdenticalTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/FalseValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/FalseValueTest.php
@@ -39,7 +39,7 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name;
 
-final class FalseValueTest extends AbstractMutatorTestCase
+class FalseValueTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Boolean;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class IdenticalEqualTest extends AbstractMutatorTestCase
+class IdenticalEqualTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/LogicalAndTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalAndTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Boolean;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class LogicalAndTest extends AbstractMutatorTestCase
+class LogicalAndTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/LogicalLowerAndTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalLowerAndTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Boolean;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class LogicalLowerAndTest extends AbstractMutatorTestCase
+class LogicalLowerAndTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/LogicalLowerOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalLowerOrTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Boolean;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class LogicalLowerOrTest extends AbstractMutatorTestCase
+class LogicalLowerOrTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/LogicalNotTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalNotTest.php
@@ -40,7 +40,7 @@ use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name;
 
-final class LogicalNotTest extends AbstractMutatorTestCase
+class LogicalNotTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Boolean;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class LogicalOrTest extends AbstractMutatorTestCase
+class LogicalOrTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/NotEqualNotIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/NotEqualNotIdenticalTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Boolean;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class NotEqualNotIdenticalTest extends AbstractMutatorTestCase
+class NotEqualNotIdenticalTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/NotIdenticalNotEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/NotIdenticalNotEqualTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Boolean;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class NotIdenticalNotEqualTest extends AbstractMutatorTestCase
+class NotIdenticalNotEqualTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/TrueValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/TrueValueTest.php
@@ -39,7 +39,7 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name;
 
-final class TrueValueTest extends AbstractMutatorTestCase
+class TrueValueTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Boolean/Yield_Test.php
+++ b/tests/phpunit/Mutator/Boolean/Yield_Test.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Boolean;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class Yield_Test extends AbstractMutatorTestCase
+class Yield_Test extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Cast/CastArrayTest.php
+++ b/tests/phpunit/Mutator/Cast/CastArrayTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Cast;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class CastArrayTest extends AbstractMutatorTestCase
+class CastArrayTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Cast/CastBoolTest.php
+++ b/tests/phpunit/Mutator/Cast/CastBoolTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Cast;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class CastBoolTest extends AbstractMutatorTestCase
+class CastBoolTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Cast/CastFloatTest.php
+++ b/tests/phpunit/Mutator/Cast/CastFloatTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Cast;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class CastFloatTest extends AbstractMutatorTestCase
+class CastFloatTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Cast/CastIntTest.php
+++ b/tests/phpunit/Mutator/Cast/CastIntTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Cast;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class CastIntTest extends AbstractMutatorTestCase
+class CastIntTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Cast/CastObjectTest.php
+++ b/tests/phpunit/Mutator/Cast/CastObjectTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Cast;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class CastObjectTest extends AbstractMutatorTestCase
+class CastObjectTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Cast/CastStringTest.php
+++ b/tests/phpunit/Mutator/Cast/CastStringTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Cast;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class CastStringTest extends AbstractMutatorTestCase
+class CastStringTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanOrEqualToTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanOrEqualToTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalBoundary;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class GreaterThanOrEqualToTest extends AbstractMutatorTestCase
+class GreaterThanOrEqualToTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalBoundary;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class GreaterThanTest extends AbstractMutatorTestCase
+class GreaterThanTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalBoundary/LessThanOrEqualToTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/LessThanOrEqualToTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalBoundary;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class LessThanOrEqualToTest extends AbstractMutatorTestCase
+class LessThanOrEqualToTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalBoundary/LessThanTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/LessThanTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalBoundary;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class LessThanTest extends AbstractMutatorTestCase
+class LessThanTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalNegotiation/EqualTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/EqualTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class EqualTest extends AbstractMutatorTestCase
+class EqualTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanNegotiationTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class GreaterThanNegotiationTest extends AbstractMutatorTestCase
+class GreaterThanNegotiationTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiationTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class GreaterThanOrEqualToNegotiationTest extends AbstractMutatorTestCase
+class GreaterThanOrEqualToNegotiationTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalNegotiation/IdenticalTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/IdenticalTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class IdenticalTest extends AbstractMutatorTestCase
+class IdenticalTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalNegotiation/LessThanNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/LessThanNegotiationTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class LessThanNegotiationTest extends AbstractMutatorTestCase
+class LessThanNegotiationTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiationTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class LessThanOrEqualToNegotiationTest extends AbstractMutatorTestCase
+class LessThanOrEqualToNegotiationTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalNegotiation/NotEqualTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/NotEqualTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class NotEqualTest extends AbstractMutatorTestCase
+class NotEqualTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ConditionalNegotiation/NotIdenticalTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/NotIdenticalTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class NotIdenticalTest extends AbstractMutatorTestCase
+class NotIdenticalTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Extensions/BCMathTest.php
+++ b/tests/phpunit/Mutator/Extensions/BCMathTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Mutator\Extensions;
 use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class BCMathTest extends AbstractMutatorTestCase
+class BCMathTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Extensions/MBStringTest.php
+++ b/tests/phpunit/Mutator/Extensions/MBStringTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Mutator\Extensions;
 use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class MBStringTest extends AbstractMutatorTestCase
+class MBStringTest extends AbstractMutatorTestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\FunctionSignature;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class ProtectedVisibilityTest extends AbstractMutatorTestCase
+class ProtectedVisibilityTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\FunctionSignature;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class PublicVisibilityTest extends AbstractMutatorTestCase
+class PublicVisibilityTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider blacklistedProvider

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Number;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class DecrementIntegerTest extends AbstractMutatorTestCase
+class DecrementIntegerTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Number;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class IncrementIntegerTest extends AbstractMutatorTestCase
+class IncrementIntegerTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Number/OneZeroFloatTest.php
+++ b/tests/phpunit/Mutator/Number/OneZeroFloatTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Number;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class OneZeroFloatTest extends AbstractMutatorTestCase
+class OneZeroFloatTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Number/OneZeroIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/OneZeroIntegerTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Number;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class OneZeroIntegerTest extends AbstractMutatorTestCase
+class OneZeroIntegerTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Operator/AssignCoalesceTest.php
+++ b/tests/phpunit/Mutator/Operator/AssignCoalesceTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Operator;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class AssignCoalesceTest extends AbstractMutatorTestCase
+class AssignCoalesceTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Operator/Break_Test.php
+++ b/tests/phpunit/Mutator/Operator/Break_Test.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Operator;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class Break_Test extends AbstractMutatorTestCase
+class Break_Test extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Operator/CoalesceTest.php
+++ b/tests/phpunit/Mutator/Operator/CoalesceTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Operator;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class CoalesceTest extends AbstractMutatorTestCase
+class CoalesceTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Operator/Continue_Test.php
+++ b/tests/phpunit/Mutator/Operator/Continue_Test.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Operator;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class Continue_Test extends AbstractMutatorTestCase
+class Continue_Test extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Operator/Finally_Test.php
+++ b/tests/phpunit/Mutator/Operator/Finally_Test.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Operator;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class Finally_Test extends AbstractMutatorTestCase
+class Finally_Test extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Operator;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class SpreadTest extends AbstractMutatorTestCase
+class SpreadTest extends AbstractMutatorTestCase
 {
     /**
      * @requires PHP >= 7.4

--- a/tests/phpunit/Mutator/Operator/Throw_Test.php
+++ b/tests/phpunit/Mutator/Operator/Throw_Test.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Operator;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class Throw_Test extends AbstractMutatorTestCase
+class Throw_Test extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Regex/PregMatchMatchesTest.php
+++ b/tests/phpunit/Mutator/Regex/PregMatchMatchesTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Regex;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class PregMatchMatchesTest extends AbstractMutatorTestCase
+class PregMatchMatchesTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider providesMutatorCases

--- a/tests/phpunit/Mutator/Regex/PregQuoteTest.php
+++ b/tests/phpunit/Mutator/Regex/PregQuoteTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Regex;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class PregQuoteTest extends AbstractMutatorTestCase
+class PregQuoteTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
@@ -39,7 +39,7 @@ use Generator;
 use Infection\Config\Exception\InvalidConfigException;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class ArrayItemRemovalTest extends AbstractMutatorTestCase
+class ArrayItemRemovalTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Removal/FunctionCallRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/FunctionCallRemovalTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Removal;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class FunctionCallRemovalTest extends AbstractMutatorTestCase
+class FunctionCallRemovalTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Removal/MethodCallRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/MethodCallRemovalTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Removal;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class MethodCallRemovalTest extends AbstractMutatorTestCase
+class MethodCallRemovalTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ReturnValue;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class ArrayOneItemTest extends AbstractMutatorTestCase
+class ArrayOneItemTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ReturnValue/FloatNegationTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/FloatNegationTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ReturnValue;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class FloatNegationTest extends AbstractMutatorTestCase
+class FloatNegationTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ReturnValue;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class FunctionCallTest extends AbstractMutatorTestCase
+class FunctionCallTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php
@@ -39,7 +39,7 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt\Return_;
 
-final class IntegerNegationTest extends AbstractMutatorTestCase
+class IntegerNegationTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ReturnValue;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class NewObjectTest extends AbstractMutatorTestCase
+class NewObjectTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ReturnValue/ThisTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ThisTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ReturnValue;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class ThisTest extends AbstractMutatorTestCase
+class ThisTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Sort/SpaceshipTest.php
+++ b/tests/phpunit/Mutator/Sort/SpaceshipTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Sort;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class SpaceshipTest extends AbstractMutatorTestCase
+class SpaceshipTest extends AbstractMutatorTestCase
 {
     public function test_get_name(): void
     {

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayChangeKeyCaseTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayChangeKeyCaseTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayChangeKeyCaseTest extends AbstractMutatorTestCase
+class UnwrapArrayChangeKeyCaseTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayChunkTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayChunkTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayChunkTest extends AbstractMutatorTestCase
+class UnwrapArrayChunkTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayColumnTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayColumnTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayColumnTest extends AbstractMutatorTestCase
+class UnwrapArrayColumnTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayCombineTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayCombineTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayCombineTest extends AbstractMutatorTestCase
+class UnwrapArrayCombineTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffAssocTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayDiffAssocTest extends AbstractMutatorTestCase
+class UnwrapArrayDiffAssocTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffKeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffKeyTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayDiffKeyTest extends AbstractMutatorTestCase
+class UnwrapArrayDiffKeyTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayDiffTest extends AbstractMutatorTestCase
+class UnwrapArrayDiffTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUassocTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayDiffUassocTest extends AbstractMutatorTestCase
+class UnwrapArrayDiffUassocTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUkeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUkeyTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayDiffUkeyTest extends AbstractMutatorTestCase
+class UnwrapArrayDiffUkeyTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayFilterTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayFilterTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayFilterTest extends AbstractMutatorTestCase
+class UnwrapArrayFilterTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayFlipTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayFlipTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayFlipTest extends AbstractMutatorTestCase
+class UnwrapArrayFlipTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectAssocTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayIntersectAssocTest extends AbstractMutatorTestCase
+class UnwrapArrayIntersectAssocTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectKeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectKeyTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayIntersectKeyTest extends AbstractMutatorTestCase
+class UnwrapArrayIntersectKeyTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayIntersectTest extends AbstractMutatorTestCase
+class UnwrapArrayIntersectTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUassocTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayIntersectUassocTest extends AbstractMutatorTestCase
+class UnwrapArrayIntersectUassocTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUkeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUkeyTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayIntersectUkeyTest extends AbstractMutatorTestCase
+class UnwrapArrayIntersectUkeyTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayKeysTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayKeysTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayKeysTest extends AbstractMutatorTestCase
+class UnwrapArrayKeysTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayMapTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayMapTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayMapTest extends AbstractMutatorTestCase
+class UnwrapArrayMapTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeRecursiveTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeRecursiveTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayMergeRecursiveTest extends AbstractMutatorTestCase
+class UnwrapArrayMergeRecursiveTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayMergeTest extends AbstractMutatorTestCase
+class UnwrapArrayMergeTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayPadTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayPadTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayPadTest extends AbstractMutatorTestCase
+class UnwrapArrayPadTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReduceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReduceTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayReduceTest extends AbstractMutatorTestCase
+class UnwrapArrayReduceTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceRecursiveTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceRecursiveTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayReplaceRecursiveTest extends AbstractMutatorTestCase
+class UnwrapArrayReplaceRecursiveTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayReplaceTest extends AbstractMutatorTestCase
+class UnwrapArrayReplaceTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReverseTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReverseTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayReverseTest extends AbstractMutatorTestCase
+class UnwrapArrayReverseTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArraySliceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArraySliceTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArraySliceTest extends AbstractMutatorTestCase
+class UnwrapArraySliceTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArraySpliceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArraySpliceTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArraySpliceTest extends AbstractMutatorTestCase
+class UnwrapArraySpliceTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffAssocTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayUdiffAssocTest extends AbstractMutatorTestCase
+class UnwrapArrayUdiffAssocTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayUdiffTest extends AbstractMutatorTestCase
+class UnwrapArrayUdiffTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffUassocTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayUdiffUassocTest extends AbstractMutatorTestCase
+class UnwrapArrayUdiffUassocTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectAssocTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayUintersectAssocTest extends AbstractMutatorTestCase
+class UnwrapArrayUintersectAssocTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayUintersectTest extends AbstractMutatorTestCase
+class UnwrapArrayUintersectTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectUassocTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayUintersectUassocTest extends AbstractMutatorTestCase
+class UnwrapArrayUintersectUassocTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUniqueTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUniqueTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayUniqueTest extends AbstractMutatorTestCase
+class UnwrapArrayUniqueTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayValuesTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayValuesTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapArrayValuesTest extends AbstractMutatorTestCase
+class UnwrapArrayValuesTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapLcFirstTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapLcFirstTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapLcFirstTest extends AbstractMutatorTestCase
+class UnwrapLcFirstTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrRepeatTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrRepeatTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapStrRepeatTest extends AbstractMutatorTestCase
+class UnwrapStrRepeatTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrReplaceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrReplaceTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapStrReplaceTest extends AbstractMutatorTestCase
+class UnwrapStrReplaceTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrToLowerTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrToLowerTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapStrToLowerTest extends AbstractMutatorTestCase
+class UnwrapStrToLowerTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrToUpperTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrToUpperTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapStrToUpperTest extends AbstractMutatorTestCase
+class UnwrapStrToUpperTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapTrimTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapTrimTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapTrimTest extends AbstractMutatorTestCase
+class UnwrapTrimTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapUcFirstTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapUcFirstTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapUcFirstTest extends AbstractMutatorTestCase
+class UnwrapUcFirstTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Unwrap/UnwrapUcWordsTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapUcWordsTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Unwrap;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class UnwrapUcWordsTest extends AbstractMutatorTestCase
+class UnwrapUcWordsTest extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php
+++ b/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php
@@ -41,7 +41,7 @@ use PhpParser\Node\Stmt\Function_;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-final class AbstractValueToNullReturnValueTest extends TestCase
+class AbstractValueToNullReturnValueTest extends TestCase
 {
     protected $testSubject;
 

--- a/tests/phpunit/Mutator/Util/MutatorConfigTest.php
+++ b/tests/phpunit/Mutator/Util/MutatorConfigTest.php
@@ -39,7 +39,7 @@ use Infection\Mutator\Util\MutatorConfig;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-final class MutatorConfigTest extends TestCase
+class MutatorConfigTest extends TestCase
 {
     /**
      * @dataProvider providesIgnoredValues

--- a/tests/phpunit/Mutator/Util/MutatorParserTest.php
+++ b/tests/phpunit/Mutator/Util/MutatorParserTest.php
@@ -40,7 +40,7 @@ use Infection\Mutator\Boolean\TrueValue;
 use Infection\Mutator\Util\MutatorParser;
 use PHPUnit\Framework\TestCase;
 
-final class MutatorParserTest extends TestCase
+class MutatorParserTest extends TestCase
 {
     public function test_it_returns_default_mutators_when_no_input_mutators(): void
     {

--- a/tests/phpunit/Mutator/Util/MutatorProfileTest.php
+++ b/tests/phpunit/Mutator/Util/MutatorProfileTest.php
@@ -39,7 +39,7 @@ use Infection\Mutator\Util\MutatorProfile;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 
-final class MutatorProfileTest extends TestCase
+class MutatorProfileTest extends TestCase
 {
     public function test_all_mutators_have_the_correct_name_in_the_full_mutator_list(): void
     {

--- a/tests/phpunit/Mutator/Util/MutatorsGeneratorTest.php
+++ b/tests/phpunit/Mutator/Util/MutatorsGeneratorTest.php
@@ -49,7 +49,7 @@ use PhpParser\Node\Scalar\DNumber;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-final class MutatorsGeneratorTest extends TestCase
+class MutatorsGeneratorTest extends TestCase
 {
     private static $countDefaultMutators = 0;
 

--- a/tests/phpunit/Mutator/ZeroIteration/For_Test.php
+++ b/tests/phpunit/Mutator/ZeroIteration/For_Test.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ZeroIteration;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class For_Test extends AbstractMutatorTestCase
+class For_Test extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Mutator/ZeroIteration/Foreach_Test.php
+++ b/tests/phpunit/Mutator/ZeroIteration/Foreach_Test.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ZeroIteration;
 
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
-final class Foreach_Test extends AbstractMutatorTestCase
+class Foreach_Test extends AbstractMutatorTestCase
 {
     /**
      * @dataProvider provideMutationCases

--- a/tests/phpunit/Performance/Limiter/MemoryLimiterTest.php
+++ b/tests/phpunit/Performance/Limiter/MemoryLimiterTest.php
@@ -43,7 +43,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
-final class MemoryLimiterTest extends TestCase
+class MemoryLimiterTest extends TestCase
 {
     private const TEST_DIR_LOCATION = __DIR__ . '/../../Fixtures/tmp-memory-files';
 

--- a/tests/phpunit/Performance/Listener/PerformanceLoggerSubscriberTest.php
+++ b/tests/phpunit/Performance/Listener/PerformanceLoggerSubscriberTest.php
@@ -46,7 +46,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class PerformanceLoggerSubscriberTest extends TestCase
+class PerformanceLoggerSubscriberTest extends TestCase
 {
     /**
      * @var OutputInterface|MockObject

--- a/tests/phpunit/Performance/Memory/MemoryFormatterTest.php
+++ b/tests/phpunit/Performance/Memory/MemoryFormatterTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Performance\Memory;
 use Infection\Performance\Memory\MemoryFormatter;
 use PHPUnit\Framework\TestCase;
 
-final class MemoryFormatterTest extends TestCase
+class MemoryFormatterTest extends TestCase
 {
     /**
      * @var MemoryFormatter

--- a/tests/phpunit/Performance/Time/TimeFormatterTest.php
+++ b/tests/phpunit/Performance/Time/TimeFormatterTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Performance\Time;
 use Infection\Performance\Time\TimeFormatter;
 use PHPUnit\Framework\TestCase;
 
-final class TimeFormatterTest extends TestCase
+class TimeFormatterTest extends TestCase
 {
     /**
      * @var TimeFormatter

--- a/tests/phpunit/Performance/Time/TimerTest.php
+++ b/tests/phpunit/Performance/Time/TimerTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Performance\Time;
 use Infection\Performance\Time\Timer;
 use PHPUnit\Framework\TestCase;
 
-final class TimerTest extends TestCase
+class TimerTest extends TestCase
 {
     /**
      * @var Timer

--- a/tests/phpunit/Process/Builder/InitialTestRunProcessBuilderTest.php
+++ b/tests/phpunit/Process/Builder/InitialTestRunProcessBuilderTest.php
@@ -40,7 +40,7 @@ use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Infection\Utils\VersionParser;
 use PHPUnit\Framework\TestCase;
 
-final class InitialTestRunProcessBuilderTest extends TestCase
+class InitialTestRunProcessBuilderTest extends TestCase
 {
     public function test_it_creates_a_process_with_no_timeout(): void
     {

--- a/tests/phpunit/Process/Builder/MutantProcessBuilderTest.php
+++ b/tests/phpunit/Process/Builder/MutantProcessBuilderTest.php
@@ -41,7 +41,7 @@ use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Infection\Utils\VersionParser;
 use PHPUnit\Framework\TestCase;
 
-final class MutantProcessBuilderTest extends TestCase
+class MutantProcessBuilderTest extends TestCase
 {
     public function test_it_creates_a_process_with_timeout(): void
     {

--- a/tests/phpunit/Process/Builder/SubscriberBuilderTest.php
+++ b/tests/phpunit/Process/Builder/SubscriberBuilderTest.php
@@ -53,7 +53,7 @@ use Symfony\Component\Filesystem\Filesystem;
  * InputInterfaces should be mocked here so that the 'getOption' method with paramater 'no-progress'
  * should return true. Otherwise you will see different results based on wheter its running in CI or not.
  */
-final class SubscriberBuilderTest extends TestCase
+class SubscriberBuilderTest extends TestCase
 {
     public function test_it_registers_the_subscribers_when_debugging(): void
     {

--- a/tests/phpunit/Process/Coverage/CoverageRequirementCheckerTest.php
+++ b/tests/phpunit/Process/Coverage/CoverageRequirementCheckerTest.php
@@ -45,7 +45,7 @@ use PHPUnit\Framework\TestCase;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-final class CoverageRequirementCheckerTest extends TestCase
+class CoverageRequirementCheckerTest extends TestCase
 {
     public function test_it_has_debugger_or_coverage_option_on_phpdbg(): void
     {

--- a/tests/phpunit/Process/Listener/CiInitialTestsConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Process/Listener/CiInitialTestsConsoleLoggerSubscriberTest.php
@@ -43,7 +43,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class CiInitialTestsConsoleLoggerSubscriberTest extends TestCase
+class CiInitialTestsConsoleLoggerSubscriberTest extends TestCase
 {
     /**
      * @var OutputInterface|MockObject

--- a/tests/phpunit/Process/Listener/CiMutantCreatingConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Process/Listener/CiMutantCreatingConsoleLoggerSubscriberTest.php
@@ -42,7 +42,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class CiMutantCreatingConsoleLoggerSubscriberTest extends TestCase
+class CiMutantCreatingConsoleLoggerSubscriberTest extends TestCase
 {
     /**
      * @var OutputInterface|MockObject

--- a/tests/phpunit/Process/Listener/CiMutationGeneratingConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Process/Listener/CiMutationGeneratingConsoleLoggerSubscriberTest.php
@@ -42,7 +42,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class CiMutationGeneratingConsoleLoggerSubscriberTest extends TestCase
+class CiMutationGeneratingConsoleLoggerSubscriberTest extends TestCase
 {
     /**
      * @var OutputInterface|MockObject

--- a/tests/phpunit/Process/Listener/CleanUpAfterMutationTestingFinishedSubscriberTest.php
+++ b/tests/phpunit/Process/Listener/CleanUpAfterMutationTestingFinishedSubscriberTest.php
@@ -40,7 +40,7 @@ use Infection\Process\Listener\CleanUpAfterMutationTestingFinishedSubscriber;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class CleanUpAfterMutationTestingFinishedSubscriberTest extends TestCase
+class CleanUpAfterMutationTestingFinishedSubscriberTest extends TestCase
 {
     public function test_it_execute_remove_on_mutation_testing_finished(): void
     {

--- a/tests/phpunit/Process/Listener/InitialTestsConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Process/Listener/InitialTestsConsoleLoggerSubscriberTest.php
@@ -43,7 +43,7 @@ use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class InitialTestsConsoleLoggerSubscriberTest extends TestCase
+class InitialTestsConsoleLoggerSubscriberTest extends TestCase
 {
     public function test_it_reacts_on_initial_test_suite_run(): void
     {

--- a/tests/phpunit/Process/Listener/MutationTestingConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Process/Listener/MutationTestingConsoleLoggerSubscriberTest.php
@@ -48,7 +48,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
+class MutationTestingConsoleLoggerSubscriberTest extends TestCase
 {
     /**
      * @var OutputInterface|MockObject

--- a/tests/phpunit/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
+++ b/tests/phpunit/Process/Listener/MutationTestingResultsLoggerSubscriberTest.php
@@ -48,7 +48,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use function sys_get_temp_dir;
 
-final class MutationTestingResultsLoggerSubscriberTest extends TestCase
+class MutationTestingResultsLoggerSubscriberTest extends TestCase
 {
     /**
      * @var OutputInterface|MockObject

--- a/tests/phpunit/Process/MutantProcessTest.php
+++ b/tests/phpunit/Process/MutantProcessTest.php
@@ -45,7 +45,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
-final class MutantProcessTest extends TestCase
+class MutantProcessTest extends TestCase
 {
     /**
      * @var MutantProcess

--- a/tests/phpunit/Process/Runner/InitialTestsFailedTest.php
+++ b/tests/phpunit/Process/Runner/InitialTestsFailedTest.php
@@ -40,7 +40,7 @@ use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
-final class InitialTestsFailedTest extends TestCase
+class InitialTestsFailedTest extends TestCase
 {
     public function test_log_initial_tests_do_not_pass(): void
     {

--- a/tests/phpunit/Process/Runner/InitialTestsRunnerTest.php
+++ b/tests/phpunit/Process/Runner/InitialTestsRunnerTest.php
@@ -45,7 +45,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
-final class InitialTestsRunnerTest extends TestCase
+class InitialTestsRunnerTest extends TestCase
 {
     public function test_it_dispatches_events(): void
     {

--- a/tests/phpunit/Process/Runner/Parallel/ParallelProcessRunnerTest.php
+++ b/tests/phpunit/Process/Runner/Parallel/ParallelProcessRunnerTest.php
@@ -45,7 +45,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
-final class ParallelProcessRunnerTest extends TestCase
+class ParallelProcessRunnerTest extends TestCase
 {
     public function test_it_does_nothing_when_nothing_to_do(): void
     {

--- a/tests/phpunit/Process/Runner/TestRunConstraintCheckerTest.php
+++ b/tests/phpunit/Process/Runner/TestRunConstraintCheckerTest.php
@@ -39,7 +39,7 @@ use Infection\Mutant\MetricsCalculator;
 use Infection\Process\Runner\TestRunConstraintChecker;
 use PHPUnit\Framework\TestCase;
 
-final class TestRunConstraintCheckerTest extends TestCase
+class TestRunConstraintCheckerTest extends TestCase
 {
     public function test_runs_fail_with_zero_mutations_and_no_ignore_msi_with_zero_mutations_and_required_msi(): void
     {

--- a/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
@@ -52,7 +52,7 @@ use Infection\StreamWrapper\IncludeInterceptor;
  * Other methods are not essential for interception to work,
  * but still are required to be implemented by a full wrapper
  */
-final class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
+class IncludeInterceptorTest extends \PHPUnit\Framework\TestCase
 {
     private static $files = [];
 

--- a/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
+++ b/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
@@ -39,7 +39,7 @@ use Infection\Locator\FileOrDirectoryNotFound;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use function Infection\Tests\normalizePath as p;
 
-final class TestFrameworkConfigLocatorTest extends \PHPUnit\Framework\TestCase
+class TestFrameworkConfigLocatorTest extends \PHPUnit\Framework\TestCase
 {
     private $baseDir = __DIR__ . '/../../Fixtures/ConfigLocator/';
 

--- a/tests/phpunit/TestFramework/Coverage/CachedTestFileDataProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/CachedTestFileDataProviderTest.php
@@ -40,7 +40,7 @@ use Infection\TestFramework\Coverage\TestFileDataProvider;
 use Infection\TestFramework\Coverage\TestFileTimeData;
 use PHPUnit\Framework\TestCase;
 
-final class CachedTestFileDataProviderTest extends TestCase
+class CachedTestFileDataProviderTest extends TestCase
 {
     public function test_the_second_call_returns_cached_result(): void
     {

--- a/tests/phpunit/TestFramework/Coverage/CoverageDoesNotExistExceptionTest.php
+++ b/tests/phpunit/TestFramework/Coverage/CoverageDoesNotExistExceptionTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\Coverage;
 use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
 use PHPUnit\Framework\TestCase;
 
-final class CoverageDoesNotExistExceptionTest extends TestCase
+class CoverageDoesNotExistExceptionTest extends TestCase
 {
     public function test_with(): void
     {

--- a/tests/phpunit/TestFramework/Coverage/CoverageFileDataTest.php
+++ b/tests/phpunit/TestFramework/Coverage/CoverageFileDataTest.php
@@ -40,7 +40,7 @@ use Infection\TestFramework\Coverage\CoverageLineData;
 use Infection\TestFramework\Coverage\MethodLocationData;
 use PHPUnit\Framework\TestCase;
 
-final class CoverageFileDataTest extends TestCase
+class CoverageFileDataTest extends TestCase
 {
     public function test_it_has_default_values(): void
     {

--- a/tests/phpunit/TestFramework/Coverage/CoverageLineDataTest.php
+++ b/tests/phpunit/TestFramework/Coverage/CoverageLineDataTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\Coverage;
 use Infection\TestFramework\Coverage\CoverageLineData;
 use PHPUnit\Framework\TestCase;
 
-final class CoverageLineDataTest extends TestCase
+class CoverageLineDataTest extends TestCase
 {
     public function test_it_creates_self_with_named_constructor_for_test_method(): void
     {

--- a/tests/phpunit/TestFramework/Coverage/MethodLocationDataTest.php
+++ b/tests/phpunit/TestFramework/Coverage/MethodLocationDataTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\Coverage;
 use Infection\TestFramework\Coverage\MethodLocationData;
 use PHPUnit\Framework\TestCase;
 
-final class MethodLocationDataTest extends TestCase
+class MethodLocationDataTest extends TestCase
 {
     public function test_it_creates_self_with_named_constructor(): void
     {

--- a/tests/phpunit/TestFramework/Coverage/NodeLineRangeDataTest.php
+++ b/tests/phpunit/TestFramework/Coverage/NodeLineRangeDataTest.php
@@ -40,7 +40,7 @@ use Infection\TestFramework\Coverage\NodeLineRangeData;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-final class NodeLineRangeDataTest extends TestCase
+class NodeLineRangeDataTest extends TestCase
 {
     public function test_it_can_not_have_an_incorrect_range(): void
     {

--- a/tests/phpunit/TestFramework/Coverage/TestFileNameNotFoundExceptionTest.php
+++ b/tests/phpunit/TestFramework/Coverage/TestFileNameNotFoundExceptionTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\Coverage;
 use Infection\TestFramework\Coverage\TestFileNameNotFoundException;
 use PHPUnit\Framework\TestCase;
 
-final class TestFileNameNotFoundExceptionTest extends TestCase
+class TestFileNameNotFoundExceptionTest extends TestCase
 {
     public function test_from_fqn(): void
     {

--- a/tests/phpunit/TestFramework/Coverage/TestFileTimeDataTest.php
+++ b/tests/phpunit/TestFramework/Coverage/TestFileTimeDataTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\Coverage;
 use Infection\TestFramework\Coverage\TestFileTimeData;
 use PHPUnit\Framework\TestCase;
 
-final class TestFileTimeDataTest extends TestCase
+class TestFileTimeDataTest extends TestCase
 {
     public function test_it_creates_self_object_with_named_constructor(): void
     {

--- a/tests/phpunit/TestFramework/Coverage/XMLLineCodeCoverageTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XMLLineCodeCoverageTest.php
@@ -47,7 +47,7 @@ use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\TestFrameworkTypes;
 use PHPUnit\Framework\TestCase;
 
-final class XMLLineCodeCoverageTest extends TestCase
+class XMLLineCodeCoverageTest extends TestCase
 {
     private $coverageDir = __DIR__ . '/../../Fixtures/Files/phpunit/coverage-xml';
 

--- a/tests/phpunit/TestFramework/FactoryTest.php
+++ b/tests/phpunit/TestFramework/FactoryTest.php
@@ -47,7 +47,7 @@ use Infection\Utils\VersionParser;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class FactoryTest extends TestCase
+class FactoryTest extends TestCase
 {
     public function test_it_throws_an_exception_if_it_cant_find_the_testframework(): void
     {

--- a/tests/phpunit/TestFramework/PhpSpec/Adapter/PhpSpecAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Adapter/PhpSpecAdapterTest.php
@@ -43,7 +43,7 @@ use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
 use Infection\Utils\VersionParser;
 use PHPUnit\Framework\TestCase;
 
-final class PhpSpecAdapterTest extends TestCase
+class PhpSpecAdapterTest extends TestCase
 {
     public function test_it_has_a_name(): void
     {

--- a/tests/phpunit/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\PhpSpec\CommandLine;
 use Infection\TestFramework\PhpSpec\CommandLine\ArgumentsAndOptionsBuilder;
 use PHPUnit\Framework\TestCase;
 
-final class ArgumentsAndOptionsBuilderTest extends TestCase
+class ArgumentsAndOptionsBuilderTest extends TestCase
 {
     public function test_it_builds_correct_command(): void
     {

--- a/tests/phpunit/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
@@ -40,7 +40,7 @@ use Infection\Utils\TmpDirectoryCreator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class InitialConfigBuilderTest extends TestCase
+class InitialConfigBuilderTest extends TestCase
 {
     /**
      * @var Filesystem

--- a/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
@@ -42,7 +42,7 @@ use Infection\Utils\TmpDirectoryCreator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class MutationConfigBuilderTest extends TestCase
+class MutationConfigBuilderTest extends TestCase
 {
     private $tmpDir;
 

--- a/tests/phpunit/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
@@ -41,7 +41,7 @@ use Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 
-final class InitialYamlConfigurationTest extends TestCase
+class InitialYamlConfigurationTest extends TestCase
 {
     protected $tempDir = '/path/to/tmp';
 

--- a/tests/phpunit/TestFramework/PhpSpec/Config/MutationYamlConfigurationTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/MutationYamlConfigurationTest.php
@@ -39,7 +39,7 @@ use Infection\TestFramework\PhpSpec\Config\MutationYamlConfiguration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 
-final class MutationYamlConfigurationTest extends TestCase
+class MutationYamlConfigurationTest extends TestCase
 {
     protected $tempDir = '/path/to/tmp';
 

--- a/tests/phpunit/TestFramework/PhpSpec/Config/NoCodeCoverageExceptionTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/NoCodeCoverageExceptionTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\PhpSpec\Config;
 use Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException;
 use PHPUnit\Framework\TestCase;
 
-final class NoCodeCoverageExceptionTest extends TestCase
+class NoCodeCoverageExceptionTest extends TestCase
 {
     public function test_from_test_framework(): void
     {

--- a/tests/phpunit/TestFramework/PhpSpec/PhpSpecExtraOptionsTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/PhpSpecExtraOptionsTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\PhpSpec;
 use Infection\TestFramework\PhpSpec\PhpSpecExtraOptions;
 use PHPUnit\Framework\TestCase;
 
-final class PhpSpecExtraOptionsTest extends TestCase
+class PhpSpecExtraOptionsTest extends TestCase
 {
     /**
      * @dataProvider mutantProcessProvider

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -45,7 +45,7 @@ use Infection\Utils\VersionParser;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-final class PhpUnitAdapterTest extends TestCase
+class PhpUnitAdapterTest extends TestCase
 {
     /**
      * @var PhpUnitAdapter|MockObject

--- a/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\PhpUnit\CommandLine;
 use Infection\TestFramework\PhpUnit\CommandLine\ArgumentsAndOptionsBuilder;
 use PHPUnit\Framework\TestCase;
 
-final class ArgumentsAndOptionsBuilderTest extends TestCase
+class ArgumentsAndOptionsBuilderTest extends TestCase
 {
     public function test_it_builds_correct_command(): void
     {

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -43,7 +43,7 @@ use Infection\Utils\TmpDirectoryCreator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class InitialConfigBuilderTest extends TestCase
+class InitialConfigBuilderTest extends TestCase
 {
     public const HASH = 'a1b2c3';
 

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -46,7 +46,7 @@ use Infection\Utils\TmpDirectoryCreator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class MutationConfigBuilderTest extends TestCase
+class MutationConfigBuilderTest extends TestCase
 {
     public const HASH = 'a1b2c3';
 

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\PhpUnit\Config\Exception;
 use Infection\TestFramework\PhpUnit\Config\Exception\InvalidPhpUnitXmlConfigException;
 use PHPUnit\Framework\TestCase;
 
-final class InvalidPhpUnitXmlConfigExceptionTest extends TestCase
+class InvalidPhpUnitXmlConfigExceptionTest extends TestCase
 {
     public function test_for_root_node(): void
     {

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
@@ -40,7 +40,7 @@ use function Infection\Tests\normalizePath as p;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class PathReplacerTest extends TestCase
+class PathReplacerTest extends TestCase
 {
     /**
      * @var string

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -41,7 +41,7 @@ use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class XmlConfigurationHelperTest extends TestCase
+class XmlConfigurationHelperTest extends TestCase
 {
     public function test_it_replaces_with_absolute_paths(): void
     {

--- a/tests/phpunit/TestFramework/PhpUnit/Coverage/CoverageXmlParserTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Coverage/CoverageXmlParserTest.php
@@ -40,7 +40,7 @@ use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\PhpUnit\Coverage\Exception\NoLinesExecutedException;
 use PHPUnit\Framework\TestCase;
 
-final class CoverageXmlParserTest extends TestCase
+class CoverageXmlParserTest extends TestCase
 {
     /**
      * @var CoverageXmlParser

--- a/tests/phpunit/TestFramework/PhpUnit/Coverage/Exception/NoLinesExecutedExceptionTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Coverage/Exception/NoLinesExecutedExceptionTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\PhpUnit\Coverage\Exception;
 use Infection\TestFramework\PhpUnit\Coverage\Exception\NoLinesExecutedException;
 use PHPUnit\Framework\TestCase;
 
-final class NoLinesExecutedExceptionTest extends TestCase
+class NoLinesExecutedExceptionTest extends TestCase
 {
     public function test_no_lines_executed(): void
     {

--- a/tests/phpunit/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProviderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Coverage/PhpUnitTestFileDataProviderTest.php
@@ -40,7 +40,7 @@ use Infection\TestFramework\Coverage\TestFileNameNotFoundException;
 use Infection\TestFramework\PhpUnit\Coverage\PhpUnitTestFileDataProvider;
 use PHPUnit\Framework\TestCase;
 
-final class PhpUnitTestFileDataProviderTest extends TestCase
+class PhpUnitTestFileDataProviderTest extends TestCase
 {
     /**
      * @var PhpUnitTestFileDataProvider

--- a/tests/phpunit/TestFramework/PhpUnit/PhpUnitExtraOptionsTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/PhpUnitExtraOptionsTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\TestFramework\PhpUnit;
 use Infection\TestFramework\PhpUnit\PhpUnitExtraOptions;
 use PHPUnit\Framework\TestCase;
 
-final class PhpUnitExtraOptionsTest extends TestCase
+class PhpUnitExtraOptionsTest extends TestCase
 {
     /**
      * @dataProvider mutantProcessProvider

--- a/tests/phpunit/Traverser/PriorityNodeTraverserTest.php
+++ b/tests/phpunit/Traverser/PriorityNodeTraverserTest.php
@@ -40,7 +40,7 @@ use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PHPUnit\Framework\TestCase;
 
-final class PriorityNodeTraverserTest extends TestCase
+class PriorityNodeTraverserTest extends TestCase
 {
     public function test_it_sorts_visitors_by_priorites(): void
     {

--- a/tests/phpunit/Utils/TmpDirectoryCreatorTest.php
+++ b/tests/phpunit/Utils/TmpDirectoryCreatorTest.php
@@ -39,7 +39,7 @@ use Infection\Utils\TmpDirectoryCreator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class TmpDirectoryCreatorTest extends TestCase
+class TmpDirectoryCreatorTest extends TestCase
 {
     /**
      * @var TmpDirectoryCreator

--- a/tests/phpunit/Utils/VersionParserTest.php
+++ b/tests/phpunit/Utils/VersionParserTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Utils;
 use Infection\Utils\VersionParser;
 use PHPUnit\Framework\TestCase;
 
-final class VersionParserTest extends TestCase
+class VersionParserTest extends TestCase
 {
     /**
      * @var VersionParser

--- a/tests/phpunit/Visitor/CloneVisitorTest.php
+++ b/tests/phpunit/Visitor/CloneVisitorTest.php
@@ -40,7 +40,7 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
-final class CloneVisitorTest extends AbstractBaseVisitorTest
+class CloneVisitorTest extends AbstractBaseVisitorTest
 {
     private const CODE = <<<'PHP'
 <?php

--- a/tests/phpunit/Visitor/CodeCoverageClassIgnoreVisitorTest.php
+++ b/tests/phpunit/Visitor/CodeCoverageClassIgnoreVisitorTest.php
@@ -40,7 +40,7 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
-final class CodeCoverageClassIgnoreVisitorTest extends AbstractBaseVisitorTest
+class CodeCoverageClassIgnoreVisitorTest extends AbstractBaseVisitorTest
 {
     private $spyVisitor;
 

--- a/tests/phpunit/Visitor/CodeCoverageMethodIgnoreVisitorTest.php
+++ b/tests/phpunit/Visitor/CodeCoverageMethodIgnoreVisitorTest.php
@@ -43,7 +43,7 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
-final class CodeCoverageMethodIgnoreVisitorTest extends AbstractBaseVisitorTest
+class CodeCoverageMethodIgnoreVisitorTest extends AbstractBaseVisitorTest
 {
     private $spyVisitor;
 

--- a/tests/phpunit/Visitor/FullyQualifiedClassNameVisitorTest.php
+++ b/tests/phpunit/Visitor/FullyQualifiedClassNameVisitorTest.php
@@ -40,7 +40,7 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
-final class FullyQualifiedClassNameVisitorTest extends AbstractBaseVisitorTest
+class FullyQualifiedClassNameVisitorTest extends AbstractBaseVisitorTest
 {
     private $spyVisitor;
 

--- a/tests/phpunit/Visitor/MutatorVisitorTest.php
+++ b/tests/phpunit/Visitor/MutatorVisitorTest.php
@@ -48,7 +48,7 @@ use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 use PHPUnit\Framework\TestCase;
 
-final class MutatorVisitorTest extends TestCase
+class MutatorVisitorTest extends TestCase
 {
     /**
      * @dataProvider providesMutationCases

--- a/tests/phpunit/Visitor/NotMutableIgnoreVisitorTest.php
+++ b/tests/phpunit/Visitor/NotMutableIgnoreVisitorTest.php
@@ -40,7 +40,7 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
-final class NotMutableIgnoreVisitorTest extends AbstractBaseVisitorTest
+class NotMutableIgnoreVisitorTest extends AbstractBaseVisitorTest
 {
     private $spyVisitor;
 

--- a/tests/phpunit/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/Visitor/ReflectionVisitorTest.php
@@ -46,7 +46,7 @@ use PhpParser\NodeVisitorAbstract;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 
-final class ReflectionVisitorTest extends AbstractBaseVisitorTest
+class ReflectionVisitorTest extends AbstractBaseVisitorTest
 {
     private $spyVisitor;
 


### PR DESCRIPTION
I do not think it brings any benefit to mark those classes as internal. Strict reviews are enough to ensure one is not abusing of tests as extension points.

You could argue this might not be a big deal as you could set up your PHP templates in phpStorm to always include final, or that typing final is not a big deal. I however argue that this default:

- requires an extra step from the "default": you need an extra action, typing a keyword or an IDE configuration
- might confuse new contributors as it is not a common practice meaning they will likely have the (auto-review) tests failing either locally or on the CI requiring an extra action again

In other words: yes it's not that big of a deal but I feel it's a small thing that unnecessarily increase the friction when you don't have the right set-up, reflex or are new to the project