### PR TITLE
Add support for BDD tests (.feature)

### DIFF
--- a/src/TestFramework/Coverage/XmlReport/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/JUnitTestFileDataProvider.php
@@ -81,10 +81,11 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
             );
         }
 
-        $feature = preg_replace("/^(.*):+.*$/", "$1.feature", $fullyQualifiedClassName);
+        $feature = preg_replace('/^(.*):+.*$/', '$1.feature', $fullyQualifiedClassName);
+
         if ($nodes->length === 0) {
-          // try another format where the class name is inside `file` attribute of `testcase` tag
-          $nodes = $xPath->query(sprintf('//testcase[contains(@file, "%s")]', $feature));
+            // try another format where the class name is inside `file` attribute of `testcase` tag
+            $nodes = $xPath->query(sprintf('//testcase[contains(@file, "%s")]', $feature));
         }
 
         if ($nodes->length === 0) {

--- a/src/TestFramework/Coverage/XmlReport/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/JUnitTestFileDataProvider.php
@@ -82,7 +82,7 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
         }
 
         $feature = preg_replace("/^(.*):+.*$/", "$1.feature", $fullyQualifiedClassName);
-        if (!$nodes->length) {
+        if ($nodes->length === 0) {
           // try another format where the class name is inside `file` attribute of `testcase` tag
           $nodes = $xPath->query(sprintf('//testcase[contains(@file, "%s")]', $feature));
         }

--- a/src/TestFramework/Coverage/XmlReport/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/JUnitTestFileDataProvider.php
@@ -81,6 +81,12 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
             );
         }
 
+        $feature = preg_replace("/^(.*):+.*$/", "$1.feature", $fullyQualifiedClassName);
+        if (!$nodes->length) {
+          // try another format where the class name is inside `file` attribute of `testcase` tag
+          $nodes = $xPath->query(sprintf('//testcase[contains(@file, "%s")]', $feature));
+        }
+
         if ($nodes->length === 0) {
             throw TestFileNameNotFoundException::notFoundFromFQN(
                 $fullyQualifiedClassName,

--- a/tests/phpunit/Fixtures/Files/phpunit/junit_feature.xml
+++ b/tests/phpunit/Fixtures/Files/phpunit/junit_feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="acceptance" tests="4" assertions="11" errors="0" failures="0" skipped="0" time="0.604773">
+    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A1" assertions="6" time="0.039365"/>
+    <testcase file="/codeception/tests/bdd/FeatureB.feature" name="Feature B: Scenario B2" assertions="2" time="0.022857"/>
+    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A2" assertions="1" time="0.029354"/>
+    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A3" assertions="2" time="0.025091"/>
+  </testsuite>
+</testsuites>

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/JUnitTestFileDataProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/JUnitTestFileDataProviderTest.php
@@ -47,6 +47,7 @@ final class JUnitTestFileDataProviderTest extends TestCase
 {
     private const JUNIT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit.xml';
     private const JUNIT_DIFF_FORMAT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit2.xml';
+    private const JUNIT_FEATURE_FORMAT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit_feature.xml';
 
     /**
      * @var JUnitTestFileDataProvider
@@ -98,5 +99,14 @@ final class JUnitTestFileDataProviderTest extends TestCase
         $testFileInfo = $provider->getTestFileInfo('App\Tests\unit\SourceClassTest');
 
         $this->assertSame('/codeception/tests/unit/SourceClassTest.php', $testFileInfo->path);
+    }
+
+    public function test_it_works_with_feature_junit_format(): void
+    {
+        $provider = new JUnitTestFileDataProvider(self::JUNIT_FEATURE_FORMAT);
+
+        $testFileInfo = $provider->getTestFileInfo('FeatureA:Scenario A1');
+
+        $this->assertSame('/codeception/tests/bdd/FeatureA.feature', $testFileInfo->path);
     }
 }


### PR DESCRIPTION
This PR:

- [x] Adds a new feature allowing to support `junit.xml` for [Codeception BDD](https://codeception.com/docs/07-BDD) testsuites
- [x] Covered by tests
- [ ] ~~Doc PR: https://github.com/infection/site/pull/XXX~~

This PR allows running `infection` with test framework `codeception` with Gherkin (BDD) style testsuite where JUnit file reference `.feature` tests instead of classes.

Example of `junit.xml`:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="acceptance" tests="4" assertions="11" errors="0" failures="0" skipped="0" time="0.604773">
    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A1" assertions="6" time="0.039365"/>
    <testcase file="/codeception/tests/bdd/FeatureB.feature" name="Feature B: Scenario B2" assertions="2" time="0.022857"/>
    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A2" assertions="1" time="0.029354"/>
    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A3" assertions="2" time="0.025091"/>
  </testsuite>
</testsuites>
```