### PR TITLE
Add a static empty constructor for Logs

### DIFF
--- a/src/Configuration/Entry/Logs.php
+++ b/src/Configuration/Entry/Logs.php
@@ -60,6 +60,17 @@ final class Logs
         $this->badge = $badge;
     }
 
+    public static function createEmpty(): self
+    {
+        return new self(
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+
     public function getTextLogFilePath(): ?string
     {
         return $this->textLogFilePath;

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -212,13 +212,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit(null, null),
                 null,
@@ -249,13 +243,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
@@ -602,13 +590,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source(['src/'], ['vendor/']),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit(null, null),
                 null,
@@ -642,13 +624,7 @@ final class ConfigurationFactoryTest extends TestCase
                 new SplFileInfo('src/Foo.php', 'src/Foo.php', 'src/Foo.php'),
                 new SplFileInfo('src/Bar.php', 'src/Bar.php', 'src/Bar.php'),
             ],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
@@ -766,13 +742,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 $schemaTimeout,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit(null, null),
                 null,
@@ -803,13 +773,7 @@ final class ConfigurationFactoryTest extends TestCase
             $expectedTimeOut,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
@@ -841,13 +805,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 $configTmpDir,
                 new PhpUnit(null, null),
                 null,
@@ -878,13 +836,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             $expectedTmpDir,
             new PhpUnit('/path/to', null),
@@ -917,13 +869,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit(null, null),
                 null,
@@ -954,13 +900,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
@@ -992,13 +932,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit($phpUnitConfigDir, null),
                 null,
@@ -1029,13 +963,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit($expectedPhpUnitConfigDir, null),
@@ -1068,13 +996,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit('/path/to', null),
                 $ignoreMsiWithNoMutationsFromSchemaConfiguration,
@@ -1105,13 +1027,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
@@ -1144,13 +1060,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit('/path/to', null),
                 null,
@@ -1181,13 +1091,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
@@ -1220,13 +1124,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit('/path/to', null),
                 null,
@@ -1257,13 +1155,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
@@ -1298,13 +1190,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit(null, null),
                 null,
@@ -1335,13 +1221,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
@@ -1374,13 +1254,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit(null, null),
                 null,
@@ -1411,13 +1285,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
@@ -1452,13 +1320,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit(null, null),
                 null,
@@ -1489,13 +1351,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
@@ -1529,13 +1385,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 '',
                 new PhpUnit(null, null),
                 null,
@@ -1566,13 +1416,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
@@ -1608,13 +1452,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/infection.json',
                 null,
                 new Source([], []),
-                new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                Logs::createEmpty(),
                 null,
                 new PhpUnit(null, null),
                 null,
@@ -1645,13 +1483,7 @@ final class ConfigurationFactoryTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),

--- a/tests/phpunit/Configuration/ConfigurationTest.php
+++ b/tests/phpunit/Configuration/ConfigurationTest.php
@@ -143,13 +143,7 @@ final class ConfigurationTest extends TestCase
             10,
             [],
             [],
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             'none',
             '',
             new PhpUnit(null, null),

--- a/tests/phpunit/Configuration/Entry/LogsTest.php
+++ b/tests/phpunit/Configuration/Entry/LogsTest.php
@@ -72,6 +72,20 @@ final class LogsTest extends TestCase
         );
     }
 
+    public function test_it_can_be_instantiated_without_any_values(): void
+    {
+        $logs = Logs::createEmpty();
+
+        $this->assertLogsStateIs(
+            $logs,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+
     public function valuesProvider(): Generator
     {
         yield 'minimal' => [

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -383,13 +383,7 @@ JSON
             ,
             self::createConfig([
                 'source' => new Source(['src'], []),
-                'logs' => new Logs(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                ),
+                'logs' => Logs::createEmpty(),
             ]),
         ];
 
@@ -2389,13 +2383,7 @@ JSON
             'path' => '/path/to/config',
             'timeout' => null,
             'source' => new Source([], []),
-            'logs' => new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            'logs' => Logs::createEmpty(),
             'tmpDir' => null,
             'phpunit' => new PhpUnit(null, null),
             'ignoreMsiWithNoMutations' => null,

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationTest.php
@@ -103,13 +103,7 @@ final class SchemaConfigurationTest extends TestCase
             '',
             null,
             new Source([], []),
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             null,
             new PhpUnit(null, null),
             null,

--- a/tests/phpunit/Logger/LoggerFactoryTest.php
+++ b/tests/phpunit/Logger/LoggerFactoryTest.php
@@ -152,13 +152,7 @@ final class LoggerFactoryTest extends TestCase
     public function logsProvider(): Generator
     {
         yield 'no logger' => [
-            new Logs(
-                null,
-                null,
-                null,
-                null,
-                null
-            ),
+            Logs::createEmpty(),
             [],
         ];
 


### PR DESCRIPTION
Removes a bit of boiler template by adding this new static constructor