### PR TITLE
Do not allow using Infection with Codeception < 3.1.1

### DIFF
--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -9,3 +9,7 @@ parameters:
             path: '%currentWorkingDirectory%/src/Process/Runner/Parallel/ParallelProcessRunner.php'
             message: '#Left side of [\&]{2} is always true#'
         - '#Method Infection\Configuration\Schema\SchemaConfigurationFile::getDecodedContents() should return stdClass but returns stdClass|null.#'
+
+        -
+            path: '%currentWorkingDirectory%/src/TestFramework/Factory.php'
+            message: '#Access to constant VERSION on an unknown class Codeception\\Codecept#'

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -51,7 +51,9 @@ use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use Infection\Utils\VersionParser;
 use InvalidArgumentException;
+use LogicException;
 use function Safe\file_get_contents;
+use function Safe\sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -168,6 +170,7 @@ final class Factory
         }
 
         if ($adapterName === TestFrameworkTypes::CODECEPTION) {
+            $this->ensureCodeceptionVersionIsSupported();
             $codeceptionConfigPath = $this->configLocator->locate(TestFrameworkTypes::CODECEPTION);
             $codeceptionConfigContentParsed = $this->parseYaml($codeceptionConfigPath);
 
@@ -206,5 +209,21 @@ final class Factory
         }
 
         return $codeceptionConfigContentParsed;
+    }
+
+    private function ensureCodeceptionVersionIsSupported(): void
+    {
+        if (!class_exists('\Codeception\Codecept')) {
+            return;
+        }
+
+        if (version_compare(\Codeception\Codecept::VERSION, '3.1.1', '<')) {
+            throw new LogicException(
+                sprintf(
+                    'Current Codeception version "%s" is not supported by Infection. Please use >=3.1.1',
+                    \Codeception\Codecept::VERSION
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
This one and ready to go.

When Test Framework adapters will be extracted to own composer packages, this will be just in `infection/codeception-adapter`'s `composer.json`:

```json
{
    "conflicts": {
        "codeception/codeception": "<3.1.1"
    }
}
```

Now, we can't do it in the root's `composer.json`, because one can use Infection with e.g. PHPSpec while having Codeception installed as well.