### PR TITLE
Rename events

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -44,7 +44,7 @@ use Infection\Console\Exception\InfectionException;
 use Infection\Console\LogVerbosity;
 use Infection\Container;
 use Infection\Engine;
-use Infection\Event\ApplicationExecutionStarted;
+use Infection\Event\ApplicationExecutionWasStarted;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\FileSystem\Locator\Locator;
 use Infection\TestFramework\Coverage\CoverageDoesNotExistException;
@@ -259,7 +259,7 @@ final class InfectionCommand extends BaseCommand
             $this->output
         );
 
-        $this->container->getEventDispatcher()->dispatch(new ApplicationExecutionStarted());
+        $this->container->getEventDispatcher()->dispatch(new ApplicationExecutionWasStarted());
     }
 
     private function initContainer(InputInterface $input): void

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -41,7 +41,7 @@ use function file_exists;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Configuration\Configuration;
 use Infection\Console\ConsoleOutput;
-use Infection\Event\ApplicationExecutionFinished;
+use Infection\Event\ApplicationExecutionWasFinished;
 use Infection\Event\EventDispatcher;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutation\MutationGenerator;
@@ -170,7 +170,7 @@ final class Engine
             );
         }
 
-        $this->eventDispatcher->dispatch(new ApplicationExecutionFinished());
+        $this->eventDispatcher->dispatch(new ApplicationExecutionWasFinished());
 
         return true;
     }

--- a/src/Event/ApplicationExecutionWasFinished.php
+++ b/src/Event/ApplicationExecutionWasFinished.php
@@ -35,22 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Event;
 
-use Infection\Process\MutantProcess;
-
 /**
  * @internal
  */
-final class MutantProcessFinished
+final class ApplicationExecutionWasFinished
 {
-    private $mutantProcess;
-
-    public function __construct(MutantProcess $mutantProcess)
-    {
-        $this->mutantProcess = $mutantProcess;
-    }
-
-    public function getMutantProcess(): MutantProcess
-    {
-        return $this->mutantProcess;
-    }
 }

--- a/src/Event/ApplicationExecutionWasStarted.php
+++ b/src/Event/ApplicationExecutionWasStarted.php
@@ -33,18 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Event;
+namespace Infection\Event;
 
-use Infection\Event\MutationGeneratingStarted;
-use PHPUnit\Framework\TestCase;
-
-final class MutationGeneratingStartedTest extends TestCase
+/**
+ * @internal
+ */
+final class ApplicationExecutionWasStarted
 {
-    public function test_it_passes_along_its_mutable_file_count_without_changing_it(): void
-    {
-        $count = 5;
-        $event = new MutationGeneratingStarted($count);
-
-        $this->assertSame($count, $event->getMutableFilesCount());
-    }
 }

--- a/src/Event/InitialTestCaseWasCompleted.php
+++ b/src/Event/InitialTestCaseWasCompleted.php
@@ -38,17 +38,6 @@ namespace Infection\Event;
 /**
  * @internal
  */
-final class MutantsCreatingStarted
+final class InitialTestCaseWasCompleted
 {
-    private $mutantCount;
-
-    public function __construct(int $mutantCount)
-    {
-        $this->mutantCount = $mutantCount;
-    }
-
-    public function getMutantCount(): int
-    {
-        return $this->mutantCount;
-    }
 }

--- a/src/Event/InitialTestSuiteWasFinished.php
+++ b/src/Event/InitialTestSuiteWasFinished.php
@@ -38,6 +38,17 @@ namespace Infection\Event;
 /**
  * @internal
  */
-final class ApplicationExecutionStarted
+final class InitialTestSuiteWasFinished
 {
+    private $outputText;
+
+    public function __construct(string $outputText)
+    {
+        $this->outputText = $outputText;
+    }
+
+    public function getOutputText(): string
+    {
+        return $this->outputText;
+    }
 }

--- a/src/Event/InitialTestSuiteWasStarted.php
+++ b/src/Event/InitialTestSuiteWasStarted.php
@@ -33,19 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Event;
+namespace Infection\Event;
 
-use Infection\Event\MutationTestingFinished;
-use PHPUnit\Framework\TestCase;
-
-final class MutationTestingFinishedTest extends TestCase
+/**
+ * @internal
+ */
+final class InitialTestSuiteWasStarted
 {
-    /**
-     * This class is only used to fire events, and the only functionality it needs is being instantiated
-     */
-    public function test_it_can_be_initialzed(): void
-    {
-        $class = new MutationTestingFinished();
-        $this->assertInstanceOf(MutationTestingFinished::class, $class);
-    }
 }

--- a/src/Event/MutableFileWasProcessed.php
+++ b/src/Event/MutableFileWasProcessed.php
@@ -33,20 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Event;
+namespace Infection\Event;
 
-use Infection\Event\MutantProcessFinished;
-use Infection\Process\MutantProcess;
-use PHPUnit\Framework\TestCase;
-
-final class MutantProcessFinishedTest extends TestCase
+/**
+ * @internal
+ */
+final class MutableFileWasProcessed
 {
-    public function test_it_passes_around_its_mutant_process_without_changing_it(): void
-    {
-        $process = $this->createMock(MutantProcess::class);
-        $process->expects($this->never())->method($this->anything());
-
-        $event = new MutantProcessFinished($process);
-        $this->assertSame($process, $event->getMutantProcess());
-    }
 }

--- a/src/Event/MutantProcessWasFinished.php
+++ b/src/Event/MutantProcessWasFinished.php
@@ -33,19 +33,24 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Event;
+namespace Infection\Event;
 
-use Infection\Event\MutationGeneratingFinished;
-use PHPUnit\Framework\TestCase;
+use Infection\Process\MutantProcess;
 
-final class MutationGeneratingFinishedTest extends TestCase
+/**
+ * @internal
+ */
+final class MutantProcessWasFinished
 {
-    /**
-     * This class is only used to fire events, and the only functionality it needs is being instantiated
-     */
-    public function test_it_can_be_initialzed(): void
+    private $mutantProcess;
+
+    public function __construct(MutantProcess $mutantProcess)
     {
-        $class = new MutationGeneratingFinished();
-        $this->assertInstanceOf(MutationGeneratingFinished::class, $class);
+        $this->mutantProcess = $mutantProcess;
+    }
+
+    public function getMutantProcess(): MutantProcess
+    {
+        return $this->mutantProcess;
     }
 }

--- a/src/Event/MutantWasCreated.php
+++ b/src/Event/MutantWasCreated.php
@@ -38,6 +38,6 @@ namespace Infection\Event;
 /**
  * @internal
  */
-final class InitialTestSuiteStarted
+final class MutantWasCreated
 {
 }

--- a/src/Event/MutantsCreationWasFinished.php
+++ b/src/Event/MutantsCreationWasFinished.php
@@ -33,19 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Event;
+namespace Infection\Event;
 
-use Infection\Event\MutantCreated;
-use PHPUnit\Framework\TestCase;
-
-final class MutantCreatedTest extends TestCase
+/**
+ * @internal
+ */
+final class MutantsCreationWasFinished
 {
-    /**
-     * This class is only used to fire events, and the only functionality it needs is being instantiated
-     */
-    public function test_it_can_be_initialzed(): void
-    {
-        $class = new MutantCreated();
-        $this->assertInstanceOf(MutantCreated::class, $class);
-    }
 }

--- a/src/Event/MutantsCreationWasStarted.php
+++ b/src/Event/MutantsCreationWasStarted.php
@@ -38,6 +38,17 @@ namespace Infection\Event;
 /**
  * @internal
  */
-final class MutantCreated
+final class MutantsCreationWasStarted
 {
+    private $mutantCount;
+
+    public function __construct(int $mutantCount)
+    {
+        $this->mutantCount = $mutantCount;
+    }
+
+    public function getMutantCount(): int
+    {
+        return $this->mutantCount;
+    }
 }

--- a/src/Event/MutationGenerationWasFinished.php
+++ b/src/Event/MutationGenerationWasFinished.php
@@ -38,17 +38,6 @@ namespace Infection\Event;
 /**
  * @internal
  */
-final class MutationTestingStarted
+final class MutationGenerationWasFinished
 {
-    private $mutationCount;
-
-    public function __construct(int $mutationCount)
-    {
-        $this->mutationCount = $mutationCount;
-    }
-
-    public function getMutationCount(): int
-    {
-        return $this->mutationCount;
-    }
 }

--- a/src/Event/MutationGenerationWasStarted.php
+++ b/src/Event/MutationGenerationWasStarted.php
@@ -38,17 +38,17 @@ namespace Infection\Event;
 /**
  * @internal
  */
-final class InitialTestSuiteFinished
+final class MutationGenerationWasStarted
 {
-    private $outputText;
+    private $mutableFilesCount;
 
-    public function __construct(string $outputText)
+    public function __construct(int $mutableFilesCount)
     {
-        $this->outputText = $outputText;
+        $this->mutableFilesCount = $mutableFilesCount;
     }
 
-    public function getOutputText(): string
+    public function getMutableFilesCount(): int
     {
-        return $this->outputText;
+        return $this->mutableFilesCount;
     }
 }

--- a/src/Event/MutationTestingWasFinished.php
+++ b/src/Event/MutationTestingWasFinished.php
@@ -33,18 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Event;
+namespace Infection\Event;
 
-use Infection\Event\MutantsCreatingStarted;
-use PHPUnit\Framework\TestCase;
-
-final class MutantsCreatingStartedTest extends TestCase
+/**
+ * @internal
+ */
+final class MutationTestingWasFinished
 {
-    public function test_it_passes_along_its_mutation_count_without_changing_it(): void
-    {
-        $count = 5;
-        $event = new MutantsCreatingStarted($count);
-
-        $this->assertSame($count, $event->getMutantCount());
-    }
 }

--- a/src/Event/MutationTestingWasStarted.php
+++ b/src/Event/MutationTestingWasStarted.php
@@ -33,19 +33,22 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Event;
+namespace Infection\Event;
 
-use Infection\Event\InitialTestSuiteStarted;
-use PHPUnit\Framework\TestCase;
-
-final class InitialTestSuiteStartedTest extends TestCase
+/**
+ * @internal
+ */
+final class MutationTestingWasStarted
 {
-    /**
-     * This class is only used to fire events, and the only functionality it needs is being instantiated
-     */
-    public function test_it_can_be_initialzed(): void
+    private $mutationCount;
+
+    public function __construct(int $mutationCount)
     {
-        $class = new InitialTestSuiteStarted();
-        $this->assertInstanceOf(InitialTestSuiteStarted::class, $class);
+        $this->mutationCount = $mutationCount;
+    }
+
+    public function getMutationCount(): int
+    {
+        return $this->mutationCount;
     }
 }

--- a/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Event\Subscriber;
 
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
-use Infection\Event\InitialTestSuiteStarted;
+use Infection\Event\InitialTestSuiteWasStarted;
 use InvalidArgumentException;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -57,11 +57,11 @@ final class CiInitialTestsConsoleLoggerSubscriber implements EventSubscriber
     public function getSubscribedEvents(): array
     {
         return [
-            InitialTestSuiteStarted::class => [$this, 'onInitialTestSuiteStarted'],
+            InitialTestSuiteWasStarted::class => [$this, 'onInitialTestSuiteWasStarted'],
         ];
     }
 
-    public function onInitialTestSuiteStarted(InitialTestSuiteStarted $event): void
+    public function onInitialTestSuiteWasStarted(InitialTestSuiteWasStarted $event): void
     {
         try {
             $version = $this->testFrameworkAdapter->getVersion();

--- a/src/Event/Subscriber/CiMutantCreatingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiMutantCreatingConsoleLoggerSubscriber.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Infection\Event\MutantsCreatingStarted;
+use Infection\Event\MutantsCreationWasStarted;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -53,11 +53,11 @@ final class CiMutantCreatingConsoleLoggerSubscriber implements EventSubscriber
     public function getSubscribedEvents(): array
     {
         return [
-            MutantsCreatingStarted::class => [$this, 'onMutantsCreatingStarted'],
+            MutantsCreationWasStarted::class => [$this, 'onMutantsCreationWasStarted'],
         ];
     }
 
-    public function onMutantsCreatingStarted(MutantsCreatingStarted $event): void
+    public function onMutantsCreationWasStarted(MutantsCreationWasStarted $event): void
     {
         $this->output->writeln([
             '',

--- a/src/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriber.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Infection\Event\MutationGeneratingStarted;
+use Infection\Event\MutationGenerationWasStarted;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -53,11 +53,11 @@ final class CiMutationGeneratingConsoleLoggerSubscriber implements EventSubscrib
     public function getSubscribedEvents(): array
     {
         return [
-            MutationGeneratingStarted::class => [$this, 'onMutationGeneratingStarted'],
+            MutationGenerationWasStarted::class => [$this, 'onMutationGenerationWasStarted'],
         ];
     }
 
-    public function onMutationGeneratingStarted(MutationGeneratingStarted $event): void
+    public function onMutationGenerationWasStarted(MutationGenerationWasStarted $event): void
     {
         $this->output->writeln([
             '',

--- a/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php
+++ b/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Infection\Event\MutationTestingFinished;
+use Infection\Event\MutationTestingWasFinished;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -55,11 +55,11 @@ final class CleanUpAfterMutationTestingFinishedSubscriber implements EventSubscr
     public function getSubscribedEvents(): array
     {
         return [
-            MutationTestingFinished::class => [$this, 'onMutationTestingFinished'],
+            MutationTestingWasFinished::class => [$this, 'onMutationTestingWasFinished'],
         ];
     }
 
-    public function onMutationTestingFinished(MutationTestingFinished $event): void
+    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
     {
         $this->filesystem->remove($this->tmpDir);
     }

--- a/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriber.php
@@ -36,9 +36,9 @@ declare(strict_types=1);
 namespace Infection\Event\Subscriber;
 
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
-use Infection\Event\InitialTestCaseCompleted;
-use Infection\Event\InitialTestSuiteFinished;
-use Infection\Event\InitialTestSuiteStarted;
+use Infection\Event\InitialTestCaseWasCompleted;
+use Infection\Event\InitialTestSuiteWasFinished;
+use Infection\Event\InitialTestSuiteWasStarted;
 use InvalidArgumentException;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -66,13 +66,13 @@ final class InitialTestsConsoleLoggerSubscriber implements EventSubscriber
     public function getSubscribedEvents(): array
     {
         return [
-            InitialTestSuiteStarted::class => [$this, 'onInitialTestSuiteStarted'],
-            InitialTestSuiteFinished::class => [$this, 'onInitialTestSuiteFinished'],
-            InitialTestCaseCompleted::class => [$this, 'onInitialTestCaseCompleted'],
+            InitialTestSuiteWasStarted::class => [$this, 'onInitialTestSuiteWasStarted'],
+            InitialTestSuiteWasFinished::class => [$this, 'onInitialTestSuiteWasFinished'],
+            InitialTestCaseWasCompleted::class => [$this, 'onInitialTestCaseWasCompleted'],
         ];
     }
 
-    public function onInitialTestSuiteStarted(InitialTestSuiteStarted $event): void
+    public function onInitialTestSuiteWasStarted(InitialTestSuiteWasStarted $event): void
     {
         try {
             $version = $this->testFrameworkAdapter->getVersion();
@@ -94,7 +94,7 @@ final class InitialTestsConsoleLoggerSubscriber implements EventSubscriber
         $this->progressBar->start();
     }
 
-    public function onInitialTestSuiteFinished(InitialTestSuiteFinished $event): void
+    public function onInitialTestSuiteWasFinished(InitialTestSuiteWasFinished $event): void
     {
         $this->progressBar->finish();
 
@@ -103,7 +103,7 @@ final class InitialTestsConsoleLoggerSubscriber implements EventSubscriber
         }
     }
 
-    public function onInitialTestCaseCompleted(InitialTestCaseCompleted $event): void
+    public function onInitialTestCaseWasCompleted(InitialTestCaseWasCompleted $event): void
     {
         $this->progressBar->advance();
     }

--- a/src/Event/Subscriber/MutantCreatingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutantCreatingConsoleLoggerSubscriber.php
@@ -35,9 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Infection\Event\MutantCreated;
-use Infection\Event\MutantsCreatingFinished;
-use Infection\Event\MutantsCreatingStarted;
+use Infection\Event\MutantsCreationWasFinished;
+use Infection\Event\MutantsCreationWasStarted;
+use Infection\Event\MutantWasCreated;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -60,24 +60,24 @@ final class MutantCreatingConsoleLoggerSubscriber implements EventSubscriber
     public function getSubscribedEvents(): array
     {
         return [
-            MutantsCreatingStarted::class => [$this, 'onMutantsCreatingStarted'],
-            MutantCreated::class => [$this, 'onMutantCreated'],
-            MutantsCreatingFinished::class => [$this, 'onMutantsCreatingFinished'],
+            MutantsCreationWasStarted::class => [$this, 'onMutantsCreationWasStarted'],
+            MutantWasCreated::class => [$this, 'onMutantWasCreated'],
+            MutantsCreationWasFinished::class => [$this, 'onMutantsCreationWasFinished'],
         ];
     }
 
-    public function onMutantsCreatingStarted(MutantsCreatingStarted $event): void
+    public function onMutantsCreationWasStarted(MutantsCreationWasStarted $event): void
     {
         $this->output->writeln(['']);
         $this->progressBar->start($event->getMutantCount());
     }
 
-    public function onMutantCreated(MutantCreated $event): void
+    public function onMutantWasCreated(MutantWasCreated $event): void
     {
         $this->progressBar->advance();
     }
 
-    public function onMutantsCreatingFinished(MutantsCreatingFinished $event): void
+    public function onMutantsCreationWasFinished(MutantsCreationWasFinished $event): void
     {
         $this->progressBar->finish();
     }

--- a/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriber.php
@@ -35,9 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Infection\Event\MutableFileProcessed;
-use Infection\Event\MutationGeneratingFinished;
-use Infection\Event\MutationGeneratingStarted;
+use Infection\Event\MutableFileWasProcessed;
+use Infection\Event\MutationGenerationWasFinished;
+use Infection\Event\MutationGenerationWasStarted;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -60,24 +60,24 @@ final class MutationGeneratingConsoleLoggerSubscriber implements EventSubscriber
     public function getSubscribedEvents(): array
     {
         return [
-            MutationGeneratingStarted::class => [$this, 'onMutationGeneratingStarted'],
-            MutableFileProcessed::class => [$this, 'onMutableFileProcessed'],
-            MutationGeneratingFinished::class => [$this, 'onMutationGeneratingFinished'],
+            MutationGenerationWasStarted::class => [$this, 'onMutationGenerationWasStarted'],
+            MutableFileWasProcessed::class => [$this, 'onMutableFileWasProcessed'],
+            MutationGenerationWasFinished::class => [$this, 'onMutationGenerationWasFinished'],
         ];
     }
 
-    public function onMutationGeneratingStarted(MutationGeneratingStarted $event): void
+    public function onMutationGenerationWasStarted(MutationGenerationWasStarted $event): void
     {
         $this->output->writeln(['', '', 'Generate mutants...', '']);
         $this->progressBar->start($event->getMutableFilesCount());
     }
 
-    public function onMutableFileProcessed(MutableFileProcessed $event): void
+    public function onMutableFileWasProcessed(MutableFileWasProcessed $event): void
     {
         $this->progressBar->advance();
     }
 
-    public function onMutationGeneratingFinished(MutationGeneratingFinished $event): void
+    public function onMutationGenerationWasFinished(MutationGenerationWasFinished $event): void
     {
         $this->progressBar->finish();
     }

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -82,8 +82,8 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
     {
         return [
             MutationTestingWasStarted::class => [$this, 'onMutationTestingWasStarted'],
-            MutationTestingWasFinished::class => [$this, 'onMutantProcessWasFinished'],
-            MutantProcessWasFinished::class => [$this, 'onMutationTestingWasFinished'],
+            MutationTestingWasFinished::class => [$this, 'onMutationTestingWasFinished'],
+            MutantProcessWasFinished::class => [$this, 'onMutantProcessWasFinished'],
         ];
     }
 

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -37,9 +37,9 @@ namespace Infection\Event\Subscriber;
 
 use Infection\Console\OutputFormatter\OutputFormatter;
 use Infection\Differ\DiffColorizer;
-use Infection\Event\MutantProcessFinished;
-use Infection\Event\MutationTestingFinished;
-use Infection\Event\MutationTestingStarted;
+use Infection\Event\MutantProcessWasFinished;
+use Infection\Event\MutationTestingWasFinished;
+use Infection\Event\MutationTestingWasStarted;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Process\MutantProcess;
 use function strlen;
@@ -81,20 +81,20 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
     public function getSubscribedEvents(): array
     {
         return [
-            MutationTestingStarted::class => [$this, 'onMutationTestingStarted'],
-            MutationTestingFinished::class => [$this, 'onMutationTestingFinished'],
-            MutantProcessFinished::class => [$this, 'onMutantProcessFinished'],
+            MutationTestingWasStarted::class => [$this, 'onMutationTestingWasStarted'],
+            MutationTestingWasFinished::class => [$this, 'onMutantProcessWasFinished'],
+            MutantProcessWasFinished::class => [$this, 'onMutationTestingWasFinished'],
         ];
     }
 
-    public function onMutationTestingStarted(MutationTestingStarted $event): void
+    public function onMutationTestingWasStarted(MutationTestingWasStarted $event): void
     {
         $this->mutationCount = $event->getMutationCount();
 
         $this->outputFormatter->start($this->mutationCount);
     }
 
-    public function onMutantProcessFinished(MutantProcessFinished $event): void
+    public function onMutantProcessWasFinished(MutantProcessWasFinished $event): void
     {
         $this->mutantProcesses[] = $event->getMutantProcess();
         $this->metricsCalculator->collect($event->getMutantProcess());
@@ -102,7 +102,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
         $this->outputFormatter->advance($event->getMutantProcess(), $this->mutationCount);
     }
 
-    public function onMutationTestingFinished(MutationTestingFinished $event): void
+    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
     {
         $this->outputFormatter->finish();
 

--- a/src/Event/Subscriber/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingResultsLoggerSubscriber.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Infection\Event\MutationTestingFinished;
+use Infection\Event\MutationTestingWasFinished;
 use Infection\Logger\MutationTestingResultsLogger;
 use Webmozart\Assert\Assert;
 
@@ -59,11 +59,11 @@ final class MutationTestingResultsLoggerSubscriber implements EventSubscriber
     public function getSubscribedEvents(): array
     {
         return [
-            MutationTestingFinished::class => [$this, 'onMutationTestingFinished'],
+            MutationTestingWasFinished::class => [$this, 'onMutationTestingWasFinished'],
         ];
     }
 
-    public function onMutationTestingFinished(MutationTestingFinished $event): void
+    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
     {
         foreach ($this->loggers as $logger) {
             $logger->log();

--- a/src/Mutation/MutationGenerator.php
+++ b/src/Mutation/MutationGenerator.php
@@ -37,9 +37,9 @@ namespace Infection\Mutation;
 
 use function count;
 use Infection\Event\EventDispatcher;
-use Infection\Event\MutableFileProcessed;
-use Infection\Event\MutationGeneratingFinished;
-use Infection\Event\MutationGeneratingStarted;
+use Infection\Event\MutableFileWasProcessed;
+use Infection\Event\MutationGenerationWasFinished;
+use Infection\Event\MutationGenerationWasStarted;
 use Infection\Mutator\Mutator;
 use Infection\TestFramework\Coverage\LineCodeCoverage;
 use PhpParser\NodeVisitor;
@@ -98,7 +98,7 @@ final class MutationGenerator
     {
         $allFilesMutations = [[]];
 
-        $this->eventDispatcher->dispatch(new MutationGeneratingStarted(count($this->sourceFiles)));
+        $this->eventDispatcher->dispatch(new MutationGenerationWasStarted(count($this->sourceFiles)));
 
         foreach ($this->sourceFiles as $fileInfo) {
             $allFilesMutations[] = $this->fileMutationGenerator->generate(
@@ -109,10 +109,10 @@ final class MutationGenerator
                 $extraNodeVisitors
             );
 
-            $this->eventDispatcher->dispatch(new MutableFileProcessed());
+            $this->eventDispatcher->dispatch(new MutableFileWasProcessed());
         }
 
-        $this->eventDispatcher->dispatch(new MutationGeneratingFinished());
+        $this->eventDispatcher->dispatch(new MutationGenerationWasFinished());
 
         return array_merge(...$allFilesMutations);
     }

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -36,9 +36,9 @@ declare(strict_types=1);
 namespace Infection\Process\Runner;
 
 use Infection\Event\EventDispatcher;
-use Infection\Event\InitialTestCaseCompleted;
-use Infection\Event\InitialTestSuiteFinished;
-use Infection\Event\InitialTestSuiteStarted;
+use Infection\Event\InitialTestCaseWasCompleted;
+use Infection\Event\InitialTestSuiteWasFinished;
+use Infection\Event\InitialTestSuiteWasStarted;
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
 use Symfony\Component\Process\Process;
 
@@ -64,17 +64,17 @@ final class InitialTestsRunner
             $phpExtraOptions
         );
 
-        $this->eventDispatcher->dispatch(new InitialTestSuiteStarted());
+        $this->eventDispatcher->dispatch(new InitialTestSuiteWasStarted());
 
         $process->run(function ($type) use ($process): void {
             if ($process::ERR === $type) {
                 $process->stop();
             }
 
-            $this->eventDispatcher->dispatch(new InitialTestCaseCompleted());
+            $this->eventDispatcher->dispatch(new InitialTestCaseWasCompleted());
         });
 
-        $this->eventDispatcher->dispatch(new InitialTestSuiteFinished($process->getOutput()));
+        $this->eventDispatcher->dispatch(new InitialTestSuiteWasFinished($process->getOutput()));
 
         return $process;
     }

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -37,11 +37,11 @@ namespace Infection\Process\Runner;
 
 use function count;
 use Infection\Event\EventDispatcher;
-use Infection\Event\MutantCreated;
-use Infection\Event\MutantsCreatingFinished;
-use Infection\Event\MutantsCreatingStarted;
-use Infection\Event\MutationTestingFinished;
-use Infection\Event\MutationTestingStarted;
+use Infection\Event\MutantsCreationWasFinished;
+use Infection\Event\MutantsCreationWasStarted;
+use Infection\Event\MutantWasCreated;
+use Infection\Event\MutationTestingWasFinished;
+use Infection\Event\MutationTestingWasStarted;
 use Infection\Mutant\MutantFactory;
 use Infection\Mutation\Mutation;
 use Infection\Process\Builder\MutantProcessBuilder;
@@ -77,7 +77,7 @@ final class MutationTestingRunner
     {
         $mutantCount = count($mutations);
 
-        $this->eventDispatcher->dispatch(new MutantsCreatingStarted($mutantCount));
+        $this->eventDispatcher->dispatch(new MutantsCreationWasStarted($mutantCount));
 
         $processes = array_map(
             function (Mutation $mutation) use ($testFrameworkExtraOptions): MutantProcess {
@@ -85,19 +85,19 @@ final class MutationTestingRunner
 
                 $process = $this->processBuilder->createProcessForMutant($mutant, $testFrameworkExtraOptions);
 
-                $this->eventDispatcher->dispatch(new MutantCreated());
+                $this->eventDispatcher->dispatch(new MutantWasCreated());
 
                 return $process;
             },
             $mutations
         );
 
-        $this->eventDispatcher->dispatch(new MutantsCreatingFinished());
+        $this->eventDispatcher->dispatch(new MutantsCreationWasFinished());
 
-        $this->eventDispatcher->dispatch(new MutationTestingStarted($mutantCount));
+        $this->eventDispatcher->dispatch(new MutationTestingWasStarted($mutantCount));
 
         $this->parallelProcessManager->run($processes, $threadCount);
 
-        $this->eventDispatcher->dispatch(new MutationTestingFinished());
+        $this->eventDispatcher->dispatch(new MutationTestingWasFinished());
     }
 }

--- a/src/Process/Runner/Parallel/ParallelProcessRunner.php
+++ b/src/Process/Runner/Parallel/ParallelProcessRunner.php
@@ -38,7 +38,7 @@ namespace Infection\Process\Runner\Parallel;
 use function assert;
 use function count;
 use Infection\Event\EventDispatcher;
-use Infection\Event\MutantProcessFinished;
+use Infection\Event\MutantProcessWasFinished;
 use Infection\Process\MutantProcess;
 use Symfony\Component\Process\Exception\LogicException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
@@ -104,7 +104,7 @@ final class ParallelProcessRunner
                 }
 
                 if (!$process->isRunning()) {
-                    $this->eventDispatcher->dispatch(new MutantProcessFinished($mutantProcess));
+                    $this->eventDispatcher->dispatch(new MutantProcessWasFinished($mutantProcess));
 
                     unset($this->currentProcesses[$index]);
 
@@ -128,7 +128,7 @@ final class ParallelProcessRunner
         $mutant = $mutantProcess->getMutant();
 
         if (!$mutant->isCoveredByTest()) {
-            $this->eventDispatcher->dispatch(new MutantProcessFinished($mutantProcess));
+            $this->eventDispatcher->dispatch(new MutantProcessWasFinished($mutantProcess));
 
             return false;
         }

--- a/src/Resource/Listener/PerformanceLoggerSubscriber.php
+++ b/src/Resource/Listener/PerformanceLoggerSubscriber.php
@@ -35,8 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Resource\Listener;
 
-use Infection\Event\ApplicationExecutionFinished;
-use Infection\Event\ApplicationExecutionStarted;
+use Infection\Event\ApplicationExecutionWasFinished;
+use Infection\Event\ApplicationExecutionWasStarted;
 use Infection\Event\Subscriber\EventSubscriber;
 use Infection\Resource\Memory\MemoryFormatter;
 use Infection\Resource\Time\Stopwatch;
@@ -68,17 +68,17 @@ final class PerformanceLoggerSubscriber implements EventSubscriber
     public function getSubscribedEvents(): array
     {
         return [
-            ApplicationExecutionStarted::class => [$this, 'onApplicationExecutionStarted'],
-            ApplicationExecutionFinished::class => [$this, 'onApplicationExecutionFinished'],
+            ApplicationExecutionWasStarted::class => [$this, 'onApplicationExecutionWasStarted'],
+            ApplicationExecutionWasFinished::class => [$this, 'onApplicationExecutionWasFinished'],
         ];
     }
 
-    public function onApplicationExecutionStarted(): void
+    public function onApplicationExecutionWasStarted(): void
     {
         $this->stopwatch->start();
     }
 
-    public function onApplicationExecutionFinished(): void
+    public function onApplicationExecutionWasFinished(): void
     {
         $time = $this->stopwatch->stop();
 

--- a/tests/phpunit/Event/ApplicationExecutionWasFinishedTest.php
+++ b/tests/phpunit/Event/ApplicationExecutionWasFinishedTest.php
@@ -33,11 +33,20 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event;
+namespace Infection\Tests\Event;
 
-/**
- * @internal
- */
-final class ApplicationExecutionFinished
+use Infection\Event\ApplicationExecutionWasFinished;
+use PHPUnit\Framework\TestCase;
+
+final class ApplicationExecutionWasFinishedTest extends TestCase
 {
+    /**
+     * This class is only used to fire events, and the only functionality it needs is being instantiated
+     */
+    public function test_it_can_be_instantiated(): void
+    {
+        $class = new ApplicationExecutionWasFinished();
+
+        $this->assertInstanceOf(ApplicationExecutionWasFinished::class, $class);
+    }
 }

--- a/tests/phpunit/Event/ApplicationExecutionWasStartedTest.php
+++ b/tests/phpunit/Event/ApplicationExecutionWasStartedTest.php
@@ -33,11 +33,19 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event;
+namespace Infection\Tests\Event;
 
-/**
- * @internal
- */
-final class MutableFileProcessed
+use Infection\Event\ApplicationExecutionWasStarted;
+use PHPUnit\Framework\TestCase;
+
+final class ApplicationExecutionWasStartedTest extends TestCase
 {
+    /**
+     * This class is only used to fire events, and the only functionality it needs is being instantiated
+     */
+    public function test_it_can_be_instantiated(): void
+    {
+        $class = new ApplicationExecutionWasStarted();
+        $this->assertInstanceOf(ApplicationExecutionWasStarted::class, $class);
+    }
 }

--- a/tests/phpunit/Event/EventDispatcherTest.php
+++ b/tests/phpunit/Event/EventDispatcherTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Event;
 
+use Infection\Event\EventDispatcher;
 use Infection\Tests\Fixtures\Event\NullSubscriber;
 use Infection\Tests\Fixtures\Event\UnknownEventSubscriber;
 use Infection\Tests\Fixtures\Event\UserEventSubscriber;
@@ -47,7 +48,7 @@ final class EventDispatcherTest extends TestCase
     {
         $userSubscriber = new UserEventSubscriber();
 
-        $dispatcher = new \Infection\Event\EventDispatcher();
+        $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber($userSubscriber);
         $dispatcher->addSubscriber(new NullSubscriber());
         $dispatcher->addSubscriber(new UnknownEventSubscriber());

--- a/tests/phpunit/Event/InitialTestCaseWasCompletedTest.php
+++ b/tests/phpunit/Event/InitialTestCaseWasCompletedTest.php
@@ -33,11 +33,20 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event;
+namespace Infection\Tests\Event;
 
-/**
- * @internal
- */
-final class MutationTestingFinished
+use Infection\Event\InitialTestCaseWasCompleted;
+use PHPUnit\Framework\TestCase;
+
+final class InitialTestCaseWasCompletedTest extends TestCase
 {
+    /**
+     * This class is only used to fire events, and the only functionality it needs is being instantiated
+     */
+    public function test_it_can_be_instantiated(): void
+    {
+        $class = new InitialTestCaseWasCompleted();
+
+        $this->assertInstanceOf(InitialTestCaseWasCompleted::class, $class);
+    }
 }

--- a/tests/phpunit/Event/InitialTestSuiteWasFinishedTest.php
+++ b/tests/phpunit/Event/InitialTestSuiteWasFinishedTest.php
@@ -33,11 +33,19 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event;
+namespace Infection\Tests\Event;
 
-/**
- * @internal
- */
-final class MutantsCreatingFinished
+use Infection\Event\InitialTestSuiteWasFinished;
+use PHPUnit\Framework\TestCase;
+
+final class InitialTestSuiteWasFinishedTest extends TestCase
 {
+    public function test_it_exposes_its_output(): void
+    {
+        $text = 'foo-bar-baz';
+
+        $class = new InitialTestSuiteWasFinished($text);
+
+        $this->assertSame($text, $class->getOutputText());
+    }
 }

--- a/tests/phpunit/Event/InitialTestSuiteWasStartedTest.php
+++ b/tests/phpunit/Event/InitialTestSuiteWasStartedTest.php
@@ -35,17 +35,18 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Event;
 
-use Infection\Event\ApplicationExecutionStarted;
+use Infection\Event\InitialTestSuiteWasStarted;
 use PHPUnit\Framework\TestCase;
 
-final class ApplicationExecutionStartedTest extends TestCase
+final class InitialTestSuiteWasStartedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated
      */
-    public function test_it_can_be_initialzed(): void
+    public function test_it_can_be_instantiated(): void
     {
-        $class = new ApplicationExecutionStarted();
-        $this->assertInstanceOf(ApplicationExecutionStarted::class, $class);
+        $class = new InitialTestSuiteWasStarted();
+
+        $this->assertInstanceOf(InitialTestSuiteWasStarted::class, $class);
     }
 }

--- a/tests/phpunit/Event/MutableFileWasProcessedTest.php
+++ b/tests/phpunit/Event/MutableFileWasProcessedTest.php
@@ -35,17 +35,18 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Event;
 
-use Infection\Event\ApplicationExecutionFinished;
+use Infection\Event\MutableFileWasProcessed;
 use PHPUnit\Framework\TestCase;
 
-final class ApplicationExecutionFinishedTest extends TestCase
+final class MutableFileWasProcessedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated
      */
-    public function test_it_can_be_initialzed(): void
+    public function test_it_can_be_instantiated(): void
     {
-        $class = new ApplicationExecutionFinished();
-        $this->assertInstanceOf(ApplicationExecutionFinished::class, $class);
+        $class = new MutableFileWasProcessed();
+
+        $this->assertInstanceOf(MutableFileWasProcessed::class, $class);
     }
 }

--- a/tests/phpunit/Event/MutantProcessWasFinishedTest.php
+++ b/tests/phpunit/Event/MutantProcessWasFinishedTest.php
@@ -33,11 +33,20 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event;
+namespace Infection\Tests\Event;
 
-/**
- * @internal
- */
-final class InitialTestCaseCompleted
+use Infection\Event\MutantProcessWasFinished;
+use Infection\Process\MutantProcess;
+use PHPUnit\Framework\TestCase;
+
+final class MutantProcessWasFinishedTest extends TestCase
 {
+    public function test_it_exposes_its_mutant_process(): void
+    {
+        $processMock = $this->createMock(MutantProcess::class);
+
+        $event = new MutantProcessWasFinished($processMock);
+
+        $this->assertSame($processMock, $event->getMutantProcess());
+    }
 }

--- a/tests/phpunit/Event/MutantWasCreatedTest.php
+++ b/tests/phpunit/Event/MutantWasCreatedTest.php
@@ -35,17 +35,18 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Event;
 
-use Infection\Event\MutableFileProcessed;
+use Infection\Event\MutantWasCreated;
 use PHPUnit\Framework\TestCase;
 
-final class MutableFileProcessedTest extends TestCase
+final class MutantWasCreatedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated
      */
-    public function test_it_can_be_initialzed(): void
+    public function test_it_can_be_instantiated(): void
     {
-        $class = new MutableFileProcessed();
-        $this->assertInstanceOf(MutableFileProcessed::class, $class);
+        $class = new MutantWasCreated();
+
+        $this->assertInstanceOf(MutantWasCreated::class, $class);
     }
 }

--- a/tests/phpunit/Event/MutantsCreationWasFinishedTest.php
+++ b/tests/phpunit/Event/MutantsCreationWasFinishedTest.php
@@ -35,17 +35,18 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Event;
 
-use Infection\Event\MutantsCreatingFinished;
+use Infection\Event\MutantsCreationWasFinished;
 use PHPUnit\Framework\TestCase;
 
-final class MutantsCreatingFinishedTest extends TestCase
+final class MutantsCreationWasFinishedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated
      */
-    public function test_it_can_be_initialzed(): void
+    public function test_it_can_be_instantiated(): void
     {
-        $class = new MutantsCreatingFinished();
-        $this->assertInstanceOf(MutantsCreatingFinished::class, $class);
+        $class = new MutantsCreationWasFinished();
+
+        $this->assertInstanceOf(MutantsCreationWasFinished::class, $class);
     }
 }

--- a/tests/phpunit/Event/MutantsCreationWasStartedTest.php
+++ b/tests/phpunit/Event/MutantsCreationWasStartedTest.php
@@ -33,11 +33,18 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event;
+namespace Infection\Tests\Event;
 
-/**
- * @internal
- */
-final class MutationGeneratingFinished
+use Infection\Event\MutantsCreationWasStarted;
+use PHPUnit\Framework\TestCase;
+
+final class MutantsCreationWasStartedTest extends TestCase
 {
+    public function test_it_exposes_its_mutant_count(): void
+    {
+        $count = 5;
+        $event = new MutantsCreationWasStarted($count);
+
+        $this->assertSame($count, $event->getMutantCount());
+    }
 }

--- a/tests/phpunit/Event/MutationGenerationWasFinishedTest.php
+++ b/tests/phpunit/Event/MutationGenerationWasFinishedTest.php
@@ -35,17 +35,18 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Event;
 
-use Infection\Event\InitialTestSuiteFinished;
+use Infection\Event\MutationGenerationWasFinished;
 use PHPUnit\Framework\TestCase;
 
-final class InitialTestSuiteFinishedTest extends TestCase
+final class MutationGenerationWasFinishedTest extends TestCase
 {
-    public function test_it_passes_the_output_along(): void
+    /**
+     * This class is only used to fire events, and the only functionality it needs is being instantiated
+     */
+    public function test_it_can_be_instantiated(): void
     {
-        $text = 'foo-bar-baz';
+        $class = new MutationGenerationWasFinished();
 
-        $class = new InitialTestSuiteFinished($text);
-
-        $this->assertSame($text, $class->getOutputText());
+        $this->assertInstanceOf(MutationGenerationWasFinished::class, $class);
     }
 }

--- a/tests/phpunit/Event/MutationGenerationWasStartedTest.php
+++ b/tests/phpunit/Event/MutationGenerationWasStartedTest.php
@@ -35,16 +35,16 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Event;
 
-use Infection\Event\MutationTestingStarted;
+use Infection\Event\MutationGenerationWasStarted;
 use PHPUnit\Framework\TestCase;
 
-final class MutationTestingStartedTest extends TestCase
+final class MutationGenerationWasStartedTest extends TestCase
 {
-    public function test_it_passes_along_its_mutation_count_without_changing_it(): void
+    public function it_exposes_its_mutable_files_count(): void
     {
         $count = 5;
-        $event = new MutationTestingStarted($count);
+        $event = new MutationGenerationWasStarted($count);
 
-        $this->assertSame($count, $event->getMutationCount());
+        $this->assertSame($count, $event->getMutableFilesCount());
     }
 }

--- a/tests/phpunit/Event/MutationGenerationWasStartedTest.php
+++ b/tests/phpunit/Event/MutationGenerationWasStartedTest.php
@@ -40,7 +40,7 @@ use PHPUnit\Framework\TestCase;
 
 final class MutationGenerationWasStartedTest extends TestCase
 {
-    public function it_exposes_its_mutable_files_count(): void
+    public function test_it_exposes_its_mutable_files_count(): void
     {
         $count = 5;
         $event = new MutationGenerationWasStarted($count);

--- a/tests/phpunit/Event/MutationTestingWasFinishedTest.php
+++ b/tests/phpunit/Event/MutationTestingWasFinishedTest.php
@@ -35,17 +35,18 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Event;
 
-use Infection\Event\InitialTestCaseCompleted;
+use Infection\Event\MutationTestingWasFinished;
 use PHPUnit\Framework\TestCase;
 
-final class InitialTestCaseCompletedTest extends TestCase
+final class MutationTestingWasFinishedTest extends TestCase
 {
     /**
      * This class is only used to fire events, and the only functionality it needs is being instantiated
      */
-    public function test_it_can_be_initialzed(): void
+    public function test_it_can_be_instantiated(): void
     {
-        $class = new InitialTestCaseCompleted();
-        $this->assertInstanceOf(InitialTestCaseCompleted::class, $class);
+        $class = new MutationTestingWasFinished();
+
+        $this->assertInstanceOf(MutationTestingWasFinished::class, $class);
     }
 }

--- a/tests/phpunit/Event/MutationTestingWasStartedTest.php
+++ b/tests/phpunit/Event/MutationTestingWasStartedTest.php
@@ -33,22 +33,18 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event;
+namespace Infection\Tests\Event;
 
-/**
- * @internal
- */
-final class MutationGeneratingStarted
+use Infection\Event\MutationTestingWasStarted;
+use PHPUnit\Framework\TestCase;
+
+final class MutationTestingWasStartedTest extends TestCase
 {
-    private $mutableFilesCount;
-
-    public function __construct(int $mutableFilesCount)
+    public function test_it_exposes_its_mutation_count(): void
     {
-        $this->mutableFilesCount = $mutableFilesCount;
-    }
+        $count = 5;
+        $event = new MutationTestingWasStarted($count);
 
-    public function getMutableFilesCount(): int
-    {
-        return $this->mutableFilesCount;
+        $this->assertSame($count, $event->getMutationCount());
     }
 }

--- a/tests/phpunit/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriberTest.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Event\Subscriber;
 
 use Infection\Event\EventDispatcher;
-use Infection\Event\InitialTestSuiteStarted;
+use Infection\Event\InitialTestSuiteWasStarted;
 use Infection\Event\Subscriber\CiInitialTestsConsoleLoggerSubscriber;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -85,6 +85,6 @@ final class CiInitialTestsConsoleLoggerSubscriberTest extends TestCase
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new CiInitialTestsConsoleLoggerSubscriber($this->output, $this->testFramework));
 
-        $dispatcher->dispatch(new InitialTestSuiteStarted());
+        $dispatcher->dispatch(new InitialTestSuiteWasStarted());
     }
 }

--- a/tests/phpunit/Event/Subscriber/CiMutantCreatingConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/CiMutantCreatingConsoleLoggerSubscriberTest.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Event\Subscriber;
 
 use Infection\Event\EventDispatcher;
-use Infection\Event\MutantsCreatingStarted;
+use Infection\Event\MutantsCreationWasStarted;
 use Infection\Event\Subscriber\CiMutantCreatingConsoleLoggerSubscriber;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -68,6 +68,6 @@ final class CiMutantCreatingConsoleLoggerSubscriberTest extends TestCase
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new CiMutantCreatingConsoleLoggerSubscriber($this->output));
 
-        $dispatcher->dispatch(new MutantsCreatingStarted(123));
+        $dispatcher->dispatch(new MutantsCreationWasStarted(123));
     }
 }

--- a/tests/phpunit/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriberTest.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Event\Subscriber;
 
 use Infection\Event\EventDispatcher;
-use Infection\Event\MutationGeneratingStarted;
+use Infection\Event\MutationGenerationWasStarted;
 use Infection\Event\Subscriber\CiMutationGeneratingConsoleLoggerSubscriber;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -70,6 +70,6 @@ final class CiMutationGeneratingConsoleLoggerSubscriberTest extends TestCase
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new CiMutationGeneratingConsoleLoggerSubscriber($this->output));
 
-        $dispatcher->dispatch(new MutationGeneratingStarted(123));
+        $dispatcher->dispatch(new MutationGenerationWasStarted(123));
     }
 }

--- a/tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberTest.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Event\Subscriber;
 
-use Infection\Event\MutationTestingFinished;
+use Infection\Event\MutationTestingWasFinished;
 use Infection\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriber;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -53,6 +53,6 @@ final class CleanUpAfterMutationTestingFinishedSubscriberTest extends TestCase
 
         $subscriber = new CleanUpAfterMutationTestingFinishedSubscriber($filesystem, sys_get_temp_dir());
 
-        $subscriber->onMutationTestingFinished(new MutationTestingFinished());
+        $subscriber->onMutationTestingWasFinished(new MutationTestingWasFinished());
     }
 }

--- a/tests/phpunit/Event/Subscriber/InitialTestsConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/InitialTestsConsoleLoggerSubscriberTest.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\Event\Subscriber;
 
 use Infection\Event\EventDispatcher;
-use Infection\Event\InitialTestSuiteFinished;
-use Infection\Event\InitialTestSuiteStarted;
+use Infection\Event\InitialTestSuiteWasFinished;
+use Infection\Event\InitialTestSuiteWasStarted;
 use Infection\Event\Subscriber\InitialTestsConsoleLoggerSubscriber;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use InvalidArgumentException;
@@ -59,7 +59,7 @@ final class InitialTestsConsoleLoggerSubscriberTest extends TestCase
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new InitialTestsConsoleLoggerSubscriber($output, $testFramework, false));
 
-        $dispatcher->dispatch(new InitialTestSuiteStarted());
+        $dispatcher->dispatch(new InitialTestSuiteWasStarted());
     }
 
     public function test_it_sets_test_framework_version_as_unknown_in_case_of_exception(): void
@@ -87,7 +87,7 @@ final class InitialTestsConsoleLoggerSubscriberTest extends TestCase
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new InitialTestsConsoleLoggerSubscriber($output, $testFramework, false));
 
-        $dispatcher->dispatch(new InitialTestSuiteStarted());
+        $dispatcher->dispatch(new InitialTestSuiteWasStarted());
     }
 
     public function test_it_outputs_the_initial_process_text_if_in_debug_mode(): void
@@ -106,6 +106,6 @@ final class InitialTestsConsoleLoggerSubscriberTest extends TestCase
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new InitialTestsConsoleLoggerSubscriber($output, $testFramework, true));
 
-        $dispatcher->dispatch(new InitialTestSuiteFinished($processText));
+        $dispatcher->dispatch(new InitialTestSuiteWasFinished($processText));
     }
 }

--- a/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberTest.php
@@ -38,9 +38,9 @@ namespace Infection\Tests\Event\Subscriber;
 use Infection\Console\OutputFormatter\OutputFormatter;
 use Infection\Differ\DiffColorizer;
 use Infection\Event\EventDispatcher;
-use Infection\Event\MutantProcessFinished;
-use Infection\Event\MutationTestingFinished;
-use Infection\Event\MutationTestingStarted;
+use Infection\Event\MutantProcessWasFinished;
+use Infection\Event\MutationTestingWasFinished;
+use Infection\Event\MutationTestingWasStarted;
 use Infection\Event\Subscriber\MutationTestingConsoleLoggerSubscriber;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Process\MutantProcess;
@@ -93,7 +93,7 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             false
         ));
 
-        $dispatcher->dispatch(new MutationTestingStarted(1));
+        $dispatcher->dispatch(new MutationTestingWasStarted(1));
     }
 
     public function test_it_reacts_on_mutation_process_finished(): void
@@ -115,7 +115,7 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             false
         ));
 
-        $dispatcher->dispatch(new MutantProcessFinished($this->createMock(MutantProcess::class)));
+        $dispatcher->dispatch(new MutantProcessWasFinished($this->createMock(MutantProcess::class)));
     }
 
     public function test_it_reacts_on_mutation_testing_finished(): void
@@ -133,7 +133,7 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             false
         ));
 
-        $dispatcher->dispatch(new MutationTestingFinished());
+        $dispatcher->dispatch(new MutationTestingWasFinished());
     }
 
     public function test_it_reacts_on_mutation_testing_finished_and_show_mutations_on(): void
@@ -154,6 +154,6 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             true
         ));
 
-        $dispatcher->dispatch(new MutationTestingFinished());
+        $dispatcher->dispatch(new MutationTestingWasFinished());
     }
 }

--- a/tests/phpunit/Event/Subscriber/MutationTestingResultsLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingResultsLoggerSubscriberTest.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Event\Subscriber;
 
 use Infection\Event\EventDispatcher;
-use Infection\Event\MutationTestingFinished;
+use Infection\Event\MutationTestingWasFinished;
 use Infection\Event\Subscriber\MutationTestingResultsLoggerSubscriber;
 use Infection\Logger\MutationTestingResultsLogger;
 use PHPUnit\Framework\TestCase;
@@ -50,6 +50,6 @@ final class MutationTestingResultsLoggerSubscriberTest extends TestCase
         $logger->expects($this->once())->method('log');
         $dispatcher->addSubscriber(new MutationTestingResultsLoggerSubscriber([$logger]));
 
-        $dispatcher->dispatch(new MutationTestingFinished());
+        $dispatcher->dispatch(new MutationTestingWasFinished());
     }
 }

--- a/tests/phpunit/Mutation/MutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/MutationGeneratorTest.php
@@ -36,9 +36,9 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutation;
 
 use Infection\Event\EventDispatcher;
-use Infection\Event\MutableFileProcessed;
-use Infection\Event\MutationGeneratingFinished;
-use Infection\Event\MutationGeneratingStarted;
+use Infection\Event\MutableFileWasProcessed;
+use Infection\Event\MutationGenerationWasFinished;
+use Infection\Event\MutationGenerationWasStarted;
 use Infection\Mutation\FileMutationGenerator;
 use Infection\Mutation\Mutation;
 use Infection\Mutation\MutationGenerator;
@@ -121,10 +121,10 @@ final class MutationGeneratorTest extends TestCase
             ->expects($this->exactly(4))
             ->method('dispatch')
             ->withConsecutive(
-                [new MutationGeneratingStarted(2)],
-                [new MutableFileProcessed()],
-                [new MutableFileProcessed()],
-                [new MutationGeneratingFinished()]
+                [new MutationGenerationWasStarted(2)],
+                [new MutableFileWasProcessed()],
+                [new MutableFileWasProcessed()],
+                [new MutationGenerationWasFinished()]
             )
         ;
 

--- a/tests/phpunit/Process/Runner/InitialTestsRunnerTest.php
+++ b/tests/phpunit/Process/Runner/InitialTestsRunnerTest.php
@@ -36,9 +36,9 @@ declare(strict_types=1);
 namespace Infection\Tests\Process\Runner;
 
 use Infection\Event\EventDispatcher;
-use Infection\Event\InitialTestCaseCompleted;
-use Infection\Event\InitialTestSuiteFinished;
-use Infection\Event\InitialTestSuiteStarted;
+use Infection\Event\InitialTestCaseWasCompleted;
+use Infection\Event\InitialTestSuiteWasFinished;
+use Infection\Event\InitialTestSuiteWasStarted;
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
 use Infection\Process\Runner\InitialTestsRunner;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -72,9 +72,9 @@ final class InitialTestsRunnerTest extends TestCase
         $eventDispatcher->expects($this->exactly(3))
             ->method('dispatch')
             ->withConsecutive(
-                [$this->isInstanceOf(InitialTestSuiteStarted::class)],
-                [$this->isInstanceOf(InitialTestCaseCompleted::class)],
-                [$this->isInstanceOf(InitialTestSuiteFinished::class)]
+                [$this->isInstanceOf(InitialTestSuiteWasStarted::class)],
+                [$this->isInstanceOf(InitialTestCaseWasCompleted::class)],
+                [$this->isInstanceOf(InitialTestSuiteWasFinished::class)]
             );
 
         $testRunner = new InitialTestsRunner($processBuilder, $eventDispatcher);

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -39,11 +39,11 @@ use function array_map;
 use function count;
 use function get_class;
 use function implode;
-use Infection\Event\MutantCreated;
-use Infection\Event\MutantsCreatingFinished;
-use Infection\Event\MutantsCreatingStarted;
-use Infection\Event\MutationTestingFinished;
-use Infection\Event\MutationTestingStarted;
+use Infection\Event\MutantsCreationWasFinished;
+use Infection\Event\MutantsCreationWasStarted;
+use Infection\Event\MutantWasCreated;
+use Infection\Event\MutationTestingWasFinished;
+use Infection\Event\MutationTestingWasStarted;
 use Infection\Mutant\Mutant;
 use Infection\Mutant\MutantFactory;
 use Infection\Mutation\Mutation;
@@ -114,10 +114,10 @@ final class MutationTestingRunnerTest extends TestCase
 
         $this->assertAreSameEvents(
             [
-                new MutantsCreatingStarted(0),
-                new MutantsCreatingFinished(),
-                new MutationTestingStarted(0),
-                new MutationTestingFinished(),
+                new MutantsCreationWasStarted(0),
+                new MutantsCreationWasFinished(),
+                new MutationTestingWasStarted(0),
+                new MutationTestingWasFinished(),
             ],
             $this->eventDispatcher->getEvents()
         );
@@ -166,12 +166,12 @@ final class MutationTestingRunnerTest extends TestCase
 
         $this->assertAreSameEvents(
             [
-                new MutantsCreatingStarted(2),
-                new MutantCreated(),
-                new MutantCreated(),
-                new MutantsCreatingFinished(),
-                new MutationTestingStarted(2),
-                new MutationTestingFinished(),
+                new MutantsCreationWasStarted(2),
+                new MutantWasCreated(),
+                new MutantWasCreated(),
+                new MutantsCreationWasFinished(),
+                new MutationTestingWasStarted(2),
+                new MutationTestingWasFinished(),
             ],
             $this->eventDispatcher->getEvents()
         );
@@ -200,25 +200,25 @@ final class MutationTestingRunnerTest extends TestCase
 
         $this->assertAreSameEvents(
             [
-                new MutationTestingStarted(0),
-                new MutationTestingFinished(),
+                new MutationTestingWasStarted(0),
+                new MutationTestingWasFinished(),
             ],
             $this->eventDispatcher->getEvents()
         );
     }
 
     /**
-     * @param array<MutationTestingStarted|MutationTestingFinished|MutantsCreatingStarted|MutantCreated|MutantsCreatingFinished> $expectedEvents
-     * @param array<MutationTestingStarted|MutationTestingFinished|MutantsCreatingStarted|MutantCreated|MutantsCreatingFinished> $actualEvents
+     * @param array<MutationTestingWasStarted|MutationTestingWasFinished|MutantsCreationWasStarted|MutantWasCreated|MutantsCreationWasFinished> $expectedEvents
+     * @param array<MutationTestingWasStarted|MutationTestingWasFinished|MutantsCreationWasStarted|MutantWasCreated|MutantsCreationWasFinished> $actualEvents
      */
     private function assertAreSameEvents(array $expectedEvents, array $actualEvents): void
     {
         $expectedClasses = [
-            MutationTestingStarted::class,
-            MutationTestingFinished::class,
-            MutantsCreatingStarted::class,
-            MutantCreated::class,
-            MutantsCreatingFinished::class,
+            MutationTestingWasStarted::class,
+            MutationTestingWasFinished::class,
+            MutantsCreationWasStarted::class,
+            MutantWasCreated::class,
+            MutantsCreationWasFinished::class,
         ];
 
         $assertionErrorMessage = sprintf(
@@ -238,13 +238,13 @@ final class MutationTestingRunnerTest extends TestCase
                 $assertionErrorMessage
             );
 
-            if ($expectedEvent instanceof MutantsCreatingStarted) {
+            if ($expectedEvent instanceof MutantsCreationWasStarted) {
                 $this->assertSame($expectedEvent->getMutantCount(), $event->getMutantCount());
 
                 continue;
             }
 
-            if ($expectedEvent instanceof MutationTestingStarted) {
+            if ($expectedEvent instanceof MutationTestingWasStarted) {
                 $this->assertSame($expectedEvent->getMutationCount(), $event->getMutationCount());
             }
         }

--- a/tests/phpunit/Process/Runner/Parallel/ParallelProcessRunnerTest.php
+++ b/tests/phpunit/Process/Runner/Parallel/ParallelProcessRunnerTest.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Process\Runner\Parallel;
 
 use Infection\Event\EventDispatcher;
-use Infection\Event\MutantProcessFinished;
+use Infection\Event\MutantProcessWasFinished;
 use Infection\Mutant\Mutant;
 use Infection\Process\MutantProcess;
 use Infection\Process\Runner\Parallel\ParallelProcessRunner;
@@ -123,7 +123,7 @@ final class ParallelProcessRunnerTest extends TestCase
         $eventDispatcher = $this->createMock(EventDispatcher::class);
         $eventDispatcher->expects($this->exactly($eventCount))
             ->method('dispatch')
-            ->with(new MutantProcessFinished($this->createMock(MutantProcess::class)));
+            ->with(new MutantProcessWasFinished($this->createMock(MutantProcess::class)));
 
         return $eventDispatcher;
     }

--- a/tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php
+++ b/tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php
@@ -35,8 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Resource\Listener;
 
-use Infection\Event\ApplicationExecutionFinished;
-use Infection\Event\ApplicationExecutionStarted;
+use Infection\Event\ApplicationExecutionWasFinished;
+use Infection\Event\ApplicationExecutionWasStarted;
 use Infection\Event\EventDispatcher;
 use Infection\Resource\Listener\PerformanceLoggerSubscriber;
 use Infection\Resource\Memory\MemoryFormatter;
@@ -75,7 +75,7 @@ final class PerformanceLoggerSubscriberTest extends TestCase
             $this->output
         ));
 
-        $dispatcher->dispatch(new ApplicationExecutionStarted());
-        $dispatcher->dispatch(new ApplicationExecutionFinished());
+        $dispatcher->dispatch(new ApplicationExecutionWasStarted());
+        $dispatcher->dispatch(new ApplicationExecutionWasFinished());
     }
 }


### PR DESCRIPTION
This is more of a nitpick than anything, but personally I like to have the code following the natural language as closely as possible provided it does not cost too much in verbosity. As such `UserWasAdded` seems more like a natural event name than `UserAdded`: the previous clearly communicates its event nature whereas the later only communicates a change of state.

But as said, it's opinions & nitpicks, so feel free to disagree