### PR TITLE
Deprecate mutators that are a semantic addition

### DIFF
--- a/src/Mutator/Boolean/IdenticalEqual.php
+++ b/src/Mutator/Boolean/IdenticalEqual.php
@@ -40,6 +40,7 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
  * @deprecated This mutator is a semantic addition
  */
 final class IdenticalEqual extends Mutator

--- a/src/Mutator/Boolean/IdenticalEqual.php
+++ b/src/Mutator/Boolean/IdenticalEqual.php
@@ -40,6 +40,7 @@ use PhpParser\Node;
 
 /**
  * @internal
+ * @deprecated This mutator is a semantic addition
  */
 final class IdenticalEqual extends Mutator
 {

--- a/src/Mutator/Boolean/NotIdenticalNotEqual.php
+++ b/src/Mutator/Boolean/NotIdenticalNotEqual.php
@@ -40,6 +40,7 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
  * @deprecated This mutator is a semantic addition
  */
 final class NotIdenticalNotEqual extends Mutator

--- a/src/Mutator/Boolean/NotIdenticalNotEqual.php
+++ b/src/Mutator/Boolean/NotIdenticalNotEqual.php
@@ -40,6 +40,7 @@ use PhpParser\Node;
 
 /**
  * @internal
+ * @deprecated This mutator is a semantic addition
  */
 final class NotIdenticalNotEqual extends Mutator
 {

--- a/src/Mutator/ConditionalBoundary/GreaterThan.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThan.php
@@ -40,6 +40,7 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
  * @deprecated This mutator is a semantic addition
  */
 final class GreaterThan extends Mutator

--- a/src/Mutator/ConditionalBoundary/GreaterThan.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThan.php
@@ -40,6 +40,7 @@ use PhpParser\Node;
 
 /**
  * @internal
+ * @deprecated This mutator is a semantic addition
  */
 final class GreaterThan extends Mutator
 {

--- a/src/Mutator/ConditionalBoundary/LessThan.php
+++ b/src/Mutator/ConditionalBoundary/LessThan.php
@@ -40,6 +40,7 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
  * @deprecated This mutator is a semantic addition
  */
 final class LessThan extends Mutator

--- a/src/Mutator/ConditionalBoundary/LessThan.php
+++ b/src/Mutator/ConditionalBoundary/LessThan.php
@@ -40,6 +40,7 @@ use PhpParser\Node;
 
 /**
  * @internal
+ * @deprecated This mutator is a semantic addition
  */
 final class LessThan extends Mutator
 {


### PR DESCRIPTION
The general consensus is that killing a mutant that is a semantic addition would require a test which tests against unspecified additions. Although it is not excluded to have some value in very specific cases, it is very hard to find reliable case where those mutants performs well and result in the vast majority in false positives.

I'll be more than happy to discuss on a case per case basis for those to prove otherwise, but based on the original promise, I think the stance should be their existence and efficiency needs to be demonstrated.

Also note that for now those mutators are simply marked as deprecated: concretely it does not change _anything_ yet. I would however work in the future on a system that would allow us to communicate to the users that a given mutator is deprecated and may be removed in future versions