### PR TITLE
Pass the config file path being used to provide more friendly error messages

### DIFF
--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -84,6 +84,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
             new InitialConfigBuilder(
                 $tmpDir,
                 $testFrameworkConfigContent,
+                $testFrameworkConfigPath,
                 $xmlConfigurationHelper,
                 $jUnitFilePath,
                 $sourceDirectories,

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -84,7 +84,6 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
             new InitialConfigBuilder(
                 $tmpDir,
                 $testFrameworkConfigContent,
-                $testFrameworkConfigPath,
                 $xmlConfigurationHelper,
                 $jUnitFilePath,
                 $sourceDirectories,

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -56,6 +56,7 @@ class InitialConfigBuilder implements ConfigBuilder
     use SafeQuery;
 
     private $tmpDir;
+    private $configPath;
     private $originalXmlConfigContent;
     private $xmlConfigurationHelper;
     private $jUnitFilePath;
@@ -67,6 +68,7 @@ class InitialConfigBuilder implements ConfigBuilder
      */
     public function __construct(
         string $tmpDir,
+        string $configPath,
         string $originalXmlConfigContent,
         XmlConfigurationHelper $xmlConfigurationHelper,
         string $jUnitFilePath,
@@ -79,6 +81,7 @@ class InitialConfigBuilder implements ConfigBuilder
         );
 
         $this->tmpDir = $tmpDir;
+        $this->configPath = $configPath;
         $this->originalXmlConfigContent = $originalXmlConfigContent;
         $this->xmlConfigurationHelper = $xmlConfigurationHelper;
         $this->jUnitFilePath = $jUnitFilePath;
@@ -97,7 +100,7 @@ class InitialConfigBuilder implements ConfigBuilder
 
         $xPath = new DOMXPath($dom);
 
-        $this->xmlConfigurationHelper->validate($xPath);
+        $this->xmlConfigurationHelper->validate($this->configPath, $xPath);
 
         $this->addCoverageFilterWhitelistIfDoesNotExist($xPath);
         $this->addRandomTestsOrderAttributesIfNotSet($version, $xPath);

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -56,7 +56,6 @@ class InitialConfigBuilder implements ConfigBuilder
     use SafeQuery;
 
     private $tmpDir;
-    private $configPath;
     private $originalXmlConfigContent;
     private $xmlConfigurationHelper;
     private $jUnitFilePath;
@@ -68,7 +67,6 @@ class InitialConfigBuilder implements ConfigBuilder
      */
     public function __construct(
         string $tmpDir,
-        string $configPath,
         string $originalXmlConfigContent,
         XmlConfigurationHelper $xmlConfigurationHelper,
         string $jUnitFilePath,
@@ -81,7 +79,6 @@ class InitialConfigBuilder implements ConfigBuilder
         );
 
         $this->tmpDir = $tmpDir;
-        $this->configPath = $configPath;
         $this->originalXmlConfigContent = $originalXmlConfigContent;
         $this->xmlConfigurationHelper = $xmlConfigurationHelper;
         $this->jUnitFilePath = $jUnitFilePath;
@@ -100,7 +97,7 @@ class InitialConfigBuilder implements ConfigBuilder
 
         $xPath = new DOMXPath($dom);
 
-        $this->xmlConfigurationHelper->validate($this->configPath, $xPath);
+        $this->xmlConfigurationHelper->validate($path, $xPath);
 
         $this->addCoverageFilterWhitelistIfDoesNotExist($xPath);
         $this->addRandomTestsOrderAttributesIfNotSet($version, $xPath);

--- a/src/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigException.php
+++ b/src/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigException.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpUnit\Config\Exception;
 
+use const PHP_EOL;
 use RuntimeException;
 use function Safe\sprintf;
 
@@ -43,13 +44,21 @@ use function Safe\sprintf;
  */
 final class InvalidPhpUnitXmlConfigException extends RuntimeException
 {
-    public static function byRootNode(): self
+    public static function byRootNode(string $configPath): self
     {
-        return new self('phpunit.xml does not contain a valid PHPUnit configuration.');
+        return new self(sprintf(
+            'The file "%s" is not a valid PHPUnit configuration file',
+            $configPath
+        ));
     }
 
-    public static function byXsdSchema(string $libXmlErrorsString): self
+    public static function byXsdSchema(string $configPath, string $libXmlErrorsString): self
     {
-        return new self(sprintf('phpunit.xml file does not pass XSD schema validation. %s', $libXmlErrorsString));
+        return new self(sprintf(
+            'The file "%s" does not pass the XSD schema validation.%s%s',
+            $configPath,
+            PHP_EOL,
+            $libXmlErrorsString
+        ));
     }
 }

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -37,6 +37,7 @@ namespace Infection\TestFramework\PhpUnit\Config;
 
 use DOMElement;
 use DOMXPath;
+use LogicException;
 use function implode;
 use Infection\TestFramework\PhpUnit\Config\Exception\InvalidPhpUnitXmlConfigException;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
@@ -46,6 +47,9 @@ use function libxml_use_internal_errors;
 use LibXMLError;
 use function Safe\sprintf;
 use Webmozart\Assert\Assert;
+use const LIBXML_ERR_ERROR;
+use const LIBXML_ERR_FATAL;
+use const LIBXML_ERR_WARNING;
 
 /**
  * @internal
@@ -163,7 +167,7 @@ final class XmlConfigurationHelper
         $errors = libxml_get_errors();
 
         foreach ($errors as $key => $error) {
-            $level = $this->getErrorLevelString($error);
+            $level = $this->getErrorLevelName($error);
             $errorsString .= sprintf('[%s] %s', $level, $error->message);
 
             if ($error->file) {
@@ -214,7 +218,7 @@ final class XmlConfigurationHelper
         }
     }
 
-    private function getErrorLevelString(LibXMLError $error): string
+    private function getErrorLevelName(LibXMLError $error): string
     {
         if ($error->level === LIBXML_ERR_WARNING) {
             return 'Warning';
@@ -224,6 +228,10 @@ final class XmlConfigurationHelper
             return 'Error';
         }
 
-        return 'Fatal';
+        if ($error->level === LIBXML_ERR_FATAL) {
+            return 'Fatal';
+        }
+
+        throw new LogicException(sprintf('Unknown lib XML error level "%s"', $error->level));
     }
 }

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -128,13 +128,10 @@ final class XmlConfigurationHelper
         );
     }
 
-    public function validate(DOMXPath $xPath): bool
+    public function validate(string $configPath, DOMXPath $xPath): bool
     {
         if (self::safeQuery($xPath, '/phpunit')->length === 0) {
-            // TODO: should have the PHPUnit config path passed otherwise we blindly assume
-            //  "phpunit.xml" without neither the path neither guarantee this is the file name
-            //  (it could be a different one passed with the --configuration option)
-            throw InvalidPhpUnitXmlConfigException::byRootNode();
+            throw InvalidPhpUnitXmlConfigException::byRootNode($configPath);
         }
 
         if (self::safeQuery($xPath, 'namespace::xsi')->length === 0) {
@@ -149,7 +146,10 @@ final class XmlConfigurationHelper
         // TODO: schemaValidate will throw a weird error if schemaPath is invalid, e.g. ''
         // check what happens with invalid URL or invalid path
         if ($schema->length && !$xPath->document->schemaValidate($schemaPath)) {
-            throw InvalidPhpUnitXmlConfigException::byXsdSchema($this->getXmlErrorsString());
+            throw InvalidPhpUnitXmlConfigException::byXsdSchema(
+                $configPath,
+                $this->getXmlErrorsString()
+            );
         }
 
         libxml_use_internal_errors($original);

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -37,12 +37,12 @@ namespace Infection\TestFramework\PhpUnit\Config;
 
 use DOMElement;
 use DOMXPath;
+use const FILTER_VALIDATE_URL;
 use function filter_var;
 use function implode;
 use Infection\TestFramework\PhpUnit\Config\Exception\InvalidPhpUnitXmlConfigException;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\SafeQuery;
-use const FILTER_VALIDATE_URL;
 use const LIBXML_ERR_ERROR;
 use const LIBXML_ERR_FATAL;
 use const LIBXML_ERR_WARNING;

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationHelper.php
@@ -37,19 +37,21 @@ namespace Infection\TestFramework\PhpUnit\Config;
 
 use DOMElement;
 use DOMXPath;
-use LogicException;
+use function filter_var;
 use function implode;
 use Infection\TestFramework\PhpUnit\Config\Exception\InvalidPhpUnitXmlConfigException;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\SafeQuery;
-use function libxml_get_errors;
-use function libxml_use_internal_errors;
-use LibXMLError;
-use function Safe\sprintf;
-use Webmozart\Assert\Assert;
+use const FILTER_VALIDATE_URL;
 use const LIBXML_ERR_ERROR;
 use const LIBXML_ERR_FATAL;
 use const LIBXML_ERR_WARNING;
+use function libxml_get_errors;
+use function libxml_use_internal_errors;
+use LibXMLError;
+use LogicException;
+use function Safe\sprintf;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal
@@ -135,7 +137,7 @@ final class XmlConfigurationHelper
             throw InvalidPhpUnitXmlConfigException::byRootNode();
         }
 
-        if (!self::safeQuery($xPath, 'namespace::xsi')->length) {
+        if (self::safeQuery($xPath, 'namespace::xsi')->length === 0) {
             return true;
         }
 
@@ -144,6 +146,8 @@ final class XmlConfigurationHelper
         $original = libxml_use_internal_errors(true);
         $schemaPath = $this->buildSchemaPath($schema[0]->nodeValue);
 
+        // TODO: schemaValidate will throw a weird error if schemaPath is invalid, e.g. ''
+        // check what happens with invalid URL or invalid path
         if ($schema->length && !$xPath->document->schemaValidate($schemaPath)) {
             throw InvalidPhpUnitXmlConfigException::byXsdSchema($this->getXmlErrorsString());
         }

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -142,7 +142,10 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
             $this->fail('Expected an exception to be thrown.');
         } catch (InvalidPhpUnitXmlConfigException $exception) {
             $this->assertSame(
-                'The file "/path/to/phpunit.xml" is not a valid PHPUnit configuration file',
+                sprintf(
+                    'The file "%s/phpunitConfiguration.initial.infection.xml" is not a valid PHPUnit configuration file',
+                    $this->tmp
+                ),
                 $exception->getMessage()
             );
         }

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -420,7 +420,6 @@ XML
 
         return new InitialConfigBuilder(
             $this->tmp,
-            '/path/to/phpunit.xml',
             file_get_contents($phpunitXmlPath),
             new XmlConfigurationHelper($replacer, ''),
             $jUnitFilePath,

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -142,7 +142,7 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
             $this->fail('Expected an exception to be thrown.');
         } catch (InvalidPhpUnitXmlConfigException $exception) {
             $this->assertSame(
-                'phpunit.xml does not contain a valid PHPUnit configuration.',
+                'The file "/path/to/phpunit.xml" is not a valid PHPUnit configuration file',
                 $exception->getMessage()
             );
         }
@@ -420,6 +420,7 @@ XML
 
         return new InitialConfigBuilder(
             $this->tmp,
+            '/path/to/phpunit.xml',
             file_get_contents($phpunitXmlPath),
             new XmlConfigurationHelper($replacer, ''),
             $jUnitFilePath,

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
@@ -42,19 +42,28 @@ final class InvalidPhpUnitXmlConfigExceptionTest extends TestCase
 {
     public function test_for_root_node(): void
     {
-        $exception = InvalidPhpUnitXmlConfigException::byRootNode();
+        $exception = InvalidPhpUnitXmlConfigException::byRootNode('/path/to/phpunit.xml');
 
-        $this->assertInstanceOf(InvalidPhpUnitXmlConfigException::class, $exception);
-
-        $this->assertSame('phpunit.xml does not contain a valid PHPUnit configuration.', $exception->getMessage());
+        $this->assertSame(
+            'The file "/path/to/phpunit.xml" is not a valid PHPUnit configuration file',
+            $exception->getMessage()
+        );
     }
 
     public function test_for_xsd_schema(): void
     {
-        $exception = InvalidPhpUnitXmlConfigException::byXsdSchema('Invalid');
+        $exception = InvalidPhpUnitXmlConfigException::byXsdSchema(
+            '/path/to/phpunit.xml',
+            '<lib-xml-errors>'
+        );
 
-        $this->assertInstanceOf(InvalidPhpUnitXmlConfigException::class, $exception);
-
-        $this->assertStringContainsString('phpunit.xml file does not pass XSD schema validation.', $exception->getMessage());
+        $this->assertSame(
+            <<<'TXT'
+The file "/path/to/phpunit.xml" does not pass the XSD schema validation.
+<lib-xml-errors>
+TXT
+            ,
+            $exception->getMessage()
+        );
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Exception/InvalidPhpUnitXmlConfigExceptionTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpUnit\Config\Exception;
 
 use Infection\TestFramework\PhpUnit\Config\Exception\InvalidPhpUnitXmlConfigException;
+use function Infection\Tests\normalizeLineReturn;
 use PHPUnit\Framework\TestCase;
 
 final class InvalidPhpUnitXmlConfigExceptionTest extends TestCase
@@ -63,7 +64,7 @@ The file "/path/to/phpunit.xml" does not pass the XSD schema validation.
 <lib-xml-errors>
 TXT
             ,
-            $exception->getMessage()
+            normalizeLineReturn($exception->getMessage())
         );
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -484,9 +484,9 @@ XML
         $xPath = $this->createXPath('<invalid></invalid>');
 
         $this->expectException(InvalidPhpUnitXmlConfigException::class);
-        $this->expectExceptionMessage('phpunit.xml does not contain a valid PHPUnit configuration.');
+        $this->expectExceptionMessage('The file "/path/to/phpunit.xml" is not a valid PHPUnit configuration file');
 
-        $this->configHelper->validate($xPath);
+        $this->configHelper->validate('/path/to/phpunit.xml', $xPath);
     }
 
     public function test_it_consider_as_valid_a_PHPUnit_XML_configuration_without_XSD(): void
@@ -498,7 +498,7 @@ XML
 XML
         );
 
-        $this->assertTrue($this->configHelper->validate($xPath));
+        $this->assertTrue($this->configHelper->validate('/path/to/phpunit.xml', $xPath));
     }
 
     /**
@@ -521,7 +521,7 @@ XML
         );
 
         try {
-            $this->configHelper->validate($xPath);
+            $this->configHelper->validate('/path/to/phpunit.xml', $xPath);
 
             $this->fail('Expected exception to be thrown');
         } catch (InvalidPhpUnitXmlConfigException $exception) {
@@ -533,7 +533,8 @@ XML
 
             $this->assertSame(
                 <<<'EOF'
-phpunit.xml file does not pass XSD schema validation. [Error] Element 'phpunit', attribute 'foo': The attribute 'foo' is not allowed.
+The file "/path/to/phpunit.xml" does not pass the XSD schema validation.
+[Error] Element 'phpunit', attribute 'foo': The attribute 'foo' is not allowed.
  in /path/to/infection/ (line 6, col 0)
 [Error] Element 'invalid': This element is not expected.
  in /path/to/infection/ (line 7, col 0)
@@ -562,7 +563,7 @@ EOF
 XML
         );
 
-        $this->assertTrue($this->configHelper->validate($xPath));
+        $this->assertTrue($this->configHelper->validate('/path/to/phpunit.xml', $xPath));
     }
 
     public function test_it_uses_the_configured_PHPUnit_config_dir_to_build_schema_paths(): void
@@ -582,7 +583,7 @@ XML
 XML
         );
 
-        $this->assertTrue($configHelper->validate($xPath));
+        $this->assertTrue($configHelper->validate('/path/to/phpunit.xml', $xPath));
     }
 
     public function test_it_removes_default_test_suite(): void

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -42,6 +42,7 @@ use Generator;
 use Infection\TestFramework\PhpUnit\Config\Exception\InvalidPhpUnitXmlConfigException;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationHelper;
+use function Infection\Tests\normalizeLineReturn;
 use const PHP_OS_FAMILY;
 use PHPUnit\Framework\TestCase;
 use function Safe\sprintf;
@@ -537,7 +538,7 @@ XML
             $errorMessage = str_replace(
                 $infectionPath,
                 '/path/to/infection',
-                $exception->getMessage()
+                normalizeLineReturn($exception->getMessage())
             );
 
             $this->assertSame(

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -50,11 +50,26 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class XmlConfigurationHelperTest extends TestCase
 {
+    /**
+     * @var XmlConfigurationHelper
+     */
+    private $configHelper;
+
+    protected function setUp(): void
+    {
+        $this->configHelper = new XmlConfigurationHelper(
+            new PathReplacer(new Filesystem()),
+            ''
+        );
+    }
+
     public function test_it_replaces_with_absolute_paths(): void
     {
-        $this->assertItChangesStandardConfiguration(static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-            $xmlconfig->replaceWithAbsolutePaths($xPath);
-        }, <<<XML
+        $this->assertItChangesStandardConfiguration(
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->replaceWithAbsolutePaths($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -89,9 +104,11 @@ XML
 
     public function test_it_removes_existing_loggers(): void
     {
-        $this->assertItChangesStandardConfiguration(static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-            $xmlconfig->removeExistingLoggers($xPath);
-        }, <<<XML
+        $this->assertItChangesStandardConfiguration(
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->removeExistingLoggers($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -123,9 +140,11 @@ XML
 
     public function test_it_sets_set_stop_on_failure(): void
     {
-        $this->assertItChangesStandardConfiguration(static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-            $xmlconfig->setStopOnFailure($xPath);
-        }, <<<XML
+        $this->assertItChangesStandardConfiguration(
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->setStopOnFailure($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -161,7 +180,7 @@ XML
 
     public function test_it_sets_set_stop_on_failure_when_it_is_already_present(): void
     {
-        $this->assertItChangesXML(<<<XML
+        $this->assertItChangesXML(<<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -178,9 +197,11 @@ XML
 >
 </phpunit>
 XML
-        , static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-            $xmlconfig->setStopOnFailure($xPath);
-        }, <<<XML
+            ,
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->setStopOnFailure($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -202,9 +223,11 @@ XML
 
     public function test_it_deactivates_colors(): void
     {
-        $this->assertItChangesStandardConfiguration(static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-            $xmlconfig->deactivateColours($xPath);
-        }, <<<XML
+        $this->assertItChangesStandardConfiguration(
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->deactivateColours($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -239,7 +262,7 @@ XML
 
     public function test_it_deactivates_colors_when_it_is_not_already_present(): void
     {
-        $this->assertItChangesXML(<<<XML
+        $this->assertItChangesXML(<<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -255,9 +278,11 @@ XML
 >
 </phpunit>
 XML
-            , static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-                $xmlconfig->deactivateColours($xPath);
-            }, <<<XML
+            ,
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->deactivateColours($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -279,7 +304,7 @@ XML
 
     public function test_it_sets_cache_result_to_false_when_it_exists(): void
     {
-        $this->assertItChangesXML(<<<XML
+        $this->assertItChangesXML(<<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -297,9 +322,11 @@ XML
 </phpunit>
 
 XML
-        , static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-            $xmlconfig->deactivateResultCaching($xPath);
-        }, <<<XML
+            ,
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->deactivateResultCaching($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -321,7 +348,7 @@ XML
 
     public function test_it_sets_cache_result_to_false_when_it_does_not_exist(): void
     {
-        $this->assertItChangesXML(<<<XML
+        $this->assertItChangesXML(<<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -337,9 +364,11 @@ XML
 >
 </phpunit>
 XML
-        , static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-            $xmlconfig->deactivateResultCaching($xPath);
-        }, <<<XML
+            ,
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->deactivateResultCaching($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -361,7 +390,7 @@ XML
 
     public function test_it_sets_stderr_to_false_when_it_exists(): void
     {
-        $this->assertItChangesXML(<<<XML
+        $this->assertItChangesXML(<<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     stderr="true"
@@ -369,9 +398,11 @@ XML
 >
 </phpunit>
 XML
-        , static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-            $xmlconfig->deactivateStderrRedirection($xPath);
-        }, <<<XML
+            ,
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->deactivateStderrRedirection($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     stderr="false"
@@ -384,16 +415,18 @@ XML
 
     public function test_it_sets_stderr_to_false_when_it_does_not_exist(): void
     {
-        $this->assertItChangesXML(<<<XML
+        $this->assertItChangesXML(<<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     syntaxCheck="false"
 >
 </phpunit>
 XML
-            , static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-                $xmlconfig->deactivateStderrRedirection($xPath);
-            }, <<<XML
+            ,
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->deactivateStderrRedirection($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     stderr="false"
@@ -406,7 +439,7 @@ XML
 
     public function test_it_removes_existing_printers(): void
     {
-        $this->assertItChangesXML(<<<XML
+        $this->assertItChangesXML(<<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -422,9 +455,11 @@ XML
 >
 </phpunit>
 XML
-            , static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-                $xmlconfig->removeExistingPrinters($xPath);
-            }, <<<XML
+            ,
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->removeExistingPrinters($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -448,13 +483,13 @@ XML
         $dom->preserveWhiteSpace = false;
         $dom->formatOutput = true;
         $dom->loadXML('<invalid></invalid>');
+
         $xPath = new DOMXPath($dom);
-        $xmlHelper = new XmlConfigurationHelper($this->getPathReplacer(), '');
 
         $this->expectException(InvalidPhpUnitXmlConfigException::class);
         $this->expectExceptionMessage('phpunit.xml does not contain a valid PHPUnit configuration.');
 
-        $xmlHelper->validate($xPath);
+        $this->configHelper->validate($xPath);
     }
 
     /**
@@ -477,20 +512,13 @@ XML
 </phpunit>
 XML
         );
+
         $xPath = new DOMXPath($dom);
-        $xmlHelper = new XmlConfigurationHelper($this->getPathReplacer(), '');
 
         $this->expectException(InvalidPhpUnitXmlConfigException::class);
         $this->expectExceptionMessageRegExp('/Element \'invalid\'\: This element is not expected/');
 
-        $xmlHelper->validate($xPath);
-    }
-
-    public function schemaProvider(): Generator
-    {
-        yield 'Remote XSD' => ['https://raw.githubusercontent.com/sebastianbergmann/phpunit/7.4.0/phpunit.xsd'];
-
-        yield 'Local XSD' => ['./vendor/phpunit/phpunit/phpunit.xsd'];
+        $this->configHelper->validate($xPath);
     }
 
     /**
@@ -512,16 +540,15 @@ XML
 </phpunit>
 XML
         );
+
         $xPath = new DOMXPath($dom);
 
-        $xmlHelper = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $this->assertTrue($xmlHelper->validate($xPath));
+        $this->assertTrue($this->configHelper->validate($xPath));
     }
 
     public function test_it_removes_default_test_suite(): void
     {
-        $this->assertItChangesXML(<<<XML
+        $this->assertItChangesXML(<<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     defaultTestSuite="unit"
@@ -532,9 +559,11 @@ XML
 </phpunit>
 
 XML
-            , static function (XmlConfigurationHelper $xmlconfig, DOMXPath $xPath, DOMDocument $dom): void {
-                $xmlconfig->removeDefaultTestSuite($xPath);
-            }, <<<XML
+            ,
+            static function (XmlConfigurationHelper $configHelper, DOMXPath $xPath): void {
+                $configHelper->removeDefaultTestSuite($xPath);
+            },
+            <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     printerClass="Fake\Printer\Class"
@@ -547,14 +576,19 @@ XML
         );
     }
 
+    public function schemaProvider(): Generator
+    {
+        yield 'Remote XSD' => ['https://raw.githubusercontent.com/sebastianbergmann/phpunit/7.4.0/phpunit.xsd'];
+
+        yield 'Local XSD' => ['./vendor/phpunit/phpunit/phpunit.xsd'];
+    }
+
     private function assertItChangesStandardConfiguration(Closure $callback, string $expectedXml): void
     {
         $dom = $this->getDomDocument();
         $xPath = new DOMXPath($dom);
 
-        $xmlConfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $callback($xmlConfig, $xPath, $dom);
+        $callback($this->configHelper, $xPath, $dom);
 
         $actualXml = $dom->saveXML();
 
@@ -562,7 +596,7 @@ XML
         $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
 
-    private function assertItChangesXML(string $inputXml, callable $callback, string $expectedXml): void
+    private function assertItChangesXML(string $inputXml, Closure $callback, string $expectedXml): void
     {
         $dom = new DOMDocument();
         $dom->preserveWhiteSpace = false;
@@ -570,9 +604,7 @@ XML
         $dom->loadXML($inputXml);
         $xPath = new DOMXPath($dom);
 
-        $xmlConfig = new XmlConfigurationHelper($this->getPathReplacer(), '');
-
-        $callback($xmlConfig, $xPath, $dom);
+        $callback($this->configHelper, $xPath, $dom);
 
         $actualXml = $dom->saveXML();
 
@@ -585,19 +617,7 @@ XML
         $dom = new DOMDocument();
         $dom->preserveWhiteSpace = false;
         $dom->formatOutput = true;
-        $dom->loadXML($this->getPHPUnitXMLConfig());
-
-        return $dom;
-    }
-
-    private function getPathReplacer(): PathReplacer
-    {
-        return new PathReplacer(new Filesystem());
-    }
-
-    private function getPHPUnitXMLConfig(): string
-    {
-        return <<<XML
+        $dom->loadXML(<<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -628,6 +648,9 @@ XML
         <log type="coverage-html" target="/path/to/tmp"/>
     </logging>
 </phpunit>
-XML;
+XML
+        );
+
+        return $dom;
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationHelperTest.php
@@ -493,14 +493,17 @@ XML
 
     public function test_it_consider_as_valid_a_PHPUnit_XML_configuration_without_XSD(): void
     {
-        $xPath = $this->createXPath(<<<XML
+        $xPath = $this->createXPath(
+            <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit>
 </phpunit>
 XML
         );
 
-        $this->assertTrue($this->configHelper->validate($xPath));
+        $this->assertTrue($this->configHelper->validate('/path/to/phpunit.xml', $xPath));
+    }
+
     /**
      * @dataProvider schemaProvider
      *


### PR DESCRIPTION
So far we unconditionally assume the PHPUnit configuration file is `phpunit.xml` (without any path) which is both wrong and very confusing. Instead this PR proposes to always pass the path to provide a more helpful error message