### PR TITLE
Mark test cases with `@group integration` when I/O operations are found

### DIFF
--- a/tests/phpunit/AutoReview/BuildConfigYmlTest.php
+++ b/tests/phpunit/AutoReview/BuildConfigYmlTest.php
@@ -43,7 +43,7 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * @coversNothing
  *
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class BuildConfigYmlTest extends TestCase
 {

--- a/tests/phpunit/AutoReview/BuildConfigYmlTest.php
+++ b/tests/phpunit/AutoReview/BuildConfigYmlTest.php
@@ -42,6 +42,8 @@ use Symfony\Component\Yaml\Yaml;
 
 /**
  * @coversNothing
+ *
+ * @group integration Requires I/O reads
  */
 final class BuildConfigYmlTest extends TestCase
 {

--- a/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\AutoReview\IntegrationGroup;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use Generator;
+use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
+use Infection\Tests\AutoReview\SourceTestClassNameScheme;
+use Infection\Tests\FileSystem\FileSystemTestCase;
+use function iterator_to_array;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
+use function Safe\file_get_contents;
+use function strpos;
+use Webmozart\Assert\Assert;
+
+final class IntegrationGroupProvider
+{
+    /**
+     * @var string[][]|null
+     */
+    private static $ioTestCaseClassesTuple;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Note that the current implementation is far from being bullet-proof. For example as of now
+     * it checks the source classes, but it is not excluded that a fixture file used in a test case
+     * contains I/O operations. In this scenario, the current implementation would miss out that one.
+     */
+    public static function provideIoTestCaseTuple(): Generator
+    {
+        if (null !== self::$ioTestCaseClassesTuple) {
+            yield from self::$ioTestCaseClassesTuple;
+
+            return;
+        }
+
+        self::$ioTestCaseClassesTuple = array_values(array_filter(array_map(
+            [self::class, 'checkIoOperations'],
+            iterator_to_array(ProjectCodeProvider::provideSourceClasses(), true)
+        )));
+
+        yield from self::$ioTestCaseClassesTuple;
+    }
+
+    public static function ioTestCaseTupleProvider(): Generator
+    {
+        yield from self::provideIoTestCaseTuple();
+    }
+
+    /**
+     * @return string[]|null
+     */
+    private static function checkIoOperations(string $className): ?array
+    {
+        $classReflection = new ReflectionClass($className);
+
+        $testCaseClass = SourceTestClassNameScheme::getTestClassName($className);
+
+        try {
+            $testCaseReflection = new ReflectionClass($testCaseClass);
+        } catch (ReflectionException $exception) {
+            // No test case could be find for this source file
+            return null;
+        }
+
+        //
+        // Check the test cases code
+        //
+        $testCaseFileName = $testCaseReflection->getFileName();
+        $testCaseCode = file_get_contents($testCaseFileName);
+
+        // Case where the test case itself use I/O functions
+        if (self::codeContainsIoFunctions($testCaseCode)) {
+            return [$testCaseClass, $testCaseFileName];
+        }
+
+        $parentTestCaseClassReflection = $testCaseReflection->getParentClass();
+
+        Assert::isInstanceOf($parentTestCaseClassReflection, ReflectionClass::class);
+
+        while ($parentTestCaseClassReflection->getName() !== TestCase::class) {
+            if ($parentTestCaseClassReflection->getName() === FileSystemTestCase::class) {
+                return [$testCaseClass, $parentTestCaseClassReflection->getFileName()];
+            }
+
+            $parentTestCaseFileName = $parentTestCaseClassReflection->getFileName();
+
+            $testCaseCode = file_get_contents($parentTestCaseFileName);
+
+            if (self::codeContainsIoFunctions($testCaseCode)) {
+                return [$testCaseClass, $parentTestCaseFileName];
+            }
+
+            $parentTestCaseClassReflection = $parentTestCaseClassReflection->getParentClass();
+
+            Assert::isInstanceOf($parentTestCaseClassReflection, ReflectionClass::class);
+        }
+
+        //
+        // Check the source class code
+        //
+        $classFileName = $classReflection->getFileName();
+        $classCode = file_get_contents($classFileName);
+
+        // Case where the test case itself use I/O functions
+        if (self::codeContainsIoFunctions($classCode)) {
+            return [$testCaseClass, $classFileName];
+        }
+
+        $parentClassReflection = $classReflection->getParentClass();
+
+        while ($parentClassReflection !== false) {
+            $parentClassFileName = $parentClassReflection->getFileName();
+
+            if ($parentClassFileName === false) {
+                break;
+            }
+
+            $parentClassCode = file_get_contents($parentClassFileName);
+
+            if (self::codeContainsIoFunctions($parentClassCode)) {
+                return [$testCaseClass, $parentClassFileName];
+            }
+
+            $parentClassReflection = $parentClassReflection->getParentClass();
+        }
+
+        return null;
+    }
+
+    private static function codeContainsIoFunctions(string $code): bool
+    {
+        if (strpos($code, 'file_get_contents') !== false) {
+            return true;
+        }
+
+        if (strpos($code, 'file_put_contents') !== false) {
+            return true;
+        }
+
+        if (strpos($code, 'file_exists') !== false) {
+            return true;
+        }
+
+        if (strpos($code, 'fopen') !== false) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupTest.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\AutoReview\IntegrationGroup;
+
+use Infection\Tests\AutoReview\PhpDoc\PHPDocParser;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use function Safe\array_flip;
+use function Safe\sprintf;
+use function strpos;
+
+final class IntegrationGroupTest extends TestCase
+{
+    /**
+     * @var PHPDocParser|null
+     */
+    private static $phpDocParser;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$phpDocParser = new PHPDocParser();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$phpDocParser = null;
+    }
+
+    /**
+     * @dataProvider \Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::ioTestCaseTupleProvider
+     */
+    public function test_the_test_cases_requiring_IO_operations_belongs_to_the_integration_group(
+        string $testCaseClassName,
+        string $fileWithIoOperations
+    ): void {
+        $reflectionClass = new ReflectionClass($testCaseClassName);
+
+        $phpDoc = (string) $reflectionClass->getDocComment();
+
+        $this->assertArrayHasKey(
+            '@group',
+            array_flip(self::$phpDocParser->parse($phpDoc)),
+            sprintf(
+                <<<'TXT'
+Expected the test case "%s" to have the annotation `@group integration` as I/O operations have been
+found in the file "%s".
+TXT
+                ,
+                $testCaseClassName,
+                $fileWithIoOperations
+            )
+        );
+
+        if (strpos($phpDoc, '@group integration') === false
+            && strpos($phpDoc, '@group e2e') === false
+        ) {
+            $this->fail(sprintf(
+                <<<'TXT'
+Expected the test case "%s" to have the annotation `@group integration` as I/O operations have been
+found in the file "%s".
+TXT
+                ,
+                $testCaseClassName,
+                $fileWithIoOperations
+            ));
+        }
+    }
+}

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -51,7 +51,7 @@ use function substr_count;
 /**
  * @coversNothing
  *
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class MakefileTest extends TestCase
 {

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -50,6 +50,8 @@ use function substr_count;
 
 /**
  * @coversNothing
+ *
+ * @group integration Requires I/O reads
  */
 final class MakefileTest extends TestCase
 {

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php
@@ -45,7 +45,7 @@ use function trait_exists;
 final class ProjectCodeProviderTest extends TestCase
 {
     /**
-     * @dataProvider \Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider::sourceClassesProvider()
+     * @dataProvider \Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider::sourceClassesProvider
      */
     public function test_source_class_provider_is_valid(string $className): void
     {

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
@@ -41,11 +41,11 @@ use function array_map;
 use function in_array;
 use Infection\StreamWrapper\IncludeInterceptor;
 use Infection\Tests\AutoReview\PhpDoc\PHPDocParser;
+use Infection\Tests\AutoReview\SourceTestClassNameScheme;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionProperty;
 use function Safe\array_flip;
-use function Safe\preg_replace;
 use function Safe\sprintf;
 
 /**
@@ -90,7 +90,7 @@ final class ProjectCodeTest extends TestCase
      */
     public function test_all_concrete_classes_have_tests(string $className): void
     {
-        $testClassName = preg_replace('/Infection/', 'Infection\\Tests', $className, 1) . 'Test';
+        $testClassName = SourceTestClassNameScheme::getTestClassName($className);
 
         if (false === in_array($className, ProjectCodeProvider::NON_TESTED_CONCRETE_CLASSES, true)) {
             $this->assertTrue(

--- a/tests/phpunit/AutoReview/SourceTestClassNameScheme.php
+++ b/tests/phpunit/AutoReview/SourceTestClassNameScheme.php
@@ -33,39 +33,23 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework;
+namespace Infection\Tests\AutoReview;
 
-use Infection\Configuration\Configuration;
-use Infection\TestFramework\CommandLineBuilder;
-use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
-use Infection\TestFramework\Factory;
-use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
-use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
-use Infection\Utils\VersionParser;
-use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Filesystem\Filesystem;
+use function Safe\preg_replace;
+use function strpos;
 
-/**
- * @group integration Requires some I/O operations
- */
-final class FactoryTest extends TestCase
+final class SourceTestClassNameScheme
 {
-    public function test_it_throws_an_exception_if_it_cant_find_the_testframework(): void
+    private function __construct()
     {
-        $factory = new Factory(
-            '',
-            '',
-            $this->createMock(TestFrameworkConfigLocatorInterface::class),
-            new XmlConfigurationHelper(new PathReplacer(new Filesystem()), ''),
-            '',
-            $this->createMock(Configuration::class),
-            $this->createMock(VersionParser::class),
-            $this->createMock(Filesystem::class),
-            new CommandLineBuilder()
-        );
+    }
 
-        $this->expectException(InvalidArgumentException::class);
-        $factory->create('Fake Test Framework', false);
+    public static function getTestClassName(string $sourceClassName): string
+    {
+        if (strpos($sourceClassName, 'Infection\\Tests') !== false) {
+            return $sourceClassName . 'Test';
+        }
+
+        return preg_replace('/Infection/', 'Infection\\Tests', $sourceClassName, 1) . 'Test';
     }
 }

--- a/tests/phpunit/AutoReview/SourceTestClassNameSchemeTest.php
+++ b/tests/phpunit/AutoReview/SourceTestClassNameSchemeTest.php
@@ -33,39 +33,25 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework;
+namespace Infection\Tests\AutoReview;
 
-use Infection\Configuration\Configuration;
-use Infection\TestFramework\CommandLineBuilder;
-use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
-use Infection\TestFramework\Factory;
-use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
-use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
-use Infection\Utils\VersionParser;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Filesystem\Filesystem;
 
-/**
- * @group integration Requires some I/O operations
- */
-final class FactoryTest extends TestCase
+final class SourceTestClassNameSchemeTest extends TestCase
 {
-    public function test_it_throws_an_exception_if_it_cant_find_the_testframework(): void
+    public function test_it_can_give_the_test_case_class_name_for_a_source_class(): void
     {
-        $factory = new Factory(
-            '',
-            '',
-            $this->createMock(TestFrameworkConfigLocatorInterface::class),
-            new XmlConfigurationHelper(new PathReplacer(new Filesystem()), ''),
-            '',
-            $this->createMock(Configuration::class),
-            $this->createMock(VersionParser::class),
-            $this->createMock(Filesystem::class),
-            new CommandLineBuilder()
+        $this->assertSame(
+            'Infection\Tests\Acme\FooTest',
+            SourceTestClassNameScheme::getTestClassName('Infection\Acme\Foo')
         );
+    }
 
-        $this->expectException(InvalidArgumentException::class);
-        $factory->create('Fake Test Framework', false);
+    public function test_it_can_give_the_test_case_class_name_for_a_test_source_class(): void
+    {
+        $this->assertSame(
+            'Infection\Tests\Acme\FooTest',
+            SourceTestClassNameScheme::getTestClassName('Infection\Tests\Acme\Foo')
+        );
     }
 }

--- a/tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php
@@ -44,6 +44,9 @@ use function random_int;
 use Symfony\Component\Filesystem\Filesystem;
 use function sys_get_temp_dir;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class ExcludeDirsProviderTest extends AbstractBaseProviderTest
 {
     /**

--- a/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
@@ -43,6 +43,9 @@ use function Infection\Tests\normalizePath as p;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Exception\RuntimeException as SymfonyRuntimeException;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProviderTest
 {
     /**

--- a/tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php
@@ -41,6 +41,9 @@ use Infection\Config\ValueProvider\SourceDirsProvider;
 use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class SourceDirsProviderTest extends AbstractBaseProviderTest
 {
     /**

--- a/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -43,6 +43,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
 {
     /**

--- a/tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php
@@ -38,6 +38,9 @@ namespace Infection\Tests\Config\ValueProvider;
 use Infection\Config\ConsoleHelper;
 use Infection\Config\ValueProvider\TextLogFileProvider;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class TextLogFileProviderTest extends AbstractBaseProviderTest
 {
     /**

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
@@ -44,6 +44,9 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Seld\JsonLint\ParsingException;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class SchemaConfigurationFileTest extends TestCase
 {
     private const FIXTURES_DIR = __DIR__ . '/../../Fixtures/Configuration';

--- a/tests/phpunit/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/Finder/TestFrameworkFinderTest.php
@@ -44,6 +44,11 @@ use function Infection\Tests\normalizePath;
 use function strlen;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @group integration Requires I/O read & writes via the MockVendor
+ *
+ * @see MockVendor
+ */
 final class TestFrameworkFinderTest extends FileSystemTestCase
 {
     /**

--- a/tests/phpunit/Json/JsonFileTest.php
+++ b/tests/phpunit/Json/JsonFileTest.php
@@ -42,6 +42,9 @@ use Infection\Tests\FileSystem\FileSystemTestCase;
 use JsonSchema\Exception\ValidationException;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class JsonFileTest extends FileSystemTestCase
 {
     /**

--- a/tests/phpunit/Locator/RootsFileLocatorTest.php
+++ b/tests/phpunit/Locator/RootsFileLocatorTest.php
@@ -47,7 +47,7 @@ use function Safe\sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration
+ * @group integration Requires IO reads
  */
 final class RootsFileLocatorTest extends TestCase
 {

--- a/tests/phpunit/Locator/RootsFileOrDirectoryLocatorTest.php
+++ b/tests/phpunit/Locator/RootsFileOrDirectoryLocatorTest.php
@@ -47,7 +47,7 @@ use function Safe\sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class RootsFileOrDirectoryLocatorTest extends TestCase
 {

--- a/tests/phpunit/Locator/RootsFileOrDirectoryLocatorTest.php
+++ b/tests/phpunit/Locator/RootsFileOrDirectoryLocatorTest.php
@@ -47,7 +47,7 @@ use function Safe\sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration
+ * @group integration Requires I/O reads
  */
 final class RootsFileOrDirectoryLocatorTest extends TestCase
 {

--- a/tests/phpunit/Logger/DebugFileLoggerTest.php
+++ b/tests/phpunit/Logger/DebugFileLoggerTest.php
@@ -46,6 +46,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class DebugFileLoggerTest extends TestCase
 {
     public function test_it_logs_correctly_with_no_mutations(): void

--- a/tests/phpunit/Logger/PerMutatorLoggerTest.php
+++ b/tests/phpunit/Logger/PerMutatorLoggerTest.php
@@ -46,6 +46,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class PerMutatorLoggerTest extends TestCase
 {
     public function test_it_correctly_build_log_lines(): void

--- a/tests/phpunit/Logger/SummaryFileLoggerTest.php
+++ b/tests/phpunit/Logger/SummaryFileLoggerTest.php
@@ -41,6 +41,9 @@ use Infection\Tests\FileSystem\FileSystemTestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class SummaryFileLoggerTest extends FileSystemTestCase
 {
     public function test_it_logs_the_correct_lines_with_no_mutations(): void

--- a/tests/phpunit/Logger/TextFileLoggerTest.php
+++ b/tests/phpunit/Logger/TextFileLoggerTest.php
@@ -48,6 +48,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class TextFileLoggerTest extends TestCase
 {
     public function test_it_logs_correctly_with_no_mutations_and_no_debug_verbosity(): void

--- a/tests/phpunit/Mutant/MutantCreatorTest.php
+++ b/tests/phpunit/Mutant/MutantCreatorTest.php
@@ -43,7 +43,7 @@ use PHPUnit\Framework\TestCase;
 use function sys_get_temp_dir;
 
 /**
- * @group integration Requires I/O reads & writes
+ * @group integration Requires some I/O operations & writes
  */
 final class MutantCreatorTest extends TestCase
 {

--- a/tests/phpunit/Mutant/MutantCreatorTest.php
+++ b/tests/phpunit/Mutant/MutantCreatorTest.php
@@ -42,6 +42,9 @@ use PhpParser\PrettyPrinter\Standard;
 use PHPUnit\Framework\TestCase;
 use function sys_get_temp_dir;
 
+/**
+ * @group integration Requires I/O reads & writes
+ */
 final class MutantCreatorTest extends TestCase
 {
     private const TEST_FILE_NAME = '/mutant.hash.infection.php';

--- a/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -39,7 +39,7 @@ use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class ProtectedVisibilityTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -38,6 +38,9 @@ namespace Infection\Tests\Mutator\FunctionSignature;
 use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class ProtectedVisibilityTest extends AbstractMutatorTestCase
 {
     /**

--- a/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
@@ -39,7 +39,7 @@ use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class PublicVisibilityTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
@@ -38,6 +38,9 @@ namespace Infection\Tests\Mutator\FunctionSignature;
 use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class PublicVisibilityTest extends AbstractMutatorTestCase
 {
     /**

--- a/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
@@ -38,6 +38,9 @@ namespace Infection\Tests\Mutator\ReturnValue;
 use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class ArrayOneItemTest extends AbstractMutatorTestCase
 {
     /**

--- a/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
@@ -39,7 +39,7 @@ use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class ArrayOneItemTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
@@ -39,7 +39,7 @@ use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class FunctionCallTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
@@ -38,6 +38,9 @@ namespace Infection\Tests\Mutator\ReturnValue;
 use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class FunctionCallTest extends AbstractMutatorTestCase
 {
     /**

--- a/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
@@ -38,6 +38,9 @@ namespace Infection\Tests\Mutator\ReturnValue;
 use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class NewObjectTest extends AbstractMutatorTestCase
 {
     /**

--- a/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
@@ -39,7 +39,7 @@ use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class NewObjectTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/Mutator/ReturnValue/ThisTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ThisTest.php
@@ -38,6 +38,9 @@ namespace Infection\Tests\Mutator\ReturnValue;
 use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class ThisTest extends AbstractMutatorTestCase
 {
     /**

--- a/tests/phpunit/Mutator/ReturnValue/ThisTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ThisTest.php
@@ -39,7 +39,7 @@ use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class ThisTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/Performance/Limiter/MemoryLimiterTest.php
+++ b/tests/phpunit/Performance/Limiter/MemoryLimiterTest.php
@@ -46,6 +46,9 @@ use ReflectionClass;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class MemoryLimiterTest extends TestCase
 {
     private const TEST_DIR_LOCATION = __DIR__ . '/../../Fixtures/tmp-memory-files';

--- a/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
@@ -58,7 +58,7 @@ use RuntimeException;
  * Other methods are not essential for interception to work,
  * but still are required to be implemented by a full wrapper
  *
- * @group integration Requires I/O reads & writes
+ * @group integration Requires some I/O operations & writes
  */
 final class IncludeInterceptorTest extends TestCase
 {

--- a/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
+++ b/tests/phpunit/StreamWrapper/IncludeInterceptorTest.php
@@ -57,6 +57,8 @@ use RuntimeException;
  *
  * Other methods are not essential for interception to work,
  * but still are required to be implemented by a full wrapper
+ *
+ * @group integration Requires I/O reads & writes
  */
 final class IncludeInterceptorTest extends TestCase
 {

--- a/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
+++ b/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
@@ -48,7 +48,7 @@ use function realpath;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class CodeceptionAdapterTest extends FileSystemTestCase
 {

--- a/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
+++ b/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
@@ -47,6 +47,9 @@ use Infection\Utils\VersionParser;
 use function realpath;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class CodeceptionAdapterTest extends FileSystemTestCase
 {
     private const MUTATION_HASH = 'a1b2c3';

--- a/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
+++ b/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
@@ -40,6 +40,9 @@ use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use function Infection\Tests\normalizePath as p;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class TestFrameworkConfigLocatorTest extends TestCase
 {
     private $baseDir = __DIR__ . '/../../Fixtures/ConfigLocator/';

--- a/tests/phpunit/TestFramework/Coverage/JUnitTestFileDataProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnitTestFileDataProviderTest.php
@@ -40,6 +40,9 @@ use Infection\TestFramework\Coverage\JUnitTestFileDataProvider;
 use Infection\TestFramework\Coverage\TestFileNameNotFoundException;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class JUnitTestFileDataProviderTest extends TestCase
 {
     private const JUNIT = __DIR__ . '/../../Fixtures/Files/phpunit/junit.xml';

--- a/tests/phpunit/TestFramework/Coverage/PhpUnitXmlCoverageFactoryTest.php
+++ b/tests/phpunit/TestFramework/Coverage/PhpUnitXmlCoverageFactoryTest.php
@@ -47,6 +47,9 @@ use Infection\TestFramework\TestFrameworkTypes;
 use PHPUnit\Framework\TestCase;
 use function Safe\realpath;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class PhpUnitXmlCoverageFactoryTest extends TestCase
 {
     private const COVERAGE_DIR = __DIR__ . '/../../Fixtures/Files/phpunit/coverage/coverage-xml';

--- a/tests/phpunit/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/Builder/InitialConfigBuilderTest.php
@@ -38,6 +38,9 @@ namespace Infection\Tests\TestFramework\PhpSpec\Config\Builder;
 use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder;
 use Infection\Tests\FileSystem\FileSystemTestCase;
 
+/**
+ * @group integration Requires some I/O operations
+ */
 final class InitialConfigBuilderTest extends FileSystemTestCase
 {
     public function test_it_builds_path_to_initial_config_file(): void

--- a/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
@@ -41,7 +41,7 @@ use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
 use Infection\Tests\FileSystem\FileSystemTestCase;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class MutationConfigBuilderTest extends FileSystemTestCase
 {

--- a/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Config/Builder/MutationConfigBuilderTest.php
@@ -40,6 +40,9 @@ use Infection\Mutation;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
 use Infection\Tests\FileSystem\FileSystemTestCase;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class MutationConfigBuilderTest extends FileSystemTestCase
 {
     private const MUTATION_HASH = 'a1b2c3';

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -46,6 +46,9 @@ use Infection\Tests\FileSystem\FileSystemTestCase;
 use function Infection\Tests\normalizePath as p;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class InitialConfigBuilderTest extends FileSystemTestCase
 {
     public const HASH = 'a1b2c3';

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -47,7 +47,7 @@ use function Infection\Tests\normalizePath as p;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class InitialConfigBuilderTest extends FileSystemTestCase
 {

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -48,7 +48,7 @@ use function Infection\Tests\normalizePath as p;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class MutationConfigBuilderTest extends FileSystemTestCase
 {

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -47,6 +47,9 @@ use Infection\Tests\FileSystem\FileSystemTestCase;
 use function Infection\Tests\normalizePath as p;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class MutationConfigBuilderTest extends FileSystemTestCase
 {
     public const HASH = 'a1b2c3';

--- a/tests/phpunit/TestFramework/PhpUnit/Coverage/IndexXmlCoverageParserTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Coverage/IndexXmlCoverageParserTest.php
@@ -47,6 +47,9 @@ use function Safe\realpath;
 use function Safe\sprintf;
 use function str_replace;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class IndexXmlCoverageParserTest extends TestCase
 {
     private const FIXTURES_SRC_DIR = __DIR__ . '/../../../Fixtures/Files/phpunit/coverage/src';

--- a/tests/phpunit/TestFramework/PhpUnit/Coverage/IndexXmlCoverageParserTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Coverage/IndexXmlCoverageParserTest.php
@@ -48,7 +48,7 @@ use function Safe\sprintf;
 use function str_replace;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class IndexXmlCoverageParserTest extends TestCase
 {

--- a/tests/phpunit/Visitor/CloneVisitorTest.php
+++ b/tests/phpunit/Visitor/CloneVisitorTest.php
@@ -41,7 +41,7 @@ use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class CloneVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/Visitor/CloneVisitorTest.php
+++ b/tests/phpunit/Visitor/CloneVisitorTest.php
@@ -40,6 +40,9 @@ use PhpParser\Node;
 use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class CloneVisitorTest extends BaseVisitorTest
 {
     private const CODE = <<<'PHP'

--- a/tests/phpunit/Visitor/FullyQualifiedClassNameVisitorTest.php
+++ b/tests/phpunit/Visitor/FullyQualifiedClassNameVisitorTest.php
@@ -41,6 +41,9 @@ use Infection\Visitor\FullyQualifiedClassNameVisitor;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class FullyQualifiedClassNameVisitorTest extends BaseVisitorTest
 {
     private $spyVisitor;

--- a/tests/phpunit/Visitor/FullyQualifiedClassNameVisitorTest.php
+++ b/tests/phpunit/Visitor/FullyQualifiedClassNameVisitorTest.php
@@ -42,7 +42,7 @@ use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class FullyQualifiedClassNameVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/Visitor/MutationsCollectorVisitorTest.php
+++ b/tests/phpunit/Visitor/MutationsCollectorVisitorTest.php
@@ -44,7 +44,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class MutationsCollectorVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/Visitor/MutationsCollectorVisitorTest.php
+++ b/tests/phpunit/Visitor/MutationsCollectorVisitorTest.php
@@ -43,6 +43,9 @@ use Prophecy\Argument\Token\TokenInterface;
 use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class MutationsCollectorVisitorTest extends BaseVisitorTest
 {
     private const CODE = <<<'PHP'

--- a/tests/phpunit/Visitor/MutatorVisitorTest.php
+++ b/tests/phpunit/Visitor/MutatorVisitorTest.php
@@ -47,6 +47,9 @@ use PhpParser\Node\Stmt\Nop;
 use PhpParser\ParserFactory;
 use function range;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class MutatorVisitorTest extends BaseVisitorTest
 {
     /**

--- a/tests/phpunit/Visitor/MutatorVisitorTest.php
+++ b/tests/phpunit/Visitor/MutatorVisitorTest.php
@@ -48,7 +48,7 @@ use PhpParser\ParserFactory;
 use function range;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class MutatorVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/Visitor/NotMutableIgnoreVisitorTest.php
+++ b/tests/phpunit/Visitor/NotMutableIgnoreVisitorTest.php
@@ -39,6 +39,9 @@ use Infection\Visitor\NotMutableIgnoreVisitor;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class NotMutableIgnoreVisitorTest extends BaseVisitorTest
 {
     private $spyVisitor;

--- a/tests/phpunit/Visitor/NotMutableIgnoreVisitorTest.php
+++ b/tests/phpunit/Visitor/NotMutableIgnoreVisitorTest.php
@@ -40,7 +40,7 @@ use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class NotMutableIgnoreVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/Visitor/ParentConnectorVisitorTest.php
+++ b/tests/phpunit/Visitor/ParentConnectorVisitorTest.php
@@ -40,6 +40,9 @@ use Infection\Visitor\ParentConnectorVisitor;
 use function is_array;
 use PhpParser\Node;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class ParentConnectorVisitorTest extends BaseVisitorTest
 {
     private const CODE = <<<'PHP'

--- a/tests/phpunit/Visitor/ParentConnectorVisitorTest.php
+++ b/tests/phpunit/Visitor/ParentConnectorVisitorTest.php
@@ -41,7 +41,7 @@ use function is_array;
 use PhpParser\Node;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class ParentConnectorVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/Visitor/PhpUnitClassCodeCoverageIgnoreVisitorTest.php
+++ b/tests/phpunit/Visitor/PhpUnitClassCodeCoverageIgnoreVisitorTest.php
@@ -41,7 +41,7 @@ use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class PhpUnitClassCodeCoverageIgnoreVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/Visitor/PhpUnitClassCodeCoverageIgnoreVisitorTest.php
+++ b/tests/phpunit/Visitor/PhpUnitClassCodeCoverageIgnoreVisitorTest.php
@@ -40,6 +40,9 @@ use Infection\Visitor\PhpUnitClassCodeCoverageIgnoreVisitor;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class PhpUnitClassCodeCoverageIgnoreVisitorTest extends BaseVisitorTest
 {
     private $spyVisitor;

--- a/tests/phpunit/Visitor/PhpUnitMethodCodeCoverageIgnoreVisitorTest.php
+++ b/tests/phpunit/Visitor/PhpUnitMethodCodeCoverageIgnoreVisitorTest.php
@@ -40,6 +40,9 @@ use Infection\Visitor\PhpUnitMethodCodeCoverageIgnoreVisitor;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class PhpUnitMethodCodeCoverageIgnoreVisitorTest extends BaseVisitorTest
 {
     private $spyVisitor;

--- a/tests/phpunit/Visitor/PhpUnitMethodCodeCoverageIgnoreVisitorTest.php
+++ b/tests/phpunit/Visitor/PhpUnitMethodCodeCoverageIgnoreVisitorTest.php
@@ -41,7 +41,7 @@ use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class PhpUnitMethodCodeCoverageIgnoreVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/Visitor/ReflectionVisitorTest.php
@@ -47,6 +47,9 @@ use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 use ReflectionClass;
 
+/**
+ * @group integration Requires I/O reads
+ */
 final class ReflectionVisitorTest extends BaseVisitorTest
 {
     private $spyVisitor;

--- a/tests/phpunit/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/Visitor/ReflectionVisitorTest.php
@@ -48,7 +48,7 @@ use PhpParser\NodeVisitorAbstract;
 use ReflectionClass;
 
 /**
- * @group integration Requires I/O reads
+ * @group integration Requires some I/O operations
  */
 final class ReflectionVisitorTest extends BaseVisitorTest
 {


### PR DESCRIPTION
Some test cases executes (or are very likely) I/O operations (read and/or write). Those test cases should be marked as `integration` in order to distinguish them from "pure" test cases as they are more likely to be:

- slower
- flaky if ever run in parallel or sub-process

This does not change much overall, just at _what_ time those tests are executed.

Since it can be quite hard/tedious to detect such cases manually, especially when retro-inspecting the code, I added a test case - which I don't claim to be full-proof, which allows to detect such test cases. And as the consequences of a mistake are minimal, it is a not a big deal if we happen to have a few false-positives.