### PR TITLE
Fix usage of SymfonyProcess 5.x

### DIFF
--- a/src/Process/Builder/MutantProcessBuilder.php
+++ b/src/Process/Builder/MutantProcessBuilder.php
@@ -70,7 +70,7 @@ final class MutantProcessBuilder
             )
         );
 
-        $process->setTimeout($this->timeout);
+        $process->setTimeout((float) $this->timeout);
 
         $symfonyProcessVersion = $this->versionParser->parse(Versions::getVersion('symfony/process'));
 


### PR DESCRIPTION
Since the SymfonyProcess component has no dependencies and requires PHP 7.2 which we do as well, we can bump that dependency and get rid of some unnecessary code