### PR TITLE
Fix "Mutation score" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Minimum PHP version: 7.2.9](https://img.shields.io/badge/php-7.2.9%2B-blue.svg)](https://packagist.org/packages/infection/infection) 
+[![Minimum PHP version: 7.2.9](https://img.shields.io/badge/php-7.2.9%2B-blue.svg)](https://packagist.org/packages/infection/infection)
 [![Latest Stable Version](https://poser.pugx.org/infection/infection/v/stable)](https://packagist.org/packages/infection/infection)
-[![Build Status](https://travis-ci.org/infection/infection.svg?branch=master)](https://travis-ci.org/infection/infection) 
+[![Build Status](https://travis-ci.org/infection/infection.svg?branch=master)](https://travis-ci.org/infection/infection)
 [![Build status](https://ci.appveyor.com/api/projects/status/km29p5r5t6arp404/branch/master?svg=true)](https://ci.appveyor.com/project/borNfreee/infection/branch/master)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/infection/infection/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/infection/infection/?branch=master) 
-[![Infection MSI](https://badge.stryker-mutator.io/github.com/infection/infection/master)](https://infection.github.io)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/infection/infection/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/infection/infection/?branch=master)
+[![Infection MSI](https://img.shields.io/endpoint?url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Finfection%2Finfection%2Fmaster)](https://infection.github.io)
 [![codecov](https://codecov.io/gh/infection/infection/branch/master/graph/badge.svg)](https://codecov.io/gh/infection/infection)
 [![Slack channel: #infection on the Symfony slack](https://img.shields.io/badge/slack-%23infection-green.svg?style=flat-square)](https://symfony.com/slack-invite)
 
@@ -17,13 +17,13 @@ Twitter: [@infection_php][twitter]
 
 ### Contributing
 
-Infection is an open source project that welcomes pull requests and issues from anyone. Before 
+Infection is an open source project that welcomes pull requests and issues from anyone. Before
 pening pull requests, please consider reading our short [Contribution Guide][contribution guide].
 
 
 ### Credits
 
-This project is highly inspired from Pádraic Brady ([@padraic][padraic])'s [Humbug library][humbug]. 
+This project is highly inspired from Pádraic Brady ([@padraic][padraic])'s [Humbug library][humbug].
 Humbug has since then been discontinued in favour of this project.
 
 


### PR DESCRIPTION
This PR:

- [x] Updates the URL of "Mutation score" badge as the old one stopped working - guys from Stryker did the same change: https://github.com/stryker-mutator/stryker/blob/master/README.md
- [x] Removes trailing whitespaces in README.md