### PR TITLE
Make PHPUnit fail on warning or risky

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,8 @@
          bootstrap="./vendor/autoload.php"
          colors="true"
          executionOrder="random"
+         failOnWarning="true"
+         failOnRisky="true"
          verbose="true"
 >
 

--- a/phpunit_autoreview.xml
+++ b/phpunit_autoreview.xml
@@ -5,6 +5,8 @@
          colors="true"
          executionOrder="random"
          stopOnFailure="true"
+         failOnWarning="true"
+         failOnRisky="true"
          verbose="true"
 >
 

--- a/tests/phpunit/AutoReview/Event/SubscriberProviderTest.php
+++ b/tests/phpunit/AutoReview/Event/SubscriberProviderTest.php
@@ -62,19 +62,4 @@ final class SubscriberProviderTest extends TestCase
             )
         );
     }
-
-    /**
-     * @dataProvider \Infection\Tests\AutoReview\Event\SubscriberProvider::subscriberSubscriptionMethodsProvider()
-     *
-     * @param class-string $className
-     * @param string[] $subscriptionMethods
-     */
-    public function test_subscriber_subscription_methods_provider_is_valid(
-        string $className,
-        array $subscriptionMethods
-    ): void {
-        foreach ($subscriptionMethods as $subscriptionMethod) {
-            $this->assertIsString($subscriptionMethod);
-        }
-    }
 }


### PR DESCRIPTION
Before:

```
pf /Users/tfidry/Project/Humbug/infection/tests/phpunit/AutoReview/Event/SubscriberProviderTest.php; echo $?                                                      tfidry@Theos-MacBook-Pro
PHPUnit 8.3.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.18 with PCOV 1.0.6
Configuration: /Users/tfidry/Project/Humbug/infection/phpunit.xml

Testing Infection\Tests\AutoReview\Event\SubscriberProviderTest
........W                                                           9 / 9 (100%)

Time: 110 ms, Memory: 12.00 MB

There was 1 warning:

1) Warning
The data provider specified for Infection\Tests\AutoReview\Event\SubscriberProviderTest::test_subscriber_subscription_methods_provider_is_valid is invalid.
Method subscriberSubscriptionMethodsProvider does not exist

WARNINGS!
Tests: 9, Assertions: 8, Warnings: 1.
0
```

After:

```
pf /Users/tfidry/Project/Humbug/infection/tests/phpunit/AutoReview/Event/SubscriberProviderTest.php; echo $?                                                      tfidry@Theos-MacBook-Pro
PHPUnit 8.3.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.18 with PCOV 1.0.6
Configuration: /Users/tfidry/Project/Humbug/infection/phpunit.xml

Testing Infection\Tests\AutoReview\Event\SubscriberProviderTest
........W                                                           9 / 9 (100%)

Time: 98 ms, Memory: 12.00 MB

There was 1 warning:

  1 Make␣PHPUnit␣fail␣on␣warning␣or␣risky¬
1) Warning
The data provider specified for Infection\Tests\AutoReview\Event\SubscriberProviderTest::test_subscriber_subscription_methods_provider_is_valid is invalid.
Method subscriberSubscriptionMethodsProvider does not exist

WARNINGS!
Tests: 9, Assertions: 8, Warnings: 1.
1
```