### PR TITLE
Tweak the PHP-Parser ParseException

### DIFF
--- a/src/Mutation/FileParser.php
+++ b/src/Mutation/FileParser.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutation;
 
-use Infection\Mutant\Exception\ParserException;
 use PhpParser\Node;
 use PhpParser\Parser;
 use Symfony\Component\Finder\SplFileInfo;
@@ -54,16 +53,21 @@ final class FileParser
     }
 
     /**
-     * @throws ParserException
+     *@throws UnparsableFile
      *
      * @return Node[]
      */
-    public function parse(SplFileInfo $file): array
+    public function parse(SplFileInfo $fileInfo): array
     {
         try {
-            return $this->parser->parse($file->getContents());
+            return $this->parser->parse($fileInfo->getContents());
         } catch (Throwable $throwable) {
-            throw ParserException::fromInvalidFile($file, $throwable);
+            $filePath = false === $fileInfo->getRealPath()
+                ? $fileInfo->getPathname()
+                : $fileInfo->getRealPath()
+            ;
+
+            throw UnparsableFile::fromInvalidFile($filePath, $throwable);
         }
     }
 }

--- a/src/Mutation/FileParser.php
+++ b/src/Mutation/FileParser.php
@@ -53,7 +53,7 @@ final class FileParser
     }
 
     /**
-     *@throws UnparsableFile
+     * @throws UnparsableFile
      *
      * @return Node[]
      */

--- a/src/Mutation/UnparsableFile.php
+++ b/src/Mutation/UnparsableFile.php
@@ -33,23 +33,22 @@
 
 declare(strict_types=1);
 
-namespace Infection\Mutant\Exception;
+namespace Infection\Mutation;
 
-use Exception;
-use SplFileInfo;
+use RuntimeException;
 use Throwable;
 
 /**
  * @internal
  */
-final class ParserException extends Exception
+final class UnparsableFile extends RuntimeException
 {
-    public static function fromInvalidFile(SplFileInfo $file, Throwable $original): self
+    public static function fromInvalidFile(string $filePath, Throwable $original): self
     {
         return new self(
             sprintf(
-                'Unable to parse file "%s", most likely due to syntax errors.',
-                $file->getRealPath()
+                'Could not parse the file "%s". Check if it is a valid PHP file',
+                $filePath
             ),
             0,
             $original

--- a/tests/phpunit/Fixtures/Files/InvalidFile/InvalidFile.php
+++ b/tests/phpunit/Fixtures/Files/InvalidFile/InvalidFile.php
@@ -1,7 +1,0 @@
-<?php
-
-This file is intended to have invalid syntax.
-
-class InvalidFile
-{
-}

--- a/tests/phpunit/Mutant/Generator/MutationsGeneratorTest.php
+++ b/tests/phpunit/Mutant/Generator/MutationsGeneratorTest.php
@@ -42,7 +42,6 @@ use Infection\Events\MutationGeneratingFinished;
 use Infection\Events\MutationGeneratingStarted;
 use Infection\Exception\InvalidMutatorException;
 use Infection\FileSystem\SourceFileCollector;
-use Infection\Mutant\Exception\ParserException;
 use Infection\Mutant\Generator\MutationsGenerator;
 use Infection\Mutation\FileParser;
 use Infection\Mutator\Arithmetic\Decrement;
@@ -126,20 +125,6 @@ final class MutationsGeneratorTest extends TestCase
         $mutations = $generator->generate(false);
 
         $this->assertCount(0, $mutations);
-    }
-
-    public function test_it_throws_correct_error_when_file_is_invalid(): void
-    {
-        $generator = $this->createMutationGenerator(
-            $this->createMock(LineCodeCoverage::class),
-            Decrement::class,
-            null,
-            [self::FIXTURES_DIR . '/InvalidFile']
-        );
-
-        $this->expectException(ParserException::class);
-        $this->expectExceptionMessageRegExp('#Fixtures(/|\\\)Files(/|\\\)InvalidFile(/|\\\)InvalidFile\.php#');
-        $generator->generate(false);
     }
 
     public function test_it_throws_correct_exception_when_mutator_is_invalid(): void

--- a/tests/phpunit/Mutation/UnparsableFileTest.php
+++ b/tests/phpunit/Mutation/UnparsableFileTest.php
@@ -33,31 +33,25 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Mutant\Exception;
+namespace Infection\Tests\Mutation;
 
 use Exception;
-use Infection\Mutant\Exception\ParserException;
+use Infection\Mutation\UnparsableFile;
 use PHPUnit\Framework\TestCase;
-use SplFileInfo;
 
-final class ParserExceptionTest extends TestCase
+final class UnparsableFileTest extends TestCase
 {
-    public function test_it_has_correct_error_message(): void
+    public function test_it_can_create_a_user_friendly_error_for_a_given_file(): void
     {
-        $file = $this->createMock(SplFileInfo::class);
-        $file->expects($this->once())
-            ->method('getRealPath')
-            ->willReturn('foo/bar/baz');
         $previous = new Exception('Unintentional thing');
 
-        $exception = ParserException::fromInvalidFile($file, $previous);
+        $exception = UnparsableFile::fromInvalidFile('/path/to/file', $previous);
 
         $this->assertSame(
-            'Unable to parse file "foo/bar/baz", most likely due to syntax errors.',
+            'Could not parse the file "/path/to/file". Check if it is a valid PHP file',
             $exception->getMessage()
         );
-        $this->assertSame($previous,
-            $exception->getPrevious()
-        );
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
     }
 }


### PR DESCRIPTION
Upon failure, the `FileParser` would throw a `ParserException` exception. There is several things however that I would like to change here:

- The current `ParserException` does not give a friendly error message if the file real path could not be retrieved. I do not thing it is a
  problem in practice since as far as I'm aware we don't handle symlinks, but it does not cost much to fix that either...
- Rename `ParserException` for a more expressive form `UnparseableFile`
- Move the old `ParserException` next to the parser rather than a generic `Exception` directory
