### PR TITLE
Allow sebastian/diff 4.0 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "justinrainbow/json-schema": "^5.2",
         "nikic/php-parser": "^4.2.2",
         "ocramius/package-versions": "^1.2",
-        "sebastian/diff": "^3.0.2",
+        "sebastian/diff": "^3.0.2 || ^4.0",
         "seld/jsonlint": "^1.7",
         "symfony/console": "^3.4.29 || ^4.0 || ^5.0",
         "symfony/filesystem": "^3.4.29 || ^4.0 || ^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f4805ddce5cd4d7c9a1a2f7fa7f08c7",
+    "content-hash": "7a9bc546d2b97ffe5cab4dd3c41ed301",
     "packages": [
         {
             "name": "composer/xdebug-handler",


### PR DESCRIPTION
This is required to allow installation of Infection alongside PHPUnit 9 using Composer.