### PR TITLE
Merge quality check steps together

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,26 +49,23 @@ cs: $(PHP_CS_FIXER)
 	LC_ALL=C sort -u .gitignore -o .gitignore
 
 .PHONY: phpstan
-phpstan:  	 ## Runs PHPStan
 phpstan: vendor $(PHPSTAN)
 	$(PHPSTAN) analyse src --level=max --configuration ./devTools/phpstan-src.neon --no-interaction --no-progress
 	$(PHPSTAN) analyse tests/phpunit --level=4 --configuration ./devTools/phpstan-tests.neon --no-interaction --no-progress
 
-.PHONY: analyze
-analyze:	 ## Runs Static analyzers and various other checks
-analyze: phpstan validate
-
 .PHONY: validate
-validate:	 ## Checks that the composer.json file is valid
 validate:
 	composer validate --strict
 
 .PHONY: test
 test:		 ## Runs all the tests
-test: test-autoreview test-unit test-e2e test-infection
+test: autoreview test-unit test-e2e test-infection
+
+.PHONY: autoreview
+autoreview: 	 ## Runs various checks (static analysis & AutoReview test suite)
+autoreview: phpstan validate test-autoreview
 
 .PHONY: test-autoreview
-test-autoreview: ## Runs the AutoReview test suite
 test-autoreview:
 	$(PHPUNIT) --configuration=phpunit_autoreview.xml
 

--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,13 @@ phpstan: vendor $(PHPSTAN)
 validate:
 	composer validate --strict
 
-.PHONY: test
-test:		 ## Runs all the tests
-test: autoreview test-unit test-e2e test-infection
-
 .PHONY: autoreview
 autoreview: 	 ## Runs various checks (static analysis & AutoReview test suite)
 autoreview: phpstan validate test-autoreview
+
+.PHONY: test
+test:		 ## Runs all the tests
+test: autoreview test-unit test-e2e test-infection
 
 .PHONY: test-autoreview
 test-autoreview:

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\AutoReview\Makefile;
 
 use function array_filter;
+use function array_replace;
 use function array_shift;
 use function current;
 use function file_get_contents;
@@ -71,11 +72,8 @@ final class MakefileTest extends TestCase
 
 [33mcompile:[0m	  Bundles Infection into a PHAR
 [33mcs:[0m	  	  Runs PHP-CS-Fixer
-[33mphpstan:[0m  	  Runs PHPStan
-[33manalyze:[0m	  Runs Static analyzers and various other checks
-[33mvalidate:[0m	  Checks that the composer.json file is valid
+[33mautoreview:[0m 	  Runs various checks (static analysis & AutoReview test suite)
 [33mtest:[0m		  Runs all the tests
-[33mtest-autoreview:[0m  Runs the AutoReview test suite
 [33mtest-unit:[0m	  Runs the unit tests
 [33mtest-e2e:[0m 	  Runs the end-to-end tests
 [33mtest-infection:[0m   Runs Infection against itself
@@ -277,6 +275,8 @@ EOF;
             ),
             0
         );
+
+        $rootTestTargets = array_replace($rootTestTargets, ['test-autoreview'], ['autoreview']);
 
         $this->assertSame($rootTestTargets, $testDependencies);
     }


### PR DESCRIPTION
I would like to simplify the "quality check" process locally and instead of having multiple commands to run:

- `make cs`
- `make analyze` which also offers the choice of the two subsets
  - `make phpstan`
  - `make validate`
- `make test-autoreview`

Instead I'm proposing `make autoreview` which does:

- `phpstan`
- `validate`
- `test-autoreview`

In other words, `make analyze`, `make cs` is kept as a separate step for now (maybe worth integrating there? I couldn't really make up my mind here). The others are **NOT** removed, simply hidden from the default help list.