### PR TITLE
MemoryLimiterTest needs an update

### DIFF
--- a/src/Resource/Memory/MemoryLimiter.php
+++ b/src/Resource/Memory/MemoryLimiter.php
@@ -36,11 +36,9 @@ declare(strict_types=1);
 namespace Infection\Resource\Memory;
 
 use Composer\XdebugHandler\XdebugHandler;
-use function file_exists;
 use Infection\AbstractTestFramework\MemoryUsageAware;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use function is_string;
-use function is_writable;
 use const PHP_EOL;
 use const PHP_SAPI;
 use function Safe\ini_get;

--- a/src/Resource/Memory/MemoryLimiterEnvironment.php
+++ b/src/Resource/Memory/MemoryLimiterEnvironment.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Resource\Memory;
+
+use Composer\XdebugHandler\XdebugHandler;
+use const PHP_SAPI;
+use function Safe\ini_get;
+
+/**
+ * @internal
+ */
+class MemoryLimiterEnvironment
+{
+    public function hasMemoryLimitSet(): bool
+    {
+        // -1 means no memory limit. Anything else means the user has set their own limits, which we
+        // don't want to mess with
+        return ini_get('memory_limit') !== '-1';
+    }
+
+    public function isUsingSystemIni(): bool
+    {
+        // Under phpdbg we're using a system php.ini and we can't add a memory limit there. If there
+        // is no skipped version of xdebug handler we are also using the system php ini
+        return PHP_SAPI === 'phpdbg' || XdebugHandler::getSkippedVersion() === '';
+    }
+}

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -62,6 +62,7 @@ use Infection\Logger\ResultsLoggerTypes;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutator\NodeMutationGenerator;
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
+use Infection\Resource\Memory\MemoryLimiterEnvironment;
 use Infection\TestFramework\Coverage\CoverageFileData;
 use Infection\TestFramework\Coverage\MethodLocationData;
 use Infection\TestFramework\Coverage\NodeLineRangeData;
@@ -122,6 +123,7 @@ final class ProjectCodeProvider
         PhpSpecMutationConfigBuilder::class,
         PhpUnitMutationConfigBuilder::class,
         IndexXmlCoverageParser::class,
+        MemoryLimiterEnvironment::class,
     ];
 
     /**

--- a/tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php
+++ b/tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Resource\Memory;
+
+use Composer\XdebugHandler\XdebugHandler;
+use Infection\Resource\Memory\MemoryLimiterEnvironment;
+use const PHP_SAPI;
+use PHPUnit\Framework\TestCase;
+use function Safe\ini_get;
+
+/**
+ * @group integration Requires some I/O operations
+ * @covers \Infection\Resource\Memory\MemoryLimiterEnvironment
+ */
+final class MemoryLimiterEnvironmentTest extends TestCase
+{
+    public function test_it_recognizes_memory_limit(): void
+    {
+        $environment = new MemoryLimiterEnvironment();
+        $this->assertSame(ini_get('memory_limit') !== '-1', $environment->hasMemoryLimitSet());
+    }
+
+    public function test_it_detects_phpdbg(): void
+    {
+        if (PHP_SAPI !== 'phpdbg') {
+            $this->markTestSkipped('This test requires PHPDBG');
+        }
+
+        $environment = new MemoryLimiterEnvironment();
+        $this->assertTrue($environment->isUsingSystemIni());
+    }
+
+    public function test_it_detects_xdebug_handler(): void
+    {
+        if (PHP_SAPI === 'phpdbg') {
+            $this->markTestSkipped('This test requires running without PHPDBG');
+        }
+
+        $environment = new MemoryLimiterEnvironment();
+        $this->assertSame(XdebugHandler::getSkippedVersion() === '', $environment->isUsingSystemIni());
+    }
+}

--- a/tests/phpunit/Resource/Memory/MemoryLimiterTest.php
+++ b/tests/phpunit/Resource/Memory/MemoryLimiterTest.php
@@ -43,9 +43,7 @@ use InvalidArgumentException;
 use Memory_Aware\FakeAwareAdapter;
 use function microtime;
 use const PHP_EOL;
-use const PHP_SAPI;
 use PHPUnit\Framework\MockObject\MockObject;
-use function Safe\ini_get;
 use function Safe\sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
@@ -77,14 +75,6 @@ final class MemoryLimiterTest extends FileSystemTestCase
 
     protected function setUp(): void
     {
-        if (ini_get('memory_limit') !== '-1') {
-            $this->markTestSkipped('Unable to test if a memory limit is already set');
-        }
-
-        if (PHP_SAPI === 'phpdbg') {
-            $this->markTestSkipped('Unable to run tests if PHPDBG is used');
-        }
-
         $this->fileSystemMock = $this->createMock(Filesystem::class);
         $this->processMock = $this->createMock(Process::class);
         $this->adapterMock = $this->createMock(AbstractTestFrameworkAdapter::class);

--- a/tests/phpunit/Resource/Memory/MemoryLimiterTest.php
+++ b/tests/phpunit/Resource/Memory/MemoryLimiterTest.php
@@ -185,13 +185,13 @@ final class MemoryLimiterTest extends FileSystemTestCase
     private function configureEnvironmentToBeCalledAtLeastOnce(): void
     {
         $this->environmentMock
-            ->expects($this->atLeastOnce())
+            ->expects($this->once())
             ->method('hasMemoryLimitSet')
             ->willReturn(false)
         ;
 
         $this->environmentMock
-            ->expects($this->atLeastOnce())
+            ->expects($this->once())
             ->method('isUsingSystemIni')
             ->willReturn(false)
         ;

--- a/tests/phpunit/Resource/Memory/MemoryLimiterTest.php
+++ b/tests/phpunit/Resource/Memory/MemoryLimiterTest.php
@@ -166,7 +166,7 @@ final class MemoryLimiterTest extends FileSystemTestCase
 
         $memoryLimiter = new MemoryLimiter($this->fileSystemMock, $filename, $this->environmentMock);
 
-        $result = $memoryLimiter->applyMemoryLimitFromProcess($this->processMock, $adapter);
+        $memoryLimiter->applyMemoryLimitFromProcess($this->processMock, $adapter);
     }
 
     public function test_it_does_nothing_when_memory_used_is_zero(): void


### PR DESCRIPTION
This test is broken currently, let's see if CI would notice.

- Previous change to this test: #1024 
- I reviewed and didn't see any obvious bugs, hoping CI would catch anything not-so-obvious.
- Yet this test fail when I run it locally:
```
1) Infection\Tests\Resource\Memory\MemoryLimiterTest::test_it_applies_memory_limit_if_possible
Expectation failed for method name is "appendToFile" when invoked 1 time(s).
Method was expected to be called 1 times, actually called 0 times.
```
- Aaand CI sees nothing wrong [because it skips the test](https://travis-ci.org/infection/infection/jobs/655174307#L579).

- [x] This PR should make the test run even during CI
- [x] Test fixed