### PR TITLE
Allow to configure ignore globally

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -112,6 +112,13 @@
             "additionalProperties": false,
             "description": "Contains the settings for different mutations and profiles",
             "properties": {
+                "ignore": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+
                 "@arithmetic": { "$ref": "#/definitions/default-mutator-config" },
                 "@boolean": { "$ref": "#/definitions/default-mutator-config" },
                 "@conditional_boundary": { "$ref": "#/definitions/default-mutator-config" },
@@ -129,7 +136,9 @@
                 "@cast": { "$ref": "#/definitions/default-mutator-config" },
                 "@unwrap": { "$ref": "#/definitions/default-mutator-config" },
                 "@extensions": { "$ref": "#/definitions/default-mutator-config" },
+
                 "@default": { "$ref": "#/definitions/default-mutator-config" },
+
                 "Assignment": { "$ref": "#/definitions/default-mutator-config" },
                 "AssignmentEqual": { "$ref": "#/definitions/default-mutator-config" },
                 "BitwiseAnd": { "$ref": "#/definitions/default-mutator-config" },

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -112,7 +112,7 @@
             "additionalProperties": false,
             "description": "Contains the settings for different mutations and profiles",
             "properties": {
-                "ignore": {
+                "global-ignore": {
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/src/Mutator/MutatorResolver.php
+++ b/src/Mutator/MutatorResolver.php
@@ -112,7 +112,7 @@ final class MutatorResolver
      * @param mixed[]|bool $settings
      * @param array<string, string[]> $globalSettings
      *
-     * @return array<string, string[]>|bool
+     * @return array<string, mixed[]>|bool
      */
     private static function resolveSettings($settings, array $globalSettings)
     {
@@ -128,7 +128,7 @@ final class MutatorResolver
     }
 
     /**
-     * @param array<string, string[]>|bool|bool $settings
+     * @param array<string, mixed[]>|bool $settings
      * @param array<string, array<string, string>> $mutators
      */
     private static function registerFromProfile(
@@ -170,7 +170,7 @@ final class MutatorResolver
     }
 
     /**
-     * @param array<string, string[]>|bool $settings
+     * @param array<string, mixed[]>|bool $settings
      * @param array<string, array<string, string>> $mutators
      */
     private static function registerFromName(

--- a/src/Mutator/MutatorResolver.php
+++ b/src/Mutator/MutatorResolver.php
@@ -41,13 +41,14 @@ use function class_exists;
 use function count;
 use InvalidArgumentException;
 use function Safe\sprintf;
-use stdClass;
 
 /**
  * @internal
  */
 final class MutatorResolver
 {
+    private const GLOBAL_IGNORE_SETTING = 'global-ignore';
+
     /**
      * Resolves the given hashmap of enabled, disabled or configured mutators
      * and profiles into a hashmap of mutator raw settings by their mutator
@@ -63,10 +64,13 @@ final class MutatorResolver
 
         $globalSettings = [];
 
-        foreach ($mutatorSettings as $mutatorOrProfile => $setting) {
-            if ($mutatorOrProfile === 'ignore') {
-                $globalSettings = ['ignore' => $setting];
-                unset($mutatorSettings['ignore']);
+        foreach ($mutatorSettings as $mutatorOrProfileOrGlobalSettingKey => $setting) {
+            if ($mutatorOrProfileOrGlobalSettingKey === self::GLOBAL_IGNORE_SETTING) {
+                /** @var string[] $globalSetting */
+                $globalSetting = $setting;
+
+                $globalSettings = ['ignore' => $globalSetting];
+                unset($mutatorSettings[self::GLOBAL_IGNORE_SETTING]);
 
                 break;
             }
@@ -105,10 +109,10 @@ final class MutatorResolver
     }
 
     /**
-     * @param array<string, string>|bool $settings
-     * @param array<string, string> $globalSettings
+     * @param mixed[]|bool $settings
+     * @param array<string, string[]> $globalSettings
      *
-     * @return array<string, string>|bool
+     * @return array<string, string[]>|bool
      */
     private static function resolveSettings($settings, array $globalSettings)
     {
@@ -124,7 +128,7 @@ final class MutatorResolver
     }
 
     /**
-     * @param array<string, string>|bool $settings
+     * @param array<string, string[]>|bool|bool $settings
      * @param array<string, array<string, string>> $mutators
      */
     private static function registerFromProfile(
@@ -166,7 +170,7 @@ final class MutatorResolver
     }
 
     /**
-     * @param array<string, string>|bool $settings
+     * @param array<string, string[]>|bool $settings
      * @param array<string, array<string, string>> $mutators
      */
     private static function registerFromName(
@@ -189,8 +193,8 @@ final class MutatorResolver
     }
 
     /**
-     * @param array<string, string>|bool|stdClass $settings
-     * @param array<string, array<string, string>> $mutators
+     * @param array<string, string[]>|bool $settings
+     * @param array<string, string[]> $mutators
      */
     private static function registerFromClass(
         string $mutatorClassName,

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -851,6 +851,66 @@ JSON
             ]),
         ];
 
+        yield '[mutators][global ignore] nominal' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "mutators": {
+        "ignore": ["A::B"]
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mutators' => [
+                    'ignore' => ['A::B'],
+                ],
+            ]),
+        ];
+
+        yield '[mutators][global ignore] empty & untrimmed ignore' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "mutators": {
+        "ignore": [" file ", " "]
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mutators' => [
+                    'ignore' => [' file ', ' '],
+                ],
+            ]),
+        ];
+
+        yield '[mutators][global ignore] empty' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "mutators": {
+        "ignore": []
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mutators' => [
+                    'ignore' => [],
+                ],
+            ]),
+        ];
+
         yield '[mutators][TrueValue] true' => [
             <<<'JSON'
 {

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -858,7 +858,7 @@ JSON
         "directories": ["src"]
     },
     "mutators": {
-        "ignore": ["A::B"]
+        "global-ignore": ["A::B"]
     }
 }
 JSON
@@ -866,7 +866,7 @@ JSON
             self::createConfig([
                 'source' => new Source(['src'], []),
                 'mutators' => [
-                    'ignore' => ['A::B'],
+                    'global-ignore' => ['A::B'],
                 ],
             ]),
         ];
@@ -878,7 +878,7 @@ JSON
         "directories": ["src"]
     },
     "mutators": {
-        "ignore": [" file ", " "]
+        "global-ignore": [" file ", " "]
     }
 }
 JSON
@@ -886,7 +886,7 @@ JSON
             self::createConfig([
                 'source' => new Source(['src'], []),
                 'mutators' => [
-                    'ignore' => [' file ', ' '],
+                    'global-ignore' => [' file ', ' '],
                 ],
             ]),
         ];
@@ -898,7 +898,7 @@ JSON
         "directories": ["src"]
     },
     "mutators": {
-        "ignore": []
+        "global-ignore": []
     }
 }
 JSON
@@ -906,7 +906,7 @@ JSON
             self::createConfig([
                 'source' => new Source(['src'], []),
                 'mutators' => [
-                    'ignore' => [],
+                    'global-ignore' => [],
                 ],
             ]),
         ];

--- a/tests/phpunit/Mutator/MutatorResolverTest.php
+++ b/tests/phpunit/Mutator/MutatorResolverTest.php
@@ -63,7 +63,7 @@ final class MutatorResolverTest extends TestCase
         $this->mutatorResolver = SingletonContainer::getContainer()->getMutatorResolver();
     }
 
-    public function test_it_resolve_no_mutator_if_no_profile_or_mutator_is_passed(): void
+    public function test_it_resolves_no_mutator_if_no_profile_or_mutator_is_passed(): void
     {
         $resolvedMutators = $this->mutatorResolver->resolve([]);
 

--- a/tests/phpunit/Mutator/MutatorResolverTest.php
+++ b/tests/phpunit/Mutator/MutatorResolverTest.php
@@ -245,7 +245,7 @@ final class MutatorResolverTest extends TestCase
     public function test_it_can_resolve_mutators_with_global_settings(): void
     {
         $resolvedMutators = $this->mutatorResolver->resolve([
-            'ignore' => ['A::B'],
+            'global-ignore' => ['A::B'],
             MutatorName::getName(Plus::class) => true,
             MutatorName::getName(For_::class) => false,
             MutatorName::getName(IdenticalEqual::class) => [
@@ -271,7 +271,7 @@ final class MutatorResolverTest extends TestCase
             MutatorName::getName(Plus::class) => [
                 'ignore' => ['B::C'],
             ],
-            'ignore' => ['A::B'],
+            'global-ignore' => ['A::B'],
         ]);
 
         $this->assertSameMutatorsByClass([Plus::class], $resolvedMutators);


### PR DESCRIPTION
As of now, if you want to add an `ignore` setting, you need to add it on a mutator basis. This however gets seriously tedious, repetitive and hard to keep in sync if you have a lot of mutators listed.

This PR proposes to allow a global ignore config which will be enriched (not overwritten) by each mutators.

- [x] Docs: https://github.com/theofidry/site/pull/1/files