### PR TITLE
Enhancement: Extract BuildContextResolver

### DIFF
--- a/src/Environment/BuildContext.php
+++ b/src/Environment/BuildContext.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Environment;
+
+/**
+ * @internal
+ */
+final class BuildContext
+{
+    private $repositorySlug;
+    private $branch;
+
+    public function __construct(string $repositorySlug, string $branch)
+    {
+        $this->repositorySlug = $repositorySlug;
+        $this->branch = $branch;
+    }
+
+    public function repositorySlug(): string
+    {
+        return $this->repositorySlug;
+    }
+
+    public function branch(): string
+    {
+        return $this->branch;
+    }
+}

--- a/src/Environment/BuildContextResolver.php
+++ b/src/Environment/BuildContextResolver.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Environment;
+
+use function Safe\sprintf;
+
+/**
+ * @internal
+ */
+final class BuildContextResolver
+{
+    /**
+     * @see https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+     *
+     * @param array<string, string> $environment
+     *
+     * @throws CouldNotResolveBuildContext
+     */
+    public function resolve(array $environment): BuildContext
+    {
+        if (
+            !array_key_exists('TRAVIS', $environment)
+            || !array_key_exists('TRAVIS_PULL_REQUEST', $environment)
+            || $environment['TRAVIS'] !== 'true'
+        ) {
+            throw CouldNotResolveBuildContext::create('it is not a Travis CI');
+        }
+
+        if ($environment['TRAVIS_PULL_REQUEST'] !== 'false') {
+            throw CouldNotResolveBuildContext::create(sprintf(
+                'build is for a pull request (TRAVIS_PULL_REQUEST=%s)',
+                $environment['TRAVIS_PULL_REQUEST']
+            ));
+        }
+
+        if (
+            !array_key_exists('TRAVIS_REPO_SLUG', $environment)
+            || !array_key_exists('TRAVIS_BRANCH', $environment)
+        ) {
+            throw CouldNotResolveBuildContext::create('repository slug nor current branch were found; not a Travis build?');
+        }
+
+        return new BuildContext(
+            $environment['TRAVIS_REPO_SLUG'],
+            $environment['TRAVIS_BRANCH']
+        );
+    }
+}

--- a/src/Environment/CouldNotResolveBuildContext.php
+++ b/src/Environment/CouldNotResolveBuildContext.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Environment;
+
+use RuntimeException;
+
+/**
+ * @internal
+ */
+final class CouldNotResolveBuildContext extends RuntimeException
+{
+    public static function create(string $message): self
+    {
+        return new self($message);
+    }
+}

--- a/src/Logger/BadgeLogger.php
+++ b/src/Logger/BadgeLogger.php
@@ -35,6 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Logger;
 
+use Infection\Environment\BuildContextResolver;
+use Infection\Environment\CouldNotResolveBuildContext;
 use Infection\Environment\CouldNotResolveStrykerApiKey;
 use Infection\Environment\StrykerApiKeyResolver;
 use Infection\Http\BadgeApiClient;
@@ -49,6 +51,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class BadgeLogger implements MutationTestingResultsLogger
 {
     private $output;
+    private $buildContextResolver;
     private $strykerApiKeyResolver;
     private $badgeApiClient;
     private $metricsCalculator;
@@ -56,12 +59,14 @@ final class BadgeLogger implements MutationTestingResultsLogger
 
     public function __construct(
         OutputInterface $output,
+        BuildContextResolver $platformResolver,
         StrykerApiKeyResolver $strykerApiKeyResolver,
         BadgeApiClient $badgeApiClient,
         MetricsCalculator $metricsCalculator,
         stdClass $config
     ) {
         $this->output = $output;
+        $this->buildContextResolver = $platformResolver;
         $this->strykerApiKeyResolver = $strykerApiKeyResolver;
         $this->badgeApiClient = $badgeApiClient;
         $this->metricsCalculator = $metricsCalculator;
@@ -70,39 +75,20 @@ final class BadgeLogger implements MutationTestingResultsLogger
 
     public function log(): void
     {
-        $travisBuild = getenv('TRAVIS');
-
-        if ($travisBuild !== 'true') {
-            $this->showInfo('it is not a Travis CI');
-
-            return;
-        }
-
-        $pullRequest = getenv('TRAVIS_PULL_REQUEST');
-
-        if ($pullRequest !== 'false') {
-            $this->showInfo("build is for a pull request (TRAVIS_PULL_REQUEST={$pullRequest})");
+        try {
+            $buildContext = $this->buildContextResolver->resolve(getenv());
+        } catch (CouldNotResolveBuildContext $exception) {
+            $this->showInfo($exception->getMessage());
 
             return;
         }
 
-        $repositorySlug = getenv('TRAVIS_REPO_SLUG');
-        $currentBranch = getenv('TRAVIS_BRANCH');
-
-        if ($repositorySlug === false || $currentBranch === false) {
-            $this->showInfo('repository slug nor current branch were found; not a Travis build?');
-
-            return;
-        }
-
-        if ($currentBranch !== $this->config->branch) {
-            $this->showInfo(
-                sprintf(
-                    'expected branch "%s", found "%s"',
-                    $this->config->branch,
-                    $currentBranch
-                )
-            );
+        if ($buildContext->branch() !== $this->config->branch) {
+            $this->showInfo(sprintf(
+                'expected branch "%s", found "%s"',
+                $this->config->branch,
+                $buildContext->branch()
+            ));
 
             return;
         }
@@ -122,8 +108,8 @@ final class BadgeLogger implements MutationTestingResultsLogger
 
         $this->badgeApiClient->sendReport(
             $apiKey,
-            'github.com/' . $repositorySlug,
-            $currentBranch,
+            'github.com/' . $buildContext->repositorySlug(),
+            $buildContext->branch(),
             $this->metricsCalculator->getMutationScoreIndicator()
         );
     }

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -37,6 +37,7 @@ namespace Infection\Logger;
 
 use Infection\Configuration\Entry\Logs;
 use Infection\Console\LogVerbosity;
+use Infection\Environment\BuildContextResolver;
 use Infection\Environment\StrykerApiKeyResolver;
 use Infection\Http\BadgeApiClient;
 use Infection\Mutant\MetricsCalculator;
@@ -168,6 +169,7 @@ final class LoggerFactory
     {
         return new BadgeLogger(
             $output,
+            new BuildContextResolver(),
             new StrykerApiKeyResolver(),
             new BadgeApiClient($output),
             $this->metricsCalculator,

--- a/tests/phpunit/Environment/BuildContextResolverTest.php
+++ b/tests/phpunit/Environment/BuildContextResolverTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Environment;
+
+use Infection\Environment\BuildContextResolver;
+use Infection\Environment\CouldNotResolveBuildContext;
+use PHPUnit\Framework\TestCase;
+use function Safe\sprintf;
+
+/**
+ * @covers \Infection\Environment\BuildContextResolver
+ */
+final class BuildContextResolverTest extends TestCase
+{
+    public function test_resolve_throws_when_travis_key_does_not_exist_in_environment(): void
+    {
+        $environment = [
+            'TRAVIS_BRANCH' => 'fix/this',
+            'TRAVIS_PULL_REQUEST' => 'false',
+            'TRAVIS_REPO_SLUG' => 'foo/bar',
+        ];
+
+        $buildContextResolver = new BuildContextResolver();
+
+        $this->expectException(CouldNotResolveBuildContext::class);
+        $this->expectExceptionMessage('it is not a Travis CI');
+
+        $buildContextResolver->resolve($environment);
+    }
+
+    public function test_resolve_throws_when_travis_key_is_not_true(): void
+    {
+        $environment = [
+            'TRAVIS' => 'false',
+            'TRAVIS_BRANCH' => 'fix/this',
+            'TRAVIS_PULL_REQUEST' => 'false',
+            'TRAVIS_REPO_SLUG' => 'foo/bar',
+        ];
+
+        $buildContextResolver = new BuildContextResolver();
+
+        $this->expectException(CouldNotResolveBuildContext::class);
+        $this->expectExceptionMessage('it is not a Travis CI');
+
+        $buildContextResolver->resolve($environment);
+    }
+
+    public function test_resolve_throws_when_travis_pull_request_key_does_not_exist_in_environment(): void
+    {
+        $environment = [
+            'TRAVIS' => 'true',
+            'TRAVIS_BRANCH' => 'fix/this',
+            'TRAVIS_REPO_SLUG' => 'foo/bar',
+        ];
+
+        $buildContextResolver = new BuildContextResolver();
+
+        $this->expectException(CouldNotResolveBuildContext::class);
+        $this->expectExceptionMessage('it is not a Travis CI');
+
+        $buildContextResolver->resolve($environment);
+    }
+
+    public function test_resolve_throws_when_travis_pull_request_is_not_false(): void
+    {
+        $environment = [
+            'TRAVIS' => 'true',
+            'TRAVIS_BRANCH' => 'fix/this',
+            'TRAVIS_PULL_REQUEST' => '9001',
+            'TRAVIS_REPO_SLUG' => 'foo/bar',
+        ];
+
+        $buildContextResolver = new BuildContextResolver();
+
+        $this->expectException(CouldNotResolveBuildContext::class);
+        $this->expectExceptionMessage(sprintf(
+            'build is for a pull request (TRAVIS_PULL_REQUEST=%s)',
+            $environment['TRAVIS_PULL_REQUEST']
+        ));
+
+        $buildContextResolver->resolve($environment);
+    }
+
+    public function test_resolve_throws_when_travis_pull_repo_slug_key_does_not_exist(): void
+    {
+        $environment = [
+            'TRAVIS' => 'true',
+            'TRAVIS_BRANCH' => 'fix/this',
+            'TRAVIS_PULL_REQUEST' => 'false',
+        ];
+
+        $buildContextResolver = new BuildContextResolver();
+
+        $this->expectException(CouldNotResolveBuildContext::class);
+        $this->expectExceptionMessage('repository slug nor current branch were found; not a Travis build?');
+
+        $buildContextResolver->resolve($environment);
+    }
+
+    public function test_resolve_throws_when_travis_branch_key_does_not_exist(): void
+    {
+        $environment = [
+            'TRAVIS' => 'true',
+            'TRAVIS_PULL_REQUEST' => 'false',
+            'TRAVIS_REPO_SLUG' => 'foo/bar',
+        ];
+
+        $buildContextResolver = new BuildContextResolver();
+
+        $this->expectException(CouldNotResolveBuildContext::class);
+        $this->expectExceptionMessage('repository slug nor current branch were found; not a Travis build?');
+
+        $buildContextResolver->resolve($environment);
+    }
+
+    public function test_resolve_returns_build_context_when_environment_is_branch_build(): void
+    {
+        $environment = [
+            'TRAVIS' => 'true',
+            'TRAVIS_BRANCH' => 'fix/this',
+            'TRAVIS_PULL_REQUEST' => 'false',
+            'TRAVIS_REPO_SLUG' => 'foo/bar',
+        ];
+
+        $buildContextResolver = new BuildContextResolver();
+
+        $buildContext = $buildContextResolver->resolve($environment);
+
+        self::assertSame($environment['TRAVIS_REPO_SLUG'], $buildContext->repositorySlug());
+        self::assertSame($environment['TRAVIS_BRANCH'], $buildContext->branch());
+    }
+}

--- a/tests/phpunit/Environment/BuildContextTest.php
+++ b/tests/phpunit/Environment/BuildContextTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Environment;
+
+use Infection\Environment\BuildContext;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Infection\Environment\BuildContext
+ */
+final class BuildContextTest extends TestCase
+{
+    public function test_constructor_sets_values(): void
+    {
+        $repositorySlug = 'foo/bar';
+        $branch = 'fix/this';
+
+        $buildContext = new BuildContext(
+            $repositorySlug,
+            $branch
+        );
+
+        self::assertSame($repositorySlug, $buildContext->repositorySlug());
+        self::assertSame($branch, $buildContext->branch());
+    }
+}

--- a/tests/phpunit/Environment/CouldNotResolveBuildContextTest.php
+++ b/tests/phpunit/Environment/CouldNotResolveBuildContextTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Environment;
+
+use Infection\Environment\CouldNotResolveBuildContext;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Infection\Environment\CouldNotResolveBuildContext
+ */
+final class CouldNotResolveBuildContextTest extends TestCase
+{
+    public function test_create_returns_exception(): void
+    {
+        $message = "Well, it's really not a good time right now.";
+
+        $exception = CouldNotResolveBuildContext::create($message);
+
+        self::assertSame($message, $exception->getMessage());
+    }
+}

--- a/tests/phpunit/Logger/BadgeLoggerTest.php
+++ b/tests/phpunit/Logger/BadgeLoggerTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Logger;
 
 use function getenv;
+use Infection\Environment\BuildContextResolver;
 use Infection\Environment\StrykerApiKeyResolver;
 use Infection\Http\BadgeApiClient;
 use Infection\Logger\BadgeLogger;
@@ -113,6 +114,7 @@ final class BadgeLoggerTest extends TestCase
 
         $this->badgeLogger = new BadgeLogger(
             $this->outputMock,
+            new BuildContextResolver(),
             new StrykerApiKeyResolver(),
             $this->badgeApiClientMock,
             $this->metricsCalculatorMock,


### PR DESCRIPTION
This PR

* [x] extracts a `BuildContext` value object and a `BuildContextResolver`

Follows #1031.
Related to #939.

💁‍♂ Possible next steps:

- rename `BuildContextResolver` to `TravisCiResolver`
- extract a `BuildContextResolver` interface
- implement a `ChainBuildContextResolver`
- implement and register additional implementations of `BuildContextResolver`

What do you think?

/cc @drupol