### PR TITLE
Rename method from `showProgress` to `noProgress` to avoid confusion 

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -246,7 +246,7 @@ class Configuration
         return $this->formatter;
     }
 
-    public function showProgress(): bool
+    public function noProgress(): bool
     {
         return $this->noProgress;
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -312,7 +312,7 @@ final class Container
                     $config->showMutations(),
                     $config->isDebugEnabled(),
                     $config->getFormatter(),
-                    $config->showProgress(),
+                    $config->noProgress(),
                     $container->getMetricsCalculator(),
                     $container->getEventDispatcher(),
                     $container->getDiffColorizer(),

--- a/tests/phpunit/Configuration/ConfigurationAssertions.php
+++ b/tests/phpunit/Configuration/ConfigurationAssertions.php
@@ -113,7 +113,7 @@ trait ConfigurationAssertions
         $this->assertSame($expectedDebug, $configuration->isDebugEnabled());
         $this->assertSame($expectedOnlyCovered, $configuration->mutateOnlyCoveredCode());
         $this->assertSame($expectedFormatter, $configuration->getFormatter());
-        $this->assertSame($expectedNoProgress, $configuration->showProgress());
+        $this->assertSame($expectedNoProgress, $configuration->noProgress());
         $this->assertSame($expectedIgnoreMsiWithNoMutations, $configuration->ignoreMsiWithNoMutations());
         $this->assertSame($expectedMinMsi, $configuration->getMinMsi());
         $this->assertSame($expectedShowMutations, $configuration->showMutations());


### PR DESCRIPTION
During reviewing of https://github.com/infection/infection/pull/1082 I noticed that Concurrent Processing should be enabled only when `--no-progress` is used, while the method that returns the value of this option is named `showProgress()` which is the opposite by its meaning

https://github.com/infection/infection/pull/1082/files#diff-5772c249f61507a501a28c2087d7d2a8R407

So here is an update.