### PR TITLE
Fix the order in which the infection configuration files are loaded

### DIFF
--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -337,10 +337,10 @@ final class InfectionCommand extends BaseCommand
     {
         try {
             $locator->locateOneOf([
-                SchemaConfigurationLoader::DEFAULT_DIST_CONFIG_FILE,
                 SchemaConfigurationLoader::DEFAULT_CONFIG_FILE,
+                SchemaConfigurationLoader::DEFAULT_DIST_CONFIG_FILE,
             ]);
-        } catch (Exception $e) {
+        } catch (Exception $exception) {
             $configureCommand = $this->getApplication()->find('configure');
 
             $args = [

--- a/src/Container.php
+++ b/src/Container.php
@@ -448,8 +448,8 @@ final class Container
                     array_filter(
                         [
                             $configFile,
-                            SchemaConfigurationLoader::DEFAULT_DIST_CONFIG_FILE,
                             SchemaConfigurationLoader::DEFAULT_CONFIG_FILE,
+                            SchemaConfigurationLoader::DEFAULT_DIST_CONFIG_FILE,
                         ]
                     )
                 );


### PR DESCRIPTION
The expected order is:

- custom file if specified
- `infection.json` file if available
- `infection.json.dist` file