### PR TITLE
Add subscriber autoreview tests

### DIFF
--- a/tests/phpunit/AutoReview/Event/SubscriberProvider.php
+++ b/tests/phpunit/AutoReview/Event/SubscriberProvider.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\AutoReview\Event;
+
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_values;
+use Generator;
+use Infection\Event\Subscriber\EventSubscriber;
+use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
+use function Infection\Tests\generator_to_phpunit_data_provider;
+use function iterator_to_array;
+use ReflectionClass;
+use function Safe\sprintf;
+use Webmozart\Assert\Assert;
+
+final class SubscriberProvider
+{
+    /**
+     * @var string[]|null
+     */
+    private static $subscriberClasses;
+
+    /**
+     * @var array<array{class-string, string[]}>|null
+     */
+    private static $subscriberMethods;
+
+    private function __construct()
+    {
+    }
+
+    public static function provideSubscriberClasses(): Generator
+    {
+        if (self::$subscriberClasses !== null) {
+            yield from self::$subscriberClasses;
+
+            return;
+        }
+
+        self::$subscriberClasses = array_values(array_filter(
+            iterator_to_array(ProjectCodeProvider::provideSourceClasses(), true),
+            static function (string $class): bool {
+                return $class !== EventSubscriber::class
+                    && (new ReflectionClass($class))->implementsInterface(EventSubscriber::class)
+                ;
+            }
+        ));
+
+        yield from self::$subscriberClasses;
+    }
+
+    public static function provideSubscriberSubscriptionMethods(): Generator
+    {
+        if (self::$subscriberMethods !== null) {
+            yield from self::$subscriberMethods;
+
+            return;
+        }
+
+        self::$subscriberMethods = array_values(array_map(
+            static function (string $subscriberClass): array {
+                /** @var EventSubscriber $subscriber */
+                $subscriber = (new ReflectionClass($subscriberClass))->newInstanceWithoutConstructor();
+
+                return [
+                    $subscriberClass,
+                    array_map(
+                        static function (string $eventClass): string {
+                            Assert::classExists(
+                                $eventClass,
+                                sprintf(
+                                    'Expected "%s" to be a valid event FQCN',
+                                    $eventClass
+                                )
+                            );
+
+                            return 'on' . (new ReflectionClass($eventClass))->getShortName();
+                        },
+                        array_keys($subscriber->getSubscribedEvents())
+                    ),
+                ];
+            },
+            iterator_to_array(self::provideSubscriberClasses(), true)
+        ));
+
+        yield from self::$subscriberMethods;
+    }
+
+    public static function subscriberClassesProvider(): Generator
+    {
+        yield from generator_to_phpunit_data_provider(self::provideSubscriberClasses());
+    }
+
+    public static function subscriberSubscriptionMethodsProvider(): Generator
+    {
+        yield from self::provideSubscriberSubscriptionMethods();
+    }
+}

--- a/tests/phpunit/AutoReview/Event/SubscriberTest.php
+++ b/tests/phpunit/AutoReview/Event/SubscriberTest.php
@@ -49,7 +49,7 @@ use function Safe\sprintf;
 final class SubscriberTest extends TestCase
 {
     /**
-     * @dataProvider Infection\Tests\AutoReview\Event\SubscriberProvider::subscriberClassesProvider
+     * @dataProvider \Infection\Tests\AutoReview\Event\SubscriberProvider::subscriberClassesProvider
      *
      * @param class-string $subscriberClass
      */
@@ -67,7 +67,7 @@ final class SubscriberTest extends TestCase
     }
 
     /**
-     * @dataProvider Infection\Tests\AutoReview\Event\SubscriberProvider::subscriberClassesProvider
+     * @dataProvider \Infection\Tests\AutoReview\Event\SubscriberProvider::subscriberClassesProvider
      *
      * @param class-string $subscriberClass
      */
@@ -82,7 +82,7 @@ final class SubscriberTest extends TestCase
     }
 
     /**
-     * @dataProvider Infection\Tests\AutoReview\Event\SubscriberProvider::subscriberSubscriptionMethodsProvider
+     * @dataProvider \Infection\Tests\AutoReview\Event\SubscriberProvider::subscriberSubscriptionMethodsProvider
      *
      * @param class-string $subscriberClass
      */

--- a/tests/phpunit/AutoReview/Event/SubscriberTest.php
+++ b/tests/phpunit/AutoReview/Event/SubscriberTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\AutoReview\Event;
+
+use function array_keys;
+use function implode;
+use Infection\Event\Subscriber\EventSubscriber;
+use const PHP_EOL;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use function Safe\array_flip;
+use function Safe\sprintf;
+
+final class SubscriberTest extends TestCase
+{
+    /**
+     * @dataProvider Infection\Tests\AutoReview\Event\SubscriberProvider::subscriberClassesProvider
+     *
+     * @param class-string $subscriberClass
+     */
+    public function test_subscription_methods_match_their_event_names(string $subscriberClass): void
+    {
+        $subscriberMethods = (new ReflectionClass($subscriberClass))->getMethods();
+
+        foreach ($subscriberMethods as $method) {
+            if (!$this->isSubscriptionMethod($method)) {
+                continue;
+            }
+
+            $this->assertIsSubscriptionMethod($subscriberClass, $method);
+        }
+    }
+
+    /**
+     * @dataProvider Infection\Tests\AutoReview\Event\SubscriberProvider::subscriberClassesProvider
+     *
+     * @param class-string $subscriberClass
+     */
+    public function test_the_subscribed_methods_can_all_be_collected(string $subscriberClass): void
+    {
+        /** @var EventSubscriber $subscriber */
+        $subscriber = (new ReflectionClass($subscriberClass))->newInstanceWithoutConstructor();
+
+        $subscriber->getSubscribedEvents();
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider Infection\Tests\AutoReview\Event\SubscriberProvider::subscriberSubscriptionMethodsProvider
+     *
+     * @param class-string $subscriberClass
+     */
+    public function test_all_subscription_methods_are_listed_by_the_subscriber(
+        string $subscriberClass,
+        array $subscriptionMethodNames
+    ): void {
+        $subscriptionMethodNames = array_flip($subscriptionMethodNames);
+
+        $subscriberMethods = (new ReflectionClass($subscriberClass))->getMethods();
+
+        foreach ($subscriberMethods as $method) {
+            if (!$this->isSubscriptionMethod($method)) {
+                continue;
+            }
+
+            $subscriptionName = $method->getName();
+
+            $this->assertArrayHasKey(
+                $subscriptionName,
+                $subscriptionMethodNames,
+                sprintf(
+                    'Expected the subscription method "%s" to be listed in "%s::%s()"',
+                    $subscriptionName,
+                    $subscriberClass,
+                    'getSubscribedEvents'
+                )
+            );
+
+            unset($subscriptionMethodNames[$subscriptionName]);
+        }
+
+        $this->assertCount(
+            0,
+            $subscriptionMethodNames,
+            sprintf(
+                'Expected to find the following subscription method(s) on "%s": "%s". %s'
+                . 'Either add them or remove them from "%s::%s()"',
+                $subscriberClass,
+                implode('","', array_keys($subscriptionMethodNames)),
+                PHP_EOL,
+                $subscriberClass,
+                'getSubscribedEvents'
+            )
+        );
+    }
+
+    private function isSubscriptionMethod(ReflectionMethod $method): bool
+    {
+        return !$method->isConstructor()
+            && $method->isPublic()
+            && $method->getName() !== 'getSubscribedEvents'
+        ;
+    }
+
+    /**
+     * @param class-string $subscriberClass
+     */
+    private function assertIsSubscriptionMethod(string $subscriberClass, ReflectionMethod $method): void
+    {
+        $this->assertSame(
+            1,
+            $method->getNumberOfParameters(),
+            sprintf(
+                'Expected a subscription method "%s::%s" to have exactly one parameter: the'
+                . ' event. Got "%d"',
+                $subscriberClass,
+                $method->getName(),
+                $method->getNumberOfParameters()
+            )
+        );
+
+        $eventParameter = $method->getParameters()[0];
+        $eventType = $eventParameter->getType();
+
+        $this->assertNotNull(
+            $eventType,
+            sprintf(
+                'Expected the parameter "%s" to have a type',
+                $eventParameter->getName()
+            )
+        );
+        $this->assertInstanceOf(
+            ReflectionNamedType::class,
+            $eventType,
+            sprintf(
+                'Expected the parameter "%s" to have the type against its class',
+                $eventParameter->getName()
+            )
+        );
+
+        $expectedSubscriptionMethodName = 'on' . (new ReflectionClass($eventType->getName()))->getShortName();
+
+        $this->assertSame(
+            $expectedSubscriptionMethodName,
+            $method->getName(),
+            'Expected the subscription method to follow the project naming convention'
+        );
+    }
+}

--- a/tests/phpunit/AutoReview/Mutator/MutatorProvider.php
+++ b/tests/phpunit/AutoReview/Mutator/MutatorProvider.php
@@ -75,7 +75,7 @@ final class MutatorProvider
     {
     }
 
-    public static function provideMutatorClassesProvider(): Generator
+    public static function provideMutatorClasses(): Generator
     {
         if (self::$mutatorClasses === null) {
             self::$mutatorClasses = array_column(
@@ -87,23 +87,23 @@ final class MutatorProvider
         yield from self::$mutatorClasses;
     }
 
-    public static function provideConcreteMutatorClassesProvider(): Generator
+    public static function provideConcreteMutatorClasses(): Generator
     {
         if (self::$concreteMutatorClasses === null) {
             self::$concreteMutatorClasses = ConcreteClassReflector::filterByConcreteClasses(
-                iterator_to_array(self::provideMutatorClassesProvider(), false)
+                iterator_to_array(self::provideMutatorClasses(), false)
             );
         }
 
         yield from self::$concreteMutatorClasses;
     }
 
-    public static function provideConfigurableMutatorClassesProvider(): Generator
+    public static function provideConfigurableMutatorClasses(): Generator
     {
         if (self::$configurableMutatorClasses === null) {
             self::$configurableMutatorClasses = [];
 
-            foreach (self::provideConcreteMutatorClassesProvider() as $mutatorClassName) {
+            foreach (self::provideConcreteMutatorClasses() as $mutatorClassName) {
                 if (in_array(ConfigurableMutator::class, class_implements($mutatorClassName), true)) {
                     self::$configurableMutatorClasses[] = $mutatorClassName;
                 }
@@ -115,16 +115,16 @@ final class MutatorProvider
 
     public static function mutatorClassesProvider(): Generator
     {
-        yield from generator_to_phpunit_data_provider(self::provideMutatorClassesProvider());
+        yield from generator_to_phpunit_data_provider(self::provideMutatorClasses());
     }
 
     public static function concreteMutatorClassesProvider(): Generator
     {
-        yield from generator_to_phpunit_data_provider(self::provideConcreteMutatorClassesProvider());
+        yield from generator_to_phpunit_data_provider(self::provideConcreteMutatorClasses());
     }
 
     public static function configurableMutatorClassesProvider(): Generator
     {
-        yield from generator_to_phpunit_data_provider(self::provideConfigurableMutatorClassesProvider());
+        yield from generator_to_phpunit_data_provider(self::provideConfigurableMutatorClasses());
     }
 }


### PR DESCRIPTION
See the test in question for the new rules. No change on the code side, just making adding more error-friendly messages when the conventions are not respected