### PR TITLE
Tweak MutantProcess

### DIFF
--- a/src/Console/OutputFormatter/DotFormatter.php
+++ b/src/Console/OutputFormatter/DotFormatter.php
@@ -35,8 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Console\OutputFormatter;
 
+use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
-use Infection\Process\MutantProcess;
 use function Safe\sprintf;
 use function str_repeat;
 use function strlen;
@@ -75,24 +75,24 @@ final class DotFormatter extends AbstractOutputFormatter
     {
         parent::advance($executionResult, $mutationCount);
 
-        switch ($executionResult->getProcessResultCode()) {
-            case MutantProcess::CODE_KILLED:
+        switch ($executionResult->getDetectionStatus()) {
+            case DetectionStatus::KILLED:
                 $this->output->write('<killed>.</killed>');
 
                 break;
-            case MutantProcess::CODE_NOT_COVERED:
+            case DetectionStatus::NOT_COVERED:
                 $this->output->write('<uncovered>S</uncovered>');
 
                 break;
-            case MutantProcess::CODE_ESCAPED:
+            case DetectionStatus::ESCAPED:
                 $this->output->write('<escaped>M</escaped>');
 
                 break;
-            case MutantProcess::CODE_TIMED_OUT:
+            case DetectionStatus::TIMED_OUT:
                 $this->output->write('<timeout>T</timeout>');
 
                 break;
-            case MutantProcess::CODE_ERROR:
+            case DetectionStatus::ERROR:
                 $this->output->write('<with-error>E</with-error>');
 
                 break;

--- a/src/Mutant/DetectionStatus.php
+++ b/src/Mutant/DetectionStatus.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutant;
+
+/**
+ * @internal
+ */
+final class DetectionStatus
+{
+    public const KILLED = 'killed';
+    public const ESCAPED = 'escaped';
+    public const ERROR = 'error';
+    public const TIMED_OUT = 'timed out';
+    public const NOT_COVERED = 'not covered';
+
+    public const ALL = [
+        self::KILLED,
+        self::ESCAPED,
+        self::ERROR,
+        self::TIMED_OUT,
+        self::NOT_COVERED,
+    ];
+}

--- a/src/Mutant/MetricsCalculator.php
+++ b/src/Mutant/MetricsCalculator.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutant;
 
-use Infection\Process\MutantProcess;
 use InvalidArgumentException;
 use function Safe\sprintf;
 
@@ -101,32 +100,32 @@ class MetricsCalculator
             ++$this->totalMutantsCount;
             $this->allExecutionResults->add($executionResult);
 
-            switch ($executionResult->getProcessResultCode()) {
-                case MutantProcess::CODE_KILLED:
+            switch ($executionResult->getDetectionStatus()) {
+                case DetectionStatus::KILLED:
                     $this->killedCount++;
                     $this->killedExecutionResults->add($executionResult);
 
                     break;
 
-                case MutantProcess::CODE_NOT_COVERED:
+                case DetectionStatus::NOT_COVERED:
                     $this->notCoveredByTestsCount++;
                     $this->notCoveredExecutionResults->add($executionResult);
 
                     break;
 
-                case MutantProcess::CODE_ESCAPED:
+                case DetectionStatus::ESCAPED:
                     $this->escapedCount++;
                     $this->escapedExecutionResults->add($executionResult);
 
                     break;
 
-                case MutantProcess::CODE_TIMED_OUT:
+                case DetectionStatus::TIMED_OUT:
                     $this->timedOutCount++;
                     $this->timedOutExecutionResults->add($executionResult);
 
                     break;
 
-                case MutantProcess::CODE_ERROR:
+                case DetectionStatus::ERROR:
                     $this->errorCount++;
                     $this->errorExecutionResults->add($executionResult);
 
@@ -135,7 +134,7 @@ class MetricsCalculator
                 default:
                     throw new InvalidArgumentException(sprintf(
                         'Unknown execution result process result code "%s"',
-                        $executionResult->getProcessResultCode()
+                        $executionResult->getDetectionStatus()
                     ));
             }
         }

--- a/src/Mutation/Mutation.php
+++ b/src/Mutation/Mutation.php
@@ -136,6 +136,11 @@ class Mutation
         return $this->attributes;
     }
 
+    public function getOriginalStartingLine(): int
+    {
+        return (int) $this->attributes['startLine'];
+    }
+
     public function getMutatedNodeClass(): string
     {
         return $this->mutatedNodeClass;

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -58,6 +58,7 @@ use Infection\FileSystem\Finder\NonExecutableFinder;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\Http\StrykerCurlClient;
 use Infection\Http\StrykerDashboardClient;
+use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutator\NodeMutationGenerator;
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
@@ -102,6 +103,7 @@ final class ProjectCodeProvider
         Engine::class,
         NonExecutableFinder::class,
         AdapterInstaller::class,
+        DetectionStatus::class,
     ];
 
     /**

--- a/tests/phpunit/Console/OutputFormatter/DotFormatterTest.php
+++ b/tests/phpunit/Console/OutputFormatter/DotFormatterTest.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\Console\OutputFormatter;
 
 use Infection\Console\OutputFormatter\DotFormatter;
+use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
-use Infection\Process\MutantProcess;
 use const PHP_EOL;
 use PHPUnit\Framework\TestCase;
 use function strip_tags;
@@ -68,51 +68,86 @@ final class DotFormatterTest extends TestCase
     public function test_killed_logs_correctly_in_console(): void
     {
         $outputKilled = $this->getStartOutputFormatter();
-        $outputKilled->expects($this->once())->method('write')->with('<killed>.</killed>');
+        $outputKilled
+            ->expects($this->once())
+            ->method('write')
+            ->with('<killed>.</killed>')
+        ;
 
         $dot = new DotFormatter($outputKilled);
         $dot->start(10);
-        $dot->advance($this->createMutantExecutionResultsOfType(MutantProcess::CODE_KILLED)[0], 10);
+        $dot->advance(
+            $this->createMutantExecutionResultsOfType(DetectionStatus::KILLED)[0],
+            10
+        );
     }
 
     public function test_escaped_logs_correctly_in_console(): void
     {
         $outputEscaped = $this->getStartOutputFormatter();
-        $outputEscaped->expects($this->once())->method('write')->with('<escaped>M</escaped>');
+        $outputEscaped
+            ->expects($this->once())
+            ->method('write')
+            ->with('<escaped>M</escaped>')
+        ;
 
         $dot = new DotFormatter($outputEscaped);
         $dot->start(10);
-        $dot->advance($this->createMutantExecutionResultsOfType(MutantProcess::CODE_ESCAPED)[0], 10);
+        $dot->advance(
+            $this->createMutantExecutionResultsOfType(DetectionStatus::ESCAPED)[0],
+            10
+        );
     }
 
     public function test_errored_logs_correctly_in_console(): void
     {
         $outputErrored = $this->getStartOutputFormatter();
-        $outputErrored->expects($this->once())->method('write')->with('<with-error>E</with-error>');
+        $outputErrored
+            ->expects($this->once())
+            ->method('write')
+            ->with('<with-error>E</with-error>')
+        ;
 
         $dot = new DotFormatter($outputErrored);
         $dot->start(10);
-        $dot->advance($this->createMutantExecutionResultsOfType(MutantProcess::CODE_ERROR)[0], 10);
+        $dot->advance(
+            $this->createMutantExecutionResultsOfType(DetectionStatus::ERROR)[0],
+            10
+        );
     }
 
     public function test_timed_out_logs_correctly_in_console(): void
     {
         $outputTimedOut = $this->getStartOutputFormatter();
-        $outputTimedOut->expects($this->once())->method('write')->with('<timeout>T</timeout>');
+        $outputTimedOut
+            ->expects($this->once())
+            ->method('write')
+            ->with('<timeout>T</timeout>')
+        ;
 
         $dot = new DotFormatter($outputTimedOut);
         $dot->start(10);
-        $dot->advance($this->createMutantExecutionResultsOfType(MutantProcess::CODE_TIMED_OUT)[0], 10);
+        $dot->advance(
+            $this->createMutantExecutionResultsOfType(DetectionStatus::TIMED_OUT)[0],
+            10
+        );
     }
 
     public function test_not_covered_correctly_in_console(): void
     {
-        $outputNotcovered = $this->getStartOutputFormatter();
-        $outputNotcovered->expects($this->once())->method('write')->with('<uncovered>S</uncovered>');
+        $outputNotCovered = $this->getStartOutputFormatter();
+        $outputNotCovered
+            ->expects($this->once())
+            ->method('write')
+            ->with('<uncovered>S</uncovered>')
+        ;
 
-        $dot = new DotFormatter($outputNotcovered);
+        $dot = new DotFormatter($outputNotCovered);
         $dot->start(10);
-        $dot->advance($this->createMutantExecutionResultsOfType(MutantProcess::CODE_NOT_COVERED)[0], 10);
+        $dot->advance(
+            $this->createMutantExecutionResultsOfType(DetectionStatus::NOT_COVERED)[0],
+            10
+        );
     }
 
     public function test_it_prints_total_number_of_mutations(): void
@@ -124,7 +159,7 @@ final class DotFormatterTest extends TestCase
         $dot->start($totalMutations);
 
         for ($i = 0; $i < $totalMutations; ++$i) {
-            $dot->advance($this->createMutantExecutionResultsOfType(MutantProcess::CODE_KILLED)[0], $totalMutations);
+            $dot->advance($this->createMutantExecutionResultsOfType(DetectionStatus::KILLED)[0], $totalMutations);
         }
 
         $this->assertSame(str_replace("\n", PHP_EOL,
@@ -150,7 +185,10 @@ TXT
         $dot->start(0);
 
         for ($i = 0; $i < $totalMutations; ++$i) {
-            $dot->advance($this->createMutantExecutionResultsOfType(MutantProcess::CODE_KILLED)[0], 0);
+            $dot->advance(
+                $this->createMutantExecutionResultsOfType(DetectionStatus::KILLED)[0],
+                0
+            );
         }
 
         $this->assertSame(str_replace("\n", PHP_EOL,
@@ -167,8 +205,10 @@ TXT
         );
     }
 
-    private function createMutantExecutionResultsOfType(int $processCode, int $count = 1): array
-    {
+    private function createMutantExecutionResultsOfType(
+        string $detectionStatus,
+        int $count = 1
+    ): array {
         $executionResults = [];
 
         for ($i = 0; $i < $count; ++$i) {
@@ -176,7 +216,7 @@ TXT
             $executionResult
                 ->expects($this->once())
                 ->method('getProcessResultCode')
-                ->willReturn($processCode)
+                ->willReturn($detectionStatus)
             ;
             $executionResults[] = $executionResult;
         }

--- a/tests/phpunit/Console/OutputFormatter/DotFormatterTest.php
+++ b/tests/phpunit/Console/OutputFormatter/DotFormatterTest.php
@@ -215,7 +215,7 @@ TXT
             $executionResult = $this->createMock(MutantExecutionResult::class);
             $executionResult
                 ->expects($this->once())
-                ->method('getProcessResultCode')
+                ->method('getDetectionStatus')
                 ->willReturn($detectionStatus)
             ;
             $executionResults[] = $executionResult;

--- a/tests/phpunit/Logger/CreateMetricsCalculator.php
+++ b/tests/phpunit/Logger/CreateMetricsCalculator.php
@@ -35,11 +35,11 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Logger;
 
+use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutator\Regex\PregQuote;
 use Infection\Mutator\ZeroIteration\For_;
-use Infection\Process\MutantProcess;
 use Infection\Tests\Mutator\MutatorName;
 use const PHP_EOL;
 use function str_replace;
@@ -54,61 +54,61 @@ trait CreateMetricsCalculator
             $this->createMutantExecutionResult(
                 0,
                 For_::class,
-                MutantProcess::CODE_KILLED,
+                DetectionStatus::KILLED,
                 'killed#0'
             ),
             $this->createMutantExecutionResult(
                 1,
                 PregQuote::class,
-                MutantProcess::CODE_KILLED,
+                DetectionStatus::KILLED,
                 'killed#1'
             ),
             $this->createMutantExecutionResult(
                 0,
                 For_::class,
-                MutantProcess::CODE_ERROR,
+                DetectionStatus::ERROR,
                 'error#0'
             ),
             $this->createMutantExecutionResult(
                 1,
                 PregQuote::class,
-                MutantProcess::CODE_ERROR,
+                DetectionStatus::ERROR,
                 'error#1'
             ),
             $this->createMutantExecutionResult(
                 0,
                 For_::class,
-                MutantProcess::CODE_ESCAPED,
+                DetectionStatus::ESCAPED,
                 'escaped#0'
             ),
             $this->createMutantExecutionResult(
                 1,
                 PregQuote::class,
-                MutantProcess::CODE_ESCAPED,
+                DetectionStatus::ESCAPED,
                 'escaped#1'
             ),
             $this->createMutantExecutionResult(
                 0,
                 For_::class,
-                MutantProcess::CODE_TIMED_OUT,
+                DetectionStatus::TIMED_OUT,
                 'timedOut#0'
             ),
             $this->createMutantExecutionResult(
                 1,
                 PregQuote::class,
-                MutantProcess::CODE_TIMED_OUT,
+                DetectionStatus::TIMED_OUT,
                 'timedOut#1'
             ),
             $this->createMutantExecutionResult(
                 0,
                 For_::class,
-                MutantProcess::CODE_NOT_COVERED,
+                DetectionStatus::NOT_COVERED,
                 'notCovered#0'
             ),
             $this->createMutantExecutionResult(
                 1,
                 PregQuote::class,
-                MutantProcess::CODE_NOT_COVERED,
+                DetectionStatus::NOT_COVERED,
                 'notCovered#1'
             )
         );
@@ -119,13 +119,13 @@ trait CreateMetricsCalculator
     private function createMutantExecutionResult(
         int $i,
         string $mutatorClassName,
-        int $resultCode,
+        string $detectionStatus,
         string $echoMutatedMessage
     ): MutantExecutionResult {
         return new MutantExecutionResult(
             'bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"',
             'process output',
-            $resultCode,
+            $detectionStatus,
             str_replace(
                 "\n",
                 PHP_EOL,

--- a/tests/phpunit/Logger/ExecutionResultSorterTest.php
+++ b/tests/phpunit/Logger/ExecutionResultSorterTest.php
@@ -37,9 +37,9 @@ namespace Infection\Tests\Logger;
 
 use Generator;
 use Infection\Logger\ExecutionResultSorter;
+use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutator\ZeroIteration\For_;
-use Infection\Process\MutantProcess;
 use Infection\Tests\Mutator\MutatorName;
 use PHPUnit\Framework\TestCase;
 
@@ -148,7 +148,7 @@ final class ExecutionResultSorterTest extends TestCase
         return new MutantExecutionResult(
             'bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"',
             'Passed!',
-            MutantProcess::CODE_ESCAPED,
+            DetectionStatus::ESCAPED,
             '#' . $id,
             MutatorName::getName(For_::class),
             $originalFilePath,

--- a/tests/phpunit/Mutant/MetricsCalculatorTest.php
+++ b/tests/phpunit/Mutant/MetricsCalculatorTest.php
@@ -36,10 +36,10 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutant;
 
 use function array_merge;
+use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutator\ZeroIteration\For_;
-use Infection\Process\MutantProcess;
 use Infection\Tests\Mutator\MutatorName;
 use PHPUnit\Framework\TestCase;
 
@@ -76,27 +76,27 @@ final class MetricsCalculatorTest extends TestCase
 
         $expectedKilledResults = $this->addMutantExecutionResult(
             $calculator,
-            MutantProcess::CODE_KILLED,
+            DetectionStatus::KILLED,
             7
         );
         $expectedErrorResults = $this->addMutantExecutionResult(
             $calculator,
-            MutantProcess::CODE_ERROR,
+            DetectionStatus::ERROR,
             2
         );
         $expectedEscapedResults = $this->addMutantExecutionResult(
             $calculator,
-            MutantProcess::CODE_ESCAPED,
+            DetectionStatus::ESCAPED,
             2
         );
         $expectedTimedOutResults = $this->addMutantExecutionResult(
             $calculator,
-            MutantProcess::CODE_TIMED_OUT,
+            DetectionStatus::TIMED_OUT,
             2
         );
         $expectedNotCoveredResults = $this->addMutantExecutionResult(
             $calculator,
-            MutantProcess::CODE_NOT_COVERED,
+            DetectionStatus::NOT_COVERED,
             1
         );
 
@@ -141,7 +141,7 @@ final class MetricsCalculatorTest extends TestCase
 
         $expectedKilledResults = $this->addMutantExecutionResult(
             $calculator,
-            MutantProcess::CODE_KILLED,
+            DetectionStatus::KILLED,
             1
         );
 
@@ -158,13 +158,13 @@ final class MetricsCalculatorTest extends TestCase
      */
     private function addMutantExecutionResult(
         MetricsCalculator $calculator,
-        int $resultCode,
+        string $detectionStatus,
         int $count
     ): array {
         $executionResults = [];
 
         for ($i = 0; $i < $count; ++$i) {
-            $executionResults[] = $this->createMutantExecutionResult($resultCode);
+            $executionResults[] = $this->createMutantExecutionResult($detectionStatus);
         }
 
         $calculator->collect(...$executionResults);
@@ -172,7 +172,7 @@ final class MetricsCalculatorTest extends TestCase
         return $executionResults;
     }
 
-    private function createMutantExecutionResult(int $resultCode): MutantExecutionResult
+    private function createMutantExecutionResult(string $detectionStatus): MutantExecutionResult
     {
         $id = $this->id;
         ++$this->id;
@@ -180,7 +180,7 @@ final class MetricsCalculatorTest extends TestCase
         return new MutantExecutionResult(
             'bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"',
             'process output',
-            $resultCode,
+            $detectionStatus,
             str_replace(
                 "\n",
                 PHP_EOL,

--- a/tests/phpunit/Mutant/SortableMutantExecutionResultsTest.php
+++ b/tests/phpunit/Mutant/SortableMutantExecutionResultsTest.php
@@ -36,10 +36,10 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutant;
 
 use Generator;
+use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutant\SortableMutantExecutionResults;
 use Infection\Mutator\ZeroIteration\For_;
-use Infection\Process\MutantProcess;
 use Infection\Tests\Mutator\MutatorName;
 use PHPUnit\Framework\TestCase;
 
@@ -191,7 +191,7 @@ final class SortableMutantExecutionResultsTest extends TestCase
         return new MutantExecutionResult(
             'bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"',
             'Passed!',
-            MutantProcess::CODE_ESCAPED,
+            DetectionStatus::ESCAPED,
             '#' . $id,
             MutatorName::getName(For_::class),
             $originalFilePath,

--- a/tests/phpunit/Mutation/MutationTest.php
+++ b/tests/phpunit/Mutation/MutationTest.php
@@ -66,6 +66,7 @@ final class MutationTest extends TestCase
         int $mutationByMutatorIndex,
         array $tests,
         array $expectedAttributes,
+        int $expectedOriginalStartingLine,
         bool $expectedCoveredByTests,
         string $expectedHash
     ): void {
@@ -84,6 +85,7 @@ final class MutationTest extends TestCase
         $this->assertSame($originalFileAst, $mutation->getOriginalFileAst());
         $this->assertSame($mutatorName, $mutation->getMutatorName());
         $this->assertSame($expectedAttributes, $mutation->getAttributes());
+        $this->assertSame($expectedOriginalStartingLine, $mutation->getOriginalStartingLine());
         $this->assertSame($mutatedNodeClass, $mutation->getMutatedNodeClass());
         $this->assertSame($mutatedNode, $mutation->getMutatedNode());
         $this->assertSame($tests, $mutation->getAllTests());
@@ -95,7 +97,7 @@ final class MutationTest extends TestCase
     public function valuesProvider(): Generator
     {
         $nominalAttributes = [
-            'startLine' => 3,
+            'startLine' => $originalStartingLine = 3,
             'endLine' => 5,
             'startTokenPos' => 21,
             'endTokenPos' => 31,
@@ -113,6 +115,7 @@ final class MutationTest extends TestCase
             -1,
             [],
             $nominalAttributes,
+            $originalStartingLine,
             false,
             md5('_Plus_-1_3_5_21_31_43_53'),
         ];
@@ -136,6 +139,7 @@ final class MutationTest extends TestCase
                 ),
             ],
             $nominalAttributes,
+            $originalStartingLine,
             true,
             md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53'),
         ];
@@ -159,6 +163,7 @@ final class MutationTest extends TestCase
                 ),
             ],
             $nominalAttributes,
+            $originalStartingLine,
             true,
             md5('/path/to/acme/Foo.php_Plus_99_3_5_21_31_43_53'),
         ];
@@ -182,6 +187,7 @@ final class MutationTest extends TestCase
                 ),
             ],
             $nominalAttributes,
+            $originalStartingLine,
             true,
             md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53'),
         ];
@@ -199,6 +205,7 @@ final class MutationTest extends TestCase
             0,
             [],
             $nominalAttributes,
+            $originalStartingLine,
             false,
             md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53'),
         ];
@@ -225,6 +232,7 @@ final class MutationTest extends TestCase
                 ),
             ],
             $nominalAttributes,
+            $originalStartingLine,
             true,
             md5('/path/to/acme/Foo.php_Plus_0_3_5_21_31_43_53'),
         ];

--- a/tests/phpunit/Process/MutantProcessTest.php
+++ b/tests/phpunit/Process/MutantProcessTest.php
@@ -122,6 +122,11 @@ final class MutantProcessTest extends TestCase
 
     public function test_it_handles_escaped_mutant(): void
     {
+        $this->process
+            ->method('isTerminated')
+            ->willReturn(true)
+        ;
+
         $this->mutant
             ->expects($this->once())
             ->method('isCoveredByTest')
@@ -150,6 +155,11 @@ final class MutantProcessTest extends TestCase
 
     public function test_it_handles_killed_mutant(): void
     {
+        $this->process
+            ->method('isTerminated')
+            ->willReturn(true)
+        ;
+
         $this->mutant
             ->expects($this->once())
             ->method('isCoveredByTest')


### PR DESCRIPTION
- Make `MutantProcess` leaner by no longer exposing properties of its underlying mutant or mutation which only introduces redundancy since we are using the underlying mutant & mutation anyway
- Propose to move out the `MutantProcess::CODE_*` into a dedicated `DetectionStatus` enum. Terminology taken from pitest: I don't think there is a consensus there but I personally like the term
- Ensure `MutantProcess#process` is terminated before getting its output (instead of "not started")
