### PR TITLE
Introduce File Parser

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -51,6 +51,7 @@ use Infection\Locator\FileOrDirectoryNotFound;
 use Infection\Locator\Locator;
 use Infection\Locator\RootsFileOrDirectoryLocator;
 use Infection\Mutant\Generator\MutationsGenerator;
+use Infection\Mutation\FileParser;
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
 use Infection\Process\Builder\MutantProcessBuilder;
 use Infection\Process\Runner\InitialTestsFailed;
@@ -337,12 +338,15 @@ final class InfectionCommand extends BaseCommand
 
         $codeCoverageData = $this->getCodeCoverageData($this->testFrameworkKey, $adapter);
 
+        /** @var FileParser $parser */
+        $parser = $this->container[FileParser::class];
+
         $mutationsGenerator = new MutationsGenerator(
             $config->getSourceFiles(),
             $codeCoverageData,
             $config->getMutators(),
             $this->eventDispatcher,
-            $this->container['parser']
+            $parser
         );
 
         $mutations = $mutationsGenerator->generate(

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -54,6 +54,7 @@ use Infection\Locator\RootsFileLocator;
 use Infection\Locator\RootsFileOrDirectoryLocator;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutant\MutantCreator;
+use Infection\Mutation\FileParser;
 use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\MutatorParser;
 use Infection\Performance\Limiter\MemoryLimiter;
@@ -204,15 +205,24 @@ final class InfectionContainer extends Container
             VersionParser::class => static function (): VersionParser {
                 return new VersionParser();
             },
-            'lexer' => static function (): Lexer {
+            Lexer::class => static function (): Lexer {
                 return new Lexer\Emulative([
                     'usedAttributes' => [
                         'comments', 'startLine', 'endLine', 'startTokenPos', 'endTokenPos', 'startFilePos', 'endFilePos',
                     ],
                 ]);
             },
-            'parser' => static function (self $container): Parser {
-                return (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $container['lexer']);
+            Parser::class => static function (self $container): Parser {
+                /** @var Lexer $lexer */
+                $lexer = $container[Lexer::class];
+
+                return (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);
+            },
+            FileParser::class => static function (self $container): FileParser {
+                /** @var Parser $phpParser */
+                $phpParser = $container[Parser::class];
+
+                return new FileParser($phpParser);
             },
             'pretty.printer' => static function (): Standard {
                 return new Standard();

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -135,7 +135,7 @@ final class MutationsGenerator
      */
     private function getMutationsFromFile(SplFileInfo $file, bool $onlyCovered, array $extraNodeVisitors): array
     {
-        $initialStatements = $this->parser->parse($file->getContents());
+        $initialStatements = $this->parser->parse($file);
 
         $traverser = new PriorityNodeTraverser();
         $filePath = $file->getRealPath();

--- a/src/Mutant/Generator/MutationsGenerator.php
+++ b/src/Mutant/Generator/MutationsGenerator.php
@@ -41,8 +41,8 @@ use Infection\EventDispatcher\EventDispatcherInterface;
 use Infection\Events\MutableFileProcessed;
 use Infection\Events\MutationGeneratingFinished;
 use Infection\Events\MutationGeneratingStarted;
-use Infection\Mutant\Exception\ParserException;
 use Infection\Mutation;
+use Infection\Mutation\FileParser;
 use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Infection\Traverser\PriorityNodeTraverser;
@@ -52,11 +52,8 @@ use Infection\Visitor\NotMutableIgnoreVisitor;
 use Infection\Visitor\ParentConnectorVisitor;
 use Infection\Visitor\ReflectionVisitor;
 use function is_string;
-use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
-use PhpParser\Parser;
 use Symfony\Component\Finder\SplFileInfo;
-use Throwable;
 
 /**
  * @internal
@@ -84,7 +81,7 @@ final class MutationsGenerator
     private $eventDispatcher;
 
     /**
-     * @var Parser
+     * @var FileParser
      */
     private $parser;
 
@@ -96,7 +93,7 @@ final class MutationsGenerator
         LineCodeCoverage $codeCoverageData,
         array $mutators,
         EventDispatcherInterface $eventDispatcher,
-        Parser $parser
+        FileParser $parser
     ) {
         $this->sourceFiles = $sourceFiles;
         $this->codeCoverageData = $codeCoverageData;
@@ -138,12 +135,7 @@ final class MutationsGenerator
      */
     private function getMutationsFromFile(SplFileInfo $file, bool $onlyCovered, array $extraNodeVisitors): array
     {
-        try {
-            /** @var Node[] $initialStatements */
-            $initialStatements = $this->parser->parse($file->getContents());
-        } catch (Throwable $t) {
-            throw ParserException::fromInvalidFile($file, $t);
-        }
+        $initialStatements = $this->parser->parse($file->getContents());
 
         $traverser = new PriorityNodeTraverser();
         $filePath = $file->getRealPath();

--- a/src/Mutation/FileParser.php
+++ b/src/Mutation/FileParser.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutation;
+
+use Infection\Mutant\Exception\ParserException;
+use PhpParser\Node;
+use PhpParser\Parser;
+use Symfony\Component\Finder\SplFileInfo;
+use Throwable;
+
+/**
+ * @internal
+ */
+final class FileParser
+{
+    private $parser;
+
+    public function __construct(Parser $parser)
+    {
+        $this->parser = $parser;
+    }
+
+    /**
+     * @throws ParserException
+     *
+     * @return Node[]
+     */
+    public function parse(SplFileInfo $file): array
+    {
+        try {
+            return $this->parser->parse($file->getContents());
+        } catch (Throwable $throwable) {
+            throw ParserException::fromInvalidFile($file, $throwable);
+        }
+    }
+}

--- a/tests/phpunit/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/phpunit/Mutant/Generator/MutationsGeneratorTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutant\Generator;
 
+use Infection\Console\InfectionContainer;
 use Infection\EventDispatcher\EventDispatcherInterface;
 use Infection\Events\MutableFileProcessed;
 use Infection\Events\MutationGeneratingFinished;
@@ -43,6 +44,7 @@ use Infection\Exception\InvalidMutatorException;
 use Infection\FileSystem\SourceFileCollector;
 use Infection\Mutant\Exception\ParserException;
 use Infection\Mutant\Generator\MutationsGenerator;
+use Infection\Mutation\FileParser;
 use Infection\Mutator\Arithmetic\Decrement;
 use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\Boolean\TrueValue;
@@ -52,9 +54,6 @@ use Infection\Mutator\Util\MutatorConfig;
 use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Infection\Tests\Fixtures\Files\Mutation\OneFile\OneFile;
 use Infection\WrongMutator\ErrorMutator;
-use PhpParser\Lexer;
-use PhpParser\Parser;
-use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 
@@ -239,18 +238,12 @@ final class MutationsGeneratorTest extends TestCase
             $codeCoverageDataMock,
             $mutators,
             $eventDispatcherMock,
-            $this->getParser()
+            InfectionContainer::create()[FileParser::class]
         );
     }
 
-    private function getParser(): Parser
+    private function getParser(): FileParser
     {
-        $lexer = new Lexer\Emulative([
-            'usedAttributes' => [
-                'comments', 'startLine', 'endLine', 'startTokenPos', 'endTokenPos', 'startFilePos', 'endFilePos',
-            ],
-        ]);
-
-        return (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);
+        return InfectionContainer::create()[FileParser::class];
     }
 }

--- a/tests/phpunit/Mutation/FileParserTest.php
+++ b/tests/phpunit/Mutation/FileParserTest.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutation;
+
+use Generator;
+use Infection\Console\InfectionContainer;
+use Infection\Mutant\Exception\ParserException;
+use Infection\Mutation\FileParser;
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\NodeDumper;
+use PhpParser\Parser;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\SplFileInfo;
+
+class FileParserTest extends TestCase
+{
+    public function test_it_parses_the_given_file_only_once(): void
+    {
+        $fileInfo = self::createFileInfo('/unknown', $fileContents = 'contents');
+
+        $phpParser = $this->createMock(Parser::class);
+
+        $phpParser
+            ->expects($this->once())
+            ->method('parse')
+            ->with($fileContents)
+            ->willReturn($expectedReturnedStatements = []);
+
+        $parser = new FileParser($phpParser);
+
+        $returnedStatements = $parser->parse($fileInfo);
+
+        $this->assertSame($expectedReturnedStatements, $returnedStatements);
+    }
+
+    /**
+     * @dataProvider fileToParserProvider
+     */
+    public function test_it_can_parse_a_file(SplFileInfo $fileInfo, string $expectedPrintedParsedContents): void
+    {
+        /** @var FileParser $parser */
+        $parser = InfectionContainer::create()[FileParser::class];
+
+        $statements = $parser->parse($fileInfo);
+
+        foreach ($statements as $statement) {
+            $this->assertInstanceOf(Node::class, $statement);
+        }
+
+        $actualPrintedParsedContents = (new NodeDumper())->dump($statements);
+
+        $this->assertSame($expectedPrintedParsedContents, $actualPrintedParsedContents);
+    }
+
+    public function test_it_throws_upon_failure(): void
+    {
+        /** @var FileParser $parser */
+        $parser = InfectionContainer::create()[FileParser::class];
+
+        try {
+            $parser->parse(self::createFileInfo('/unknown', '<?php use foo as self;'));
+
+            $this->fail('Expected PHPParser to be unable to parse the above expression');
+        } catch (ParserException $exception) {
+            $this->assertSame(
+                'Unable to parse file "", most likely due to syntax errors.',
+                $exception->getMessage()
+            );
+            $this->assertSame(0, $exception->getCode());
+            $this->assertInstanceOf(Error::class, $exception->getPrevious());
+        }
+    }
+
+    public function fileToParserProvider(): Generator
+    {
+        yield 'empty file' => [
+            self::createFileInfo('/unknown', ''),
+            <<<'AST'
+array(
+)
+AST
+            ,
+        ];
+
+        yield 'empty PHP file' => [
+            self::createFileInfo(
+                '/unknown',
+                <<<'PHP'
+<?php
+PHP
+            ),
+            <<<'AST'
+array(
+    0: Stmt_InlineHTML(
+        value: <?php
+    )
+)
+AST
+        ];
+
+        yield 'nominal' => [
+            self::createFileInfo(
+                '/unknown',
+                <<<'PHP'
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * ...
+ */
+
+// Disable strict types for now: https://github.com/infection/infection/pull/720#issuecomment-506546284
+
+$autoloaderInWorkingDirectory = getcwd() . '/vendor/autoload.php';
+
+use Infection\Console\Application;
+use Infection\Console\InfectionContainer;
+
+(new Application(InfectionContainer::create()))->run();
+
+PHP
+            ),
+            <<<'AST'
+array(
+    0: Stmt_InlineHTML(
+        value: #!/usr/bin/env php
+    
+    )
+    1: Stmt_Declare(
+        declares: array(
+            0: Stmt_DeclareDeclare(
+                key: Identifier(
+                    name: strict_types
+                )
+                value: Scalar_LNumber(
+                    value: 1
+                )
+            )
+        )
+        stmts: null
+    )
+    2: Stmt_Expression(
+        expr: Expr_Assign(
+            var: Expr_Variable(
+                name: autoloaderInWorkingDirectory
+            )
+            expr: Expr_BinaryOp_Concat(
+                left: Expr_FuncCall(
+                    name: Name(
+                        parts: array(
+                            0: getcwd
+                        )
+                    )
+                    args: array(
+                    )
+                )
+                right: Scalar_String(
+                    value: /vendor/autoload.php
+                )
+            )
+        )
+    )
+    3: Stmt_Use(
+        type: TYPE_NORMAL (1)
+        uses: array(
+            0: Stmt_UseUse(
+                type: TYPE_UNKNOWN (0)
+                name: Name(
+                    parts: array(
+                        0: Infection
+                        1: Console
+                        2: Application
+                    )
+                )
+                alias: null
+            )
+        )
+    )
+    4: Stmt_Use(
+        type: TYPE_NORMAL (1)
+        uses: array(
+            0: Stmt_UseUse(
+                type: TYPE_UNKNOWN (0)
+                name: Name(
+                    parts: array(
+                        0: Infection
+                        1: Console
+                        2: InfectionContainer
+                    )
+                )
+                alias: null
+            )
+        )
+    )
+    5: Stmt_Expression(
+        expr: Expr_MethodCall(
+            var: Expr_New(
+                class: Name(
+                    parts: array(
+                        0: Application
+                    )
+                )
+                args: array(
+                    0: Arg(
+                        value: Expr_StaticCall(
+                            class: Name(
+                                parts: array(
+                                    0: InfectionContainer
+                                )
+                            )
+                            name: Identifier(
+                                name: create
+                            )
+                            args: array(
+                            )
+                        )
+                        byRef: false
+                        unpack: false
+                    )
+                )
+            )
+            name: Identifier(
+                name: run
+            )
+            args: array(
+            )
+        )
+    )
+)
+AST
+        ];
+    }
+
+    private static function createFileInfo(string $path, string $contents): SplFileInfo
+    {
+        return new class($path, $contents) extends SplFileInfo {
+            private $contents;
+
+            public function __construct(string $path, string $contents)
+            {
+                parent::__construct($path, $path, $path);
+
+                $this->contents = $contents;
+            }
+
+            public function getContents(): string
+            {
+                return $this->contents;
+            }
+        };
+    }
+}

--- a/tests/phpunit/Mutation/FileParserTest.php
+++ b/tests/phpunit/Mutation/FileParserTest.php
@@ -46,7 +46,7 @@ use PhpParser\Parser;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\SplFileInfo;
 
-class FileParserTest extends TestCase
+final class FileParserTest extends TestCase
 {
     public function test_it_parses_the_given_file_only_once(): void
     {


### PR DESCRIPTION
This adds an adapter `FileParser` to wrap around the nikic/PHP-Parser one. The adapter is very thin because there is not much to do, but good to do nonetheless IMO. Indeed it provides:

- An easier way to test _our_ PHP-Parser integration (the adapter test are an integration one - we test against how we configured the PHP-Parser in the container)
- Allows to adapt the usage to handle:
  - parsing a `SplFileInfo` instead of `string`
  - throwing one of our own exception instead of an arbitrary one
  - properly return `Node[]` instead of `Stmt[]|null`