### PR TITLE
Fix test warning that prevented its execution

### DIFF
--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -183,23 +183,28 @@ final class MutationTestingRunnerTest extends TestCase
         $threadCount = 4;
         $testFrameworkExtraOptions = '--filter=acme/FooTest.php';
 
+        $this->processBuilderMock
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
         $this->mutantFactoryMock
-            ->expects($this->once())
-            ->method('create')
-            ->with($mutations, $testFrameworkExtraOptions)
-            ->willReturn($processes = [])
+            ->expects($this->never())
+            ->method($this->anything())
         ;
 
         $this->parallelProcessRunnerMock
             ->expects($this->once())
             ->method('run')
-            ->with($processes, $threadCount)
+            ->with([], $threadCount)
         ;
 
         $this->runner->run($mutations, $threadCount, $testFrameworkExtraOptions);
 
         $this->assertAreSameEvents(
             [
+                new MutantsCreationWasStarted(0),
+                new MutantsCreationWasFinished(),
                 new MutationTestingWasStarted(0),
                 new MutationTestingWasFinished(),
             ],


### PR DESCRIPTION
This PR fixes the `test_it_dispatches_events_even_when_no_mutations_is_given` test.

It gave a phpunit warning that the return type of the mock ans the real class don't match. This prevented the method from being executed any further, as the test itself was also faulty.