### PR TITLE
PHPUnit group name accepts no comments

### DIFF
--- a/tests/phpunit/AutoReview/BuildConfigYmlTest.php
+++ b/tests/phpunit/AutoReview/BuildConfigYmlTest.php
@@ -46,7 +46,7 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * @coversNothing
  *
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class BuildConfigYmlTest extends TestCase
 {

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -51,7 +51,7 @@ use function substr_count;
 /**
  * @coversNothing
  *
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class MakefileTest extends TestCase
 {

--- a/tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php
@@ -45,7 +45,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use function sys_get_temp_dir;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class ExcludeDirsProviderTest extends AbstractBaseProviderTest
 {

--- a/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
@@ -46,7 +46,7 @@ use function Safe\realpath;
 use Symfony\Component\Console\Exception\RuntimeException as SymfonyRuntimeException;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class PhpUnitCustomExecutablePathProviderTest extends AbstractBaseProviderTest
 {

--- a/tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php
@@ -42,7 +42,7 @@ use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class SourceDirsProviderTest extends AbstractBaseProviderTest
 {

--- a/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -45,7 +45,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class TestFrameworkConfigPathProviderTest extends AbstractBaseProviderTest
 {

--- a/tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php
@@ -39,7 +39,7 @@ use Infection\Config\ConsoleHelper;
 use Infection\Config\ValueProvider\TextLogFileProvider;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class TextLogFileProviderTest extends AbstractBaseProviderTest
 {

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -61,7 +61,7 @@ use Symfony\Component\Finder\SplFileInfo;
 use function sys_get_temp_dir;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class ConfigurationFactoryTest extends TestCase
 {

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
@@ -48,7 +48,7 @@ use ReflectionClass;
 use function Safe\realpath;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class SchemaConfigurationFileLoaderTest extends TestCase
 {

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
@@ -46,7 +46,7 @@ use function Safe\sprintf;
 use Seld\JsonLint\ParsingException;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class SchemaConfigurationFileTest extends TestCase
 {

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -70,7 +70,7 @@ use Symfony\Component\Process\Process;
 
 /**
  * @group e2e
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class E2ETest extends TestCase
 {

--- a/tests/phpunit/ContainerTest.php
+++ b/tests/phpunit/ContainerTest.php
@@ -40,7 +40,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class ContainerTest extends TestCase
 {

--- a/tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberTest.php
@@ -41,7 +41,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class CleanUpAfterMutationTestingFinishedSubscriberTest extends TestCase
 {

--- a/tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php
+++ b/tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php
@@ -47,7 +47,7 @@ use function Safe\sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class RootsFileOrDirectoryLocatorTest extends TestCase
 {

--- a/tests/phpunit/Logger/FileLoggerTest.php
+++ b/tests/phpunit/Logger/FileLoggerTest.php
@@ -46,7 +46,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class FileLoggerTest extends FileSystemTestCase
 {

--- a/tests/phpunit/Logger/LoggerFactoryTest.php
+++ b/tests/phpunit/Logger/LoggerFactoryTest.php
@@ -58,7 +58,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class LoggerFactoryTest extends TestCase
 {

--- a/tests/phpunit/Mutant/MutantFactoryTest.php
+++ b/tests/phpunit/Mutant/MutantFactoryTest.php
@@ -52,7 +52,7 @@ use function Safe\file_put_contents;
 use function Safe\sprintf;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class MutantFactoryTest extends FileSystemTestCase
 {

--- a/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -41,7 +41,7 @@ use function Safe\file_get_contents;
 use function Safe\sprintf;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class ProtectedVisibilityTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
@@ -41,7 +41,7 @@ use function Safe\file_get_contents;
 use function Safe\sprintf;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class PublicVisibilityTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
@@ -41,7 +41,7 @@ use function Safe\file_get_contents;
 use function Safe\sprintf;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class ArrayOneItemTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
@@ -41,7 +41,7 @@ use function Safe\file_get_contents;
 use function Safe\sprintf;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class FunctionCallTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
@@ -41,7 +41,7 @@ use function Safe\file_get_contents;
 use function Safe\sprintf;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class NewObjectTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/Mutator/ReturnValue/ThisTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ThisTest.php
@@ -41,7 +41,7 @@ use function Safe\file_get_contents;
 use function Safe\sprintf;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class ThisTest extends AbstractMutatorTestCase
 {

--- a/tests/phpunit/PhpParser/FileParserTest.php
+++ b/tests/phpunit/PhpParser/FileParserTest.php
@@ -49,7 +49,7 @@ use function Safe\sprintf;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class FileParserTest extends TestCase
 {

--- a/tests/phpunit/PhpParser/Visitor/CloneVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/CloneVisitorTest.php
@@ -42,7 +42,7 @@ use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class CloneVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameVisitorTest.php
@@ -42,7 +42,7 @@ use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class FullyQualifiedClassNameVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/PhpParser/Visitor/MutationsCollectorVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/MutationsCollectorVisitorTest.php
@@ -44,7 +44,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class MutationsCollectorVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php
@@ -50,7 +50,7 @@ use PhpParser\Node\Stmt\Nop;
 use PhpParser\ParserFactory;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class MutatorVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitorTest.php
@@ -41,7 +41,7 @@ use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class NonMutableNodesIgnorerVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/PhpParser/Visitor/ParentConnectorVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ParentConnectorVisitorTest.php
@@ -41,7 +41,7 @@ use function is_array;
 use PhpParser\Node;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class ParentConnectorVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
@@ -53,7 +53,7 @@ use PhpParser\NodeVisitorAbstract;
 use ReflectionClass;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class ReflectionVisitorTest extends BaseVisitorTest
 {

--- a/tests/phpunit/Process/Builder/SubscriberBuilderTest.php
+++ b/tests/phpunit/Process/Builder/SubscriberBuilderTest.php
@@ -57,7 +57,7 @@ use function sys_get_temp_dir;
  * InputInterfaces should be mocked here so that the 'getOption' method with paramater 'no-progress'
  * should return true. Otherwise you will see different results based on wheter its running in CI or not.
  *
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class SubscriberBuilderTest extends TestCase
 {

--- a/tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php
+++ b/tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php
@@ -42,7 +42,7 @@ use PHPUnit\Framework\TestCase;
 use function Safe\ini_get;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class MemoryLimiterEnvironmentTest extends TestCase
 {

--- a/tests/phpunit/Resource/Memory/MemoryLimiterTest.php
+++ b/tests/phpunit/Resource/Memory/MemoryLimiterTest.php
@@ -49,7 +49,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class MemoryLimiterTest extends FileSystemTestCase
 {

--- a/tests/phpunit/TestFramework/CommandLineBuilderTest.php
+++ b/tests/phpunit/TestFramework/CommandLineBuilderTest.php
@@ -39,7 +39,7 @@ use Infection\TestFramework\CommandLineBuilder;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class CommandLineBuilderTest extends TestCase
 {

--- a/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
+++ b/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
@@ -42,7 +42,7 @@ use PHPUnit\Framework\TestCase;
 use function Safe\sprintf;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class TestFrameworkConfigLocatorTest extends TestCase
 {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/JUnitTestFileDataProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/JUnitTestFileDataProviderTest.php
@@ -44,7 +44,7 @@ use function Safe\tempnam;
 use function Safe\unlink;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class JUnitTestFileDataProviderTest extends TestCase
 {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageFactoryTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageFactoryTest.php
@@ -50,7 +50,7 @@ use PHPUnit\Framework\TestCase;
 use function Safe\realpath;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class PhpUnitXmlCoverageFactoryTest extends TestCase
 {

--- a/tests/phpunit/TestFramework/FactoryTest.php
+++ b/tests/phpunit/TestFramework/FactoryTest.php
@@ -45,7 +45,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class FactoryTest extends TestCase
 {

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
@@ -39,7 +39,7 @@ use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class PhpUnitAdapterFactoryTest extends TestCase
 {

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -53,7 +53,7 @@ use function simplexml_load_string;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class InitialConfigBuilderTest extends FileSystemTestCase
 {

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -56,7 +56,7 @@ use function Safe\sprintf;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class MutationConfigBuilderTest extends FileSystemTestCase
 {

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
@@ -44,7 +44,7 @@ use function Safe\realpath;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class PathReplacerTest extends TestCase
 {

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -55,7 +55,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class XmlConfigurationManipulatorTest extends TestCase
 {

--- a/tests/phpunit/TestFramework/PhpUnit/Coverage/IndexXmlCoverageParserTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Coverage/IndexXmlCoverageParserTest.php
@@ -48,7 +48,7 @@ use function Safe\sprintf;
 use function str_replace;
 
 /**
- * @group integration Requires some I/O operations
+ * @group integration
  */
 final class IndexXmlCoverageParserTest extends TestCase
 {


### PR DESCRIPTION
Apparently PHPUnit cannot handle `@group name Comment` format. For example, this command should not execute any tests in this file:
```
php vendor/bin/phpunit  --debug --exclude-group=integration tests/phpunit/TestFramework/PhpUnit/Coverage/IndexXmlCoverageParserTest.php
```

But it does. This PR solves this problem.