### PR TITLE
Make E2ETest a member of integration group

### DIFF
--- a/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
@@ -38,19 +38,29 @@ namespace Infection\Tests\AutoReview\IntegrationGroup;
 use function array_filter;
 use function array_map;
 use function array_values;
+use function class_exists;
 use Generator;
 use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
 use Infection\Tests\AutoReview\SourceTestClassNameScheme;
+use Infection\Tests\Console\E2ETest;
 use Infection\Tests\FileSystem\FileSystemTestCase;
 use function iterator_to_array;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use ReflectionException;
 use function Safe\file_get_contents;
 use Webmozart\Assert\Assert;
 
 final class IntegrationGroupProvider
 {
+    /**
+     * List of known integrational tests that must be treated as such.
+     *
+     * A better solution would be to find all tests that do not have corresponding class.
+     */
+    private const KNOWN_INTEGRATIONAL_TESTS = [
+        E2ETest::class,
+    ];
+
     /**
      * @var string[][]|null
      */
@@ -75,10 +85,21 @@ final class IntegrationGroupProvider
 
         self::$ioTestCaseClassesTuple = array_values(array_filter(array_map(
             static function (string $className): ?array {
-                return self::checkIoOperations($className);
+                return self::ioTestCaseTuple($className);
             },
             iterator_to_array(ProjectCodeProvider::provideSourceClasses(), true)
         )));
+
+        foreach (self::KNOWN_INTEGRATIONAL_TESTS as $testCaseClass) {
+            $testCaseReflection = new ReflectionClass($testCaseClass);
+            Assert::isInstanceOf($testCaseReflection, ReflectionClass::class);
+
+            self::$ioTestCaseClassesTuple[] = [
+                $testCaseClass,
+                $testCaseReflection->getFileName(),
+            ];
+
+        }
 
         yield from self::$ioTestCaseClassesTuple;
     }
@@ -89,29 +110,47 @@ final class IntegrationGroupProvider
     }
 
     /**
-     * @return string[]|null
+     * @return ?array{0: string, 1: string}
      */
-    private static function checkIoOperations(string $className): ?array
+    private static function ioTestCaseTuple(string $className): ?array
     {
-        $classReflection = new ReflectionClass($className);
-
         $testCaseClass = SourceTestClassNameScheme::getTestClassName($className);
 
-        try {
-            $testCaseReflection = new ReflectionClass($testCaseClass);
-        } catch (ReflectionException $exception) {
+        if (!class_exists($testCaseClass)) {
             // No test case could be find for this source file
             return null;
         }
 
-        //
-        // Check the test cases code
-        //
+        foreach ([
+            self::checkTestCaseForIoOperations($testCaseClass),
+            self::checkTestedClassForIoOperations($className),
+        ] as $classFileNameWithIoOperations) {
+            if ($classFileNameWithIoOperations === null) {
+                continue;
+            }
+
+            return [
+                $testCaseClass,
+                $classFileNameWithIoOperations,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Check the test cases code.
+     */
+    private static function checkTestCaseForIoOperations(string $testCaseClass): ?string
+    {
+        $testCaseReflection = new ReflectionClass($testCaseClass);
+        Assert::isInstanceOf($testCaseReflection, ReflectionClass::class);
+
         $testCaseFileName = $testCaseReflection->getFileName();
         $testCaseCode = file_get_contents($testCaseFileName);
 
         if (IoCodeDetector::codeContainsIoOperations($testCaseCode)) {
-            return [$testCaseClass, $testCaseFileName];
+            return $testCaseFileName;
         }
 
         $parentTestCaseClassReflection = $testCaseReflection->getParentClass();
@@ -120,7 +159,7 @@ final class IntegrationGroupProvider
 
         while ($parentTestCaseClassReflection->getName() !== TestCase::class) {
             if ($parentTestCaseClassReflection->getName() === FileSystemTestCase::class) {
-                return [$testCaseClass, $parentTestCaseClassReflection->getFileName()];
+                return $parentTestCaseClassReflection->getFileName();
             }
 
             $parentTestCaseFileName = $parentTestCaseClassReflection->getFileName();
@@ -128,7 +167,7 @@ final class IntegrationGroupProvider
             $testCaseCode = file_get_contents($parentTestCaseFileName);
 
             if (IoCodeDetector::codeContainsIoOperations($testCaseCode)) {
-                return [$testCaseClass, $parentTestCaseFileName];
+                return $parentTestCaseFileName;
             }
 
             $parentTestCaseClassReflection = $parentTestCaseClassReflection->getParentClass();
@@ -136,14 +175,21 @@ final class IntegrationGroupProvider
             Assert::isInstanceOf($parentTestCaseClassReflection, ReflectionClass::class);
         }
 
-        //
-        // Check the source class code
-        //
+        return null;
+    }
+
+    /**
+     * Check the source class code.
+     */
+    private static function checkTestedClassForIoOperations(string $className): ?string
+    {
+        $classReflection = new ReflectionClass($className);
+
         $classFileName = $classReflection->getFileName();
         $classCode = file_get_contents($classFileName);
 
         if (IoCodeDetector::codeContainsIoOperations($classCode)) {
-            return [$testCaseClass, $classFileName];
+            return $classFileName;
         }
 
         $parentClassReflection = $classReflection->getParentClass();
@@ -158,7 +204,7 @@ final class IntegrationGroupProvider
             $parentClassCode = file_get_contents($parentClassFileName);
 
             if (IoCodeDetector::codeContainsIoOperations($parentClassCode)) {
-                return [$testCaseClass, $parentClassFileName];
+                return $parentClassFileName;
             }
 
             $parentClassReflection = $parentClassReflection->getParentClass();

--- a/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
@@ -98,7 +98,6 @@ final class IntegrationGroupProvider
                 $testCaseClass,
                 $testCaseReflection->getFileName(),
             ];
-
         }
 
         yield from self::$ioTestCaseClassesTuple;

--- a/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php
@@ -86,5 +86,4 @@ final class IntegrationGroupProviderTest extends TestCase
 
         $this->fail('IntegrationGroupProvider could not find E2ETest, a known test case without a class but with a lot of IO');
     }
-
 }

--- a/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\AutoReview\IntegrationGroup;
 
 use function class_exists;
+use Infection\Tests\Console\E2ETest;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use function Safe\sprintf;
@@ -72,4 +73,18 @@ final class IntegrationGroupProviderTest extends TestCase
 
         $this->assertFileExists($fileWithIoOperations);
     }
+
+    public function test_it_finds_e2e_test(): void
+    {
+        foreach (IntegrationGroupProvider::ioTestCaseTupleProvider() as $tuple) {
+            if ($tuple[0] === E2ETest::class) {
+                $this->addToAssertionCount(1);
+
+                return;
+            }
+        }
+
+        $this->fail('IntegrationGroupProvider could not find E2ETest, a known test case without a class but with a lot of IO');
+    }
+
 }

--- a/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupTest.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupTest.php
@@ -69,9 +69,7 @@ TXT
             )
         );
 
-        if (strpos($phpDoc, '@group integration') === false
-            && strpos($phpDoc, '@group e2e') === false
-        ) {
+        if (strpos($phpDoc, '@group integration') === false) {
             $this->fail(sprintf(
                 <<<'TXT'
 Expected the test case "%s" to have the annotation `@group integration` as I/O operations have been

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -69,6 +69,7 @@ use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 /**
+ * @group e2e
  * @group integration Requires some I/O operations
  */
 final class E2ETest extends TestCase

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -69,11 +69,14 @@ use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 /**
- * @group e2e
- * @group integration
+ * @group integration Requires some I/O operations
  */
 final class E2ETest extends TestCase
 {
+    /**
+     * This group must be excluded from E2E testing to avoid endless recursive testing loop situation.
+     */
+    private const EXCLUDED_GROUP = 'integration';
     private const MAX_FAILING_COMPOSER_INSTALL = 5;
     private const EXPECT_ERROR = 1;
     private const EXPECT_SUCCESS = 0;
@@ -122,16 +125,6 @@ final class E2ETest extends TestCase
     }
 
     /**
-     * Ensure this test belongs to e2e group. We exclude it during E2E testing
-     * from this class to avoid causing endless recursive testing loop.
-     */
-    public function test_it_belongs_to_e2e_group(): void
-    {
-        // Should not match the test itself.
-        $this->assertSame(1, substr_count(file_get_contents(__FILE__), '@group ' . 'e2e'));
-    }
-
-    /**
      * Longest test: runs under about 160-200 sec
      *
      * To be run with:
@@ -151,7 +144,7 @@ final class E2ETest extends TestCase
         }
 
         $output = $this->runInfection(self::EXPECT_SUCCESS, [
-            '--test-framework-options="--exclude-group=e2e"',
+            '--test-framework-options="--exclude-group=' . self::EXCLUDED_GROUP . '"',
         ]);
 
         $this->assertRegExp('/\d+ mutations were generated/', $output);

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -122,13 +122,22 @@ final class E2ETest extends TestCase
     }
 
     /**
+     * Ensure this test belongs to e2e group. We exclude it during E2E testing
+     * from this class to avoid causing endless recursive testing loop.
+     */
+    public function test_it_belongs_to_e2e_group(): void
+    {
+        // Should not match the test itself.
+        $this->assertSame(1, substr_count(file_get_contents(__FILE__), '@group ' . 'e2e'));
+    }
+
+    /**
      * Longest test: runs under about 160-200 sec
      *
      * To be run with:
      *
      * php -dmemory_limit=128M vendor/bin/phpunit --group=large
      *
-     * @group e2e
      * @large
      */
     public function test_it_runs_on_itself(): void
@@ -149,9 +158,6 @@ final class E2ETest extends TestCase
         $this->assertRegExp('/\d{2,} mutants were killed/', $output);
     }
 
-    /**
-     * @group e2e
-     */
     public function test_it_runs_configure_command_if_no_configuration(): void
     {
         chdir('tests/e2e/Unconfigured/');
@@ -163,7 +169,6 @@ final class E2ETest extends TestCase
 
     /**
      * @dataProvider e2eTestSuiteDataProvider
-     * @group e2e
      * @runInSeparateProcess
      */
     public function test_it_runs_an_e2e_test_with_success(string $fullPath): void

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -70,6 +70,7 @@ use Symfony\Component\Process\Process;
 
 /**
  * @group e2e
+ * @group integration
  */
 final class E2ETest extends TestCase
 {

--- a/tests/phpunit/TestFramework/CommandLineBuilderTest.php
+++ b/tests/phpunit/TestFramework/CommandLineBuilderTest.php
@@ -45,7 +45,7 @@ final class CommandLineBuilderTest extends TestCase
 {
     private const PHP_EXTRA_ARGS = ['-d zend_extension=xdebug.so'];
 
-    private const TEST_FRAMEWORK_ARGS = ['--filter XYZ', '--exclude-group=e2e'];
+    private const TEST_FRAMEWORK_ARGS = ['--filter XYZ', '--exclude-group=integration'];
 
     /**
      * @var CommandLineBuilder
@@ -65,7 +65,7 @@ final class CommandLineBuilderTest extends TestCase
 
         $this->assertContains('phpunit.bat', $commandLine);
         $this->assertContains('--filter XYZ', $commandLine);
-        $this->assertContains('--exclude-group=e2e', $commandLine);
+        $this->assertContains('--exclude-group=integration', $commandLine);
     }
 
     public function test_it_builds_command_line_with_empty_php_args(): void
@@ -74,6 +74,6 @@ final class CommandLineBuilderTest extends TestCase
 
         $this->assertContains('vendor/bin/phpunit', $commandLine);
         $this->assertContains('--filter XYZ', $commandLine);
-        $this->assertContains('--exclude-group=e2e', $commandLine);
+        $this->assertContains('--exclude-group=integration', $commandLine);
     }
 }


### PR DESCRIPTION
- Make E2ETest a member of integration group, because it is very IO intensive.
- Update `IntegrationGroupProviderTest` to include an explicit check for E2ETest. It is important that we do not include E2ETest when running Infection from the very test.

`vendor/bin/phpunit --exclude-group=integration` should be much faster
