### PR TITLE
Upload codecov only with pcov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
       php: 7.3
       env: DRIVER="pcov"
       after_success:
-          - bash <(curl -s https://codecov.io/bash)
+        - bash <(curl -s https://codecov.io/bash)
 
     - <<: *STANDARD_TEST_JOB
       php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,12 +80,11 @@ jobs:
             phpdbg -qrr bin/infection $INFECTION_FLAGS $INFECTION_PR_FLAGS;
           fi
 
-      after_success:
-        - bash <(curl -s https://codecov.io/bash)
-
     - <<: *STANDARD_TEST_JOB
       php: 7.3
       env: DRIVER="pcov"
+      after_success:
+          - bash <(curl -s https://codecov.io/bash)
 
     - <<: *STANDARD_TEST_JOB
       php: 7.3


### PR DESCRIPTION
I'm not quite sure codecov handles correctly that we are uploading multiple reports for the same changes and more than once we got the issue of a negative code coverage delta despite the code coverage being increased.

For this reason, I propose to restrict it to the pcov build only, since it's the most accurate coverage tool available.

I also don't think that any difference we could get from running it in a different PHP version or something is big enough to matter to use in practice, at least not in the current form. Indeed right now if you try to go to codecov with a tiny negative delta, it just doesn't show enough information to be actionable