### PR TITLE
Simplify `IgnoreMutator`

### DIFF
--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -92,12 +92,8 @@ final class IgnoreMutator
         return $this->mutator->mutate($node);
     }
 
-    // TODO: this function is necessary for now mostly because Mutations requires Mutator which is
-    //  expected to be the underlying mutator for now.
-    //  It might be possible to remove this getter if it turns out that Mutation may not require
-    //  the full Mutator object but just some elements of it.
-    public function getMutator(): Mutator
+    public function getMutatorName(): string
     {
-        return $this->mutator;
+        return $this->mutator::getName();
     }
 }

--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -64,7 +64,7 @@ final class IgnoreMutator
         $this->mutator = $mutator;
     }
 
-    public function shouldMutate(Node $node): bool
+    public function canMutate(Node $node): bool
     {
         if (!$this->mutator->canMutate($node)) {
             return false;

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -101,7 +101,7 @@ class NodeMutationGenerator
     private function generateForMutator(Node $node, IgnoreMutator $mutator, array $mutations): array
     {
         try {
-            if (!$mutator->shouldMutate($node)) {
+            if (!$mutator->canMutate($node)) {
                 return $mutations;
             }
         } catch (Throwable $throwable) {

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -107,7 +107,7 @@ class NodeMutationGenerator
         } catch (Throwable $throwable) {
             throw InvalidMutator::create(
                 $this->filePath,
-                $mutator->getMutator()::getName(),
+                $mutator->getMutatorName(),
                 $throwable
             );
         }
@@ -138,7 +138,7 @@ class NodeMutationGenerator
             $mutations[] = new Mutation(
                 $this->filePath,
                 $this->fileNodes,
-                $mutator->getMutator()::getName(),
+                $mutator->getMutatorName(),
                 $node->getAttributes(),
                 get_class($node),
                 MutatedNode::wrap($mutatedNode),

--- a/tests/phpunit/Mutator/IgnoreMutatorTest.php
+++ b/tests/phpunit/Mutator/IgnoreMutatorTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator;
 
 use Generator;
+use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\Util\MutatorConfig;
@@ -167,10 +168,12 @@ final class IgnoreMutatorTest extends TestCase
         $this->assertSame([$mutatedNodeMock], iterator_to_array($mutatedNode));
     }
 
-    public function test_it_exposes_its_decorated_mutator(): void
+    public function test_it_exposes_its_decorated_mutator_name(): void
     {
-        $ignoreMutator = new IgnoreMutator(new MutatorConfig([]), $this->mutatorMock);
+        $config = new MutatorConfig([]);
 
-        $this->assertSame($this->mutatorMock, $ignoreMutator->getMutator());
+        $ignoreMutator = new IgnoreMutator($config, new Plus($config));
+
+        $this->assertSame(Plus::getName(), $ignoreMutator->getMutatorName());
     }
 }

--- a/tests/phpunit/Mutator/IgnoreMutatorTest.php
+++ b/tests/phpunit/Mutator/IgnoreMutatorTest.php
@@ -75,7 +75,7 @@ final class IgnoreMutatorTest extends TestCase
             ->willReturn(false)
         ;
 
-        $mutate = $ignoreMutator->shouldMutate($this->nodeMock);
+        $mutate = $ignoreMutator->canMutate($this->nodeMock);
 
         $this->assertFalse($mutate);
     }
@@ -98,7 +98,7 @@ final class IgnoreMutatorTest extends TestCase
             ->willReturn(false)
         ;
 
-        $mutate = $ignoreMutator->shouldMutate($this->nodeMock);
+        $mutate = $ignoreMutator->canMutate($this->nodeMock);
 
         $this->assertTrue($mutate);
     }
@@ -142,7 +142,7 @@ final class IgnoreMutatorTest extends TestCase
 
         $ignoreMutator = new IgnoreMutator($configMock, $this->mutatorMock);
 
-        $mutate = $ignoreMutator->shouldMutate($this->nodeMock);
+        $mutate = $ignoreMutator->canMutate($this->nodeMock);
 
         $this->assertFalse($mutate);
     }

--- a/tests/phpunit/Mutator/MutatorFactoryTest.php
+++ b/tests/phpunit/Mutator/MutatorFactoryTest.php
@@ -92,7 +92,7 @@ final class MutatorFactoryTest extends TestCase
     public function test_it_can_creates_the_profile_mutators_with_the_given_settings(): void
     {
         // TODO: refactor this test to check the mutator configuration directly instead of relying
-        // on the shouldMutate() API which ends up testing other stuff and is also more cumbersome
+        // on the canMutate() API which ends up testing other stuff and is also more cumbersome
         // to employ.
 
         $mutators = $this->mutatorFactory->create([
@@ -116,9 +116,9 @@ final class MutatorFactoryTest extends TestCase
         $falseNode = $this->createBoolNode('false', 'B', $reflectionMock);
         $trueNode = $this->createBoolNode('true', 'B', $reflectionMock);
 
-        $this->assertTrue($mutators[Plus::getName()]->shouldMutate($plusNode));
-        $this->assertFalse($mutators[TrueValue::getName()]->shouldMutate($trueNode));
-        $this->assertFalse($mutators[FalseValue::getName()]->shouldMutate($falseNode));
+        $this->assertTrue($mutators[Plus::getName()]->canMutate($plusNode));
+        $this->assertFalse($mutators[TrueValue::getName()]->canMutate($trueNode));
+        $this->assertFalse($mutators[FalseValue::getName()]->canMutate($falseNode));
     }
 
     public function test_it_can_ignore_a_profile(): void
@@ -188,7 +188,7 @@ final class MutatorFactoryTest extends TestCase
     public function test_it_can_create_a_mutator_with_the_given_settings(): void
     {
         // TODO: refactor this test to check the mutator configuration directly instead of relying
-        // on the shouldMutate() API which ends up testing other stuff and is also more cumbersome
+        // on the canMutate() API which ends up testing other stuff and is also more cumbersome
         // to employ.
 
         $mutators = $this->mutatorFactory->create([
@@ -211,8 +211,8 @@ final class MutatorFactoryTest extends TestCase
         $falseNode = $this->createBoolNode('false', 'B', $reflectionMock);
         $trueNode = $this->createBoolNode('true', 'B', $reflectionMock);
 
-        $this->assertFalse($mutators[TrueValue::getName()]->shouldMutate($trueNode));
-        $this->assertTrue($mutators[FalseValue::getName()]->shouldMutate($falseNode));
+        $this->assertFalse($mutators[TrueValue::getName()]->canMutate($trueNode));
+        $this->assertTrue($mutators[FalseValue::getName()]->canMutate($falseNode));
     }
 
     public function test_it_can_ignore_a_mutator(): void


### PR DESCRIPTION
- Rename `IgnoreMutator` `shouldMutate()` to `canMutate()` to be more in line with the `Mutator` interface
- Only expose the decorated mutator name instead of the instance itself