### PR TITLE
Revert change regarding Mutation#mutatedNode

### DIFF
--- a/devTools/check_trailing_whitespaces.sh
+++ b/devTools/check_trailing_whitespaces.sh
@@ -23,6 +23,7 @@
 
 set -Eeuo pipefail
 
+# TODO: some tests could leverage the new StringNormalizerTest to avoid having to be ignored here
 files_with_trailing_whitespaces=$(
     find . \
         -type f \
@@ -35,7 +36,7 @@ files_with_trailing_whitespaces=$(
         -not -path "./tests/e2e/*" \
         -not -path "./tests/phpunit/Mutator/*" \
         -not -path "./tests/phpunit/Mutation/FileParserTest.php" \
-        -not -path "./tests/phpunit/Visitor/MutatorVisitorTest.php" \
+        -not -path "./tests/phpunit/StringNormalizerTest.php" \
         -exec grep -EIHn "\\s$" {} \;
 )
 

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -79,6 +79,7 @@ class Mutation
     /**
      * @param Node[] $originalFileAst
      * @param array<string|int|float> $attributes
+     * @param Node|Node[] $mutatedNode
      * @param CoverageLineData[] $tests
      */
     public function __construct(
@@ -87,7 +88,7 @@ class Mutation
         string $mutatorName,
         array $attributes,
         string $mutatedNodeClass,
-        Node $mutatedNode,
+        $mutatedNode,
         int $mutationByMutatorIndex,
         array $tests
     ) {
@@ -109,6 +110,19 @@ class Mutation
         $this->coveredByTests = count($tests) > 0;
     }
 
+    public function getOriginalFilePath(): string
+    {
+        return $this->originalFilePath;
+    }
+
+    /**
+     * return Node[]
+     */
+    public function getOriginalFileAst(): array
+    {
+        return $this->originalFileAst;
+    }
+
     public function getMutatorName(): string
     {
         return $this->mutatorName;
@@ -122,31 +136,22 @@ class Mutation
         return $this->attributes;
     }
 
-    public function getOriginalFilePath(): string
-    {
-        return $this->originalFilePath;
-    }
-
     public function getMutatedNodeClass(): string
     {
         return $this->mutatedNodeClass;
     }
 
-    public function getHash(): string
+    /**
+     * @return Node|Node[]
+     */
+    public function getMutatedNode()
     {
-        if ($this->hash === null) {
-            $this->hash = $this->createHash();
-        }
-
-        return $this->hash;
+        return $this->mutatedNode;
     }
 
-    /**
-     * return Node[]
-     */
-    public function getOriginalFileAst(): array
+    public function isCoveredByTest(): bool
     {
-        return $this->originalFileAst;
+        return $this->coveredByTests;
     }
 
     /**
@@ -157,14 +162,13 @@ class Mutation
         return $this->tests;
     }
 
-    public function isCoveredByTest(): bool
+    public function getHash(): string
     {
-        return $this->coveredByTests;
-    }
+        if ($this->hash === null) {
+            $this->hash = $this->createHash();
+        }
 
-    public function getMutatedNode(): Node
-    {
-        return $this->mutatedNode;
+        return $this->hash;
     }
 
     private function createHash(): string

--- a/tests/phpunit/MutationTest.php
+++ b/tests/phpunit/MutationTest.php
@@ -51,6 +51,7 @@ final class MutationTest extends TestCase
      *
      * @param Node[] $originalFileAst
      * @param array<string|int|float> $attributes
+     * @param Node|Node[] $mutatedNode
      * @param array<string|int|float> $expectedAttributes
      * @param CoverageLineData[] $tests
      */
@@ -60,7 +61,7 @@ final class MutationTest extends TestCase
         string $mutatorName,
         array $attributes,
         string $mutatedNodeClass,
-        Node $mutatedNode,
+        $mutatedNode,
         int $mutationByMutatorIndex,
         array $tests,
         array $expectedAttributes,
@@ -198,6 +199,32 @@ final class MutationTest extends TestCase
             [],
             $nominalAttributes,
             false,
+            md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53'),
+        ];
+
+        yield 'nominal with a test and multiple mutated nodes' => [
+            '/path/to/acme/Foo.php',
+            [new Node\Stmt\Namespace_(
+                new Node\Name('Acme'),
+                [new Node\Scalar\LNumber(0)]
+            )],
+            Plus::getName(),
+            $nominalAttributes,
+            Node\Scalar\LNumber::class,
+            [
+                new Node\Scalar\LNumber(1),
+                new Node\Scalar\LNumber(-1),
+            ],
+            0,
+            [
+                CoverageLineData::with(
+                    'FooTest::test_it_can_instantiate',
+                    '/path/to/acme/FooTest.php',
+                    0.01
+                ),
+            ],
+            $nominalAttributes,
+            true,
             md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53'),
         ];
     }

--- a/tests/phpunit/StringNormalizer.php
+++ b/tests/phpunit/StringNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests;
+
+use function array_map;
+use function explode;
+use function implode;
+
+final class StringNormalizer
+{
+    private function __construct()
+    {
+    }
+
+    public static function normalizeString(string $string): string
+    {
+        return implode(
+            "\n",
+            array_map('rtrim', explode("\n", $string))
+        );
+    }
+}

--- a/tests/phpunit/StringNormalizerTest.php
+++ b/tests/phpunit/StringNormalizerTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+
+final class StringNormalizerTest extends TestCase
+{
+    /**
+     * @dataProvider stringValuesProvider
+     */
+    public function test_it_can_remove_right_trailing_spaces(string $input, string $expected): void
+    {
+        $actual = StringNormalizer::normalizeString($input);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function stringValuesProvider(): Generator
+    {
+        yield 'empty' => ['', ''];
+
+        yield 'spaces' => [' ', ''];
+
+        yield 'multi-line spaces' => [
+            <<<'TXT'
+ 
+ 
+TXT
+            ,
+            <<<'TXT'
+
+
+TXT
+        ];
+
+        yield 'text' => ['foo', 'foo'];
+
+        yield 'text with spaces' => [' foo ', ' foo'];
+
+        yield 'multi-line text with spaces' => [
+            <<<'TXT'
+ 
+ foo
+ bar 
+ 
+TXT
+            ,
+            <<<'TXT'
+
+ foo
+ bar
+
+TXT
+        ];
+    }
+}

--- a/tests/phpunit/Visitor/MutatorVisitorTest.php
+++ b/tests/phpunit/Visitor/MutatorVisitorTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Visitor;
 use Generator;
 use Infection\Mutation;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
+use Infection\Tests\StringNormalizer;
 use Infection\Visitor\MutatorVisitor;
 use PhpParser\Lexer;
 use PhpParser\Node;
@@ -64,7 +65,7 @@ final class MutatorVisitorTest extends BaseVisitorTest
 
         $output = $this->print($nodes);
 
-        $this->assertSame($expectedCodeOutput, $output);
+        $this->assertSame($expectedCodeOutput, StringNormalizer::normalizeString($output));
     }
 
     public function providesMutationCases(): Generator
@@ -96,7 +97,7 @@ class Test
     {
         return 'hello';
     }
-    
+
 }
 PHP
                 ,
@@ -114,6 +115,58 @@ PHP
                     ],
                     ClassMethod::class,
                     new Nop(),
+                    0,
+                    []
+                ),
+            ];
+        })();
+
+        yield 'it can mutate the node with multiple-ones' => (function () {
+            return [
+                $nodes = $this->parseCode(<<<'PHP'
+<?php
+
+class Test
+{
+    public function hello() : string
+    {
+        return 'hello';
+    }
+    public function bye() : string
+    {
+        return 'bye';
+    }
+}
+PHP
+                ),
+                <<<'PHP'
+<?php
+
+class Test
+{
+    public function hello() : string
+    {
+        return 'hello';
+    }
+
+
+}
+PHP
+                ,
+                new Mutation(
+                    'path/to/file',
+                    $nodes,
+                    PublicVisibility::getName(),
+                    [
+                        'startTokenPos' => 29,
+                        'endTokenPos' => 48,
+                        'startLine' => -1,
+                        'endLine' => -1,
+                        'startFilePos' => -1,
+                        'endFilePos' => -1,
+                    ],
+                    ClassMethod::class,
+                    [new Nop(), new Nop()],
                     0,
                     []
                 ),


### PR DESCRIPTION
`Mutation#mutatedNode` is indeed a `Node|Node[]`. I was confused by the original where it was and was not captured by the tests. So this PR reverts this change and ensure this is better tested