### PR TITLE
An empty phpfile should have no AST

### DIFF
--- a/tests/phpunit/Mutation/FileParserTest.php
+++ b/tests/phpunit/Mutation/FileParserTest.php
@@ -146,13 +146,11 @@ AST
                 '/unknown',
                 <<<'PHP'
 <?php
+
 PHP
             ),
             <<<'AST'
 array(
-    0: Stmt_InlineHTML(
-        value: <?php
-    )
 )
 AST
         ];


### PR DESCRIPTION
This PR fixes the fileparser test, so that it also works on php 7.4