### PR TITLE
Use method_exists instead of versions

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -87,7 +87,6 @@ use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use Infection\TestFramework\PhpUnit\Coverage\IndexXmlCoverageParser;
 use Infection\TestFramework\TestFrameworkAdapter;
-use Infection\Utils\VersionParser;
 use InvalidArgumentException;
 use function is_callable;
 use function php_ini_loaded_file;
@@ -211,9 +210,6 @@ final class Container
                 return new MemoizedTestFileDataProvider(
                     new JUnitTestFileDataProvider($container->getJUnitFilePath())
                 );
-            },
-            VersionParser::class => static function (): VersionParser {
-                return new VersionParser();
             },
             Lexer::class => static function (): Lexer {
                 $attributes = Mutation::ATTRIBUTE_KEYS;
@@ -359,8 +355,7 @@ final class Container
             },
             InitialTestRunProcessBuilder::class => static function (self $container): InitialTestRunProcessBuilder {
                 return new InitialTestRunProcessBuilder(
-                    $container->getTestFrameworkAdapter(),
-                    $container->getVersionParser()
+                    $container->getTestFrameworkAdapter()
                 );
             },
             InitialTestsRunner::class => static function (self $container): InitialTestsRunner {
@@ -372,7 +367,6 @@ final class Container
             MutantProcessBuilder::class => static function (self $container): MutantProcessBuilder {
                 return new MutantProcessBuilder(
                     $container->getTestFrameworkAdapter(),
-                    $container->getVersionParser(),
                     $container->getConfiguration()->getProcessTimeout()
                 );
             },
@@ -567,11 +561,6 @@ final class Container
     public function getMemoizedTestFileDataProvider(): MemoizedTestFileDataProvider
     {
         return $this->get(MemoizedTestFileDataProvider::class);
-    }
-
-    public function getVersionParser(): VersionParser
-    {
-        return $this->get(VersionParser::class);
     }
 
     public function getLexer(): Lexer

--- a/src/Process/Builder/InitialTestRunProcessBuilder.php
+++ b/src/Process/Builder/InitialTestRunProcessBuilder.php
@@ -37,8 +37,7 @@ namespace Infection\Process\Builder;
 
 use Infection\Console\Util\PhpProcess;
 use Infection\TestFramework\TestFrameworkAdapter;
-use Infection\Utils\VersionParser;
-use PackageVersions\Versions;
+use function method_exists;
 use Symfony\Component\Process\Process;
 
 /**
@@ -47,12 +46,10 @@ use Symfony\Component\Process\Process;
 class InitialTestRunProcessBuilder
 {
     private $testFrameworkAdapter;
-    private $versionParser;
 
-    public function __construct(TestFrameworkAdapter $testFrameworkAdapter, VersionParser $versionParser)
+    public function __construct(TestFrameworkAdapter $testFrameworkAdapter)
     {
         $this->testFrameworkAdapter = $testFrameworkAdapter;
-        $this->versionParser = $versionParser;
     }
 
     /**
@@ -77,9 +74,7 @@ class InitialTestRunProcessBuilder
 
         $process->setTimeout(null); // ignore the default timeout of 60 seconds
 
-        $symfonyProcessVersion = $this->versionParser->parse(Versions::getVersion('symfony/process'));
-
-        if (version_compare($symfonyProcessVersion, '4.4.0', '<')) {
+        if (method_exists($process, 'inheritEnvironmentVariables')) {
             // in version 4.4.0 this method is deprecated and removed in 5.0.0
             $process->inheritEnvironmentVariables();
         }

--- a/src/Process/Builder/MutantProcessBuilder.php
+++ b/src/Process/Builder/MutantProcessBuilder.php
@@ -38,8 +38,7 @@ namespace Infection\Process\Builder;
 use Infection\Mutant\Mutant;
 use Infection\Process\MutantProcess;
 use Infection\TestFramework\TestFrameworkAdapter;
-use Infection\Utils\VersionParser;
-use PackageVersions\Versions;
+use function method_exists;
 use Symfony\Component\Process\Process;
 
 /**
@@ -49,13 +48,11 @@ final class MutantProcessBuilder
 {
     private $testFrameworkAdapter;
     private $timeout;
-    private $versionParser;
 
-    public function __construct(TestFrameworkAdapter $testFrameworkAdapter, VersionParser $versionParser, int $timeout)
+    public function __construct(TestFrameworkAdapter $testFrameworkAdapter, int $timeout)
     {
         $this->testFrameworkAdapter = $testFrameworkAdapter;
         $this->timeout = $timeout;
-        $this->versionParser = $versionParser;
     }
 
     public function createProcessForMutant(Mutant $mutant, string $testFrameworkExtraOptions = ''): MutantProcess
@@ -72,9 +69,7 @@ final class MutantProcessBuilder
 
         $process->setTimeout((float) $this->timeout);
 
-        $symfonyProcessVersion = $this->versionParser->parse(Versions::getVersion('symfony/process'));
-
-        if (version_compare($symfonyProcessVersion, '4.4.0', '<')) {
+        if (method_exists($process, 'inheritEnvironmentVariables')) {
             // in version 4.4.0 this method is deprecated and removed in 5.0.0
             $process->inheritEnvironmentVariables();
         }

--- a/tests/phpunit/Process/Builder/InitialTestRunProcessBuilderTest.php
+++ b/tests/phpunit/Process/Builder/InitialTestRunProcessBuilderTest.php
@@ -37,7 +37,6 @@ namespace Infection\Tests\Process\Builder;
 
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
-use Infection\Utils\VersionParser;
 use PHPUnit\Framework\TestCase;
 
 final class InitialTestRunProcessBuilderTest extends TestCase
@@ -48,7 +47,7 @@ final class InitialTestRunProcessBuilderTest extends TestCase
         $fwAdapter->method('getInitialTestRunCommandLine')
             ->willReturn(['/usr/bin/php']);
 
-        $builder = new InitialTestRunProcessBuilder($fwAdapter, new VersionParser());
+        $builder = new InitialTestRunProcessBuilder($fwAdapter);
 
         $process = $builder->createProcess('', false);
 

--- a/tests/phpunit/Process/Builder/MutantProcessBuilderTest.php
+++ b/tests/phpunit/Process/Builder/MutantProcessBuilderTest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\Process\Builder;
 use Infection\Mutant\Mutant;
 use Infection\Process\Builder\MutantProcessBuilder;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
-use Infection\Utils\VersionParser;
 use PHPUnit\Framework\TestCase;
 
 final class MutantProcessBuilderTest extends TestCase
@@ -49,7 +48,7 @@ final class MutantProcessBuilderTest extends TestCase
         $fwAdapter->method('getMutantCommandLine')
             ->willReturn(['/usr/bin/php']);
 
-        $builder = new MutantProcessBuilder($fwAdapter, new VersionParser(), 100);
+        $builder = new MutantProcessBuilder($fwAdapter, 100);
 
         $process = $builder->createProcessForMutant($this->createMock(Mutant::class))->getProcess();
 


### PR DESCRIPTION
This PR:

Fixes #1007

Replace usage of `VersionParser` with `method_exists` since its behavior is not consistent with different dependency options (for example. transitive dependencies)