### PR TITLE
Introduce a FileSystemTestCase to simplify some I/O dependent test cases

### DIFF
--- a/tests/phpunit/FileSystem/FileSystemTestCase.php
+++ b/tests/phpunit/FileSystem/FileSystemTestCase.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the box project.
+ *
+ * (c) Kevin Herrera <kevin@herrera.io>
+ *     Théo Fidry <theo.fidry@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Infection\Tests\FileSystem;
+
+use function array_map;
+use function array_values;
+use function chdir;
+use const DIRECTORY_SEPARATOR;
+use function getcwd;
+use function Infection\Tests\make_tmp_dir;
+use function Infection\Tests\normalizePath;
+use function natcasesort;
+use PHPUnit\Framework\TestCase;
+use function realpath;
+use function str_replace;
+use Symfony\Component\Filesystem\Filesystem;
+use function sys_get_temp_dir;
+
+/**
+ * @private
+ */
+abstract class FileSystemTestCase extends TestCase
+{
+    /** @var string */
+    protected $cwd;
+
+    /** @var string */
+    protected $tmp;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Cleans up whatever was there before. Indeed upon failure PHPUnit fails to trigger the `tearDown()` method
+        // and as a result some temporary files may still remain.
+        (new Filesystem())->remove(
+            normalizePath(realpath(sys_get_temp_dir()) . '/infection-test')
+        );
+
+        $this->cwd = getcwd();
+        $this->tmp = make_tmp_dir('infection-test', self::class);
+
+        chdir($this->tmp);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        chdir($this->cwd);
+
+        (new Filesystem())->remove($this->tmp);
+    }
+
+    /**
+     * @param string[] $files
+     *
+     * @return string[] File real paths relative to the current temporary directory
+     */
+    final protected function normalizePaths(array $files): array
+    {
+        $root = $this->tmp;
+
+        $files = array_values(
+            array_map(
+                static function (string $file) use ($root): string {
+                    return str_replace($root . DIRECTORY_SEPARATOR, '', $file);
+                },
+                $files
+            )
+        );
+
+        natcasesort($files);
+
+        return array_values($files);
+    }
+}

--- a/tests/phpunit/FileSystem/FileSystemTestCase.php
+++ b/tests/phpunit/FileSystem/FileSystemTestCase.php
@@ -48,7 +48,6 @@ namespace Infection\Tests\FileSystem;
 use function Infection\Tests\make_tmp_dir;
 use function Infection\Tests\normalizePath;
 use PHPUnit\Framework\TestCase;
-use function Safe\chdir;
 use function Safe\getcwd;
 use function Safe\realpath;
 use Symfony\Component\Filesystem\Filesystem;
@@ -80,24 +79,16 @@ abstract class FileSystemTestCase extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         // Cleans up whatever was there before. Indeed upon failure PHPUnit fails to trigger the
         // `tearDown()` method and as a result some temporary files may still remain.
         self::removeTmpDir();
 
         $this->cwd = getcwd();
         $this->tmp = make_tmp_dir(self::TMP_DIR_NAME, self::class);
-
-        chdir($this->tmp);
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
-        chdir($this->cwd);
-
         (new Filesystem())->remove($this->tmp);
     }
 

--- a/tests/phpunit/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/Finder/TestFrameworkFinderTest.php
@@ -39,15 +39,12 @@ use const DIRECTORY_SEPARATOR;
 use Infection\Finder\Exception\FinderException;
 use Infection\Finder\TestFrameworkFinder;
 use Infection\TestFramework\TestFrameworkTypes;
+use Infection\Tests\FileSystem\FileSystemTestCase;
 use function Infection\Tests\normalizePath;
-use Infection\Utils\TmpDirectoryCreator;
-use function microtime;
-use PHPUnit\Framework\TestCase;
-use function random_int;
 use function strlen;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class TestFrameworkFinderTest extends TestCase
+final class TestFrameworkFinderTest extends FileSystemTestCase
 {
     /**
      * @var string
@@ -70,16 +67,6 @@ final class TestFrameworkFinderTest extends TestCase
     private $fileSystem;
 
     /**
-     * @var string
-     */
-    private $workspace;
-
-    /**
-     * @var string
-     */
-    private $tmpDir;
-
-    /**
      * Saves the current environment
      */
     public static function setUpBeforeClass(): void
@@ -100,21 +87,14 @@ final class TestFrameworkFinderTest extends TestCase
 
     protected function setUp(): void
     {
-        self::restorePathEnvironment();
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . microtime(true) . random_int(100, 999);
+        parent::setUp();
 
         $this->fileSystem = new Filesystem();
-        $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->fileSystem->remove($this->workspace);
     }
 
     public function test_it_can_load_a_custom_path(): void
     {
-        $filename = $this->fileSystem->tempnam($this->tmpDir, 'test');
+        $filename = $this->fileSystem->tempnam($this->tmp, 'test');
 
         $frameworkFinder = new TestFrameworkFinder('not-used', $filename);
 
@@ -123,7 +103,7 @@ final class TestFrameworkFinderTest extends TestCase
 
     public function test_invalid_custom_path_throws_exception(): void
     {
-        $filename = $this->fileSystem->tempnam($this->tmpDir, 'test');
+        $filename = $this->fileSystem->tempnam($this->tmp, 'test');
         // Remove it so that the file doesn't exist
         $this->fileSystem->remove($filename);
 
@@ -171,7 +151,7 @@ final class TestFrameworkFinderTest extends TestCase
 
     public function test_it_finds_framework_executable(): void
     {
-        $mock = new MockVendor($this->tmpDir, $this->fileSystem);
+        $mock = new MockVendor($this->tmp, $this->fileSystem);
         $mock->setUpPlatformTest();
 
         // Set the path to a single directory (vendor/bin)
@@ -199,7 +179,7 @@ final class TestFrameworkFinderTest extends TestCase
      */
     public function test_it_finds_framework_script_from_bat(string $methodName): void
     {
-        $mock = new MockVendor($this->tmpDir, $this->fileSystem);
+        $mock = new MockVendor($this->tmp, $this->fileSystem);
         $mock->{$methodName}();
 
         // Set the path to a single directory (vendor/bin)

--- a/tests/phpunit/Json/JsonFileTest.php
+++ b/tests/phpunit/Json/JsonFileTest.php
@@ -35,51 +35,32 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Json;
 
-use const DIRECTORY_SEPARATOR;
 use Generator;
 use Infection\Json\Exception\ParseException;
 use Infection\Json\JsonFile;
-use Infection\Utils\TmpDirectoryCreator;
+use Infection\Tests\FileSystem\FileSystemTestCase;
 use JsonSchema\Exception\ValidationException;
-use function microtime;
-use PHPUnit\Framework\TestCase;
-use function random_int;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class JsonFileTest extends TestCase
+final class JsonFileTest extends FileSystemTestCase
 {
     /**
      * @var Filesystem
      */
     private $filesystem;
 
-    /**
-     * @var string
-     */
-    private $workspace;
-
-    /**
-     * @var string
-     */
-    private $tmpDir;
-
     protected function setUp(): void
     {
-        $this->filesystem = new Filesystem();
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . microtime(true) . random_int(100, 999);
-        $this->tmpDir = (new TmpDirectoryCreator($this->filesystem))->createAndGet($this->workspace);
-    }
+        parent::setUp();
 
-    protected function tearDown(): void
-    {
-        $this->filesystem->remove($this->workspace);
+        $this->filesystem = new Filesystem();
     }
 
     public function test_it_creates_successfully(): void
     {
         $jsonString = '{"timeout": 25, "source": {"directories": ["src"]}}';
 
-        $jsonPath = $this->tmpDir . '/file.json';
+        $jsonPath = $this->tmp . '/file.json';
 
         $this->filesystem->dumpFile($jsonPath, $jsonString);
 
@@ -93,7 +74,7 @@ final class JsonFileTest extends TestCase
     {
         $jsonString = '{"timeout": 25,}';
 
-        $jsonPath = $this->tmpDir . '/file.json';
+        $jsonPath = $this->tmp . '/file.json';
 
         $this->filesystem->dumpFile($jsonPath, $jsonString);
 
@@ -104,7 +85,7 @@ final class JsonFileTest extends TestCase
 
     public function test_it_throws_parse_exception_when_file_is_not_found(): void
     {
-        $jsonPath = $this->tmpDir . '/missing-invalid.json';
+        $jsonPath = $this->tmp . '/missing-invalid.json';
         self::assertFileNotExists($jsonPath);
 
         self::expectException(ParseException::class);
@@ -116,7 +97,7 @@ final class JsonFileTest extends TestCase
     {
         $jsonString = '{"timeout": 25}';
 
-        $jsonPath = $this->tmpDir . '/file.json';
+        $jsonPath = $this->tmp . '/file.json';
 
         $this->filesystem->dumpFile($jsonPath, $jsonString);
 
@@ -130,7 +111,7 @@ final class JsonFileTest extends TestCase
      */
     public function test_it_validates_true_value_mutator(string $jsonString): void
     {
-        $jsonPath = $this->tmpDir . '/file.json';
+        $jsonPath = $this->tmp . '/file.json';
 
         $this->filesystem->dumpFile($jsonPath, $jsonString);
 
@@ -181,7 +162,7 @@ JSON
      */
     public function test_it_throws_exception_for_invalid_true_value_mutator(string $jsonString, string $expectedMessageRegex): void
     {
-        $jsonPath = $this->tmpDir . '/file.json';
+        $jsonPath = $this->tmp . '/file.json';
 
         $this->filesystem->dumpFile($jsonPath, $jsonString);
 

--- a/tests/phpunit/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
@@ -35,50 +35,17 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpSpec\Config\Builder;
 
-use const DIRECTORY_SEPARATOR;
 use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder;
-use Infection\Utils\TmpDirectoryCreator;
-use function microtime;
-use PHPUnit\Framework\TestCase;
-use function random_int;
-use Symfony\Component\Filesystem\Filesystem;
+use Infection\Tests\FileSystem\FileSystemTestCase;
 
-final class InitialConfigBuilderTest extends TestCase
+final class InitialConfigBuilderTest extends FileSystemTestCase
 {
-    /**
-     * @var Filesystem
-     */
-    private $fileSystem;
-
-    /**
-     * @var string
-     */
-    private $tmpDir;
-
-    /**
-     * @var string
-     */
-    private $workspace;
-
-    protected function setUp(): void
-    {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . microtime(true) . random_int(100, 999);
-        $this->fileSystem = new Filesystem();
-
-        $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->fileSystem->remove($this->workspace);
-    }
-
     public function test_it_builds_path_to_initial_config_file(): void
     {
         $originalYamlConfigPath = __DIR__ . '/../../../../Fixtures/Files/phpspec/phpspec.yml';
 
-        $builder = new InitialConfigBuilder($this->tmpDir, $originalYamlConfigPath, false);
+        $builder = new InitialConfigBuilder($this->tmp, $originalYamlConfigPath, false);
 
-        $this->assertSame($this->tmpDir . '/phpspecConfiguration.initial.infection.yml', $builder->build('2.0'));
+        $this->assertSame($this->tmp . '/phpspecConfiguration.initial.infection.yml', $builder->build('2.0'));
     }
 }

--- a/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
@@ -35,43 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpSpec\Config\Builder;
 
-use const DIRECTORY_SEPARATOR;
 use Infection\Mutant\MutantInterface;
 use Infection\MutationInterface;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
-use Infection\Utils\TmpDirectoryCreator;
-use function microtime;
-use PHPUnit\Framework\TestCase;
-use function random_int;
-use Symfony\Component\Filesystem\Filesystem;
+use Infection\Tests\FileSystem\FileSystemTestCase;
 
-final class MutationConfigBuilderTest extends TestCase
+final class MutationConfigBuilderTest extends FileSystemTestCase
 {
-    private $tmpDir;
-
-    /**
-     * @var Filesystem
-     */
-    private $fileSystem;
-
-    /**
-     * @var string
-     */
-    private $workspace;
-
-    protected function setUp(): void
-    {
-        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'infection-test' . microtime(true) . random_int(100, 999);
-
-        $this->fileSystem = new Filesystem();
-        $this->tmpDir = (new TmpDirectoryCreator($this->fileSystem))->createAndGet($this->workspace);
-    }
-
-    protected function tearDown(): void
-    {
-        $this->fileSystem->remove($this->workspace);
-    }
-
     public function test_it_builds_path_to_mutation_config_file(): void
     {
         $projectDir = '/project/dir';
@@ -91,9 +61,9 @@ final class MutationConfigBuilderTest extends TestCase
 
         // TODO for PhpSpec pass file content as well
         // TODO test phpspec after that
-        $builder = new MutationConfigBuilder($this->tmpDir, $originalYamlConfigPath, $projectDir);
+        $builder = new MutationConfigBuilder($this->tmp, $originalYamlConfigPath, $projectDir);
 
-        $this->assertSame($this->tmpDir . '/phpspecConfiguration.a1b2c3.infection.yml', $builder->build($mutant));
+        $this->assertSame($this->tmp . '/phpspecConfiguration.a1b2c3.infection.yml', $builder->build($mutant));
     }
 
     public function test_it_adds_original_bootstrap_file_to_custom_autoload(): void
@@ -113,12 +83,12 @@ final class MutationConfigBuilderTest extends TestCase
         $mutant->method('getMutatedFilePath')
             ->willReturn('/mutated/file/path');
 
-        $builder = new MutationConfigBuilder($this->tmpDir, $originalYamlConfigPath, $projectDir);
+        $builder = new MutationConfigBuilder($this->tmp, $originalYamlConfigPath, $projectDir);
 
-        $this->assertSame($this->tmpDir . '/phpspecConfiguration.a1b2c3.infection.yml', $builder->build($mutant));
+        $this->assertSame($this->tmp . '/phpspecConfiguration.a1b2c3.infection.yml', $builder->build($mutant));
         $this->assertStringContainsString(
             "require_once '/project/dir/bootstrap.php';",
-            file_get_contents($this->tmpDir . '/interceptor.phpspec.autoload.a1b2c3.infection.php')
+            file_get_contents($this->tmp . '/interceptor.phpspec.autoload.a1b2c3.infection.php')
         );
     }
 }


### PR DESCRIPTION
I wanted to get rid of the `TmpDirectoryCreator` class but turns out it's used a lot in our tests, so here is an attempt at addressing the issue.

I think I'll create a filesystem repository soon with some elements from Box since it doesn't look like https://github.com/symfony/symfony/pull/31965 and https://github.com/symfony/symfony/pull/30969 will get merged