### PR TITLE
Extracts the mutation generation from `MutationsCollectorVisitor`

### DIFF
--- a/src/Mutation/FileMutationGenerator.php
+++ b/src/Mutation/FileMutationGenerator.php
@@ -38,6 +38,7 @@ namespace Infection\Mutation;
 use function array_key_exists;
 use function get_class;
 use Infection\Mutation;
+use Infection\Mutator\NodeMutationGenerator;
 use Infection\Mutator\Util\Mutator;
 use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Infection\Visitor\MutationsCollectorVisitor;
@@ -102,11 +103,13 @@ class FileMutationGenerator
         $initialStatements = $this->parser->parse($fileInfo);
 
         $mutationsCollectorVisitor = new MutationsCollectorVisitor(
-            $mutators,
-            $filePath,
-            $initialStatements,
-            $codeCoverage,
-            $onlyCovered
+            new NodeMutationGenerator(
+                $mutators,
+                $filePath,
+                $initialStatements,
+                $codeCoverage,
+                $onlyCovered
+            )
         );
 
         $extraNodeVisitors[self::MUTATION_COLLECTOR_VISITOR_PRIORITY] = $mutationsCollectorVisitor;

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator;
+
+use function array_reduce;
+use function count;
+use Generator;
+use function get_class;
+use Infection\Exception\InvalidMutatorException;
+use Infection\Mutation;
+use Infection\Mutator\Util\Mutator;
+use Infection\TestFramework\Coverage\LineCodeCoverage;
+use Infection\TestFramework\Coverage\NodeLineRangeData;
+use Infection\Visitor\ParentConnectorVisitor;
+use Infection\Visitor\ReflectionVisitor;
+use PhpParser\Node;
+use Throwable;
+
+/**
+ * @internal
+ * @final
+ */
+class NodeMutationGenerator
+{
+    private $mutators;
+    private $filePath;
+    private $fileNodes;
+    private $codeCoverageData;
+    private $onlyCovered;
+
+    /**
+     * @param Mutator[] $mutators
+     * @param Node[]    $fileNodes
+     */
+    public function __construct(
+        array $mutators,
+        string $filePath,
+        array $fileNodes,
+        LineCodeCoverage $codeCoverageData,
+        bool $onlyCovered
+    ) {
+        $this->mutators = $mutators;
+        $this->filePath = $filePath;
+        $this->fileNodes = $fileNodes;
+        $this->codeCoverageData = $codeCoverageData;
+        $this->onlyCovered = $onlyCovered;
+    }
+
+    /**
+     * @return Mutation[]
+     */
+    public function generate(Node $node): array
+    {
+        return array_reduce(
+            $this->mutators,
+            function (array $mutations, Mutator $mutator) use ($node): array {
+                return $this->generateForMutator($node, $mutator, $mutations);
+            },
+            []
+        );
+    }
+
+    /**
+     * @return Mutation[]
+     */
+    public function generateForMutator(Node $node, Mutator $mutator, array $mutations): array
+    {
+        try {
+            if (!$mutator->shouldMutate($node)) {
+                return $mutations;
+            }
+        } catch (Throwable $throwable) {
+            throw InvalidMutatorException::create($this->filePath, $mutator, $throwable);
+        }
+
+        $isOnFunctionSignature = $node->getAttribute(ReflectionVisitor::IS_ON_FUNCTION_SIGNATURE, false);
+
+        if (!$isOnFunctionSignature
+            && !$node->getAttribute(ReflectionVisitor::IS_INSIDE_FUNCTION_KEY)
+        ) {
+            return $mutations;
+        }
+
+        $tests = $this->codeCoverageData->getAllTestsForMutation(
+            $this->filePath,
+            $this->getNodeRange($node, $isOnFunctionSignature),
+            $isOnFunctionSignature
+        );
+
+        if ($this->onlyCovered && count($tests) === 0) {
+            return $mutations;
+        }
+
+        $mutatedResult = $mutator->mutate($node);
+
+        $mutatedNodes = $mutatedResult instanceof Generator ? $mutatedResult : [$mutatedResult];
+
+        foreach ($mutatedNodes as $mutationByMutatorIndex => $mutatedNode) {
+            $mutations[] = new Mutation(
+                $this->filePath,
+                $this->fileNodes,
+                $mutator,
+                $node->getAttributes(),
+                get_class($node),
+                $mutatedNode,
+                $mutationByMutatorIndex,
+                $tests
+            );
+        }
+
+        return $mutations;
+    }
+
+    /**
+     * If the node is part of an array, this will find the outermost array.
+     * Otherwise this will return the node itself
+     */
+    private function getOuterMostArrayNode(Node $node): Node
+    {
+        $outerMostArrayParent = $node;
+
+        do {
+            if ($node instanceof Node\Expr\Array_) {
+                $outerMostArrayParent = $node;
+            }
+        } while ($node = $node->getAttribute(ParentConnectorVisitor::PARENT_KEY));
+
+        return $outerMostArrayParent;
+    }
+
+    private function getNodeRange(Node $node, bool $isOnFunctionSignature): NodeLineRangeData
+    {
+        if ($isOnFunctionSignature) {
+            $node = $this->getOuterMostArrayNode($node);
+        }
+
+        return new NodeLineRangeData($node->getStartLine(), $node->getEndLine());
+    }
+}

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -96,7 +96,7 @@ class NodeMutationGenerator
     /**
      * @return Mutation[]
      */
-    public function generateForMutator(Node $node, Mutator $mutator, array $mutations): array
+    private function generateForMutator(Node $node, Mutator $mutator, array $mutations): array
     {
         try {
             if (!$mutator->shouldMutate($node)) {

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -57,9 +57,16 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
         $this->mutationGenerator = $mutationGenerator;
     }
 
+    public function beforeTraverse(array $nodes): void
+    {
+        $this->mutations = [];
+    }
+
     public function leaveNode(Node $node): ?Node
     {
-        $this->mutations = $this->mutationGenerator->generate($node);
+        foreach ($this->mutationGenerator->generate($node) as $mutation) {
+            $this->mutations[] = $mutation;
+        }
 
         return null;
     }

--- a/src/Visitor/MutationsCollectorVisitor.php
+++ b/src/Visitor/MutationsCollectorVisitor.php
@@ -35,17 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\Visitor;
 
-use function count;
-use Generator;
-use function get_class;
-use Infection\Exception\InvalidMutatorException;
 use Infection\Mutation;
-use Infection\Mutator\Util\Mutator;
-use Infection\TestFramework\Coverage\LineCodeCoverage;
-use Infection\TestFramework\Coverage\NodeLineRangeData;
+use Infection\Mutator\NodeMutationGenerator;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
-use Throwable;
 
 /**
  * @internal
@@ -57,76 +50,16 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
      */
     private $mutations = [];
 
-    private $mutators;
-    private $filePath;
-    private $fileNodes;
-    private $codeCoverageData;
-    private $onlyCovered;
+    private $mutationGenerator;
 
-    /**
-     * @param Mutator[] $mutators
-     * @param Node[]    $fileNodes
-     */
-    public function __construct(
-        array $mutators,
-        string $filePath,
-        array $fileNodes,
-        LineCodeCoverage $codeCoverageData,
-        bool $onlyCovered
-    ) {
-        $this->mutators = $mutators;
-        $this->filePath = $filePath;
-        $this->fileNodes = $fileNodes;
-        $this->codeCoverageData = $codeCoverageData;
-        $this->onlyCovered = $onlyCovered;
+    public function __construct(NodeMutationGenerator $mutationGenerator)
+    {
+        $this->mutationGenerator = $mutationGenerator;
     }
 
     public function leaveNode(Node $node): ?Node
     {
-        foreach ($this->mutators as $mutator) {
-            try {
-                if (!$mutator->shouldMutate($node)) {
-                    continue;
-                }
-            } catch (Throwable $throwable) {
-                throw InvalidMutatorException::create($this->filePath, $mutator, $throwable);
-            }
-
-            $isOnFunctionSignature = $node->getAttribute(ReflectionVisitor::IS_ON_FUNCTION_SIGNATURE, false);
-
-            if (!$isOnFunctionSignature
-                && !$node->getAttribute(ReflectionVisitor::IS_INSIDE_FUNCTION_KEY)
-            ) {
-                continue;
-            }
-
-            $tests = $this->codeCoverageData->getAllTestsForMutation(
-                $this->filePath,
-                $this->getNodeRange($node, $isOnFunctionSignature),
-                $isOnFunctionSignature
-            );
-
-            if ($this->onlyCovered && count($tests) === 0) {
-                continue;
-            }
-
-            $mutatedResult = $mutator->mutate($node);
-
-            $mutatedNodes = $mutatedResult instanceof Generator ? $mutatedResult : [$mutatedResult];
-
-            foreach ($mutatedNodes as $mutationByMutatorIndex => $mutatedNode) {
-                $this->mutations[] = new Mutation(
-                    $this->filePath,
-                    $this->fileNodes,
-                    $mutator,
-                    $node->getAttributes(),
-                    get_class($node),
-                    $mutatedNode,
-                    $mutationByMutatorIndex,
-                    $tests
-                );
-            }
-        }
+        $this->mutations = $this->mutationGenerator->generate($node);
 
         return null;
     }
@@ -137,31 +70,5 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
     public function getMutations(): array
     {
         return $this->mutations;
-    }
-
-    /**
-     * If the node is part of an array, this will find the outermost array.
-     * Otherwise this will return the node itself
-     */
-    private function getOuterMostArrayNode(Node $node): Node
-    {
-        $outerMostArrayParent = $node;
-
-        do {
-            if ($node instanceof Node\Expr\Array_) {
-                $outerMostArrayParent = $node;
-            }
-        } while ($node = $node->getAttribute(ParentConnectorVisitor::PARENT_KEY));
-
-        return $outerMostArrayParent;
-    }
-
-    private function getNodeRange(Node $node, bool $isOnFunctionSignature): NodeLineRangeData
-    {
-        if ($isOnFunctionSignature) {
-            $node = $this->getOuterMostArrayNode($node);
-        }
-
-        return new NodeLineRangeData($node->getStartLine(), $node->getEndLine());
     }
 }

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -57,6 +57,7 @@ use Infection\Finder\TestFrameworkFinder;
 use Infection\Http\BadgeApiClient;
 use Infection\Logger\ResultsLoggerTypes;
 use Infection\Mutant\MetricsCalculator;
+use Infection\Mutator\NodeMutationGenerator;
 use Infection\Mutator\Util\Mutator;
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
 use Infection\Process\Listener\MutantCreatingConsoleLoggerSubscriber;
@@ -75,7 +76,6 @@ use Infection\TestFramework\PhpUnit\Coverage\CoverageXmlParser;
 use Infection\TestFramework\TestFrameworkTypes;
 use function Infection\Tests\generator_to_phpunit_data_provider;
 use Infection\Utils\VersionParser;
-use Infection\Visitor\MutationsCollectorVisitor;
 use function iterator_to_array;
 use ReflectionClass;
 use const SORT_STRING;
@@ -101,7 +101,7 @@ final class ProjectCodeProvider
         MutationGeneratingConsoleLoggerSubscriber::class,
         MutationTestingRunner::class,
         TestFrameworkTypes::class,
-        MutationsCollectorVisitor::class,
+        NodeMutationGenerator::class,
         FilterableFinder::class,
     ];
 

--- a/tests/phpunit/Visitor/MutationsCollectorVisitorTest.php
+++ b/tests/phpunit/Visitor/MutationsCollectorVisitorTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Visitor;
+
+use Infection\Mutator\NodeMutationGenerator;
+use Infection\Visitor\MutationsCollectorVisitor;
+use PhpParser\Node;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use stdClass;
+
+final class MutationsCollectorVisitorTest extends BaseVisitorTest
+{
+    private const CODE = <<<'PHP'
+<?php
+
+class Foo {}
+
+PHP;
+
+    public function test_it_collects_the_generated_mutations(): void
+    {
+        $nodeMutationGeneratorMock = $this->createMock(NodeMutationGenerator::class);
+        $nodeMutationGeneratorMock
+            ->expects($this->exactly(2))
+            ->method('generate')
+            ->willReturn($mutations = [new stdClass()])
+        ;
+
+        $visitor = new MutationsCollectorVisitor($nodeMutationGeneratorMock);
+
+        $this->traverse(
+            $this->parseCode(self::CODE),
+            [$visitor]
+        );
+
+        $this->assertSame($mutations, $visitor->getMutations());
+    }
+
+    public function test_it_resets_its_state_between_two_traverse(): void
+    {
+        /** @var ObjectProphecy|NodeMutationGenerator $nodeMutationGeneratorProphecy */
+        $nodeMutationGeneratorProphecy = $this->prophesize(NodeMutationGenerator::class);
+
+        $node0 = $this->createMock(Node::class);
+        $node1 = $this->createMock(Node::class);
+
+        $nodeMutationGeneratorProphecy
+            ->generate(Argument::that(static function ($arg) use ($node0): bool {
+                return $arg === $node0;
+            }))
+            ->willReturn($mutations0 = [new stdClass()])
+        ;
+        $nodeMutationGeneratorProphecy
+            ->generate(Argument::that(static function ($arg) use ($node1): bool {
+                return $arg === $node1;
+            }))
+            ->willReturn($mutations1 = [new stdClass()])
+        ;
+
+        $visitor = new MutationsCollectorVisitor($nodeMutationGeneratorProphecy->reveal());
+
+        // Sanity check
+        $this->assertNotSame($mutations1, $mutations0);
+
+        $this->traverse(
+            [$node0],
+            [$visitor]
+        );
+
+        $this->assertSame($mutations0, $visitor->getMutations());
+
+        $this->traverse(
+            [$node1],
+            [$visitor]
+        );
+
+        $this->assertSame($mutations1, $visitor->getMutations());
+    }
+}


### PR DESCRIPTION
This allows to simplify `MutationsCollectorVisitor` and let it focus only on collecting the mutations at each traverse.

This allowed to highlight and test the statefulness of `MutationsCollectorVisitor`. I took the opportunity to ensure its state is reset before each traverse otherwise the result of the previous traverse would pollute the second one (although it is unlikely to cause an issue in practice).