### PR TITLE
Accounting For Codeception Cest Tests In JUnit File.

### DIFF
--- a/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageFactory.php
+++ b/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageFactory.php
@@ -120,7 +120,7 @@ class PhpUnitXmlCoverageFactory
         CoverageLineData $test,
         TestFileDataProvider $testFileDataProvider
     ): void {
-        $class = explode('::', $test->testMethod, 2)[0];
+        $class = explode(':', $test->testMethod, 2)[0];
 
         $testFileData = $testFileDataProvider->getTestFileInfo($class);
 

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageFactoryTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageFactoryTest.php
@@ -111,6 +111,61 @@ final class PhpUnitXmlCoverageFactoryTest extends TestCase
         );
     }
 
+    public function test_it_can_parse_codeception_cest_coverage(): void
+    {
+        $coverageXmlParserMock = $this->createMock(IndexXmlCoverageParser::class);
+        $coverageXmlParserMock
+            ->expects($this->once())
+            ->method('parse')
+            ->willReturn($this->getParsedCodeCoverageData('Acme\FooCest:test_it_can_be_instantiated'))
+        ;
+
+        $testFileDataProvider = $this->createMock(TestFileDataProvider::class);
+        $testFileDataProvider
+            ->expects($this->any())
+            ->method('getTestFileInfo')
+            ->with('Acme\FooCest')
+            ->willReturn(
+                new TestFileTimeData(
+                    '/path/to/acme/FooCest.php',
+                    0.000234
+                )
+            )
+        ;
+
+        $coverageFactory = new PhpUnitXmlCoverageFactory(
+            realpath(self::COVERAGE_DIR),
+            $coverageXmlParserMock,
+            TestFrameworkTypes::PHPUNIT,
+            $testFileDataProvider
+        );
+
+        $coverage = $coverageFactory->createCoverage();
+
+        $this->assertSame(
+            [
+                '/path/to/acme/Foo.php' => [
+                    'byLine' => [
+                        11 => [
+                            [
+                                'testMethod' => 'Acme\FooCest:test_it_can_be_instantiated',
+                                'testFilePath' => '/path/to/acme/FooCest.php',
+                                'time' => 0.000234,
+                            ],
+                        ],
+                    ],
+                    'byMethod' => [
+                        '__construct' => [
+                            'startLine' => 19,
+                            'endLine' => 22,
+                        ],
+                    ],
+                ],
+            ],
+            CoverageHelper::convertToArray($coverage)
+        );
+    }
+
     public function test_it_cannot_create_coverage_if_cannot_locate_the_coverage_index_file(): void
     {
         $coverageXmlParserMock = $this->createMock(IndexXmlCoverageParser::class);
@@ -189,13 +244,13 @@ TXT
         );
     }
 
-    private function getParsedCodeCoverageData(): array
+    private function getParsedCodeCoverageData(string $testMethod = 'Acme\FooTest::test_it_can_be_instantiated'): array
     {
         return [
             '/path/to/acme/Foo.php' => new CoverageFileData(
                 [
                     11 => [
-                        CoverageLineData::withTestMethod('Acme\FooTest::test_it_can_be_instantiated'),
+                        CoverageLineData::withTestMethod($testMethod),
                     ],
                 ],
                 [


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [x] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

Due the way Codeception 'Cests' or 'Codeception Tests' work, code coverage xml generated by the cest files do not exactly match the format that Infection requires for the files to work. Cest files, by their nature, have no extension. When PHP-Coverage runs, it expectedly checks that the file extends TestCase to properly generate the JUnit file. Since Cest tests do not, they lines get added with a single `:` instead of two. This causes a FQNS errors when infection tries to run against the file. This is easily fixed in infection by search for the single `:` instead of the double.

Note: Still testing this change internally. Just getting this prepped for the moment.