### PR TITLE
Enhancement: Extract StrykerApiKeyResolver

### DIFF
--- a/src/Environment/CouldNotResolveStrykerApiKey.php
+++ b/src/Environment/CouldNotResolveStrykerApiKey.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Environment;
+
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class CouldNotResolveStrykerApiKey extends RuntimeException
+{
+    public static function from(string ...$names): self
+    {
+        return new self(sprintf(
+            'The Stryker API key needs to be configured using one of the environment variables "%s", but could not find any of these.',
+            implode(
+                '" or "',
+                $names
+            )
+        ));
+    }
+}

--- a/src/Environment/StrykerApiKeyResolver.php
+++ b/src/Environment/StrykerApiKeyResolver.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Environment;
+
+/**
+ * @internal
+ *
+ * @see https://github.com/stryker-mutator/stryker-handbook/blob/master/dashboard.md#send-a-report-direcly-from-stryker
+ */
+final class StrykerApiKeyResolver
+{
+    /**
+     * @param array<string, string> $environment
+     *
+     * @throws CouldNotResolveStrykerApiKey
+     */
+    public function resolve(array $environment): string
+    {
+        $names = [
+            'INFECTION_BADGE_API_KEY',
+            'STRYKER_DASHBOARD_API_KEY',
+        ];
+
+        foreach ($names as $name) {
+            if (!array_key_exists($name, $environment) || !is_string($environment[$name])) {
+                continue;
+            }
+
+            return $environment[$name];
+        }
+
+        throw CouldNotResolveStrykerApiKey::from(...$names);
+    }
+}

--- a/src/Logger/BadgeLogger.php
+++ b/src/Logger/BadgeLogger.php
@@ -48,10 +48,10 @@ final class BadgeLogger implements MutationTestingResultsLogger
     public const ENV_INFECTION_BADGE_API_KEY = 'INFECTION_BADGE_API_KEY';
     public const ENV_STRYKER_DASHBOARD_API_KEY = 'STRYKER_DASHBOARD_API_KEY';
 
+    private $output;
     private $badgeApiClient;
     private $metricsCalculator;
     private $config;
-    private $output;
 
     public function __construct(OutputInterface $output, BadgeApiClient $badgeApiClient, MetricsCalculator $metricsCalculator, stdClass $config)
     {

--- a/src/Logger/BadgeLogger.php
+++ b/src/Logger/BadgeLogger.php
@@ -35,6 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Logger;
 
+use Infection\Environment\CouldNotResolveStrykerApiKey;
+use Infection\Environment\StrykerApiKeyResolver;
 use Infection\Http\BadgeApiClient;
 use Infection\Mutant\MetricsCalculator;
 use stdClass;
@@ -49,13 +51,20 @@ final class BadgeLogger implements MutationTestingResultsLogger
     public const ENV_STRYKER_DASHBOARD_API_KEY = 'STRYKER_DASHBOARD_API_KEY';
 
     private $output;
+    private $strykerApiKeyResolver;
     private $badgeApiClient;
     private $metricsCalculator;
     private $config;
 
-    public function __construct(OutputInterface $output, BadgeApiClient $badgeApiClient, MetricsCalculator $metricsCalculator, stdClass $config)
-    {
+    public function __construct(
+        OutputInterface $output,
+        StrykerApiKeyResolver $strykerApiKeyResolver,
+        BadgeApiClient $badgeApiClient,
+        MetricsCalculator $metricsCalculator,
+        stdClass $config
+    ) {
         $this->output = $output;
+        $this->strykerApiKeyResolver = $strykerApiKeyResolver;
         $this->badgeApiClient = $badgeApiClient;
         $this->metricsCalculator = $metricsCalculator;
         $this->config = $config;
@@ -100,24 +109,10 @@ final class BadgeLogger implements MutationTestingResultsLogger
             return;
         }
 
-        $apiKey = getenv(self::ENV_INFECTION_BADGE_API_KEY);
-
-        /*
-         * Original Stryker Dashboard manual warrants a different API key:
-         * fall back to theirs if our isn't present
-         */
-        if ($apiKey === false) {
-            $apiKey = getenv(self::ENV_STRYKER_DASHBOARD_API_KEY);
-        }
-
-        if ($apiKey === false) {
-            $this->showInfo(
-                sprintf(
-                    'neither %s nor %s were found in the environment',
-                    self::ENV_INFECTION_BADGE_API_KEY,
-                    self::ENV_STRYKER_DASHBOARD_API_KEY
-                )
-            );
+        try {
+            $apiKey = $this->strykerApiKeyResolver->resolve(getenv());
+        } catch (CouldNotResolveStrykerApiKey $exception) {
+            $this->showInfo($exception->getMessage());
 
             return;
         }

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -37,6 +37,7 @@ namespace Infection\Logger;
 
 use Infection\Configuration\Entry\Logs;
 use Infection\Console\LogVerbosity;
+use Infection\Environment\StrykerApiKeyResolver;
 use Infection\Http\BadgeApiClient;
 use Infection\Mutant\MetricsCalculator;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -167,6 +168,7 @@ final class LoggerFactory
     {
         return new BadgeLogger(
             $output,
+            new StrykerApiKeyResolver(),
             new BadgeApiClient($output),
             $this->metricsCalculator,
             (object) ['branch' => $branch]

--- a/tests/phpunit/Environment/CouldNotResolveStrykerApiKeyTest.php
+++ b/tests/phpunit/Environment/CouldNotResolveStrykerApiKeyTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Environment;
+
+use Infection\Environment\CouldNotResolveStrykerApiKey;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Infection\Environment\CouldNotResolveStrykerApiKey
+ */
+final class CouldNotResolveStrykerApiKeyTest extends TestCase
+{
+    public function test_from_returns_exception(): void
+    {
+        $names = [
+            'FOO',
+            'BAR',
+        ];
+
+        $exception = CouldNotResolveStrykerApiKey::from(...$names);
+
+        $message = sprintf(
+            'The Stryker API key needs to be configured using one of the environment variables "%s", but could not find any of these.',
+            implode(
+                '" or "',
+                $names
+            )
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+}

--- a/tests/phpunit/Environment/StrykerApiKeyResolverTest.php
+++ b/tests/phpunit/Environment/StrykerApiKeyResolverTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Environment;
+
+use Infection\Environment\CouldNotResolveStrykerApiKey;
+use Infection\Environment\StrykerApiKeyResolver;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * @covers \Infection\Environment\StrykerApiKeyResolver
+ */
+final class StrykerApiKeyResolverTest extends TestCase
+{
+    public function test_resolve_throws_when_environment_is_empty_array(): void
+    {
+        $environment = [];
+
+        $resolver = new StrykerApiKeyResolver();
+
+        $this->expectException(CouldNotResolveStrykerApiKey::class);
+
+        $resolver->resolve($environment);
+    }
+
+    public function test_resolve_throws_when_environment_does_not_contain_any_known_environment_variable_names(): void
+    {
+        $environment = [
+            'API_KEY' => 'foo',
+        ];
+
+        $resolver = new StrykerApiKeyResolver();
+
+        $this->expectException(CouldNotResolveStrykerApiKey::class);
+
+        $resolver->resolve($environment);
+    }
+
+    public function test_resolve_throws_when_value_of_known_environment_variables_is_not_a_string(): void
+    {
+        $environment = [
+            'API_KEY' => 'foo',
+            'INFECTION_BADGE_API_KEY' => 9000,
+            'STRYKER_DASHBOARD_API_KEY' => new stdClass(),
+        ];
+
+        $resolver = new StrykerApiKeyResolver();
+
+        $this->expectException(CouldNotResolveStrykerApiKey::class);
+
+        $resolver->resolve($environment);
+    }
+
+    public function test_resolve_returns_value_of_infection_badge_api_key_when_available(): void
+    {
+        $environment = [
+            'API_KEY' => 'foo',
+            'INFECTION_BADGE_API_KEY' => 'bar',
+            'STRYKER_DASHBOARD_API_KEY' => 'baz',
+        ];
+
+        $resolver = new StrykerApiKeyResolver();
+
+        self::assertSame('bar', $resolver->resolve($environment));
+    }
+
+    public function test_resolve_returns_value_of_stryker_dashboard_api_key_when_available(): void
+    {
+        $environment = [
+            'API_KEY' => 'foo',
+            'STRYKER_DASHBOARD_API_KEY' => 'baz',
+        ];
+
+        $resolver = new StrykerApiKeyResolver();
+
+        self::assertSame('baz', $resolver->resolve($environment));
+    }
+}

--- a/tests/phpunit/Logger/BadgeLoggerTest.php
+++ b/tests/phpunit/Logger/BadgeLoggerTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Logger;
 
 use function getenv;
+use Infection\Environment\StrykerApiKeyResolver;
 use Infection\Http\BadgeApiClient;
 use Infection\Logger\BadgeLogger;
 use Infection\Mutant\MetricsCalculator;
@@ -76,8 +77,8 @@ final class BadgeLoggerTest extends TestCase
             'TRAVIS_BRANCH',
             'TRAVIS_REPO_SLUG',
             'TRAVIS_PULL_REQUEST',
-            BadgeLogger::ENV_INFECTION_BADGE_API_KEY,
-            BadgeLogger::ENV_STRYKER_DASHBOARD_API_KEY,
+            'INFECTION_BADGE_API_KEY',
+            'STRYKER_DASHBOARD_API_KEY',
         ];
 
         foreach ($names as $name) {
@@ -109,6 +110,7 @@ final class BadgeLoggerTest extends TestCase
 
         $this->badgeLogger = new BadgeLogger(
             $this->outputMock,
+            new StrykerApiKeyResolver(),
             $this->badgeApiClientMock,
             $this->metricsCalculatorMock,
             $config
@@ -215,13 +217,12 @@ final class BadgeLoggerTest extends TestCase
         putenv('TRAVIS_PULL_REQUEST=false');
         putenv('TRAVIS_REPO_SLUG=a/b');
         putenv('TRAVIS_BRANCH=master');
-
-        putenv(BadgeLogger::ENV_INFECTION_BADGE_API_KEY);
-        putenv(BadgeLogger::ENV_STRYKER_DASHBOARD_API_KEY);
+        putenv('INFECTION_BADGE_API_KEY');
+        putenv('STRYKER_DASHBOARD_API_KEY');
 
         $this->outputMock
             ->method('writeln')
-            ->with('Dashboard report has not been sent: neither INFECTION_BADGE_API_KEY nor STRYKER_DASHBOARD_API_KEY were found in the environment')
+            ->with('Dashboard report has not been sent: The Stryker API key needs to be configured using one of the environment variables "INFECTION_BADGE_API_KEY" or "STRYKER_DASHBOARD_API_KEY", but could not find any of these.')
         ;
 
         $this->badgeApiClientMock
@@ -234,7 +235,7 @@ final class BadgeLoggerTest extends TestCase
 
     public function test_it_sends_report_when_everything_is_ok_with_stryker_key(): void
     {
-        putenv(BadgeLogger::ENV_STRYKER_DASHBOARD_API_KEY . '=abc');
+        putenv('STRYKER_DASHBOARD_API_KEY=abc');
         putenv('TRAVIS=true');
         putenv('TRAVIS_PULL_REQUEST=false');
         putenv('TRAVIS_REPO_SLUG=a/b');
@@ -261,7 +262,7 @@ final class BadgeLoggerTest extends TestCase
 
     public function test_it_sends_report_when_everything_is_ok_with_our_key(): void
     {
-        putenv(BadgeLogger::ENV_INFECTION_BADGE_API_KEY . '=abc');
+        putenv('INFECTION_BADGE_API_KEY=abc');
         putenv('TRAVIS=true');
         putenv('TRAVIS_PULL_REQUEST=false');
         putenv('TRAVIS_REPO_SLUG=a/b');


### PR DESCRIPTION
This PR

* [x] extracts a `StrykerApiKeyResolver`
* [x] fixes the order of fields in `BadgeLogger` so it is consistent with the order of constructor parameters (and assignments)

💁‍♂ Related to #939.