### PR TITLE
Move VersionParser under the TestFramework namespace

### DIFF
--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -38,7 +38,6 @@ namespace Infection\TestFramework;
 use Infection\TestFramework\Config\InitialConfigBuilder;
 use Infection\TestFramework\Config\MutationConfigBuilder;
 use Infection\TestFramework\Coverage\CoverageLineData;
-use Infection\Utils\VersionParser;
 use InvalidArgumentException;
 use Symfony\Component\Process\Process;
 

--- a/src/TestFramework/Codeception/Adapter/CodeceptionAdapter.php
+++ b/src/TestFramework/Codeception/Adapter/CodeceptionAdapter.php
@@ -35,9 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Codeception\Adapter;
 
-use function array_key_exists;
-use function assert;
-use function dirname;
 use Infection\TestFramework\Codeception\Stringifier;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\Coverage\CoverageLineData;
@@ -45,13 +42,16 @@ use Infection\TestFramework\Coverage\XmlReport\JUnitTestCaseSorter;
 use Infection\TestFramework\MemoryUsageAware;
 use Infection\TestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\TestFrameworkTypes;
-use Infection\Utils\VersionParser;
+use Infection\TestFramework\VersionParser;
 use InvalidArgumentException;
-use function is_string;
 use Phar;
-use function Safe\file_put_contents;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
+use function array_key_exists;
+use function assert;
+use function dirname;
+use function is_string;
+use function Safe\file_put_contents;
 
 /**
  * @internal

--- a/src/TestFramework/Codeception/Adapter/CodeceptionAdapter.php
+++ b/src/TestFramework/Codeception/Adapter/CodeceptionAdapter.php
@@ -35,6 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Codeception\Adapter;
 
+use function array_key_exists;
+use function assert;
+use function dirname;
 use Infection\TestFramework\Codeception\Stringifier;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\Coverage\CoverageLineData;
@@ -44,14 +47,11 @@ use Infection\TestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\TestFrameworkTypes;
 use Infection\TestFramework\VersionParser;
 use InvalidArgumentException;
+use function is_string;
 use Phar;
+use function Safe\file_put_contents;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
-use function array_key_exists;
-use function assert;
-use function dirname;
-use function is_string;
-use function Safe\file_put_contents;
 
 /**
  * @internal

--- a/src/TestFramework/Codeception/Adapter/CodeceptionAdapterFactory.php
+++ b/src/TestFramework/Codeception/Adapter/CodeceptionAdapterFactory.php
@@ -42,11 +42,11 @@ use Infection\TestFramework\TestFrameworkAdapterFactory;
 use Infection\TestFramework\TestFrameworkConfigParseException;
 use Infection\TestFramework\VersionParser;
 use LogicException;
+use function Safe\file_get_contents;
+use function Safe\sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
-use function Safe\file_get_contents;
-use function Safe\sprintf;
 
 /**
  * @internal

--- a/src/TestFramework/Codeception/Adapter/CodeceptionAdapterFactory.php
+++ b/src/TestFramework/Codeception/Adapter/CodeceptionAdapterFactory.php
@@ -40,13 +40,13 @@ use Infection\TestFramework\Coverage\XmlReport\JUnitTestCaseSorter;
 use Infection\TestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\TestFrameworkAdapterFactory;
 use Infection\TestFramework\TestFrameworkConfigParseException;
-use Infection\Utils\VersionParser;
+use Infection\TestFramework\VersionParser;
 use LogicException;
-use function Safe\file_get_contents;
-use function Safe\sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
+use function Safe\file_get_contents;
+use function Safe\sprintf;
 
 /**
  * @internal

--- a/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapterFactory.php
+++ b/src/TestFramework/PhpSpec/Adapter/PhpSpecAdapterFactory.php
@@ -41,7 +41,7 @@ use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\TestFrameworkAdapterFactory;
-use Infection\Utils\VersionParser;
+use Infection\TestFramework\VersionParser;
 
 /**
  * @internal

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -44,9 +44,9 @@ use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use Infection\TestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\TestFrameworkAdapterFactory;
-use Infection\Utils\VersionParser;
-use function Safe\file_get_contents;
+use Infection\TestFramework\VersionParser;
 use Symfony\Component\Filesystem\Filesystem;
+use function Safe\file_get_contents;
 
 /**
  * @internal

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -45,8 +45,8 @@ use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
 use Infection\TestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\TestFrameworkAdapterFactory;
 use Infection\TestFramework\VersionParser;
-use Symfony\Component\Filesystem\Filesystem;
 use function Safe\file_get_contents;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal

--- a/src/TestFramework/VersionParser.php
+++ b/src/TestFramework/VersionParser.php
@@ -33,11 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Utils;
+namespace Infection\TestFramework;
 
+use Webmozart\Assert\Assert;
 use function Safe\preg_match;
 use function Safe\sprintf;
-use Webmozart\Assert\Assert;
 
 /**
  * @internal

--- a/src/TestFramework/VersionParser.php
+++ b/src/TestFramework/VersionParser.php
@@ -35,9 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework;
 
-use Webmozart\Assert\Assert;
 use function Safe\preg_match;
 use function Safe\sprintf;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal

--- a/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
+++ b/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
@@ -41,11 +41,11 @@ use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\Coverage\XmlReport\JUnitTestCaseSorter;
 use Infection\TestFramework\MemoryUsageAware;
 use Infection\TestFramework\TestFrameworkTypes;
+use Infection\TestFramework\VersionParser;
 use Infection\Tests\FileSystem\FileSystemTestCase;
-use function Infection\Tests\normalizePath as p;
-use Infection\Utils\VersionParser;
-use function realpath;
 use Symfony\Component\Filesystem\Filesystem;
+use function Infection\Tests\normalizePath as p;
+use function realpath;
 
 /**
  * @group integration Requires some I/O operations

--- a/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
+++ b/tests/phpunit/TestFramework/Codeception/Adapter/CodeceptionAdapterTest.php
@@ -43,9 +43,9 @@ use Infection\TestFramework\MemoryUsageAware;
 use Infection\TestFramework\TestFrameworkTypes;
 use Infection\TestFramework\VersionParser;
 use Infection\Tests\FileSystem\FileSystemTestCase;
-use Symfony\Component\Filesystem\Filesystem;
 use function Infection\Tests\normalizePath as p;
 use function realpath;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @group integration Requires some I/O operations

--- a/tests/phpunit/TestFramework/PhpSpec/Adapter/PhpSpecAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpSpec/Adapter/PhpSpecAdapterTest.php
@@ -40,7 +40,7 @@ use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapter;
 use Infection\TestFramework\PhpSpec\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpSpec\Config\Builder\MutationConfigBuilder;
-use Infection\Utils\VersionParser;
+use Infection\TestFramework\VersionParser;
 use PHPUnit\Framework\TestCase;
 
 final class PhpSpecAdapterTest extends TestCase

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -41,7 +41,7 @@ use Infection\TestFramework\MemoryUsageAware;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
 use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
-use Infection\Utils\VersionParser;
+use Infection\TestFramework\VersionParser;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/phpunit/TestFramework/VersionParserTest.php
+++ b/tests/phpunit/TestFramework/VersionParserTest.php
@@ -33,10 +33,10 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Utils;
+namespace Infection\Tests\TestFramework;
 
 use Generator;
-use Infection\Utils\VersionParser;
+use Infection\TestFramework\VersionParser;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
Since `VersionParser` is no longer used with `Process` (cf. #1008), it is only used for the test frameworks hence the move