### PR TITLE
Improve TextLogger

### DIFF
--- a/devTools/check_trailing_whitespaces.sh
+++ b/devTools/check_trailing_whitespaces.sh
@@ -35,6 +35,7 @@ files_with_trailing_whitespaces=$(
         -not -path "./tests/e2e/*" \
         -not -path "./tests/phpunit/Fixtures/Files/phpunit/format-whitespace/original-phpunit.xml" \
         -not -path "./tests/phpunit/StringNormalizerTest.php" \
+        -not -path "./tests/phpunit/StrTest.php" \
         -exec grep -EIHn "\\s$" {} \;
 )
 

--- a/src/Str.php
+++ b/src/Str.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection;
+
+use function array_values;
+
+/**
+ * @internal
+ */
+final class Str
+{
+    private function __construct()
+    {
+    }
+
+    public static function trimLineReturns(string $string): string
+    {
+        $lines = explode(PHP_EOL, $string);
+        $linesCount = count($lines);
+
+        // Trim leading empty lines
+        for ($i = 0; $i < $linesCount; ++$i) {
+            $line = $lines[$i];
+
+            if (trim($line) === '') {
+                unset($lines[$i]);
+
+                continue;
+            }
+
+            break;
+        }
+
+        $lines = array_values($lines);
+        $linesCount = count($lines);
+
+        // Trim trailing empty lines
+        for ($i = $linesCount - 1; $i >= 0; --$i) {
+            $line = $lines[$i];
+
+            if (trim($line) === '') {
+                unset($lines[$i]);
+
+                continue;
+            }
+
+            break;
+        }
+
+        return implode(PHP_EOL, $lines);
+    }
+}

--- a/src/Str.php
+++ b/src/Str.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection;
 
 use function array_values;
+use function str_replace;
 
 /**
  * @internal
@@ -48,7 +49,10 @@ final class Str
 
     public static function trimLineReturns(string $string): string
     {
-        $lines = explode(PHP_EOL, $string);
+        $lines = explode(
+            "\n",
+            str_replace("\r\n", "\n", $string)
+        );
         $linesCount = count($lines);
 
         // Trim leading empty lines

--- a/tests/phpunit/Logger/TextFileLoggerTest.php
+++ b/tests/phpunit/Logger/TextFileLoggerTest.php
@@ -244,7 +244,6 @@ TXT
 Escaped mutants:
 ================
 
-
 1) foo/bar:9    [M] PregQuote
 
 --- Original
@@ -264,9 +263,9 @@ Escaped mutants:
 - echo 'original';
 + echo 'escaped#0';
 
+
 Timed Out mutants:
 ==================
-
 
 1) foo/bar:9    [M] PregQuote
 
@@ -287,9 +286,9 @@ Timed Out mutants:
 - echo 'original';
 + echo 'timedOut#0';
 
+
 Not Covered mutants:
 ====================
-
 
 1) foo/bar:9    [M] PregQuote
 
@@ -321,7 +320,6 @@ TXT
 Escaped mutants:
 ================
 
-
 1) foo/bar:9    [M] PregQuote
 
 --- Original
@@ -331,7 +329,8 @@ Escaped mutants:
 - echo 'original';
 + echo 'escaped#1';
 
-process output
+  process output
+
 
 2) foo/bar:10    [M] For_
 
@@ -342,10 +341,11 @@ process output
 - echo 'original';
 + echo 'escaped#0';
 
-process output
+  process output
+
+
 Timed Out mutants:
 ==================
-
 
 1) foo/bar:9    [M] PregQuote
 
@@ -356,7 +356,8 @@ Timed Out mutants:
 - echo 'original';
 + echo 'timedOut#1';
 
-process output
+  process output
+
 
 2) foo/bar:10    [M] For_
 
@@ -367,10 +368,11 @@ process output
 - echo 'original';
 + echo 'timedOut#0';
 
-process output
+  process output
+
+
 Killed mutants:
 ===============
-
 
 1) foo/bar:9    [M] PregQuote
 
@@ -381,7 +383,8 @@ Killed mutants:
 - echo 'original';
 + echo 'killed#1';
 
-process output
+  process output
+
 
 2) foo/bar:10    [M] For_
 
@@ -392,10 +395,11 @@ process output
 - echo 'original';
 + echo 'killed#0';
 
-process output
+  process output
+
+
 Errors mutants:
 ===============
-
 
 1) foo/bar:9    [M] PregQuote
 
@@ -406,7 +410,8 @@ Errors mutants:
 - echo 'original';
 + echo 'error#1';
 
-process output
+  process output
+
 
 2) foo/bar:10    [M] For_
 
@@ -417,10 +422,11 @@ process output
 - echo 'original';
 + echo 'error#0';
 
-process output
+  process output
+
+
 Not Covered mutants:
 ====================
-
 
 1) foo/bar:9    [M] PregQuote
 
@@ -431,7 +437,8 @@ Not Covered mutants:
 - echo 'original';
 + echo 'notCovered#1';
 
-process output
+  process output
+
 
 2) foo/bar:10    [M] For_
 
@@ -442,7 +449,8 @@ process output
 - echo 'original';
 + echo 'notCovered#0';
 
-process output
+  process output
+
 TXT
         ];
 
@@ -454,9 +462,8 @@ TXT
 Escaped mutants:
 ================
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -464,9 +471,11 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'escaped#1';
 
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -474,12 +483,14 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'escaped#0';
 
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
+
 Timed Out mutants:
 ==================
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -487,9 +498,11 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'timedOut#1';
 
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -497,12 +510,14 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'timedOut#0';
 
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
+
 Not Covered mutants:
 ====================
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -510,15 +525,19 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'notCovered#1';
 
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
 
 - echo 'original';
 + echo 'notCovered#0';
+
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
 
 TXT
         ];
@@ -531,9 +550,8 @@ TXT
 Escaped mutants:
 ================
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -541,10 +559,12 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'escaped#1';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -552,13 +572,15 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'escaped#0';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
+
 Timed Out mutants:
 ==================
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -566,10 +588,12 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'timedOut#1';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -577,13 +601,15 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'timedOut#0';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
+
 Killed mutants:
 ===============
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -591,10 +617,12 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'killed#1';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -602,13 +630,15 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'killed#0';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
+
 Errors mutants:
 ===============
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -616,10 +646,12 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'error#1';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -627,13 +659,15 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'error#0';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
+
 Not Covered mutants:
 ====================
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -641,10 +675,12 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'notCovered#1';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -652,7 +688,9 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'notCovered#0';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
 TXT
         ];
 
@@ -664,7 +702,6 @@ TXT
 Escaped mutants:
 ================
 
-
 1) foo/bar:9    [M] PregQuote
 
 --- Original
@@ -684,9 +721,9 @@ Escaped mutants:
 - echo 'original';
 + echo 'escaped#0';
 
+
 Timed Out mutants:
 ==================
-
 
 1) foo/bar:9    [M] PregQuote
 
@@ -718,7 +755,6 @@ TXT
 Escaped mutants:
 ================
 
-
 1) foo/bar:9    [M] PregQuote
 
 --- Original
@@ -728,7 +764,8 @@ Escaped mutants:
 - echo 'original';
 + echo 'escaped#1';
 
-process output
+  process output
+
 
 2) foo/bar:10    [M] For_
 
@@ -739,10 +776,11 @@ process output
 - echo 'original';
 + echo 'escaped#0';
 
-process output
+  process output
+
+
 Timed Out mutants:
 ==================
-
 
 1) foo/bar:9    [M] PregQuote
 
@@ -753,7 +791,8 @@ Timed Out mutants:
 - echo 'original';
 + echo 'timedOut#1';
 
-process output
+  process output
+
 
 2) foo/bar:10    [M] For_
 
@@ -764,10 +803,11 @@ process output
 - echo 'original';
 + echo 'timedOut#0';
 
-process output
+  process output
+
+
 Killed mutants:
 ===============
-
 
 1) foo/bar:9    [M] PregQuote
 
@@ -778,7 +818,8 @@ Killed mutants:
 - echo 'original';
 + echo 'killed#1';
 
-process output
+  process output
+
 
 2) foo/bar:10    [M] For_
 
@@ -789,10 +830,11 @@ process output
 - echo 'original';
 + echo 'killed#0';
 
-process output
+  process output
+
+
 Errors mutants:
 ===============
-
 
 1) foo/bar:9    [M] PregQuote
 
@@ -803,7 +845,8 @@ Errors mutants:
 - echo 'original';
 + echo 'error#1';
 
-process output
+  process output
+
 
 2) foo/bar:10    [M] For_
 
@@ -814,7 +857,8 @@ process output
 - echo 'original';
 + echo 'error#0';
 
-process output
+  process output
+
 TXT
         ];
 
@@ -826,9 +870,8 @@ TXT
 Escaped mutants:
 ================
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -836,9 +879,11 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'escaped#1';
 
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -846,12 +891,14 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'escaped#0';
 
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
+
 Timed Out mutants:
 ==================
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -859,15 +906,19 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'timedOut#1';
 
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
 
 - echo 'original';
 + echo 'timedOut#0';
+
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
 
 TXT
         ];
@@ -880,9 +931,8 @@ TXT
 Escaped mutants:
 ================
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -890,10 +940,12 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'escaped#1';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -901,13 +953,15 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'escaped#0';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
+
 Timed Out mutants:
 ==================
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -915,10 +969,12 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'timedOut#1';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -926,13 +982,15 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'timedOut#0';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
+
 Killed mutants:
 ===============
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -940,10 +998,12 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'killed#1';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -951,13 +1011,15 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'killed#0';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
+
 Errors mutants:
 ===============
 
-
 1) foo/bar:9    [M] PregQuote
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -965,10 +1027,12 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'error#1';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
 
 2) foo/bar:10    [M] For_
-bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+
 --- Original
 +++ New
 @@ @@
@@ -976,7 +1040,9 @@ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTe
 - echo 'original';
 + echo 'error#0';
 
-process output
+$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
+  process output
+
 TXT
         ];
     }

--- a/tests/phpunit/StrTest.php
+++ b/tests/phpunit/StrTest.php
@@ -46,7 +46,10 @@ final class StrTest extends TestCase
      */
     public function test_it_can_trim_string_of_line_returns(string $value, string $expected): void
     {
-        $this->assertSame($expected, Str::trimLineReturns($value));
+        $this->assertSame(
+            $expected,
+            normalizeLineReturn(Str::trimLineReturns($value))
+        );
     }
 
     public function stringProvider(): Generator

--- a/tests/phpunit/StrTest.php
+++ b/tests/phpunit/StrTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests;
+
+use Generator;
+use Infection\Str;
+use PHPUnit\Framework\TestCase;
+
+final class StrTest extends TestCase
+{
+    /**
+     * @dataProvider stringProvider
+     */
+    public function test_it_can_trim_string_of_line_returns(string $value, string $expected): void
+    {
+        $this->assertSame($expected, Str::trimLineReturns($value));
+    }
+
+    public function stringProvider(): Generator
+    {
+        yield 'empty' => [
+            '',
+            '',
+        ];
+
+        yield 'string with untrimmed spaces' => [
+            '  ',
+            '',
+        ];
+
+        yield 'string without line return' => [
+            'Hello!',
+            'Hello!',
+        ];
+
+        yield 'string with leading line returns' => [
+            <<<'TXT'
+
+
+Hello!
+TXT
+            ,
+            'Hello!',
+        ];
+
+        yield 'string with trailing line returns' => [
+            <<<'TXT'
+Hello!
+
+
+TXT
+            ,
+            'Hello!',
+        ];
+
+        yield 'string with leading & trailing line returns' => [
+            <<<'TXT'
+
+
+Hello!
+
+
+TXT
+            ,
+            'Hello!',
+        ];
+
+        yield 'string with leading, trailing & in-between line returns' => [
+            <<<'TXT'
+
+
+Hello...
+
+...World!
+
+
+TXT
+            ,
+            <<<'TXT'
+Hello...
+
+...World!
+TXT
+        ];
+
+        yield 'string with leading, trailing & in-between line returns & dirty empty strings' => [
+            <<<'TXT'
+  
+
+  Hello...
+    
+ ...World!
+  
+
+TXT
+            ,
+            <<<'TXT'
+  Hello...
+    
+ ...World!
+TXT
+        ];
+    }
+}


### PR DESCRIPTION
Before (full log)

<details>
<summary>infection-before.txt</summary>

```
Escaped mutants:
================


1) foo/bar:9    [M] PregQuote
bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'escaped#1';

process output

2) foo/bar:10    [M] For_
bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'escaped#0';

process output
Timed Out mutants:
==================


1) foo/bar:9    [M] PregQuote
bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'timedOut#1';

process output

2) foo/bar:10    [M] For_
bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'timedOut#0';

process output
Killed mutants:
===============


1) foo/bar:9    [M] PregQuote
bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'killed#1';

process output

2) foo/bar:10    [M] For_
bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'killed#0';

process output
Errors mutants:
===============


1) foo/bar:9    [M] PregQuote
bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'error#1';

process output

2) foo/bar:10    [M] For_
bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'error#0';

process output
```
</details>

After (full log)

<details>
<summary>infection-after.txt</summary>

```
Escaped mutants:
================

1) foo/bar:9    [M] PregQuote

--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'escaped#1';

$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
  process output


2) foo/bar:10    [M] For_

--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'escaped#0';

$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
  process output


Timed Out mutants:
==================

1) foo/bar:9    [M] PregQuote

--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'timedOut#1';

$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
  process output


2) foo/bar:10    [M] For_

--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'timedOut#0';

$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
  process output


Killed mutants:
===============

1) foo/bar:9    [M] PregQuote

--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'killed#1';

$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
  process output


2) foo/bar:10    [M] For_

--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'killed#0';

$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
  process output


Errors mutants:
===============

1) foo/bar:9    [M] PregQuote

--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'error#1';

$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
  process output


2) foo/bar:10    [M] For_

--- Original
+++ New
@@ @@

- echo 'original';
+ echo 'error#0';

$ bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"
  process output

```
</details>

A more detailed list of the improvements:

Change the order from:
  - mutation line
  - command line
  - diff
  - process output

to:
  - mutation line
  - diff
  - command line
  - process output

- Prefix the command line by `$ `
- Indent the output to make it a bit clearer (two spaces)

Any other changes are about to make the log file format consistent, i.e. ensure we have the write space here and there. Basically the output becomes way more predictable.