### PR TITLE
Exclude --configuration from PhpUnit options

### DIFF
--- a/src/TestFramework/PhpUnit/PhpUnitExtraOptions.php
+++ b/src/TestFramework/PhpUnit/PhpUnitExtraOptions.php
@@ -47,6 +47,6 @@ final class PhpUnitExtraOptions extends TestFrameworkExtraOptions
      */
     protected function getInitialRunOnlyOptions(): array
     {
-        return ['--filter', '--testsuite'];
+        return ['--configuration', '--filter', '--testsuite'];
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/PhpUnitExtraOptionsTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/PhpUnitExtraOptionsTest.php
@@ -71,6 +71,11 @@ final class PhpUnitExtraOptionsTest extends TestCase
             ['--a --testsuite someTest#2 --b=value', '--a --b=value'],
             ['--a --testsuite="some Test#2" --b=value', '--a --b=value'],
             ['--a --testsuite=\'some Test#2\' --b=value', '--a --b=value'],
+            ['--configuration=someTest#2 --a --b=value', '--a --b=value'],
+            ['--a --configuration=someTest#2 --b=value', '--a --b=value'],
+            ['--a --configuration someTest#2 --b=value', '--a --b=value'],
+            ['--a --configuration="some Test#2" --b=value', '--a --b=value'],
+            ['--a --configuration=\'some Test#2\' --b=value', '--a --b=value'],
         ];
     }
 }


### PR DESCRIPTION
This PR:

- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/153

If you run `infection --test-framework-options="--configuration=custom.xml"` then no mutations are detected as the generated configuration is overridden and regular autoloading is used.