### PR TITLE
Tweak VersionParser

### DIFF
--- a/src/Utils/VersionParser.php
+++ b/src/Utils/VersionParser.php
@@ -35,23 +35,27 @@ declare(strict_types=1);
 
 namespace Infection\Utils;
 
-use InvalidArgumentException;
+use function Safe\preg_match;
+use function Safe\sprintf;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal
  */
-class VersionParser
+final class VersionParser
 {
-    private const VERSION_REGEX = '/(?<version>[0-9]+\.[0-9]+\.?[0-9]*)(?<prerelease>-[0-9a-zA-Z.]+)?(?<build>\+[0-9a-zA-Z.]+)?/';
+    private const VERSION_REGEX = '/(?<version>\d+\.\d+\.?\d*)(?<prerelease>-[0-9a-zA-Z.]+)?(?<build>\+[0-9a-zA-Z.]+)?/';
 
     public function parse(string $content): string
     {
         $matches = [];
         $matched = preg_match(self::VERSION_REGEX, $content, $matches);
 
-        if (!$matched) {
-            throw new InvalidArgumentException('Parameter does not contain a valid SemVer (sub)string.');
-        }
+        Assert::notSame(
+            $matched,
+            0,
+            sprintf('Expected "%s" to be contain a valid SemVer (sub)string value.', $content)
+        );
 
         return $matches[0];
     }

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -75,7 +75,6 @@ use Infection\TestFramework\PhpUnit\Coverage\IndexXmlCoverageParser;
 use Infection\TestFramework\TestFrameworkTypes;
 use Infection\Tests\AutoReview\ConcreteClassReflector;
 use function Infection\Tests\generator_to_phpunit_data_provider;
-use Infection\Utils\VersionParser;
 use function iterator_to_array;
 use ReflectionClass;
 use const SORT_STRING;
@@ -122,7 +121,6 @@ final class ProjectCodeProvider
         PhpSpecMutationConfigBuilder::class,
         PhpUnitMutationConfigBuilder::class,
         IndexXmlCoverageParser::class,
-        VersionParser::class,
     ];
 
     /**

--- a/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
+++ b/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
@@ -353,12 +353,10 @@ final class CodeceptionAdapterTest extends FileSystemTestCase
 
     private function createAdapter(?array $config = null): CodeceptionAdapter
     {
-        $versionParser = $this->createMock(VersionParser::class);
-
         return new CodeceptionAdapter(
             '/path/to/codeception',
             new CommandLineBuilder(),
-            $versionParser,
+            new VersionParser(),
             new JUnitTestCaseSorter(),
             new Filesystem(),
             'path/to/junit',

--- a/tests/phpunit/TestFramework/PhpSpec/Adapter/PhpSpecAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Adapter/PhpSpecAdapterTest.php
@@ -129,7 +129,7 @@ OUTPUT;
             $this->createMock(InitialConfigBuilder::class),
             $this->createMock(MutationConfigBuilder::class),
             $this->createMock(CommandLineArgumentsAndOptionsBuilder::class),
-            $this->createMock(VersionParser::class),
+            new VersionParser(),
             new CommandLineBuilder()
         );
     }

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -57,14 +57,13 @@ final class PhpUnitAdapterTest extends TestCase
         $initialConfigBuilder = $this->createMock(InitialConfigBuilder::class);
         $mutationConfigBuilder = $this->createMock(MutationConfigBuilder::class);
         $cliArgumentsBuilder = $this->createMock(CommandLineArgumentsAndOptionsBuilder::class);
-        $versionParser = $this->createMock(VersionParser::class);
 
         $this->adapter = new PhpUnitAdapter(
             '/path/to/phpunit',
             $initialConfigBuilder,
             $mutationConfigBuilder,
             $cliArgumentsBuilder,
-            $versionParser,
+            new VersionParser(),
             new CommandLineBuilder()
         );
     }

--- a/tests/phpunit/Utils/VersionParserTest.php
+++ b/tests/phpunit/Utils/VersionParserTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Utils;
 
+use Generator;
 use Infection\Utils\VersionParser;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -63,22 +64,52 @@ final class VersionParserTest extends TestCase
 
     public function test_it_throws_exception_when_content_has_no_version_substring(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        try {
+            $this->versionParser->parse('abc');
 
-        $this->versionParser->parse('abc');
+            $this->fail();
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'Expected "abc" to be contain a valid SemVer (sub)string value.',
+                $exception->getMessage()
+            );
+        }
     }
 
-    public function versionProvider()
+    public function versionProvider(): Generator
     {
-        return [
-            ['Codeception 3.1.0', '3.1.0'],
-            ['phpspec version 1.2.3', '1.2.3'],
-            ['PHPUnit 1.2.3 by Sebastian Bergmann and contributors.', '1.2.3'],
-            ['1.2.3', '1.2.3'],
-            ['10.20.13', '10.20.13'],
-            ['a 1.2.3-patch b', '1.2.3-patch'],
-            ['v1.2.3', '1.2.3'],
-            ['6.5-abcde', '6.5-abcde'],
-        ];
+        yield 'nominal stable' => ['7.0.2', '7.0.2'];
+
+        yield 'nominal development' => ['0.2.8', '0.2.8'];
+
+        yield 'stable variant' => ['v7.0.2', '7.0.2'];
+
+        yield 'development variant' => ['v0.2.8', '0.2.8'];
+
+        yield 'patch' => ['7.0.2-patch', '7.0.2-patch'];
+
+        yield 'versioned patch' => ['7.0.2-patch.0', '7.0.2-patch.0'];
+
+        yield 'RC' => ['7.0.2-rc', '7.0.2-rc'];
+
+        yield 'uppercase RC' => ['7.0.2-RC', '7.0.2-RC'];
+
+        yield 'versioned RC' => ['7.0.2-rc.0', '7.0.2-rc.0'];
+
+        yield 'with spaces' => [' 7.0.2 ', '7.0.2'];
+
+        yield 'nonsense suffix 0' => ['7.0.2foo', '7.0.2'];
+
+        yield 'nonsense suffix 1' => ['7.0.2-foo', '7.0.2-foo'];
+
+        yield 'Hoa' => ['3.17.05.02', '3.17.05'];
+
+        yield 'Codeception' => ['Codeception 3.1.0', '3.1.0'];
+
+        yield 'phpspec stable' => ['phpspec version 1.2.3', '1.2.3'];
+
+        yield 'phpspec RC' => ['phpspec version 5.0.0-rc1', '5.0.0-rc1'];
+
+        yield 'PHPUnit' => ['PHPUnit 7.5.11 by Sebastian Bergmann and contributors.', '7.5.11'];
     }
 }


### PR DESCRIPTION
- Make `VersionParser` final: the few places where it was mocked it was an unspecified stub hence safe to replace by a plain instance
- Change `[0-9]` for `\d` in the regex when possible (purely aesthetic change unless the regex engine has an optimization of some kinds that I'm not aware of)
- Change the error message to make it more friendly
- Add a few more tests
