### PR TITLE
Get rid of MutantInterface in TestFrameworkAdapter interface

### DIFF
--- a/src/Process/Builder/MutantProcessBuilder.php
+++ b/src/Process/Builder/MutantProcessBuilder.php
@@ -62,7 +62,10 @@ final class MutantProcessBuilder
     {
         $process = new Process(
             $this->testFrameworkAdapter->getMutantCommandLine(
-                $mutant,
+                $mutant->getCoverageTests(),
+                $mutant->getMutatedFilePath(),
+                $mutant->getMutation()->getHash(),
+                $mutant->getMutation()->getOriginalFilePath(),
                 $testFrameworkExtraOptions
             )
         );

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -35,9 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework;
 
-use Infection\Mutant\MutantInterface;
 use Infection\TestFramework\Config\InitialConfigBuilder;
 use Infection\TestFramework\Config\MutationConfigBuilder;
+use Infection\TestFramework\Coverage\CoverageLineData;
 use Infection\Utils\VersionParser;
 use InvalidArgumentException;
 use Symfony\Component\Process\Process;
@@ -99,11 +99,28 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
     /**
      * Returns array of arguments to pass them into the Mutant Symfony Process
      *
+     * @param CoverageLineData[] $coverageTests
+     *
      * @return string[]
      */
-    public function getMutantCommandLine(MutantInterface $mutant, string $extraOptions): array
-    {
-        return $this->getCommandLine($this->buildMutationConfigFile($mutant), $extraOptions, [], false);
+    public function getMutantCommandLine(
+        array $coverageTests,
+        string $mutatedFilePath,
+        string $mutationHash,
+        string $mutationOriginalFilePath,
+        string $extraOptions
+    ): array {
+        return $this->getCommandLine(
+            $this->buildMutationConfigFile(
+                $coverageTests,
+                $mutatedFilePath,
+                $mutationHash,
+                $mutationOriginalFilePath
+            ),
+            $extraOptions,
+            [],
+            false
+        );
     }
 
     public function getVersion(): string
@@ -144,9 +161,21 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         return $this->initialConfigBuilder->build($this->getVersion());
     }
 
-    protected function buildMutationConfigFile(MutantInterface $mutant): string
-    {
-        return $this->mutationConfigBuilder->build($mutant);
+    /**
+     * @param CoverageLineData[] $coverageTests
+     */
+    protected function buildMutationConfigFile(
+       array $coverageTests,
+       string $mutatedFilePath,
+       string $mutationHash,
+       string $mutationOriginalFilePath
+    ): string {
+        return $this->mutationConfigBuilder->build(
+            $coverageTests,
+            $mutatedFilePath,
+            $mutationHash,
+            $mutationOriginalFilePath
+        );
     }
 
     /**

--- a/src/TestFramework/Config/MutationConfigBuilder.php
+++ b/src/TestFramework/Config/MutationConfigBuilder.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\TestFramework\Config;
 
 use function assert;
-use Infection\Mutant\MutantInterface;
+use Infection\TestFramework\Coverage\CoverageLineData;
 use function is_string;
 use Phar;
 
@@ -45,7 +45,15 @@ use Phar;
  */
 abstract class MutationConfigBuilder
 {
-    abstract public function build(MutantInterface $mutant): string;
+    /**
+     * @param CoverageLineData[] $coverageTests
+     */
+    abstract public function build(
+        array $coverageTests,
+        string $mutatedFilePath,
+        string $mutationHash,
+        string $mutationOriginalFilePath
+    ): string;
 
     protected function getInterceptorFileContent(string $interceptorPath, string $originalFilePath, string $mutatedFilePath): string
     {

--- a/src/TestFramework/TestFrameworkAdapter.php
+++ b/src/TestFramework/TestFrameworkAdapter.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework;
 
-use Infection\Mutant\MutantInterface;
+use Infection\TestFramework\Coverage\CoverageLineData;
 
 /**
  * @internal
@@ -58,9 +58,17 @@ interface TestFrameworkAdapter
     public function getInitialTestRunCommandLine(string $extraOptions, array $phpExtraArgs, bool $skipCoverage): array;
 
     /**
+     * @param CoverageLineData[] $coverageTests
+     *
      * @return string[]
      */
-    public function getMutantCommandLine(MutantInterface $mutant, string $extraOptions): array;
+    public function getMutantCommandLine(
+        array $coverageTests,
+        string $mutatedFilePath,
+        string $mutationHash,
+        string $mutationOriginalFilePath,
+        string $extraOptions
+    ): array;
 
     public function getVersion(): string;
 

--- a/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
@@ -42,28 +42,28 @@ use Infection\Tests\FileSystem\FileSystemTestCase;
 
 final class MutationConfigBuilderTest extends FileSystemTestCase
 {
+    private const MUTATION_HASH = 'a1b2c3';
+    private const ORIGINAL_FILE_PATH = '/original/file/path';
+    private const MUTATED_FILE_PATH = '/mutated/file/path';
+
     public function test_it_builds_path_to_mutation_config_file(): void
     {
         $projectDir = '/project/dir';
         $originalYamlConfigPath = __DIR__ . '/../../../../Fixtures/Files/phpspec/phpspec.yml';
 
-        $mutation = $this->createMock(MutationInterface::class);
-        $mutation->method('getHash')
-            ->willReturn('a1b2c3');
-        $mutation->method('getOriginalFilePath')
-            ->willReturn('/original/file/path');
-
-        $mutant = $this->createMock(MutantInterface::class);
-        $mutant->method('getMutation')
-            ->willReturn($mutation);
-        $mutant->method('getMutatedFilePath')
-            ->willReturn('/mutated/file/path');
-
         // TODO for PhpSpec pass file content as well
         // TODO test phpspec after that
         $builder = new MutationConfigBuilder($this->tmp, $originalYamlConfigPath, $projectDir);
 
-        $this->assertSame($this->tmp . '/phpspecConfiguration.a1b2c3.infection.yml', $builder->build($mutant));
+        $this->assertSame(
+            $this->tmp . '/phpspecConfiguration.a1b2c3.infection.yml',
+            $builder->build(
+                [],
+                self::MUTATED_FILE_PATH,
+                self::MUTATION_HASH,
+                self::ORIGINAL_FILE_PATH
+            )
+        );
     }
 
     public function test_it_adds_original_bootstrap_file_to_custom_autoload(): void
@@ -85,7 +85,15 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
 
         $builder = new MutationConfigBuilder($this->tmp, $originalYamlConfigPath, $projectDir);
 
-        $this->assertSame($this->tmp . '/phpspecConfiguration.a1b2c3.infection.yml', $builder->build($mutant));
+        $this->assertSame(
+            $this->tmp . '/phpspecConfiguration.a1b2c3.infection.yml',
+            $builder->build(
+                [],
+                self::MUTATED_FILE_PATH,
+                self::MUTATION_HASH,
+                self::ORIGINAL_FILE_PATH
+            )
+        );
         $this->assertStringContainsString(
             "require_once '/project/dir/bootstrap.php';",
             file_get_contents($this->tmp . '/interceptor.phpspec.autoload.a1b2c3.infection.php')


### PR DESCRIPTION
First step to extract Test Framework Adapters out of the core. See https://github.com/infection/infection/issues/922

This is needed to decouple `TestFrameworkAdapter` from the chain
of several interfaces and classes

Before:
`TestFrameworkAdapter -> MutantInterface -> MutationInterface -> Mutator concrete class -> MutatorConfig`

After:
`TestFrameworkAdapter` independent interface

* It allows to make only 1 interface public - `TestFrameworkAdapter` instead of making public `TestFrameworkAdapter`, `MutantInterface`, `MutationInterface`, `Mutator`
* Related to https://github.com/infection/infection/pull/872. Without this PR, #872 can not be merged, because in this case we will have to make public a concrete `Mutation` class, which is not what we want

