### PR TITLE
Move coverage dir constants to Test Framework Adapters

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -60,7 +60,7 @@ use Infection\Process\Runner\InitialTestsRunner;
 use Infection\Process\Runner\MutationTestingRunner;
 use Infection\Process\Runner\TestRunConstraintChecker;
 use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
-use Infection\TestFramework\Coverage\XMLLineCodeCoverage;
+use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Infection\TestFramework\HasExtraNodeVisitors;
 use Infection\TestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\TestFrameworkTypes;
@@ -458,7 +458,7 @@ final class InfectionCommand extends BaseCommand
 
         $coverageDir = $config->getCoveragePath();
 
-        $coverageIndexFilePath = $coverageDir . '/' . XMLLineCodeCoverage::COVERAGE_INDEX_FILE_NAME;
+        $coverageIndexFilePath = $coverageDir . '/' . LineCodeCoverage::COVERAGE_INDEX_FILE_NAME;
 
         $processInfo = sprintf(
             '%sCommand line: %s%sProcess Output: %s',

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -43,7 +43,6 @@ use Infection\FileSystem\SourceFileCollector;
 use Infection\FileSystem\TmpDirProvider;
 use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\MutatorParser;
-use Infection\TestFramework\Coverage\XMLLineCodeCoverage;
 use Infection\TestFramework\PhpSpec\PhpSpecExtraOptions;
 use Infection\TestFramework\PhpUnit\PhpUnitExtraOptions;
 use Infection\TestFramework\TestFrameworkExtraOptions;
@@ -65,9 +64,9 @@ class ConfigurationFactory
     private const DEFAULT_TIMEOUT = 10;
 
     private const TEST_FRAMEWORK_COVERAGE_DIRECTORY = [
-        TestFrameworkTypes::PHPUNIT => XMLLineCodeCoverage::PHP_UNIT_COVERAGE_DIR,
-        TestFrameworkTypes::PHPSPEC => XMLLineCodeCoverage::PHP_SPEC_COVERAGE_DIR,
-        TestFrameworkTypes::CODECEPTION => XMLLineCodeCoverage::CODECEPTION_COVERAGE_DIR,
+        TestFrameworkTypes::PHPUNIT => 'coverage-xml',
+        TestFrameworkTypes::PHPSPEC => TestFrameworkTypes::PHPSPEC . '-coverage-xml',
+        TestFrameworkTypes::CODECEPTION => TestFrameworkTypes::CODECEPTION . '-coverage-xml',
     ];
 
     private $tmpDirProvider;

--- a/src/TestFramework/Codeception/Adapter/CodeceptionAdapter.php
+++ b/src/TestFramework/Codeception/Adapter/CodeceptionAdapter.php
@@ -42,7 +42,6 @@ use Infection\TestFramework\Codeception\Stringifier;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\Coverage\CoverageLineData;
 use Infection\TestFramework\Coverage\JUnitTestCaseSorter;
-use Infection\TestFramework\Coverage\XMLLineCodeCoverage;
 use Infection\TestFramework\MemoryUsageAware;
 use Infection\TestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\TestFrameworkTypes;
@@ -60,6 +59,8 @@ use Symfony\Component\Process\Process;
 final class CodeceptionAdapter implements MemoryUsageAware, TestFrameworkAdapter
 {
     public const EXECUTABLE = 'codecept';
+
+    public const COVERAGE_DIR = 'codeception-coverage-xml';
 
     private const DEFAULT_ARGS_AND_OPTIONS = [
         'run',
@@ -162,7 +163,7 @@ final class CodeceptionAdapter implements MemoryUsageAware, TestFrameworkAdapter
                 $argumentsAndOptions,
                 [
                     '--coverage-phpunit',
-                    XMLLineCodeCoverage::CODECEPTION_COVERAGE_DIR,
+                    self::COVERAGE_DIR,
                     // JUnit report
                     '--xml',
                     $this->jUnitFilePath,

--- a/src/TestFramework/Coverage/LineCodeCoverage.php
+++ b/src/TestFramework/Coverage/LineCodeCoverage.php
@@ -40,6 +40,8 @@ namespace Infection\TestFramework\Coverage;
  */
 interface LineCodeCoverage
 {
+    public const COVERAGE_INDEX_FILE_NAME = 'index.xml';
+
     public function hasTests(string $filePath): bool;
 
     /**

--- a/src/TestFramework/Coverage/XMLLineCodeCoverage.php
+++ b/src/TestFramework/Coverage/XMLLineCodeCoverage.php
@@ -47,8 +47,6 @@ use function Safe\file_get_contents;
  */
 final class XMLLineCodeCoverage implements LineCodeCoverage
 {
-    public const COVERAGE_INDEX_FILE_NAME = 'index.xml';
-
     /**
      * @var array
      */

--- a/src/TestFramework/Coverage/XMLLineCodeCoverage.php
+++ b/src/TestFramework/Coverage/XMLLineCodeCoverage.php
@@ -47,9 +47,6 @@ use function Safe\file_get_contents;
  */
 final class XMLLineCodeCoverage implements LineCodeCoverage
 {
-    public const PHP_UNIT_COVERAGE_DIR = 'coverage-xml';
-    public const PHP_SPEC_COVERAGE_DIR = 'phpspec-coverage-xml';
-    public const CODECEPTION_COVERAGE_DIR = 'codeception-coverage-xml';
     public const COVERAGE_INDEX_FILE_NAME = 'index.xml';
 
     /**

--- a/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapter.php
+++ b/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapter.php
@@ -42,6 +42,8 @@ use Infection\TestFramework\AbstractTestFrameworkAdapter;
  */
 final class PhpSpecAdapter extends AbstractTestFrameworkAdapter
 {
+    public const COVERAGE_DIR = 'phpspec-coverage-xml';
+
     private const ERROR_REGEXPS = [
         '/Fatal error\:/',
         '/Fatal error happened/i',

--- a/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
+++ b/src/TestFramework/PhpSpec/Config/InitialYamlConfiguration.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpSpec\Config;
 
-use Infection\TestFramework\Coverage\XMLLineCodeCoverage;
+use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapter;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -76,7 +76,7 @@ final class InitialYamlConfiguration extends AbstractYamlConfiguration
 
             $options['format'] = ['xml'];
             $options['output'] = [
-                'xml' => $this->tempDirectory . '/' . XMLLineCodeCoverage::PHP_SPEC_COVERAGE_DIR,
+                'xml' => $this->tempDirectory . '/' . PhpSpecAdapter::COVERAGE_DIR,
             ];
         }
         unset($options);

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -46,6 +46,8 @@ use Infection\Visitor\PhpUnitMethodCodeCoverageIgnoreVisitor;
  */
 final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements HasExtraNodeVisitors, MemoryUsageAware
 {
+    public const COVERAGE_DIR = 'coverage-xml';
+
     public function hasJUnitReport(): bool
     {
         return true;

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -40,7 +40,7 @@ use DOMDocument;
 use DOMElement;
 use DOMXPath;
 use Infection\TestFramework\Config\InitialConfigBuilder as ConfigBuilder;
-use Infection\TestFramework\Coverage\XMLLineCodeCoverage;
+use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 
 /**
@@ -126,7 +126,7 @@ class InitialConfigBuilder implements ConfigBuilder
 
         $coverageXmlLog = $xPath->document->createElement('log');
         $coverageXmlLog->setAttribute('type', 'coverage-xml');
-        $coverageXmlLog->setAttribute('target', $this->tmpDir . '/' . XMLLineCodeCoverage::PHP_UNIT_COVERAGE_DIR);
+        $coverageXmlLog->setAttribute('target', $this->tmpDir . '/' . PhpUnitAdapter::COVERAGE_DIR);
 
         $logging->appendChild($coverageXmlLog);
     }

--- a/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
+++ b/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
@@ -39,7 +39,6 @@ use Generator;
 use Infection\TestFramework\Codeception\Adapter\CodeceptionAdapter;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\Coverage\JUnitTestCaseSorter;
-use Infection\TestFramework\Coverage\XMLLineCodeCoverage;
 use Infection\TestFramework\MemoryUsageAware;
 use Infection\TestFramework\TestFrameworkTypes;
 use Infection\Tests\FileSystem\FileSystemTestCase;
@@ -142,7 +141,7 @@ final class CodeceptionAdapterTest extends FileSystemTestCase
         $commandLine = $adapter->getInitialTestRunCommandLine('', [], true);
 
         $this->assertContains('--coverage-phpunit', $commandLine);
-        $this->assertContains(XMLLineCodeCoverage::CODECEPTION_COVERAGE_DIR, $commandLine);
+        $this->assertContains(CodeceptionAdapter::COVERAGE_DIR, $commandLine);
     }
 
     public function test_it_sets_junit_xml_path(): void

--- a/tests/phpunit/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/InitialYamlConfigurationTest.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpSpec\Config;
 
-use Infection\TestFramework\Coverage\XMLLineCodeCoverage;
+use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapter;
 use Infection\TestFramework\PhpSpec\Config\InitialYamlConfiguration;
 use Infection\TestFramework\PhpSpec\Config\NoCodeCoverageException;
 use PHPUnit\Framework\TestCase;
@@ -88,7 +88,7 @@ final class InitialYamlConfigurationTest extends TestCase
         $configuration = $this->getConfigurationObject();
 
         $parsedYaml = Yaml::parse($configuration->getYaml());
-        $expectedPath = $this->tempDir . '/' . XMLLineCodeCoverage::PHP_SPEC_COVERAGE_DIR;
+        $expectedPath = $this->tempDir . '/' . PhpSpecAdapter::COVERAGE_DIR;
 
         $this->assertSame($expectedPath, $parsedYaml['extensions']['PhpSpecCodeCoverageExtension']['output']['xml']);
     }


### PR DESCRIPTION
* Move coverage dir constants to Test Framework Adapters
* Move `COVERAGE_INDEX_FILE_NAME` const from concrete class (`XMLLineCodeCoverage`) to its interface (abstraction - `LineCodeCoverage`)

`XMLLineCodeCoverage` (and its interface) should not be aware of what and how many Test Framework Adapters we have. That's why each Test Framework should be responsible for own code coverage dir.

This is a preparation for extracting test framework adapters to separate packages - se we decouple Test Framework Adapter from another classes.