### PR TITLE
Pass the total coverage to the metrics calculator

### DIFF
--- a/src/Event/InitialTestSuiteWasFinished.php
+++ b/src/Event/InitialTestSuiteWasFinished.php
@@ -41,14 +41,21 @@ namespace Infection\Event;
 final class InitialTestSuiteWasFinished
 {
     private $outputText;
+    private $totalCoverage;
 
-    public function __construct(string $outputText)
+    public function __construct(string $outputText, float $totalCoverage)
     {
         $this->outputText = $outputText;
+        $this->totalCoverage = $totalCoverage;
     }
 
     public function getOutputText(): string
     {
         return $this->outputText;
+    }
+
+    public function getTotalCoverage(): float
+    {
+        return $this->totalCoverage;
     }
 }

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -98,6 +98,11 @@ class MetricsCalculator
     private $notCoveredMutantProcesses = [];
 
     /**
+     * @var float|null
+     */
+    private $totalCoverage;
+
+    /**
      * Build a metric calculator with a sub-set of mutators
      *
      * @param MutantProcess[] $mutantProcesses
@@ -113,6 +118,11 @@ class MetricsCalculator
         }
 
         return $self;
+    }
+
+    public function registerTotalCoverage(float $totalCoverage): void
+    {
+        $this->totalCoverage = $totalCoverage;
     }
 
     public function collect(MutantProcess $mutantProcess): void

--- a/src/Process/Builder/SubscriberBuilder.php
+++ b/src/Process/Builder/SubscriberBuilder.php
@@ -203,7 +203,12 @@ final class SubscriberBuilder
             return new CiInitialTestsConsoleLoggerSubscriber($output, $testFrameworkAdapter);
         }
 
-        return new InitialTestsConsoleLoggerSubscriber($output, $testFrameworkAdapter, $this->debug);
+        return new InitialTestsConsoleLoggerSubscriber(
+            $output,
+            $testFrameworkAdapter,
+            $this->debug,
+            $this->metricsCalculator
+        );
     }
 
     private function shouldSkipProgressBars(): bool

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -40,6 +40,7 @@ use Infection\Event\InitialTestCaseWasCompleted;
 use Infection\Event\InitialTestSuiteWasFinished;
 use Infection\Event\InitialTestSuiteWasStarted;
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
+use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Symfony\Component\Process\Process;
 
 /**
@@ -49,11 +50,16 @@ final class InitialTestsRunner
 {
     private $processBuilder;
     private $eventDispatcher;
+    private $coverage;
 
-    public function __construct(InitialTestRunProcessBuilder $processBuilder, EventDispatcher $eventDispatcher)
-    {
+    public function __construct(
+        InitialTestRunProcessBuilder $processBuilder,
+        EventDispatcher $eventDispatcher,
+        LineCodeCoverage $coverage
+    ) {
         $this->processBuilder = $processBuilder;
         $this->eventDispatcher = $eventDispatcher;
+        $this->coverage = $coverage;
     }
 
     /**
@@ -77,7 +83,10 @@ final class InitialTestsRunner
             $this->eventDispatcher->dispatch(new InitialTestCaseWasCompleted());
         });
 
-        $this->eventDispatcher->dispatch(new InitialTestSuiteWasFinished($process->getOutput()));
+        $this->eventDispatcher->dispatch(new InitialTestSuiteWasFinished(
+            $process->getOutput(),
+            $this->coverage->getTotalCoverage()
+        ));
 
         return $process;
     }

--- a/src/TestFramework/Coverage/LineCodeCoverage.php
+++ b/src/TestFramework/Coverage/LineCodeCoverage.php
@@ -43,6 +43,11 @@ use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 interface LineCodeCoverage
 {
     /**
+     * @return float Total coverage in percent
+     */
+    public function getTotalCoverage(): float;
+
+    /**
      * @throws CoverageDoesNotExistException
      */
     public function hasTests(string $filePath): bool;

--- a/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageFactory.php
+++ b/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageFactory.php
@@ -108,6 +108,10 @@ class PhpUnitXmlCoverageFactory
         }
 
         foreach ($coverage as $sourceFilePath => $fileCoverageData) {
+            if ($sourceFilePath === 'totalCoverage') {
+                continue;
+            }
+
             foreach ($fileCoverageData->byLine as $line => $linesCoverageData) {
                 foreach ($linesCoverageData as $test) {
                     self::updateTestExecutionInfo($test, $this->testFileDataProvider);

--- a/src/TestFramework/Coverage/XmlReport/XMLLineCodeCoverage.php
+++ b/src/TestFramework/Coverage/XmlReport/XMLLineCodeCoverage.php
@@ -44,12 +44,18 @@ use Infection\TestFramework\Coverage\CoverageFileData;
 use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Infection\TestFramework\Coverage\NodeLineRangeData;
 use function range;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal
  */
 final class XMLLineCodeCoverage implements LineCodeCoverage
 {
+    /**
+     * @var float|null
+     */
+    private $totalCoverage;
+
     /**
      * @var array<string, CoverageFileData>|null
      */
@@ -78,6 +84,15 @@ final class XMLLineCodeCoverage implements LineCodeCoverage
         );
 
         return count($coveredLineTestMethods) > 0;
+    }
+
+    public function getTotalCoverage(): float
+    {
+        $this->getCoverage();
+
+        Assert::notNull($this->totalCoverage);
+
+        return $this->totalCoverage;
     }
 
     public function getAllTestsForMutation(
@@ -162,7 +177,11 @@ final class XMLLineCodeCoverage implements LineCodeCoverage
     private function getCoverage(): array
     {
         if ($this->coverage === null) {
-            $this->coverage = $this->coverageFactory->createCoverage();
+            $coverage = $this->coverageFactory->createCoverage();
+
+            $this->totalCoverage = $coverage['totalCoverage'];
+            unset($coverage['totalCoverage']);
+            $this->coverage = $coverage;
         }
 
         return $this->coverage;


### PR DESCRIPTION
This is laying out the necessary foundations with #1065 to be able to calculate the mutation coverage based on the code coverage rather than mutating uncovered code