### PR TITLE
Fix: Remove unused constants

### DIFF
--- a/src/Logger/BadgeLogger.php
+++ b/src/Logger/BadgeLogger.php
@@ -48,9 +48,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class BadgeLogger implements MutationTestingResultsLogger
 {
-    public const ENV_INFECTION_BADGE_API_KEY = 'INFECTION_BADGE_API_KEY';
-    public const ENV_STRYKER_DASHBOARD_API_KEY = 'STRYKER_DASHBOARD_API_KEY';
-
     private $output;
     private $strykerApiKeyResolver;
     private $badgeApiClient;


### PR DESCRIPTION
This PR

* [x] removes unused constants

Follows #1031.