### PR TITLE
Make check_trailing_whitespaces.sh ignore untracked files

### DIFF
--- a/devTools/check_trailing_whitespaces.sh
+++ b/devTools/check_trailing_whitespaces.sh
@@ -35,6 +35,7 @@ files_with_trailing_whitespaces=$(
         -not -path "./tests/e2e/*" \
         -not -path "./tests/phpunit/Fixtures/Files/phpunit/format-whitespace/original-phpunit.xml" \
         -not -path "./tests/phpunit/StringNormalizerTest.php" \
+        -not -exec git ls-files --error-unmatch {} 2>/dev/null \;
         -exec grep -EIHn "\\s$" {} \;
 )
 

--- a/devTools/check_trailing_whitespaces.sh
+++ b/devTools/check_trailing_whitespaces.sh
@@ -35,7 +35,7 @@ files_with_trailing_whitespaces=$(
         -not -path "./tests/e2e/*" \
         -not -path "./tests/phpunit/Fixtures/Files/phpunit/format-whitespace/original-phpunit.xml" \
         -not -path "./tests/phpunit/StringNormalizerTest.php" \
-        -not -exec git ls-files --error-unmatch {} 2>/dev/null \;
+        -not -exec git ls-files --error-unmatch {} 2>/dev/null \; \
         -exec grep -EIHn "\\s$" {} \;
 )
 


### PR DESCRIPTION
Should be a no-brainer.

Verify:
```
touch devTools/foobar
find devTools/ -type f -not -exec git ls-files --error-unmatch {} 2>/dev/null \;
rm devTools/foobar
```
Should not have `devTools/foobar` in the output.