### PR TITLE
Make `Mutator::getName()` non-static

### DIFF
--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -92,8 +92,8 @@ final class IgnoreMutator
         return $this->mutator->mutate($node);
     }
 
-    public function getMutatorName(): string
+    public function getName(): string
     {
-        return $this->mutator::getName();
+        return $this->mutator->getName();
     }
 }

--- a/src/Mutator/Mutator.php
+++ b/src/Mutator/Mutator.php
@@ -45,7 +45,7 @@ interface Mutator
 {
     public static function getDefinition(): ?Definition;
 
-    public static function getName(): string;
+    public function getName(): string;
 
     public function canMutate(Node $node): bool;
 

--- a/src/Mutator/MutatorFactory.php
+++ b/src/Mutator/MutatorFactory.php
@@ -177,7 +177,7 @@ final class MutatorFactory
             /** @var Mutator $mutator */
             $mutator = new $mutatorClass($mutatorConfig);
 
-            $mutators[$mutator::getName()] = new IgnoreMutator($mutatorConfig, $mutator);
+            $mutators[$mutator->getName()] = new IgnoreMutator($mutatorConfig, $mutator);
         }
 
         return $mutators;

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -107,7 +107,7 @@ class NodeMutationGenerator
         } catch (Throwable $throwable) {
             throw InvalidMutator::create(
                 $this->filePath,
-                $mutator->getMutatorName(),
+                $mutator->getName(),
                 $throwable
             );
         }
@@ -138,7 +138,7 @@ class NodeMutationGenerator
             $mutations[] = new Mutation(
                 $this->filePath,
                 $this->fileNodes,
-                $mutator->getMutatorName(),
+                $mutator->getName(),
                 $node->getAttributes(),
                 get_class($node),
                 MutatedNode::wrap($mutatedNode),

--- a/src/Mutator/Util/Mutator.php
+++ b/src/Mutator/Util/Mutator.php
@@ -57,7 +57,7 @@ abstract class Mutator implements MutatorInterface
         return null;
     }
 
-    final public static function getName(): string
+    final public function getName(): string
     {
         $parts = explode('\\', static::class);
 

--- a/tests/phpunit/Fixtures/Mutator/FakeMutator.php
+++ b/tests/phpunit/Fixtures/Mutator/FakeMutator.php
@@ -48,7 +48,7 @@ final class FakeMutator implements Mutator
         throw new LogicException('Not expected to be called');
     }
 
-    public static function getName(): string
+    public function getName(): string
     {
         throw new LogicException('Not expected to be called');
     }

--- a/tests/phpunit/Logger/DebugFileLoggerTest.php
+++ b/tests/phpunit/Logger/DebugFileLoggerTest.php
@@ -40,6 +40,7 @@ use Infection\Mutant\MetricsCalculator;
 use Infection\Mutator\Boolean\TrueValue;
 use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
+use Infection\Tests\Mutator\MutatorName;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -171,7 +172,7 @@ TXT;
 
         for ($i = 0; $i < 5; ++$i) {
             $process = $this->createMock(MutantProcess::class);
-            $process->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
+            $process->expects($this->once())->method('getMutatorName')->willReturn(MutatorName::getName(For_::class));
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
@@ -180,7 +181,7 @@ TXT;
 
         for ($i = 0; $i < 5; ++$i) {
             $process = $this->createMock(MutantProcess::class);
-            $process->expects($this->once())->method('getMutatorName')->willReturn(TrueValue::getName());
+            $process->expects($this->once())->method('getMutatorName')->willReturn(MutatorName::getName(TrueValue::class));
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(20 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('bar/bar');
@@ -190,7 +191,7 @@ TXT;
 
         for ($i = 0; $i < 2; ++$i) {
             $process = $this->createMock(MutantProcess::class);
-            $process->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
+            $process->expects($this->once())->method('getMutatorName')->willReturn(MutatorName::getName(For_::class));
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');

--- a/tests/phpunit/Logger/PerMutatorLoggerTest.php
+++ b/tests/phpunit/Logger/PerMutatorLoggerTest.php
@@ -40,6 +40,7 @@ use Infection\Mutant\MetricsCalculator;
 use Infection\Mutator\Regex\PregQuote;
 use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
+use Infection\Tests\Mutator\MutatorName;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -88,21 +89,21 @@ TXT;
 
         for ($i = 0; $i < 10; ++$i) {
             $mutantFor = $this->createMock(MutantProcess::class);
-            $mutantFor->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
+            $mutantFor->expects($this->once())->method('getMutatorName')->willReturn(MutatorName::getName(For_::class));
             $mutantFor->expects($this->exactly(2))->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $processes[] = $mutantFor;
         }
 
         for ($i = 0; $i < 5; ++$i) {
             $mutantFor = $this->createMock(MutantProcess::class);
-            $mutantFor->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
+            $mutantFor->expects($this->once())->method('getMutatorName')->willReturn(MutatorName::getName(For_::class));
             $mutantFor->expects($this->exactly(2))->method('getResultCode')->willReturn(MutantProcess::CODE_NOT_COVERED);
             $processes[] = $mutantFor;
         }
 
         for ($i = 0; $i < 5; ++$i) {
             $mutantFor = $this->createMock(MutantProcess::class);
-            $mutantFor->expects($this->once())->method('getMutatorName')->willReturn(PregQuote::getName());
+            $mutantFor->expects($this->once())->method('getMutatorName')->willReturn(MutatorName::getName(PregQuote::class));
             $mutantFor->expects($this->exactly(2))->method('getResultCode')->willReturn(MutantProcess::CODE_NOT_COVERED);
             $processes[] = $mutantFor;
         }

--- a/tests/phpunit/Logger/TextFileLoggerTest.php
+++ b/tests/phpunit/Logger/TextFileLoggerTest.php
@@ -41,6 +41,7 @@ use Infection\Mutant\Mutant;
 use Infection\Mutator\Boolean\TrueValue;
 use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
+use Infection\Tests\Mutator\MutatorName;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -321,7 +322,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->once())->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
+            $process->expects($this->once())->method('getMutatorName')->willReturn(MutatorName::getName(For_::class));
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
@@ -341,7 +342,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->once())->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->once())->method('getMutatorName')->willReturn(TrueValue::getName());
+            $process->expects($this->once())->method('getMutatorName')->willReturn(MutatorName::getName(TrueValue::class));
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_ESCAPED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(20 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('bar/bar');
@@ -362,7 +363,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->once())->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->once())->method('getMutatorName')->willReturn(For_::getName());
+            $process->expects($this->once())->method('getMutatorName')->willReturn(MutatorName::getName(For_::class));
             $process->expects($this->once())->method('getResultCode')->willReturn(MutantProcess::CODE_NOT_COVERED);
             $process->expects($this->atLeast(2))->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->expects($this->atLeast(1))->method('getOriginalFilePath')->willReturn('foo/bar');
@@ -382,7 +383,7 @@ TXT;
             $process->method('getProcess')->willReturn($phpProcess);
             $process->expects($this->atMost(1))->method('getMutant')->willReturn($mutant);
 
-            $process->expects($this->atMost(1))->method('getMutatorName')->willReturn(For_::getName());
+            $process->expects($this->atMost(1))->method('getMutatorName')->willReturn(MutatorName::getName(For_::class));
             $process->expects($this->atMost(1))->method('getResultCode')->willReturn(MutantProcess::CODE_KILLED);
             $process->method('getOriginalStartingLine')->willReturn(10 - $i);
             $process->method('getOriginalFilePath')->willReturn('foo/bar');

--- a/tests/phpunit/Mutant/MutantCodeFactoryTest.php
+++ b/tests/phpunit/Mutant/MutantCodeFactoryTest.php
@@ -41,6 +41,7 @@ use Infection\Mutant\MutantCodeFactory;
 use Infection\MutatedNode;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\Arithmetic\Plus;
+use Infection\Tests\Mutator\MutatorName;
 use PhpParser\Node;
 use PhpParser\NodeDumper;
 use PHPUnit\Framework\TestCase;
@@ -138,7 +139,7 @@ final class MutantCodeFactoryTest extends TestCase
                         'kind' => 1,
                     ]
                 )],
-                Plus::getName(),
+                MutatorName::getName(Plus::class),
                 [
                     'startLine' => 5,
                     'startTokenPos' => 9,

--- a/tests/phpunit/Mutant/MutantFactoryTest.php
+++ b/tests/phpunit/Mutant/MutantFactoryTest.php
@@ -43,6 +43,7 @@ use Infection\Mutation\Mutation;
 use Infection\Mutator\Arithmetic\Plus;
 use Infection\TestFramework\Coverage\CoverageLineData;
 use Infection\Tests\FileSystem\FileSystemTestCase;
+use Infection\Tests\Mutator\MutatorName;
 use PhpParser\Node;
 use PhpParser\PrettyPrinterAbstract;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -234,7 +235,7 @@ final class MutantFactoryTest extends FileSystemTestCase
         return new Mutation(
             '/path/to/acme/Foo.php',
             $originalNodes,
-            Plus::getName(),
+            MutatorName::getName(Plus::class),
             [
                 'startLine' => 3,
                 'endLine' => 5,

--- a/tests/phpunit/Mutant/MutantTest.php
+++ b/tests/phpunit/Mutant/MutantTest.php
@@ -41,6 +41,7 @@ use Infection\MutatedNode;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\Arithmetic\Plus;
 use Infection\TestFramework\Coverage\CoverageLineData;
+use Infection\Tests\Mutator\MutatorName;
 use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
 
@@ -99,7 +100,7 @@ final class MutantTest extends TestCase
                     new Node\Name('Acme'),
                     [new Node\Scalar\LNumber(0)]
                 )],
-                Plus::getName(),
+                MutatorName::getName(Plus::class),
                 $nominalAttributes,
                 Node\Scalar\LNumber::class,
                 MutatedNode::wrap(new Node\Scalar\LNumber(1)),
@@ -119,7 +120,7 @@ final class MutantTest extends TestCase
                     new Node\Name('Acme'),
                     [new Node\Scalar\LNumber(0)]
                 )],
-                Plus::getName(),
+                MutatorName::getName(Plus::class),
                 $nominalAttributes,
                 Node\Scalar\LNumber::class,
                 MutatedNode::wrap(new Node\Scalar\LNumber(1)),

--- a/tests/phpunit/Mutation/FileMutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/FileMutationGeneratorTest.php
@@ -50,6 +50,7 @@ use Infection\Mutator\Util\MutatorConfig;
 use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Infection\Tests\Fixtures\PhpParser\FakeNode;
 use Infection\Tests\Fixtures\PhpParser\FakeVisitor;
+use Infection\Tests\Mutator\MutatorName;
 use Infection\Visitor\MutationsCollectorVisitor;
 use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -116,7 +117,10 @@ final class FileMutationGeneratorTest extends TestCase
         /** @var Mutation $mutation */
         $mutation = current($mutations);
 
-        $this->assertSame(Plus::getName(), $mutation->getMutatorName());
+        $this->assertSame(
+            MutatorName::getName(Plus::class),
+            $mutation->getMutatorName()
+        );
     }
 
     /**

--- a/tests/phpunit/Mutation/MutationTest.php
+++ b/tests/phpunit/Mutation/MutationTest.php
@@ -41,6 +41,7 @@ use Infection\MutatedNode;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\Arithmetic\Plus;
 use Infection\TestFramework\Coverage\CoverageLineData;
+use Infection\Tests\Mutator\MutatorName;
 use function md5;
 use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
@@ -105,7 +106,7 @@ final class MutationTest extends TestCase
         yield 'empty' => [
             '',
             [],
-            Plus::getName(),
+            MutatorName::getName(Plus::class),
             $nominalAttributes,
             Node\Scalar\LNumber::class,
             MutatedNode::wrap(new Node\Scalar\LNumber(1)),
@@ -122,7 +123,7 @@ final class MutationTest extends TestCase
                 new Node\Name('Acme'),
                 [new Node\Scalar\LNumber(0)]
             )],
-            Plus::getName(),
+            MutatorName::getName(Plus::class),
             $nominalAttributes,
             Node\Scalar\LNumber::class,
             MutatedNode::wrap(new Node\Scalar\LNumber(1)),
@@ -145,7 +146,7 @@ final class MutationTest extends TestCase
                 new Node\Name('Acme'),
                 [new Node\Scalar\LNumber(0)]
             )],
-            Plus::getName(),
+            MutatorName::getName(Plus::class),
             $nominalAttributes,
             Node\Scalar\LNumber::class,
             MutatedNode::wrap(new Node\Scalar\LNumber(1)),
@@ -168,7 +169,7 @@ final class MutationTest extends TestCase
                 new Node\Name('Acme'),
                 [new Node\Scalar\LNumber(0)]
             )],
-            Plus::getName(),
+            MutatorName::getName(Plus::class),
             array_merge($nominalAttributes, ['foo' => 100, 'bar' => 1000]),
             Node\Scalar\LNumber::class,
             MutatedNode::wrap(new Node\Scalar\LNumber(1)),
@@ -191,7 +192,7 @@ final class MutationTest extends TestCase
                 new Node\Name('Acme'),
                 [new Node\Scalar\LNumber(0)]
             )],
-            Plus::getName(),
+            MutatorName::getName(Plus::class),
             $nominalAttributes,
             Node\Scalar\LNumber::class,
             MutatedNode::wrap(new Node\Scalar\LNumber(1)),
@@ -208,7 +209,7 @@ final class MutationTest extends TestCase
                 new Node\Name('Acme'),
                 [new Node\Scalar\LNumber(0)]
             )],
-            Plus::getName(),
+            MutatorName::getName(Plus::class),
             $nominalAttributes,
             Node\Scalar\LNumber::class,
             MutatedNode::wrap([

--- a/tests/phpunit/Mutator/AbstractMutatorTestCase.php
+++ b/tests/phpunit/Mutator/AbstractMutatorTestCase.php
@@ -210,7 +210,7 @@ abstract class AbstractMutatorTestCase extends TestCase
             $returnCode,
             sprintf(
                 'Mutator %s produces invalid code',
-                $this->createMutator()::getName()
+                $this->createMutator()->getName()
             )
         );
     }

--- a/tests/phpunit/Mutator/IgnoreMutatorTest.php
+++ b/tests/phpunit/Mutator/IgnoreMutatorTest.php
@@ -174,6 +174,9 @@ final class IgnoreMutatorTest extends TestCase
 
         $ignoreMutator = new IgnoreMutator($config, new Plus($config));
 
-        $this->assertSame(Plus::getName(), $ignoreMutator->getMutatorName());
+        $this->assertSame(
+            MutatorName::getName(Plus::class),
+            $ignoreMutator->getName()
+        );
     }
 }

--- a/tests/phpunit/Mutator/InvalidMutatorTest.php
+++ b/tests/phpunit/Mutator/InvalidMutatorTest.php
@@ -48,7 +48,7 @@ final class InvalidMutatorTest extends TestCase
 
         $exception = InvalidMutator::create(
             '/path/to/acme/Foo.php',
-            Plus::getName(),
+            MutatorName::getName(Plus::class),
             $previous
         );
 

--- a/tests/phpunit/Mutator/MutatorFactoryTest.php
+++ b/tests/phpunit/Mutator/MutatorFactoryTest.php
@@ -116,9 +116,9 @@ final class MutatorFactoryTest extends TestCase
         $falseNode = $this->createBoolNode('false', 'B', $reflectionMock);
         $trueNode = $this->createBoolNode('true', 'B', $reflectionMock);
 
-        $this->assertTrue($mutators[Plus::getName()]->canMutate($plusNode));
-        $this->assertFalse($mutators[TrueValue::getName()]->canMutate($trueNode));
-        $this->assertFalse($mutators[FalseValue::getName()]->canMutate($falseNode));
+        $this->assertTrue($mutators[MutatorName::getName(Plus::class)]->canMutate($plusNode));
+        $this->assertFalse($mutators[MutatorName::getName(TrueValue::class)]->canMutate($trueNode));
+        $this->assertFalse($mutators[MutatorName::getName(FalseValue::class)]->canMutate($falseNode));
     }
 
     public function test_it_can_ignore_a_profile(): void
@@ -156,8 +156,8 @@ final class MutatorFactoryTest extends TestCase
     public function test_it_can_create_mutators_from_their_names(): void
     {
         $mutators = $this->mutatorFactory->create([
-            Plus::getName() => true,
-            Minus::getName() => true,
+            MutatorName::getName(Plus::class) => true,
+            MutatorName::getName(Minus::class) => true,
         ]);
 
         $this->assertSameMutatorsByClass(
@@ -172,8 +172,8 @@ final class MutatorFactoryTest extends TestCase
     public function test_it_can_create_mutators_with_empty_settings_from_their_names(): void
     {
         $mutators = $this->mutatorFactory->create([
-            Plus::getName() => [],
-            Minus::getName() => [],
+            MutatorName::getName(Plus::class) => [],
+            MutatorName::getName(Minus::class) => [],
         ]);
 
         $this->assertSameMutatorsByClass(
@@ -193,7 +193,7 @@ final class MutatorFactoryTest extends TestCase
 
         $mutators = $this->mutatorFactory->create([
             '@boolean' => true,
-            TrueValue::getName() => [
+            MutatorName::getName(TrueValue::class) => [
                 'ignore' => ['A::B'],
             ],
         ]);
@@ -211,13 +211,13 @@ final class MutatorFactoryTest extends TestCase
         $falseNode = $this->createBoolNode('false', 'B', $reflectionMock);
         $trueNode = $this->createBoolNode('true', 'B', $reflectionMock);
 
-        $this->assertFalse($mutators[TrueValue::getName()]->canMutate($trueNode));
-        $this->assertTrue($mutators[FalseValue::getName()]->canMutate($falseNode));
+        $this->assertFalse($mutators[MutatorName::getName(TrueValue::class)]->canMutate($trueNode));
+        $this->assertTrue($mutators[MutatorName::getName(FalseValue::class)]->canMutate($falseNode));
     }
 
     public function test_it_can_ignore_a_mutator(): void
     {
-        $mutators = $this->mutatorFactory->create([Plus::getName() => false]);
+        $mutators = $this->mutatorFactory->create([MutatorName::getName(Plus::class) => false]);
 
         $this->assertCount(0, $mutators);
     }
@@ -226,7 +226,7 @@ final class MutatorFactoryTest extends TestCase
     {
         $mutators = $this->mutatorFactory->create([
             '@equal' => true,
-            IdenticalEqual::getName() => false,
+            MutatorName::getName(IdenticalEqual::class) => false,
         ]);
 
         $this->assertSameMutatorsByClass(
@@ -238,7 +238,7 @@ final class MutatorFactoryTest extends TestCase
     public function test_it_will_not_remove_the_ignored_mutators_if_they_were_included_afterwards(): void
     {
         $mutators = $this->mutatorFactory->create([
-            IdenticalEqual::getName() => false,
+            MutatorName::getName(IdenticalEqual::class) => false,
             '@equal' => true,
         ]);
 
@@ -248,9 +248,9 @@ final class MutatorFactoryTest extends TestCase
     public function test_a_mutator_will_be_created_only_once_even_if_included_multiple_times(): void
     {
         $mutators = $this->mutatorFactory->create([
-            IdenticalEqual::getName() => true,
+            MutatorName::getName(IdenticalEqual::class) => true,
             '@equal' => true,
-            NotIdenticalNotEqual::getName() => true,
+            MutatorName::getName(NotIdenticalNotEqual::class) => true,
         ]);
 
         $this->assertSameMutatorsByClass(ProfileList::EQUAL_PROFILE, $mutators);

--- a/tests/phpunit/Mutator/MutatorName.php
+++ b/tests/phpunit/Mutator/MutatorName.php
@@ -33,43 +33,22 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Mutator\Sort;
+namespace Infection\Tests\Mutator;
 
-use Generator;
-use Infection\Tests\Mutator\AbstractMutatorTestCase;
+use function array_flip;
+use Infection\Mutator\ProfileList;
+use Webmozart\Assert\Assert;
 
-final class SpaceshipTest extends AbstractMutatorTestCase
+final class MutatorName
 {
-    public function test_get_name(): void
+    private function __construct()
     {
-        $this->assertSame('Spaceship', $this->createMutator()->getName());
     }
 
-    /**
-     * @dataProvider mutationsProvider
-     *
-     * @param string|string[] $expected
-     */
-    public function test_it_can_mutate(string $input, $expected = []): void
+    public static function getName(string $mutatorClass): string
     {
-        $this->doTest($input, $expected);
-    }
+        Assert::oneOf($mutatorClass, ProfileList::ALL_MUTATORS);
 
-    public function mutationsProvider(): Generator
-    {
-        yield 'It swaps spaceship operators' => [
-            <<<'PHP'
-<?php
-
-$a <=> $b;
-PHP
-            ,
-            <<<'PHP'
-<?php
-
-$b <=> $a;
-PHP
-            ,
-        ];
+        return array_flip(ProfileList::ALL_MUTATORS)[$mutatorClass];
     }
 }

--- a/tests/phpunit/Mutator/MutatorRobustnessTest.php
+++ b/tests/phpunit/Mutator/MutatorRobustnessTest.php
@@ -82,7 +82,7 @@ final class MutatorRobustnessTest extends TestCase
         } catch (Throwable $throwable) {
             $this->fail(sprintf(
                'The mutator "%s" could not parse the file "%s": %s.',
-               $mutator::getName(),
+               $mutator->getName(),
                $fileName,
                $throwable->getMessage()
             ));

--- a/tests/phpunit/Mutator/ProfileListTest.php
+++ b/tests/phpunit/Mutator/ProfileListTest.php
@@ -52,7 +52,7 @@ final class ProfileListTest extends TestCase
         string $expectedMutatorName,
         string $mutatorClass
     ): void {
-        $actualMutatorName = $mutatorClass::getName();
+        $actualMutatorName = MutatorName::getName($mutatorClass);
 
         $this->assertSame(
             $expectedMutatorName,

--- a/tests/phpunit/MutatorNameTest.php
+++ b/tests/phpunit/MutatorNameTest.php
@@ -33,43 +33,20 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Mutator\Sort;
+namespace Infection\Tests;
 
-use Generator;
-use Infection\Tests\Mutator\AbstractMutatorTestCase;
+use Infection\Tests\Mutator\MutatorName;
+use PHPUnit\Framework\TestCase;
 
-final class SpaceshipTest extends AbstractMutatorTestCase
+final class MutatorNameTest extends TestCase
 {
-    public function test_get_name(): void
-    {
-        $this->assertSame('Spaceship', $this->createMutator()->getName());
-    }
-
     /**
-     * @dataProvider mutationsProvider
-     *
-     * @param string|string[] $expected
+     * @dataProvider \Infection\Tests\Mutator\ProfileListProvider::mutatorNameAndClassProvider
      */
-    public function test_it_can_mutate(string $input, $expected = []): void
+    public function test_it_can_provide_the_mutator_name(string $expectedName, string $mutatorClassName): void
     {
-        $this->doTest($input, $expected);
-    }
+        $actualName = MutatorName::getName($mutatorClassName);
 
-    public function mutationsProvider(): Generator
-    {
-        yield 'It swaps spaceship operators' => [
-            <<<'PHP'
-<?php
-
-$a <=> $b;
-PHP
-            ,
-            <<<'PHP'
-<?php
-
-$b <=> $a;
-PHP
-            ,
-        ];
+        $this->assertSame($expectedName, $actualName);
     }
 }

--- a/tests/phpunit/Process/MutantProcessTest.php
+++ b/tests/phpunit/Process/MutantProcessTest.php
@@ -40,6 +40,7 @@ use Infection\Mutation\Mutation;
 use Infection\Mutator\ZeroIteration\For_;
 use Infection\Process\MutantProcess;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\Tests\Mutator\MutatorName;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
@@ -168,7 +169,7 @@ final class MutantProcessTest extends TestCase
         $mutation = $this->createMock(Mutation::class);
         $mutation->expects($this->once())
             ->method('getMutatorName')
-            ->willReturn(For_::getName());
+            ->willReturn(MutatorName::getName(For_::class));
 
         $this->mutant
             ->expects($this->once())

--- a/tests/phpunit/Visitor/MutatorVisitorTest.php
+++ b/tests/phpunit/Visitor/MutatorVisitorTest.php
@@ -39,6 +39,7 @@ use Generator;
 use Infection\MutatedNode;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
+use Infection\Tests\Mutator\MutatorName;
 use Infection\Tests\StringNormalizer;
 use Infection\Visitor\MutatorVisitor;
 use PhpParser\Lexer;
@@ -108,7 +109,7 @@ PHP
                 new Mutation(
                     'path/to/file',
                     $nodes,
-                    PublicVisibility::getName(),
+                    MutatorName::getName(PublicVisibility::class),
                     [
                         'startTokenPos' => 29,
                         'endTokenPos' => 48,
@@ -160,7 +161,7 @@ PHP
                 new Mutation(
                     'path/to/file',
                     $nodes,
-                    PublicVisibility::getName(),
+                    MutatorName::getName(PublicVisibility::class),
                     [
                         'startTokenPos' => 29,
                         'endTokenPos' => 48,
@@ -214,7 +215,7 @@ PHP
                 new Mutation(
                     'path/to/file',
                     $nodes,
-                    PublicVisibility::getName(),
+                    MutatorName::getName(PublicVisibility::class),
                     [
                         'startTokenPos' => 29,
                         'endTokenPos' => 50,
@@ -282,7 +283,7 @@ PHP
                 new Mutation(
                     'path/to/file',
                     $nodes,
-                    PublicVisibility::getName(),
+                    MutatorName::getName(PublicVisibility::class),
                     [
                         'startTokenPos' => 29,
                         'endTokenPos' => 48,
@@ -291,7 +292,7 @@ PHP
                         'startFilePos' => -1,
                         'endFilePos' => -1,
                     ],
-                    PublicVisibility::getName(),
+                    MutatorName::getName(PublicVisibility::class),
                     MutatedNode::wrap(new Nop()),
                     0,
                     []


### PR DESCRIPTION
When attempting to make `IgnoreMutator` a `Mutator` instead of an adapter, it turned out to not be possible due to `getName()` which is static, hence `IgnoreMutator` cannot provide the decorated instance name.

There is really no (easy at least) way to get around the problem. So as a last ditch attempt, out of curiosity, I tried to make `getName()` non-static. Turns out we are only relying on the static access _in the tests_. As a result, I think a utility `MutatorName` introduced here is good enough for keeping it simple in our tests whilst making the design simpler.