### PR TITLE
Introduce `MutatorResolver`

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -36,13 +36,16 @@ declare(strict_types=1);
 namespace Infection\Configuration;
 
 use function array_fill_keys;
+use function count;
 use function dirname;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Schema\SchemaConfiguration;
 use Infection\FileSystem\SourceFileCollector;
 use Infection\FileSystem\TmpDirProvider;
+use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\MutatorParser;
+use Infection\Mutator\MutatorResolver;
 use Infection\TestFramework\PhpSpec\PhpSpecExtraOptions;
 use Infection\TestFramework\PhpUnit\PhpUnitExtraOptions;
 use Infection\TestFramework\TestFrameworkExtraOptions;
@@ -70,17 +73,20 @@ class ConfigurationFactory
     ];
 
     private $tmpDirProvider;
+    private $mutatorResolver;
     private $mutatorFactory;
     private $mutatorParser;
     private $sourceFileCollector;
 
     public function __construct(
         TmpDirProvider $tmpDirProvider,
+        MutatorResolver $mutatorResolver,
         MutatorFactory $mutatorFactory,
         MutatorParser $mutatorParser,
         SourceFileCollector $sourceFileCollector
     ) {
         $this->tmpDirProvider = $tmpDirProvider;
+        $this->mutatorResolver = $mutatorResolver;
         $this->mutatorFactory = $mutatorFactory;
         $this->mutatorParser = $mutatorParser;
         $this->sourceFileCollector = $sourceFileCollector;
@@ -106,8 +112,6 @@ class ConfigurationFactory
     ): Configuration {
         $configDir = dirname($schema->getFile());
 
-        $schemaMutators = $schema->getMutators();
-
         $namespacedTmpDir = $this->retrieveTmpDir($schema, $configDir);
 
         $testFramework = $testFramework ?? $schema->getTestFramework() ?? TestFrameworkTypes::PHPUNIT;
@@ -132,14 +136,7 @@ class ConfigurationFactory
             $logVerbosity,
             $namespacedTmpDir,
             $this->retrievePhpUnit($schema, $configDir),
-            $this->mutatorFactory->create(
-                $this->retrieveMutators(
-                    $schemaMutators === []
-                        ? ['@default' => true]
-                        : $schemaMutators,
-                    $mutatorsInput
-                )
-            ),
+            $this->retrieveMutators($schema->getMutators(), $mutatorsInput),
             $testFramework,
             $schema->getBootstrap(),
             $initialTestsPhpOptions ?? $schema->getInitialTestsPhpOptions(),
@@ -189,6 +186,28 @@ class ConfigurationFactory
         return $phpUnit;
     }
 
+    /**
+     * @return array<string, Mutator>
+     */
+    private function retrieveMutators(array $schemaMutators, string $mutatorsInput): array
+    {
+        if (count($schemaMutators) === 0) {
+            $schemaMutators = ['@default' => true];
+        }
+
+        $parsedMutatorsInput = $this->mutatorParser->parse($mutatorsInput);
+
+        if ([] === $parsedMutatorsInput) {
+            $mutatorsList = $schemaMutators;
+        } else {
+            $mutatorsList = array_fill_keys($parsedMutatorsInput, true);
+        }
+
+        return $this->mutatorFactory->create(
+            $this->mutatorResolver->resolve($mutatorsList)
+        );
+    }
+
     private static function retrieveCoveragePath(
         string $coverageBasePath,
         string $testFramework
@@ -218,17 +237,6 @@ class ConfigurationFactory
         }
 
         return sprintf('%s/%s', $configDir, $existingCoveragePath);
-    }
-
-    private function retrieveMutators(array $schemaMutators, string $mutatorsInput): array
-    {
-        $parsedMutatorsInput = $this->mutatorParser->parse($mutatorsInput);
-
-        if ([] === $parsedMutatorsInput) {
-            return $schemaMutators;
-        }
-
-        return array_fill_keys($parsedMutatorsInput, true);
     }
 
     private static function retrieveTestFrameworkExtraOptions(

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -197,7 +197,7 @@ class ConfigurationFactory
 
         $parsedMutatorsInput = $this->mutatorParser->parse($mutatorsInput);
 
-        if ([] === $parsedMutatorsInput) {
+        if ($parsedMutatorsInput === []) {
             $mutatorsList = $schemaMutators;
         } else {
             $mutatorsList = array_fill_keys($parsedMutatorsInput, true);

--- a/src/Container.php
+++ b/src/Container.php
@@ -275,6 +275,7 @@ final class Container
             ConfigurationFactory::class => static function (self $container): ConfigurationFactory {
                 return new ConfigurationFactory(
                     $container->getTmpDirProvider(),
+                    $container->getMutatorResolver(),
                     $container->getMutatorFactory(),
                     $container->getMutatorParser(),
                     $container->getSourceFileCollector()

--- a/src/Container.php
+++ b/src/Container.php
@@ -64,6 +64,7 @@ use Infection\Mutation\MutationGenerator;
 use Infection\Mutation\NodeTraverserFactory;
 use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\MutatorParser;
+use Infection\Mutator\MutatorResolver;
 use Infection\Performance\Limiter\MemoryLimiter;
 use Infection\Performance\Memory\MemoryFormatter;
 use Infection\Performance\Time\TimeFormatter;
@@ -278,6 +279,9 @@ final class Container
                     $container->getMutatorParser(),
                     $container->getSourceFileCollector()
                 );
+            },
+            MutatorResolver::class => static function (): MutatorResolver {
+                return new MutatorResolver();
             },
             MutatorFactory::class => static function (): MutatorFactory {
                 return new MutatorFactory();
@@ -647,6 +651,11 @@ final class Container
     public function getConfigurationFactory(): ConfigurationFactory
     {
         return $this->get(ConfigurationFactory::class);
+    }
+
+    public function getMutatorResolver(): MutatorResolver
+    {
+        return $this->get(MutatorResolver::class);
     }
 
     public function getMutatorFactory(): MutatorFactory

--- a/src/Mutator/MutatorFactory.php
+++ b/src/Mutator/MutatorFactory.php
@@ -35,12 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\Mutator;
 
-use function array_key_exists;
-use function class_exists;
 use Infection\Mutator\Util\MutatorConfig;
-use InvalidArgumentException;
+use function Safe\array_flip;
 use function sprintf;
-use stdClass;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal
@@ -48,130 +46,30 @@ use stdClass;
 final class MutatorFactory
 {
     /**
-     * @param array<string, bool|array<string, string>> $mutatorSettings
+     * @param array<string, array<mixed>> $resolvedMutators
      *
      * @return array<string, Mutator>
      */
-    public function create(array $mutatorSettings): array
-    {
-        return self::createFromNames(
-            self::retrieveMutatorNames($mutatorSettings)
-        );
-    }
-
-    /**
-     * @param array<string, bool|array<string, string>> $mutatorSettings
-     *
-     * @return array<string, array<string, string>>
-     */
-    private static function retrieveMutatorNames(array $mutatorSettings): array
+    public function create(array $resolvedMutators): array
     {
         $mutators = [];
 
-        foreach ($mutatorSettings as $mutatorOrProfile => $setting) {
-            if (array_key_exists($mutatorOrProfile, ProfileList::ALL_PROFILES)) {
-                self::registerFromProfile($mutatorOrProfile, $setting, $mutators);
+        $knownMutatorClasses = array_flip(ProfileList::ALL_MUTATORS);
 
-                continue;
-            }
+        foreach ($resolvedMutators as $mutatorClass => $settings) {
+            Assert::keyExists(
+                $knownMutatorClasses,
+                $mutatorClass,
+                sprintf('Unknown mutator "%s"', $mutatorClass)
+            );
+            Assert::isArray(
+                $settings,
+                sprintf(
+                    'Expected settings of the mutator "%s" to be an array. Got "%%s" instead',
+                    $mutatorClass
+                )
+            );
 
-            if (array_key_exists($mutatorOrProfile, ProfileList::ALL_MUTATORS)) {
-                self::registerFromName($mutatorOrProfile, $setting, $mutators);
-
-                continue;
-            }
-
-            throw new InvalidArgumentException(sprintf(
-                'The profile or mutator "%s" was not recognized.',
-                $mutatorOrProfile
-            ));
-        }
-
-        return $mutators;
-    }
-
-    /**
-     * @param array<string, string>|bool           $settings
-     * @param array<string, array<string, string>> $mutators
-     */
-    private static function registerFromProfile(
-        string $profile,
-        $settings,
-        array &$mutators
-    ): void {
-        foreach (ProfileList::ALL_PROFILES[$profile] as $mutatorOrProfile) {
-            /** @var string $mutatorOrProfile */
-
-            // A profile may refer to another collection of profiles
-            if (array_key_exists($mutatorOrProfile, ProfileList::ALL_PROFILES)) {
-                self::registerFromProfile($mutatorOrProfile, $settings, $mutators);
-
-                continue;
-            }
-
-            if (class_exists($mutatorOrProfile, true)) {
-                self::registerFromClass($mutatorOrProfile, $settings, $mutators);
-
-                continue;
-            }
-
-            throw new InvalidArgumentException(sprintf(
-                'The "%s" profile contains the "%s" mutator which was not recognized.',
-                $profile,
-                $mutatorOrProfile
-            ));
-        }
-    }
-
-    /**
-     * @param array<string, string>|bool           $settings
-     * @param array<string, array<string, string>> $mutators
-     */
-    private static function registerFromName(
-        string $mutator,
-        $settings,
-        array &$mutators
-    ): void {
-        if (!array_key_exists($mutator, ProfileList::ALL_MUTATORS)) {
-            throw new InvalidArgumentException(sprintf(
-                'The "%s" mutator/profile was not recognized.',
-                $mutator
-            ));
-        }
-
-        self::registerFromClass(
-            ProfileList::ALL_MUTATORS[$mutator],
-            $settings,
-            $mutators
-        );
-    }
-
-    /**
-     * @param array<string, string>|bool|stdClass  $settings
-     * @param array<string, array<string, string>> $mutators
-     */
-    private static function registerFromClass(
-        string $mutator,
-        $settings,
-        array &$mutators
-    ): void {
-        if ($settings === false) {
-            unset($mutators[$mutator]);
-        } else {
-            $mutators[$mutator] = $settings === true ? [] : (array) $settings;
-        }
-    }
-
-    /**
-     * @param array<string, array<string, string>> $mutatorNames
-     *
-     * @return array<string, Mutator>
-     */
-    private static function createFromNames(array $mutatorNames): array
-    {
-        $mutators = [];
-
-        foreach ($mutatorNames as $mutatorClass => $settings) {
             $mutatorConfig = new MutatorConfig($settings);
 
             // TODO: only pass the mutator config if necessary

--- a/src/Mutator/MutatorResolver.php
+++ b/src/Mutator/MutatorResolver.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator;
+
+use function array_key_exists;
+use function class_exists;
+use InvalidArgumentException;
+use function Safe\sprintf;
+use stdClass;
+
+/**
+ * @internal
+ */
+final class MutatorResolver
+{
+    /**
+     * Resolves the given hashmap of enabled, disabled or configured mutators
+     * and profiles into a hashmap of mutator raw settings by their mutator
+     * class name.
+     *
+     * @param array<string, bool|array<mixed>> $mutatorSettings
+     *
+     * @return array<string, array<mixed>>
+     */
+    public function resolve(array $mutatorSettings): array
+    {
+        $mutators = [];
+
+        foreach ($mutatorSettings as $mutatorOrProfile => $setting) {
+            if (array_key_exists($mutatorOrProfile, ProfileList::ALL_PROFILES)) {
+                self::registerFromProfile($mutatorOrProfile, $setting, $mutators);
+
+                continue;
+            }
+
+            if (array_key_exists($mutatorOrProfile, ProfileList::ALL_MUTATORS)) {
+                self::registerFromName($mutatorOrProfile, $setting, $mutators);
+
+                continue;
+            }
+
+            throw new InvalidArgumentException(sprintf(
+                'The profile or mutator "%s" was not recognized.',
+                $mutatorOrProfile
+            ));
+        }
+
+        return $mutators;
+    }
+
+    /**
+     * @param array<string, string>|bool           $settings
+     * @param array<string, array<string, string>> $mutators
+     */
+    private static function registerFromProfile(
+        string $profile,
+        $settings,
+        array &$mutators
+    ): void {
+        foreach (ProfileList::ALL_PROFILES[$profile] as $mutatorOrProfile) {
+            /** @var string $mutatorOrProfile */
+
+            // A profile may refer to another collection of profiles
+            if (array_key_exists($mutatorOrProfile, ProfileList::ALL_PROFILES)) {
+                self::registerFromProfile($mutatorOrProfile, $settings, $mutators);
+
+                continue;
+            }
+
+            if (class_exists($mutatorOrProfile, true)) {
+                self::registerFromClass($mutatorOrProfile, $settings, $mutators);
+
+                continue;
+            }
+
+            throw new InvalidArgumentException(sprintf(
+                'The "%s" profile contains the "%s" mutator which was not recognized.',
+                $profile,
+                $mutatorOrProfile
+            ));
+        }
+    }
+
+    /**
+     * @param array<string, string>|bool           $settings
+     * @param array<string, array<string, string>> $mutators
+     */
+    private static function registerFromName(
+        string $mutator,
+        $settings,
+        array &$mutators
+    ): void {
+        if (!array_key_exists($mutator, ProfileList::ALL_MUTATORS)) {
+            throw new InvalidArgumentException(sprintf(
+                'The "%s" mutator/profile was not recognized.',
+                $mutator
+            ));
+        }
+
+        self::registerFromClass(
+            ProfileList::ALL_MUTATORS[$mutator],
+            $settings,
+            $mutators
+        );
+    }
+
+    /**
+     * @param array<string, string>|bool|stdClass  $settings
+     * @param array<string, array<string, string>> $mutators
+     */
+    private static function registerFromClass(
+        string $mutatorClassName,
+        $settings,
+        array &$mutators
+    ): void {
+        if ($settings === false) {
+            unset($mutators[$mutatorClassName]);
+        } else {
+            $mutators[$mutatorClassName] = $settings === true ? [] : (array) $settings;
+        }
+    }
+}

--- a/src/Mutator/MutatorResolver.php
+++ b/src/Mutator/MutatorResolver.php
@@ -61,13 +61,21 @@ final class MutatorResolver
 
         foreach ($mutatorSettings as $mutatorOrProfile => $setting) {
             if (array_key_exists($mutatorOrProfile, ProfileList::ALL_PROFILES)) {
-                self::registerFromProfile($mutatorOrProfile, $setting, $mutators);
+                self::registerFromProfile(
+                    $mutatorOrProfile,
+                    $setting,
+                    $mutators
+                );
 
                 continue;
             }
 
             if (array_key_exists($mutatorOrProfile, ProfileList::ALL_MUTATORS)) {
-                self::registerFromName($mutatorOrProfile, $setting, $mutators);
+                self::registerFromName(
+                    $mutatorOrProfile,
+                    $setting,
+                    $mutators
+                );
 
                 continue;
             }
@@ -95,19 +103,28 @@ final class MutatorResolver
 
             // A profile may refer to another collection of profiles
             if (array_key_exists($mutatorOrProfile, ProfileList::ALL_PROFILES)) {
-                self::registerFromProfile($mutatorOrProfile, $settings, $mutators);
+                self::registerFromProfile(
+                    $mutatorOrProfile,
+                    $settings,
+                    $mutators
+                );
 
                 continue;
             }
 
             if (class_exists($mutatorOrProfile, true)) {
-                self::registerFromClass($mutatorOrProfile, $settings, $mutators);
+                self::registerFromClass(
+                    $mutatorOrProfile,
+                    $settings,
+                    $mutators
+                );
 
                 continue;
             }
 
             throw new InvalidArgumentException(sprintf(
-                'The "%s" profile contains the "%s" mutator which was not recognized.',
+                'The "%s" profile contains the "%s" mutator which was '
+                . 'not recognized.',
                 $profile,
                 $mutatorOrProfile
             ));

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -51,6 +51,7 @@ use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\MutatorParser;
+use Infection\Mutator\MutatorResolver;
 use Infection\Mutator\Removal\MethodCallRemoval;
 use Infection\Mutator\Util\MutatorConfig;
 use Infection\TestFramework\PhpSpec\PhpSpecExtraOptions;
@@ -100,6 +101,7 @@ final class ConfigurationFactoryTest extends TestCase
 
         $this->configFactory = new ConfigurationFactory(
             new TmpDirProvider(),
+            new MutatorResolver(),
             new MutatorFactory(),
             new MutatorParser(),
             $sourceFilesCollectorProphecy->reveal()
@@ -1293,7 +1295,9 @@ final class ConfigurationFactoryTest extends TestCase
     private static function getDefaultMutators(): array
     {
         if (null === self::$mutators) {
-            self::$mutators = (new MutatorFactory())->create(['@default' => true]);
+            self::$mutators = (new MutatorFactory())->create(
+                (new MutatorResolver())->resolve(['@default' => true])
+            );
         }
 
         return self::$mutators;

--- a/tests/phpunit/Mutator/MutatorFactoryTest.php
+++ b/tests/phpunit/Mutator/MutatorFactoryTest.php
@@ -35,20 +35,15 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator;
 
-use function array_diff;
 use function array_values;
 use function count;
 use function get_class;
-use Infection\Mutator\Arithmetic\Minus;
 use Infection\Mutator\Arithmetic\Plus;
-use Infection\Mutator\Boolean\FalseValue;
 use Infection\Mutator\Boolean\IdenticalEqual;
-use Infection\Mutator\Boolean\NotIdenticalNotEqual;
 use Infection\Mutator\Boolean\TrueValue;
 use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorFactory;
-use Infection\Mutator\ProfileList;
 use Infection\Visitor\ReflectionVisitor;
 use InvalidArgumentException;
 use PhpParser\Node;
@@ -73,117 +68,17 @@ final class MutatorFactoryTest extends TestCase
     {
         $mutators = $this->mutatorFactory->create([]);
 
-        $this->assertCount(0, $mutators);
+        $this->assertSame([], $mutators);
     }
 
-    public function test_it_can_creates_the_mutators_for_a_given_profile(): void
-    {
-        $mutators = $this->mutatorFactory->create(['@boolean' => true]);
-
-        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $mutators);
-    }
-
-    public function test_it_can_creates_the_mutators_with_empty_settings_for_a_given_profile(): void
-    {
-        $mutators = $this->mutatorFactory->create(['@boolean' => []]);
-
-        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $mutators);
-    }
-
-    public function test_it_can_creates_the_profile_mutators_with_the_given_settings(): void
-    {
-        // TODO: refactor this test to check the mutator configuration directly instead of relying
-        // on the canMutate() API which ends up testing other stuff and is also more cumbersome
-        // to employ.
-
-        $mutators = $this->mutatorFactory->create([
-            '@default' => true,
-            '@boolean' => [
-                'ignore' => ['A::B'],
-            ],
-        ]);
-
-        $this->assertSameMutatorsByClass(ProfileList::getDefaultProfileMutators(), $mutators);
-
-        /** @var MockObject|ReflectionClass $reflectionMock */
-        $reflectionMock = $this->createMock(ReflectionClass::class);
-        $reflectionMock
-            ->expects($this->exactly(3))
-            ->method('getName')
-            ->willReturn('A')
-        ;
-
-        $plusNode = $this->createPlusNode('B', $reflectionMock);
-        $falseNode = $this->createBoolNode('false', 'B', $reflectionMock);
-        $trueNode = $this->createBoolNode('true', 'B', $reflectionMock);
-
-        $this->assertTrue($mutators[MutatorName::getName(Plus::class)]->canMutate($plusNode));
-        $this->assertFalse($mutators[MutatorName::getName(TrueValue::class)]->canMutate($trueNode));
-        $this->assertFalse($mutators[MutatorName::getName(FalseValue::class)]->canMutate($falseNode));
-    }
-
-    public function test_it_can_ignore_a_profile(): void
-    {
-        $mutators = $this->mutatorFactory->create(['@boolean' => false]);
-
-        $this->assertCount(0, $mutators);
-    }
-
-    public function test_it_will_remove_the_mutators_from_the_ignored_profile_even_if_included_from_a_different_profile(): void
+    public function test_it_can_create_the_mutators_with_empty_settings(): void
     {
         $mutators = $this->mutatorFactory->create([
-             '@default' => true,
-             '@boolean' => false,
+            Plus::class => [],
+            IdenticalEqual::class => [],
         ]);
 
-        $expectedMutators = array_values(array_diff(
-            ProfileList::getDefaultProfileMutators(),
-            ProfileList::BOOLEAN_PROFILE
-        ));
-
-        $this->assertSameMutatorsByClass($expectedMutators, $mutators);
-    }
-
-    public function test_it_will_not_remove_the_mutators_from_the_ignored_profile_if_its_mutators_are_included_after(): void
-    {
-        $mutators = $this->mutatorFactory->create([
-            '@default' => false,
-            '@boolean' => true,
-        ]);
-
-        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $mutators);
-    }
-
-    public function test_it_can_create_mutators_from_their_names(): void
-    {
-        $mutators = $this->mutatorFactory->create([
-            MutatorName::getName(Plus::class) => true,
-            MutatorName::getName(Minus::class) => true,
-        ]);
-
-        $this->assertSameMutatorsByClass(
-            [
-                Plus::class,
-                Minus::class,
-            ],
-            $mutators
-        );
-    }
-
-    public function test_it_can_create_mutators_with_empty_settings_from_their_names(): void
-    {
-        $mutators = $this->mutatorFactory->create([
-            MutatorName::getName(Plus::class) => [],
-            MutatorName::getName(Minus::class) => [],
-        ]);
-
-        $this->assertSameMutatorsByClass(
-            [
-                Plus::class,
-                Minus::class,
-            ],
-            $mutators
-        );
+        $this->assertSameMutatorsByClass([Plus::class, IdenticalEqual::class], $mutators);
     }
 
     public function test_it_can_create_a_mutator_with_the_given_settings(): void
@@ -193,112 +88,74 @@ final class MutatorFactoryTest extends TestCase
         // to employ.
 
         $mutators = $this->mutatorFactory->create([
-            '@boolean' => true,
-            MutatorName::getName(TrueValue::class) => [
+            TrueValue::class => [
                 'ignore' => ['A::B'],
             ],
         ]);
 
-        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $mutators);
+        $this->assertSameMutatorsByClass([TrueValue::class], $mutators);
 
         /** @var MockObject|ReflectionClass $reflectionMock */
         $reflectionMock = $this->createMock(ReflectionClass::class);
         $reflectionMock
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('getName')
             ->willReturn('A')
         ;
 
-        $falseNode = $this->createBoolNode('false', 'B', $reflectionMock);
-        $trueNode = $this->createBoolNode('true', 'B', $reflectionMock);
+        $trueNode = $this->createBoolNode(
+            'true',
+            'B',
+            $reflectionMock
+        );
 
-        $this->assertFalse($mutators[MutatorName::getName(TrueValue::class)]->canMutate($trueNode));
-        $this->assertTrue($mutators[MutatorName::getName(FalseValue::class)]->canMutate($falseNode));
-    }
-
-    public function test_it_can_ignore_a_mutator(): void
-    {
-        $mutators = $this->mutatorFactory->create([MutatorName::getName(Plus::class) => false]);
-
-        $this->assertCount(0, $mutators);
-    }
-
-    public function test_it_will_remove_the_ignored_mutators_if_they_were_included_previously(): void
-    {
-        $mutators = $this->mutatorFactory->create([
-            '@equal' => true,
-            MutatorName::getName(IdenticalEqual::class) => false,
-        ]);
-
-        $this->assertSameMutatorsByClass(
-            [NotIdenticalNotEqual::class],
-            $mutators
+        $this->assertFalse(
+            $mutators[MutatorName::getName(TrueValue::class)]->canMutate($trueNode)
         );
     }
 
-    public function test_it_will_not_remove_the_ignored_mutators_if_they_were_included_afterwards(): void
-    {
-        $mutators = $this->mutatorFactory->create([
-            MutatorName::getName(IdenticalEqual::class) => false,
-            '@equal' => true,
-        ]);
-
-        $this->assertSameMutatorsByClass(ProfileList::EQUAL_PROFILE, $mutators);
-    }
-
-    public function test_a_mutator_will_be_created_only_once_even_if_included_multiple_times(): void
-    {
-        $mutators = $this->mutatorFactory->create([
-            MutatorName::getName(IdenticalEqual::class) => true,
-            '@equal' => true,
-            MutatorName::getName(NotIdenticalNotEqual::class) => true,
-        ]);
-
-        $this->assertSameMutatorsByClass(ProfileList::EQUAL_PROFILE, $mutators);
-    }
-
-    public function test_it_cannot_create_mutators_for_unknown_profiles(): void
+    public function test_it_cannot_create_a_mutator_with_invalid_settings(): void
     {
         try {
-            $this->mutatorFactory->create(['@unknown-profile' => true]);
+            $this->mutatorFactory->create([Plus::class => false]);
 
             $this->fail();
         } catch (InvalidArgumentException $exception) {
             $this->assertSame(
-                'The profile or mutator "@unknown-profile" was not recognized.',
+                'Expected settings of the mutator "Infection\Mutator\Arithmetic\Plus" to be an array. Got "boolean" instead',
                 $exception->getMessage()
             );
         }
+    }
+
+    public function test_it_can_create_the_mutators_with_unknown_settings(): void
+    {
+        $mutators = $this->mutatorFactory->create([
+            Plus::class => ['unknown' => 'dunno'],
+        ]);
+
+        $this->assertSameMutatorsByClass([Plus::class], $mutators);
     }
 
     public function test_it_cannot_create_an_unknown_mutator(): void
     {
         try {
-            $this->mutatorFactory->create(['Unknwon\Mutator' => true]);
+            $this->mutatorFactory->create(['Unknwon\Mutator' => []]);
 
             $this->fail();
         } catch (InvalidArgumentException $exception) {
             $this->assertSame(
-                'The profile or mutator "Unknwon\Mutator" was not recognized.',
+                'Unknown mutator "Unknwon\Mutator"',
                 $exception->getMessage()
             );
         }
     }
 
-    private function createPlusNode(string $functionName, ReflectionClass $reflectionMock): Node
-    {
-        return new Node\Expr\BinaryOp\Plus(
-            new Node\Scalar\DNumber(1.23),
-            new Node\Scalar\DNumber(1.23),
-            [
-                ReflectionVisitor::REFLECTION_CLASS_KEY => $reflectionMock,
-                ReflectionVisitor::FUNCTION_NAME => $functionName,
-            ]
-        );
-    }
-
-    private function createBoolNode(string $boolean, string $functionName, ReflectionClass $reflectionMock): Node
-    {
+    private function createBoolNode(
+        string $boolean,
+        string $functionName,
+        ReflectionClass $reflectionMock
+    ): Node {
         return new Node\Expr\ConstFetch(
             new Node\Name($boolean),
             [
@@ -309,22 +166,22 @@ final class MutatorFactoryTest extends TestCase
     }
 
     /**
-     * @param string[]               $expectedMutators
+     * @param string[]               $expectedMutatorClassNames
      * @param array<string, Mutator> $actualMutators
      */
-    private function assertSameMutatorsByClass(array $expectedMutators, array $actualMutators): void
-    {
-        $this->assertCount(count($expectedMutators), $actualMutators);
+    private function assertSameMutatorsByClass(
+        array $expectedMutatorClassNames,
+        array $actualMutators
+    ): void {
+        $this->assertCount(count($expectedMutatorClassNames), $actualMutators);
 
-        $ignoreMutatorReflection = new ReflectionClass(IgnoreMutator::class);
-
-        $decoratedMutatorReflection = $ignoreMutatorReflection->getProperty('mutator');
+        $decoratedMutatorReflection = (new ReflectionClass(IgnoreMutator::class))->getProperty('mutator');
         $decoratedMutatorReflection->setAccessible(true);
 
         foreach (array_values($actualMutators) as $index => $mutator) {
             $this->assertInstanceOf(IgnoreMutator::class, $mutator);
 
-            $expectedMutatorClass = $expectedMutators[$index];
+            $expectedMutatorClass = $expectedMutatorClassNames[$index];
             $actualMutatorClass = get_class($decoratedMutatorReflection->getValue($mutator));
 
             $this->assertSame(

--- a/tests/phpunit/Mutator/MutatorFactoryTest.php
+++ b/tests/phpunit/Mutator/MutatorFactoryTest.php
@@ -78,7 +78,10 @@ final class MutatorFactoryTest extends TestCase
             IdenticalEqual::class => [],
         ]);
 
-        $this->assertSameMutatorsByClass([Plus::class, IdenticalEqual::class], $mutators);
+        $this->assertSameMutatorsByClass(
+            [Plus::class, IdenticalEqual::class],
+            $mutators
+        );
     }
 
     public function test_it_can_create_a_mutator_with_the_given_settings(): void

--- a/tests/phpunit/Mutator/MutatorResolverTest.php
+++ b/tests/phpunit/Mutator/MutatorResolverTest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\Mutator;
 use function array_diff;
 use function array_values;
 use function count;
-use function in_array;
 use Infection\Mutator\Arithmetic\Minus;
 use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\Boolean\IdenticalEqual;
@@ -74,14 +73,20 @@ final class MutatorResolverTest extends TestCase
     {
         $resolvedMutators = $this->mutatorResolver->resolve(['@boolean' => true]);
 
-        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $resolvedMutators);
+        $this->assertSameMutatorsByClass(
+            ProfileList::BOOLEAN_PROFILE,
+            $resolvedMutators
+        );
     }
 
     public function test_it_can_resolves_the_mutators_with_empty_settings_for_a_given_profile(): void
     {
         $resolvedMutators = $this->mutatorResolver->resolve(['@boolean' => []]);
 
-        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $resolvedMutators);
+        $this->assertSameMutatorsByClass(
+            ProfileList::BOOLEAN_PROFILE,
+            $resolvedMutators
+        );
     }
 
     public function test_it_can_resolves_the_profile_mutators_with_the_given_settings(): void
@@ -93,7 +98,10 @@ final class MutatorResolverTest extends TestCase
             ],
         ]);
 
-        $this->assertSameMutatorsByClass(ProfileList::getDefaultProfileMutators(), $resolvedMutators);
+        $this->assertSameMutatorsByClass(
+            ProfileList::getDefaultProfileMutators(),
+            $resolvedMutators
+        );
 
         foreach (ProfileList::BOOLEAN_PROFILE as $booleanMutatorClassName) {
             $this->assertSame($settings, $resolvedMutators[$booleanMutatorClassName]);
@@ -129,7 +137,10 @@ final class MutatorResolverTest extends TestCase
             '@boolean' => true,
         ]);
 
-        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $resolvedMutators);
+        $this->assertSameMutatorsByClass(
+            ProfileList::BOOLEAN_PROFILE,
+            $resolvedMutators
+        );
     }
 
     public function test_it_can_resolve_mutators_from_their_names(): void
@@ -173,14 +184,19 @@ final class MutatorResolverTest extends TestCase
             ],
         ]);
 
-        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $resolvedMutators);
+        $this->assertSameMutatorsByClass(
+            ProfileList::BOOLEAN_PROFILE,
+            $resolvedMutators
+        );
 
         $this->assertSame($settings, $resolvedMutators[TrueValue::class]);
     }
 
     public function test_it_can_ignore_a_mutator(): void
     {
-        $resolvedMutators = $this->mutatorResolver->resolve([MutatorName::getName(Plus::class) => false]);
+        $resolvedMutators = $this->mutatorResolver->resolve(
+            [MutatorName::getName(Plus::class) => false]
+        );
 
         $this->assertCount(0, $resolvedMutators);
     }
@@ -205,7 +221,10 @@ final class MutatorResolverTest extends TestCase
             '@equal' => true,
         ]);
 
-        $this->assertSameMutatorsByClass(ProfileList::EQUAL_PROFILE, $resolvedMutators);
+        $this->assertSameMutatorsByClass(
+            ProfileList::EQUAL_PROFILE,
+            $resolvedMutators
+        );
     }
 
     public function test_a_mutator_will_be_resolved_only_once_even_if_included_multiple_times(): void
@@ -216,7 +235,10 @@ final class MutatorResolverTest extends TestCase
             MutatorName::getName(NotIdenticalNotEqual::class) => true,
         ]);
 
-        $this->assertSameMutatorsByClass(ProfileList::EQUAL_PROFILE, $resolvedMutators);
+        $this->assertSameMutatorsByClass(
+            ProfileList::EQUAL_PROFILE,
+            $resolvedMutators
+        );
     }
 
     public function test_it_cannot_resolve_mutators_for_unknown_profiles(): void
@@ -258,7 +280,7 @@ final class MutatorResolverTest extends TestCase
         $index = 0;
 
         foreach ($actualMutators as $mutatorClassName => $settings) {
-            $this->assertTrue(in_array($mutatorClassName, ProfileList::ALL_MUTATORS, true));
+            $this->assertContains($mutatorClassName, ProfileList::ALL_MUTATORS);
 
             $expectedMutatorClass = $expectedMutators[$index];
 

--- a/tests/phpunit/Mutator/MutatorResolverTest.php
+++ b/tests/phpunit/Mutator/MutatorResolverTest.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator;
+
+use function array_diff;
+use function array_values;
+use function count;
+use function in_array;
+use Infection\Mutator\Arithmetic\Minus;
+use Infection\Mutator\Arithmetic\Plus;
+use Infection\Mutator\Boolean\IdenticalEqual;
+use Infection\Mutator\Boolean\NotIdenticalNotEqual;
+use Infection\Mutator\Boolean\TrueValue;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\MutatorResolver;
+use Infection\Mutator\ProfileList;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use function Safe\sprintf;
+
+final class MutatorResolverTest extends TestCase
+{
+    /**
+     * @var MutatorResolver
+     */
+    private $mutatorResolver;
+
+    protected function setUp(): void
+    {
+        $this->mutatorResolver = new MutatorResolver();
+    }
+
+    public function test_it_resolves_no_mutator_if_no_profile_or_mutator_is_passed(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([]);
+
+        $this->assertCount(0, $resolvedMutators);
+    }
+
+    public function test_it_can_resolves_the_mutators_for_a_given_profile(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve(['@boolean' => true]);
+
+        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $resolvedMutators);
+    }
+
+    public function test_it_can_resolves_the_mutators_with_empty_settings_for_a_given_profile(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve(['@boolean' => []]);
+
+        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $resolvedMutators);
+    }
+
+    public function test_it_can_resolves_the_profile_mutators_with_the_given_settings(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([
+            '@default' => true,
+            '@boolean' => $settings = [
+                'ignore' => ['A::B'],
+            ],
+        ]);
+
+        $this->assertSameMutatorsByClass(ProfileList::getDefaultProfileMutators(), $resolvedMutators);
+
+        foreach (ProfileList::BOOLEAN_PROFILE as $booleanMutatorClassName) {
+            $this->assertSame($settings, $resolvedMutators[$booleanMutatorClassName]);
+        }
+    }
+
+    public function test_it_can_ignore_a_profile(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve(['@boolean' => false]);
+
+        $this->assertCount(0, $resolvedMutators);
+    }
+
+    public function test_it_will_remove_the_mutators_from_the_ignored_profile_even_if_included_from_a_different_profile(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([
+             '@default' => true,
+             '@boolean' => false,
+        ]);
+
+        $expectedMutators = array_values(array_diff(
+            ProfileList::getDefaultProfileMutators(),
+            ProfileList::BOOLEAN_PROFILE
+        ));
+
+        $this->assertSameMutatorsByClass($expectedMutators, $resolvedMutators);
+    }
+
+    public function test_it_will_not_remove_the_mutators_from_the_ignored_profile_if_its_mutators_are_included_after(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([
+            '@default' => false,
+            '@boolean' => true,
+        ]);
+
+        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $resolvedMutators);
+    }
+
+    public function test_it_can_resolve_mutators_from_their_names(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([
+            MutatorName::getName(Plus::class) => true,
+            MutatorName::getName(Minus::class) => true,
+        ]);
+
+        $this->assertSameMutatorsByClass(
+            [
+                Plus::class,
+                Minus::class,
+            ],
+            $resolvedMutators
+        );
+    }
+
+    public function test_it_can_resolve_mutators_with_empty_settings_from_their_names(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([
+            MutatorName::getName(Plus::class) => [],
+            MutatorName::getName(Minus::class) => [],
+        ]);
+
+        $this->assertSameMutatorsByClass(
+            [
+                Plus::class,
+                Minus::class,
+            ],
+            $resolvedMutators
+        );
+    }
+
+    public function test_it_can_resolve_a_mutator_with_the_given_settings(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([
+            '@boolean' => true,
+            MutatorName::getName(TrueValue::class) => $settings = [
+                'ignore' => ['A::B'],
+            ],
+        ]);
+
+        $this->assertSameMutatorsByClass(ProfileList::BOOLEAN_PROFILE, $resolvedMutators);
+
+        $this->assertSame($settings, $resolvedMutators[TrueValue::class]);
+    }
+
+    public function test_it_can_ignore_a_mutator(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([MutatorName::getName(Plus::class) => false]);
+
+        $this->assertCount(0, $resolvedMutators);
+    }
+
+    public function test_it_will_remove_the_ignored_mutators_if_they_were_included_previously(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([
+            '@equal' => true,
+            MutatorName::getName(IdenticalEqual::class) => false,
+        ]);
+
+        $this->assertSameMutatorsByClass(
+            [NotIdenticalNotEqual::class],
+            $resolvedMutators
+        );
+    }
+
+    public function test_it_will_not_remove_the_ignored_mutators_if_they_were_included_afterwards(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([
+            MutatorName::getName(IdenticalEqual::class) => false,
+            '@equal' => true,
+        ]);
+
+        $this->assertSameMutatorsByClass(ProfileList::EQUAL_PROFILE, $resolvedMutators);
+    }
+
+    public function test_a_mutator_will_be_resolved_only_once_even_if_included_multiple_times(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([
+            MutatorName::getName(IdenticalEqual::class) => true,
+            '@equal' => true,
+            MutatorName::getName(NotIdenticalNotEqual::class) => true,
+        ]);
+
+        $this->assertSameMutatorsByClass(ProfileList::EQUAL_PROFILE, $resolvedMutators);
+    }
+
+    public function test_it_cannot_resolve_mutators_for_unknown_profiles(): void
+    {
+        try {
+            $this->mutatorResolver->resolve(['@unknown-profile' => true]);
+
+            $this->fail();
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'The profile or mutator "@unknown-profile" was not recognized.',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    public function test_it_cannot_resolve_an_unknown_mutator(): void
+    {
+        try {
+            $this->mutatorResolver->resolve(['Unknwon\Mutator' => true]);
+
+            $this->fail();
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(
+                'The profile or mutator "Unknwon\Mutator" was not recognized.',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    /**
+     * @param string[]               $expectedMutators
+     * @param array<string, Mutator> $actualMutators
+     */
+    private function assertSameMutatorsByClass(array $expectedMutators, array $actualMutators): void
+    {
+        $this->assertCount(count($expectedMutators), $actualMutators);
+
+        $index = 0;
+
+        foreach ($actualMutators as $mutatorClassName => $settings) {
+            $this->assertTrue(in_array($mutatorClassName, ProfileList::ALL_MUTATORS, true));
+
+            $expectedMutatorClass = $expectedMutators[$index];
+
+            $this->assertSame(
+                $expectedMutatorClass,
+                $mutatorClassName,
+                sprintf(
+                    'Expected the %d-th mutator to be an instance of "%s". Got "%s"',
+                    $index,
+                    $expectedMutatorClass,
+                    $mutatorClassName
+                )
+            );
+
+            $this->assertIsArray($settings);
+
+            ++$index;
+        }
+    }
+}


### PR DESCRIPTION
The current `MutatorFactory` is doing a bit too much IMO. Indeed it:

- _resolves_ the mutators, i.e. working out from the list of mutator names/class names and profiles with settings, the final list of mutator class names with their settings
- instantiate the mutators from that resolved list

Since so far the instantiation part was relatively trivial, it was ok. But as I'm introducing #1004 and #1005, the instantiate is going to get a bit more interesting. As a result, it makes more sense to split up the factory now with `MutatorResolver` which does the resolving part