### PR TITLE
Make TestFrameworkFinder stateless and work with different test frameworks in one object

### DIFF
--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -127,7 +127,7 @@ final class ConfigureCommand extends BaseCommand
         $phpUnitConfigPathProvider = new TestFrameworkConfigPathProvider($testFrameworkConfigLocator, $consoleHelper, $questionHelper);
         $phpUnitConfigPath = $phpUnitConfigPathProvider->get($input, $output, $dirsInCurrentDir, $input->getOption('test-framework'));
 
-        $phpUnitExecutableFinder = new TestFrameworkFinder(TestFrameworkTypes::PHPUNIT);
+        $phpUnitExecutableFinder = new TestFrameworkFinder();
         $phpUnitCustomExecutablePathProvider = new PhpUnitCustomExecutablePathProvider($phpUnitExecutableFinder, $consoleHelper, $questionHelper);
         $phpUnitCustomExecutablePath = $phpUnitCustomExecutablePathProvider->get($input, $output);
 

--- a/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
+++ b/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
@@ -40,6 +40,7 @@ use const DIRECTORY_SEPARATOR;
 use Infection\Config\ConsoleHelper;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
+use Infection\TestFramework\TestFrameworkTypes;
 use RuntimeException;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -65,7 +66,7 @@ final class PhpUnitCustomExecutablePathProvider
     public function get(InputInterface $input, OutputInterface $output)
     {
         try {
-            $this->phpUnitExecutableFinder->find();
+            $this->phpUnitExecutableFinder->find(TestFrameworkTypes::PHPUNIT);
         } catch (FinderException $e) {
             $output->writeln(['']);
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -50,6 +50,7 @@ use Infection\Differ\DiffColorizer;
 use Infection\Differ\Differ;
 use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\EventDispatcher\SyncEventDispatcher;
+use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\FileSystem\Locator\RootsFileLocator;
 use Infection\FileSystem\Locator\RootsFileOrDirectoryLocator;
 use Infection\FileSystem\SourceFileCollector;
@@ -169,6 +170,7 @@ final class Container
                     $config->getTmpDir(),
                     $container->getProjectDir(),
                     $container->getTestFrameworkConfigLocator(),
+                    $container->getTestFrameworkFinder(),
                     $container->getJUnitFilePath(),
                     $config
                 );
@@ -396,6 +398,9 @@ final class Container
                     $container->getParallelProcessRunner(),
                     $container->getEventDispatcher()
                 );
+            },
+            TestFrameworkFinder::class => static function (): TestFrameworkFinder {
+                return new TestFrameworkFinder();
             },
         ]);
     }
@@ -736,6 +741,11 @@ final class Container
     public function getConfiguration(): Configuration
     {
         return $this->get(Configuration::class);
+    }
+
+    public function getTestFrameworkFinder(): TestFrameworkFinder
+    {
+        return $this->get(TestFrameworkFinder::class);
     }
 
     /**

--- a/src/FileSystem/Finder/ComposerExecutableFinder.php
+++ b/src/FileSystem/Finder/ComposerExecutableFinder.php
@@ -42,7 +42,7 @@ use Symfony\Component\Process\PhpExecutableFinder;
 /**
  * @internal
  */
-final class ComposerExecutableFinder extends AbstractExecutableFinder
+final class ComposerExecutableFinder
 {
     public function find(): string
     {
@@ -64,7 +64,8 @@ final class ComposerExecutableFinder extends AbstractExecutableFinder
          * Check for options without execute permissions and prefix the PHP
          * executable instead.
          */
-        $path = $this->searchNonExecutables($probable, $immediatePaths);
+        $nonExecutableFinder = new NonExecutableFinder();
+        $path = $nonExecutableFinder->searchNonExecutables($probable, $immediatePaths);
 
         if ($path !== null) {
             return $this->makeExecutable($path);

--- a/src/FileSystem/Finder/NonExecutableFinder.php
+++ b/src/FileSystem/Finder/NonExecutableFinder.php
@@ -38,11 +38,9 @@ namespace Infection\FileSystem\Finder;
 /**
  * @internal
  */
-abstract class AbstractExecutableFinder
+final class NonExecutableFinder
 {
-    abstract public function find(): string;
-
-    protected function searchNonExecutables(array $probableNames, array $extraDirectories = []): ?string
+    public function searchNonExecutables(array $probableNames, array $extraDirectories = []): ?string
     {
         $path = getenv('PATH') ?: getenv('Path');
 

--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -44,54 +44,48 @@ use function Safe\realpath;
 use function substr;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal
  */
-class TestFrameworkFinder extends AbstractExecutableFinder
+class TestFrameworkFinder
 {
-    private $testFrameworkName;
-    private $customPath;
-
     /**
-     * @var string
+     * @var array<string, string>
      */
-    private $cachedPath;
+    private $cachedPath = [];
 
-    public function __construct(string $testFrameworkName, string $customPath = '')
+    public function find(string $testFrameworkName, string $customPath = ''): string
     {
-        $this->testFrameworkName = $testFrameworkName;
-        $this->customPath = $customPath;
-    }
-
-    public function find(): string
-    {
-        if (!isset($this->cachedPath)) {
-            if (!$this->shouldUseCustomPath()) {
+        if (!array_key_exists($testFrameworkName, $this->cachedPath)) {
+            if (!$this->shouldUseCustomPath($testFrameworkName, $customPath)) {
                 $this->addVendorBinToPath();
             }
 
-            $this->cachedPath = realpath($this->findTestFramework());
+            $this->cachedPath[$testFrameworkName] = realpath($this->findTestFramework($testFrameworkName, $customPath));
 
-            if (substr($this->cachedPath, -4) === '.bat') {
-                $this->cachedPath = $this->findFromBatchFile($this->cachedPath);
+            Assert::string($this->cachedPath[$testFrameworkName]);
+
+            if (substr($this->cachedPath[$testFrameworkName], -4) === '.bat') {
+                $this->cachedPath[$testFrameworkName] = $this->findFromBatchFile($this->cachedPath[$testFrameworkName]);
             }
         }
 
-        return $this->cachedPath;
+        return $this->cachedPath[$testFrameworkName];
     }
 
-    private function shouldUseCustomPath(): bool
+    private function shouldUseCustomPath(string $testFrameworkName, string $customPath): bool
     {
-        if (!$this->customPath) {
+        if (!$customPath) {
             return false;
         }
 
-        if (file_exists($this->customPath)) {
+        if (file_exists($customPath)) {
             return true;
         }
 
-        throw FinderException::testCustomPathDoesNotExist($this->testFrameworkName, $this->customPath);
+        throw FinderException::testCustomPathDoesNotExist($testFrameworkName, $customPath);
     }
 
     private function addVendorBinToPath(): void
@@ -126,10 +120,10 @@ class TestFrameworkFinder extends AbstractExecutableFinder
         return (new ComposerExecutableFinder())->find();
     }
 
-    private function findTestFramework(): string
+    private function findTestFramework(string $testFrameworkName, string $customPath): string
     {
-        if ($this->shouldUseCustomPath()) {
-            return $this->customPath;
+        if ($this->shouldUseCustomPath($testFrameworkName, $customPath)) {
+            return $customPath;
         }
 
         /*
@@ -138,12 +132,12 @@ class TestFrameworkFinder extends AbstractExecutableFinder
          * Therefore we have to explicitly look for a .bat first.
          */
         $candidates = [
-            $this->testFrameworkName . '.bat',
-            $this->testFrameworkName,
-            $this->testFrameworkName . '.phar',
+            $testFrameworkName . '.bat',
+            $testFrameworkName,
+            $testFrameworkName . '.phar',
         ];
 
-        if ($this->testFrameworkName === TestFrameworkTypes::PHPUNIT) {
+        if ($testFrameworkName === TestFrameworkTypes::PHPUNIT) {
             $candidates[] = 'simple-phpunit.bat';
             $candidates[] = 'simple-phpunit';
             $candidates[] = 'simple-phpunit.phar';
@@ -160,13 +154,14 @@ class TestFrameworkFinder extends AbstractExecutableFinder
             }
         }
 
-        $path = $this->searchNonExecutables($candidates, $extraDirs);
+        $nonExecutableFinder = new NonExecutableFinder();
+        $path = $nonExecutableFinder->searchNonExecutables($candidates, $extraDirs);
 
         if ($path !== null) {
             return $path;
         }
 
-        throw FinderException::testFrameworkNotFound($this->testFrameworkName);
+        throw FinderException::testFrameworkNotFound($testFrameworkName);
     }
 
     private function findFromBatchFile(string $path): string

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -52,8 +52,9 @@ use function Safe\sprintf;
 final class Factory
 {
     private $tmpDir;
-    private $configLocator;
     private $projectDir;
+    private $configLocator;
+    private $testFrameworkFinder;
     private $jUnitFilePath;
     private $infectionConfig;
 
@@ -61,6 +62,7 @@ final class Factory
         string $tmpDir,
         string $projectDir,
         TestFrameworkConfigLocatorInterface $configLocator,
+        TestFrameworkFinder $testFrameworkFinder,
         string $jUnitFilePath,
         Configuration $infectionConfig
     ) {
@@ -69,6 +71,7 @@ final class Factory
         $this->projectDir = $projectDir;
         $this->jUnitFilePath = $jUnitFilePath;
         $this->infectionConfig = $infectionConfig;
+        $this->testFrameworkFinder = $testFrameworkFinder;
     }
 
     public function create(string $adapterName, bool $skipCoverage): TestFrameworkAdapter
@@ -77,10 +80,10 @@ final class Factory
             $phpUnitConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPUNIT);
 
             return PhpUnitAdapterFactory::create(
-                (new TestFrameworkFinder(
+                $this->testFrameworkFinder->find(
                     TestFrameworkTypes::PHPUNIT,
                     (string) $this->infectionConfig->getPhpUnit()->getCustomPath()
-                ))->find(),
+                ),
                 $this->tmpDir,
                 $phpUnitConfigPath,
                 (string) $this->infectionConfig->getPhpUnit()->getConfigDir(),
@@ -95,7 +98,7 @@ final class Factory
             $phpSpecConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPSPEC);
 
             return PhpSpecAdapterFactory::create(
-                (new TestFrameworkFinder(TestFrameworkTypes::PHPSPEC))->find(),
+                $this->testFrameworkFinder->find(TestFrameworkTypes::PHPSPEC),
                 $this->tmpDir,
                 $phpSpecConfigPath,
                 null,
@@ -110,7 +113,7 @@ final class Factory
             $codeceptionConfigPath = $this->configLocator->locate(TestFrameworkTypes::CODECEPTION);
 
             return CodeceptionAdapterFactory::create(
-                (new TestFrameworkFinder('codecept'))->find(),
+                $this->testFrameworkFinder->find('codecept'),
                 $this->tmpDir,
                 $codeceptionConfigPath,
                 null,

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -55,6 +55,7 @@ use Infection\Event\Subscriber\MutantCreatingConsoleLoggerSubscriber;
 use Infection\Event\Subscriber\MutationGeneratingConsoleLoggerSubscriber;
 use Infection\FileSystem\Finder\ComposerExecutableFinder;
 use Infection\FileSystem\Finder\FilterableFinder;
+use Infection\FileSystem\Finder\NonExecutableFinder;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\Http\BadgeApiClient;
 use Infection\Logger\ResultsLoggerTypes;
@@ -100,6 +101,7 @@ final class ProjectCodeProvider
         NodeMutationGenerator::class,
         FilterableFinder::class,
         Engine::class,
+        NonExecutableFinder::class,
     ];
 
     /**

--- a/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
@@ -39,6 +39,7 @@ use Infection\Config\ConsoleHelper;
 use Infection\Config\ValueProvider\PhpUnitCustomExecutablePathProvider;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
+use Infection\TestFramework\TestFrameworkTypes;
 use function Infection\Tests\normalizePath as p;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Exception\RuntimeException as SymfonyRuntimeException;
@@ -73,7 +74,8 @@ final class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProvider
     {
         $this->finderMock
             ->expects($this->once())
-            ->method('find');
+            ->method('find')
+            ->with(TestFrameworkTypes::PHPUNIT);
 
         $this->assertNull(
             $this->provider->get($this->createStreamableInputInterfaceMock(), $this->createOutputInterface())
@@ -85,6 +87,7 @@ final class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProvider
         $this->finderMock
             ->expects($this->once())
             ->method('find')
+            ->with(TestFrameworkTypes::PHPUNIT)
             ->will($this->throwException(new FinderException()));
 
         $customExecutable = p(realpath(__DIR__ . '/../../Fixtures/Files/phpunit/phpunit.phar'));
@@ -106,6 +109,7 @@ final class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProvider
         $this->finderMock
             ->expects($this->once())
             ->method('find')
+            ->with(TestFrameworkTypes::PHPUNIT)
             ->will($this->throwException(new FinderException()));
 
         $this->expectException(SymfonyRuntimeException::class);

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -101,9 +101,9 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
     {
         $filename = $this->fileSystem->tempnam($this->tmp, 'test');
 
-        $frameworkFinder = new TestFrameworkFinder('not-used', $filename);
+        $frameworkFinder = new TestFrameworkFinder();
 
-        $this->assertSame($filename, $frameworkFinder->find(), 'Should return the custom path');
+        $this->assertSame($filename, $frameworkFinder->find('not-used', $filename), 'Should return the custom path');
     }
 
     public function test_invalid_custom_path_throws_exception(): void
@@ -112,19 +112,19 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         // Remove it so that the file doesn't exist
         $this->fileSystem->remove($filename);
 
-        $frameworkFinder = new TestFrameworkFinder('not-used', $filename);
+        $frameworkFinder = new TestFrameworkFinder();
 
         $this->expectException(FinderException::class);
         $this->expectExceptionMessageRegExp('/custom path/');
 
-        $frameworkFinder->find();
+        $frameworkFinder->find('not-used', $filename);
     }
 
     public function test_it_adds_vendor_bin_to_path_if_needed(): void
     {
         $path = getenv(self::$pathName);
 
-        $frameworkFinder = new TestFrameworkFinder(TestFrameworkTypes::PHPUNIT);
+        $frameworkFinder = new TestFrameworkFinder();
 
         if ('\\' === DIRECTORY_SEPARATOR) {
             // The main script must be found from the .bat file
@@ -135,7 +135,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
 
         $this->assertSame(
             normalizePath($expected),
-            normalizePath($frameworkFinder->find()),
+            normalizePath($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
             'Should return the phpunit path'
         );
 
@@ -163,7 +163,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         putenv(sprintf('%s=%s', self::$pathName, $mock->getVendorBinDir()));
         putenv('PATHEXT=');
 
-        $frameworkFinder = new TestFrameworkFinder($mock::PACKAGE);
+        $frameworkFinder = new TestFrameworkFinder();
 
         if ('\\' === DIRECTORY_SEPARATOR) {
             // This .bat has no code, so main script will not be found
@@ -174,7 +174,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
 
         $this->assertSame(
             normalizePath(realpath($expected)),
-            normalizePath(realpath($frameworkFinder->find())),
+            normalizePath(realpath($frameworkFinder->find($mock::PACKAGE))),
             'should return the vendor bin link or .bat'
         );
     }
@@ -191,11 +191,11 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         putenv(sprintf('%s=%s', self::$pathName, $mock->getVendorBinDir()));
         putenv('PATHEXT=');
 
-        $frameworkFinder = new TestFrameworkFinder($mock::PACKAGE);
+        $frameworkFinder = new TestFrameworkFinder();
 
         $this->assertSame(
             normalizePath(realpath($mock->getPackageScript())),
-            normalizePath(realpath($frameworkFinder->find())),
+            normalizePath(realpath($frameworkFinder->find($mock::PACKAGE))),
             'should return the package script from .bat'
         );
     }

--- a/tests/phpunit/TestFramework/FactoryTest.php
+++ b/tests/phpunit/TestFramework/FactoryTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework;
 
 use Infection\Configuration\Configuration;
+use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\Factory;
 use InvalidArgumentException;
@@ -52,6 +53,7 @@ final class FactoryTest extends TestCase
             '',
             '',
             $this->createMock(TestFrameworkConfigLocatorInterface::class),
+            $this->createMock(TestFrameworkFinder::class),
             '',
             $this->createMock(Configuration::class)
         );


### PR DESCRIPTION
See this thread https://github.com/infection/infection/pull/1019#discussion_r371027044.

TL;DR to make it possible to inject and mock `TestFrameworkFinder`, we need to move parameters from its constructor to method `find()`

```diff
- $finder = new TestFrameworkExecutable('phpunit');
- $finder->find();

+ $finder = new TestFrameworkExecutable();
+ $finder->find('phpunit);

// possible to find other executables without recreating TestFrameworkFinder
// which was not possible before
$finder->find('phpspec');
$finder->find('codeception');
```
