### PR TITLE
Enhancement: Rename BuildContextResolver to TravisCiResolver

### DIFF
--- a/src/Logger/BadgeLogger.php
+++ b/src/Logger/BadgeLogger.php
@@ -59,14 +59,14 @@ final class BadgeLogger implements MutationTestingResultsLogger
 
     public function __construct(
         OutputInterface $output,
-        BuildContextResolver $platformResolver,
+        BuildContextResolver $buildContextResolver,
         StrykerApiKeyResolver $strykerApiKeyResolver,
         BadgeApiClient $badgeApiClient,
         MetricsCalculator $metricsCalculator,
         stdClass $config
     ) {
         $this->output = $output;
-        $this->buildContextResolver = $platformResolver;
+        $this->buildContextResolver = $buildContextResolver;
         $this->strykerApiKeyResolver = $strykerApiKeyResolver;
         $this->badgeApiClient = $badgeApiClient;
         $this->metricsCalculator = $metricsCalculator;

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -37,8 +37,8 @@ namespace Infection\Logger;
 
 use Infection\Configuration\Entry\Logs;
 use Infection\Console\LogVerbosity;
-use Infection\Environment\BuildContextResolver;
 use Infection\Environment\StrykerApiKeyResolver;
+use Infection\Environment\TravisCiResolver;
 use Infection\Http\BadgeApiClient;
 use Infection\Mutant\MetricsCalculator;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -169,7 +169,7 @@ final class LoggerFactory
     {
         return new BadgeLogger(
             $output,
-            new BuildContextResolver(),
+            new TravisCiResolver(),
             new StrykerApiKeyResolver(),
             new BadgeApiClient($output),
             $this->metricsCalculator,

--- a/tests/phpunit/Environment/TravisCiResolverTest.php
+++ b/tests/phpunit/Environment/TravisCiResolverTest.php
@@ -35,15 +35,15 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Environment;
 
-use Infection\Environment\BuildContextResolver;
 use Infection\Environment\CouldNotResolveBuildContext;
+use Infection\Environment\TravisCiResolver;
 use PHPUnit\Framework\TestCase;
 use function Safe\sprintf;
 
 /**
  * @covers \Infection\Environment\BuildContextResolver
  */
-final class BuildContextResolverTest extends TestCase
+final class TravisCiResolverTest extends TestCase
 {
     public function test_resolve_throws_when_travis_key_does_not_exist_in_environment(): void
     {
@@ -53,7 +53,7 @@ final class BuildContextResolverTest extends TestCase
             'TRAVIS_REPO_SLUG' => 'foo/bar',
         ];
 
-        $buildContextResolver = new BuildContextResolver();
+        $buildContextResolver = new TravisCiResolver();
 
         $this->expectException(CouldNotResolveBuildContext::class);
         $this->expectExceptionMessage('it is not a Travis CI');
@@ -70,7 +70,7 @@ final class BuildContextResolverTest extends TestCase
             'TRAVIS_REPO_SLUG' => 'foo/bar',
         ];
 
-        $buildContextResolver = new BuildContextResolver();
+        $buildContextResolver = new TravisCiResolver();
 
         $this->expectException(CouldNotResolveBuildContext::class);
         $this->expectExceptionMessage('it is not a Travis CI');
@@ -86,7 +86,7 @@ final class BuildContextResolverTest extends TestCase
             'TRAVIS_REPO_SLUG' => 'foo/bar',
         ];
 
-        $buildContextResolver = new BuildContextResolver();
+        $buildContextResolver = new TravisCiResolver();
 
         $this->expectException(CouldNotResolveBuildContext::class);
         $this->expectExceptionMessage('it is not a Travis CI');
@@ -103,7 +103,7 @@ final class BuildContextResolverTest extends TestCase
             'TRAVIS_REPO_SLUG' => 'foo/bar',
         ];
 
-        $buildContextResolver = new BuildContextResolver();
+        $buildContextResolver = new TravisCiResolver();
 
         $this->expectException(CouldNotResolveBuildContext::class);
         $this->expectExceptionMessage(sprintf(
@@ -122,7 +122,7 @@ final class BuildContextResolverTest extends TestCase
             'TRAVIS_PULL_REQUEST' => 'false',
         ];
 
-        $buildContextResolver = new BuildContextResolver();
+        $buildContextResolver = new TravisCiResolver();
 
         $this->expectException(CouldNotResolveBuildContext::class);
         $this->expectExceptionMessage('repository slug nor current branch were found; not a Travis build?');
@@ -138,7 +138,7 @@ final class BuildContextResolverTest extends TestCase
             'TRAVIS_REPO_SLUG' => 'foo/bar',
         ];
 
-        $buildContextResolver = new BuildContextResolver();
+        $buildContextResolver = new TravisCiResolver();
 
         $this->expectException(CouldNotResolveBuildContext::class);
         $this->expectExceptionMessage('repository slug nor current branch were found; not a Travis build?');
@@ -155,7 +155,7 @@ final class BuildContextResolverTest extends TestCase
             'TRAVIS_REPO_SLUG' => 'foo/bar',
         ];
 
-        $buildContextResolver = new BuildContextResolver();
+        $buildContextResolver = new TravisCiResolver();
 
         $buildContext = $buildContextResolver->resolve($environment);
 

--- a/tests/phpunit/Logger/BadgeLoggerTest.php
+++ b/tests/phpunit/Logger/BadgeLoggerTest.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\Logger;
 
 use function getenv;
-use Infection\Environment\BuildContextResolver;
 use Infection\Environment\StrykerApiKeyResolver;
+use Infection\Environment\TravisCiResolver;
 use Infection\Http\BadgeApiClient;
 use Infection\Logger\BadgeLogger;
 use Infection\Mutant\MetricsCalculator;
@@ -114,7 +114,7 @@ final class BadgeLoggerTest extends TestCase
 
         $this->badgeLogger = new BadgeLogger(
             $this->outputMock,
-            new BuildContextResolver(),
+            new TravisCiResolver(),
             new StrykerApiKeyResolver(),
             $this->badgeApiClientMock,
             $this->metricsCalculatorMock,


### PR DESCRIPTION
This PR

* [x] renames the `BuildContextResolver` to `TravisCiResolver` and extracts a `BuildContextResolver` interface

Follows #1047.
Related to #939.