### PR TITLE
Remove unnecessary phpdoc

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -47,14 +47,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 abstract class BaseCommand extends Command
 {
-    /**
-     * @var InputInterface
-     */
     protected $input;
-
-    /**
-     * @var OutputInterface
-     */
     protected $output;
 
     protected function initialize(InputInterface $input, OutputInterface $output): void

--- a/src/Config/ConsoleHelper.php
+++ b/src/Config/ConsoleHelper.php
@@ -43,9 +43,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ConsoleHelper
 {
-    /**
-     * @var FormatterHelper
-     */
     private $formatterHelper;
 
     public function __construct(FormatterHelper $formatterHelper)

--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -54,19 +54,8 @@ final class ExcludeDirsProvider
 {
     public const EXCLUDED_ROOT_DIRS = ['vendor', 'tests', 'test'];
 
-    /**
-     * @var ConsoleHelper
-     */
     private $consoleHelper;
-
-    /**
-     * @var QuestionHelper
-     */
     private $questionHelper;
-
-    /**
-     * @var Filesystem
-     */
     private $filesystem;
 
     public function __construct(ConsoleHelper $consoleHelper, QuestionHelper $questionHelper, Filesystem $filesystem)

--- a/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
+++ b/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
@@ -51,18 +51,8 @@ use Symfony\Component\Console\Question\Question;
  */
 final class PhpUnitCustomExecutablePathProvider
 {
-    /**
-     * @var TestFrameworkFinder
-     */
     private $phpUnitExecutableFinder;
-    /**
-     * @var ConsoleHelper
-     */
     private $consoleHelper;
-
-    /**
-     * @var QuestionHelper
-     */
     private $questionHelper;
 
     public function __construct(TestFrameworkFinder $phpUnitExecutableFinder, ConsoleHelper $consoleHelper, QuestionHelper $questionHelper)

--- a/src/Config/ValueProvider/SourceDirsProvider.php
+++ b/src/Config/ValueProvider/SourceDirsProvider.php
@@ -50,19 +50,8 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
  */
 final class SourceDirsProvider
 {
-    /**
-     * @var ConsoleHelper
-     */
     private $consoleHelper;
-
-    /**
-     * @var QuestionHelper
-     */
     private $questionHelper;
-
-    /**
-     * @var SourceDirGuesser
-     */
     private $sourceDirGuesser;
 
     public function __construct(ConsoleHelper $consoleHelper, QuestionHelper $questionHelper, SourceDirGuesser $sourceDirGuesser)

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -54,18 +54,8 @@ use Symfony\Component\Console\Question\Question;
  */
 final class TestFrameworkConfigPathProvider
 {
-    /**
-     * @var TestFrameworkConfigLocatorInterface
-     */
     private $testFrameworkConfigLocator;
-    /**
-     * @var ConsoleHelper
-     */
     private $consoleHelper;
-
-    /**
-     * @var QuestionHelper
-     */
     private $questionHelper;
 
     public function __construct(TestFrameworkConfigLocatorInterface $testFrameworkConfigLocator, ConsoleHelper $consoleHelper, QuestionHelper $questionHelper)

--- a/src/Config/ValueProvider/TextLogFileProvider.php
+++ b/src/Config/ValueProvider/TextLogFileProvider.php
@@ -48,14 +48,7 @@ final class TextLogFileProvider
 {
     public const TEXT_LOG_FILE_NAME = 'infection.log';
 
-    /**
-     * @var ConsoleHelper
-     */
     private $consoleHelper;
-
-    /**
-     * @var QuestionHelper
-     */
     private $questionHelper;
 
     public function __construct(ConsoleHelper $consoleHelper, QuestionHelper $questionHelper)

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -68,9 +68,6 @@ final class Application extends BaseApplication
 /___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/
 ';
 
-    /**
-     * @var InfectionContainer
-     */
     private $container;
 
     /**

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -50,9 +50,6 @@ final class ConsoleOutput
     private const CI_FLAG_ERROR = 'The minimum required %s percentage should be %s%%, but actual is %s%%. Improve your tests!';
     private const MIN_MSI_CAN_GET_INCREASED_NOTICE = 'The %s is %s%% percent points over the required %s. Consider increasing the required %s percentage the next time you run infection.';
 
-    /**
-     * @var SymfonyStyle
-     */
     private $io;
 
     public function __construct(SymfonyStyle $io)

--- a/src/Console/OutputFormatter/DotFormatter.php
+++ b/src/Console/OutputFormatter/DotFormatter.php
@@ -47,9 +47,6 @@ final class DotFormatter extends AbstractOutputFormatter
 {
     private const DOTS_PER_ROW = 50;
 
-    /**
-     * @var OutputInterface
-     */
     private $output;
 
     public function __construct(OutputInterface $output)

--- a/src/Console/OutputFormatter/ProgressFormatter.php
+++ b/src/Console/OutputFormatter/ProgressFormatter.php
@@ -43,9 +43,6 @@ use Symfony\Component\Console\Helper\ProgressBar;
  */
 final class ProgressFormatter extends AbstractOutputFormatter
 {
-    /**
-     * @var ProgressBar
-     */
     private $progressBar;
 
     public function __construct(ProgressBar $progressBar)

--- a/src/Differ/Differ.php
+++ b/src/Differ/Differ.php
@@ -44,9 +44,6 @@ class Differ
 {
     public const DIFF_MAX_LINES = 12;
 
-    /**
-     * @var BaseDiffer
-     */
     private $differ;
 
     public function __construct(BaseDiffer $differ)

--- a/src/Events/InitialTestSuiteFinished.php
+++ b/src/Events/InitialTestSuiteFinished.php
@@ -40,9 +40,6 @@ namespace Infection\Events;
  */
 final class InitialTestSuiteFinished
 {
-    /**
-     * @var string
-     */
     private $outputText;
 
     public function __construct(string $outputText)

--- a/src/Events/MutantProcessFinished.php
+++ b/src/Events/MutantProcessFinished.php
@@ -42,9 +42,6 @@ use Infection\Process\MutantProcessInterface;
  */
 final class MutantProcessFinished
 {
-    /**
-     * @var MutantProcessInterface
-     */
     private $mutantProcess;
 
     public function __construct(MutantProcessInterface $mutantProcess)

--- a/src/Events/MutantsCreatingStarted.php
+++ b/src/Events/MutantsCreatingStarted.php
@@ -40,9 +40,6 @@ namespace Infection\Events;
  */
 final class MutantsCreatingStarted
 {
-    /**
-     * @var int
-     */
     private $mutantCount;
 
     public function __construct(int $mutantCount)

--- a/src/Events/MutationGeneratingStarted.php
+++ b/src/Events/MutationGeneratingStarted.php
@@ -40,9 +40,6 @@ namespace Infection\Events;
  */
 final class MutationGeneratingStarted
 {
-    /**
-     * @var int
-     */
     private $mutableFilesCount;
 
     public function __construct(int $mutableFilesCount)

--- a/src/Events/MutationTestingStarted.php
+++ b/src/Events/MutationTestingStarted.php
@@ -40,9 +40,6 @@ namespace Infection\Events;
  */
 final class MutationTestingStarted
 {
-    /**
-     * @var int
-     */
     private $mutationCount;
 
     public function __construct(int $mutationCount)

--- a/src/Finder/TestFrameworkFinder.php
+++ b/src/Finder/TestFrameworkFinder.php
@@ -49,14 +49,7 @@ use Symfony\Component\Process\Process;
  */
 class TestFrameworkFinder extends AbstractExecutableFinder
 {
-    /**
-     * @var string
-     */
     private $testFrameworkName;
-
-    /**
-     * @var string
-     */
     private $customPath;
 
     /**

--- a/src/Http/BadgeApiClient.php
+++ b/src/Http/BadgeApiClient.php
@@ -48,9 +48,6 @@ class BadgeApiClient
 
     private const CREATED_RESPONSE_CODE = 201;
 
-    /**
-     * @var OutputInterface
-     */
     private $output;
 
     public function __construct(OutputInterface $output)

--- a/src/Json/JsonFile.php
+++ b/src/Json/JsonFile.php
@@ -48,9 +48,6 @@ final class JsonFile
 {
     private const SCHEMA_FILE = __DIR__ . '/../../resources/schema.json';
 
-    /**
-     * @var string
-     */
     private $path;
 
     /**

--- a/src/Logger/BadgeLogger.php
+++ b/src/Logger/BadgeLogger.php
@@ -48,24 +48,9 @@ final class BadgeLogger implements MutationTestingResultsLogger
     public const ENV_INFECTION_BADGE_API_KEY = 'INFECTION_BADGE_API_KEY';
     public const ENV_STRYKER_DASHBOARD_API_KEY = 'STRYKER_DASHBOARD_API_KEY';
 
-    /**
-     * @var BadgeApiClient
-     */
     private $badgeApiClient;
-
-    /**
-     * @var MetricsCalculator
-     */
     private $metricsCalculator;
-
-    /**
-     * @var stdClass
-     */
     private $config;
-
-    /**
-     * @var OutputInterface
-     */
     private $output;
 
     public function __construct(OutputInterface $output, BadgeApiClient $badgeApiClient, MetricsCalculator $metricsCalculator, stdClass $config)

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -47,39 +47,12 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 abstract class FileLogger implements MutationTestingResultsLogger
 {
-    /**
-     * @var MetricsCalculator
-     */
     protected $metricsCalculator;
-
-    /**
-     * @var bool
-     */
     protected $isDebugVerbosity;
-
-    /**
-     * @var bool
-     */
     protected $isDebugMode;
-
-    /**
-     * @var bool
-     */
     protected $isOnlyCoveredMode;
-
-    /**
-     * @var string
-     */
     private $logFilePath;
-
-    /**
-     * @var Filesystem
-     */
     private $fs;
-
-    /**
-     * @var OutputInterface
-     */
     private $output;
 
     public function __construct(

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -43,10 +43,12 @@ use Infection\Process\MutantProcessInterface;
  */
 class MetricsCalculator
 {
-    /**
-     * @var int
-     */
     private $killedCount = 0;
+    private $errorCount = 0;
+    private $escapedCount = 0;
+    private $timedOutCount = 0;
+    private $notCoveredByTestsCount = 0;
+    private $totalMutantsCount = 0;
 
     /**
      * @var MutantProcessInterface[]
@@ -54,19 +56,9 @@ class MetricsCalculator
     private $killedMutantProcesses = [];
 
     /**
-     * @var int
-     */
-    private $errorCount = 0;
-
-    /**
      * @var MutantProcessInterface[]
      */
     private $errorProcesses = [];
-
-    /**
-     * @var int
-     */
-    private $escapedCount = 0;
 
     /**
      * @var MutantProcessInterface[]
@@ -74,29 +66,14 @@ class MetricsCalculator
     private $escapedMutantProcesses = [];
 
     /**
-     * @var int
-     */
-    private $timedOutCount = 0;
-
-    /**
      * @var MutantProcessInterface[]
      */
     private $timedOutProcesses = [];
 
     /**
-     * @var int
-     */
-    private $notCoveredByTestsCount = 0;
-
-    /**
      * @var MutantProcessInterface[]
      */
     private $notCoveredMutantProcesses = [];
-
-    /**
-     * @var int
-     */
-    private $totalMutantsCount = 0;
 
     /**
      * Build a metric calculator with a sub-set of mutators

--- a/src/Mutant/Mutant.php
+++ b/src/Mutant/Mutant.php
@@ -43,19 +43,8 @@ use Infection\TestFramework\Coverage\CoverageLineData;
  */
 final class Mutant implements MutantInterface
 {
-    /**
-     * @var string
-     */
     private $mutatedFilePath;
-
-    /**
-     * @var MutationInterface
-     */
     private $mutation;
-
-    /**
-     * @var string
-     */
     private $diff;
 
     public function __construct(string $mutatedFilePath, MutationInterface $mutation, string $diff)

--- a/src/Mutant/MutantCreator.php
+++ b/src/Mutant/MutantCreator.php
@@ -48,19 +48,8 @@ use function Safe\file_get_contents;
  */
 final class MutantCreator
 {
-    /**
-     * @var string
-     */
     private $tempDir;
-
-    /**
-     * @var Differ
-     */
     private $differ;
-
-    /**
-     * @var Standard
-     */
     private $prettyPrinter;
 
     /**

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -73,8 +73,8 @@ final class Mutation implements MutationInterface
     private $tests;
 
     /**
-     * @param Node[]   $originalFileAst
-     * @param (string|int|float)[]   $attributes
+     * @param Node[] $originalFileAst
+     * @param array<string|int|float> $attributes
      * @param Node|Node[] $mutatedNode
      */
     public function __construct(

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -46,10 +46,11 @@ use PhpParser\Node;
  */
 final class Mutation implements MutationInterface
 {
-    /**
-     * @var Mutator
-     */
+    private $originalFilePath;
     private $mutator;
+    private $mutatedNodeClass;
+    private $mutatedNode;
+    private $mutationByMutatorIndex;
 
     /**
      * @var array
@@ -57,40 +58,25 @@ final class Mutation implements MutationInterface
     private $attributes;
 
     /**
-     * @var string
-     */
-    private $originalFilePath;
-
-    /**
      * @var Node[]
      */
     private $originalFileAst;
 
     /**
-     * @var string
-     */
-    private $mutatedNodeClass;
-
-    /**
-     * @var string
+     * @var string|null
      */
     private $hash;
-
-    /**
-     * @var Node|Node[]
-     */
-    private $mutatedNode;
-
-    /**
-     * @var int
-     */
-    private $mutationByMutatorIndex;
 
     /**
      * @var CoverageLineData[]
      */
     private $tests;
 
+    /**
+     * @param Node[]   $originalFileAst
+     * @param (string|int|float)[]   $attributes
+     * @param Node|Node[] $mutatedNode
+     */
     public function __construct(
         string $originalFilePath,
         array $originalFileAst,
@@ -116,6 +102,9 @@ final class Mutation implements MutationInterface
         return $this->mutator;
     }
 
+    /**
+     * @return (string|int|float)[]   $attributes
+     */
     public function getAttributes(): array
     {
         return $this->attributes;
@@ -157,6 +146,9 @@ final class Mutation implements MutationInterface
         return $this->hash;
     }
 
+    /**
+     * return Node[]
+     */
     public function getOriginalFileAst(): array
     {
         return $this->originalFileAst;
@@ -175,6 +167,9 @@ final class Mutation implements MutationInterface
         return count($this->getAllTests()) !== 0;
     }
 
+    /**
+     * @return Node|Node[]
+     */
     public function getMutatedNode()
     {
         return $this->mutatedNode;

--- a/src/Mutation/MutationGenerator.php
+++ b/src/Mutation/MutationGenerator.php
@@ -57,20 +57,12 @@ final class MutationGenerator
     private $sourceFiles;
 
     /**
-     * @var LineCodeCoverage
-     */
-    private $codeCoverageData;
-
-    /**
      * @var Mutator[]
      */
     private $mutators;
 
-    /**
-     * @var EventDispatcherInterface
-     */
+    private $codeCoverageData;
     private $eventDispatcher;
-
     private $fileMutationGenerator;
 
     /**

--- a/src/MutationInterface.php
+++ b/src/MutationInterface.php
@@ -48,6 +48,9 @@ interface MutationInterface
 {
     public function getMutator(): Mutator;
 
+    /**
+     * @return (string|int|float)[]   $attributes
+     */
     public function getAttributes(): array;
 
     public function getOriginalFilePath(): string;
@@ -56,6 +59,9 @@ interface MutationInterface
 
     public function getHash(): string;
 
+    /**
+     * @return Node[]
+     */
     public function getOriginalFileAst(): array;
 
     /**

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -62,9 +62,14 @@ final class ArrayItemRemoval extends Mutator
         'limit' => PHP_INT_MAX,
     ];
 
-    /** @var string first|last|all */
+    /**
+     * @var string first|last|all
+     */
     private $remove;
-    /** @var int */
+
+    /**
+     * @var int
+     */
     private $limit;
 
     public function __construct(MutatorConfig $config)

--- a/src/Mutator/Util/AbstractValueToNullReturnValue.php
+++ b/src/Mutator/Util/AbstractValueToNullReturnValue.php
@@ -46,7 +46,7 @@ abstract class AbstractValueToNullReturnValue extends Mutator
 {
     protected function isNullReturnValueAllowed(Node $node): bool
     {
-        /** @var \PhpParser\Node\Stmt\Function_|null $functionScope */
+        /** @var Node\Stmt\Function_|null $functionScope */
         $functionScope = $node->getAttribute(ReflectionVisitor::FUNCTION_SCOPE_KEY, null);
 
         if (null === $functionScope) {

--- a/src/Mutator/Util/Mutator.php
+++ b/src/Mutator/Util/Mutator.php
@@ -41,9 +41,6 @@ use PhpParser\Node;
 
 abstract class Mutator
 {
-    /**
-     * @var MutatorConfig
-     */
     private $config;
 
     public function __construct(MutatorConfig $config)

--- a/src/Performance/Limiter/MemoryLimiter.php
+++ b/src/Performance/Limiter/MemoryLimiter.php
@@ -47,16 +47,12 @@ use Symfony\Component\Process\Process;
  */
 final class MemoryLimiter
 {
-    /**
-     * @var Filesystem
-     */
     private $fs;
-
-    /**
-     * @var string|false
-     */
     private $iniLocation;
 
+    /**
+     * @param string|false $iniLocation
+     */
     public function __construct(Filesystem $fs, $iniLocation)
     {
         $this->fs = $fs;

--- a/src/Performance/Listener/PerformanceLoggerSubscriber.php
+++ b/src/Performance/Listener/PerformanceLoggerSubscriber.php
@@ -48,24 +48,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class PerformanceLoggerSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var Timer
-     */
     private $timer;
-
-    /**
-     * @var OutputInterface
-     */
     private $output;
-
-    /**
-     * @var TimeFormatter
-     */
     private $timeFormatter;
-
-    /**
-     * @var MemoryFormatter
-     */
     private $memoryFormatter;
 
     public function __construct(

--- a/src/Process/Builder/InitialTestRunProcessBuilder.php
+++ b/src/Process/Builder/InitialTestRunProcessBuilder.php
@@ -46,14 +46,7 @@ use Symfony\Component\Process\Process;
  */
 class InitialTestRunProcessBuilder
 {
-    /**
-     * @var TestFrameworkAdapter
-     */
     private $testFrameworkAdapter;
-
-    /**
-     * @var VersionParser
-     */
     private $versionParser;
 
     public function __construct(TestFrameworkAdapter $testFrameworkAdapter, VersionParser $versionParser)

--- a/src/Process/Builder/MutantProcessBuilder.php
+++ b/src/Process/Builder/MutantProcessBuilder.php
@@ -47,19 +47,8 @@ use Symfony\Component\Process\Process;
  */
 final class MutantProcessBuilder
 {
-    /**
-     * @var TestFrameworkAdapter
-     */
     private $testFrameworkAdapter;
-
-    /**
-     * @var int
-     */
     private $timeout;
-
-    /**
-     * @var VersionParser
-     */
     private $versionParser;
 
     public function __construct(TestFrameworkAdapter $testFrameworkAdapter, VersionParser $versionParser, int $timeout)

--- a/src/Process/Builder/SubscriberBuilder.php
+++ b/src/Process/Builder/SubscriberBuilder.php
@@ -67,79 +67,20 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class SubscriberBuilder
 {
-    /**
-     * @var bool
-     */
     private $showMutations;
-
-    /**
-     * @var string
-     */
     private $logVerbosity;
-
-    /**
-     * @var bool
-     */
     private $debug;
-
-    /**
-     * @var bool
-     */
     private $onlyCovered;
-
-    /**
-     * @var bool
-     */
     private $noProgress;
-
-    /**
-     * @var string
-     */
     private $formatter;
-
-    /**
-     * @var MetricsCalculator
-     */
     private $metricsCalculator;
-
-    /**
-     * @var EventDispatcherInterface
-     */
     private $eventDispatcher;
-
-    /**
-     * @var DiffColorizer
-     */
     private $diffColorizer;
-
-    /**
-     * @var Configuration
-     */
     private $infectionConfig;
-
-    /**
-     * @var Filesystem
-     */
     private $fs;
-
-    /**
-     * @var string
-     */
     private $tmpDir;
-
-    /**
-     * @var Timer
-     */
     private $timer;
-
-    /**
-     * @var TimeFormatter
-     */
     private $timeFormatter;
-
-    /**
-     * @var MemoryFormatter
-     */
     private $memoryFormatter;
 
     public function __construct(

--- a/src/Process/Coverage/CoverageRequirementChecker.php
+++ b/src/Process/Coverage/CoverageRequirementChecker.php
@@ -44,14 +44,7 @@ use const PHP_SAPI;
  */
 final class CoverageRequirementChecker
 {
-    /**
-     * @var bool
-     */
     private $skipCoverage;
-
-    /**
-     * @var string
-     */
     private $initialTestPhpOptions;
 
     public function __construct(bool $skipCoverage, string $initialTestPhpOptions)

--- a/src/Process/Listener/CiInitialTestsConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/CiInitialTestsConsoleLoggerSubscriber.php
@@ -46,14 +46,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class CiInitialTestsConsoleLoggerSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var OutputInterface
-     */
     private $output;
-
-    /**
-     * @var TestFrameworkAdapter
-     */
     private $testFrameworkAdapter;
 
     public function __construct(OutputInterface $output, TestFrameworkAdapter $testFrameworkAdapter)

--- a/src/Process/Listener/CiMutantCreatingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/CiMutantCreatingConsoleLoggerSubscriber.php
@@ -44,9 +44,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class CiMutantCreatingConsoleLoggerSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var OutputInterface
-     */
     private $output;
 
     public function __construct(OutputInterface $output)

--- a/src/Process/Listener/CiMutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/CiMutationGeneratingConsoleLoggerSubscriber.php
@@ -44,9 +44,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class CiMutationGeneratingConsoleLoggerSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var OutputInterface
-     */
     private $output;
 
     public function __construct(OutputInterface $output)

--- a/src/Process/Listener/CleanUpAfterMutationTestingFinishedSubscriber.php
+++ b/src/Process/Listener/CleanUpAfterMutationTestingFinishedSubscriber.php
@@ -44,14 +44,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class CleanUpAfterMutationTestingFinishedSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var Filesystem
-     */
     private $filesystem;
-
-    /**
-     * @var string
-     */
     private $tmpDir;
 
     public function __construct(Filesystem $filesystem, string $tmpDir)

--- a/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/InitialTestsConsoleLoggerSubscriber.php
@@ -49,24 +49,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class InitialTestsConsoleLoggerSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var OutputInterface
-     */
     private $output;
-
-    /**
-     * @var ProgressBar
-     */
     private $progressBar;
-
-    /**
-     * @var TestFrameworkAdapter
-     */
     private $testFrameworkAdapter;
-
-    /**
-     * @var bool
-     */
     private $debug;
 
     public function __construct(OutputInterface $output, TestFrameworkAdapter $testFrameworkAdapter, bool $debug)

--- a/src/Process/Listener/MutantCreatingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutantCreatingConsoleLoggerSubscriber.php
@@ -47,14 +47,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutantCreatingConsoleLoggerSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var OutputInterface
-     */
     private $output;
-
-    /**
-     * @var ProgressBar
-     */
     private $progressBar;
 
     public function __construct(OutputInterface $output)

--- a/src/Process/Listener/MutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationGeneratingConsoleLoggerSubscriber.php
@@ -47,14 +47,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutationGeneratingConsoleLoggerSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var OutputInterface
-     */
     private $output;
-
-    /**
-     * @var ProgressBar
-     */
     private $progressBar;
 
     public function __construct(OutputInterface $output)

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -54,38 +54,15 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInt
     private const PAD_LENGTH = 8;
 
     /**
-     * @var OutputInterface
-     */
-    private $output;
-
-    /**
-     * @var OutputFormatter
-     */
-    private $outputFormatter;
-
-    /**
      * @var MutantProcessInterface[]
      */
     private $mutantProcesses = [];
 
-    /**
-     * @var MetricsCalculator
-     */
+    private $output;
+    private $outputFormatter;
     private $metricsCalculator;
-
-    /**
-     * @var bool
-     */
     private $showMutations;
-
-    /**
-     * @var DiffColorizer
-     */
     private $diffColorizer;
-
-    /**
-     * @var int
-     */
     private $mutationCount = 0;
 
     public function __construct(

--- a/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingResultsLoggerSubscriber.php
@@ -57,39 +57,12 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class MutationTestingResultsLoggerSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var Configuration
-     */
     private $infectionConfig;
-
-    /**
-     * @var MetricsCalculator
-     */
     private $metricsCalculator;
-
-    /**
-     * @var Filesystem
-     */
     private $fs;
-
-    /**
-     * @var string
-     */
     private $logVerbosity;
-
-    /**
-     * @var OutputInterface
-     */
     private $output;
-
-    /**
-     * @var bool
-     */
     private $isDebugMode;
-
-    /**
-     * @var bool
-     */
     private $isOnlyCoveredMode;
 
     public function __construct(

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -63,24 +63,9 @@ final class MutantProcess implements MutantProcessInterface
         self::PROCESS_MISUSE_SHELL_BUILTINS,
     ];
 
-    /**
-     * @var Process
-     */
     private $process;
-
-    /**
-     * @var MutantInterface
-     */
     private $mutant;
-
-    /**
-     * @var bool
-     */
     private $isTimedOut = false;
-
-    /**
-     * @var TestFrameworkAdapter
-     */
     private $testFrameworkAdapter;
 
     public function __construct(Process $process, MutantInterface $mutant, TestFrameworkAdapter $testFrameworkAdapter)

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -47,14 +47,7 @@ use Symfony\Component\Process\Process;
  */
 final class InitialTestsRunner
 {
-    /**
-     * @var InitialTestRunProcessBuilder
-     */
     private $processBuilder;
-
-    /**
-     * @var EventDispatcherInterface
-     */
     private $eventDispatcher;
 
     public function __construct(InitialTestRunProcessBuilder $processBuilder, EventDispatcherInterface $eventDispatcher)

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -54,28 +54,15 @@ use Infection\Process\Runner\Parallel\ParallelProcessRunner;
  */
 final class MutationTestingRunner
 {
-    /**
-     * @var MutantProcessBuilder
-     */
     private $processBuilder;
-
-    /**
-     * @var Mutation[]
-     */
     private $mutations;
-    /**
-     * @var MutantCreator
-     */
     private $mutantCreator;
-    /**
-     * @var ParallelProcessRunner
-     */
     private $parallelProcessManager;
-    /**
-     * @var EventDispatcherInterface
-     */
     private $eventDispatcher;
 
+    /**
+     * @param Mutation[] $mutations
+     */
     public function __construct(MutantProcessBuilder $processBuilder, ParallelProcessRunner $parallelProcessManager, MutantCreator $mutantCreator, EventDispatcherInterface $eventDispatcher, array $mutations)
     {
         $this->processBuilder = $processBuilder;

--- a/src/Process/Runner/Parallel/ParallelProcessRunner.php
+++ b/src/Process/Runner/Parallel/ParallelProcessRunner.php
@@ -52,9 +52,6 @@ use Symfony\Component\Process\Exception\RuntimeException;
  */
 final class ParallelProcessRunner
 {
-    /**
-     * @var EventDispatcherInterface
-     */
     private $eventDispatcher;
 
     /**

--- a/src/Process/Runner/TestRunConstraintChecker.php
+++ b/src/Process/Runner/TestRunConstraintChecker.php
@@ -52,34 +52,11 @@ final class TestRunConstraintChecker
 
     private const VALUE_OVER_REQUIRED_TOLERANCE = 0.1;
 
-    /**
-     * @var MetricsCalculator
-     */
     private $metricsCalculator;
-
-    /**
-     * @var bool
-     */
     private $ignoreMsiWithNoMutations;
-
-    /**
-     * @var float
-     */
     private $minMsi;
-
-    /**
-     * @var float
-     */
     private $minCoveredMsi;
-
-    /**
-     * @var string
-     */
     private $failureType = '';
-
-    /**
-     * @var string
-     */
     private $actualOverRequiredType = '';
 
     public function __construct(

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -47,40 +47,17 @@ use Symfony\Component\Process\Process;
  */
 abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
 {
-    /**
-     * @var string
-     */
     private $testFrameworkExecutable;
-
-    /**
-     * @var CommandLineArgumentsAndOptionsBuilder
-     */
     private $argumentsAndOptionsBuilder;
-
-    /**
-     * @var InitialConfigBuilder
-     */
     private $initialConfigBuilder;
-
-    /**
-     * @var MutationConfigBuilder
-     */
     private $mutationConfigBuilder;
-
-    /**
-     * @var VersionParser
-     */
     private $versionParser;
+    private $commandLineBuilder;
 
     /**
      * @var string|null
      */
     private $cachedVersion;
-
-    /**
-     * @var CommandLineBuilder
-     */
-    private $commandLineBuilder;
 
     public function __construct(
         string $testFrameworkExecutable,

--- a/src/TestFramework/Codeception/Adapter/CodeceptionAdapter.php
+++ b/src/TestFramework/Codeception/Adapter/CodeceptionAdapter.php
@@ -67,50 +67,16 @@ final class CodeceptionAdapter implements MemoryUsageAware, TestFrameworkAdapter
         '--fail-fast',
     ];
 
-    /**
-     * @var string
-     */
     private $testFrameworkExecutable;
-
-    /**
-     * @var CommandLineBuilder
-     */
     private $commandLineBuilder;
-
-    /**
-     * @var VersionParser
-     */
     private $versionParser;
-
-    /**
-     * @var JUnitTestCaseSorter
-     */
     private $jUnitTestCaseSorter;
-
-    /**
-     * @var Filesystem
-     */
     private $filesystem;
-
-    /**
-     * @var string
-     */
     private $jUnitFilePath;
-
-    /**
-     * @var string
-     */
     private $tmpDir;
-
-    /**
-     * @var string
-     */
     private $projectDir;
-
-    /**
-     * @var array<string, mixed>
-     */
     private $originalConfigContentParsed;
+    private $srcDirs;
 
     /**
      * @var string|null
@@ -118,10 +84,8 @@ final class CodeceptionAdapter implements MemoryUsageAware, TestFrameworkAdapter
     private $cachedVersion;
 
     /**
-     * @var string[]
+     * @param  array<string, mixed> $originalConfigContentParsed
      */
-    private $srcDirs;
-
     public function __construct(
         string $testFrameworkExecutable,
         CommandLineBuilder $commandLineBuilder,

--- a/src/TestFramework/Coverage/CachedTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/CachedTestFileDataProvider.php
@@ -42,9 +42,6 @@ use function array_key_exists;
  */
 final class CachedTestFileDataProvider implements TestFileDataProvider
 {
-    /**
-     * @var TestFileDataProvider
-     */
     private $testFileDataProvider;
 
     /**

--- a/src/TestFramework/Coverage/CoverageFileData.php
+++ b/src/TestFramework/Coverage/CoverageFileData.php
@@ -40,14 +40,7 @@ namespace Infection\TestFramework\Coverage;
  */
 final class CoverageFileData
 {
-    /**
-     * @var array<int, array<int, CoverageLineData>>
-     */
     public $byLine = [];
-
-    /**
-     * @var MethodLocationData[]
-     */
     public $byMethod = [];
 
     /**

--- a/src/TestFramework/Coverage/CoverageLineData.php
+++ b/src/TestFramework/Coverage/CoverageLineData.php
@@ -46,12 +46,12 @@ final class CoverageLineData
     public $testMethod;
 
     /**
-     * @var ?string
+     * @var string|null
      */
     public $testFilePath;
 
     /**
-     * @var ?float
+     * @var float|null
      */
     public $time;
 

--- a/src/TestFramework/Coverage/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnitTestFileDataProvider.php
@@ -43,9 +43,6 @@ use DOMXPath;
  */
 final class JUnitTestFileDataProvider implements TestFileDataProvider
 {
-    /**
-     * @var string
-     */
     private $jUnitFilePath;
 
     /**

--- a/src/TestFramework/Coverage/MethodLocationData.php
+++ b/src/TestFramework/Coverage/MethodLocationData.php
@@ -40,14 +40,7 @@ namespace Infection\TestFramework\Coverage;
  */
 final class MethodLocationData
 {
-    /**
-     * @var int
-     */
     public $startLine;
-
-    /**
-     * @var int
-     */
     public $endLine;
 
     public function __construct(int $startLine, int $endLine)

--- a/src/TestFramework/Coverage/TestFileTimeData.php
+++ b/src/TestFramework/Coverage/TestFileTimeData.php
@@ -40,14 +40,7 @@ namespace Infection\TestFramework\Coverage;
  */
 final class TestFileTimeData
 {
-    /**
-     * @var string
-     */
     public $path;
-
-    /**
-     * @var float
-     */
     public $time;
 
     public function __construct(string $path, float $time)

--- a/src/TestFramework/Coverage/XMLLineCodeCoverage.php
+++ b/src/TestFramework/Coverage/XMLLineCodeCoverage.php
@@ -57,24 +57,9 @@ final class XMLLineCodeCoverage implements LineCodeCoverage
      */
     private $coverage;
 
-    /**
-     * @var string
-     */
     private $coverageDir;
-
-    /**
-     * @var CoverageXmlParser
-     */
     private $parser;
-
-    /**
-     * @var TestFileDataProvider|null
-     */
     private $testFileDataProvider;
-
-    /**
-     * @var string
-     */
     private $testFrameworkKey;
 
     public function __construct(string $coverageDir, CoverageXmlParser $coverageXmlParser, string $testFrameworkKey, ?TestFileDataProvider $testFileDataProvider = null)

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -63,49 +63,14 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class Factory
 {
-    /**
-     * @var string
-     */
     private $tmpDir;
-
-    /**
-     * @var XmlConfigurationHelper
-     */
     private $xmlConfigurationHelper;
-
-    /**
-     * @var TestFrameworkConfigLocatorInterface
-     */
     private $configLocator;
-
-    /**
-     * @var string
-     */
     private $projectDir;
-
-    /**
-     * @var string
-     */
     private $jUnitFilePath;
-
-    /**
-     * @var Configuration
-     */
     private $infectionConfig;
-
-    /**
-     * @var VersionParser
-     */
     private $versionParser;
-
-    /**
-     * @var Filesystem
-     */
     private $filesystem;
-
-    /**
-     * @var CommandLineBuilder
-     */
     private $commandLineBuilder;
 
     public function __construct(

--- a/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/AbstractYamlConfiguration.php
@@ -42,14 +42,7 @@ use function array_key_exists;
  */
 abstract class AbstractYamlConfiguration
 {
-    /**
-     * @var string
-     */
     protected $tempDirectory;
-
-    /**
-     * @var array
-     */
     protected $parsedYaml;
 
     public function __construct(string $tmpDir, array $parsedYaml)

--- a/src/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilder.php
@@ -44,18 +44,8 @@ use Symfony\Component\Yaml\Yaml;
  */
 class InitialConfigBuilder implements ConfigBuilder
 {
-    /**
-     * @var string
-     */
     private $tempDirectory;
-    /**
-     * @var string
-     */
     private $originalYamlConfigPath;
-
-    /**
-     * @var bool
-     */
     private $skipCoverage;
 
     public function __construct(string $tempDirectory, string $originalYamlConfigPath, bool $skipCoverage)

--- a/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilder.php
@@ -47,18 +47,8 @@ use Symfony\Component\Yaml\Yaml;
  */
 class MutationConfigBuilder extends ConfigBuilder
 {
-    /**
-     * @var string
-     */
     private $tempDirectory;
-
-    /**
-     * @var string
-     */
     private $originalYamlConfigPath;
-    /**
-     * @var string
-     */
     private $projectDir;
 
     public function __construct(string $tempDirectory, string $originalYamlConfigPath, string $projectDir)

--- a/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
@@ -43,9 +43,6 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class InitialYamlConfiguration extends AbstractYamlConfiguration
 {
-    /**
-     * @var bool
-     */
     private $skipCoverage;
 
     public function __construct(string $tmpDir, array $parsedYaml, bool $skipCoverage)

--- a/src/TestFramework/PhpSpec/Config/MutationYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/MutationYamlConfiguration.php
@@ -42,12 +42,9 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class MutationYamlConfiguration extends AbstractYamlConfiguration
 {
-    /**
-     * @var string
-     */
     private $customAutoloadFilePath;
 
-    public function __construct($tmpDir, array $parsedYaml, string $customAutoloadFilePath)
+    public function __construct(string $tmpDir, array $parsedYaml, string $customAutoloadFilePath)
     {
         parent::__construct($tmpDir, $parsedYaml);
 

--- a/src/TestFramework/PhpSpec/PhpSpecExtraOptions.php
+++ b/src/TestFramework/PhpSpec/PhpSpecExtraOptions.php
@@ -42,6 +42,9 @@ use Infection\TestFramework\TestFrameworkExtraOptions;
  */
 final class PhpSpecExtraOptions extends TestFrameworkExtraOptions
 {
+    /**
+     * @return string[]
+     */
     protected function getInitialRunOnlyOptions(): array
     {
         return [];

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -48,33 +48,11 @@ use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
  */
 class InitialConfigBuilder implements ConfigBuilder
 {
-    /**
-     * @var string
-     */
     private $tmpDir;
-
-    /**
-     * @var string
-     */
     private $originalXmlConfigContent;
-    /**
-     * @var XmlConfigurationHelper
-     */
     private $xmlConfigurationHelper;
-
-    /**
-     * @var string
-     */
     private $jUnitFilePath;
-
-    /**
-     * @var array
-     */
     private $srcDirs = [];
-
-    /**
-     * @var bool
-     */
     private $skipCoverage;
 
     public function __construct(

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -51,29 +51,10 @@ use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
  */
 class MutationConfigBuilder extends ConfigBuilder
 {
-    /**
-     * @var string
-     */
     private $tempDirectory;
-
-    /**
-     * @var string
-     */
     private $projectDir;
-
-    /**
-     * @var XmlConfigurationHelper
-     */
     private $xmlConfigurationHelper;
-
-    /**
-     * @var DOMDocument
-     */
     private $dom;
-
-    /**
-     * @var JUnitTestCaseSorter
-     */
     private $jUnitTestCaseSorter;
 
     public function __construct(

--- a/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
+++ b/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
@@ -44,14 +44,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class PathReplacer
 {
-    /**
-     * @var Filesystem
-     */
     private $filesystem;
-
-    /**
-     * @var string|null
-     */
     private $phpUnitConfigDir;
 
     public function __construct(Filesystem $filesystem, ?string $phpUnitConfigDir = null)

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -47,14 +47,7 @@ use LibXMLError;
  */
 final class XmlConfigurationHelper
 {
-    /**
-     * @var PathReplacer
-     */
     private $pathReplacer;
-
-    /**
-     * @var string
-     */
     private $phpUnitConfigDir;
 
     public function __construct(PathReplacer $pathReplacer, string $phpUnitConfigDir)

--- a/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/CoverageXmlParser.php
@@ -54,9 +54,6 @@ use function Safe\realpath;
  */
 class CoverageXmlParser
 {
-    /**
-     * @var string
-     */
     private $coverageDir;
 
     public function __construct(string $coverageDir)

--- a/src/TestFramework/PhpUnit/PhpUnitExtraOptions.php
+++ b/src/TestFramework/PhpUnit/PhpUnitExtraOptions.php
@@ -42,6 +42,9 @@ use Infection\TestFramework\TestFrameworkExtraOptions;
  */
 final class PhpUnitExtraOptions extends TestFrameworkExtraOptions
 {
+    /**
+     * @return string[]
+     */
     protected function getInitialRunOnlyOptions(): array
     {
         return ['--filter', '--testsuite'];

--- a/src/TestFramework/TestFrameworkExtraOptions.php
+++ b/src/TestFramework/TestFrameworkExtraOptions.php
@@ -40,9 +40,6 @@ namespace Infection\TestFramework;
  */
 abstract class TestFrameworkExtraOptions
 {
-    /**
-     * @var string
-     */
     private $extraOptions;
 
     public function __construct(?string $extraOptions = null)
@@ -60,12 +57,14 @@ abstract class TestFrameworkExtraOptions
         $extraOptions = $this->extraOptions;
 
         foreach ($this->getInitialRunOnlyOptions() as $initialRunOnlyOption) {
-            /** @var string $extraOptions */
             $extraOptions = preg_replace(sprintf('/%s[\=| ](?:\"[^\"]*\"|\'[^\']*\'|[^\ ]*)/', $initialRunOnlyOption), '', $extraOptions);
         }
 
         return (string) preg_replace('/\s+/', ' ', trim($extraOptions));
     }
 
+    /**
+     * @return string[]
+     */
     abstract protected function getInitialRunOnlyOptions(): array;
 }

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -53,34 +53,20 @@ use Throwable;
 final class MutationsCollectorVisitor extends NodeVisitorAbstract
 {
     /**
-     * @var Mutator[]
-     */
-    private $mutators;
-
-    /**
      * @var Mutation[]
      */
     private $mutations = [];
 
-    /**
-     * @var string
-     */
+    private $mutators;
     private $filePath;
-
-    /**
-     * @var Node[]
-     */
     private $fileAst;
-
-    /**
-     * @var LineCodeCoverage
-     */
     private $codeCoverageData;
-    /**
-     * @var bool
-     */
     private $onlyCovered;
 
+    /**
+     * @param Mutator[] $mutators
+     * @param  Node[] $fileAst
+     */
     public function __construct(
         array $mutators,
         string $filePath,

--- a/src/Visitor/MutatorVisitor.php
+++ b/src/Visitor/MutatorVisitor.php
@@ -47,9 +47,6 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class MutatorVisitor extends NodeVisitorAbstract
 {
-    /**
-     * @var MutationInterface
-     */
     private $mutation;
 
     public function __construct(MutationInterface $mutation)


### PR DESCRIPTION
⚠️  _Controversial PR_ ⚠️

IMO, phpdoc in PHP is here only to complement the typesystem, e.g. to annotate `Node[]` instead of `array` or provide more explanation regarding an element, e.g. about the effect of one parameter.

As a result, in the following case:

```php
class Foo {
  private $x;

  public function __construct(X $) {
    $this->x = $x;
  }

  public function getX(): X {
    return $this->x;
  }
}
``` 

I find excessive to add:

```php
/**
 * @var X
 */
private $x
```

On the same token, if you have:

```php
class Foo {
  private $x = 0;
}
```

I find unnecessary to add `@var int` unless you want to expand the type to put `@var int|false` for example.

To me there is three reasons for this change:

- It is unneeded (an SA tool or IDE will understand it) and does not improve readability
- Only increase redundancy, i.e. make the code more noisy
- Provides no guarantee meaning if you change the typehint in the constructor or the `@param` in the constructor, you need to rely on the SA to catch that the `@var` has not been updated

In light of this, I'm proposing the following PR where I remove the `@var` _only in the two scenarios listed above_.