### PR TITLE
ConsoleLoggerSubscriber should not collect mutations for no reason

### DIFF
--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -56,10 +56,6 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
 {
     private const PAD_LENGTH = 8;
 
-    /**
-     * @var MutantExecutionResult[]
-     */
-    private $mutantExecutionResults = [];
     private $output;
     private $outputFormatter;
     private $metricsCalculator;
@@ -103,10 +99,11 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
 
     public function onMutantProcessWasFinished(MutantProcessWasFinished $event): void
     {
-        $this->mutantExecutionResults[] = $event->getExecutionResult();
-        $this->metricsCalculator->collect($event->getExecutionResult());
+        $executionResult = $event->getExecutionResult();
 
-        $this->outputFormatter->advance($event->getExecutionResult(), $this->mutationCount);
+        $this->metricsCalculator->collect($executionResult);
+
+        $this->outputFormatter->advance($executionResult, $this->mutationCount);
     }
 
     public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void


### PR DESCRIPTION
It isn't used anywhere. Should be a no-brainer. 

Small bit from the work I'm doing in preparation for a follow-up to #1082.

Ballpark figure for a single mutation result is in range of 2 Kb for non-debugging runs. It's 20 Mb for 10K mutations, not such a big deal but still.
