### PR TITLE
Move the filter input as a dynamic container parameter

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -336,18 +336,19 @@ final class InfectionCommand extends BaseCommand
         $processBuilder = new MutantProcessBuilder($adapter, $this->versionParser, $config->getProcessTimeout());
 
         $codeCoverageData = $this->getCodeCoverageData($this->testFrameworkKey, $adapter);
+
         $mutationsGenerator = new MutationsGenerator(
             $config->getSource()->getDirectories(),
             $config->getSource()->getExcludes(),
             $codeCoverageData,
             $config->getMutators(),
             $this->eventDispatcher,
-            $this->container['parser']
+            $this->container['parser'],
+            $config->getFilter()
         );
 
         $mutations = $mutationsGenerator->generate(
-            $this->input->getOption('only-covered'),
-            $this->input->getOption('filter'),
+            $config->mutateOnlyCoveredCode(),
             $adapter instanceof HasExtraNodeVisitors ? $adapter->getMutationsCollectionNodeVisitors() : []
         );
 
@@ -433,7 +434,8 @@ final class InfectionCommand extends BaseCommand
             null === $minMsi ? null : (float) $minMsi,
             null === $minCoveredMsi ? null : (float) $minCoveredMsi,
             '' === $testFramework ? null : $testFramework,
-            '' === $testFrameworkOptions ? null : $testFrameworkOptions
+            '' === $testFrameworkOptions ? null : $testFrameworkOptions,
+            trim((string) $input->getOption('filter'))
         );
     }
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -79,6 +79,7 @@ class Configuration
     private $minMsi;
     private $showMutations;
     private $minCoveredMsi;
+    private $filter;
 
     /**
      * @param array<string, Mutator> $mutators
@@ -103,7 +104,8 @@ class Configuration
         bool $ignoreMsiWithNoMutations,
         ?float $minMsi,
         bool $showMutations,
-        ?float $minCoveredMsi
+        ?float $minCoveredMsi,
+        string $filter
     ) {
         Assert::nullOrGreaterThanEq($timeout, 1);
         Assert::allIsInstanceOf($mutators, Mutator::class);
@@ -132,6 +134,7 @@ class Configuration
         $this->minMsi = $minMsi;
         $this->showMutations = $showMutations;
         $this->minCoveredMsi = $minCoveredMsi;
+        $this->filter = $filter;
     }
 
     public function getProcessTimeout(): int
@@ -235,5 +238,10 @@ class Configuration
     public function getMinCoveredMsi(): ?float
     {
         return $this->minCoveredMsi;
+    }
+
+    public function getFilter(): string
+    {
+        return $this->filter;
     }
 }

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -80,7 +80,8 @@ class ConfigurationFactory
         ?float $minCoveredMsi,
         string $mutatorsInput,
         ?string $testFramework,
-        ?string $testFrameworkOptions
+        ?string $testFrameworkOptions,
+        string $filter
     ): Configuration {
         $configDir = dirname($schema->getFile());
 
@@ -131,7 +132,8 @@ class ConfigurationFactory
             $ignoreMsiWithNoMutations,
             $minMsi,
             $showMutations,
-            $minCoveredMsi
+            $minCoveredMsi,
+            $filter
         );
     }
 

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -353,7 +353,8 @@ final class InfectionContainer extends Container
         ?float $minMsi,
         ?float $minCoveredMsi,
         ?string $testFramework,
-        ?string $testFrameworkOptions
+        ?string $testFrameworkOptions,
+        string $filter
     ): self {
         $clone = clone $this;
 
@@ -379,7 +380,8 @@ final class InfectionContainer extends Container
             $minCoveredMsi,
             $mutatorsInput,
             $testFramework,
-            $testFrameworkOptions
+            $testFrameworkOptions,
+            $filter
         ): Configuration {
             /** @var ConfigurationFactory $configurationFactory */
             $configurationFactory = $container[ConfigurationFactory::class];
@@ -399,7 +401,8 @@ final class InfectionContainer extends Container
                 $minCoveredMsi,
                 $mutatorsInput,
                 $testFramework,
-                $testFrameworkOptions
+                $testFrameworkOptions,
+                $filter
             );
         };
 

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -92,6 +92,7 @@ final class MutationsGenerator
      * @var Parser
      */
     private $parser;
+    private $filter;
 
     public function __construct(
         array $srcDirs,
@@ -99,7 +100,8 @@ final class MutationsGenerator
         LineCodeCoverage $codeCoverageData,
         array $mutators,
         EventDispatcherInterface $eventDispatcher,
-        Parser $parser
+        Parser $parser,
+        string $filter
     ) {
         $this->srcDirs = $srcDirs;
         $this->codeCoverageData = $codeCoverageData;
@@ -107,6 +109,7 @@ final class MutationsGenerator
         $this->mutators = $mutators;
         $this->eventDispatcher = $eventDispatcher;
         $this->parser = $parser;
+        $this->filter = $filter;
     }
 
     /**
@@ -115,10 +118,10 @@ final class MutationsGenerator
      *
      * @return Mutation[]
      */
-    public function generate(bool $onlyCovered, string $filter = '', array $extraNodeVisitors = []): array
+    public function generate(bool $onlyCovered, array $extraNodeVisitors = []): array
     {
         $sourceFilesFinder = new SourceFilesFinder($this->srcDirs, $this->excludeDirsOrFiles);
-        $files = $sourceFilesFinder->getSourceFiles($filter);
+        $files = $sourceFilesFinder->getSourceFiles($this->filter);
         $allFilesMutations = [[]];
 
         $this->eventDispatcher->dispatch(new MutationGeneratingStarted($files->count()));

--- a/tests/phpunit/Configuration/ConfigurationAssertions.php
+++ b/tests/phpunit/Configuration/ConfigurationAssertions.php
@@ -70,7 +70,8 @@ trait ConfigurationAssertions
         bool $expectedIgnoreMsiWithNoMutations,
         ?float $expectedMinMsi,
         bool $expectedShowMutations,
-        ?float $expectedMinCoveredMsi
+        ?float $expectedMinCoveredMsi,
+        string $expectedFilter
     ): void {
         $this->assertSame($expectedTimeout, $configuration->getProcessTimeout());
         $this->assertSourceStateIs(
@@ -107,5 +108,6 @@ trait ConfigurationAssertions
         $this->assertSame($expectedMinMsi, $configuration->getMinMsi());
         $this->assertSame($expectedShowMutations, $configuration->showMutations());
         $this->assertSame($expectedMinCoveredMsi, $configuration->getMinCoveredMsi());
+        $this->assertSame($expectedFilter, $configuration->getFilter());
     }
 }

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -99,6 +99,7 @@ final class ConfigurationFactoryTest extends TestCase
         string $inputMutators,
         ?string $inputTestFramework,
         ?string $inputTestFrameworkOptions,
+        string $inputFilter,
         int $expectedTimeout,
         Source $expectedSource,
         Logs $expectedLogs,
@@ -118,7 +119,8 @@ final class ConfigurationFactoryTest extends TestCase
         bool $expectedIgnoreMsiWithNoMutations,
         ?float $expectedMinMsi,
         bool $expectedShowMutations,
-        ?float $expectedMinCoveredMsi
+        ?float $expectedMinCoveredMsi,
+        string $expectedFilter
     ): void {
         $config = $this->configFactory->create(
             $schema,
@@ -135,7 +137,8 @@ final class ConfigurationFactoryTest extends TestCase
             $inputMinCoveredMsi,
             $inputMutators,
             $inputTestFramework,
-            $inputTestFrameworkOptions
+            $inputTestFrameworkOptions,
+            $inputFilter
         );
 
         $this->assertConfigurationStateIs(
@@ -159,7 +162,8 @@ final class ConfigurationFactoryTest extends TestCase
             $expectedIgnoreMsiWithNoMutations,
             $expectedMinMsi,
             $expectedShowMutations,
-            $expectedMinCoveredMsi
+            $expectedMinCoveredMsi,
+            $expectedFilter
         );
     }
 
@@ -199,6 +203,7 @@ final class ConfigurationFactoryTest extends TestCase
             '',
             null,
             null,
+            '',
             10,
             new Source([], []),
             new Logs(
@@ -225,6 +230,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            '',
         ];
 
         yield 'null timeout' => self::createValueForTimeout(
@@ -422,6 +428,7 @@ final class ConfigurationFactoryTest extends TestCase
             'TrueValue',
             'phpspec',
             '--stop-on-failure',
+            'src/Foo.php, src/Bar.php',
             10,
             new Source(['src/'], ['vendor/']),
             new Logs(
@@ -453,6 +460,7 @@ final class ConfigurationFactoryTest extends TestCase
             72.3,
             true,
             81.5,
+            'src/Foo.php, src/Bar.php',
         ];
     }
 
@@ -494,6 +502,7 @@ final class ConfigurationFactoryTest extends TestCase
             '',
             null,
             null,
+            '',
             $expectedTimeOut,
             new Source([], []),
             new Logs(
@@ -520,6 +529,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            '',
         ];
     }
 
@@ -561,6 +571,7 @@ final class ConfigurationFactoryTest extends TestCase
             '',
             null,
             null,
+            '',
             10,
             new Source([], []),
             new Logs(
@@ -587,6 +598,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            '',
         ];
     }
 
@@ -628,6 +640,7 @@ final class ConfigurationFactoryTest extends TestCase
             '',
             null,
             null,
+            '',
             10,
             new Source([], []),
             new Logs(
@@ -654,6 +667,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            '',
         ];
     }
 
@@ -696,6 +710,7 @@ final class ConfigurationFactoryTest extends TestCase
             '',
             $inputTestFramework,
             null,
+            '',
             10,
             new Source([], []),
             new Logs(
@@ -722,6 +737,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            '',
         ];
     }
 
@@ -764,6 +780,7 @@ final class ConfigurationFactoryTest extends TestCase
             '',
             null,
             null,
+            '',
             10,
             new Source([], []),
             new Logs(
@@ -790,6 +807,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            '',
         ];
     }
 
@@ -832,6 +850,7 @@ final class ConfigurationFactoryTest extends TestCase
             '',
             null,
             $inputInitialTestsFrameworkOptions,
+            '',
             10,
             new Source([], []),
             new Logs(
@@ -858,6 +877,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            '',
         ];
     }
 
@@ -903,6 +923,7 @@ final class ConfigurationFactoryTest extends TestCase
             $inputMutators,
             null,
             null,
+            '',
             10,
             new Source([], []),
             new Logs(
@@ -929,6 +950,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            '',
         ];
     }
 

--- a/tests/phpunit/Configuration/ConfigurationTest.php
+++ b/tests/phpunit/Configuration/ConfigurationTest.php
@@ -71,7 +71,8 @@ final class ConfigurationTest extends TestCase
         bool $ignoreMsiWithNoMutations,
         ?float $minMsi,
         bool $showMutations,
-        ?float $minCoveredMsi
+        ?float $minCoveredMsi,
+        string $filter
     ): void {
         $config = new Configuration(
             $timeout,
@@ -93,7 +94,8 @@ final class ConfigurationTest extends TestCase
             $ignoreMsiWithNoMutations,
             $minMsi,
             $showMutations,
-            $minCoveredMsi
+            $minCoveredMsi,
+            $filter
         );
 
         $this->assertConfigurationStateIs(
@@ -117,13 +119,14 @@ final class ConfigurationTest extends TestCase
             $ignoreMsiWithNoMutations,
             $minMsi,
             $showMutations,
-            $minCoveredMsi
+            $minCoveredMsi,
+            $filter
         );
     }
 
     public function valueProvider(): Generator
     {
-        yield [
+        yield 'empty' => [
             10,
             new Source([], []),
             new Logs(
@@ -150,9 +153,10 @@ final class ConfigurationTest extends TestCase
             null,
             false,
             null,
+            '',
         ];
 
-        yield [
+        yield 'nominal' => [
             10,
             new Source(['src', 'lib'], ['fixtures', 'tests']),
             new Logs(
@@ -181,6 +185,7 @@ final class ConfigurationTest extends TestCase
             43.,
             true,
             43.,
+            'src/Foo.php, src/Bar.php',
         ];
     }
 }

--- a/tests/phpunit/Console/InfectionContainerTest.php
+++ b/tests/phpunit/Console/InfectionContainerTest.php
@@ -104,6 +104,7 @@ final class InfectionContainerTest extends TestCase
             .0,
             .0,
             'phpunit',
+            '',
             ''
         );
 

--- a/tests/phpunit/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/phpunit/Mutant/Generator/MutationsGeneratorTest.php
@@ -174,7 +174,8 @@ final class MutationsGeneratorTest extends TestCase
             $this->createMock(LineCodeCoverage::class),
             [new Plus(new MutatorConfig([]))],
             $eventDispatcher,
-            $this->getParser()
+            $this->getParser(),
+            ''
         );
 
         $generator->generate(false);
@@ -231,7 +232,8 @@ final class MutationsGeneratorTest extends TestCase
             $codeCoverageDataMock,
             $mutators,
             $eventDispatcherMock,
-            $this->getParser()
+            $this->getParser(),
+            ''
         );
     }
 

--- a/tests/phpunit/TestFramework/FactoryTest.php
+++ b/tests/phpunit/TestFramework/FactoryTest.php
@@ -85,7 +85,8 @@ final class FactoryTest extends TestCase
                 false,
                 null,
                 false,
-                null
+                null,
+                ''
             ),
             $this->createMock(VersionParser::class),
             $this->createMock(Filesystem::class),


### PR DESCRIPTION
This PR:

- Moves the `filter` parameter of `MutationsGenerator` in the constructor instead of the `generate()` method
- Moves the passed `filter` value from the input to the `Configuration` instead, allowing:
  - `MutationsGenerator` to depend on `Configuration` only instead of `Configuration` and `InputInterface` (to be instantiated, so it's not a dependency at the class level itself but about how we use it)
  - Move `filter` into `InfectionContainer::withDynamicParameters()` with the other parameters which makes it more consistent with the rest of the code

If you pay attention you might notice that we then have all the necessary parameters to collect the source files right in the constructor of `MutatorsGenerator`. The ultimate goal here is to move the collection of the source files in `ConfigurationFactory`. I kept the PR at this because attempting to go further involves a lot more changes. It was tough but I found a way to split this work into 3-4 PRs this one being the first one.