### PR TITLE
Mutator tests 💅

### DIFF
--- a/tests/phpunit/Mutator/AbstractMutatorTestCase.php
+++ b/tests/phpunit/Mutator/AbstractMutatorTestCase.php
@@ -83,7 +83,7 @@ abstract class AbstractMutatorTestCase extends TestCase
         $this->mutator = $this->createMutator();
     }
 
-    final public function doTest(string $inputCode, $expectedCode = null, array $settings = []): void
+    final public function doTest(string $inputCode, $expectedCode = [], array $settings = []): void
     {
         $expectedCodeSamples = (array) $expectedCode;
 
@@ -105,17 +105,17 @@ abstract class AbstractMutatorTestCase extends TestCase
             )
         );
 
-        if ($expectedCode !== null) {
-            foreach ($mutants as $realMutatedCode) {
-                $expectedCodeSample = array_shift($expectedCodeSamples);
+        foreach ($mutants as $realMutatedCode) {
+            $expectedCodeSample = array_shift($expectedCodeSamples);
 
-                if ($expectedCodeSample === null) {
-                    $this->fail('The number of expected mutated code samples must equal the number of generated Mutants by mutator.');
-                }
-                $expectedCodeSample = rtrim($expectedCodeSample, "\n");
-                $this->assertSame($expectedCodeSample, $realMutatedCode);
-                $this->assertSyntaxIsValid($realMutatedCode);
+            if ($expectedCodeSample === null) {
+                $this->fail('The number of expected mutated code samples must equal the number of generated Mutants by mutator.');
             }
+
+            $expectedCodeSample = rtrim($expectedCodeSample, "\n");
+
+            $this->assertSame($expectedCodeSample, $realMutatedCode);
+            $this->assertSyntaxIsValid($realMutatedCode);
         }
     }
 

--- a/tests/phpunit/Mutator/Arithmetic/AssignmentEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/AssignmentEqualTest.php
@@ -35,73 +35,78 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class AssignmentEqualTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates a comparison to an assignment' => [
-                <<<'PHP'
+        yield 'It mutates a comparison to an assignment' => [
+            <<<'PHP'
 <?php
 
 if ($a == $b) {
 }
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 if ($a = $b) {
 }
 PHP
-                ,
-            ],
-            'It does not mutate comparsion to an impossible assignment' => [
-                        <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate comparsion to an impossible assignment' => [
+            <<<'PHP'
 <?php
 
 if (1 == $a) {
 }
 PHP
-                        ,
-            ],
-            'It does not try to assign a variable to a class constant' => [
-                        <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not try to assign a variable to a class constant' => [
+            <<<'PHP'
 <?php
 
 if (BaseClass::CLASS_CONST == $a) {
 }
 PHP
-                        ,
-            ],
-            'It does not try to assign a variable to a built in constant' => [
-                        <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not try to assign a variable to a built in constant' => [
+            <<<'PHP'
 <?php
 
 if (PHP_EOL == $a) {
 }
 PHP
-                        ,
-            ],
-            'It does not try to assign a scalar to a result of a function call' => [
-                        <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not try to assign a scalar to a result of a function call' => [
+            <<<'PHP'
 <?php
 
 if ($x->getFoo() == 1) {
 }
 PHP
-                        ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/AssignmentTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/AssignmentTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class AssignmentTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseAndTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseAndTest.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class BitwiseAndTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            [
-                <<<'PHP'
+        yield [
+            <<<'PHP'
 <?php
 
 1 & 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 | 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseNotTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseNotTest.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class BitwiseNotTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            [
-                <<<'PHP'
+        yield [
+            <<<'PHP'
 <?php
 
 ~2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseOrTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseOrTest.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class BitwiseOrTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            [
-                <<<'PHP'
+        yield [
+            <<<'PHP'
 <?php
 
 1 | 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 & 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseXorTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseXorTest.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class BitwiseXorTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            [
-                <<<'PHP'
+        yield[
+            <<<'PHP'
 <?php
 
 1 ^ 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 & 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/DecrementTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/DecrementTest.php
@@ -35,61 +35,64 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class DecrementTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It replaces post decrement' => [
-                <<<'PHP'
+        yield 'It replaces post decrement' => [
+            <<<'PHP'
 <?php
 
 $a = 1; 
 $a--;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a++;
 PHP
-                ,
-            ],
-            'It replaces pre decrement' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It replaces pre decrement' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 --$a;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 ++$a;
 PHP
-                ,
-            ],
-            'It does not change when its not a real decrement' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not change when its not a real decrement' => [
+            <<<'PHP'
 <?php
 
 $b - -$a;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/DivEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/DivEqualTest.php
@@ -35,45 +35,47 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class DivEqualTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It changes divison equals' => [
-                <<<'PHP'
+        yield 'It changes divison equals' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a /=2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a *= 2;
 PHP
-                ,
-            ],
-            'It does not change normal division' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not change normal division' => [
+            <<<'PHP'
 <?php
 
 $a = 10 / 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/DivisionTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/DivisionTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class DivisionTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It changes regular divison' => [
                 <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/ExponentiationTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ExponentiationTest.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ExponentiationTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            [
-                <<<'PHP'
+        yield [
+            <<<'PHP'
 <?php
 
 1 ** 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 / 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/IncrementTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/IncrementTest.php
@@ -35,61 +35,64 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class IncrementTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It replaces post increment' => [
-                <<<'PHP'
+        yield 'It replaces post increment' => [
+            <<<'PHP'
 <?php
 
 $a = 1; 
 $a++;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a--;
 PHP
-                ,
-            ],
-            'It replaces pre increment' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It replaces pre increment' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 ++$a;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 --$a;
 PHP
-                ,
-            ],
-            'It does not change when its not a real increment' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not change when its not a real increment' => [
+            <<<'PHP'
 <?php
 
 $b + +$a;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/MinusEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MinusEqualTest.php
@@ -35,46 +35,48 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class MinusEqualTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates minus equals' => [
-                <<<'PHP'
+        yield 'It mutates minus equals' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a -=2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a += 2;
 PHP
-                ,
-            ],
-            'It does not mutate normal minus' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate normal minus' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a = $a - 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/MinusTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MinusTest.php
@@ -35,69 +35,73 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class MinusTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates normal minus' => [
-                <<<'PHP'
+        yield 'It mutates normal minus' => [
+            <<<'PHP'
 <?php
 
 $a = 1 - 1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1 + 1;
 PHP
-                ,
-            ],
-            'It does not mutate minus equals' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate minus equals' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a -= 2;
 PHP
-                ,
-            ],
-            'It does not mutate decrement' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate decrement' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a--;
 PHP
-                ,
-            ],
-            'It does mutate a fake decrement' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does mutate a fake decrement' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a - -1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a + -1;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/ModEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ModEqualTest.php
@@ -35,45 +35,47 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ModEqualTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates mod equal' => [
-                <<<'PHP'
+        yield 'It mutates mod equal' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a %= 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a *= 2;
 PHP
-                ,
-            ],
-            'It does not mutate normal mod' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate normal mod' => [
+            <<<'PHP'
 <?php
 
 $a = 10 % 3;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/ModulusTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ModulusTest.php
@@ -35,44 +35,46 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ModulusTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates normal mod' => [
-                <<<'PHP'
+        yield 'It mutates normal mod' => [
+            <<<'PHP'
 <?php
 
 $a = 10 % 3;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 10 * 3;
 PHP
-                ,
-            ],
-            'It does not mutate mod equals' => [
-                <<<'PHP'
-<?php
+            ,
+        ];
 
-$a = 1;
-$a %= 2;
+        yield 'It does not mutate mod equals' => [
+            <<<'PHP'
+    <?php
+    
+    $a = 1;
+    $a %= 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/MulEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MulEqualTest.php
@@ -35,45 +35,47 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class MulEqualTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates multiply equal' => [
-                <<<'PHP'
+        yield 'It mutates multiply equal' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a *= 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a /= 2;
 PHP
-                ,
-            ],
-            'It does not mutate normal multiply' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate normal multiply' => [
+            <<<'PHP'
 <?php
 
 $a = 10 * 3;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/MultiplicationTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MultiplicationTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class MultiplicationTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates normal multiplication' => [
                 <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/PlusEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/PlusEqualTest.php
@@ -35,45 +35,47 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class PlusEqualTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates plus equal' => [
-                <<<'PHP'
+        yield 'It mutates plus equal' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a += 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a -= 2;
 PHP
-                ,
-            ],
-            'It does not mutate normal plus' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate normal plus' => [
+            <<<'PHP'
 <?php
 
 $a = 10 + 3;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/PlusTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/PlusTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
@@ -43,74 +44,78 @@ use PhpParser\Node\Scalar\LNumber;
 final class PlusTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates normal plus' => [
-                <<<'PHP'
+        yield 'It mutates normal plus' => [
+            <<<'PHP'
 <?php
 
 $a = 10 + 3;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 10 - 3;
 PHP
-                ,
-            ],
-            'It does not mutate plus equals' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate plus equals' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a += 2;
 PHP
-                ,
-            ],
-            'It does not mutate increment' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate increment' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a++;
 PHP
-                ,
-            ],
-            'It does mutate a fake increment' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does mutate a fake increment' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a + +1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a - +1;
 PHP
-                ,
-                ],
-                'It does not mutate additon of arrays' => [
-                    <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate additon of arrays' => [
+            <<<'PHP'
 <?php
 
 $a = [0 => 1] + [1 => 3];
 $b = 1 + [1 => 3];
 $c = [1 => 1] + 3;
 PHP
-                    ,
-            ],
+            ,
         ];
     }
 

--- a/tests/phpunit/Mutator/Arithmetic/PowEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/PowEqualTest.php
@@ -35,45 +35,47 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class PowEqualTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates pow equal' => [
-                <<<'PHP'
+        yield 'It mutates pow equal' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a **= 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a /= 2;
 PHP
-                ,
-            ],
-            'It does not mutate normal pow' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate normal pow' => [
+            <<<'PHP'
 <?php
 
 $a = 10 ** 3;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/RoundingFamilyTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/RoundingFamilyTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class RoundingFamilyTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates round() to floor() and ceil()' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/ShiftLeftTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ShiftLeftTest.php
@@ -35,46 +35,48 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ShiftLeftTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates shift left' => [
-                <<<'PHP'
+        yield 'It mutates shift left' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a << 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a >> 2;
 PHP
-                ,
-            ],
-            'It does not mutate shift right' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate shift right' => [
+        <<<'PHP'
 <?php
 
 $a = 1;
 $a >> 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/ShiftRightTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ShiftRightTest.php
@@ -35,46 +35,48 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ShiftRightTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates shift right' => [
-                <<<'PHP'
+        yield 'It mutates shift right' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a >> 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = 1;
 $a << 2;
 PHP
-                ,
-            ],
-            'It does not mutate shift left' => [
-                <<<'PHP'
-<?php
+            ,
+        ];
 
+        yield 'It does not mutate shift left' => [
+            <<<'PHP'
+<?php
+    
 $a = 1;
 $a << 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 

--- a/tests/phpunit/Mutator/Boolean/ArrayItemTest.php
+++ b/tests/phpunit/Mutator/Boolean/ArrayItemTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class ArrayItemTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates double arrow operator to a greater than comparison when operands can have side-effects and left is property' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class EqualIdenticalTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates with two variables' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/FalseValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/FalseValueTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name;
@@ -42,52 +43,54 @@ use PhpParser\Node\Name;
 final class FalseValueTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates false to true' => [
-                <<<'PHP'
+        yield 'It mutates false to true' => [
+            <<<'PHP'
 <?php
 
 return false;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 return true;
 PHP
-                ,
-            ],
-            'It does not mutate the string false to true' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate the string false to true' => [
+            <<<'PHP'
 <?php
 
 return 'false';
 PHP
-                ,
-            ],
-            'It mutates all caps false to true' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It mutates all caps false to true' => [
+            <<<'PHP'
 <?php
 
 return FALSE;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 return true;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 

--- a/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class IdenticalEqualTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates identical operator into equal operator with two variables' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/LogicalAndTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalAndTest.php
@@ -35,43 +35,45 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LogicalAndTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates logical and' => [
-                <<<'PHP'
+        yield 'It mutates logical and' => [
+            <<<'PHP'
 <?php
 
 true && false;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 true || false;
 PHP
-                ,
-            ],
-            'It does not mutate logical lower and' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate logical lower and' => [
+            <<<'PHP'
 <?php
 
 true and false;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Boolean/LogicalLowerAndTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalLowerAndTest.php
@@ -35,43 +35,45 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LogicalLowerAndTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates logical lower and' => [
-                <<<'PHP'
+        yield 'It mutates logical lower and' => [
+            <<<'PHP'
 <?php
 
 true and false;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 true or false;
 PHP
-                ,
-            ],
-            'It does not mutate logical and' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate logical and' => [
+            <<<'PHP'
 <?php
 
 true && false;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Boolean/LogicalLowerOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalLowerOrTest.php
@@ -35,43 +35,45 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LogicalLowerOrTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates logical lower or' => [
-                <<<'PHP'
+        yield 'It mutates logical lower or' => [
+            <<<'PHP'
 <?php
 
 true or false;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 true and false;
 PHP
-                ,
-            ],
-            'It does not mutate logical or' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate logical or' => [
+            <<<'PHP'
 <?php
 
 true || false;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Boolean/LogicalNotTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalNotTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\ConstFetch;
@@ -43,38 +44,39 @@ use PhpParser\Node\Name;
 final class LogicalNotTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It removes logical not' => [
-                <<<'PHP'
+        yield 'It removes logical not' => [
+            <<<'PHP'
 <?php
 
 return !false;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 return false;
 PHP
-                ,
-            ],
-            'It does not remove double logical not' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not remove double logical not' => [
+            <<<'PHP'
 <?php
 
 return !!false;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 

--- a/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
@@ -35,43 +35,45 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LogicalOrTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates logical or' => [
-                <<<'PHP'
+        yield 'It mutates logical or' => [
+            <<<'PHP'
 <?php
 
 true || false;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 true && false;
 PHP
-                ,
-            ],
-            'It does not mutate logical lower or' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate logical lower or' => [
+            <<<'PHP'
 <?php
 
 true or false;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Boolean/NotEqualNotIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/NotEqualNotIdenticalTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class NotEqualNotIdenticalTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates with two variables' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/NotIdenticalNotEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/NotIdenticalNotEqualTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class NotIdenticalNotEqualTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates not identical operator into not equal operator with two variables' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/TrueValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/TrueValueTest.php
@@ -43,14 +43,16 @@ use PhpParser\Node\Name;
 final class TrueValueTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null, array $settings = []): void
+    public function test_it_can_mutate($input, $expected = [], array $settings = []): void
     {
         $this->doTest($input, $expected, $settings);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates true to false' => [
                 <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/Yield_Test.php
+++ b/tests/phpunit/Mutator/Boolean/Yield_Test.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class Yield_Test extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates a yield with a double arrow to a yield with a greater than comparison' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastArrayTest.php
+++ b/tests/phpunit/Mutator/Cast/CastArrayTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class CastArrayTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It removes casting to array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastBoolTest.php
+++ b/tests/phpunit/Mutator/Cast/CastBoolTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class CastBoolTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It removes casting to bool with "bool"' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastFloatTest.php
+++ b/tests/phpunit/Mutator/Cast/CastFloatTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class CastFloatTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It removes casting to float' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastIntTest.php
+++ b/tests/phpunit/Mutator/Cast/CastIntTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class CastIntTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It removes casting to int' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastObjectTest.php
+++ b/tests/phpunit/Mutator/Cast/CastObjectTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class CastObjectTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It removes casting to object' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastStringTest.php
+++ b/tests/phpunit/Mutator/Cast/CastStringTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class CastStringTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It removes casting to string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanOrEqualToTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanOrEqualToTest.php
@@ -35,51 +35,54 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalBoundary;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class GreaterThanOrEqualToTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates greater than or equal to' => [
-                <<<'PHP'
+        yield 'It mutates greater than or equal to' => [
+            <<<'PHP'
 <?php
 
 1 >= 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 > 2;
 PHP
-                ,
-            ],
-            'It does not mutate an arrow' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate an arrow' => [
+            <<<'PHP'
 <?php
 
 [1 => 2];
 PHP
-                ,
-            ],
-            'It does not mutate a spaceship' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate a spaceship' => [
+            <<<'PHP'
 <?php
 
 1 <=> 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanTest.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalBoundary;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class GreaterThanTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates greater than' => [
-                <<<'PHP'
+        yield 'It mutates greater than' => [
+            <<<'PHP'
 <?php
 
 1 > 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 >= 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalBoundary/LessThanOrEqualToTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/LessThanOrEqualToTest.php
@@ -35,51 +35,54 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalBoundary;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LessThanOrEqualToTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates less than or equal to' => [
-                <<<'PHP'
+        yield 'It mutates less than or equal to' => [
+            <<<'PHP'
 <?php
 
 1 <= 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 < 2;
 PHP
-                ,
-            ],
-            'It does not mutate an arrow' => [
-                <<<'PHP'
-<?php
+            ,
+        ];
 
-[1 => 2];
+        yield 'It does not mutate an arrow' => [
+            <<<'PHP'
+    <?php
+    
+    [1 => 2];
 PHP
-                ,
-            ],
-            'It does not mutate a spaceship' => [
-                <<<'PHP'
-<?php
+            ,
+        ];
 
-1 <=> 2;
+        yield 'It does not mutate a spaceship' => [
+            <<<'PHP'
+    <?php
+    
+    1 <=> 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalBoundary/LessThanTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/LessThanTest.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalBoundary;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LessThanTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates less than' => [
-                <<<'PHP'
+        yield 'It mutates less than' => [
+            <<<'PHP'
 <?php
 
 1 < 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 <= 2;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/EqualTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/EqualTest.php
@@ -35,51 +35,54 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class EqualTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates not strict comparison' => [
-                <<<'PHP'
+        yield 'It mutates not strict comparison' => [
+            <<<'PHP'
 <?php
 
 1 == 1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 != 1;
 PHP
-                ,
-            ],
-            'It does not mutate strict comparison' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate strict comparison' => [
+            <<<'PHP'
 <?php
 
 1 === 1;
 PHP
-                ,
-            ],
-            'It does not mutate not equals comparison' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate not equals comparison' => [
+            <<<'PHP'
 <?php
 
 1 !== 1;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanNegotiationTest.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class GreaterThanNegotiationTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates greater than' => [
-                <<<'PHP'
+        yield 'It mutates greater than' => [
+            <<<'PHP'
 <?php
 
 1 > 1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 <= 1;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiationTest.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class GreaterThanOrEqualToNegotiationTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates greater than or equal to' => [
-                <<<'PHP'
+        yield 'It mutates greater than or equal to' => [
+            <<<'PHP'
 <?php
 
 1 >= 1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 < 1;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/IdenticalTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/IdenticalTest.php
@@ -35,51 +35,54 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class IdenticalTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates strict comparison' => [
-                <<<'PHP'
+        yield 'It mutates strict comparison' => [
+            <<<'PHP'
 <?php
 
 1 === 1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 !== 1;
 PHP
-                ,
-            ],
-            'It does not mutate not strict comparison' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate not strict comparison' => [
+            <<<'PHP'
 <?php
 
 1 == 1;
 PHP
-                ,
-            ],
-            'It does not mutate not comparison' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate not comparison' => [
+            <<<'PHP'
 <?php
 
-1 !== 1;
+    1 !== 1;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/LessThanNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/LessThanNegotiationTest.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LessThanNegotiationTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates less than' => [
-                <<<'PHP'
+        yield 'It mutates less than' => [
+            <<<'PHP'
 <?php
 
 1 < 1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 >= 1;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiationTest.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LessThanOrEqualToNegotiationTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates less than or equal to' => [
-                <<<'PHP'
+        yield 'It mutates less than or equal to' => [
+            <<<'PHP'
 <?php
 
 1 <= 1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 > 1;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/NotEqualTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/NotEqualTest.php
@@ -35,51 +35,54 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class NotEqualTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates not strict comparison' => [
-                <<<'PHP'
+        yield 'It mutates not strict comparison' => [
+            <<<'PHP'
 <?php
 
 1 != 1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 == 1;
 PHP
-                ,
-            ],
-            'It does not mutate strict comparison' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate strict comparison' => [
+            <<<'PHP'
 <?php
 
 1 !== 1;
 PHP
-                ,
-            ],
-            'It does not mutate normal equals comparison' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate normal equals comparison' => [
+            <<<'PHP'
 <?php
 
 1 == 1;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/NotIdenticalTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/NotIdenticalTest.php
@@ -35,51 +35,54 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class NotIdenticalTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates strict comparison' => [
-                <<<'PHP'
+        yield 'It mutates strict comparison' => [
+            <<<'PHP'
 <?php
 
 1 !== 1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 1 === 1;
 PHP
-                ,
-            ],
-            'It does not mutate not strict comparison' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate not strict comparison' => [
+            <<<'PHP'
 <?php
 
 1 != 1;
 PHP
-                ,
-            ],
-            'It does not mutate normal comparison' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate normal comparison' => [
+            <<<'PHP'
 <?php
 
 1 === 1;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Extensions/BCMathTest.php
+++ b/tests/phpunit/Mutator/Extensions/BCMathTest.php
@@ -44,35 +44,37 @@ use function range;
 final class BCMathTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator(string $input, ?string $expected = null, array $settings = []): void
+    public function test_it_can_mutate(string $input, $expected = [], array $settings = []): void
     {
         $this->doTest($input, $expected, $settings);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
-        yield from $this->provideMutationCasesForBinaryOperator('bcadd', '+', 'summation');
+        yield from $this->mutationsProviderForBinaryOperator('bcadd', '+', 'summation');
 
-        yield from $this->provideMutationCasesForBinaryOperator('bcdiv', '/', 'division');
+        yield from $this->mutationsProviderForBinaryOperator('bcdiv', '/', 'division');
 
-        yield from $this->provideMutationCasesForBinaryOperator('bcmod', '%', 'modulo');
+        yield from $this->mutationsProviderForBinaryOperator('bcmod', '%', 'modulo');
 
-        yield from $this->provideMutationCasesForBinaryOperator('bcmul', '*', 'multiplication');
+        yield from $this->mutationsProviderForBinaryOperator('bcmul', '*', 'multiplication');
 
-        yield from $this->provideMutationCasesForBinaryOperator('bcsub', '-', 'subtraction');
+        yield from $this->mutationsProviderForBinaryOperator('bcsub', '-', 'subtraction');
 
-        yield from $this->provideMutationCasesForPowerOperator();
+        yield from $this->mutationsProviderForPowerOperator();
 
-        yield from $this->provideMutationCasesForSquareRoot();
+        yield from $this->mutationsProviderForSquareRoot();
 
-        yield from $this->provideMutationCasesForPowerModulo();
+        yield from $this->mutationsProviderForPowerModulo();
 
-        yield from $this->provideMutationCasesForComparision();
+        yield from $this->mutationsProviderForComparision();
     }
 
-    private function provideMutationCasesForBinaryOperator(string $bcFunc, string $op, string $expression): Generator
+    private function mutationsProviderForBinaryOperator(string $bcFunc, string $op, string $expression): Generator
     {
         yield "It converts $bcFunc to $expression expression" => [
             "<?php \\$bcFunc('3', \$b);",
@@ -92,7 +94,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         yield from $this->provideCasesWhereMutatorShouldNotApply($bcFunc);
     }
 
-    private function provideMutationCasesForPowerOperator(): Generator
+    private function mutationsProviderForPowerOperator(): Generator
     {
         yield 'It converts bcpow to power expression' => [
             '<?php \\bcpow(5, $b);',
@@ -112,7 +114,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         yield from $this->provideCasesWhereMutatorShouldNotApply('bcpow');
     }
 
-    private function provideMutationCasesForSquareRoot(): Generator
+    private function mutationsProviderForSquareRoot(): Generator
     {
         yield 'It converts bcsqrt to sqrt call' => [
             '<?php \\bcsqrt(2);',
@@ -132,7 +134,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         yield from $this->provideCasesWhereMutatorShouldNotApply('bcsqrt', 1);
     }
 
-    private function provideMutationCasesForPowerModulo(): Generator
+    private function mutationsProviderForPowerModulo(): Generator
     {
         yield 'It converts bcpowmod to power modulo expression' => [
             '<?php \\bcpowmod($a, $b, $mod);',
@@ -152,7 +154,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         yield from $this->provideCasesWhereMutatorShouldNotApply('bcpowmod', 3);
     }
 
-    private function provideMutationCasesForComparision(): Generator
+    private function mutationsProviderForComparision(): Generator
     {
         yield 'It converts bccomp to spaceship expression' => [
             '<?php \\bccomp(\'3\', $b);',

--- a/tests/phpunit/Mutator/Extensions/MBStringTest.php
+++ b/tests/phpunit/Mutator/Extensions/MBStringTest.php
@@ -48,14 +48,16 @@ final class MBStringTest extends AbstractMutatorTestCase
     }
 
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator(string $input, ?string $expected = null, array $settings = []): void
+    public function test_it_can_mutate(string $input, $expected = [], array $settings = []): void
     {
         $this->doTest($input, $expected, $settings);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It converts mb_strlen with leading slash' => [
             "<?php \mb_strlen('test');",
@@ -83,44 +85,44 @@ final class MBStringTest extends AbstractMutatorTestCase
             ['settings' => ['mb_strlen' => false]],
         ];
 
-        yield from $this->provideMutationCasesForChr();
+        yield from $this->mutationsProviderForChr();
 
-        yield from $this->provideMutationCasesForOrd();
+        yield from $this->mutationsProviderForOrd();
 
-        yield from $this->provideMutationCasesForParseStr();
+        yield from $this->mutationsProviderForParseStr();
 
-        yield from $this->provideMutationCasesForSendMail();
+        yield from $this->mutationsProviderForSendMail();
 
-        yield from $this->provideMutationCasesForStrCut();
+        yield from $this->mutationsProviderForStrCut();
 
-        yield from $this->provideMutationCasesForStrPos();
+        yield from $this->mutationsProviderForStrPos();
 
-        yield from $this->provideMutationCasesForStrIPos();
+        yield from $this->mutationsProviderForStrIPos();
 
-        yield from $this->provideMutationCasesForStrIStr();
+        yield from $this->mutationsProviderForStrIStr();
 
-        yield from $this->provideMutationCasesForStrRiPos();
+        yield from $this->mutationsProviderForStrRiPos();
 
-        yield from $this->provideMutationCasesForStrRPos();
+        yield from $this->mutationsProviderForStrRPos();
 
-        yield from $this->provideMutationCasesForStrStr();
+        yield from $this->mutationsProviderForStrStr();
 
-        yield from $this->provideMutationCasesForStrToLower();
+        yield from $this->mutationsProviderForStrToLower();
 
-        yield from $this->provideMutationCasesForStrToUpper();
+        yield from $this->mutationsProviderForStrToUpper();
 
-        yield from $this->provideMutationCasesForSubStrCount();
+        yield from $this->mutationsProviderForSubStrCount();
 
-        yield from $this->provideMutationCasesForSubStr();
+        yield from $this->mutationsProviderForSubStr();
 
-        yield from $this->provideMutationCasesForStrRChr();
+        yield from $this->mutationsProviderForStrRChr();
 
-        yield from $this->provideMutationCasesForConvertCase();
+        yield from $this->mutationsProviderForConvertCase();
 
-        yield from $this->provideMutationCasesForStrSplit();
+        yield from $this->mutationsProviderForStrSplit();
     }
 
-    private function provideMutationCasesForChr(): Generator
+    private function mutationsProviderForChr(): Generator
     {
         yield 'It converts mb_chr to chr' => [
             '<?php mb_chr(74);',
@@ -142,7 +144,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForOrd(): Generator
+    private function mutationsProviderForOrd(): Generator
     {
         yield 'It converts mb_ord to ord' => [
             "<?php mb_ord('T');",
@@ -164,7 +166,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForParseStr(): Generator
+    private function mutationsProviderForParseStr(): Generator
     {
         yield 'It converts mb_parse_str to parse_str' => [
             "<?php mb_parse_str('T');",
@@ -186,7 +188,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForSendMail(): Generator
+    private function mutationsProviderForSendMail(): Generator
     {
         yield 'It converts mb_send_mail to mail' => [
             "<?php mb_send_mail('to', 'subject', 'msg');",
@@ -208,7 +210,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForStrCut(): Generator
+    private function mutationsProviderForStrCut(): Generator
     {
         yield 'It converts mb_strcut to substr' => [
             "<?php mb_strcut('subject', 1);",
@@ -235,7 +237,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForStrPos(): Generator
+    private function mutationsProviderForStrPos(): Generator
     {
         yield 'It converts mb_strpos to strpos' => [
             "<?php mb_strpos('subject', 'b');",
@@ -262,7 +264,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForStrIPos(): Generator
+    private function mutationsProviderForStrIPos(): Generator
     {
         yield 'It converts mb_stripos to stripos' => [
             "<?php mb_stripos('subject', 'b');",
@@ -289,7 +291,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForStrIStr(): Generator
+    private function mutationsProviderForStrIStr(): Generator
     {
         yield 'It converts mb_stristr to stristr' => [
             "<?php mb_stristr('subject', 'b');",
@@ -316,7 +318,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForStrRiPos(): Generator
+    private function mutationsProviderForStrRiPos(): Generator
     {
         yield 'It converts mb_strripos to strripos' => [
             "<?php mb_strripos('subject', 'b');",
@@ -343,7 +345,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForStrRPos(): Generator
+    private function mutationsProviderForStrRPos(): Generator
     {
         yield 'It converts mb_strrpos to strrpos' => [
             "<?php mb_strrpos('subject', 'b');",
@@ -370,7 +372,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForStrStr(): Generator
+    private function mutationsProviderForStrStr(): Generator
     {
         yield 'It converts mb_strstr to strstr' => [
             "<?php mb_strstr('subject', 'b');",
@@ -397,7 +399,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForStrToLower(): Generator
+    private function mutationsProviderForStrToLower(): Generator
     {
         yield 'It converts mb_strtolower to strtolower' => [
             "<?php mb_strtolower('test');",
@@ -419,7 +421,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForStrToUpper(): Generator
+    private function mutationsProviderForStrToUpper(): Generator
     {
         yield 'It converts mb_strtoupper to strtoupper' => [
             "<?php mb_strtoupper('test');",
@@ -441,7 +443,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForSubStrCount(): Generator
+    private function mutationsProviderForSubStrCount(): Generator
     {
         yield 'It converts mb_substr_count to substr_count' => [
             "<?php mb_substr_count('test', 't');",
@@ -463,7 +465,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForSubStr(): Generator
+    private function mutationsProviderForSubStr(): Generator
     {
         yield 'It converts mb_substr to substr' => [
             "<?php mb_substr('test', 2);",
@@ -490,7 +492,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForStrRChr(): Generator
+    private function mutationsProviderForStrRChr(): Generator
     {
         yield 'It converts mb_strrchr to strrchr' => [
             "<?php mb_strrchr('subject', 'b');",
@@ -517,7 +519,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForConvertCase(): Generator
+    private function mutationsProviderForConvertCase(): Generator
     {
         yield 'It converts mb_convert_case with MB_CASE_UPPER mode to strtoupper' => [
             "<?php mb_convert_case('test', MB_CASE_UPPER);",
@@ -582,7 +584,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function provideMutationCasesForStrSplit()
+    private function mutationsProviderForStrSplit()
     {
         yield 'It converts mb_str_split to str_split' => [
             "<?php mb_str_split('test', 2);",

--- a/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class ProtectedVisibilityTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates protected to private' => [
             $this->getFileContent('pv-one-class.php'),

--- a/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
@@ -67,14 +67,16 @@ final class PublicVisibilityTest extends AbstractMutatorTestCase
     }
 
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates public to protected' => [
             $this->getFileContent('pv-one-class.php'),

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -35,335 +35,363 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Number;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class DecrementIntegerTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It does not decrement an integer in a comparison' => [
-                <<<'PHP'
+        yield 'It does not decrement an integer in a comparison' => [
+            <<<'PHP'
 <?php
 
 if ($foo < 10) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not decrement the number one' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement the number one' => [
+            <<<'PHP'
 <?php
 
 $a = 1;
 PHP
-                ,
-            ],
-            'It does not decrement zero when it is being compared as identical with result of count()' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement zero when it is being compared as identical with result of count()' => [
+            <<<'PHP'
 <?php
 
 if (count($a) === 0) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not decrement zero with yoda style when it is being compared as identical with result of count()' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement zero with yoda style when it is being compared as identical with result of count()' => [
+            <<<'PHP'
 <?php
 
 if (0 === count($a)) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not decrement zero with when it is being compared as identical with result of cOunT()' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement zero with when it is being compared as identical with result of cOunT()' => [
+            <<<'PHP'
 <?php
 
 if (cOunT($a) === 0) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not decrement zero when it is being compared as identical with result of sizeOf()' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement zero when it is being compared as identical with result of sizeOf()' => [
+            <<<'PHP'
 <?php
 
 if (sizeOf($a) === 0) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not decrement zero when it is being compared as not identical with result of count()' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement zero when it is being compared as not identical with result of count()' => [
+            <<<'PHP'
 <?php
 
 if (count($a) !== 0) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not decrement zero when it is compared as equal with result of count()' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement zero when it is compared as equal with result of count()' => [
+            <<<'PHP'
 <?php
 
 if (count($a) == 0) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not decrement zero when it is compared as not equal with result of count()' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement zero when it is compared as not equal with result of count()' => [
+            <<<'PHP'
 <?php
 
 if (count($a) != 0) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not decrement zero when it is compared as more than count()' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement zero when it is compared as more than count()' => [
+            <<<'PHP'
 <?php
 
 if (count($a) > 0) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not decrement zero when it is compared as less than count() on the right side' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement zero when it is compared as less than count() on the right side' => [
+            <<<'PHP'
 <?php
 
 if (0 < count($a)) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not decrement zero when it is compared as less than or equal to count() on the right side' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement zero when it is compared as less than or equal to count() on the right side' => [
+            <<<'PHP'
 <?php
 
 if (0 <= count($a)) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not decrement zero when it is compared as equal to count() on the right side' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not decrement zero when it is compared as equal to count() on the right side' => [
+            <<<'PHP'
 <?php
 
 if (0 == count($a)) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
+            ,
+        ];
 
-            'It does not decrement zero when it is compared as greater than count() on the right side' => [
-                <<<'PHP'
+        yield 'It does not decrement zero when it is compared as greater than count() on the right side' => [
+            <<<'PHP'
 <?php
 
 if (0 > count($a)) {
     echo 'bar';
 }
 PHP
-            ],
-            'It does not decrement zero when it is compared as more or equal than count()' => [
-                <<<'PHP'
+        ];
+
+        yield 'It does not decrement zero when it is compared as more or equal than count()' => [
+            <<<'PHP'
 <?php
 
 if (count($a) >= 0) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It doest not decrement zero when it is compared as less than count()' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It doest not decrement zero when it is compared as less than count()' => [
+            <<<'PHP'
 <?php
 
 if (count($a) < 0) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does decrement when compared against a variable function' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does decrement when compared against a variable function' => [
+            <<<'PHP'
 <?php
 
 if ($foo === 0) {
     echo 'bar';
 }
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 if ($foo === -1) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It decrements zero when it is compared any other, not count() function' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It decrements zero when it is compared any other, not count() function' => [
+            <<<'PHP'
 <?php
 
 if (abs($a) === 0) {
     echo 'bar';
 }
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 if (abs($a) === -1) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It doest not decrements zero when it is compared as less or equal than count()' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It doest not decrements zero when it is compared as less or equal than count()' => [
+            <<<'PHP'
 <?php
 
 if (count($a) <= 0) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It decrements zero' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It decrements zero' => [
+            <<<'PHP'
 <?php
 
 $a = 0;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $a = -1;
 PHP
-                ,
-            ],
-            'It increments a negative integer' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It increments a negative integer' => [
+            <<<'PHP'
 <?php
 
 if ($foo === -10) {
     echo 'bar';
 }
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 if ($foo === -9) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It decrements an assignment' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It decrements an assignment' => [
+            <<<'PHP'
 <?php
 
 $foo = 10;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $foo = 9;
 PHP
-            ],
-            'It decrements an assignment of 0' => [
-                <<<'PHP'
+        ];
+
+        yield 'It decrements an assignment of 0' => [
+            <<<'PHP'
 <?php
 
 $foo = 0;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $foo = -1;
 PHP
-            ],
-            'It does not decrement an assignment of 1' => [
-                <<<'PHP'
+        ];
+
+        yield 'It does not decrement an assignment of 1' => [
+            <<<'PHP'
 <?php
 
 $foo = 1;
 PHP
-            ],
-            'It does not decrement zero when it is being compared as identical with result of grapheme_strlen()' => [
-                <<<'PHP'
+        ];
+
+        yield 'It does not decrement zero when it is being compared as identical with result of grapheme_strlen()' => [
+            <<<'PHP'
 <?php
 
 if (grapheme_strlen($a) === 0) {
     echo 'bar';
 }
 PHP
-            ],
-            'It does not decrement zero when it is being compared as identical with result of iconv_strlen()' => [
-                <<<'PHP'
+        ];
+
+        yield 'It does not decrement zero when it is being compared as identical with result of iconv_strlen()' => [
+            <<<'PHP'
 <?php
 
 if (iconv_strlen($a) === 0) {
     echo 'bar';
 }
 PHP
-            ],
-            'It does not decrement zero when it is being compared as identical with result of mb_strlen()' => [
-                <<<'PHP'
+        ];
+
+        yield 'It does not decrement zero when it is being compared as identical with result of mb_strlen()' => [
+            <<<'PHP'
 <?php
 
 if (mb_strlen($a) === 0) {
     echo 'bar';
 }
 PHP
-            ],
-            'It does not decrement zero when it is being compared as identical with result of sizeof()' => [
-                <<<'PHP'
+        ];
+
+        yield 'It does not decrement zero when it is being compared as identical with result of sizeof()' => [
+            <<<'PHP'
 <?php
 
 if (sizeof($a) === 0) {
     echo 'bar';
 }
 PHP
-            ],
-            'It does not decrement zero when it is being compared as identical with result of strlen()' => [
-                <<<'PHP'
+        ];
+
+        yield 'It does not decrement zero when it is being compared as identical with result of strlen()' => [
+            <<<'PHP'
 <?php
 
 if (strlen($a) === 0) {
     echo 'bar';
 }
 PHP
-            ],
         ];
     }
 }

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -35,94 +35,99 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Number;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class IncrementIntegerTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It increments an integer' => [
-                <<<'PHP'
+        yield 'It increments an integer' => [
+            <<<'PHP'
 <?php
 
 if ($foo === 10) {
     echo 'bar';
 }
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 if ($foo === 11) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not increment the number zero' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not increment the number zero' => [
+            <<<'PHP'
 <?php
 
 if ($foo < 0) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It increments one' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It increments one' => [
+            <<<'PHP'
 <?php
 
 if ($foo === 1) {
     echo 'bar';
 }
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 if ($foo === 2) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
-            'It does not increment floats' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not increment floats' => [
+            <<<'PHP'
 <?php
 
 if ($foo === 1.0) {
     echo 'bar';
 }
 PHP
-            ],
-            'It decrements a negative integer' => [
-                <<<'PHP'
+        ];
+
+        yield 'It decrements a negative integer' => [
+            <<<'PHP'
 <?php
 
 if ($foo === -10) {
     echo 'bar';
 }
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 if ($foo === -11) {
     echo 'bar';
 }
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Number/OneZeroFloatTest.php
+++ b/tests/phpunit/Mutator/Number/OneZeroFloatTest.php
@@ -35,91 +35,98 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Number;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class OneZeroFloatTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates float one to zero' => [
-                <<<'PHP'
+        yield 'It mutates float one to zero' => [
+            <<<'PHP'
 <?php
 
 10 + 1.0;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 10 + 0.0;
 PHP
-                ,
-            ],
-            'It mutates float zero to one' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It mutates float zero to one' => [
+            <<<'PHP'
 <?php
 
 10 + 0.0;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 10 + 1.0;
 PHP
-                ,
-            ],
-            'It does not mutate int zero to one' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate int zero to one' => [
+            <<<'PHP'
 <?php
 
 10 + 0;
 PHP
-                ,
-            ],
-            'It does not mutate int one to zer0' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate int one to zer0' => [
+            <<<'PHP'
 <?php
 
 10 + 1;
 PHP
-                ,
-            ],
-            'It does not mutate the string 0.0' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate the string 0.0' => [
+            <<<'PHP'
 <?php
 
 'a' . '0.0';
 PHP
-            ],
-            'It does not mutate other floats' => [
-                <<<'PHP'
+        ];
+
+        yield 'It does not mutate other floats' => [
+            <<<'PHP'
 <?php
 
 10 + 2.0;
 10 + 1.1;
 10 + 0.5;
 PHP
-                ,
-            ],
-            'It does not mutate in a comparison' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate in a comparison' => [
+            <<<'PHP'
 <?php
 
 if ($a < 0.0) {
     echo "small";
 }
 PHP
-            ],
         ];
     }
 }

--- a/tests/phpunit/Mutator/Number/OneZeroIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/OneZeroIntegerTest.php
@@ -35,81 +35,87 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Number;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class OneZeroIntegerTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates int one to zero' => [
-                <<<'PHP'
+        yield 'It mutates int one to zero' => [
+            <<<'PHP'
 <?php
 
 10 + 1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 10 + 0;
 PHP
-                ,
-            ],
-            'It mutates int zero to one' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It mutates int zero to one' => [
+            <<<'PHP'
 <?php
 
 10 + 0;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 10 + 1;
 PHP
-                ,
-            ],
-            'It does not mutate float zero to one' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate float zero to one' => [
+            <<<'PHP'
 <?php
 
 10 + 0.0;
 PHP
-                ,
-            ],
-            'It does not mutate float one to zero' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate float one to zero' => [
+            <<<'PHP'
 <?php
 
 10 + 1.0;
 PHP
-                ,
-            ],
-            'It does not mutate the string zero' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate the string zero' => [
+            <<<'PHP'
 <?php
 
 'a' . '0';
 PHP
-            ],
-            'It does not mutate in a comparison' => [
-                <<<'PHP'
+        ];
+
+        yield 'It does not mutate in a comparison' => [
+            <<<'PHP'
 <?php
 
 if ($a < 0) {
     echo "small";
 }
 PHP
-            ],
         ];
     }
 }

--- a/tests/phpunit/Mutator/Operator/AssignCoalesceTest.php
+++ b/tests/phpunit/Mutator/Operator/AssignCoalesceTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class AssignCoalesceTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'Mutate coalesce when right part is a scalar value' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Operator/Break_Test.php
+++ b/tests/phpunit/Mutator/Operator/Break_Test.php
@@ -35,41 +35,44 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Operator;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class Break_Test extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It replaces break with continue in while' => [
-                <<<'PHP'
+        yield 'It replaces break with continue in while' => [
+            <<<'PHP'
 <?php
 
 while (true) {
     break;
 }
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 while (true) {
     continue;
 }
 PHP
-                ,
-            ],
-            'It does not replaces break with continue in switch' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not replaces break with continue in switch' => [
+            <<<'PHP'
 <?php
 
 switch (1) {
@@ -77,8 +80,7 @@ switch (1) {
         break;
 }
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Operator/CoalesceTest.php
+++ b/tests/phpunit/Mutator/Operator/CoalesceTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class CoalesceTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'Mutate coalesce with scalar values' => [
             <<<PHP

--- a/tests/phpunit/Mutator/Operator/Continue_Test.php
+++ b/tests/phpunit/Mutator/Operator/Continue_Test.php
@@ -35,41 +35,44 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Operator;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class Continue_Test extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It replaces continue with break in while' => [
-                <<<'PHP'
+        yield 'It replaces continue with break in while' => [
+            <<<'PHP'
 <?php
 
 while (true) {
     continue;
 }
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 while (true) {
     break;
 }
 PHP
-                ,
-            ],
-            'It does not replaces continue with break in switch' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not replaces continue with break in switch' => [
+            <<<'PHP'
 <?php
 
 switch (1) {
@@ -77,8 +80,7 @@ switch (1) {
         continue;
 }
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Operator/Finally_Test.php
+++ b/tests/phpunit/Mutator/Operator/Finally_Test.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class Finally_Test extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It removes the finally statement' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -42,14 +42,14 @@ final class SpreadTest extends AbstractMutatorTestCase
 {
     /**
      * @requires PHP >= 7.4
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'Spread for a raw array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Operator/Throw_Test.php
+++ b/tests/phpunit/Mutator/Operator/Throw_Test.php
@@ -35,35 +35,36 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Operator;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class Throw_Test extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It removes the throw statement' => [
-                <<<'PHP'
+        yield 'It removes the throw statement' => [
+            <<<'PHP'
 <?php
 
 throw new \Exception();
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 new \Exception();
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Regex/PregMatchMatchesTest.php
+++ b/tests/phpunit/Mutator/Regex/PregMatchMatchesTest.php
@@ -41,14 +41,14 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class PregMatchMatchesTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider providesMutatorCases
+     * @dataProvider mutationsProvider
      */
-    public function test_mutator(string $input, ?string $output = null): void
+    public function test_it_can_mutate(string $input, $output = []): void
     {
         $this->doTest($input, $output);
     }
 
-    public function providesMutatorCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates ' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Regex/PregQuoteTest.php
+++ b/tests/phpunit/Mutator/Regex/PregQuoteTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class PregQuoteTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
@@ -42,14 +42,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class ArrayItemRemovalTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator(string $input, $expected = null, array $settings = []): void
+    public function test_it_can_mutate(string $input, $expected = [], array $settings = []): void
     {
         $this->doTest($input, $expected, $settings);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It does not mutate empty arrays' => [
             '<?php $a = [];',

--- a/tests/phpunit/Mutator/Removal/CloneRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/CloneRemovalTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class CloneRemovalTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator(string $input, ?string $expected): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It removes clone from expression clone-new' => [
           <<<'PHP'

--- a/tests/phpunit/Mutator/Removal/FunctionCallRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/FunctionCallRemovalTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class FunctionCallRemovalTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It removes a function call without parameters' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Removal/MethodCallRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/MethodCallRemovalTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class MethodCallRemovalTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It removes a method call without parameters' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class ArrayOneItemTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates when return typehint is not nullable array' => [
             $this->getFileContent('mutates-not-nullable-array.php'),

--- a/tests/phpunit/Mutator/ReturnValue/FloatNegationTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/FloatNegationTest.php
@@ -35,65 +35,69 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ReturnValue;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class FloatNegationTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates negative float return to positive' => [
-                <<<'PHP'
+        yield 'It mutates negative float return to positive' => [
+            <<<'PHP'
 <?php
 
 return -2.0;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 return 2.0;
 PHP
-                ,
-            ],
-            'It mutates positive float return to negative' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It mutates positive float return to negative' => [
+            <<<'PHP'
 <?php
 
 return 2.0;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 return -2.0;
 PHP
-                ,
-            ],
-            'It does not mutate float zero' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate float zero' => [
+            <<<'PHP'
 <?php
 
 return 0.0;
 PHP
-                ,
-            ],
-            'It does not mutate integers' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate integers' => [
+            <<<'PHP'
 <?php
 
 return 1;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class FunctionCallTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It does not mutate with not nullable return typehint' => [
             $this->getFileContent('fc-not-mutates-with-not-nullable-typehint.php'),

--- a/tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ReturnValue;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt\Return_;
@@ -42,88 +43,93 @@ use PhpParser\Node\Stmt\Return_;
 final class IntegerNegationTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It mutates negative -1 int return to positive' => [
-                <<<'PHP'
+        yield 'It mutates negative -1 int return to positive' => [
+            <<<'PHP'
 <?php
 
 return -1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 return 1;
 PHP
-                ,
-            ],
-            'It mutates negative -2 int return to positive' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It mutates negative -2 int return to positive' => [
+            <<<'PHP'
 <?php
 
 return -2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 return 2;
 PHP
-                ,
-            ],
-            'It mutates positive 1 int return to negative' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It mutates positive 1 int return to negative' => [
+            <<<'PHP'
 <?php
 
 return 1;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 return -1;
 PHP
-                ,
-            ],
-            'It mutates positive 2 int return to negative' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It mutates positive 2 int return to negative' => [
+            <<<'PHP'
 <?php
 
 return 2;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 return -2;
 PHP
-                ,
-            ],
-            'It does not mutate int zero' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate int zero' => [
+            <<<'PHP'
 <?php
 
 return 0;
 PHP
-                ,
-            ],
-            'It does not mutate floats' => [
-                <<<'PHP'
+            ,
+        ];
+
+        yield 'It does not mutate floats' => [
+            <<<'PHP'
 <?php
 
 return 1.0;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 

--- a/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
@@ -41,9 +41,11 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class NewObjectTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null, bool $allowed = true, $message = ''): void
+    public function test_it_can_mutate($input, $expected = [], bool $allowed = true, $message = ''): void
     {
         if (!$allowed) {
             $this->markTestSkipped($message);
@@ -51,7 +53,7 @@ final class NewObjectTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It does not mutate if no class name found' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ReturnValue/ThisTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ThisTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class ThisTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It does mutate with no typehint' => [
             $this->getFileContent('this_return-this.php'),

--- a/tests/phpunit/Mutator/Sort/SpaceshipTest.php
+++ b/tests/phpunit/Mutator/Sort/SpaceshipTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Sort;
 
+use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class SpaceshipTest extends AbstractMutatorTestCase
@@ -45,30 +46,30 @@ final class SpaceshipTest extends AbstractMutatorTestCase
     }
 
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): array
+    public function mutationsProvider(): Generator
     {
-        return [
-            'It swaps spaceship operators' => [
-                <<<'PHP'
+        yield 'It swaps spaceship operators' => [
+            <<<'PHP'
 <?php
 
 $a <=> $b;
 PHP
-                ,
-                <<<'PHP'
+            ,
+            <<<'PHP'
 <?php
 
 $b <=> $a;
 PHP
-                ,
-            ],
+            ,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayChangeKeyCaseTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayChangeKeyCaseTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayChangeKeyCaseTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayChunkTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayChunkTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayChunkTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayColumnTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayColumnTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayColumnTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayCombineTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayCombineTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayCombineTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffAssocTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayDiffAssocTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffKeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffKeyTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayDiffKeyTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayDiffTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUassocTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayDiffUassocTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUkeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUkeyTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayDiffUkeyTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayFilterTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayFilterTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayFilterTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayFlipTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayFlipTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayFlipTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectAssocTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayIntersectAssocTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectKeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectKeyTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayIntersectKeyTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayIntersectTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUassocTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayIntersectUassocTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUkeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUkeyTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayIntersectUkeyTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayKeysTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayKeysTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayKeysTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayMapTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayMapTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayMapTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeRecursiveTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeRecursiveTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayMergeRecursiveTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayMergeTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayPadTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayPadTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayPadTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReduceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReduceTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayReduceTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when the $initial parameter is provided as an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceRecursiveTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceRecursiveTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayReplaceRecursiveTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayReplaceTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReverseTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReverseTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayReverseTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArraySliceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArraySliceTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArraySliceTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArraySpliceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArraySpliceTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArraySpliceTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffAssocTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayUdiffAssocTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayUdiffTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffUassocTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayUdiffUassocTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectAssocTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayUintersectAssocTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayUintersectTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectUassocTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayUintersectUassocTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUniqueTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUniqueTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayUniqueTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayValuesTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayValuesTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapArrayValuesTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapLcFirstTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapLcFirstTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapLcFirstTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrRepeatTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrRepeatTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapStrRepeatTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrReplaceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrReplaceTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapStrReplaceTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrToLowerTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrToLowerTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapStrToLowerTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrToUpperTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrToUpperTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapStrToUpperTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with an string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapTrimTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapTrimTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapTrimTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapUcFirstTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapUcFirstTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapUcFirstTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapUcWordsTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapUcWordsTest.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class UnwrapUcWordsTest extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ZeroIteration/For_Test.php
+++ b/tests/phpunit/Mutator/ZeroIteration/For_Test.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class For_Test extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates to false in for loop condition' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ZeroIteration/Foreach_Test.php
+++ b/tests/phpunit/Mutator/ZeroIteration/Foreach_Test.php
@@ -41,14 +41,16 @@ use Infection\Tests\Mutator\AbstractMutatorTestCase;
 final class Foreach_Test extends AbstractMutatorTestCase
 {
     /**
-     * @dataProvider provideMutationCases
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
      */
-    public function test_mutator($input, $expected = null): void
+    public function test_it_can_mutate(string $input, $expected = []): void
     {
         $this->doTest($input, $expected);
     }
 
-    public function provideMutationCases(): Generator
+    public function mutationsProvider(): Generator
     {
         yield 'It mutates to new array in foreach' => [
             <<<'PHP'


### PR DESCRIPTION
This PR:

- Rename the test method `test_mutator` to `test_it_can_mutate` which is a bit more conventional
- Use the default value `[]` instead of `null`: it should be possible to remove the `null` value completely later on without too much work
- Rename the data provider `provideMutationCases` to `mutationsProvider` (a bit more conventional)
- Move from array data providers to generators