### PR TITLE
Use `infection/extension-installer` to automatically register Test Framework Adapters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "composer/xdebug-handler": "^1.3.3",
         "infection/abstract-testframework-adapter": "^0.2.3",
         "infection/codeception-adapter": "^0.3.0",
+        "infection/extension-installer": "^0.1.0",
         "infection/include-interceptor": "^0.2.2",
         "justinrainbow/json-schema": "^5.2",
         "nikic/php-parser": "^4.2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a9bc546d2b97ffe5cab4dd3c41ed301",
+    "content-hash": "da1ca960b2e2f98fe5c4b69911d05b7f",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -131,6 +131,49 @@
             ],
             "description": "Codeception Test Framework Adapter for Infection",
             "time": "2020-01-19T20:11:57+00:00"
+        },
+        {
+            "name": "infection/extension-installer",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/extension-installer.git",
+                "reference": "c8aebfcbef3015f3869c64fb1a0b02f6dbc51564"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/extension-installer/zipball/c8aebfcbef3015f3869c64fb1a0b02f6dbc51564",
+                "reference": "c8aebfcbef3015f3869c64fb1a0b02f6dbc51564",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9",
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Infection\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Infection\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com"
+                }
+            ],
+            "description": "Infection Extension Installer",
+            "time": "2020-01-24T07:44:13+00:00"
         },
         {
             "name": "infection/include-interceptor",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da1ca960b2e2f98fe5c4b69911d05b7f",
+    "content-hash": "cc29be5b5519ae9b900e9b7a34f24475",
     "packages": [
         {
             "name": "composer/xdebug-handler",

--- a/src/Container.php
+++ b/src/Container.php
@@ -50,6 +50,7 @@ use Infection\Differ\DiffColorizer;
 use Infection\Differ\Differ;
 use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\EventDispatcher\SyncEventDispatcher;
+use Infection\ExtensionInstaller\GeneratedExtensionsConfig;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\FileSystem\Locator\RootsFileLocator;
 use Infection\FileSystem\Locator\RootsFileOrDirectoryLocator;
@@ -172,7 +173,8 @@ final class Container
                     $container->getTestFrameworkConfigLocator(),
                     $container->getTestFrameworkFinder(),
                     $container->getJUnitFilePath(),
-                    $config
+                    $config,
+                    GeneratedExtensionsConfig::EXTENSIONS
                 );
             },
             XmlConfigurationHelper::class => static function (self $container): XmlConfigurationHelper {

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -39,6 +39,7 @@ use function implode;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
 use Infection\Configuration\Configuration;
+use Infection\ExtensionInstaller\GeneratedExtensionsConfig;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapterFactory;
@@ -110,32 +111,26 @@ final class Factory
             );
         }
 
-        $extensionsClassExists = class_exists('\Infection\ExtensionInstaller\GeneratedExtensionsConfig');
+        foreach (GeneratedExtensionsConfig::EXTENSIONS as $packageName => $installedExtension) {
+            $factory = $installedExtension['extra']['class'];
 
-        if ($extensionsClassExists) {
-            $installedExtensions = \Infection\ExtensionInstaller\GeneratedExtensionsConfig::EXTENSIONS;
+            Assert::classExists($factory);
 
-            foreach ($installedExtensions as $packageName => $installedExtension) {
-                $factory = $installedExtension['extra']['class'];
+            if (!is_a($factory, TestFrameworkAdapterFactory::class, true)) {
+                continue;
+            }
 
-                Assert::classExists($factory);
-
-                if (!is_a($factory, TestFrameworkAdapterFactory::class, true)) {
-                    continue;
-                }
-
-                if ($adapterName === $factory::getAdapterName()) {
-                    return $factory::create(
-                        $this->testFrameworkFinder->find($factory::getExecutableName())
-                        $this->tmpDir,
-                        $this->configLocator->locate($factory::getAdapterName()),
-                        null,
-                        $this->jUnitFilePath,
-                        $this->projectDir,
-                        $this->infectionConfig->getSourceDirectories(),
-                        $skipCoverage
-                    );
-                }
+            if ($adapterName === $factory::getAdapterName()) {
+                return $factory::create(
+                    $this->testFrameworkFinder->find($factory::getExecutableName())
+                    $this->tmpDir,
+                    $this->configLocator->locate($factory::getAdapterName()),
+                    null,
+                    $this->jUnitFilePath,
+                    $this->projectDir,
+                    $this->infectionConfig->getSourceDirectories(),
+                    $skipCoverage
+                );
             }
         }
 

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -39,7 +39,6 @@ use function implode;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
 use Infection\Configuration\Configuration;
-use Infection\ExtensionInstaller\GeneratedExtensionsConfig;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\PhpSpec\Adapter\PhpSpecAdapterFactory;
@@ -60,13 +59,19 @@ final class Factory
     private $jUnitFilePath;
     private $infectionConfig;
 
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    private $installedExtensions;
+
     public function __construct(
         string $tmpDir,
         string $projectDir,
         TestFrameworkConfigLocatorInterface $configLocator,
         TestFrameworkFinder $testFrameworkFinder,
         string $jUnitFilePath,
-        Configuration $infectionConfig
+        Configuration $infectionConfig,
+        array $installedExtensions
     ) {
         $this->tmpDir = $tmpDir;
         $this->configLocator = $configLocator;
@@ -74,6 +79,7 @@ final class Factory
         $this->jUnitFilePath = $jUnitFilePath;
         $this->infectionConfig = $infectionConfig;
         $this->testFrameworkFinder = $testFrameworkFinder;
+        $this->installedExtensions = $installedExtensions;
     }
 
     public function create(string $adapterName, bool $skipCoverage): TestFrameworkAdapter
@@ -111,7 +117,7 @@ final class Factory
             );
         }
 
-        foreach (GeneratedExtensionsConfig::EXTENSIONS as $packageName => $installedExtension) {
+        foreach ($this->installedExtensions as $packageName => $installedExtension) {
             $factory = $installedExtension['extra']['class'];
 
             Assert::classExists($factory);
@@ -122,7 +128,7 @@ final class Factory
 
             if ($adapterName === $factory::getAdapterName()) {
                 return $factory::create(
-                    $this->testFrameworkFinder->find($factory::getExecutableName())
+                    $this->testFrameworkFinder->find($factory::getExecutableName()),
                     $this->tmpDir,
                     $this->configLocator->locate($factory::getAdapterName()),
                     null,

--- a/tests/phpunit/Fixtures/TestFramework/DummyTestFrameworkAdapter.php
+++ b/tests/phpunit/Fixtures/TestFramework/DummyTestFrameworkAdapter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Fixtures\TestFramework;
+
+use Infection\AbstractTestFramework\Coverage\CoverageLineData;
+use Infection\AbstractTestFramework\TestFrameworkAdapter;
+
+final class DummyTestFrameworkAdapter implements TestFrameworkAdapter
+{
+    public function getName(): string
+    {
+        return 'dummy';
+    }
+
+    public function testsPass(string $output): bool
+    {
+        return true;
+    }
+
+    public function hasJUnitReport(): bool
+    {
+        return false;
+    }
+
+    public function getInitialTestRunCommandLine(string $extraOptions, array $phpExtraArgs, bool $skipCoverage): array
+    {
+        return ['/bin/dummy'];
+    }
+
+    public function getMutantCommandLine(array $coverageTests, string $mutatedFilePath, string $mutationHash, string $mutationOriginalFilePath, string $extraOptions): array
+    {
+        return ['/bin/dummy'];
+    }
+
+    public function getVersion(): string
+    {
+        return '1.0.0';
+    }
+
+    public function getInitialTestsFailRecommendations(string $commandLine): string
+    {
+        return 'foo';
+    }
+}

--- a/tests/phpunit/Fixtures/TestFramework/DummyTestFrameworkFactory.php
+++ b/tests/phpunit/Fixtures/TestFramework/DummyTestFrameworkFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Fixtures\TestFramework;
+
+use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
+
+final class DummyTestFrameworkFactory implements TestFrameworkAdapterFactory
+{
+    public static function create(string $testFrameworkExecutable, string $tmpDir, string $testFrameworkConfigPath, ?string $testFrameworkConfigDir, string $jUnitFilePath, string $projectDir, array $sourceDirectories, bool $skipCoverage): TestFrameworkAdapter
+    {
+        return new DummyTestFrameworkAdapter();
+    }
+
+    public static function getAdapterName(): string
+    {
+        return 'dummy';
+    }
+
+    public static function getExecutableName(): string
+    {
+        return 'dummy';
+    }
+}

--- a/tests/phpunit/TestFramework/FactoryTest.php
+++ b/tests/phpunit/TestFramework/FactoryTest.php
@@ -39,6 +39,8 @@ use Infection\Configuration\Configuration;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\Factory;
+use Infection\Tests\Fixtures\TestFramework\DummyTestFrameworkAdapter;
+use Infection\Tests\Fixtures\TestFramework\DummyTestFrameworkFactory;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
@@ -55,10 +57,34 @@ final class FactoryTest extends TestCase
             $this->createMock(TestFrameworkConfigLocatorInterface::class),
             $this->createMock(TestFrameworkFinder::class),
             '',
-            $this->createMock(Configuration::class)
+            $this->createMock(Configuration::class),
+            []
         );
 
         $this->expectException(InvalidArgumentException::class);
         $factory->create('Fake Test Framework', false);
+    }
+
+    public function test_it_uses_installed_test_framework_adapters(): void
+    {
+        $factory = new Factory(
+            '',
+            '',
+            $this->createMock(TestFrameworkConfigLocatorInterface::class),
+            $this->createMock(TestFrameworkFinder::class),
+            '',
+            $this->createMock(Configuration::class),
+            [
+                'infection/codeception-adapter' => [
+                        'install_path' => '/path/to/dummy/adapter/factory.php',
+                        'extra' => ['class' => DummyTestFrameworkFactory::class],
+                        'version' => '1.0.0',
+                    ],
+            ]
+        );
+
+        $adapter = $factory->create('dummy', false);
+
+        $this->assertInstanceOf(DummyTestFrameworkAdapter::class, $adapter);
     }
 }


### PR DESCRIPTION
This will allow to not add any new code to `infection/infection` when the new Test Framework Adapter is created.

It will be automatically discovered and used thanks to `infection/extensions-installer`.

See a detailed documentation about how it works internally: [`infection/extension-installer`](https://github.com/infection/extension-installer#infection---extensions-installer)

Basically, this is an idea taken from `phpstan/extension-installer` and Psalm:

* https://github.com/phpstan/extension-installer
* https://psalm.dev/docs/running_psalm/plugins/authoring_plugins/#authoring-composer-based-plugins

## How it works?

Each Test Framework Adapter (a separate composer package) should use a special type - `infection-extension`

https://github.com/infection/codeception-adapter/blob/6ba9944830a510d10bad9f95e2a1e04d91b9e2a5/composer.json#L2-L3

and declare a class that is responsible to adapter's creation

https://github.com/infection/codeception-adapter/blob/6ba9944830a510d10bad9f95e2a1e04d91b9e2a5/composer.json#L39-L42


`composer require infection/codeception-adapter`:

<img width="580" alt="zsh 2020-01-24 11-05-10" src="https://user-images.githubusercontent.com/3725595/73054291-1ae09400-3e9b-11ea-8dce-674c512d8bc9.png">

Then, as soon as such a package is installed, `infection/extension-installer` scans a packages (after `composer update` and `composer require` commands) and creates a config inside `vendor` folders.

Then, Infection during its work, checks whether this config contains any of the autodiscovered packages, and if so - uses them.

As simple as that!

## What does it mean for us?

It means that we can add additional Test Framemowrk Adapters and they will be installed / registered automatically after `composer require infection/x-adapter` execution.

## Next steps

Next steps (in different PRs)

* remove a `infection/codeception-adapter` dependency from `infection/infection`'s composer.json file and execute `composer require infection/codeception-adapter` *automatically* during the Configuration Phase
* Add an ability to enable / disable plugins in `infection.json`