### PR TITLE
Introduce `IgnoreConfig`

### DIFF
--- a/src/Mutator/IgnoreConfig.php
+++ b/src/Mutator/IgnoreConfig.php
@@ -41,8 +41,9 @@ use function in_array;
 
 /**
  * @internal
+ * @final
  */
-final class IgnoreConfig
+class IgnoreConfig
 {
     private $ignored;
 

--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator;
 
 use DomainException;
 use Generator;
-use Infection\Mutator\Util\MutatorConfig;
 use Infection\Visitor\ReflectionVisitor;
 use PhpParser\Node;
 use ReflectionClass;
@@ -60,7 +59,7 @@ final class IgnoreMutator implements Mutator
     private $config;
     private $mutator;
 
-    public function __construct(MutatorConfig $config, Mutator $mutator)
+    public function __construct(IgnoreConfig $config, Mutator $mutator)
     {
         $this->config = $config;
         $this->mutator = $mutator;

--- a/src/Mutator/MutatorFactory.php
+++ b/src/Mutator/MutatorFactory.php
@@ -178,7 +178,10 @@ final class MutatorFactory
             /** @var Mutator $mutator */
             $mutator = new $mutatorClass($mutatorConfig);
 
-            $mutators[$mutator->getName()] = new IgnoreMutator($mutatorConfig, $mutator);
+            $mutators[$mutator->getName()] = new IgnoreMutator(
+                new IgnoreConfig($mutatorConfig['ignore'] ?? []),
+                $mutator
+            );
         }
 
         return $mutators;

--- a/src/Mutator/MutatorFactory.php
+++ b/src/Mutator/MutatorFactory.php
@@ -172,14 +172,12 @@ final class MutatorFactory
         $mutators = [];
 
         foreach ($mutatorNames as $mutatorClass => $settings) {
-            $mutatorConfig = new MutatorConfig($settings);
-
             // TODO: only pass the mutator config if necessary
             /** @var Mutator $mutator */
-            $mutator = new $mutatorClass($mutatorConfig);
+            $mutator = new $mutatorClass(new MutatorConfig($settings));
 
             $mutators[$mutator->getName()] = new IgnoreMutator(
-                new IgnoreConfig($mutatorConfig['ignore'] ?? []),
+                new IgnoreConfig($settings['ignore'] ?? []),
                 $mutator
             );
         }

--- a/src/Mutator/MutatorFactory.php
+++ b/src/Mutator/MutatorFactory.php
@@ -174,7 +174,9 @@ final class MutatorFactory
         foreach ($mutatorNames as $mutatorClass => $settings) {
             // TODO: only pass the mutator config if necessary
             /** @var Mutator $mutator */
-            $mutator = new $mutatorClass(new MutatorConfig($settings));
+            $mutator = new $mutatorClass(
+                new MutatorConfig($settings['settings'] ?? [])
+            );
 
             $mutators[$mutator->getName()] = new IgnoreMutator(
                 new IgnoreConfig($settings['ignore'] ?? []),

--- a/src/Mutator/MutatorFactory.php
+++ b/src/Mutator/MutatorFactory.php
@@ -171,15 +171,18 @@ final class MutatorFactory
     {
         $mutators = [];
 
-        foreach ($mutatorNames as $mutatorClass => $settings) {
+        foreach ($mutatorNames as $mutatorClass => $config) {
+            /** @var string[] $settings */
+            $settings = $config['settings'] ?? [];
+            /** @var string[] $ignored */
+            $ignored = $config['ignore'] ?? [];
+
             // TODO: only pass the mutator config if necessary
             /** @var Mutator $mutator */
-            $mutator = new $mutatorClass(
-                new MutatorConfig($settings['settings'] ?? [])
-            );
+            $mutator = new $mutatorClass(new MutatorConfig($settings));
 
             $mutators[$mutator->getName()] = new IgnoreMutator(
-                new IgnoreConfig($settings['ignore'] ?? []),
+                new IgnoreConfig($ignored),
                 $mutator
             );
         }

--- a/src/Mutator/Util/MutatorConfig.php
+++ b/src/Mutator/Util/MutatorConfig.php
@@ -35,8 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Util;
 
-use function in_array;
-
 /**
  * @internal
  * @final
@@ -55,30 +53,7 @@ class MutatorConfig
 
     public function __construct(array $config)
     {
-        $this->ignoreConfig = $config['ignore'] ?? [];
         $this->mutatorSettings = (array) ($config['settings'] ?? []);
-    }
-
-    public function isIgnored(string $class, string $method, ?int $lineNumber = null): bool
-    {
-        if (in_array($class, $this->ignoreConfig)) {
-            return true;
-        }
-
-        if (in_array($class . '::' . $method, $this->ignoreConfig)) {
-            return true;
-        }
-
-        foreach ($this->ignoreConfig as $ignorePattern) {
-            if (fnmatch($ignorePattern, $class, FNM_NOESCAPE)
-                || fnmatch($ignorePattern, $class . '::' . $method, FNM_NOESCAPE)
-                || ($lineNumber !== null && fnmatch($ignorePattern, $class . '::' . $method . '::' . $lineNumber, FNM_NOESCAPE))
-            ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     public function getMutatorSettings(): array

--- a/src/Mutator/Util/MutatorConfig.php
+++ b/src/Mutator/Util/MutatorConfig.php
@@ -44,11 +44,6 @@ class MutatorConfig
     /**
      * @var array
      */
-    private $ignoreConfig;
-
-    /**
-     * @var array
-     */
     private $mutatorSettings;
 
     public function __construct(array $config)

--- a/src/Mutator/Util/MutatorConfig.php
+++ b/src/Mutator/Util/MutatorConfig.php
@@ -41,9 +41,6 @@ namespace Infection\Mutator\Util;
  */
 class MutatorConfig
 {
-    /**
-     * @var array
-     */
     private $mutatorSettings;
 
     public function __construct(array $settings)

--- a/src/Mutator/Util/MutatorConfig.php
+++ b/src/Mutator/Util/MutatorConfig.php
@@ -46,9 +46,9 @@ class MutatorConfig
      */
     private $mutatorSettings;
 
-    public function __construct(array $config)
+    public function __construct(array $settings)
     {
-        $this->mutatorSettings = (array) ($config['settings'] ?? []);
+        $this->mutatorSettings = $settings;
     }
 
     public function getMutatorSettings(): array

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -47,6 +47,7 @@ use Infection\FileSystem\TmpDirProvider;
 use Infection\Mutator\Arithmetic\AssignmentEqual;
 use Infection\Mutator\Boolean\EqualIdentical;
 use Infection\Mutator\Boolean\TrueValue;
+use Infection\Mutator\IgnoreConfig;
 use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorFactory;
@@ -464,10 +465,8 @@ final class ConfigurationFactoryTest extends TestCase
             '',
             [
                 'MethodCallRemoval' => new IgnoreMutator(
-                    new MutatorConfig([
-                        'ignore' => [
-                            'Infection\Finder\SourceFilesFinder::__construct::63',
-                        ],
+                    new IgnoreConfig([
+                        'Infection\Finder\SourceFilesFinder::__construct::63',
                     ]),
                     new MethodCallRemoval()
                 ),
@@ -488,8 +487,14 @@ final class ConfigurationFactoryTest extends TestCase
                 $config = new MutatorConfig([]);
 
                 return [
-                    'AssignmentEqual' => new IgnoreMutator($config, new AssignmentEqual()),
-                    'EqualIdentical' => new IgnoreMutator($config, new EqualIdentical()),
+                    'AssignmentEqual' => new IgnoreMutator(
+                        new IgnoreConfig([]),
+                        new AssignmentEqual(new MutatorConfig([]))
+                    ),
+                    'EqualIdentical' => new IgnoreMutator(
+                        new IgnoreConfig([]),
+                        new EqualIdentical(new MutatorConfig([]))
+                    ),
                 ];
             })()
         );
@@ -620,10 +625,11 @@ final class ConfigurationFactoryTest extends TestCase
                 'config/phpunit'
             ),
             (static function (): array {
-                $config = new MutatorConfig([]);
-
                 return [
-                    'TrueValue' => new IgnoreMutator($config, new TrueValue($config)),
+                    'TrueValue' => new IgnoreMutator(
+                        new IgnoreConfig([]),
+                        new TrueValue(new MutatorConfig([]))
+                    ),
                 ];
             })(),
             'phpspec',

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -489,11 +489,11 @@ final class ConfigurationFactoryTest extends TestCase
                 return [
                     'AssignmentEqual' => new IgnoreMutator(
                         new IgnoreConfig([]),
-                        new AssignmentEqual(new MutatorConfig([]))
+                        new AssignmentEqual()
                     ),
                     'EqualIdentical' => new IgnoreMutator(
                         new IgnoreConfig([]),
-                        new EqualIdentical(new MutatorConfig([]))
+                        new EqualIdentical()
                     ),
                 ];
             })()

--- a/tests/phpunit/Configuration/ConfigurationTest.php
+++ b/tests/phpunit/Configuration/ConfigurationTest.php
@@ -40,9 +40,9 @@ use Infection\Configuration\Configuration;
 use Infection\Configuration\Entry\Badge;
 use Infection\Configuration\Entry\Logs;
 use Infection\Configuration\Entry\PhpUnit;
+use Infection\Mutator\IgnoreConfig;
 use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Mutator;
-use Infection\Mutator\Util\MutatorConfig;
 use Infection\TestFramework\TestFrameworkExtraOptions;
 use Infection\Tests\Fixtures\Mutator\FakeMutator;
 use Infection\Tests\Fixtures\TestFramework\DummyTestFrameworkExtraOptions;
@@ -187,7 +187,7 @@ final class ConfigurationTest extends TestCase
             'custom-dir',
             new PhpUnit('dist/phpunit', 'bin/phpunit'),
             [
-                'Fake' => new IgnoreMutator(new MutatorConfig([]), new FakeMutator()),
+                'Fake' => new IgnoreMutator(new IgnoreConfig([]), new FakeMutator()),
             ],
             'phpunit',
             'bin/bootstrap.php',

--- a/tests/phpunit/Mutation/FileMutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/FileMutationGeneratorTest.php
@@ -45,6 +45,7 @@ use Infection\Mutation\Mutation;
 use Infection\Mutation\NodeTraverserFactory;
 use Infection\Mutation\PrioritizedVisitorsNodeTraverser;
 use Infection\Mutator\Arithmetic\Plus;
+use Infection\Mutator\IgnoreConfig;
 use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Util\MutatorConfig;
 use Infection\TestFramework\Coverage\LineCodeCoverage;
@@ -98,7 +99,7 @@ final class FileMutationGeneratorTest extends TestCase
             new SplFileInfo(self::FIXTURES_DIR . '/Mutation/OneFile/OneFile.php', '', ''),
             false,
             $codeCoverageMock,
-            [new IgnoreMutator(new MutatorConfig([]), new Plus())],
+            [new IgnoreMutator(new IgnoreConfig([]), new Plus())],
             []
         );
 
@@ -173,7 +174,7 @@ final class FileMutationGeneratorTest extends TestCase
             $fileInfo,
             $onlyCovered,
             $codeCoverage,
-            [new IgnoreMutator(new MutatorConfig([]), new Plus())],
+            [new IgnoreMutator(new IgnoreConfig([]), new Plus())],
             $extraVisitors
         );
 
@@ -244,7 +245,7 @@ final class FileMutationGeneratorTest extends TestCase
                 $fileInfo,
                 false,
                 $this->createMock(LineCodeCoverage::class),
-                [new IgnoreMutator(new MutatorConfig([]), new Plus())],
+                [new IgnoreMutator(new IgnoreConfig([]), new Plus())],
                 $extraVisitors
             );
 

--- a/tests/phpunit/Mutation/FileMutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/FileMutationGeneratorTest.php
@@ -47,7 +47,6 @@ use Infection\Mutation\PrioritizedVisitorsNodeTraverser;
 use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\IgnoreConfig;
 use Infection\Mutator\IgnoreMutator;
-use Infection\Mutator\Util\MutatorConfig;
 use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Infection\Tests\Fixtures\PhpParser\FakeNode;
 use Infection\Tests\Fixtures\PhpParser\FakeVisitor;
@@ -210,7 +209,7 @@ final class FileMutationGeneratorTest extends TestCase
                 $expectedFilePath,
                 false
             ),
-            [new IgnoreMutator(new MutatorConfig([]), new Plus())],
+            [new IgnoreMutator(new IgnoreConfig([]), new Plus())],
             []
         );
 

--- a/tests/phpunit/Mutation/MutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/MutationGeneratorTest.php
@@ -42,8 +42,8 @@ use Infection\Events\MutationGeneratingStarted;
 use Infection\Mutation\FileMutationGenerator;
 use Infection\Mutation\Mutation;
 use Infection\Mutation\MutationGenerator;
+use Infection\Mutator\IgnoreConfig;
 use Infection\Mutator\IgnoreMutator;
-use Infection\Mutator\Util\MutatorConfig;
 use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Infection\Tests\Fixtures\Mutator\FakeMutator;
 use Infection\Tests\Fixtures\PhpParser\FakeVisitor;
@@ -61,7 +61,7 @@ final class MutationGeneratorTest extends TestCase
         ];
 
         $codeCoverageMock = $this->createMock(LineCodeCoverage::class);
-        $mutators = ['Fake' => new IgnoreMutator(new MutatorConfig([]), new FakeMutator())];
+        $mutators = ['Fake' => new IgnoreMutator(new IgnoreConfig([]), new FakeMutator())];
         $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $onlyCovered = true;
         $extraVisitors = [2 => new FakeVisitor()];

--- a/tests/phpunit/Mutator/Boolean/TrueValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/TrueValueTest.php
@@ -171,9 +171,7 @@ PHP
 \in_array($a, $b, false);
 PHP
                 ,
-                [
-                    'settings' => ['in_array' => true],
-                ],
+                ['in_array' => true],
             ];
 
         yield 'It does not mutate when used in "\in_array" function and explicitly disabled' => [
@@ -184,9 +182,7 @@ PHP
 PHP
                 ,
                 [],
-                [
-                    'settings' => ['in_array' => false],
-                ],
+                ['in_array' => false],
             ];
 
         yield 'It does not mutate when used in "array_search" function by default' => [
@@ -235,9 +231,7 @@ PHP
 array_search($a, $b, false);
 PHP
             ,
-            [
-                'settings' => ['array_search' => true],
-            ],
+            ['array_search' => true],
         ];
 
         yield 'It does not mutate when used in "\array_search" function and explicitly disabled' => [
@@ -248,9 +242,7 @@ PHP
 PHP
             ,
             [],
-            [
-                'settings' => ['array_search' => false],
-            ],
+            ['array_search' => false],
         ];
 
         yield 'It does not mutate when used in "\array_search" function and explicitly disabled and function is wrongly capitalized' => [
@@ -261,9 +253,7 @@ PHP
 PHP
             ,
             [],
-            [
-                'settings' => ['array_search' => false],
-            ],
+            ['array_search' => false],
         ];
     }
 

--- a/tests/phpunit/Mutator/Extensions/BCMathTest.php
+++ b/tests/phpunit/Mutator/Extensions/BCMathTest.php
@@ -190,7 +190,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         yield "It does not convert $bcFunc when disabled" => [
             "<?php $bcFunc($validArgumentsExpression);",
             null,
-            ['settings' => [$bcFunc => false]],
+            [$bcFunc => false],
         ];
     }
 

--- a/tests/phpunit/Mutator/Extensions/MBStringTest.php
+++ b/tests/phpunit/Mutator/Extensions/MBStringTest.php
@@ -76,13 +76,13 @@ final class MBStringTest extends AbstractMutatorTestCase
         yield 'It converts mb_strlen with encoding to strlen' => [
             "<?php mb_strlen('test', 'utf-8');",
             "<?php\n\nstrlen('test');",
-            ['settings' => ['mb_strlen' => true]],
+            ['mb_strlen' => true],
         ];
 
         yield 'It does not convert mb_strlen when disabled' => [
             "<?php mb_strlen('test');",
             null,
-            ['settings' => ['mb_strlen' => false]],
+            ['mb_strlen' => false],
         ];
 
         yield from $this->mutationsProviderForChr();

--- a/tests/phpunit/Mutator/IgnoreConfigTest.php
+++ b/tests/phpunit/Mutator/IgnoreConfigTest.php
@@ -71,84 +71,127 @@ final class IgnoreConfigTest extends TestCase
 
     public function ignoredValuesProvider(): Generator
     {
-        yield 'full class' => [
-            ['Foo\Bar\Test'],
-            'Foo\Bar\Test',
-            'method',
-            null,
-        ];
+        foreach ([null, 50] as $lineNumber) {
+            $titleSuffix = null === $lineNumber ? '' : ' with line number #' . $lineNumber;
 
-        yield 'full class with method' => [
-            ['Foo\Bar\Test::method'],
-            'Foo\Bar\Test',
-            'method',
-            null,
-        ];
+            yield 'full class' . $titleSuffix => [
+                ['Acme\FooTest'],
+                'Acme\FooTest',
+                'test_it_can_create_instance',
+                $lineNumber,
+            ];
 
-        yield 'pattern of a class' => [
-            ['Foo\*\Test'],
-            'Foo\Bar\Test',
-            'method',
-            null,
-        ];
+            yield 'full class with method' . $titleSuffix => [
+                ['Acme\FooTest::test_it_can_create_instance'],
+                'Acme\FooTest',
+                'test_it_can_create_instance',
+                $lineNumber,
+            ];
 
-        yield 'all classes in the namespace' => [
-            ['Foo\Test\*'],
-            'Foo\Test\Baz',
-            'method',
-            null,
-        ];
+            yield 'pattern of a class' . $titleSuffix => [
+                ['Acme\*\FooTest'],
+                'Acme\Test\FooTest',
+                'test_it_can_create_instance',
+                $lineNumber,
+            ];
 
-        yield 'pattern of a class with method' => [
-            ['Foo\*::method'],
-            'Foo\Bar\Test',
-            'method',
-            null,
-        ];
+            yield 'all classes in the namespace' . $titleSuffix => [
+                ['Acme\Test\*'],
+                'Acme\Test\FooTest',
+                'test_it_can_create_instance',
+                $lineNumber,
+            ];
 
-        yield 'pattern of a method' => [
-            ['Foo\Bar\Test::m?th?d'],
-            'Foo\Bar\Test',
-            'method',
-            null,
-        ];
+            yield 'pattern of a class with method' . $titleSuffix => [
+                ['Acme\Test\*::test_it_can_create_instance'],
+                'Acme\Test\FooTest',
+                'test_it_can_create_instance',
+                $lineNumber,
+            ];
 
-        yield 'specific line number' => [
-            ['Foo\Bar\Test::method::63'],
-            'Foo\Bar\Test',
-            'method',
-            63,
+            yield 'pattern of a method' . $titleSuffix => [
+                ['Acme\Test\FooTest::test_i?_can_create_instanc?'],
+                'Acme\Test\FooTest',
+                'test_it_can_create_instance',
+                $lineNumber,
+            ];
+        }
+
+        yield 'full class with method and line number' => [
+            ['Acme\FooTest::test_it_can_create_instance::50'],
+            'Acme\FooTest',
+            'test_it_can_create_instance',
+            50,
         ];
     }
 
     public function nonIgnoredValuesProvider(): Generator
     {
-        yield 'full class when the methods dont match' => [
-            ['Foo\Bar\Test::otherMethod'],
-            'Foo\Bar\Test',
-            'method',
-            null,
-        ];
+        foreach ([null, 50] as $lineNumber) {
+            $titleSuffix = null === $lineNumber ? '' : ' with line number #' . $lineNumber;
 
-        yield 'class if casing doesnt match' => [
-            ['FoO\BAr\tEst'],
-            'Foo\Bar\Test',
-            'method',
-            null,
-        ];
+            yield 'full class with non-matching class' . $titleSuffix => [
+                ['Acme\FooTest'],
+                'Acme\BarTest',
+                'test_it_can_create_instance',
+                $lineNumber,
+            ];
 
-        yield 'pattern of a class if the method does not match' => [
-            ['Foo\*\Test::other'],
-            'Foo\Bar\Test',
-            'method',
-            null,
-        ];
+            yield 'full class with non-matching case of the class' . $titleSuffix => [
+                ['Acme\FooTest'],
+                'AcmE\FoOTesT',
+                'test_it_can_create_instance',
+                $lineNumber,
+            ];
 
-        yield 'pattern of a class with method if the class doesnt match' => [
-            ['Foo\*::method'],
-            'Bar\Foo\Test',
-            'method',
-            null,
+            yield 'full class with method with non-matching class' . $titleSuffix => [
+                ['Acme\FooTest::test_it_can_create_instance'],
+                'Acme\BarTest',
+                'test_it_can_create_instance',
+                $lineNumber,
+            ];
+
+            yield 'full class with method with non-matching method' . $titleSuffix => [
+                ['Acme\FooTest::test_it_can_create_instance'],
+                'Acme\FooTest',
+                'test_it_is_another_method',
+                $lineNumber,
+            ];
+
+            yield 'full class with method with non-matching case of method' . $titleSuffix => [
+                ['Acme\FooTest::test_it_can_create_instance'],
+                'Acme\FooTest',
+                'test_It_Can_Create_Instance',
+                $lineNumber,
+            ];
+
+            yield 'non-matching pattern of a class' . $titleSuffix => [
+                ['Acme\*\FooTest'],
+                'Acme\FooTest',
+                'test_it_can_create_instance',
+                $lineNumber,
+            ];
+
+            yield 'pattern of a class with non-matching method' . $titleSuffix => [
+                ['Acme\Test\*::test_it_can_create_instance'],
+                'Acme\Test\FooTest',
+                'test_it_is_another_method',
+                $lineNumber,
+            ];
+
+            yield 'non-matching pattern of a method' . $titleSuffix => [
+                ['Acme\Test\FooTest::test_i?_can_create_instanc?'],
+                'Acme\Test\FooTest',
+                'test_it_is_another_method',
+                $lineNumber,
+            ];
+        }
+
+        yield 'full class with method and non-matching line number' => [
+            ['Acme\FooTest::test_it_can_create_instance::50'],
+            'Acme\FooTest',
+            'test_it_can_create_instance',
+            70,
         ];
     }
 }

--- a/tests/phpunit/Mutator/IgnoreConfigTest.php
+++ b/tests/phpunit/Mutator/IgnoreConfigTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator;
+
+use Generator;
+use Infection\Mutator\IgnoreConfig;
+use PHPUnit\Framework\TestCase;
+
+final class IgnoreConfigTest extends TestCase
+{
+    /**
+     * @dataProvider ignoredValuesProvider
+     */
+    public function test_it_can_check_that_the_given_elements_are_ignored(
+        array $ignored,
+        string $class,
+        string $method,
+        ?int $lineNumber
+    ): void {
+        $config = new IgnoreConfig($ignored);
+
+        $this->assertTrue($config->isIgnored($class, $method, $lineNumber));
+    }
+
+    /**
+     * @dataProvider nonIgnoredValuesProvider
+     */
+    public function test_it_can_check_that_the_given_elements_are_not_ignored(
+        array $ignored,
+        string $class,
+        string $method,
+        ?int $lineNumber
+    ): void {
+        $config = new IgnoreConfig($ignored);
+
+        $this->assertFalse($config->isIgnored($class, $method, $lineNumber));
+    }
+
+    public function ignoredValuesProvider(): Generator
+    {
+        yield 'full class' => [
+            ['Foo\Bar\Test'],
+            'Foo\Bar\Test',
+            'method',
+            null,
+        ];
+
+        yield 'full class with method' => [
+            ['Foo\Bar\Test::method'],
+            'Foo\Bar\Test',
+            'method',
+            null,
+        ];
+
+        yield 'pattern of a class' => [
+            ['Foo\*\Test'],
+            'Foo\Bar\Test',
+            'method',
+            null,
+        ];
+
+        yield 'all classes in the namespace' => [
+            ['Foo\Test\*'],
+            'Foo\Test\Baz',
+            'method',
+            null,
+        ];
+
+        yield 'pattern of a class with method' => [
+            ['Foo\*::method'],
+            'Foo\Bar\Test',
+            'method',
+            null,
+        ];
+
+        yield 'pattern of a method' => [
+            ['Foo\Bar\Test::m?th?d'],
+            'Foo\Bar\Test',
+            'method',
+            null,
+        ];
+
+        yield 'specific line number' => [
+            ['Foo\Bar\Test::method::63'],
+            'Foo\Bar\Test',
+            'method',
+            63,
+        ];
+    }
+
+    public function nonIgnoredValuesProvider(): Generator
+    {
+        yield 'full class when the methods dont match' => [
+            ['Foo\Bar\Test::otherMethod'],
+            'Foo\Bar\Test',
+            'method',
+            null,
+        ];
+
+        yield 'class if casing doesnt match' => [
+            ['FoO\BAr\tEst'],
+            'Foo\Bar\Test',
+            'method',
+            null,
+        ];
+
+        yield 'pattern of a class if the method does not match' => [
+            ['Foo\*\Test::other'],
+            'Foo\Bar\Test',
+            'method',
+            null,
+        ];
+
+        yield 'pattern of a class with method if the class doesnt match' => [
+            ['Foo\*::method'],
+            'Bar\Foo\Test',
+            'method',
+            null,
+        ];
+    }
+}

--- a/tests/phpunit/Mutator/IgnoreConfigTest.php
+++ b/tests/phpunit/Mutator/IgnoreConfigTest.php
@@ -39,6 +39,9 @@ use Generator;
 use Infection\Mutator\IgnoreConfig;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group integration This is probably a false-positive of the IO checker regarding `fnmatch()`
+ */
 final class IgnoreConfigTest extends TestCase
 {
     /**

--- a/tests/phpunit/Mutator/IgnoreMutatorTest.php
+++ b/tests/phpunit/Mutator/IgnoreMutatorTest.php
@@ -38,9 +38,9 @@ namespace Infection\Tests\Mutator;
 use DomainException;
 use Generator;
 use Infection\Mutator\Arithmetic\Plus;
+use Infection\Mutator\IgnoreConfig;
 use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Mutator;
-use Infection\Mutator\Util\MutatorConfig;
 use Infection\Visitor\ReflectionVisitor;
 use function iterator_to_array;
 use PhpParser\Node;
@@ -82,7 +82,7 @@ final class IgnoreMutatorTest extends TestCase
 
     public function test_it_should_not_mutate_node_if_its_decorated_mutator_cannot(): void
     {
-        $ignoreMutator = new IgnoreMutator(new MutatorConfig([]), $this->mutatorMock);
+        $ignoreMutator = new IgnoreMutator(new IgnoreConfig([]), $this->mutatorMock);
 
         $this->mutatorMock
             ->expects($this->once())
@@ -98,7 +98,7 @@ final class IgnoreMutatorTest extends TestCase
 
     public function test_it_should_mutate_node_if_its_decorated_mutator_can_and_no_reflection_class_could_be_found_for_the_node(): void
     {
-        $ignoreMutator = new IgnoreMutator(new MutatorConfig([]), $this->mutatorMock);
+        $ignoreMutator = new IgnoreMutator(new IgnoreConfig([]), $this->mutatorMock);
 
         $this->mutatorMock
             ->expects($this->once())
@@ -147,16 +147,16 @@ final class IgnoreMutatorTest extends TestCase
             ->willReturn(10)
         ;
 
-        $configMock = $this->createMock(MutatorConfig::class);
+        $ignoreConfigMock = $this->createMock(IgnoreConfig::class);
 
-        $configMock
+        $ignoreConfigMock
             ->expects($this->once())
             ->method('isIgnored')
             ->with(self::class, 'foo', 10)
             ->willReturn(true)
         ;
 
-        $ignoreMutator = new IgnoreMutator($configMock, $this->mutatorMock);
+        $ignoreMutator = new IgnoreMutator($ignoreConfigMock, $this->mutatorMock);
 
         $mutate = $ignoreMutator->canMutate($this->nodeMock);
 
@@ -165,7 +165,7 @@ final class IgnoreMutatorTest extends TestCase
 
     public function test_it_mutates_the_node_via_its_decorated_mutator(): void
     {
-        $ignoreMutator = new IgnoreMutator(new MutatorConfig([]), $this->mutatorMock);
+        $ignoreMutator = new IgnoreMutator(new IgnoreConfig([]), $this->mutatorMock);
 
         $mutatedNodeMock = $this->createMock(Node::class);
 
@@ -185,7 +185,7 @@ final class IgnoreMutatorTest extends TestCase
 
     public function test_it_exposes_its_decorated_mutator_name(): void
     {
-        $ignoreMutator = new IgnoreMutator(new MutatorConfig([]), new Plus());
+        $ignoreMutator = new IgnoreMutator(new IgnoreConfig([]), new Plus());
 
         $this->assertSame(
             MutatorName::getName(Plus::class),

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
@@ -65,7 +65,7 @@ final class ArrayItemRemovalTest extends AbstractMutatorTestCase
         yield 'It removes only last item when set to do so' => [
             '<?php $a = [1, 2, 3];',
             "<?php\n\n\$a = [1, 2];",
-            ['settings' => ['remove' => 'last']],
+            ['remove' => 'last'],
         ];
 
         yield 'It removes every item on by one when set to `all`' => [
@@ -75,7 +75,7 @@ final class ArrayItemRemovalTest extends AbstractMutatorTestCase
                 "<?php\n\n\$a = [1, 3];",
                 "<?php\n\n\$a = [1, 2];",
             ],
-            ['settings' => ['remove' => 'all']],
+            ['remove' => 'all'],
         ];
 
         yield 'It obeys limit when mutating arrays in `all` mode' => [
@@ -84,7 +84,7 @@ final class ArrayItemRemovalTest extends AbstractMutatorTestCase
                 "<?php\n\n\$a = [2, 3];",
                 "<?php\n\n\$a = [1, 3];",
             ],
-            ['settings' => ['remove' => 'all', 'limit' => 2]],
+            ['remove' => 'all', 'limit' => 2],
         ];
 
         yield 'It mutates arrays having required items count when removing `all` items' => [
@@ -93,7 +93,7 @@ final class ArrayItemRemovalTest extends AbstractMutatorTestCase
                 "<?php\n\n\$a = [2];",
                 "<?php\n\n\$a = [1];",
             ],
-            ['settings' => ['remove' => 'all', 'limit' => 2]],
+            ['remove' => 'all', 'limit' => 2],
         ];
 
         yield 'It mutates correctly for limit value (1)' => [
@@ -101,7 +101,7 @@ final class ArrayItemRemovalTest extends AbstractMutatorTestCase
             [
                 "<?php\n\n\$a = [];",
             ],
-            ['settings' => ['remove' => 'all', 'limit' => 1]],
+            ['remove' => 'all', 'limit' => 1],
         ];
     }
 
@@ -119,7 +119,7 @@ final class ArrayItemRemovalTest extends AbstractMutatorTestCase
         $this->doTest(
             '<?php $a = [1, 2, 3];',
             "<?php\n\n\$a = [2, 3];",
-            ['settings' => [$setting => $value]]
+            [$setting => $value]
         );
     }
 

--- a/tests/phpunit/Mutator/Util/MutatorConfigTest.php
+++ b/tests/phpunit/Mutator/Util/MutatorConfigTest.php
@@ -45,7 +45,7 @@ final class MutatorConfigTest extends TestCase
     {
         $settings = new stdClass();
         $settings->foo = 'bar';
-        $config = new MutatorConfig(['settings' => $settings]);
+        $config = new MutatorConfig($settings);
         $this->assertSame(['foo' => 'bar'], $config->getMutatorSettings());
     }
 

--- a/tests/phpunit/Mutator/Util/MutatorConfigTest.php
+++ b/tests/phpunit/Mutator/Util/MutatorConfigTest.php
@@ -37,15 +37,12 @@ namespace Infection\Tests\Mutator\Util;
 
 use Infection\Mutator\Util\MutatorConfig;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 final class MutatorConfigTest extends TestCase
 {
     public function test_it_correctly_converts_settings(): void
     {
-        $settings = new stdClass();
-        $settings->foo = 'bar';
-        $config = new MutatorConfig($settings);
+        $config = new MutatorConfig(['foo' => 'bar']);
         $this->assertSame(['foo' => 'bar'], $config->getMutatorSettings());
     }
 


### PR DESCRIPTION
Extracts the ignore role of `Util\MutatorConfig` into `IgnoreConfig` which is now a simple specific class which can be injected in `IgnoreMutator` only, simplifying `MutatorConfig` only leaving it with settings. I plan to further change that as well [how `MutatorConfig` works] later but it will be in another PR.