### PR TITLE
Add missing types when fetching services from the container

### DIFF
--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -53,6 +53,7 @@ use stdClass;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
@@ -113,10 +114,13 @@ final class ConfigureCommand extends BaseCommand
             return 1;
         }
 
+        /** @var Filesystem $fileSystem */
+        $fileSystem = $this->getApplication()->getContainer()['filesystem'];
+
         $excludeDirsProvider = new ExcludeDirsProvider(
             $consoleHelper,
             $questionHelper,
-            $this->getApplication()->getContainer()['filesystem']
+            $fileSystem
         );
 
         $excludedDirs = $excludeDirsProvider->get($input, $output, $dirsInCurrentDir, $sourceDirs);

--- a/src/Config/Guesser/PhpUnitPathGuesser.php
+++ b/src/Config/Guesser/PhpUnitPathGuesser.php
@@ -73,7 +73,7 @@ final class PhpUnitPathGuesser implements Guesser
     private function getPhpUnitDir(array $parsedPaths)
     {
         foreach ($parsedPaths as $namespace => $parsedPath) {
-            // for old Symfony prjects (<=2.7) phpunit.xml is located in ./app folder
+            // for old Symfony projects (<=2.7) phpunit.xml is located in ./app folder
             if (strpos($namespace, 'SymfonyStandard') !== false && trim($parsedPath, '/') === 'app') {
                 return 'app';
             }


### PR DESCRIPTION
Although I'm not a fan of it, doing without hurts discoverability (e.g. doing a "find usage for a given class") and reliability (from type checks provided by SA tools like phpStan or IDEs like phpStorm).