### PR TITLE
Tweak MutatorProfile

### DIFF
--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -250,6 +250,7 @@ final class ProfileList
         '@cast',
         '@conditional_boundary',
         '@conditional_negotiation',
+        '@extensions',
         '@function_signature',
         '@number',
         '@operator',
@@ -257,9 +258,8 @@ final class ProfileList
         '@removal',
         '@return_value',
         '@sort',
-        '@zero_iteration',
-        '@extensions',
         '@unwrap',
+        '@zero_iteration',
     ];
 
     public const ALL_MUTATORS = [

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -33,40 +33,40 @@
 
 declare(strict_types=1);
 
-namespace Infection\Mutator\Util;
+namespace Infection\Mutator;
 
 use Infection\Mutator;
 
 /**
  * @internal
  */
-final class MutatorProfile
+final class ProfileList
 {
-    public const MUTATOR_PROFILE_LIST = [
-        //Per category
-        '@arithmetic' => self::ARITHMETIC,
-        '@boolean' => self::BOOLEAN,
-        '@conditional_boundary' => self::CONDITIONAL_BOUNDARY,
-        '@conditional_negotiation' => self::CONDITIONAL_NEGOTIATION,
-        '@equal' => self::EQUAL,
-        '@function_signature' => self::FUNCTION_SIGNATURE,
-        '@identical' => self::IDENTICAL,
-        '@number' => self::NUMBER,
-        '@operator' => self::OPERATOR,
-        '@regex' => self::REGEX,
-        '@removal' => self::REMOVAL,
-        '@return_value' => self::RETURN_VALUE,
-        '@sort' => self::SORT,
-        '@zero_iteration' => self::ZERO_ITERATION,
-        '@cast' => self::CAST,
-        '@unwrap' => self::UNWRAP,
-        '@extensions' => self::EXTENSIONS,
+    public const ALL_PROFILES = [
+        // Per category
+        '@arithmetic' => self::ARITHMETIC_PROFILE,
+        '@boolean' => self::BOOLEAN_PROFILE,
+        '@conditional_boundary' => self::CONDITIONAL_BOUNDARY_PROFILE,
+        '@conditional_negotiation' => self::CONDITIONAL_NEGOTIATION_PROFILE,
+        '@equal' => self::EQUAL_PROFILE,
+        '@function_signature' => self::FUNCTION_SIGNATURE_PROFILE,
+        '@identical' => self::IDENTICAL_PROFILE,
+        '@number' => self::NUMBER_PROFILE,
+        '@operator' => self::OPERATOR_PROFILE,
+        '@regex' => self::REGEX_PROFILE,
+        '@removal' => self::REMOVAL_PROFILE,
+        '@return_value' => self::RETURN_VALUE_PROFILE,
+        '@sort' => self::SORT_PROFILE,
+        '@zero_iteration' => self::ZERO_ITERATION_PROFILE,
+        '@cast' => self::CAST_PROFILE,
+        '@unwrap' => self::UNWRAP_PROFILE,
+        '@extensions' => self::EXTENSIONS_PROFILE,
 
-        //Special Profiles
-        '@default' => self::DEFAULT,
+        // Special Profiles
+        '@default' => self::DEFAULT_PROFILE,
     ];
 
-    public const ARITHMETIC = [
+    public const ARITHMETIC_PROFILE = [
         Mutator\Arithmetic\Assignment::class,
         Mutator\Arithmetic\AssignmentEqual::class,
         Mutator\Arithmetic\BitwiseAnd::class,
@@ -92,7 +92,7 @@ final class MutatorProfile
         Mutator\Arithmetic\ShiftRight::class,
     ];
 
-    public const BOOLEAN = [
+    public const BOOLEAN_PROFILE = [
         Mutator\Boolean\ArrayItem::class,
         Mutator\Boolean\FalseValue::class,
         Mutator\Boolean\LogicalAnd::class,
@@ -104,14 +104,14 @@ final class MutatorProfile
         Mutator\Boolean\Yield_::class,
     ];
 
-    public const CONDITIONAL_BOUNDARY = [
+    public const CONDITIONAL_BOUNDARY_PROFILE = [
         Mutator\ConditionalBoundary\GreaterThan::class,
         Mutator\ConditionalBoundary\GreaterThanOrEqualTo::class,
         Mutator\ConditionalBoundary\LessThan::class,
         Mutator\ConditionalBoundary\LessThanOrEqualTo::class,
     ];
 
-    public const CONDITIONAL_NEGOTIATION = [
+    public const CONDITIONAL_NEGOTIATION_PROFILE = [
         Mutator\ConditionalNegotiation\Equal::class,
         Mutator\ConditionalNegotiation\GreaterThanNegotiation::class,
         Mutator\ConditionalNegotiation\GreaterThanOrEqualToNegotiation::class,
@@ -122,29 +122,29 @@ final class MutatorProfile
         Mutator\ConditionalNegotiation\NotIdentical::class,
     ];
 
-    public const EQUAL = [
+    public const EQUAL_PROFILE = [
         Mutator\Boolean\IdenticalEqual::class,
         Mutator\Boolean\NotIdenticalNotEqual::class,
     ];
 
-    public const FUNCTION_SIGNATURE = [
+    public const FUNCTION_SIGNATURE_PROFILE = [
         Mutator\FunctionSignature\ProtectedVisibility::class,
         Mutator\FunctionSignature\PublicVisibility::class,
     ];
 
-    public const IDENTICAL = [
+    public const IDENTICAL_PROFILE = [
         Mutator\Boolean\EqualIdentical::class,
         Mutator\Boolean\NotEqualNotIdentical::class,
     ];
 
-    public const NUMBER = [
+    public const NUMBER_PROFILE = [
         Mutator\Number\DecrementInteger::class,
         Mutator\Number\IncrementInteger::class,
         Mutator\Number\OneZeroFloat::class,
         Mutator\Number\OneZeroInteger::class,
     ];
 
-    public const OPERATOR = [
+    public const OPERATOR_PROFILE = [
         Mutator\Operator\AssignCoalesce::class,
         Mutator\Operator\Break_::class,
         Mutator\Operator\Coalesce::class,
@@ -154,19 +154,19 @@ final class MutatorProfile
         Mutator\Operator\Throw_::class,
     ];
 
-    public const REGEX = [
+    public const REGEX_PROFILE = [
         Mutator\Regex\PregMatchMatches::class,
         Mutator\Regex\PregQuote::class,
     ];
 
-    public const REMOVAL = [
+    public const REMOVAL_PROFILE = [
         Mutator\Removal\ArrayItemRemoval::class,
         Mutator\Removal\CloneRemoval::class,
         Mutator\Removal\FunctionCallRemoval::class,
         Mutator\Removal\MethodCallRemoval::class,
     ];
 
-    public const RETURN_VALUE = [
+    public const RETURN_VALUE_PROFILE = [
         Mutator\ReturnValue\ArrayOneItem::class,
         Mutator\ReturnValue\FloatNegation::class,
         Mutator\ReturnValue\FunctionCall::class,
@@ -175,16 +175,16 @@ final class MutatorProfile
         Mutator\ReturnValue\This::class,
     ];
 
-    public const SORT = [
+    public const SORT_PROFILE = [
         Mutator\Sort\Spaceship::class,
     ];
 
-    public const ZERO_ITERATION = [
+    public const ZERO_ITERATION_PROFILE = [
         Mutator\ZeroIteration\For_::class,
         Mutator\ZeroIteration\Foreach_::class,
     ];
 
-    public const CAST = [
+    public const CAST_PROFILE = [
         Mutator\Cast\CastArray::class,
         Mutator\Cast\CastBool::class,
         Mutator\Cast\CastFloat::class,
@@ -193,7 +193,7 @@ final class MutatorProfile
         Mutator\Cast\CastString::class,
     ];
 
-    public const UNWRAP = [
+    public const UNWRAP_PROFILE = [
         Mutator\Unwrap\UnwrapArrayChangeKeyCase::class,
         Mutator\Unwrap\UnwrapArrayChunk::class,
         Mutator\Unwrap\UnwrapArrayColumn::class,
@@ -239,12 +239,12 @@ final class MutatorProfile
         Mutator\Unwrap\UnwrapUcWords::class,
     ];
 
-    public const EXTENSIONS = [
+    public const EXTENSIONS_PROFILE = [
         Mutator\Extensions\BCMath::class,
         Mutator\Extensions\MBString::class,
     ];
 
-    public const DEFAULT = [
+    public const DEFAULT_PROFILE = [
         '@arithmetic',
         '@boolean',
         '@cast',
@@ -262,8 +262,8 @@ final class MutatorProfile
         '@unwrap',
     ];
 
-    public const FULL_MUTATOR_LIST = [
-        //Arithmetic
+    public const ALL_MUTATORS = [
+        // Arithmetic
         'Assignment' => Mutator\Arithmetic\Assignment::class,
         'AssignmentEqual' => Mutator\Arithmetic\AssignmentEqual::class,
         'BitwiseAnd' => Mutator\Arithmetic\BitwiseAnd::class,
@@ -288,7 +288,7 @@ final class MutatorProfile
         'ShiftRight' => Mutator\Arithmetic\ShiftRight::class,
         'RoundingFamily' => Mutator\Arithmetic\RoundingFamily::class,
 
-        //Boolean
+        // Boolean
         'ArrayItem' => Mutator\Boolean\ArrayItem::class,
         'EqualIdentical' => Mutator\Boolean\EqualIdentical::class,
         'FalseValue' => Mutator\Boolean\FalseValue::class,
@@ -303,13 +303,13 @@ final class MutatorProfile
         'TrueValue' => Mutator\Boolean\TrueValue::class,
         'Yield_' => Mutator\Boolean\Yield_::class,
 
-        //Conditional Boundary
+        // Conditional Boundary
         'GreaterThan' => Mutator\ConditionalBoundary\GreaterThan::class,
         'GreaterThanOrEqualTo' => Mutator\ConditionalBoundary\GreaterThanOrEqualTo::class,
         'LessThan' => Mutator\ConditionalBoundary\LessThan::class,
         'LessThanOrEqualTo' => Mutator\ConditionalBoundary\LessThanOrEqualTo::class,
 
-        //Conditional Negotiation
+        // Conditional Negotiation
         'Equal' => Mutator\ConditionalNegotiation\Equal::class,
         'GreaterThanNegotiation' => Mutator\ConditionalNegotiation\GreaterThanNegotiation::class,
         'GreaterThanOrEqualToNegotiation' => Mutator\ConditionalNegotiation\GreaterThanOrEqualToNegotiation::class,
@@ -319,17 +319,17 @@ final class MutatorProfile
         'NotEqual' => Mutator\ConditionalNegotiation\NotEqual::class,
         'NotIdentical' => Mutator\ConditionalNegotiation\NotIdentical::class,
 
-        //Function Signature
+        // Function Signature
         'PublicVisibility' => Mutator\FunctionSignature\PublicVisibility::class,
         'ProtectedVisibility' => Mutator\FunctionSignature\ProtectedVisibility::class,
 
-        //Number
+        // Number
         'DecrementInteger' => Mutator\Number\DecrementInteger::class,
         'IncrementInteger' => Mutator\Number\IncrementInteger::class,
         'OneZeroInteger' => Mutator\Number\OneZeroInteger::class,
         'OneZeroFloat' => Mutator\Number\OneZeroFloat::class,
 
-        //Operator
+        // Operator
         'AssignCoalesce' => Mutator\Operator\AssignCoalesce::class,
         'Break_' => Mutator\Operator\Break_::class,
         'Continue_' => Mutator\Operator\Continue_::class,
@@ -338,17 +338,17 @@ final class MutatorProfile
         'Coalesce' => Mutator\Operator\Coalesce::class,
         'Spread' => Mutator\Operator\Spread::class,
 
-        //Regex
+        // Regex
         'PregQuote' => Mutator\Regex\PregQuote::class,
         'PregMatchMatches' => Mutator\Regex\PregMatchMatches::class,
 
-        //Removal
+        // Removal
         'ArrayItemRemoval' => Mutator\Removal\ArrayItemRemoval::class,
         'CloneRemoval' => Mutator\Removal\CloneRemoval::class,
         'FunctionCallRemoval' => Mutator\Removal\FunctionCallRemoval::class,
         'MethodCallRemoval' => Mutator\Removal\MethodCallRemoval::class,
 
-        //Return Value
+        // Return Value
         'ArrayOneItem' => Mutator\ReturnValue\ArrayOneItem::class,
         'FloatNegation' => Mutator\ReturnValue\FloatNegation::class,
         'FunctionCall' => Mutator\ReturnValue\FunctionCall::class,
@@ -356,10 +356,10 @@ final class MutatorProfile
         'NewObject' => Mutator\ReturnValue\NewObject::class,
         'This' => Mutator\ReturnValue\This::class,
 
-        //Sort
+        // Sort
         'Spaceship' => Mutator\Sort\Spaceship::class,
 
-        //Zero Iteration
+        // Zero Iteration
         'Foreach_' => Mutator\ZeroIteration\Foreach_::class,
         'For_' => Mutator\ZeroIteration\For_::class,
 
@@ -420,4 +420,8 @@ final class MutatorProfile
         'BCMath' => Mutator\Extensions\BCMath::class,
         'MBString' => Mutator\Extensions\MBString::class,
     ];
+
+    private function __construct()
+    {
+    }
 }

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -281,9 +281,9 @@ final class ProfileList
         'Plus' => Mutator\Arithmetic\Plus::class,
         'PlusEqual' => Mutator\Arithmetic\PlusEqual::class,
         'PowEqual' => Mutator\Arithmetic\PowEqual::class,
+        'RoundingFamily' => Mutator\Arithmetic\RoundingFamily::class,
         'ShiftLeft' => Mutator\Arithmetic\ShiftLeft::class,
         'ShiftRight' => Mutator\Arithmetic\ShiftRight::class,
-        'RoundingFamily' => Mutator\Arithmetic\RoundingFamily::class,
 
         // Boolean
         'ArrayItem' => Mutator\Boolean\ArrayItem::class,
@@ -317,27 +317,27 @@ final class ProfileList
         'NotIdentical' => Mutator\ConditionalNegotiation\NotIdentical::class,
 
         // Function Signature
-        'PublicVisibility' => Mutator\FunctionSignature\PublicVisibility::class,
         'ProtectedVisibility' => Mutator\FunctionSignature\ProtectedVisibility::class,
+        'PublicVisibility' => Mutator\FunctionSignature\PublicVisibility::class,
 
         // Number
         'DecrementInteger' => Mutator\Number\DecrementInteger::class,
         'IncrementInteger' => Mutator\Number\IncrementInteger::class,
-        'OneZeroInteger' => Mutator\Number\OneZeroInteger::class,
         'OneZeroFloat' => Mutator\Number\OneZeroFloat::class,
+        'OneZeroInteger' => Mutator\Number\OneZeroInteger::class,
 
         // Operator
         'AssignCoalesce' => Mutator\Operator\AssignCoalesce::class,
         'Break_' => Mutator\Operator\Break_::class,
-        'Continue_' => Mutator\Operator\Continue_::class,
-        'Throw_' => Mutator\Operator\Throw_::class,
-        'Finally_' => Mutator\Operator\Finally_::class,
         'Coalesce' => Mutator\Operator\Coalesce::class,
+        'Continue_' => Mutator\Operator\Continue_::class,
+        'Finally_' => Mutator\Operator\Finally_::class,
         'Spread' => Mutator\Operator\Spread::class,
+        'Throw_' => Mutator\Operator\Throw_::class,
 
         // Regex
-        'PregQuote' => Mutator\Regex\PregQuote::class,
         'PregMatchMatches' => Mutator\Regex\PregMatchMatches::class,
+        'PregQuote' => Mutator\Regex\PregQuote::class,
 
         // Removal
         'ArrayItemRemoval' => Mutator\Removal\ArrayItemRemoval::class,

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -43,12 +43,14 @@ use Infection\Mutator;
 final class ProfileList
 {
     public const ALL_PROFILES = [
-        // Per category
         '@arithmetic' => self::ARITHMETIC_PROFILE,
         '@boolean' => self::BOOLEAN_PROFILE,
+        '@cast' => self::CAST_PROFILE,
         '@conditional_boundary' => self::CONDITIONAL_BOUNDARY_PROFILE,
         '@conditional_negotiation' => self::CONDITIONAL_NEGOTIATION_PROFILE,
+        '@default' => self::DEFAULT_PROFILE,
         '@equal' => self::EQUAL_PROFILE,
+        '@extensions' => self::EXTENSIONS_PROFILE,
         '@function_signature' => self::FUNCTION_SIGNATURE_PROFILE,
         '@identical' => self::IDENTICAL_PROFILE,
         '@number' => self::NUMBER_PROFILE,
@@ -57,13 +59,8 @@ final class ProfileList
         '@removal' => self::REMOVAL_PROFILE,
         '@return_value' => self::RETURN_VALUE_PROFILE,
         '@sort' => self::SORT_PROFILE,
-        '@zero_iteration' => self::ZERO_ITERATION_PROFILE,
-        '@cast' => self::CAST_PROFILE,
         '@unwrap' => self::UNWRAP_PROFILE,
-        '@extensions' => self::EXTENSIONS_PROFILE,
-
-        // Special Profiles
-        '@default' => self::DEFAULT_PROFILE,
+        '@zero_iteration' => self::ZERO_ITERATION_PROFILE,
     ];
 
     public const ARITHMETIC_PROFILE = [

--- a/src/Mutator/Util/MutatorsGenerator.php
+++ b/src/Mutator/Util/MutatorsGenerator.php
@@ -37,6 +37,7 @@ namespace Infection\Mutator\Util;
 
 use function array_key_exists;
 use Infection\Config\Exception\InvalidConfigException;
+use Infection\Mutator\ProfileList;
 use stdClass;
 
 /**
@@ -79,7 +80,7 @@ final class MutatorsGenerator
         $this->mutatorList = [];
 
         foreach ($this->mutatorSettings as $mutatorOrProfile => $setting) {
-            if (array_key_exists($mutatorOrProfile, MutatorProfile::MUTATOR_PROFILE_LIST)) {
+            if (array_key_exists($mutatorOrProfile, ProfileList::ALL_PROFILES)) {
                 $this->registerFromProfile($mutatorOrProfile, $setting);
 
                 continue;
@@ -104,10 +105,10 @@ final class MutatorsGenerator
      */
     private function registerFromProfile(string $profile, $setting): void
     {
-        $mutators = MutatorProfile::MUTATOR_PROFILE_LIST[$profile];
+        $mutators = ProfileList::ALL_PROFILES[$profile];
 
         foreach ($mutators as $mutatorOrProfile) {
-            if (array_key_exists($mutatorOrProfile, MutatorProfile::MUTATOR_PROFILE_LIST)) {
+            if (array_key_exists($mutatorOrProfile, ProfileList::ALL_PROFILES)) {
                 $this->registerFromProfile($mutatorOrProfile, $setting);
 
                 continue;
@@ -146,11 +147,11 @@ final class MutatorsGenerator
      */
     private function registerFromName(string $mutator, $setting): void
     {
-        if (!array_key_exists($mutator, MutatorProfile::FULL_MUTATOR_LIST)) {
+        if (!array_key_exists($mutator, ProfileList::ALL_MUTATORS)) {
             throw InvalidConfigException::invalidMutator($mutator);
         }
 
-        $this->registerFromClass(MutatorProfile::FULL_MUTATOR_LIST[$mutator], $setting);
+        $this->registerFromClass(ProfileList::ALL_MUTATORS[$mutator], $setting);
     }
 
     /**

--- a/tests/phpunit/AutoReview/MutatorTest.php
+++ b/tests/phpunit/AutoReview/MutatorTest.php
@@ -35,14 +35,11 @@ declare(strict_types=1);
 
 namespace Infection\Tests\AutoReview;
 
-use Infection\Tests\Mutator\ProfileListProvider;
 use function array_column;
+use Infection\Tests\Mutator\ProfileListProvider;
 use function iterator_to_array;
-use const DIRECTORY_SEPARATOR;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @coversNothing

--- a/tests/phpunit/AutoReview/MutatorTest.php
+++ b/tests/phpunit/AutoReview/MutatorTest.php
@@ -35,6 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Tests\AutoReview;
 
+use Infection\Tests\Mutator\ProfileListProvider;
+use function array_column;
+use function iterator_to_array;
 use const DIRECTORY_SEPARATOR;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -126,31 +129,10 @@ final class MutatorTest extends TestCase
             return $classes;
         }
 
-        $finder = Finder::create()
-            ->files()
-            ->name('*.php')
-            ->in(__DIR__ . '/../../../src/Mutator')
-            ->exclude([
-                'Util',
-            ])
-        ;
-
-        $classes = array_map(
-            static function (SplFileInfo $file) {
-                $fqcnPart = ltrim(str_replace('phpunit', '', $file->getRelativePath()), DIRECTORY_SEPARATOR);
-                $fqcnPart = strtr($fqcnPart, DIRECTORY_SEPARATOR, '\\');
-
-                return sprintf(
-                    '%s\\%s%s%s',
-                    'Infection\\Mutator',
-                    $fqcnPart,
-                    $file->getRelativePath() === 'phpunit' ? '' : '\\',
-                    $file->getBasename('.' . $file->getExtension())
-                );
-            },
-            iterator_to_array($finder, false)
+        $classes = array_column(
+            iterator_to_array(ProfileListProvider::mutatorNameAndClassProvider(), false),
+            1
         );
-        sort($classes);
 
         return $classes;
     }

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -45,7 +45,6 @@ use Infection\Config\Guesser\SourceDirGuesser;
 use Infection\Config\InfectionConfig;
 use Infection\Configuration\Configuration;
 use Infection\Configuration\ConfigurationFactory;
-use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Schema\SchemaConfigurationFactory;
 use Infection\Configuration\Schema\SchemaConfigurationFileLoader;
 use Infection\Configuration\Schema\SchemaValidator;
@@ -158,10 +157,6 @@ final class ProjectCodeProvider
      * @var string[]|null
      */
     private static $testClasses;
-
-    private function __construct()
-    {
-    }
 
     public static function provideSourceClasses(): Generator
     {
@@ -316,5 +311,9 @@ final class ProjectCodeProvider
         yield from generator_to_phpunit_data_provider(
             self::NON_FINAL_EXTENSION_CLASSES
         );
+    }
+
+    private function __construct()
+    {
     }
 }

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -158,6 +158,10 @@ final class ProjectCodeProvider
      */
     private static $testClasses;
 
+    private function __construct()
+    {
+    }
+
     public static function provideSourceClasses(): Generator
     {
         if (null !== self::$sourceClasses) {
@@ -311,9 +315,5 @@ final class ProjectCodeProvider
         yield from generator_to_phpunit_data_provider(
             self::NON_FINAL_EXTENSION_CLASSES
         );
-    }
-
-    private function __construct()
-    {
     }
 }

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -49,7 +49,7 @@ use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Entry\Source;
 use Infection\Configuration\Schema\SchemaConfiguration;
 use Infection\Configuration\Schema\SchemaConfigurationFactory;
-use Infection\Mutator\Util\MutatorProfile;
+use Infection\Mutator\ProfileList;
 use JsonSchema\Validator;
 use const PHP_EOL;
 use PHPUnit\Framework\TestCase;
@@ -1492,7 +1492,7 @@ JSON
         ];
 
         $genericMutatorNamesList = array_keys(array_diff_key(
-            MutatorProfile::FULL_MUTATOR_LIST,
+            ProfileList::ALL_MUTATORS,
             array_fill_keys(
                 [
                     'TrueValue',

--- a/tests/phpunit/Mutator/AllMutatorTest.php
+++ b/tests/phpunit/Mutator/AllMutatorTest.php
@@ -36,9 +36,9 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator;
 
 use Generator;
+use Infection\Mutator\ProfileList;
 use Infection\Mutator\Util\Mutator;
 use Infection\Mutator\Util\MutatorConfig;
-use Infection\Mutator\Util\MutatorProfile;
 use Infection\Tests\Fixtures\NullMutationVisitor;
 use Infection\Visitor\FullyQualifiedClassNameVisitor;
 use Infection\Visitor\NotMutableIgnoreVisitor;
@@ -88,7 +88,7 @@ final class AllMutatorTest extends TestCase
     public function provideMutatorAndCodeCases(): Generator
     {
         foreach ($this->getCodeSamples() as $codeSample) {
-            foreach (MutatorProfile::FULL_MUTATOR_LIST as $mutator) {
+            foreach (ProfileList::ALL_MUTATORS as $mutator) {
                 yield [$codeSample->getContents(), new $mutator(new MutatorConfig([])), $codeSample->getFilename()];
             }
         }

--- a/tests/phpunit/Mutator/ProfileListProvider.php
+++ b/tests/phpunit/Mutator/ProfileListProvider.php
@@ -104,14 +104,12 @@ final class ProfileListProvider
                 continue;
             }
 
-            $mutatorParentReflection = $mutatorReflection->getParentClass();
-
-            if (false === $mutatorParentReflection || Mutator::class !== $mutatorParentReflection->getName()) {
+            if (!self::extendsMutator($mutatorReflection)) {
                 continue;
             }
 
             $mutators[$className] = [
-                realpath($file->getPath()),
+                realpath($file->getPathname()),
                 $className,
                 $shortClassName,
             ];
@@ -165,6 +163,17 @@ final class ProfileListProvider
                 $profileOrMutators,
             ];
         }
+    }
+
+    private static function extendsMutator(ReflectionClass $mutatorReflection): bool
+    {
+        $mutatorParentReflection = $mutatorReflection->getParentClass();
+
+        if (false === $mutatorParentReflection) {
+            return Mutator::class === $mutatorReflection->getName();
+        }
+
+        return self::extendsMutator($mutatorParentReflection);
     }
 
     private function __construct()

--- a/tests/phpunit/Mutator/ProfileListProvider.php
+++ b/tests/phpunit/Mutator/ProfileListProvider.php
@@ -55,7 +55,7 @@ use Webmozart\PathUtil\Path;
 final class ProfileListProvider
 {
     /**
-     * @var string[]|null
+     * @var array<int, array<int, string>>|null
      */
     private static $mutators;
 

--- a/tests/phpunit/Mutator/ProfileListProvider.php
+++ b/tests/phpunit/Mutator/ProfileListProvider.php
@@ -35,28 +35,22 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator;
 
+use function array_filter;
+use const ARRAY_FILTER_USE_KEY;
+use function array_values;
 use Generator;
 use Infection\Mutator\ProfileList;
 use Infection\Mutator\Util\Mutator;
-use PHPUnit\Framework\TestCase;
-use ReflectionClass;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
-use Webmozart\PathUtil\Path;
-use function array_filter;
-use function array_map;
-use function array_values;
-use function in_array;
-use function iterator_to_array;
 use function ksort;
-use function sort;
+use ReflectionClass;
+use function Safe\realpath;
+use const SORT_STRING;
 use function sprintf;
 use function str_replace;
 use function substr;
-use const ARRAY_FILTER_USE_KEY;
-use const DIRECTORY_SEPARATOR;
-use const SORT_STRING;
-use function Safe\realpath;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Webmozart\PathUtil\Path;
 
 final class ProfileListProvider
 {
@@ -69,6 +63,10 @@ final class ProfileListProvider
      * @var array<string,string[]>|null
      */
     private static $profileConstants;
+
+    private function __construct()
+    {
+    }
 
     public static function mutatorNameAndClassProvider(): Generator
     {
@@ -94,7 +92,6 @@ final class ProfileListProvider
 
         foreach ($finder as $file) {
             /** @var SplFileInfo $file */
-
             $shortClassName = substr($file->getFilename(), 0, -4);
             $className = self::getMutatorClassNameFromPath($file->getPathname());
 
@@ -141,20 +138,6 @@ final class ProfileListProvider
         return self::$profileConstants;
     }
 
-    private static function getMutatorClassNameFromPath(string $path): string
-    {
-        $cleanedRelativePath = substr(
-            Path::makeRelative($path, __DIR__.'/../../../src'),
-            0,
-            -4
-        );
-
-        return sprintf(
-            'Infection\%s',
-            str_replace('/', '\\', $cleanedRelativePath)
-        );
-    }
-
     public static function profileProvider(): Generator
     {
         foreach (self::getProfiles() as $profile => $profileOrMutators) {
@@ -163,6 +146,20 @@ final class ProfileListProvider
                 $profileOrMutators,
             ];
         }
+    }
+
+    private static function getMutatorClassNameFromPath(string $path): string
+    {
+        $cleanedRelativePath = substr(
+            Path::makeRelative($path, __DIR__ . '/../../../src'),
+            0,
+            -4
+        );
+
+        return sprintf(
+            'Infection\%s',
+            str_replace('/', '\\', $cleanedRelativePath)
+        );
     }
 
     private static function extendsMutator(ReflectionClass $mutatorReflection): bool
@@ -174,9 +171,5 @@ final class ProfileListProvider
         }
 
         return self::extendsMutator($mutatorParentReflection);
-    }
-
-    private function __construct()
-    {
     }
 }

--- a/tests/phpunit/Mutator/ProfileListProvider.php
+++ b/tests/phpunit/Mutator/ProfileListProvider.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator;
+
+use Generator;
+use Infection\Mutator\ProfileList;
+use Infection\Mutator\Util\Mutator;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Webmozart\PathUtil\Path;
+use function array_filter;
+use function array_map;
+use function array_values;
+use function in_array;
+use function iterator_to_array;
+use function ksort;
+use function sort;
+use function sprintf;
+use function str_replace;
+use function substr;
+use const ARRAY_FILTER_USE_KEY;
+use const DIRECTORY_SEPARATOR;
+use const SORT_STRING;
+use function Safe\realpath;
+
+final class ProfileListProvider
+{
+    /**
+     * @var string[]|null
+     */
+    private static $mutators;
+
+    /**
+     * @var array<string,string[]>|null
+     */
+    private static $profileConstants;
+
+    public static function mutatorNameAndClassProvider(): Generator
+    {
+        foreach (ProfileList::ALL_MUTATORS as $name => $class) {
+            yield [$name, $class];
+        }
+    }
+
+    public static function implementedMutatorProvider(): Generator
+    {
+        if (null !== self::$mutators) {
+            yield from self::$mutators;
+        }
+
+        $finder = Finder::create()
+            ->files()
+            ->name('*.php')
+            ->in(__DIR__ . '/../../../src/Mutator')
+            ->exclude('Util')
+        ;
+
+        $mutators = [];
+
+        foreach ($finder as $file) {
+            /** @var SplFileInfo $file */
+
+            $shortClassName = substr($file->getFilename(), 0, -4);
+            $className = self::getMutatorClassNameFromPath($file->getPathname());
+
+            $relativeClassName = str_replace(
+                '/',
+                '\\',
+                substr($file->getRelativePathname(), 0, -4)
+            );
+
+            $mutatorReflection = new ReflectionClass($className);
+
+            if ($mutatorReflection->isAbstract()) {
+                continue;
+            }
+
+            $mutatorParentReflection = $mutatorReflection->getParentClass();
+
+            if (false === $mutatorParentReflection || Mutator::class !== $mutatorParentReflection->getName()) {
+                continue;
+            }
+
+            $mutators[$className] = [
+                realpath($file->getPath()),
+                $className,
+                $shortClassName,
+                $relativeClassName,
+            ];
+        }
+
+        ksort($mutators, SORT_STRING);
+
+        self::$mutators = array_values($mutators);
+
+        yield from self::$mutators;
+    }
+
+    public static function getProfiles(): array
+    {
+        if (null !== self::$profileConstants) {
+            return self::$profileConstants;
+        }
+
+        $profileListReflection = new ReflectionClass(ProfileList::class);
+
+        self::$profileConstants = array_filter(
+            $profileListReflection->getConstants(),
+            static function (string $constantName): bool {
+                return substr($constantName, -8) === '_PROFILE';
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+
+        return self::$profileConstants;
+    }
+
+    private static function getMutatorClassNameFromPath(string $path): string
+    {
+        $cleanedRelativePath = substr(
+            Path::makeRelative($path, __DIR__.'/../../../src'),
+            0,
+            -4
+        );
+
+        return sprintf(
+            'Infection\%s',
+            str_replace('/', '\\', $cleanedRelativePath)
+        );
+    }
+
+    public static function profileProvider(): Generator
+    {
+        foreach (self::getProfiles() as $profile => $profileOrMutators) {
+            yield $profile => [
+                $profile,
+                $profileOrMutators,
+            ];
+        }
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/tests/phpunit/Mutator/ProfileListProvider.php
+++ b/tests/phpunit/Mutator/ProfileListProvider.php
@@ -98,12 +98,6 @@ final class ProfileListProvider
             $shortClassName = substr($file->getFilename(), 0, -4);
             $className = self::getMutatorClassNameFromPath($file->getPathname());
 
-            $relativeClassName = str_replace(
-                '/',
-                '\\',
-                substr($file->getRelativePathname(), 0, -4)
-            );
-
             $mutatorReflection = new ReflectionClass($className);
 
             if ($mutatorReflection->isAbstract()) {
@@ -120,7 +114,6 @@ final class ProfileListProvider
                 realpath($file->getPath()),
                 $className,
                 $shortClassName,
-                $relativeClassName,
             ];
         }
 

--- a/tests/phpunit/Mutator/ProfileListTest.php
+++ b/tests/phpunit/Mutator/ProfileListTest.php
@@ -35,20 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator;
 
-use Generator;
+use function array_keys;
+use function in_array;
 use Infection\Mutator\ProfileList;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
-use Symfony\Component\Finder\Finder;
-use function array_keys;
-use function array_merge;
-use function array_values;
-use function in_array;
 use function sort;
-use function sprintf;
-use function str_replace;
-use function substr;
 use const SORT_STRING;
+use function sprintf;
 
 final class ProfileListTest extends TestCase
 {
@@ -58,8 +51,7 @@ final class ProfileListTest extends TestCase
     public function test_all_mutators_to_be_listed_by_their_short_and_fully_qualified_class_names(
         string $expectedMutatorName,
         string $mutatorClass
-    ): void
-    {
+    ): void {
         $actualMutatorName = $mutatorClass::getName();
 
         $this->assertSame(
@@ -81,14 +73,13 @@ final class ProfileListTest extends TestCase
         string $mutatorFilePath,
         string $mutatorClassName,
         string $mutatorShortClassName
-    ): void
-    {
+    ): void {
         $this->assertArrayHasKey(
             $mutatorShortClassName,
             ProfileList::ALL_MUTATORS,
             sprintf(
                 'Expected to find the mutator "%s" (found in "%s") to be listed in '
-                .'%s::ALL_MUTATORS',
+                . '%s::ALL_MUTATORS',
                 $mutatorClassName,
                 $mutatorFilePath,
                 ProfileList::class
@@ -102,13 +93,12 @@ final class ProfileListTest extends TestCase
     public function test_all_mutators_are_listed_by_at_least_one_profile(
         string $mutatorFilePath,
         string $mutatorClassName
-    ): void
-    {
+    ): void {
         $this->assertTrue(
             self::isMutatorInAtLeastOneProfile($mutatorClassName),
             sprintf(
                 'Expected the mutator "%s" (found in "%s") to be listed in at least one '
-                .'profile. Please add it to the appropriate %s::*_PROFILE constant',
+                . 'profile. Please add it to the appropriate %s::*_PROFILE constant',
                 $mutatorClassName,
                 $mutatorFilePath,
                 ProfileList::class
@@ -122,8 +112,7 @@ final class ProfileListTest extends TestCase
     public function test_all_mutator_profiles_are_sorted_lexicographically(
         string $profile,
         array $profileOrMutators
-    ): void
-    {
+    ): void {
         $sortedProfileOrMutators = (static function (array $value): array {
             sort($value, SORT_STRING);
 

--- a/tests/phpunit/Mutator/ProfileListTest.php
+++ b/tests/phpunit/Mutator/ProfileListTest.php
@@ -40,6 +40,7 @@ use Infection\Mutator\ProfileList;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
+use function array_keys;
 use function in_array;
 use function sort;
 use function sprintf;
@@ -116,7 +117,7 @@ final class ProfileListTest extends TestCase
     /**
      * @dataProvider \Infection\Tests\Mutator\ProfileListProvider::profileProvider
      */
-    public function test_all_mutator_profiles_are_sorted(
+    public function test_all_mutator_profiles_are_sorted_lexicographically(
         string $profile,
         array $profileOrMutators
     ): void
@@ -134,7 +135,28 @@ final class ProfileListTest extends TestCase
                 'Expected the profiles and mutators listed in %s::%s to be sorted lexicographically',
                 ProfileList::class,
                 $profile
-        ));
+            )
+        );
+    }
+
+    public function test_the_all_profile_constant_lists_profiles_in_a_lexicographical_order(): void
+    {
+        $allProfiles = array_keys(ProfileList::ALL_PROFILES);
+
+        $sortedAllProfiles = (static function (array $value): array {
+            sort($value, SORT_STRING);
+
+            return $value;
+        })($allProfiles);
+
+        $this->assertSame(
+            $sortedAllProfiles,
+            $allProfiles,
+            sprintf(
+                'Expected profiles in %s::ALL_PROFILES to be sorted lexicographically',
+                ProfileList::class
+            )
+        );
     }
 
     private static function isMutatorInAtLeastOneProfile(string $className): bool

--- a/tests/phpunit/Mutator/ProfileListTest.php
+++ b/tests/phpunit/Mutator/ProfileListTest.php
@@ -41,6 +41,8 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
 use function array_keys;
+use function array_merge;
+use function array_values;
 use function in_array;
 use function sort;
 use function sprintf;

--- a/tests/phpunit/Mutator/ProfileListTest.php
+++ b/tests/phpunit/Mutator/ProfileListTest.php
@@ -91,21 +91,6 @@ final class ProfileListTest extends TestCase
                 ProfileList::class
             )
         );
-
-        $listedMutatorClassName = ProfileList::ALL_MUTATORS[$mutatorShortClassName];
-
-        $this->assertSame(
-            $mutatorClassName,
-            $listedMutatorClassName,
-            sprintf(
-                'Expected to find the mutator "%s" for the key "%s" of %s::ALL_MUTATORS. '
-                .'Got "%s',
-                $mutatorClassName,
-                $mutatorShortClassName,
-                ProfileList::class,
-                ProfileList::ALL_MUTATORS[$mutatorShortClassName]
-            )
-        );
     }
 
     /**
@@ -120,7 +105,7 @@ final class ProfileListTest extends TestCase
             self::isMutatorInAtLeastOneProfile($mutatorClassName),
             sprintf(
                 'Expected the mutator "%s" (found in "%s") to be listed in at least one '
-                .'profile. Please add it to one of the *_PROFILE constants of "%s"',
+                .'profile. Please add it to the appropriate %s::*_PROFILE constant',
                 $mutatorClassName,
                 $mutatorFilePath,
                 ProfileList::class

--- a/tests/phpunit/Mutator/ProfileListTest.php
+++ b/tests/phpunit/Mutator/ProfileListTest.php
@@ -52,7 +52,7 @@ final class ProfileListTest extends TestCase
     /**
      * @dataProvider \Infection\Tests\Mutator\ProfileListProvider::mutatorNameAndClassProvider
      */
-    public function test_all_mutators_have_the_correct_name_in_the_full_mutator_list(
+    public function test_all_mutators_to_be_listed_by_their_short_and_fully_qualified_class_names(
         string $expectedMutatorName,
         string $mutatorClass
     ): void

--- a/tests/phpunit/Mutator/ProfileListTest.php
+++ b/tests/phpunit/Mutator/ProfileListTest.php
@@ -33,16 +33,16 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Mutator\Util;
+namespace Infection\Tests\Mutator;
 
 use Generator;
-use function in_array;
 use Infection\Mutator\ProfileList;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
+use function in_array;
 
-final class MutatorProfileTest extends TestCase
+final class ProfileListTest extends TestCase
 {
     public function test_all_mutators_have_the_correct_name_in_the_full_mutator_list(): void
     {

--- a/tests/phpunit/Mutator/ProfileListTest.php
+++ b/tests/phpunit/Mutator/ProfileListTest.php
@@ -41,122 +41,121 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
 use function in_array;
+use function sort;
+use function sprintf;
+use function str_replace;
+use function substr;
+use const SORT_STRING;
 
 final class ProfileListTest extends TestCase
 {
-    public function test_all_mutators_have_the_correct_name_in_the_full_mutator_list(): void
-    {
-        foreach (ProfileList::ALL_MUTATORS as $name => $class) {
-            $this->assertSame(
-                $name,
-                $class::getName(),
-                sprintf(
-                    'Invalid name "%s" provided for the class "%s", expected "%s" as key',
-                    $name,
-                    $class,
-                    $class::getName()
-                )
-            );
-        }
-    }
-
-    public function test_all_mutators_are_part_of_the_full_mutators_list(): void
-    {
-        foreach ($this->getMutatorFiles() as $file) {
-            $class = substr($file->getFilename(), 0, -4);
-
-            $this->assertArrayHasKey(
-                $class,
-                ProfileList::ALL_MUTATORS,
-                sprintf(
-                    'The mutator "%s" located in "%s" has not been added to the FULL_MUTATOR_LIST in the MutatorProfile class. ' .
-                    'Please add it to ensure it can be used.',
-                    $class,
-                    $file->getPath()
-                )
-            );
-        }
-    }
-
-    public function test_all_mutators_are_part_of_at_least_one_profile(): void
-    {
-        $profileConstants = $this->getMutatorProfileConstants();
-
-        foreach ($this->getMutatorFiles() as $file) {
-            $className = substr($file->getFilename(), 0, -4);
-            $relativeClassName = str_replace(
-                '/',
-                '\\',
-                substr($file->getRelativePathname(), 0, -4)
-            );
-
-            $this->assertTrue(
-                $this->isMutatorInAtLeastOneProfile($relativeClassName, $profileConstants),
-                sprintf(
-                    'The mutator "%s" located in "%s" has not been added to any profile in the MutatorProfile class. ' .
-                    'Please add it to ensure it can be used.',
-                    $className,
-                    $file->getPath()
-                )
-            );
-        }
-    }
-
     /**
-     * @dataProvider providerMutatorProfile
+     * @dataProvider \Infection\Tests\Mutator\ProfileListProvider::mutatorNameAndClassProvider
      */
-    public function test_all_mutator_profiles_are_sorted(string $name, array $mutators): void
+    public function test_all_mutators_have_the_correct_name_in_the_full_mutator_list(
+        string $expectedMutatorName,
+        string $mutatorClass
+    ): void
     {
-        $sorted = $mutators;
+        $actualMutatorName = $mutatorClass::getName();
 
-        sort($sorted);
-
-        $this->assertSame($sorted, $mutators, sprintf(
-            'Failed asserting that mutators listed in profile "%s" are sorted by name, please sort them.',
-            $name
-        ));
-    }
-
-    public function providerMutatorProfile(): Generator
-    {
-        foreach ($this->getMutatorProfileConstants() as $name => $mutators) {
-            yield $name => [
-                $name,
-                $mutators,
-            ];
-        }
-    }
-
-    private function getMutatorFiles(): Finder
-    {
-        return Finder::create()
-            ->name('*.php')
-            ->in('src/Mutator')
-            ->exclude('Util')
-            ->notName('/Abstract.*/')
-            ->files();
-    }
-
-    private function getMutatorProfileConstants(): array
-    {
-        $reflectionClass = new ReflectionClass(ProfileList::class);
-        $excludedConstants = ['MUTATOR_PROFILE_LIST', 'DEFAULT', 'FULL_MUTATOR_LIST'];
-
-        return array_filter(
-            $reflectionClass->getConstants(),
-            static function (string $constantName) use ($excludedConstants): bool {
-                return !in_array($constantName, $excludedConstants, true);
-            },
-            ARRAY_FILTER_USE_KEY
+        $this->assertSame(
+            $expectedMutatorName,
+            $actualMutatorName,
+            sprintf(
+                'Expected the name "%s" for the mutator "%s". Got "%s"',
+                $actualMutatorName,
+                $expectedMutatorName,
+                $mutatorClass
+            )
         );
     }
 
-    private function isMutatorInAtLeastOneProfile(string $relativeClassName, array $profiles): bool
+    /**
+     * @dataProvider \Infection\Tests\Mutator\ProfileListProvider::implementedMutatorProvider
+     */
+    public function test_all_mutators_are_listed_in_the_all_mutators_constant(
+        string $mutatorFilePath,
+        string $mutatorClassName,
+        string $mutatorShortClassName
+    ): void
     {
-        foreach ($profiles as $mutatorsInProfile) {
-            $fqcn = sprintf('Infection\\Mutator\\%s', $relativeClassName);
+        $this->assertArrayHasKey(
+            $mutatorShortClassName,
+            ProfileList::ALL_MUTATORS,
+            sprintf(
+                'Expected to find the mutator "%s" (found in "%s") to be listed in '
+                .'%s::ALL_MUTATORS',
+                $mutatorClassName,
+                $mutatorFilePath,
+                ProfileList::class
+            )
+        );
 
-            if (in_array($fqcn, $mutatorsInProfile, true)) {
+        $listedMutatorClassName = ProfileList::ALL_MUTATORS[$mutatorShortClassName];
+
+        $this->assertSame(
+            $mutatorClassName,
+            $listedMutatorClassName,
+            sprintf(
+                'Expected to find the mutator "%s" for the key "%s" of %s::ALL_MUTATORS. '
+                .'Got "%s',
+                $mutatorClassName,
+                $mutatorShortClassName,
+                ProfileList::class,
+                ProfileList::ALL_MUTATORS[$mutatorShortClassName]
+            )
+        );
+    }
+
+    /**
+     * @dataProvider \Infection\Tests\Mutator\ProfileListProvider::implementedMutatorProvider
+     */
+    public function test_all_mutators_are_listed_by_at_least_one_profile(
+        string $mutatorFilePath,
+        string $mutatorClassName
+    ): void
+    {
+        $this->assertTrue(
+            self::isMutatorInAtLeastOneProfile($mutatorClassName),
+            sprintf(
+                'Expected the mutator "%s" (found in "%s") to be listed in at least one '
+                .'profile. Please add it to one of the *_PROFILE constants of "%s"',
+                $mutatorClassName,
+                $mutatorFilePath,
+                ProfileList::class
+            )
+        );
+    }
+
+    /**
+     * @dataProvider \Infection\Tests\Mutator\ProfileListProvider::profileProvider
+     */
+    public function test_all_mutator_profiles_are_sorted(
+        string $profile,
+        array $profileOrMutators
+    ): void
+    {
+        $sortedProfileOrMutators = (static function (array $value): array {
+            sort($value, SORT_STRING);
+
+            return $value;
+        })($profileOrMutators);
+
+        $this->assertSame(
+            $sortedProfileOrMutators,
+            $profileOrMutators,
+            sprintf(
+                'Expected the profiles and mutators listed in %s::%s to be sorted lexicographically',
+                ProfileList::class,
+                $profile
+        ));
+    }
+
+    private static function isMutatorInAtLeastOneProfile(string $className): bool
+    {
+        foreach (ProfileListProvider::getProfiles() as $profile => $profileOrMutators) {
+            if (in_array($className, $profileOrMutators, true)) {
                 return true;
             }
         }

--- a/tests/phpunit/Mutator/Util/MutatorProfileTest.php
+++ b/tests/phpunit/Mutator/Util/MutatorProfileTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\Util;
 
 use Generator;
 use function in_array;
-use Infection\Mutator\Util\MutatorProfile;
+use Infection\Mutator\ProfileList;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
@@ -46,7 +46,7 @@ final class MutatorProfileTest extends TestCase
 {
     public function test_all_mutators_have_the_correct_name_in_the_full_mutator_list(): void
     {
-        foreach (MutatorProfile::FULL_MUTATOR_LIST as $name => $class) {
+        foreach (ProfileList::ALL_MUTATORS as $name => $class) {
             $this->assertSame(
                 $name,
                 $class::getName(),
@@ -67,7 +67,7 @@ final class MutatorProfileTest extends TestCase
 
             $this->assertArrayHasKey(
                 $class,
-                MutatorProfile::FULL_MUTATOR_LIST,
+                ProfileList::ALL_MUTATORS,
                 sprintf(
                     'The mutator "%s" located in "%s" has not been added to the FULL_MUTATOR_LIST in the MutatorProfile class. ' .
                     'Please add it to ensure it can be used.',
@@ -139,7 +139,7 @@ final class MutatorProfileTest extends TestCase
 
     private function getMutatorProfileConstants(): array
     {
-        $reflectionClass = new ReflectionClass(MutatorProfile::class);
+        $reflectionClass = new ReflectionClass(ProfileList::class);
         $excludedConstants = ['MUTATOR_PROFILE_LIST', 'DEFAULT', 'FULL_MUTATOR_LIST'];
 
         return array_filter(

--- a/tests/phpunit/Mutator/Util/MutatorsGeneratorTest.php
+++ b/tests/phpunit/Mutator/Util/MutatorsGeneratorTest.php
@@ -58,7 +58,7 @@ final class MutatorsGeneratorTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         foreach (ProfileList::DEFAULT_PROFILE as $profileName) {
-            self::$countDefaultMutators += count(\Infection\Mutator\ProfileList::ALL_PROFILES[$profileName]);
+            self::$countDefaultMutators += count(ProfileList::ALL_PROFILES[$profileName]);
         }
     }
 

--- a/tests/phpunit/Mutator/Util/MutatorsGeneratorTest.php
+++ b/tests/phpunit/Mutator/Util/MutatorsGeneratorTest.php
@@ -40,7 +40,7 @@ use Infection\Config\Exception\InvalidConfigException;
 use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\Boolean\FalseValue;
 use Infection\Mutator\Boolean\TrueValue;
-use Infection\Mutator\Util\MutatorProfile;
+use Infection\Mutator\ProfileList;
 use Infection\Mutator\Util\MutatorsGenerator;
 use Infection\Tests\Fixtures\StubMutator;
 use Infection\Visitor\ReflectionVisitor;
@@ -57,8 +57,8 @@ final class MutatorsGeneratorTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        foreach (MutatorProfile::DEFAULT as $profileName) {
-            self::$countDefaultMutators += count(MutatorProfile::MUTATOR_PROFILE_LIST[$profileName]);
+        foreach (ProfileList::DEFAULT_PROFILE as $profileName) {
+            self::$countDefaultMutators += count(\Infection\Mutator\ProfileList::ALL_PROFILES[$profileName]);
         }
     }
 
@@ -76,7 +76,7 @@ final class MutatorsGeneratorTest extends TestCase
         ]);
         $mutators = $mutatorGenerator->generate();
 
-        $this->assertCount(count(MutatorProfile::BOOLEAN), $mutators);
+        $this->assertCount(count(ProfileList::BOOLEAN_PROFILE), $mutators);
     }
 
     public function test_mutators_can_be_ignored(): void
@@ -98,7 +98,7 @@ final class MutatorsGeneratorTest extends TestCase
         ]);
         $mutators = $mutatorGenerator->generate();
 
-        $this->assertCount(self::$countDefaultMutators - count(MutatorProfile::BOOLEAN), $mutators);
+        $this->assertCount(self::$countDefaultMutators - count(\Infection\Mutator\ProfileList::BOOLEAN_PROFILE), $mutators);
     }
 
     public function test_names_can_be_ignored(): void
@@ -212,7 +212,7 @@ final class MutatorsGeneratorTest extends TestCase
         ]);
         $mutators = $mutatorGenerator->generate();
 
-        $this->assertCount(count(MutatorProfile::BOOLEAN), $mutators);
+        $this->assertCount(count(ProfileList::BOOLEAN_PROFILE), $mutators);
 
         $this->assertArrayNotHasKey(Plus::getName(), $mutators);
 
@@ -227,7 +227,7 @@ final class MutatorsGeneratorTest extends TestCase
         ]);
         $mutators = $mutatorGenerator->generate();
 
-        $this->assertCount(count(MutatorProfile::BOOLEAN), $mutators);
+        $this->assertCount(count(ProfileList::BOOLEAN_PROFILE), $mutators);
 
         $this->assertArrayNotHasKey(Plus::getName(), $mutators);
     }


### PR DESCRIPTION
Rework `MutatorProfile` to attempt to have more accurate names and more performant/easier to read tests.

- Rename `MutatorProfile` to `ProfileList` which is slightly more accurate but still fails to capture the `ALL_MUTATORS` one; that said I think the name is description enough without being overly too long
- Move up `MutatorProfile` by a namespace: I don't think it belongs to `Util` (which ultimately I want to get rid of)
- Rename `MUTATOR_PROFILE_LIST` to `ALL_PROFILES`
- Rename `ARITHMETIC` and other profile constants to `ARITHMETIC_PROFILE`
- Rename `FULL_MUTATOR_LIST` to `ALL_MUTATORS`
- Make `ProfileList ` non instantiable making it closer to an actual enum
- Refactor `ProfileListTest` (previously `MutatorProfileTest`) to make use of an external provider, `ProfileListProvider` the same way we do for `ProjectCodeTest` with `ProjectCodeTestProvider`
- Consolidate the tests and rework the failure messages to be more in line with the regular PHPUnit failure messages