### PR TITLE
Draft: Count timeouts as escapes

### DIFF
--- a/src/Mutant/Calculator.php
+++ b/src/Mutant/Calculator.php
@@ -105,6 +105,7 @@ final class Calculator
 
         $score = 0.;
         $coveredTotal = $this->killedCount + $this->errorCount;
+
         if (!$this->treatTimeoutsAsEscapes) {
             $coveredTotal += $this->timedOutCount;
         }
@@ -149,6 +150,7 @@ final class Calculator
         $score = 0.;
         $testedTotal = $this->totalCount - $this->notTestedCount;
         $coveredTotal = $this->killedCount + $this->errorCount;
+
         if (!$this->treatTimeoutsAsEscapes) {
             $coveredTotal += $this->timedOutCount;
         }

--- a/src/Mutant/Calculator.php
+++ b/src/Mutant/Calculator.php
@@ -89,7 +89,8 @@ final class Calculator
             $calculator->getErrorCount(),
             $calculator->getTimedOutCount(),
             $calculator->getNotTestedCount(),
-            $calculator->getTotalMutantsCount()
+            $calculator->getTotalMutantsCount(),
+            $calculator->getTreatTimeoutsAsEscapes()
         );
     }
 

--- a/src/Mutant/Calculator.php
+++ b/src/Mutant/Calculator.php
@@ -61,18 +61,25 @@ final class Calculator
      */
     private $coveredMutationScoreIndicator;
 
+    /**
+     * @var bool
+     */
+    private $treatTimeoutsAsEscapes = false;
+
     public function __construct(
         int $killedCount,
         int $errorCount,
         int $timedOutCount,
         int $notTestedCount,
-        int $totalCount
+        int $totalCount,
+        bool $treatTimeoutsAsEscapes = false
     ) {
         $this->killedCount = $killedCount;
         $this->errorCount = $errorCount;
         $this->timedOutCount = $timedOutCount;
         $this->notTestedCount = $notTestedCount;
         $this->totalCount = $totalCount;
+        $this->treatTimeoutsAsEscapes = $treatTimeoutsAsEscapes;
     }
 
     public static function fromMetrics(MetricsCalculator $calculator): self
@@ -96,7 +103,10 @@ final class Calculator
         }
 
         $score = 0.;
-        $coveredTotal = $this->killedCount + $this->timedOutCount + $this->errorCount;
+        $coveredTotal = $this->killedCount + $this->errorCount;
+        if (!$this->treatTimeoutsAsEscapes) {
+            $coveredTotal += $this->timedOutCount;
+        }
         $totalCount = $this->totalCount;
 
         if ($totalCount !== 0) {
@@ -137,7 +147,10 @@ final class Calculator
 
         $score = 0.;
         $testedTotal = $this->totalCount - $this->notTestedCount;
-        $coveredTotal = $this->killedCount + $this->timedOutCount + $this->errorCount;
+        $coveredTotal = $this->killedCount + $this->errorCount;
+        if (!$this->treatTimeoutsAsEscapes) {
+            $coveredTotal += $this->timedOutCount;
+        }
 
         if ($testedTotal !== 0) {
             $score = 100 * $coveredTotal / $testedTotal;

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -85,7 +85,12 @@ class MetricsCalculator
      */
     private $calculator;
 
-    public function __construct()
+    /**
+     * @var bool
+     */
+    private $treatTimeoutsAsEscapes = false;
+
+    public function __construct(bool $treatTimeoutsAsEscapes = false)
     {
         $this->killedExecutionResults = new SortableMutantExecutionResults();
         $this->errorExecutionResults = new SortableMutantExecutionResults();
@@ -93,6 +98,7 @@ class MetricsCalculator
         $this->timedOutExecutionResults = new SortableMutantExecutionResults();
         $this->notCoveredExecutionResults = new SortableMutantExecutionResults();
         $this->allExecutionResults = new SortableMutantExecutionResults();
+        $this->treatTimeoutsAsEscapes = $treatTimeoutsAsEscapes;
     }
 
     public function collect(MutantExecutionResult ...$executionResults): void
@@ -246,5 +252,15 @@ class MetricsCalculator
     private function getCalculator(): Calculator
     {
         return $this->calculator ?? Calculator::fromMetrics($this);
+    }
+
+    /**
+     * Are mutaiton timeouts treated as escapes?
+     *
+     * @return bool
+     */
+    public function getTreatTimeoutsAsEscapes(): bool
+    {
+        return $this->treatTimeoutsAsEscapes;
     }
 }

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -249,18 +249,16 @@ class MetricsCalculator
         return $this->getCalculator()->getCoveredCodeMutationScoreIndicator();
     }
 
-    private function getCalculator(): Calculator
-    {
-        return $this->calculator ?? Calculator::fromMetrics($this);
-    }
-
     /**
-     * Are mutaiton timeouts treated as escapes?
-     *
-     * @return bool
+     * Are mutation timeouts treated as escapes?
      */
     public function getTreatTimeoutsAsEscapes(): bool
     {
         return $this->treatTimeoutsAsEscapes;
+    }
+
+    private function getCalculator(): Calculator
+    {
+        return $this->calculator ?? Calculator::fromMetrics($this);
     }
 }

--- a/tests/phpunit/Logger/CreateMetricsCalculator.php
+++ b/tests/phpunit/Logger/CreateMetricsCalculator.php
@@ -46,9 +46,9 @@ use function str_replace;
 
 trait CreateMetricsCalculator
 {
-    private function createCompleteMetricsCalculator(): MetricsCalculator
+    private function createCompleteMetricsCalculator(bool $timeoutAsEscape = false): MetricsCalculator
     {
-        $calculator = new MetricsCalculator();
+        $calculator = new MetricsCalculator($timeoutAsEscape);
 
         $calculator->collect(
             $this->createMutantExecutionResult(

--- a/tests/phpunit/Mutant/CalculatorTest.php
+++ b/tests/phpunit/Mutant/CalculatorTest.php
@@ -137,6 +137,22 @@ final class CalculatorTest extends TestCase
         $this->assertSame($expectedCoveredMsi, $calculator->getCoveredCodeMutationScoreIndicator());
     }
 
+    /**
+     * @dataProvider metricsCalculatorWithTimeoutProvider
+     */
+    public function test_it_can_be_created_from_a_metrics_calculator_while_counting_timeouts_as_escapes(
+        MetricsCalculator $metricsCalculator,
+        float $expectedMsi,
+        float $expectedCoverageRate,
+        float $expectedCoveredMsi
+    ): void {
+        $calculator = Calculator::fromMetrics($metricsCalculator);
+
+        $this->assertSame($expectedMsi, $calculator->getMutationScoreIndicator());
+        $this->assertSame($expectedCoverageRate, $calculator->getCoverageRate());
+        $this->assertSame($expectedCoveredMsi, $calculator->getCoveredCodeMutationScoreIndicator());
+    }
+
     public function metricsProvider(): Generator
     {
         yield 'empty' => [
@@ -245,6 +261,23 @@ final class CalculatorTest extends TestCase
             60.,
             80.0,
             75.0,
+        ];
+    }
+
+    public function metricsCalculatorWithTimeoutProvider(): Generator
+    {
+        yield 'empty' => [
+            new MetricsCalculator(true),
+            0.,
+            0.,
+            0.,
+        ];
+
+        yield 'nominal' => [
+            $this->createCompleteMetricsCalculator(true),
+            40.0,
+            80.0,
+            50.0,
         ];
     }
 }


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [x] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

Fixes https://github.com/infection/infection/issues/1133

This PR adds a boolean flag to both the Calculator and MetricsCalculator classes in the Infection\Mutant namespace that, per my issue #1133 , counts timed-out mutants as escapes/failures (with resulting effect on calculated MSI.

I haven't charged ahead into the config side hookup both because I got a little lost tracking it down, and I wanted to solicit workable names for the configuration and/or command line options that would be used to enable this behaviour.  I suspect what I've used internally, countTimeoutsAsEscapes, might be a bit too long.
