### PR TITLE
Increase niceness for mutant processes

### DIFF
--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -164,6 +164,9 @@ class MutationConfigBuilder extends ConfigBuilder
             <<<'PHP'
 <?php
 
+if (function_exists('proc_nice')) {
+    proc_nice(10);
+}
 %s
 require_once '%s';
 

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -165,7 +165,7 @@ class MutationConfigBuilder extends ConfigBuilder
 <?php
 
 if (function_exists('proc_nice')) {
-    proc_nice(10);
+    proc_nice(1);
 }
 %s
 require_once '%s';

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -212,7 +212,7 @@ XML
 <?php
 
 if (function_exists('proc_nice')) {
-    proc_nice(10);
+    proc_nice(1);
 }
 
 require_once '$interceptorPath';
@@ -281,7 +281,7 @@ XML
 <?php
 
 if (function_exists('proc_nice')) {
-    proc_nice(10);
+    proc_nice(1);
 }
 
 require_once '$interceptorPath';

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -40,6 +40,8 @@ use DOMDocument;
 use DOMNode;
 use DOMNodeList;
 use DOMXPath;
+use function escapeshellarg;
+use function exec;
 use Generator;
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 use Infection\StreamWrapper\IncludeInterceptor;
@@ -202,10 +204,16 @@ XML
                 )
             )
         );
+
+        $phpCode = file_get_contents($this->tmp . '/interceptor.autoload.hash1.infection.php');
+
         $this->assertSame(
             <<<PHP
 <?php
 
+if (function_exists('proc_nice')) {
+    proc_nice(10);
+}
 
 require_once '$interceptorPath';
 
@@ -217,8 +225,10 @@ require_once '$projectPath/app/autoload2.php';
 
 PHP
             ,
-            file_get_contents($this->tmp . '/interceptor.autoload.hash1.infection.php')
+            $phpCode
         );
+
+        $this->assertPHPSyntaxIsValid($phpCode);
 
         $this->assertSame(
             <<<XML
@@ -263,10 +273,16 @@ XML
                 )
             )
         );
+
+        $phpCode = file_get_contents($this->tmp . '/interceptor.autoload.hash2.infection.php');
+
         $this->assertSame(
             <<<PHP
 <?php
 
+if (function_exists('proc_nice')) {
+    proc_nice(10);
+}
 
 require_once '$interceptorPath';
 
@@ -278,8 +294,10 @@ require_once '$projectPath/app/autoload2.php';
 
 PHP
             ,
-            file_get_contents($this->tmp . '/interceptor.autoload.hash2.infection.php')
+            $phpCode
         );
+
+        $this->assertPHPSyntaxIsValid($phpCode);
     }
 
     public function test_it_builds_path_to_mutation_config_file(): void
@@ -586,6 +604,21 @@ PHP
             new XmlConfigurationManipulator($replacer, ''),
             'project/dir',
             new JUnitTestCaseSorter()
+        );
+    }
+
+    private function assertPHPSyntaxIsValid(string $phpCode): void
+    {
+        exec(
+            sprintf('echo %s | php -l', escapeshellarg($phpCode)),
+            $output,
+            $returnCode
+        );
+
+        $this->assertSame(
+            0,
+            $returnCode,
+            'Builder produced invalid code'
         );
     }
 }


### PR DESCRIPTION
A runaway mutation (#1145) can cause a system resource exhaustion. Therefore, Infection may not be able to secure enough CPU cycles to stop this malignant mutation on time.

- We can work around this issue if we make Infection run with a higher priority by lowering priority of mutant processes. (Raising own priority usually is impossible, and not advisable in principle.)
- Downside of running anything with lower priority is that OS will not spin up CPU as much as it would for a higher- or normal-priority processes. Therefore Infection may run slower on energy-limited devices like laptops.
- This approach [works on Windows too](https://www.php.net/manual/en/function.proc-nice.php#refsect1-function.proc-nice-changelog).

This PR also add syntax validation, which we can keep if the above idea does not find approval.