### PR TITLE
Use `$this` instead of `self` for assertions

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -141,6 +141,9 @@ return Config::create()
             'case' => 'snake',
             'style' => 'prefix',
         ],
+        'php_unit_test_case_static_method_calls' => [
+            'call_type' => 'this',
+        ],
         'self_static_accessor' => true,
         'single_line_throw' => false,
         'static_lambda' => true,

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
@@ -105,7 +105,7 @@ final class SchemaConfigurationFileLoaderTest extends TestCase
     private static function createRawConfigWithPathArgument(string $path): Constraint
     {
         return new Callback(static function (SchemaConfigurationFile $config) use ($path) {
-            $this->assertSame($path, $config->getPath());
+            self::assertSame($path, $config->getPath());
 
             return true;
         });

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
@@ -105,7 +105,7 @@ final class SchemaConfigurationFileLoaderTest extends TestCase
     private static function createRawConfigWithPathArgument(string $path): Constraint
     {
         return new Callback(static function (SchemaConfigurationFile $config) use ($path) {
-            self::assertSame($path, $config->getPath());
+            $this->assertSame($path, $config->getPath());
 
             return true;
         });

--- a/tests/phpunit/Environment/BuildContextTest.php
+++ b/tests/phpunit/Environment/BuildContextTest.php
@@ -53,7 +53,7 @@ final class BuildContextTest extends TestCase
             $branch
         );
 
-        self::assertSame($repositorySlug, $buildContext->repositorySlug());
-        self::assertSame($branch, $buildContext->branch());
+        $this->assertSame($repositorySlug, $buildContext->repositorySlug());
+        $this->assertSame($branch, $buildContext->branch());
     }
 }

--- a/tests/phpunit/Environment/CouldNotResolveBuildContextTest.php
+++ b/tests/phpunit/Environment/CouldNotResolveBuildContextTest.php
@@ -49,6 +49,6 @@ final class CouldNotResolveBuildContextTest extends TestCase
 
         $exception = CouldNotResolveBuildContext::create($message);
 
-        self::assertSame($message, $exception->getMessage());
+        $this->assertSame($message, $exception->getMessage());
     }
 }

--- a/tests/phpunit/Environment/CouldNotResolveStrykerApiKeyTest.php
+++ b/tests/phpunit/Environment/CouldNotResolveStrykerApiKeyTest.php
@@ -61,6 +61,6 @@ final class CouldNotResolveStrykerApiKeyTest extends TestCase
             )
         );
 
-        self::assertSame($message, $exception->getMessage());
+        $this->assertSame($message, $exception->getMessage());
     }
 }

--- a/tests/phpunit/Environment/StrykerApiKeyResolverTest.php
+++ b/tests/phpunit/Environment/StrykerApiKeyResolverTest.php
@@ -94,7 +94,7 @@ final class StrykerApiKeyResolverTest extends TestCase
 
         $resolver = new StrykerApiKeyResolver();
 
-        self::assertSame('bar', $resolver->resolve($environment));
+        $this->assertSame('bar', $resolver->resolve($environment));
     }
 
     public function test_resolve_returns_value_of_stryker_dashboard_api_key_when_available(): void
@@ -106,6 +106,6 @@ final class StrykerApiKeyResolverTest extends TestCase
 
         $resolver = new StrykerApiKeyResolver();
 
-        self::assertSame('baz', $resolver->resolve($environment));
+        $this->assertSame('baz', $resolver->resolve($environment));
     }
 }

--- a/tests/phpunit/Environment/TravisCiResolverTest.php
+++ b/tests/phpunit/Environment/TravisCiResolverTest.php
@@ -159,7 +159,7 @@ final class TravisCiResolverTest extends TestCase
 
         $buildContext = $buildContextResolver->resolve($environment);
 
-        self::assertSame($environment['TRAVIS_REPO_SLUG'], $buildContext->repositorySlug());
-        self::assertSame($environment['TRAVIS_BRANCH'], $buildContext->branch());
+        $this->assertSame($environment['TRAVIS_REPO_SLUG'], $buildContext->repositorySlug());
+        $this->assertSame($environment['TRAVIS_BRANCH'], $buildContext->branch());
     }
 }


### PR DESCRIPTION
I don't feel strongly about either conventions but given that we use `$this->assertX()` everywhere in the codebase, I don't think we should introduce `self::assertX()` in a few places: let's keep only one convention and if we want to change it let's change it everywhere.