### PR TITLE
Add support for BDD tests (.feature)

### DIFF
--- a/src/TestFramework/Coverage/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnitTestFileDataProvider.php
@@ -69,9 +69,8 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
             $nodes = $xPath->query(sprintf('//testcase[@class="%s"]', $fullyQualifiedClassName));
         }
 
-        $feature = preg_replace('/^(.*):+.*$/', '$1.feature', $fullyQualifiedClassName);
-
         if (!$nodes->length) {
+            $feature = preg_replace('/^(.*):+.*$/', '$1.feature', $fullyQualifiedClassName);
             // try another format where the class name is inside `file` attribute of `testcase` tag
             $nodes = $xPath->query(sprintf('//testcase[contains(@file, "%s")]', $feature));
         }

--- a/src/TestFramework/Coverage/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnitTestFileDataProvider.php
@@ -69,6 +69,13 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
             $nodes = $xPath->query(sprintf('//testcase[@class="%s"]', $fullyQualifiedClassName));
         }
 
+        $feature = preg_replace('/^(.*):+.*$/', '$1.feature', $fullyQualifiedClassName);
+
+        if (!$nodes->length) {
+            // try another format where the class name is inside `file` attribute of `testcase` tag
+            $nodes = $xPath->query(sprintf('//testcase[contains(@file, "%s")]', $feature));
+        }
+
         if (!$nodes->length) {
             throw TestFileNameNotFoundException::notFoundFromFQN($fullyQualifiedClassName, $this->jUnitFilePath);
         }

--- a/tests/phpunit/Fixtures/Files/phpunit/junit_feature.xml
+++ b/tests/phpunit/Fixtures/Files/phpunit/junit_feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="acceptance" tests="4" assertions="11" errors="0" failures="0" skipped="0" time="0.604773">
+    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A1" assertions="6" time="0.039365"/>
+    <testcase file="/codeception/tests/bdd/FeatureB.feature" name="Feature B: Scenario B2" assertions="2" time="0.022857"/>
+    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A2" assertions="1" time="0.029354"/>
+    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A3" assertions="2" time="0.025091"/>
+  </testsuite>
+</testsuites>

--- a/tests/phpunit/TestFramework/Coverage/JUnitTestFileDataProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnitTestFileDataProviderTest.php
@@ -97,4 +97,15 @@ final class JUnitTestFileDataProviderTest extends TestCase
 
         $this->assertSame('/codeception/tests/unit/SourceClassTest.php', $info1->path);
     }
+
+    public function test_it_works_with_feature_junit_format(): void
+    {
+        $provider = new JUnitTestFileDataProvider(
+            __DIR__ . '/../../Fixtures/Files/phpunit/junit_feature.xml'
+        );
+
+        $testFileInfo = $provider->getTestFileInfo('FeatureA:Scenario A1');
+
+        $this->assertSame('/codeception/tests/bdd/FeatureA.feature', $testFileInfo->path);
+    }
 }


### PR DESCRIPTION
This PR:

- [x] Adds a new feature allowing to support `junit.xml` for [Codeception BDD](https://codeception.com/docs/07-BDD) testsuites
- [x] Covered by tests
- [ ] ~~Doc PR: https://github.com/infection/site/pull/XXX~~

This PR allows running `infection` with test framework `codeception` with Gherkin (BDD) style testsuite where JUnit file reference `.feature` tests instead of classes.

Example of `junit.xml`:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="acceptance" tests="4" assertions="11" errors="0" failures="0" skipped="0" time="0.604773">
    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A1" assertions="6" time="0.039365"/>
    <testcase file="/codeception/tests/bdd/FeatureB.feature" name="Feature B: Scenario B2" assertions="2" time="0.022857"/>
    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A2" assertions="1" time="0.029354"/>
    <testcase file="/codeception/tests/bdd/FeatureA.feature" name="Feature A: Scenario A3" assertions="2" time="0.025091"/>
  </testsuite>
</testsuites>
```

> This is a new PR based on the discussion in PR #1033