### PR TITLE
Check for trailing spaces _after_ running PHP-CS-Fixer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,10 @@ check_trailing_whitespaces:
 
 .PHONY: cs
 cs:	  	 ## Runs PHP-CS-Fixer
-cs: check_trailing_whitespaces $(PHP_CS_FIXER)
+cs: $(PHP_CS_FIXER)
 	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE)
 	LC_ALL=C sort -u .gitignore -o .gitignore
+	$(MAKE) check_trailing_whitespaces
 
 .PHONY: phpstan
 phpstan: vendor $(PHPSTAN)


### PR DESCRIPTION
Otherwise this could lead in errors which could be handled by the CS fixer, requiring manual intervention for a task that can be automated