### PR TITLE
Remove unnecessary @covers annotations

### DIFF
--- a/tests/phpunit/Environment/BuildContextTest.php
+++ b/tests/phpunit/Environment/BuildContextTest.php
@@ -38,9 +38,6 @@ namespace Infection\Tests\Environment;
 use Infection\Environment\BuildContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Infection\Environment\BuildContext
- */
 final class BuildContextTest extends TestCase
 {
     public function test_constructor_sets_values(): void

--- a/tests/phpunit/Environment/CouldNotResolveBuildContextTest.php
+++ b/tests/phpunit/Environment/CouldNotResolveBuildContextTest.php
@@ -38,9 +38,6 @@ namespace Infection\Tests\Environment;
 use Infection\Environment\CouldNotResolveBuildContext;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Infection\Environment\CouldNotResolveBuildContext
- */
 final class CouldNotResolveBuildContextTest extends TestCase
 {
     public function test_create_returns_exception(): void

--- a/tests/phpunit/Environment/CouldNotResolveStrykerApiKeyTest.php
+++ b/tests/phpunit/Environment/CouldNotResolveStrykerApiKeyTest.php
@@ -39,9 +39,6 @@ use Infection\Environment\CouldNotResolveStrykerApiKey;
 use PHPUnit\Framework\TestCase;
 use function Safe\sprintf;
 
-/**
- * @covers \Infection\Environment\CouldNotResolveStrykerApiKey
- */
 final class CouldNotResolveStrykerApiKeyTest extends TestCase
 {
     public function test_from_returns_exception(): void

--- a/tests/phpunit/Environment/StrykerApiKeyResolverTest.php
+++ b/tests/phpunit/Environment/StrykerApiKeyResolverTest.php
@@ -40,9 +40,6 @@ use Infection\Environment\StrykerApiKeyResolver;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * @covers \Infection\Environment\StrykerApiKeyResolver
- */
 final class StrykerApiKeyResolverTest extends TestCase
 {
     public function test_resolve_throws_when_environment_is_empty_array(): void

--- a/tests/phpunit/Environment/TravisCiResolverTest.php
+++ b/tests/phpunit/Environment/TravisCiResolverTest.php
@@ -40,9 +40,6 @@ use Infection\Environment\TravisCiResolver;
 use PHPUnit\Framework\TestCase;
 use function Safe\sprintf;
 
-/**
- * @covers \Infection\Environment\BuildContextResolver
- */
 final class TravisCiResolverTest extends TestCase
 {
     public function test_resolve_throws_when_travis_key_does_not_exist_in_environment(): void


### PR DESCRIPTION
Thanks to the PHPUnit bridge `Symfony\Bridge\PhpUnit\CoverageListener` registered in `phpunit.xml.dist`, we do not need those `@covers` annotations