### PR TITLE
CoverageDoesNotExistException - fix message

### DIFF
--- a/src/TestFramework/Coverage/CoverageDoesNotExistException.php
+++ b/src/TestFramework/Coverage/CoverageDoesNotExistException.php
@@ -45,6 +45,7 @@ final class CoverageDoesNotExistException extends InfectionException
     private const INFECTION_USAGE_SUGGESTION = <<<TXT
 - Enable xdebug and run infection again
 - Use phpdbg: phpdbg -qrr infection
+- Enable pcov and run infection again
 - Use --coverage option with path to the existing coverage report
 - Use --initial-tests-php-options option with `-d zend_extension=xdebug.so` and/or any extra php parameters
 TXT
@@ -84,7 +85,7 @@ TXT
     public static function unableToGenerate(): self
     {
         return new self(
-            'Neither phpdbg or xdebug has been found. One of those is required by Infection in order to generate coverage data. Either:' .
+            'Neither pcov, phpdbg or xdebug has been found. One of those is required by Infection in order to generate coverage data. Either:' .
             "\n" .
             self::INFECTION_USAGE_SUGGESTION
         );

--- a/tests/phpunit/TestFramework/Coverage/CoverageDoesNotExistExceptionTest.php
+++ b/tests/phpunit/TestFramework/Coverage/CoverageDoesNotExistExceptionTest.php
@@ -53,6 +53,7 @@ final class CoverageDoesNotExistExceptionTest extends TestCase
             'Code Coverage does not exist. File file-index-path is not found. Check phpunit version Infection was run with and generated config files inside tempdir. Make sure to either: ' . "\n" .
             '- Enable xdebug and run infection again' . "\n" .
             '- Use phpdbg: phpdbg -qrr infection' . "\n" .
+            '- Enable pcov and run infection again' . "\n" .
             '- Use --coverage option with path to the existing coverage report' . "\n" .
             '- Use --initial-tests-php-options option with `-d zend_extension=xdebug.so` and/or any extra php parameters', $exception->getMessage()
         );
@@ -87,9 +88,10 @@ final class CoverageDoesNotExistExceptionTest extends TestCase
 
     public function test_log_missed_debugger_or_coverage_option(): void
     {
-        $message = 'Neither phpdbg or xdebug has been found. One of those is required by Infection in order to generate coverage data. Either:' . "\n" .
+        $message = 'Neither pcov, phpdbg or xdebug has been found. One of those is required by Infection in order to generate coverage data. Either:' . "\n" .
             '- Enable xdebug and run infection again' . "\n" .
             '- Use phpdbg: phpdbg -qrr infection' . "\n" .
+            '- Enable pcov and run infection again' . "\n" .
             '- Use --coverage option with path to the existing coverage report' . "\n" .
             '- Use --initial-tests-php-options option with `-d zend_extension=xdebug.so` and/or any extra php parameters';
 


### PR DESCRIPTION
Since PCOV is allowed let's the message - when no coverage tool is used - reflects that.