### PR TITLE
Improve IgnoreConfig

### DIFF
--- a/src/Mutator/MutatorFactory.php
+++ b/src/Mutator/MutatorFactory.php
@@ -83,7 +83,6 @@ final class MutatorFactory
             } else {
                 $mutator = new $mutatorClassName();
             }
-            /* @var Mutator $mutator */
 
             $mutators[(string) $mutator->getName()] = new IgnoreMutator(
                 new IgnoreConfig($ignored),

--- a/tests/phpunit/Mutator/IgnoreConfigTest.php
+++ b/tests/phpunit/Mutator/IgnoreConfigTest.php
@@ -44,6 +44,13 @@ use PHPUnit\Framework\TestCase;
  */
 final class IgnoreConfigTest extends TestCase
 {
+    public function test_it_returns_early_if_nothing_is_ignored(): void
+    {
+        $config = new IgnoreConfig([]);
+
+        $this->assertFalse($config->isIgnored('Foo', 'bar', 100));
+    }
+
     /**
      * @dataProvider ignoredValuesProvider
      */


### PR DESCRIPTION
- Profiling shows that IgnoreConfig in a very hot class, and casual observation confirms that indeed it has a method potentially called for every mutator, for every line in every file.
- Update it to return early if nothing is ignored. This is the most common case.
- Use `array_key_exists` on a map instead of `in_array` which is a linear search.