### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,19 +5,16 @@
 *.jpg binary
 
 # Directories and files we do not want to distribute
-/.build/              export-ignore
-/.ci/                 export-ignore
-/.github/             export-ignore
-/devTools/            export-ignore
-/tests/               export-ignore
-/.editorconfig        export-ignore
-/.gitattributes       export-ignore
-/.gitignore           export-ignore
-/.php_cs.dist         export-ignore
-/.travis.yml          export-ignore
-/appveyor.yml         export-ignore
-/box.json.dist        export-ignore
-/codecov.yml          export-ignore
-/infection.json.dist  export-ignore
-/Makefile             export-ignore
-/phpunit.xml.dist     export-ignore
+/.*                     export-ignore
+/adr/                   export-ignore
+/build/                 export-ignore
+/devTools/              export-ignore
+/tests/                 export-ignore
+/appveyor.yml           export-ignore
+/box.json.dist          export-ignore
+/codecov.yml            export-ignore
+/infection.json.dist    export-ignore
+/Makefile               export-ignore
+/phpunit.xml.dist       export-ignore
+/phpunit_autoreview.xml export-ignore
+/setup_environment.sh   export-ignore


### PR DESCRIPTION
- `/.*` will make all files starting with `.` excluded witch is consistent with the convention that those are hidden ones.
- add `adr` directory
- fix directory name `.build` to `build`
- add file `phpunit_autoreview.xml`
- add file `setup_environment.sh`