### PR TITLE
Remove codecov from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,11 +51,5 @@ test_script:
     - vendor\bin\phpunit --prepend=devTools/xdebug-filter.php --coverage-clover=clover.xml --coverage-xml=coverage/coverage-xml --log-junit=coverage/junit.xml
     - php bin\infection --threads=4 --log-verbosity=none --coverage=coverage
 
-after_test:
-  - ps: |
-      $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
-      Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
-      bash codecov.sh
-
 matrix:
   fast_finish: true


### PR DESCRIPTION
I would like to propose to remove CodeCov from the AppVeyor build. The two main motivators for this are:

- AppVeyor is quite unreliable overall (it's the CI failing the most sporadically)
- The code coverage is not expected to differ much from Travis to AppVeyor since we have very little Windows specific code if any

