### PR TITLE
Move creation of Test Framework Adapters to their own factory classes

### DIFF
--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -11,5 +11,5 @@ parameters:
         - '#Method Infection\Configuration\Schema\SchemaConfigurationFile::getDecodedContents() should return stdClass but returns stdClass|null.#'
 
         -
-            path: '%currentWorkingDirectory%/src/TestFramework/Factory.php'
+            path: '%currentWorkingDirectory%/src/TestFramework/Codeception/Adapter/CodeceptionAdapterFactory.php'
             message: '#Access to constant VERSION on an unknown class Codeception\\Codecept#'

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -443,7 +443,8 @@
             "description": "Sets the framework to use for testing. Defaults to phpunit.",
             "anyOf": [
                 "phpunit",
-                "phpspec"
+                "phpspec",
+                "codeception"
             ]
         },
         "bootstrap": {

--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -167,12 +167,8 @@ final class InfectionContainer extends Container
                     $config->getTmpDir(),
                     $container['project.dir'],
                     $container['testframework.config.locator'],
-                    $container['xml.configuration.helper'],
                     $container['junit.file.path'],
-                    $container[Configuration::class],
-                    $container[VersionParser::class],
-                    $container['filesystem'],
-                    $container[CommandLineBuilder::class]
+                    $container[Configuration::class]
                 );
             },
             'xml.configuration.helper' => static function (self $container): XmlConfigurationHelper {

--- a/src/TestFramework/Codeception/Adapter/CodeceptionAdapterFactory.php
+++ b/src/TestFramework/Codeception/Adapter/CodeceptionAdapterFactory.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\TestFramework\Codeception\Adapter;
+
+use Infection\TestFramework\CommandLineBuilder;
+use Infection\TestFramework\Coverage\JUnitTestCaseSorter;
+use Infection\TestFramework\TestFrameworkAdapter;
+use Infection\TestFramework\TestFrameworkAdapterFactory;
+use Infection\TestFramework\TestFrameworkConfigParseException;
+use Infection\Utils\VersionParser;
+use LogicException;
+use function Safe\file_get_contents;
+use function Safe\sprintf;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * @internal
+ */
+final class CodeceptionAdapterFactory implements TestFrameworkAdapterFactory
+{
+    public static function create(
+        string $testFrameworkExecutable,
+        string $tmpDir,
+        string $testFrameworkConfigPath,
+        ?string $testFrameworkConfigDir,
+        string $jUnitFilePath,
+        string $projectDir,
+        array $sourceDirectories,
+        bool $skipCoverage
+    ): TestFrameworkAdapter {
+        self::ensureCodeceptionVersionIsSupported();
+
+        return new CodeceptionAdapter(
+            $testFrameworkExecutable,
+            new CommandLineBuilder(),
+            new VersionParser(),
+            new JUnitTestCaseSorter(),
+            new Filesystem(),
+            $jUnitFilePath,
+            $tmpDir,
+            $projectDir,
+            self::parseYaml($testFrameworkConfigPath),
+            $sourceDirectories
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function parseYaml(string $codeceptionConfigPath): array
+    {
+        $codeceptionConfigContent = file_get_contents($codeceptionConfigPath);
+
+        try {
+            $codeceptionConfigContentParsed = Yaml::parse($codeceptionConfigContent);
+        } catch (ParseException $e) {
+            throw TestFrameworkConfigParseException::fromPath($codeceptionConfigPath, $e);
+        }
+
+        return $codeceptionConfigContentParsed;
+    }
+
+    private static function ensureCodeceptionVersionIsSupported(): void
+    {
+        if (!class_exists('\Codeception\Codecept')) {
+            return;
+        }
+
+        if (version_compare(\Codeception\Codecept::VERSION, '3.1.1', '<')) {
+            throw new LogicException(
+                sprintf(
+                    'Current Codeception version "%s" is not supported by Infection. Please use >=3.1.1',
+                    \Codeception\Codecept::VERSION
+                )
+            );
+        }
+    }
+}

--- a/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapterFactory.php
+++ b/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapterFactory.php
@@ -33,30 +33,38 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework;
+namespace Infection\TestFramework\PhpSpec\Adapter;
 
-use Infection\Configuration\Configuration;
-use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
-use Infection\TestFramework\Factory;
-use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use Infection\TestFramework\CommandLineBuilder;
+use Infection\TestFramework\PhpSpec\CommandLine\ArgumentsAndOptionsBuilder;
+use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder;
+use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
+use Infection\TestFramework\TestFrameworkAdapter;
+use Infection\TestFramework\TestFrameworkAdapterFactory;
+use Infection\Utils\VersionParser;
 
 /**
- * @group integration Requires some I/O operations
+ * @internal
  */
-final class FactoryTest extends TestCase
+final class PhpSpecAdapterFactory implements TestFrameworkAdapterFactory
 {
-    public function test_it_throws_an_exception_if_it_cant_find_the_testframework(): void
-    {
-        $factory = new Factory(
-            '',
-            '',
-            $this->createMock(TestFrameworkConfigLocatorInterface::class),
-            '',
-            $this->createMock(Configuration::class)
+    public static function create(
+        string $testFrameworkExecutable,
+        string $tmpDir,
+        string $testFrameworkConfigPath,
+        ?string $testFrameworkConfigDir,
+        string $jUnitFilePath,
+        string $projectDir,
+        array $sourceDirectories,
+        bool $skipCoverage
+    ): TestFrameworkAdapter {
+        return new PhpSpecAdapter(
+            $testFrameworkExecutable,
+            new InitialConfigBuilder($tmpDir, $testFrameworkConfigPath, $skipCoverage),
+            new MutationConfigBuilder($tmpDir, $testFrameworkConfigPath, $projectDir),
+            new ArgumentsAndOptionsBuilder(),
+            new VersionParser(),
+            new CommandLineBuilder()
         );
-
-        $this->expectException(InvalidArgumentException::class);
-        $factory->create('Fake Test Framework', false);
     }
 }

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\TestFramework\PhpUnit\Adapter;
+
+use Infection\TestFramework\CommandLineBuilder;
+use Infection\TestFramework\Coverage\JUnitTestCaseSorter;
+use Infection\TestFramework\PhpUnit\CommandLine\ArgumentsAndOptionsBuilder;
+use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder;
+use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
+use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
+use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
+use Infection\TestFramework\TestFrameworkAdapter;
+use Infection\TestFramework\TestFrameworkAdapterFactory;
+use Infection\Utils\VersionParser;
+use function Safe\file_get_contents;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
+{
+    public static function create(
+        string $testFrameworkExecutable,
+        string $tmpDir,
+        string $testFrameworkConfigPath,
+        ?string $testFrameworkConfigDir,
+        string $jUnitFilePath,
+        string $projectDir,
+        array $sourceDirectories,
+        bool $skipCoverage
+    ): TestFrameworkAdapter {
+        $testFrameworkConfigContent = file_get_contents($testFrameworkConfigPath);
+
+        $xmlConfigurationHelper = new XmlConfigurationHelper(
+            new PathReplacer(
+                new Filesystem(),
+                $testFrameworkConfigDir
+            ),
+            $testFrameworkConfigDir
+        );
+
+        return new PhpUnitAdapter(
+            $testFrameworkExecutable,
+            new InitialConfigBuilder(
+                $tmpDir,
+                $testFrameworkConfigContent,
+                $xmlConfigurationHelper,
+                $jUnitFilePath,
+                $sourceDirectories,
+                $skipCoverage
+            ),
+            new MutationConfigBuilder($tmpDir, $testFrameworkConfigContent, $xmlConfigurationHelper, $projectDir, new JUnitTestCaseSorter()),
+            new ArgumentsAndOptionsBuilder(),
+            new VersionParser(),
+            new CommandLineBuilder()
+        );
+    }
+}

--- a/src/TestFramework/TestFrameworkAdapterFactory.php
+++ b/src/TestFramework/TestFrameworkAdapterFactory.php
@@ -33,30 +33,21 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework;
-
-use Infection\Configuration\Configuration;
-use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
-use Infection\TestFramework\Factory;
-use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+namespace Infection\TestFramework;
 
 /**
- * @group integration Requires some I/O operations
+ * @internal
  */
-final class FactoryTest extends TestCase
+interface TestFrameworkAdapterFactory
 {
-    public function test_it_throws_an_exception_if_it_cant_find_the_testframework(): void
-    {
-        $factory = new Factory(
-            '',
-            '',
-            $this->createMock(TestFrameworkConfigLocatorInterface::class),
-            '',
-            $this->createMock(Configuration::class)
-        );
-
-        $this->expectException(InvalidArgumentException::class);
-        $factory->create('Fake Test Framework', false);
-    }
+    public static function create(
+        string $testFrameworkExecutable,
+        string $tmpDir,
+        string $testFrameworkConfigPath,
+        string $testFrameworkConfigDir,
+        string $jUnitFilePath,
+        string $projectDir,
+        array $sourceDirectories,
+        bool $skipCoverage
+    ): TestFrameworkAdapter;
 }

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -588,6 +588,38 @@ JSON
             ]),
         ];
 
+        yield '[testFramework] phpspec' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "testFramework": "phpspec"
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'testFramework' => 'phpspec',
+            ]),
+        ];
+
+        yield '[testFramework] codeception' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "testFramework": "codeception"
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'testFramework' => 'codeception',
+            ]),
+        ];
+
         yield '[bootstrap] nominal' => [
             <<<'JSON'
 {

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -50,6 +50,7 @@ use Infection\Configuration\Entry\Source;
 use Infection\Configuration\Schema\SchemaConfiguration;
 use Infection\Configuration\Schema\SchemaConfigurationFactory;
 use Infection\Mutator\ProfileList;
+use Infection\TestFramework\TestFrameworkTypes;
 use JsonSchema\Validator;
 use const PHP_EOL;
 use PHPUnit\Framework\TestCase;
@@ -588,37 +589,27 @@ JSON
             ]),
         ];
 
-        yield '[testFramework] phpspec' => [
-            <<<'JSON'
+        foreach (TestFrameworkTypes::TYPES as $testFrameworkType) {
+            yield '[testFramework] ' . $testFrameworkType => (static function () use (
+                $testFrameworkType
+            ): array {
+                return [
+                    <<<"JSON"
 {
     "source": {
         "directories": ["src"]
     },
-    "testFramework": "phpspec"
+    "testFramework": "{$testFrameworkType}"
 }
 JSON
-            ,
-            self::createConfig([
-                'source' => new Source(['src'], []),
-                'testFramework' => 'phpspec',
-            ]),
-        ];
-
-        yield '[testFramework] codeception' => [
-            <<<'JSON'
-{
-    "source": {
-        "directories": ["src"]
-    },
-    "testFramework": "codeception"
-}
-JSON
-            ,
-            self::createConfig([
-                'source' => new Source(['src'], []),
-                'testFramework' => 'codeception',
-            ]),
-        ];
+                    ,
+                    self::createConfig([
+                        'source' => new Source(['src'], []),
+                        'testFramework' => $testFrameworkType,
+                    ]),
+                ];
+            })();
+        }
 
         yield '[bootstrap] nominal' => [
             <<<'JSON'

--- a/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterFactoryTest.php
+++ b/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterFactoryTest.php
@@ -33,30 +33,27 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework;
+namespace Infection\Tests\TestFramework\Codeception\Adapter;
 
-use Infection\Configuration\Configuration;
-use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
-use Infection\TestFramework\Factory;
-use InvalidArgumentException;
+use Infection\TestFramework\Codeception\Adapter\CodeceptionAdapter;
+use Infection\TestFramework\Codeception\Adapter\CodeceptionAdapterFactory;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group integration Requires some I/O operations
- */
-final class FactoryTest extends TestCase
+final class CodeceptionAdapterFactoryTest extends TestCase
 {
-    public function test_it_throws_an_exception_if_it_cant_find_the_testframework(): void
+    public function test_it_creates_codeception_adapter(): void
     {
-        $factory = new Factory(
-            '',
-            '',
-            $this->createMock(TestFrameworkConfigLocatorInterface::class),
-            '',
-            $this->createMock(Configuration::class)
+        $adapter = CodeceptionAdapterFactory::create(
+            '/path/to/codecept',
+            '/tmp',
+            __DIR__ . '/../../../Fixtures/Files/codeception/codeception.yml',
+            null,
+            '/path/to/junit.xml',
+            '/path/to/project',
+            [],
+            true
         );
 
-        $this->expectException(InvalidArgumentException::class);
-        $factory->create('Fake Test Framework', false);
+        $this->assertInstanceOf(CodeceptionAdapter::class, $adapter);
     }
 }

--- a/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterFactoryTest.php
+++ b/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterFactoryTest.php
@@ -39,6 +39,9 @@ use Infection\TestFramework\Codeception\Adapter\CodeceptionAdapter;
 use Infection\TestFramework\Codeception\Adapter\CodeceptionAdapterFactory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class CodeceptionAdapterFactoryTest extends TestCase
 {
     public function test_it_creates_codeception_adapter(): void

--- a/tests/phpunit/TestFramework/PhpSpec/Adapter/PhpSpecAdapterFactoryTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Adapter/PhpSpecAdapterFactoryTest.php
@@ -33,30 +33,27 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework;
+namespace Infection\Tests\TestFramework\PhpSpec\Adapter;
 
-use Infection\Configuration\Configuration;
-use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
-use Infection\TestFramework\Factory;
-use InvalidArgumentException;
+use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapter;
+use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapterFactory;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group integration Requires some I/O operations
- */
-final class FactoryTest extends TestCase
+final class PhpSpecAdapterFactoryTest extends TestCase
 {
-    public function test_it_throws_an_exception_if_it_cant_find_the_testframework(): void
+    public function test_it_creates_phpspec_adapter(): void
     {
-        $factory = new Factory(
-            '',
-            '',
-            $this->createMock(TestFrameworkConfigLocatorInterface::class),
-            '',
-            $this->createMock(Configuration::class)
+        $adapter = PhpSpecAdapterFactory::create(
+            '/path/to/phpspec',
+            '/tmp',
+            __DIR__ . '/../../../Fixtures/Files/phpspec/phpspec.yml',
+            null,
+            '/path/to/junit.xml',
+            '/path/to/project',
+            [],
+            true
         );
 
-        $this->expectException(InvalidArgumentException::class);
-        $factory->create('Fake Test Framework', false);
+        $this->assertInstanceOf(PhpSpecAdapter::class, $adapter);
     }
 }

--- a/tests/phpunit/TestFramework/PhpSpec/Adapter/PhpSpecAdapterFactoryTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Adapter/PhpSpecAdapterFactoryTest.php
@@ -39,6 +39,9 @@ use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapter;
 use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapterFactory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class PhpSpecAdapterFactoryTest extends TestCase
 {
     public function test_it_creates_phpspec_adapter(): void

--- a/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
@@ -83,7 +83,7 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
         $mutant = $this->createMock(Mutant::class);
         $mutant->method('getMutation')
             ->willReturn($mutation);
-        $mutant->method('getMutatedFilePath')
+        $mutant->method('getMutantFilePath')
             ->willReturn('/mutated/file/path');
 
         $builder = new MutationConfigBuilder($this->tmp, $originalYamlConfigPath, $projectDir);

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
@@ -33,30 +33,27 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework;
+namespace Infection\Tests\TestFramework\PhpUnit\Adapter;
 
-use Infection\Configuration\Configuration;
-use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
-use Infection\TestFramework\Factory;
-use InvalidArgumentException;
+use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
+use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group integration Requires some I/O operations
- */
-final class FactoryTest extends TestCase
+final class PhpUnitAdapterFactoryTest extends TestCase
 {
-    public function test_it_throws_an_exception_if_it_cant_find_the_testframework(): void
+    public function test_it_creates_phpunit_adapter(): void
     {
-        $factory = new Factory(
-            '',
-            '',
-            $this->createMock(TestFrameworkConfigLocatorInterface::class),
-            '',
-            $this->createMock(Configuration::class)
+        $adapter = PhpUnitAdapterFactory::create(
+            '/path/to/phpunit',
+            '/tmp',
+            __DIR__ . '/../../../Fixtures/Files/phpunit/phpunit.xml',
+            '/path/to/config-dir',
+            '/path/to/junit.xml',
+            '/path/to/project',
+            [],
+            true
         );
 
-        $this->expectException(InvalidArgumentException::class);
-        $factory->create('Fake Test Framework', false);
+        $this->assertInstanceOf(PhpUnitAdapter::class, $adapter);
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
@@ -39,6 +39,9 @@ use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class PhpUnitAdapterFactoryTest extends TestCase
 {
     public function test_it_creates_phpunit_adapter(): void


### PR DESCRIPTION
### Why?

Each Test Framework will be extracted to its own package. And to be able to create all of them in a similar manner (even without any knowledge what the adapter is being created), we need some common Factory interface.

Here it is:

```php
interface TestFrameworkAdapterFactory
{
    public static function create(
        string $testFrameworkExecutable,
        string $tmpDir,
        string $testFrameworkConfigPath,
        string $testFrameworkConfigDir,
        string $jUnitFilePath,
        string $projectDir,
        array $sourceDirectories,
        bool $skipCoverage
    ): TestFrameworkAdapter;
}
```

So, instead of 1 class to be responsible for creating all possible adapters, now each adapter's factory knows how to create particular adapter.

### Future goal

Then, when adapters are extracted, and we will implement autodiscovery of adapters, this code will look like

```php
# pseudocode

foreach($autodiscoveredAdapterFactories as $adapterFactory) {
    if ($adapterName === $adapterFactory::getAdapterName()) {
        return $adapterFactory::create(
            (new TestFrameworkFinder($adapterFactory::getAdapterName()))->find(),
            $this-tmpDir,
            ...
        );
    }
}
```

Thus, we can register any adapter from any package, and this package will be responsible for instantiating an adapter object.