### PR TITLE
Move individual logger factories out of LoggerFactory

### DIFF
--- a/src/Logger/BadgeLoggerFactory.php
+++ b/src/Logger/BadgeLoggerFactory.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Logger;
+
+use Infection\Environment\ChainBuildContextResolver;
+use Infection\Environment\StrykerApiKeyResolver;
+use Infection\Environment\TravisCiResolver;
+use Infection\Http\BadgeApiClient;
+use Infection\Mutant\MetricsCalculator;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final class BadgeLoggerFactory
+{
+    private $metricsCalculator;
+
+    public function __construct(MetricsCalculator $metricsCalculator)
+    {
+        $this->metricsCalculator = $metricsCalculator;
+    }
+
+    public function create(OutputInterface $output, string $branch): BadgeLogger
+    {
+        return new BadgeLogger(
+            $output,
+            new ChainBuildContextResolver(new TravisCiResolver()),
+            new StrykerApiKeyResolver(),
+            new BadgeApiClient($output),
+            $this->metricsCalculator,
+            $branch
+        );
+    }
+}

--- a/src/Logger/DebugFileLoggerFactory.php
+++ b/src/Logger/DebugFileLoggerFactory.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Logger;
+
+use Infection\Mutant\MetricsCalculator;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class DebugFileLoggerFactory
+{
+    private $metricsCalculator;
+    private $fileSystem;
+    private $debugVerbosity;
+    private $debugMode;
+    private $onlyCoveredMode;
+
+    public function __construct(
+        MetricsCalculator $metricsCalculator,
+        Filesystem $fileSystem,
+        bool $debugVerbosity,
+        bool $debugMode,
+        bool $onlyCoveredMode
+    ) {
+        $this->metricsCalculator = $metricsCalculator;
+        $this->fileSystem = $fileSystem;
+        $this->debugVerbosity = $debugVerbosity;
+        $this->debugMode = $debugMode;
+        $this->onlyCoveredMode = $onlyCoveredMode;
+    }
+
+    public function create(OutputInterface $output, string $filePath): DebugFileLogger
+    {
+        return new DebugFileLogger(
+            $output,
+            $filePath,
+            $this->metricsCalculator,
+            $this->fileSystem,
+            $this->debugVerbosity,
+            $this->debugMode,
+            $this->onlyCoveredMode
+        );
+    }
+}

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -177,11 +177,4 @@ final class LoggerFactory
             $branch
         );
     }
-
-    private function isAllowedToLog(string $logType): bool
-    {
-        return $this->logVerbosity !== LogVerbosity::NONE
-            || in_array($logType, ResultsLoggerTypes::ALLOWED_WITHOUT_LOGGING, true)
-        ;
-    }
 }

--- a/src/Logger/PerMutatorLoggerFactory.php
+++ b/src/Logger/PerMutatorLoggerFactory.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Logger;
+
+use Infection\Mutant\MetricsCalculator;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class PerMutatorLoggerFactory
+{
+    private $metricsCalculator;
+    private $fileSystem;
+    private $debugVerbosity;
+    private $debugMode;
+    private $onlyCoveredMode;
+
+    public function __construct(
+        MetricsCalculator $metricsCalculator,
+        Filesystem $fileSystem,
+        bool $debugVerbosity,
+        bool $debugMode,
+        bool $onlyCoveredMode
+    ) {
+        $this->metricsCalculator = $metricsCalculator;
+        $this->fileSystem = $fileSystem;
+        $this->debugVerbosity = $debugVerbosity;
+        $this->debugMode = $debugMode;
+        $this->onlyCoveredMode = $onlyCoveredMode;
+    }
+
+    public function create(OutputInterface $output, string $filePath): PerMutatorLogger
+    {
+        return new PerMutatorLogger(
+            $output,
+            $filePath,
+            $this->metricsCalculator,
+            $this->fileSystem,
+            $this->debugVerbosity,
+            $this->debugMode,
+            $this->onlyCoveredMode
+        );
+    }
+}

--- a/src/Logger/SummaryFileLoggerFactory.php
+++ b/src/Logger/SummaryFileLoggerFactory.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Logger;
+
+use Infection\Mutant\MetricsCalculator;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class SummaryFileLoggerFactory
+{
+    private $metricsCalculator;
+    private $fileSystem;
+    private $debugVerbosity;
+    private $debugMode;
+    private $onlyCoveredMode;
+
+    public function __construct(
+        MetricsCalculator $metricsCalculator,
+        Filesystem $fileSystem,
+        bool $debugVerbosity,
+        bool $debugMode,
+        bool $onlyCoveredMode
+    ) {
+        $this->metricsCalculator = $metricsCalculator;
+        $this->fileSystem = $fileSystem;
+        $this->debugVerbosity = $debugVerbosity;
+        $this->debugMode = $debugMode;
+        $this->onlyCoveredMode = $onlyCoveredMode;
+    }
+
+    public function create(OutputInterface $output, string $filePath): SummaryFileLogger
+    {
+        return new SummaryFileLogger(
+            $output,
+            $filePath,
+            $this->metricsCalculator,
+            $this->fileSystem,
+            $this->debugVerbosity,
+            $this->debugMode,
+            $this->onlyCoveredMode
+        );
+    }
+}

--- a/src/Logger/TextLoggerFactory.php
+++ b/src/Logger/TextLoggerFactory.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Logger;
+
+use Infection\Mutant\MetricsCalculator;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+final class TextLoggerFactory
+{
+    private $metricsCalculator;
+    private $fileSystem;
+    private $debugVerbosity;
+    private $debugMode;
+    private $onlyCoveredMode;
+
+    public function __construct(
+        MetricsCalculator $metricsCalculator,
+        Filesystem $fileSystem,
+        bool $debugVerbosity,
+        bool $debugMode,
+        bool $onlyCoveredMode
+    ) {
+        $this->metricsCalculator = $metricsCalculator;
+        $this->fileSystem = $fileSystem;
+        $this->debugVerbosity = $debugVerbosity;
+        $this->debugMode = $debugMode;
+        $this->onlyCoveredMode = $onlyCoveredMode;
+    }
+
+    public function create(OutputInterface $output, string $filePath): TextFileLogger
+    {
+        return new TextFileLogger(
+            $output,
+            $filePath,
+            $this->metricsCalculator,
+            $this->fileSystem,
+            $this->debugVerbosity,
+            $this->debugMode,
+            $this->onlyCoveredMode
+        );
+    }
+}

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -35,6 +35,11 @@ declare(strict_types=1);
 
 namespace Infection\Tests\AutoReview\ProjectCode;
 
+use Infection\Logger\BadgeLoggerFactory;
+use Infection\Logger\DebugFileLoggerFactory;
+use Infection\Logger\PerMutatorLoggerFactory;
+use Infection\Logger\SummaryFileLoggerFactory;
+use Infection\Logger\TextLoggerFactory;
 use const DIRECTORY_SEPARATOR;
 use Generator;
 use function in_array;
@@ -103,6 +108,11 @@ final class ProjectCodeProvider
         FilterableFinder::class,
         Engine::class,
         NonExecutableFinder::class,
+        BadgeLoggerFactory::class,
+        DebugFileLoggerFactory::class,
+        PerMutatorLoggerFactory::class,
+        SummaryFileLoggerFactory::class,
+        TextLoggerFactory::class,
     ];
 
     /**

--- a/tests/phpunit/Process/Builder/SubscriberBuilderTest.php
+++ b/tests/phpunit/Process/Builder/SubscriberBuilderTest.php
@@ -50,6 +50,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use function sys_get_temp_dir;
 
 /**
  * NOTE:
@@ -100,31 +101,36 @@ final class SubscriberBuilderTest extends TestCase
 
     private function makeSubscriberBuilder(bool $debug, string $formatter, bool $noProgress, int $addSubscriber, int $getLogs = 1): SubscriberBuilder
     {
-        $calculator = new MetricsCalculator();
         $dispatcher = $this->createMock(EventDispatcher::class);
-        $dispatcher->expects($this->exactly($addSubscriber))->method('addSubscriber');
-        $diff = $this->createMock(DiffColorizer::class);
-        $config = $this->createMock(Configuration::class);
-        $config->expects($this->exactly($getLogs))->method('getLogs')->willReturn(
-            new Logs(null, null, null, null, null)
-        );
-        $fs = $this->createMock(Filesystem::class);
+        $dispatcher
+            ->expects($this->exactly($addSubscriber))
+            ->method('addSubscriber')
+        ;
+
+        $configMock = $this->createMock(Configuration::class);
+        $configMock
+            ->expects($this->exactly($getLogs))
+            ->method('getLogs')
+            ->willReturn(
+                new Logs(null, null, null, null, null)
+            )
+        ;
 
         return new SubscriberBuilder(
             true,
             $debug,
             $formatter,
             $noProgress,
-            $calculator,
+            new MetricsCalculator(),
             $dispatcher,
-            $diff,
-            $config,
-            $fs,
+            $this->createMock(DiffColorizer::class),
+            $configMock,
+            $this->createMock(Filesystem::class),
             sys_get_temp_dir(),
             new Stopwatch(),
             new TimeFormatter(),
             new MemoryFormatter(),
-            new LoggerFactory($calculator, $fs, 'all', false, false)
+            $this->createMock(LoggerFactory::class)
         );
     }
 }


### PR DESCRIPTION
This is a bit more of a controversial side of my logger refactoring hence the dedicated PR.

For context: in the refactoring I'm doing, I'm kind of moving away from away from inheriting `FileLogger`: the reason is that it requires a few parameters and force all the downstream loggers to use them although they might not need any (most of them just need the metrics calculator). And if most loggers requires a common parameter, e.g. the metrics calculator, it's moved upstream to `FileLogger` because it makes it more convenient...

In the mist of all of that, `LoggerFactory` suffers the most: any new parameter you need to pass to any of the logger needs to be added to `LoggerFactory` as state.

So the proposal is the following: have a dedicated factory for each loggers. Then `FactoryLogger` can focus on creating the right loggers without worrying about the parameters of each loggers. It is more verbose, but allows to refactor an individual logger without touching `LoggerFactory`.

That said I must say I'm not myself 100% convinced on that one, so submitting for review & opinion