### PR TITLE
Tweak the Mutation class

### DIFF
--- a/src/Console/InfectionContainer.php
+++ b/src/Console/InfectionContainer.php
@@ -54,6 +54,7 @@ use Infection\Locator\RootsFileOrDirectoryLocator;
 use Infection\Logger\LoggerFactory;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutant\MutantCreator;
+use Infection\Mutation;
 use Infection\Mutation\FileMutationGenerator;
 use Infection\Mutation\FileParser;
 use Infection\Mutation\MutationGenerator;
@@ -224,17 +225,10 @@ final class InfectionContainer extends Container
                 return new VersionParser();
             },
             Lexer::class => static function (): Lexer {
-                return new Lexer\Emulative([
-                    'usedAttributes' => [
-                        'comments',
-                        'startLine',
-                        'endLine',
-                        'startTokenPos',
-                        'endTokenPos',
-                        'startFilePos',
-                        'endFilePos',
-                    ],
-                ]);
+                $attributes = Mutation::ATTRIBUTE_KEYS;
+                $attributes[] = 'comments';
+
+                return new Lexer\Emulative(['usedAttributes' => $attributes]);
             },
             Parser::class => static function (self $container): Parser {
                 /** @var Lexer $lexer */

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -87,7 +87,7 @@ final class DebugFileLogger extends FileLogger
 
         foreach ($processes as $mutantProcess) {
             $logParts[] = '';
-            $logParts[] = 'Mutator: ' . $mutantProcess->getMutator()::getName();
+            $logParts[] = 'Mutator: ' . $mutantProcess->getMutatorClass()::getName();
             $logParts[] = 'Line ' . $mutantProcess->getOriginalStartingLine();
         }
 

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -87,7 +87,7 @@ final class DebugFileLogger extends FileLogger
 
         foreach ($processes as $mutantProcess) {
             $logParts[] = '';
-            $logParts[] = 'Mutator: ' . $mutantProcess->getMutatorClass()::getName();
+            $logParts[] = 'Mutator: ' . $mutantProcess->getMutatorName();
             $logParts[] = 'Line ' . $mutantProcess->getOriginalStartingLine();
         }
 

--- a/src/Logger/PerMutatorLogger.php
+++ b/src/Logger/PerMutatorLogger.php
@@ -79,7 +79,7 @@ final class PerMutatorLogger extends FileLogger
         $processPerMutator = [];
 
         foreach ($processes as $process) {
-            $mutatorName = $process->getMutatorClass()::getName();
+            $mutatorName = $process->getMutatorName();
             $processPerMutator[$mutatorName][] = $process;
         }
 

--- a/src/Logger/PerMutatorLogger.php
+++ b/src/Logger/PerMutatorLogger.php
@@ -79,7 +79,7 @@ final class PerMutatorLogger extends FileLogger
         $processPerMutator = [];
 
         foreach ($processes as $process) {
-            $mutatorName = $process->getMutator()::getName();
+            $mutatorName = $process->getMutatorClass()::getName();
             $processPerMutator[$mutatorName][] = $process;
         }
 

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -104,7 +104,7 @@ final class TextFileLogger extends FileLogger
             $index + 1,
             $mutantProcess->getOriginalFilePath(),
             $mutantProcess->getOriginalStartingLine(),
-            $mutantProcess->getMutatorClass()::getName()
+            $mutantProcess->getMutatorName()
         );
     }
 }

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -104,7 +104,7 @@ final class TextFileLogger extends FileLogger
             $index + 1,
             $mutantProcess->getOriginalFilePath(),
             $mutantProcess->getOriginalStartingLine(),
-            $mutantProcess->getMutator()::getName()
+            $mutantProcess->getMutatorClass()::getName()
         );
     }
 }

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -36,8 +36,6 @@ declare(strict_types=1);
 namespace Infection;
 
 use function count;
-use function get_class;
-use Infection\Mutator\Mutator;
 use Infection\TestFramework\Coverage\CoverageLineData;
 use PhpParser\Node;
 
@@ -48,7 +46,7 @@ use PhpParser\Node;
 class Mutation
 {
     private $originalFilePath;
-    private $mutator;
+    private $mutatorClass;
     private $mutatedNodeClass;
     private $mutatedNode;
     private $mutationByMutatorIndex;
@@ -81,7 +79,7 @@ class Mutation
     public function __construct(
         string $originalFilePath,
         array $originalFileAst,
-        Mutator $mutator,
+        string $mutatorClass,
         array $attributes,
         string $mutatedNodeClass,
         $mutatedNode,
@@ -90,7 +88,7 @@ class Mutation
     ) {
         $this->originalFilePath = $originalFilePath;
         $this->originalFileAst = $originalFileAst;
-        $this->mutator = $mutator;
+        $this->mutatorClass = $mutatorClass;
         $this->attributes = $attributes;
         $this->mutatedNodeClass = $mutatedNodeClass;
         $this->mutatedNode = $mutatedNode;
@@ -98,9 +96,9 @@ class Mutation
         $this->tests = $tests;
     }
 
-    public function getMutator(): Mutator
+    public function getMutatorClass(): string
     {
-        return $this->mutator;
+        return $this->mutatorClass;
     }
 
     /**
@@ -124,10 +122,10 @@ class Mutation
     public function getHash(): string
     {
         if (!isset($this->hash)) {
-            $mutatorClass = get_class($this->getMutator());
             $attributes = $this->getAttributes();
+
             $attributeValues = [
-                $mutatorClass,
+                $this->mutatorClass,
                 $attributes['startLine'],
                 $attributes['endLine'],
                 $attributes['startTokenPos'],
@@ -137,7 +135,7 @@ class Mutation
             ];
 
             $hashKeys = array_merge(
-                [$this->getOriginalFilePath(), $mutatorClass, $this->mutationByMutatorIndex],
+                [$this->getOriginalFilePath(), $this->mutatorClass, $this->mutationByMutatorIndex],
                 $attributeValues
             );
 

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -35,17 +35,16 @@ declare(strict_types=1);
 
 namespace Infection;
 
-use Infection\Mutator\ProfileList;
-use Webmozart\Assert\Assert;
 use function array_flip;
 use function array_intersect_key;
 use function array_keys;
-use function array_merge;
 use function count;
-use Infection\TestFramework\Coverage\CoverageLineData;
-use PhpParser\Node;
 use function implode;
+use Infection\Mutator\ProfileList;
+use Infection\TestFramework\Coverage\CoverageLineData;
 use function md5;
+use PhpParser\Node;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal
@@ -53,7 +52,7 @@ use function md5;
  */
 class Mutation
 {
-    private const ATTRIBUTE_KEYS = [
+    public const ATTRIBUTE_KEYS = [
         'startLine',
         'endLine',
         'startTokenPos',
@@ -173,7 +172,7 @@ class Mutation
         $hashKeys = [
             $this->originalFilePath,
             $this->mutatorName,
-            $this->mutationByMutatorIndex
+            $this->mutationByMutatorIndex,
         ];
 
         foreach ($this->attributes as $attribute) {

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -35,9 +35,17 @@ declare(strict_types=1);
 
 namespace Infection;
 
+use Infection\Mutator\ProfileList;
+use Webmozart\Assert\Assert;
+use function array_flip;
+use function array_intersect_key;
+use function array_keys;
+use function array_merge;
 use function count;
 use Infection\TestFramework\Coverage\CoverageLineData;
 use PhpParser\Node;
+use function implode;
+use function md5;
 
 /**
  * @internal
@@ -45,21 +53,24 @@ use PhpParser\Node;
  */
 class Mutation
 {
+    private const ATTRIBUTE_KEYS = [
+        'startLine',
+        'endLine',
+        'startTokenPos',
+        'endTokenPos',
+        'startFilePos',
+        'endFilePos',
+    ];
+
     private $originalFilePath;
-    private $mutatorClass;
+    private $mutatorName;
     private $mutatedNodeClass;
     private $mutatedNode;
     private $mutationByMutatorIndex;
-
-    /**
-     * @var array
-     */
     private $attributes;
-
-    /**
-     * @var Node[]
-     */
     private $originalFileAst;
+    private $tests;
+    private $coveredByTests;
 
     /**
      * @var string|null
@@ -67,42 +78,45 @@ class Mutation
     private $hash;
 
     /**
-     * @var CoverageLineData[]
-     */
-    private $tests;
-
-    /**
      * @param Node[] $originalFileAst
      * @param array<string|int|float> $attributes
-     * @param Node|Node[] $mutatedNode
+     * @param CoverageLineData[] $tests
      */
     public function __construct(
         string $originalFilePath,
         array $originalFileAst,
-        string $mutatorClass,
+        string $mutatorName,
         array $attributes,
         string $mutatedNodeClass,
-        $mutatedNode,
+        Node $mutatedNode,
         int $mutationByMutatorIndex,
         array $tests
     ) {
+        Assert::oneOf($mutatorName, array_keys(ProfileList::ALL_MUTATORS));
+        Assert::allIsInstanceOf($tests, CoverageLineData::class);
+
+        foreach (self::ATTRIBUTE_KEYS as $key) {
+            Assert::keyExists($attributes, $key);
+        }
+
         $this->originalFilePath = $originalFilePath;
         $this->originalFileAst = $originalFileAst;
-        $this->mutatorClass = $mutatorClass;
-        $this->attributes = $attributes;
+        $this->mutatorName = $mutatorName;
+        $this->attributes = array_intersect_key($attributes, array_flip(self::ATTRIBUTE_KEYS));
         $this->mutatedNodeClass = $mutatedNodeClass;
         $this->mutatedNode = $mutatedNode;
         $this->mutationByMutatorIndex = $mutationByMutatorIndex;
         $this->tests = $tests;
+        $this->coveredByTests = count($tests) > 0;
     }
 
-    public function getMutatorClass(): string
+    public function getMutatorName(): string
     {
-        return $this->mutatorClass;
+        return $this->mutatorName;
     }
 
     /**
-     * @return (string|int|float)[]   $attributes
+     * @return (string|int|float)[]
      */
     public function getAttributes(): array
     {
@@ -121,25 +135,8 @@ class Mutation
 
     public function getHash(): string
     {
-        if (!isset($this->hash)) {
-            $attributes = $this->getAttributes();
-
-            $attributeValues = [
-                $this->mutatorClass,
-                $attributes['startLine'],
-                $attributes['endLine'],
-                $attributes['startTokenPos'],
-                $attributes['endTokenPos'],
-                $attributes['startFilePos'],
-                $attributes['endFilePos'],
-            ];
-
-            $hashKeys = array_merge(
-                [$this->getOriginalFilePath(), $this->mutatorClass, $this->mutationByMutatorIndex],
-                $attributeValues
-            );
-
-            $this->hash = md5(implode('_', $hashKeys));
+        if ($this->hash === null) {
+            $this->hash = $this->createHash();
         }
 
         return $this->hash;
@@ -163,14 +160,26 @@ class Mutation
 
     public function isCoveredByTest(): bool
     {
-        return count($this->getAllTests()) !== 0;
+        return $this->coveredByTests;
     }
 
-    /**
-     * @return Node|Node[]
-     */
-    public function getMutatedNode()
+    public function getMutatedNode(): Node
     {
         return $this->mutatedNode;
+    }
+
+    private function createHash(): string
+    {
+        $hashKeys = [
+            $this->originalFilePath,
+            $this->mutatorName,
+            $this->mutationByMutatorIndex
+        ];
+
+        foreach ($this->attributes as $attribute) {
+            $hashKeys[] = $attribute;
+        }
+
+        return md5(implode('_', $hashKeys));
     }
 }

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -138,7 +138,7 @@ class NodeMutationGenerator
             $mutations[] = new Mutation(
                 $this->filePath,
                 $this->fileNodes,
-                get_class($mutator->getMutator()),
+                $mutator->getMutator()::getName(),
                 $node->getAttributes(),
                 get_class($node),
                 $mutatedNode,

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -138,7 +138,7 @@ class NodeMutationGenerator
             $mutations[] = new Mutation(
                 $this->filePath,
                 $this->fileNodes,
-                $mutator->getMutator(),
+                get_class($mutator->getMutator()),
                 $node->getAttributes(),
                 get_class($node),
                 $mutatedNode,

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -142,7 +142,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInt
                     $index + 1,
                     $mutation->getOriginalFilePath(),
                     (int) $mutation->getAttributes()['startLine'],
-                    $mutation->getMutator()::getName()
+                    $mutation->getMutatorClass()::getName()
                 ),
             ]);
 

--- a/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Process/Listener/MutationTestingConsoleLoggerSubscriber.php
@@ -142,7 +142,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriberInt
                     $index + 1,
                     $mutation->getOriginalFilePath(),
                     (int) $mutation->getAttributes()['startLine'],
-                    $mutation->getMutatorClass()::getName()
+                    $mutation->getMutatorName()::getName()
                 ),
             ]);
 

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -38,7 +38,6 @@ namespace Infection\Process;
 use function in_array;
 use Infection\Mutant\MutantInterface;
 use Infection\Mutation;
-use Infection\Mutator\Mutator;
 use Infection\TestFramework\TestFrameworkAdapter;
 use Symfony\Component\Process\Process;
 
@@ -111,9 +110,9 @@ final class MutantProcess implements MutantProcessInterface
         return self::CODE_KILLED;
     }
 
-    public function getMutator(): Mutator
+    public function getMutatorClass(): string
     {
-        return $this->getMutation()->getMutator();
+        return $this->getMutation()->getMutatorClass();
     }
 
     public function getOriginalFilePath(): string

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -110,9 +110,9 @@ final class MutantProcess implements MutantProcessInterface
         return self::CODE_KILLED;
     }
 
-    public function getMutatorClass(): string
+    public function getMutatorName(): string
     {
-        return $this->getMutation()->getMutatorClass();
+        return $this->getMutation()->getMutatorName();
     }
 
     public function getOriginalFilePath(): string

--- a/src/Process/MutantProcessInterface.php
+++ b/src/Process/MutantProcessInterface.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Process;
 
 use Infection\Mutant\MutantInterface;
-use Infection\Mutator\Mutator;
 use Symfony\Component\Process\Process;
 
 /**
@@ -54,7 +53,7 @@ interface MutantProcessInterface
 
     public function getResultCode(): int;
 
-    public function getMutator(): Mutator;
+    public function getMutatorClass(): string;
 
     public function getOriginalFilePath(): string;
 

--- a/src/Process/MutantProcessInterface.php
+++ b/src/Process/MutantProcessInterface.php
@@ -53,7 +53,7 @@ interface MutantProcessInterface
 
     public function getResultCode(): int;
 
-    public function getMutatorClass(): string;
+    public function getMutatorName(): string;
 
     public function getOriginalFilePath(): string;
 

--- a/tests/phpunit/Logger/DebugFileLoggerTest.php
+++ b/tests/phpunit/Logger/DebugFileLoggerTest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\Logger;
 use Infection\Logger\DebugFileLogger;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutator\Boolean\TrueValue;
-use Infection\Mutator\Util\MutatorConfig;
 use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessInterface;
@@ -170,7 +169,7 @@ TXT;
 
         for ($i = 0; $i < 5; ++$i) {
             $process = $this->createMock(MutantProcessInterface::class);
-            $process->expects($this->once())->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $process->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
@@ -179,7 +178,7 @@ TXT;
 
         for ($i = 0; $i < 5; ++$i) {
             $process = $this->createMock(MutantProcessInterface::class);
-            $process->expects($this->once())->method('getMutator')->willReturn(new TrueValue(new MutatorConfig([])));
+            $process->expects($this->once())->method('getMutatorClass')->willReturn(TrueValue::class);
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(20 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('bar/bar');
@@ -189,7 +188,7 @@ TXT;
 
         for ($i = 0; $i < 2; ++$i) {
             $process = $this->createMock(MutantProcessInterface::class);
-            $process->expects($this->once())->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $process->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');

--- a/tests/phpunit/Logger/DebugFileLoggerTest.php
+++ b/tests/phpunit/Logger/DebugFileLoggerTest.php
@@ -169,7 +169,7 @@ TXT;
 
         for ($i = 0; $i < 5; ++$i) {
             $process = $this->createMock(MutantProcessInterface::class);
-            $process->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
+            $process->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
@@ -178,7 +178,7 @@ TXT;
 
         for ($i = 0; $i < 5; ++$i) {
             $process = $this->createMock(MutantProcessInterface::class);
-            $process->expects($this->once())->method('getMutatorClass')->willReturn(TrueValue::class);
+            $process->expects($this->once())->method('getMutatorName')->willReturn(TrueValue::getName());
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(20 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('bar/bar');
@@ -188,7 +188,7 @@ TXT;
 
         for ($i = 0; $i < 2; ++$i) {
             $process = $this->createMock(MutantProcessInterface::class);
-            $process->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
+            $process->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');

--- a/tests/phpunit/Logger/PerMutatorLoggerTest.php
+++ b/tests/phpunit/Logger/PerMutatorLoggerTest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\Logger;
 use Infection\Logger\PerMutatorLogger;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutator\Regex\PregQuote;
-use Infection\Mutator\Util\MutatorConfig;
 use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessInterface;
@@ -87,21 +86,21 @@ TXT;
 
         for ($i = 0; $i < 10; ++$i) {
             $mutantFor = $this->createMock(MutantProcessInterface::class);
-            $mutantFor->expects($this->once())->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $mutantFor->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
             $mutantFor->expects($this->exactly(2))->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $processes[] = $mutantFor;
         }
 
         for ($i = 0; $i < 5; ++$i) {
             $mutantFor = $this->createMock(MutantProcessInterface::class);
-            $mutantFor->expects($this->once())->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $mutantFor->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
             $mutantFor->expects($this->exactly(2))->method('getResultCode')->willReturn(MutantProcess::CODE_NOT_COVERED);
             $processes[] = $mutantFor;
         }
 
         for ($i = 0; $i < 5; ++$i) {
             $mutantFor = $this->createMock(MutantProcessInterface::class);
-            $mutantFor->expects($this->once())->method('getMutator')->willReturn(new PregQuote(new MutatorConfig([])));
+            $mutantFor->expects($this->once())->method('getMutatorClass')->willReturn(PregQuote::class);
             $mutantFor->expects($this->exactly(2))->method('getResultCode')->willReturn(MutantProcess::CODE_NOT_COVERED);
             $processes[] = $mutantFor;
         }

--- a/tests/phpunit/Logger/PerMutatorLoggerTest.php
+++ b/tests/phpunit/Logger/PerMutatorLoggerTest.php
@@ -86,21 +86,21 @@ TXT;
 
         for ($i = 0; $i < 10; ++$i) {
             $mutantFor = $this->createMock(MutantProcessInterface::class);
-            $mutantFor->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
+            $mutantFor->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
             $mutantFor->expects($this->exactly(2))->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $processes[] = $mutantFor;
         }
 
         for ($i = 0; $i < 5; ++$i) {
             $mutantFor = $this->createMock(MutantProcessInterface::class);
-            $mutantFor->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
+            $mutantFor->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
             $mutantFor->expects($this->exactly(2))->method('getResultCode')->willReturn(MutantProcess::CODE_NOT_COVERED);
             $processes[] = $mutantFor;
         }
 
         for ($i = 0; $i < 5; ++$i) {
             $mutantFor = $this->createMock(MutantProcessInterface::class);
-            $mutantFor->expects($this->once())->method('getMutatorClass')->willReturn(PregQuote::class);
+            $mutantFor->expects($this->once())->method('getMutatorName')->willReturn(PregQuote::getName());
             $mutantFor->expects($this->exactly(2))->method('getResultCode')->willReturn(MutantProcess::CODE_NOT_COVERED);
             $processes[] = $mutantFor;
         }

--- a/tests/phpunit/Logger/TextFileLoggerTest.php
+++ b/tests/phpunit/Logger/TextFileLoggerTest.php
@@ -319,7 +319,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->once())->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
+            $process->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
@@ -339,7 +339,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->once())->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->once())->method('getMutatorClass')->willReturn(TrueValue::class);
+            $process->expects($this->once())->method('getMutatorName')->willReturn(TrueValue::getName());
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(20 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('bar/bar');
@@ -360,7 +360,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->once())->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
+            $process->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_NOT_COVERED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
@@ -380,7 +380,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->atMost(1))->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->atMost(1))->method('getMutatorClass')->willReturn(For_::class);
+            $process->expects($this->atMost(1))->method('getMutatorName')->willReturn(For_::getName());
             $process->expects($this->atMost(1))->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $process->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->method('getOriginalFilePath')->willReturn('foo/bar');

--- a/tests/phpunit/Logger/TextFileLoggerTest.php
+++ b/tests/phpunit/Logger/TextFileLoggerTest.php
@@ -39,7 +39,6 @@ use Infection\Logger\TextFileLogger;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutant\MutantInterface;
 use Infection\Mutator\Boolean\TrueValue;
-use Infection\Mutator\Util\MutatorConfig;
 use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessInterface;
@@ -320,7 +319,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->once())->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->once())->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $process->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
@@ -340,7 +339,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->once())->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->once())->method('getMutator')->willReturn(new TrueValue(new MutatorConfig([])));
+            $process->expects($this->once())->method('getMutatorClass')->willReturn(TrueValue::class);
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(20 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('bar/bar');
@@ -361,7 +360,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->once())->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->once())->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $process->expects($this->once())->method('getMutatorClass')->willReturn(For_::class);
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_NOT_COVERED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
@@ -381,7 +380,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->atMost(1))->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->atMost(1))->method('getMutator')->willReturn(new For_(new MutatorConfig([])));
+            $process->expects($this->atMost(1))->method('getMutatorClass')->willReturn(For_::class);
             $process->expects($this->atMost(1))->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $process->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->method('getOriginalFilePath')->willReturn('foo/bar');

--- a/tests/phpunit/Mutation/FileMutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/FileMutationGeneratorTest.php
@@ -116,7 +116,7 @@ final class FileMutationGeneratorTest extends TestCase
         /** @var Mutation $mutation */
         $mutation = current($mutations);
 
-        $this->assertInstanceOf(Plus::class, $mutation->getMutator());
+        $this->assertSame(Plus::class, $mutation->getMutatorClass());
     }
 
     /**

--- a/tests/phpunit/Mutation/FileMutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/FileMutationGeneratorTest.php
@@ -116,7 +116,7 @@ final class FileMutationGeneratorTest extends TestCase
         /** @var Mutation $mutation */
         $mutation = current($mutations);
 
-        $this->assertSame(Plus::class, $mutation->getMutatorClass());
+        $this->assertSame(Plus::class, $mutation->getMutatorName());
     }
 
     /**

--- a/tests/phpunit/Mutation/FileMutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/FileMutationGeneratorTest.php
@@ -116,7 +116,7 @@ final class FileMutationGeneratorTest extends TestCase
         /** @var Mutation $mutation */
         $mutation = current($mutations);
 
-        $this->assertSame(Plus::class, $mutation->getMutatorName());
+        $this->assertSame(Plus::getName(), $mutation->getMutatorName());
     }
 
     /**

--- a/tests/phpunit/Mutation/MutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/MutationGeneratorTest.php
@@ -42,7 +42,6 @@ use Infection\Events\MutationGeneratingStarted;
 use Infection\Mutation;
 use Infection\Mutation\FileMutationGenerator;
 use Infection\Mutation\MutationGenerator;
-use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Util\MutatorConfig;
 use Infection\TestFramework\Coverage\LineCodeCoverage;

--- a/tests/phpunit/Mutation/MutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/MutationGeneratorTest.php
@@ -67,9 +67,9 @@ final class MutationGeneratorTest extends TestCase
         $onlyCovered = true;
         $extraVisitors = [2 => new FakeVisitor()];
 
-        $mutation0 = self::createMutation();
-        $mutation1 = self::createMutation();
-        $mutation2 = self::createMutation();
+        $mutation0 = $this->createMock(Mutation::class);
+        $mutation1 = $this->createMock(Mutation::class);
+        $mutation2 = $this->createMock(Mutation::class);
 
         /** @var FileMutationGenerator|ObjectProphecy $fileMutationGeneratorProphecy */
         $fileMutationGeneratorProphecy = $this->prophesize(FileMutationGenerator::class);
@@ -148,19 +148,5 @@ final class MutationGeneratorTest extends TestCase
         );
 
         $mutationGenerator->generate(false, []);
-    }
-
-    private static function createMutation(): Mutation
-    {
-        return new Mutation(
-            '',
-            [],
-            new Plus(new MutatorConfig([])),
-            [],
-            '',
-            null,
-            0,
-            []
-        );
     }
 }

--- a/tests/phpunit/MutationTest.php
+++ b/tests/phpunit/MutationTest.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Tests;
 
+use function array_merge;
 use Generator;
 use Infection\Mutation;
 use Infection\Mutator\Arithmetic\Plus;
 use Infection\TestFramework\Coverage\CoverageLineData;
+use function md5;
 use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
-use function array_merge;
-use function md5;
 
 final class MutationTest extends TestCase
 {
@@ -66,8 +66,7 @@ final class MutationTest extends TestCase
         array $expectedAttributes,
         bool $expectedCoveredByTests,
         string $expectedHash
-    ): void
-    {
+    ): void {
         $mutation = new Mutation(
             $originalFilePath,
             $originalFileAst,
@@ -113,7 +112,7 @@ final class MutationTest extends TestCase
             [],
             $nominalAttributes,
             false,
-            md5('_Plus_-1_3_5_21_31_43_53')
+            md5('_Plus_-1_3_5_21_31_43_53'),
         ];
 
         yield 'nominal with a test' => [
@@ -136,7 +135,7 @@ final class MutationTest extends TestCase
             ],
             $nominalAttributes,
             true,
-            md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53')
+            md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53'),
         ];
 
         yield 'nominal with a test with a different mutator index' => [
@@ -159,7 +158,7 @@ final class MutationTest extends TestCase
             ],
             $nominalAttributes,
             true,
-            md5('/path/to/acme/Foo.php_Plus_99_3_5_21_31_43_53')
+            md5('/path/to/acme/Foo.php_Plus_99_3_5_21_31_43_53'),
         ];
 
         yield 'nominal with a test and additional attributes' => [
@@ -182,7 +181,7 @@ final class MutationTest extends TestCase
             ],
             $nominalAttributes,
             true,
-            md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53')
+            md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53'),
         ];
 
         yield 'nominal without a test' => [
@@ -199,7 +198,7 @@ final class MutationTest extends TestCase
             [],
             $nominalAttributes,
             false,
-            md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53')
+            md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53'),
         ];
     }
 }

--- a/tests/phpunit/MutationTest.php
+++ b/tests/phpunit/MutationTest.php
@@ -37,7 +37,6 @@ namespace Infection\Tests;
 
 use Infection\Mutation;
 use Infection\Mutator\Arithmetic\Plus;
-use Infection\Mutator\Util\MutatorConfig;
 use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
 
@@ -45,7 +44,6 @@ final class MutationTest extends TestCase
 {
     public function test_it_correctly_generates_hash(): void
     {
-        $mutator = new Plus(new MutatorConfig([]));
         $attributes = [
             'startLine' => 3,
             'endLine' => 5,
@@ -58,7 +56,7 @@ final class MutationTest extends TestCase
         $mutation = new Mutation(
             '/abc.php',
             [],
-            $mutator,
+            Plus::class,
             $attributes,
             'Interface_',
             new Node\Scalar\LNumber(1),
@@ -71,7 +69,6 @@ final class MutationTest extends TestCase
 
     public function test_it_correctly_sets_original_file_ast(): void
     {
-        $mutator = new Plus(new MutatorConfig([]));
         $attributes = [
             'startLine' => 3,
             'endLine' => 5,
@@ -85,7 +82,7 @@ final class MutationTest extends TestCase
         $mutation = new Mutation(
             '/abc.php',
             $fileAst,
-            $mutator,
+            Plus::class,
             $attributes,
             'Interface_',
             new Node\Scalar\LNumber(1),

--- a/tests/phpunit/MutationTest.php
+++ b/tests/phpunit/MutationTest.php
@@ -35,41 +35,65 @@ declare(strict_types=1);
 
 namespace Infection\Tests;
 
+use Generator;
 use Infection\Mutation;
 use Infection\Mutator\Arithmetic\Plus;
+use Infection\TestFramework\Coverage\CoverageLineData;
 use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
+use function array_merge;
+use function md5;
 
 final class MutationTest extends TestCase
 {
-    public function test_it_correctly_generates_hash(): void
+    /**
+     * @dataProvider valuesProvider
+     *
+     * @param Node[] $originalFileAst
+     * @param array<string|int|float> $attributes
+     * @param array<string|int|float> $expectedAttributes
+     * @param CoverageLineData[] $tests
+     */
+    public function test_it_can_be_instantiated(
+        string $originalFilePath,
+        array $originalFileAst,
+        string $mutatorName,
+        array $attributes,
+        string $mutatedNodeClass,
+        Node $mutatedNode,
+        int $mutationByMutatorIndex,
+        array $tests,
+        array $expectedAttributes,
+        bool $expectedCoveredByTests,
+        string $expectedHash
+    ): void
     {
-        $attributes = [
-            'startLine' => 3,
-            'endLine' => 5,
-            'startTokenPos' => 21,
-            'endTokenPos' => 31,
-            'startFilePos' => 43,
-            'endFilePos' => 53,
-        ];
-
         $mutation = new Mutation(
-            '/abc.php',
-            [],
-            Plus::class,
+            $originalFilePath,
+            $originalFileAst,
+            $mutatorName,
             $attributes,
-            'Interface_',
-            new Node\Scalar\LNumber(1),
-            0,
-            [1, 2, 3]
+            $mutatedNodeClass,
+            $mutatedNode,
+            $mutationByMutatorIndex,
+            $tests
         );
 
-        $this->assertSame('2930c05082a35248987760a81b9f9a08', $mutation->getHash());
+        $this->assertSame($originalFilePath, $mutation->getOriginalFilePath());
+        $this->assertSame($originalFileAst, $mutation->getOriginalFileAst());
+        $this->assertSame($mutatorName, $mutation->getMutatorName());
+        $this->assertSame($expectedAttributes, $mutation->getAttributes());
+        $this->assertSame($mutatedNodeClass, $mutation->getMutatedNodeClass());
+        $this->assertSame($mutatedNode, $mutation->getMutatedNode());
+        $this->assertSame($tests, $mutation->getAllTests());
+        $this->assertSame($expectedCoveredByTests, $mutation->isCoveredByTest());
+
+        $this->assertSame($expectedHash, $mutation->getHash());
     }
 
-    public function test_it_correctly_sets_original_file_ast(): void
+    public function valuesProvider(): Generator
     {
-        $attributes = [
+        $nominalAttributes = [
             'startLine' => 3,
             'endLine' => 5,
             'startTokenPos' => 21,
@@ -77,19 +101,105 @@ final class MutationTest extends TestCase
             'startFilePos' => 43,
             'endFilePos' => 53,
         ];
-        $fileAst = ['file' => 'ast'];
 
-        $mutation = new Mutation(
-            '/abc.php',
-            $fileAst,
-            Plus::class,
-            $attributes,
-            'Interface_',
+        yield 'empty' => [
+            '',
+            [],
+            Plus::getName(),
+            $nominalAttributes,
+            Node\Scalar\LNumber::class,
+            new Node\Scalar\LNumber(1),
+            -1,
+            [],
+            $nominalAttributes,
+            false,
+            md5('_Plus_-1_3_5_21_31_43_53')
+        ];
+
+        yield 'nominal with a test' => [
+            '/path/to/acme/Foo.php',
+            [new Node\Stmt\Namespace_(
+                new Node\Name('Acme'),
+                [new Node\Scalar\LNumber(0)]
+            )],
+            Plus::getName(),
+            $nominalAttributes,
+            Node\Scalar\LNumber::class,
             new Node\Scalar\LNumber(1),
             0,
-            [1, 2, 3]
-        );
+            [
+                CoverageLineData::with(
+                    'FooTest::test_it_can_instantiate',
+                    '/path/to/acme/FooTest.php',
+                    0.01
+                ),
+            ],
+            $nominalAttributes,
+            true,
+            md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53')
+        ];
 
-        $this->assertSame($fileAst, $mutation->getOriginalFileAst());
+        yield 'nominal with a test with a different mutator index' => [
+            '/path/to/acme/Foo.php',
+            [new Node\Stmt\Namespace_(
+                new Node\Name('Acme'),
+                [new Node\Scalar\LNumber(0)]
+            )],
+            Plus::getName(),
+            $nominalAttributes,
+            Node\Scalar\LNumber::class,
+            new Node\Scalar\LNumber(1),
+            99,
+            [
+                CoverageLineData::with(
+                    'FooTest::test_it_can_instantiate',
+                    '/path/to/acme/FooTest.php',
+                    0.01
+                ),
+            ],
+            $nominalAttributes,
+            true,
+            md5('/path/to/acme/Foo.php_Plus_99_3_5_21_31_43_53')
+        ];
+
+        yield 'nominal with a test and additional attributes' => [
+            '/path/to/acme/Foo.php',
+            [new Node\Stmt\Namespace_(
+                new Node\Name('Acme'),
+                [new Node\Scalar\LNumber(0)]
+            )],
+            Plus::getName(),
+            array_merge($nominalAttributes, ['foo' => 100, 'bar' => 1000]),
+            Node\Scalar\LNumber::class,
+            new Node\Scalar\LNumber(1),
+            0,
+            [
+                CoverageLineData::with(
+                    'FooTest::test_it_can_instantiate',
+                    '/path/to/acme/FooTest.php',
+                    0.01
+                ),
+            ],
+            $nominalAttributes,
+            true,
+            md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53')
+        ];
+
+        yield 'nominal without a test' => [
+            '/path/to/acme/Foo.php',
+            [new Node\Stmt\Namespace_(
+                new Node\Name('Acme'),
+                [new Node\Scalar\LNumber(0)]
+            )],
+            Plus::getName(),
+            $nominalAttributes,
+            Node\Scalar\LNumber::class,
+            new Node\Scalar\LNumber(1),
+            0,
+            [],
+            $nominalAttributes,
+            false,
+            md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53')
+        ];
     }
 }

--- a/tests/phpunit/Process/MutantProcessTest.php
+++ b/tests/phpunit/Process/MutantProcessTest.php
@@ -37,7 +37,6 @@ namespace Infection\Tests\Process;
 
 use Infection\Mutant\MutantInterface;
 use Infection\Mutation;
-use Infection\Mutator\Util\MutatorConfig;
 use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
@@ -166,19 +165,17 @@ final class MutantProcessTest extends TestCase
 
     public function test_it_knows_its_mutator(): void
     {
-        $mutator = new For_(new MutatorConfig([]));
-
         $mutation = $this->createMock(Mutation::class);
         $mutation->expects($this->once())
-            ->method('getMutator')
-            ->willReturn($mutator);
+            ->method('getMutatorClass')
+            ->willReturn(For_::class);
 
         $this->mutant
             ->expects($this->once())
             ->method('getMutation')
             ->willReturn($mutation);
 
-        $this->assertSame($mutator, $this->mutantProcess->getMutator());
+        $this->assertSame(For_::class, $this->mutantProcess->getMutatorClass());
     }
 
     public function test_it_knows_its_original_path(): void

--- a/tests/phpunit/Process/MutantProcessTest.php
+++ b/tests/phpunit/Process/MutantProcessTest.php
@@ -167,15 +167,15 @@ final class MutantProcessTest extends TestCase
     {
         $mutation = $this->createMock(Mutation::class);
         $mutation->expects($this->once())
-            ->method('getMutatorClass')
-            ->willReturn(For_::class);
+            ->method('getMutatorName')
+            ->willReturn(For_::getName());
 
         $this->mutant
             ->expects($this->once())
             ->method('getMutation')
             ->willReturn($mutation);
 
-        $this->assertSame(For_::class, $this->mutantProcess->getMutatorClass());
+        $this->assertSame('For_', $this->mutantProcess->getMutatorName());
     }
 
     public function test_it_knows_its_original_path(): void

--- a/tests/phpunit/Visitor/MutatorVisitorTest.php
+++ b/tests/phpunit/Visitor/MutatorVisitorTest.php
@@ -105,15 +105,19 @@ PHP
                 new Mutation(
                     'path/to/file',
                     $nodes,
-                    new PublicVisibility(new MutatorConfig([])),
+                    PublicVisibility::getName(),
                     [
                         'startTokenPos' => 29,
                         'endTokenPos' => 48,
+                        'startLine' => -1,
+                        'endLine' => -1,
+                        'startFilePos' => -1,
+                        'endFilePos' => -1,
                     ],
                     ClassMethod::class,
                     new Nop(),
                     0,
-                    range(29, 48)
+                    []
                 ),
             ];
         })();
@@ -155,15 +159,19 @@ PHP
                 new Mutation(
                     'path/to/file',
                     $nodes,
-                    new PublicVisibility(new MutatorConfig([])),
+                    PublicVisibility::getName(),
                     [
                         'startTokenPos' => 29,
                         'endTokenPos' => 50,
+                        'startLine' => -1,
+                        'endLine' => -1,
+                        'startFilePos' => -1,
+                        'endFilePos' => -1,
                     ],
                     ClassMethod::class,
                     new Nop(),
                     0,
-                    range(29, 50)
+                    []
                 ),
             ];
         })();
@@ -219,15 +227,19 @@ PHP
                 new Mutation(
                     'path/to/file',
                     $nodes,
-                    new PublicVisibility(new MutatorConfig([])),
+                    PublicVisibility::getName(),
                     [
                         'startTokenPos' => 29,
                         'endTokenPos' => 48,
+                        'startLine' => -1,
+                        'endLine' => -1,
+                        'startFilePos' => -1,
+                        'endFilePos' => -1,
                     ],
-                    ClassMethod::class,
+                    PublicVisibility::getName(),
                     new Nop(),
                     0,
-                    range(29, 48)
+                    []
                 ),
             ];
         })();

--- a/tests/phpunit/Visitor/MutatorVisitorTest.php
+++ b/tests/phpunit/Visitor/MutatorVisitorTest.php
@@ -38,14 +38,12 @@ namespace Infection\Tests\Visitor;
 use Generator;
 use Infection\Mutation;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
-use Infection\Mutator\Util\MutatorConfig;
 use Infection\Visitor\MutatorVisitor;
 use PhpParser\Lexer;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\ParserFactory;
-use function range;
 
 final class MutatorVisitorTest extends BaseVisitorTest
 {


### PR DESCRIPTION
This PR:

- Exposes only the `Mutator` name instead of the full instance in order to reduce the (mutable) state exposed (besides not being used for anything else that getting the name)
- Slightly optimize the hash creation
- Validate the mutator name
- Narrow `$mutatedNode` to `Node` instead of `Node|Node[]` (no other implications in practice)
- Tweak the Lexer configured in the container to make sure it includes the attributes used by `Mutation`
- Only select the necessary attributes and ensure they all exists

Note that the hash calculation is slightly changed since we pick the mutator name instead of class but it work as well.