### PR TITLE
Replace Generator with more generic type, hiding implementation detail

### DIFF
--- a/src/Mutator/Arithmetic/Assignment.php
+++ b/src/Mutator/Arithmetic/Assignment.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -65,9 +64,9 @@ TXT
     /**
      * @param Node\Expr\AssignOp $node
      *
-     * @return Generator<Node\Expr\Assign>
+     * @return iterable<Node\Expr\Assign>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\Assign($node->var, $node->expr, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/AssignmentEqual.php
+++ b/src/Mutator/Arithmetic/AssignmentEqual.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Equal $node
      *
-     * @return Generator<Node\Expr\Assign>
+     * @return iterable<Node\Expr\Assign>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\Assign($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/BitwiseAnd.php
+++ b/src/Mutator/Arithmetic/BitwiseAnd.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class BitwiseAnd implements Mutator
     /**
      * @param Node\Expr\BinaryOp\BooleanAnd $node
      *
-     * @return Generator<Node\Expr\BinaryOp\BitwiseOr>
+     * @return iterable<Node\Expr\BinaryOp\BitwiseOr>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\BitwiseOr($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/BitwiseNot.php
+++ b/src/Mutator/Arithmetic/BitwiseNot.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class BitwiseNot implements Mutator
     /**
      * @param Node\Expr\BitwiseNot $node
      *
-     * @return Generator<Node\Expr>
+     * @return iterable<Node\Expr>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield $node->expr;
     }

--- a/src/Mutator/Arithmetic/BitwiseOr.php
+++ b/src/Mutator/Arithmetic/BitwiseOr.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class BitwiseOr implements Mutator
     /**
      * @param Node\Expr\BinaryOp\BitwiseOr $node
      *
-     * @return Generator<Node\Expr\BinaryOp\BitwiseAnd>
+     * @return iterable<Node\Expr\BinaryOp\BitwiseAnd>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\BitwiseAnd($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/BitwiseXor.php
+++ b/src/Mutator/Arithmetic/BitwiseXor.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class BitwiseXor implements Mutator
     /**
      * @param Node\Expr\BinaryOp\BitwiseXor $node
      *
-     * @return Generator<Node\Expr\BinaryOp\BitwiseAnd>
+     * @return iterable<Node\Expr\BinaryOp\BitwiseAnd>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\BitwiseAnd($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/Decrement.php
+++ b/src/Mutator/Arithmetic/Decrement.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -65,9 +64,9 @@ TXT
     /**
      * @param Node\Expr\PreDec|Node\Expr\PostDec $node
      *
-     * @return Generator<Node\Expr\PreInc|Node\Expr\PostInc>
+     * @return iterable<Node\Expr\PreInc|Node\Expr\PostInc>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         if ($node instanceof Node\Expr\PreDec) {
             yield new Node\Expr\PreInc($node->var, $node->getAttributes());

--- a/src/Mutator/Arithmetic/DivEqual.php
+++ b/src/Mutator/Arithmetic/DivEqual.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\AssignOp\Div $node
      *
-     * @return Generator<Node\Expr\AssignOp\Mul>
+     * @return iterable<Node\Expr\AssignOp\Mul>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\AssignOp\Mul($node->var, $node->expr, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/Division.php
+++ b/src/Mutator/Arithmetic/Division.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class Division implements Mutator
     /**
      * @param Node\Expr\BinaryOp\Div $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Mul>
+     * @return iterable<Node\Expr\BinaryOp\Mul>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Mul($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/Exponentiation.php
+++ b/src/Mutator/Arithmetic/Exponentiation.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Pow $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Div>
+     * @return iterable<Node\Expr\BinaryOp\Div>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Div($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/Increment.php
+++ b/src/Mutator/Arithmetic/Increment.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -65,9 +64,9 @@ TXT
     /**
      * @param Node\Expr\PostInc|Node\Expr\PreInc $node
      *
-     * @return Generator<Node\Expr\PreDec|Node\Expr\PostDec>
+     * @return iterable<Node\Expr\PreDec|Node\Expr\PostDec>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         if ($node instanceof Node\Expr\PreInc) {
             yield new Node\Expr\PreDec($node->var, $node->getAttributes());

--- a/src/Mutator/Arithmetic/Minus.php
+++ b/src/Mutator/Arithmetic/Minus.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class Minus implements Mutator
     /**
      * @param Node\Expr\BinaryOp\Minus $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Plus>
+     * @return iterable<Node\Expr\BinaryOp\Plus>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Plus($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/MinusEqual.php
+++ b/src/Mutator/Arithmetic/MinusEqual.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\AssignOp\Minus $node
      *
-     * @return Generator<Node\Expr\AssignOp\Plus>
+     * @return iterable<Node\Expr\AssignOp\Plus>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\AssignOp\Plus($node->var, $node->expr, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/ModEqual.php
+++ b/src/Mutator/Arithmetic/ModEqual.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\AssignOp\Mod $node
      *
-     * @return Generator<Node\Expr\AssignOp\Mul>
+     * @return iterable<Node\Expr\AssignOp\Mul>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\AssignOp\Mul($node->var, $node->expr, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/Modulus.php
+++ b/src/Mutator/Arithmetic/Modulus.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class Modulus implements Mutator
     /**
      * @param Node\Expr\BinaryOp\Mod $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Mul>
+     * @return iterable<Node\Expr\BinaryOp\Mul>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Mul($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/MulEqual.php
+++ b/src/Mutator/Arithmetic/MulEqual.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\AssignOp\Mul $node
      *
-     * @return Generator<Node\Expr\AssignOp\Div>
+     * @return iterable<Node\Expr\AssignOp\Div>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\AssignOp\Div($node->var, $node->expr, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/Multiplication.php
+++ b/src/Mutator/Arithmetic/Multiplication.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Mul $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Div>
+     * @return iterable<Node\Expr\BinaryOp\Div>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Div($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/Plus.php
+++ b/src/Mutator/Arithmetic/Plus.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Plus $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Minus>
+     * @return iterable<Node\Expr\BinaryOp\Minus>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Minus($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/PlusEqual.php
+++ b/src/Mutator/Arithmetic/PlusEqual.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -66,9 +65,9 @@ TXT
      *
      * @param Node\Expr\AssignOp\Plus $node
      *
-     * @return Generator<Node\Expr\AssignOp\Minus>
+     * @return iterable<Node\Expr\AssignOp\Minus>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\AssignOp\Minus($node->var, $node->expr, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/PowEqual.php
+++ b/src/Mutator/Arithmetic/PowEqual.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -66,9 +65,9 @@ TXT
      *
      * @param Node\Expr\AssignOp\Pow $node
      *
-     * @return Generator<Node\Expr\AssignOp\Div>
+     * @return iterable<Node\Expr\AssignOp\Div>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\AssignOp\Div($node->var, $node->expr, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/RoundingFamily.php
+++ b/src/Mutator/Arithmetic/RoundingFamily.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use function in_array;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
@@ -71,9 +70,9 @@ TXT
     /**
      * @param Node\Expr\FuncCall $node
      *
-     * @return Generator<Node\Expr\FuncCall>
+     * @return iterable<Node\Expr\FuncCall>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         /** @var Node\Name $name */
         $name = $node->name;

--- a/src/Mutator/Arithmetic/ShiftLeft.php
+++ b/src/Mutator/Arithmetic/ShiftLeft.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\ShiftLeft $node
      *
-     * @return Generator<Node\Expr\BinaryOp\ShiftRight>
+     * @return iterable<Node\Expr\BinaryOp\ShiftRight>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\ShiftRight($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Arithmetic/ShiftRight.php
+++ b/src/Mutator/Arithmetic/ShiftRight.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\ShiftRight $node
      *
-     * @return Generator<Node\Expr\BinaryOp\ShiftLeft>
+     * @return iterable<Node\Expr\BinaryOp\ShiftLeft>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\ShiftLeft($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Boolean/ArrayItem.php
+++ b/src/Mutator/Boolean/ArrayItem.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -70,9 +69,9 @@ TXT
     /**
      * @param Node\Expr\ArrayItem $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Greater>
+     * @return iterable<Node\Expr\BinaryOp\Greater>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         /** @var Node\Expr $key */
         $key = $node->key;

--- a/src/Mutator/Boolean/EqualIdentical.php
+++ b/src/Mutator/Boolean/EqualIdentical.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -65,9 +64,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Equal $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Identical>
+     * @return iterable<Node\Expr\BinaryOp\Identical>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Identical($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class FalseValue implements Mutator
     /**
      * @param Node\Expr\ConstFetch $node
      *
-     * @return Generator<Node\Expr\ConstFetch>
+     * @return iterable<Node\Expr\ConstFetch>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\ConstFetch(new Node\Name('true'));
     }

--- a/src/Mutator/Boolean/IdenticalEqual.php
+++ b/src/Mutator/Boolean/IdenticalEqual.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -67,9 +66,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Identical $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Equal>
+     * @return iterable<Node\Expr\BinaryOp\Equal>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Equal($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Boolean/LogicalAnd.php
+++ b/src/Mutator/Boolean/LogicalAnd.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class LogicalAnd implements Mutator
     /**
      * @param Node\Expr\BinaryOp\LogicalOr $node
      *
-     * @return Generator<Node\Expr\BinaryOp\BooleanOr>
+     * @return iterable<Node\Expr\BinaryOp\BooleanOr>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\BooleanOr($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Boolean/LogicalLowerAnd.php
+++ b/src/Mutator/Boolean/LogicalLowerAnd.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -63,9 +62,9 @@ final class LogicalLowerAnd implements Mutator
      *
      * @param Node\Expr\BinaryOp\LogicalAnd $node
      *
-     * @return Generator<Node\Expr\BinaryOp\LogicalOr>
+     * @return iterable<Node\Expr\BinaryOp\LogicalOr>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\LogicalOr($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Boolean/LogicalLowerOr.php
+++ b/src/Mutator/Boolean/LogicalLowerOr.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class LogicalLowerOr implements Mutator
     /**
      * @param Node\Expr\BinaryOp\LogicalOr $node
      *
-     * @return Generator<Node\Expr\BinaryOp\LogicalAnd>
+     * @return iterable<Node\Expr\BinaryOp\LogicalAnd>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\LogicalAnd($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Boolean/LogicalNot.php
+++ b/src/Mutator/Boolean/LogicalNot.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class LogicalNot implements Mutator
     /**
      * @param Node\Expr\BooleanNot $node
      *
-     * @return Generator<Node\Expr>
+     * @return iterable<Node\Expr>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield $node->expr;
     }

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -63,9 +62,9 @@ final class LogicalOr implements Mutator
      *
      * @param Node\Expr\BinaryOp\BooleanOr $node
      *
-     * @return Generator<Node\Expr\BinaryOp\BooleanAnd>
+     * @return iterable<Node\Expr\BinaryOp\BooleanAnd>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\BooleanAnd($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Boolean/NotEqualNotIdentical.php
+++ b/src/Mutator/Boolean/NotEqualNotIdentical.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -65,9 +64,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\NotEqual $node
      *
-     * @return Generator<Node\Expr\BinaryOp\NotIdentical>
+     * @return iterable<Node\Expr\BinaryOp\NotIdentical>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\NotIdentical($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Boolean/NotIdenticalNotEqual.php
+++ b/src/Mutator/Boolean/NotIdenticalNotEqual.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -67,9 +66,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\NotIdentical $node
      *
-     * @return Generator<Node\Expr\BinaryOp\NotEqual>
+     * @return iterable<Node\Expr\BinaryOp\NotEqual>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\NotEqual($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Mutator\Boolean;
 
 use function array_key_exists;
-use Generator;
 use Infection\Mutator\ConfigurableMutator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetConfigClassName;
@@ -76,9 +75,9 @@ final class TrueValue implements ConfigurableMutator
     /**
      * @param Node\Expr\ConstFetch $node
      *
-     * @return Generator<Node\Expr\ConstFetch>
+     * @return iterable<Node\Expr\ConstFetch>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\ConstFetch(new Node\Name('false'));
     }

--- a/src/Mutator/Boolean/Yield_.php
+++ b/src/Mutator/Boolean/Yield_.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -70,9 +69,9 @@ TXT
     /**
      * @param Node\Expr\Yield_ $node
      *
-     * @return Generator<Node\Expr\Yield_>
+     * @return iterable<Node\Expr\Yield_>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         /** @var Node\Expr $key */
         $key = $node->key;

--- a/src/Mutator/Cast/AbstractCastMutator.php
+++ b/src/Mutator/Cast/AbstractCastMutator.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Cast;
 
-use Generator;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use PhpParser\Node;
@@ -50,9 +49,9 @@ abstract class AbstractCastMutator implements Mutator
     /**
      * @param Node\Expr\Cast $node
      *
-     * @return Generator<Node\Expr>
+     * @return iterable<Node\Expr>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield $node->expr;
     }

--- a/src/Mutator/ConditionalBoundary/GreaterThan.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThan.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalBoundary;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -66,9 +65,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Greater $node
      *
-     * @return Generator<Node\Expr\BinaryOp\GreaterOrEqual>
+     * @return iterable<Node\Expr\BinaryOp\GreaterOrEqual>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\GreaterOrEqual($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalBoundary;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\GreaterOrEqual $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Greater>
+     * @return iterable<Node\Expr\BinaryOp\Greater>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Greater($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/ConditionalBoundary/LessThan.php
+++ b/src/Mutator/ConditionalBoundary/LessThan.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalBoundary;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -66,9 +65,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Smaller $node
      *
-     * @return Generator<Node\Expr\BinaryOp\SmallerOrEqual>
+     * @return iterable<Node\Expr\BinaryOp\SmallerOrEqual>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\SmallerOrEqual($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalBoundary;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\SmallerOrEqual $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Smaller>
+     * @return iterable<Node\Expr\BinaryOp\Smaller>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Smaller($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/ConditionalNegotiation/Equal.php
+++ b/src/Mutator/ConditionalNegotiation/Equal.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Equal $node
      *
-     * @return Generator<Node\Expr\BinaryOp\NotEqual>
+     * @return iterable<Node\Expr\BinaryOp\NotEqual>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\NotEqual($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Greater $node
      *
-     * @return Generator<Node\Expr\BinaryOp\SmallerOrEqual>
+     * @return iterable<Node\Expr\BinaryOp\SmallerOrEqual>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\SmallerOrEqual($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\GreaterOrEqual $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Smaller>
+     * @return iterable<Node\Expr\BinaryOp\Smaller>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Smaller($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/ConditionalNegotiation/Identical.php
+++ b/src/Mutator/ConditionalNegotiation/Identical.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Identical $node
      *
-     * @return Generator<Node\Expr\BinaryOp\NotIdentical>
+     * @return iterable<Node\Expr\BinaryOp\NotIdentical>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\NotIdentical($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Smaller $node
      *
-     * @return Generator<Node\Expr\BinaryOp\GreaterOrEqual>
+     * @return iterable<Node\Expr\BinaryOp\GreaterOrEqual>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\GreaterOrEqual($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\SmallerOrEqual $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Greater>
+     * @return iterable<Node\Expr\BinaryOp\Greater>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Greater($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/ConditionalNegotiation/NotEqual.php
+++ b/src/Mutator/ConditionalNegotiation/NotEqual.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\NotEqual $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Equal>
+     * @return iterable<Node\Expr\BinaryOp\Equal>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Equal($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/ConditionalNegotiation/NotIdentical.php
+++ b/src/Mutator/ConditionalNegotiation/NotIdentical.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -66,9 +65,9 @@ TXT
      *
      * @param Node\Expr\BinaryOp\NotIdentical $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Identical>
+     * @return iterable<Node\Expr\BinaryOp\Identical>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Identical($node->left, $node->right, $node->getAttributes());
     }

--- a/src/Mutator/Extensions/BCMath.php
+++ b/src/Mutator/Extensions/BCMath.php
@@ -39,7 +39,6 @@ use function array_fill_keys;
 use function array_intersect_key;
 use Closure;
 use function count;
-use Generator;
 use Infection\Mutator\ConfigurableMutator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetConfigClassName;
@@ -56,7 +55,7 @@ final class BCMath implements ConfigurableMutator
     use GetConfigClassName;
 
     /**
-     * @var array<string, Closure(Node\Expr\FuncCall): Generator<Node\Expr>>
+     * @var array<string, Closure(Node\Expr\FuncCall): iterable<Node\Expr>>
      */
     private $converters;
 
@@ -90,9 +89,9 @@ TXT
     /**
      * @param Node\Expr\FuncCall $node
      *
-     * @return Generator<Node\Expr>
+     * @return iterable<Node\Expr>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         /** @var Node\Name $name */
         $name = $node->name;
@@ -112,7 +111,7 @@ TXT
     /**
      * @param string[] $functionsMap
      *
-     * @return array<string, Closure(Node\Expr\FuncCall): Generator<Node\Expr>>
+     * @return array<string, Closure(Node\Expr\FuncCall): iterable<Node\Expr>>
      */
     private static function createConverters(array $functionsMap): array
     {
@@ -176,13 +175,13 @@ TXT
     }
 
     /**
-     * @param Closure(Node\Expr\FuncCall): Generator<Node\Expr> $converter
+     * @param Closure(Node\Expr\FuncCall): iterable<Node\Expr> $converter
      *
-     * @return Closure(Node\Expr\FuncCall): Generator<Node\Expr>
+     * @return Closure(Node\Expr\FuncCall): iterable<Node\Expr>
      */
     private static function makeCheckingMinArgsMapper(int $minimumArgsCount, Closure $converter): Closure
     {
-        return static function (Node\Expr\FuncCall $node) use ($minimumArgsCount, $converter): Generator {
+        return static function (Node\Expr\FuncCall $node) use ($minimumArgsCount, $converter): iterable {
             if (count($node->args) >= $minimumArgsCount) {
                 yield from $converter($node);
             }
@@ -190,13 +189,13 @@ TXT
     }
 
     /**
-     * @param Closure(Node\Expr\FuncCall): Generator<Node\Expr> $converter
+     * @param Closure(Node\Expr\FuncCall): iterable<Node\Expr> $converter
      *
-     * @return Closure(Node\Expr\FuncCall): Generator<Node\Expr\Cast\String_>
+     * @return Closure(Node\Expr\FuncCall): iterable<Node\Expr\Cast\String_>
      */
     private static function makeCastToStringMapper(Closure $converter): Closure
     {
-        return static function (Node\Expr\FuncCall $node) use ($converter): Generator {
+        return static function (Node\Expr\FuncCall $node) use ($converter): iterable {
             foreach ($converter($node) as $newNode) {
                 yield new Node\Expr\Cast\String_($newNode);
             }
@@ -206,31 +205,31 @@ TXT
     /**
      * @phpstan-param class-string<Node\Expr\BinaryOp> $operator
      *
-     * @return Closure(Node\Expr\FuncCall): Generator<Node\Expr\BinaryOp>
+     * @return Closure(Node\Expr\FuncCall): iterable<Node\Expr\BinaryOp>
      */
     private static function makeBinaryOperatorMapper(string $operator): Closure
     {
-        return static function (Node\Expr\FuncCall $node) use ($operator): Generator {
+        return static function (Node\Expr\FuncCall $node) use ($operator): iterable {
             yield new $operator($node->args[0]->value, $node->args[1]->value);
         };
     }
 
     /**
-     * @return Closure(Node\Expr\FuncCall): Generator<Node\Expr\FuncCall>
+     * @return Closure(Node\Expr\FuncCall): iterable<Node\Expr\FuncCall>
      */
     private static function makeSquareRootsMapper(): Closure
     {
-        return static function (Node\Expr\FuncCall $node): Generator {
+        return static function (Node\Expr\FuncCall $node): iterable {
             yield new Node\Expr\FuncCall(new Node\Name('\sqrt'), [$node->args[0]]);
         };
     }
 
     /**
-     * @return Closure(Node\Expr\FuncCall): Generator<Node\Expr\BinaryOp\Mod>
+     * @return Closure(Node\Expr\FuncCall): iterable<Node\Expr\BinaryOp\Mod>
      */
     private static function makePowerModuloMapper(): Closure
     {
-        return static function (Node\Expr\FuncCall $node): Generator {
+        return static function (Node\Expr\FuncCall $node): iterable {
             yield new Node\Expr\BinaryOp\Mod(
                 new Node\Expr\FuncCall(
                     new Node\Name('\pow'),

--- a/src/Mutator/Extensions/MBString.php
+++ b/src/Mutator/Extensions/MBString.php
@@ -60,7 +60,7 @@ final class MBString implements ConfigurableMutator
     use GetConfigClassName;
 
     /**
-     * @var array<string, Closure(Node\Expr\FuncCall): Generator<Node\Expr\FuncCall>>
+     * @var array<string, Closure(Node\Expr\FuncCall): iterable<Node\Expr\FuncCall>>
      */
     private $converters;
 
@@ -95,9 +95,9 @@ TXT
     /**
      * @param Node\Expr\FuncCall $node
      *
-     * @return Generator<Node\Expr\FuncCall>
+     * @return iterable<Node\Expr\FuncCall>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         /** @var Node\Name $name */
         $name = $node->name;
@@ -148,31 +148,31 @@ TXT
     }
 
     /**
-     * @return Closure(Node\Expr\FuncCall): Generator<Node\Expr\FuncCall>
+     * @return Closure(Node\Expr\FuncCall): iterable<Node\Expr\FuncCall>
      */
     private static function makeFunctionMapper(string $newFunctionName): Closure
     {
-        return static function (Node\Expr\FuncCall $node) use ($newFunctionName): Generator {
+        return static function (Node\Expr\FuncCall $node) use ($newFunctionName): iterable {
             yield self::mapFunctionCall($node, $newFunctionName, $node->args);
         };
     }
 
     /**
-     * @return Closure(Node\Expr\FuncCall): Generator<Node\Expr\FuncCall>
+     * @return Closure(Node\Expr\FuncCall): iterable<Node\Expr\FuncCall>
      */
     private static function makeFunctionAndRemoveExtraArgsMapper(string $newFunctionName, int $argsAtMost): Closure
     {
-        return static function (Node\Expr\FuncCall $node) use ($newFunctionName, $argsAtMost): Generator {
+        return static function (Node\Expr\FuncCall $node) use ($newFunctionName, $argsAtMost): iterable {
             yield self::mapFunctionCall($node, $newFunctionName, array_slice($node->args, 0, $argsAtMost));
         };
     }
 
     /**
-     * @return Closure(Node\Expr\FuncCall): Generator<Node\Expr\FuncCall>
+     * @return Closure(Node\Expr\FuncCall): iterable<Node\Expr\FuncCall>
      */
     private static function makeConvertCaseMapper(): Closure
     {
-        return static function (Node\Expr\FuncCall $node): Generator {
+        return static function (Node\Expr\FuncCall $node): Generator { // PHPStan can't infer this from yield
             $modeValue = self::getConvertCaseModeValue($node);
 
             if ($modeValue === null) {

--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\FunctionSignature;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ final class ProtectedVisibility implements Mutator
     /**
      * @param Node\Stmt\ClassMethod $node
      *
-     * @return Generator<Node\Stmt\ClassMethod>
+     * @return iterable<Node\Stmt\ClassMethod>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         /* @var Node\Stmt\ClassMethod $node */
         yield new Node\Stmt\ClassMethod(

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\FunctionSignature;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ final class PublicVisibility implements Mutator
     /**
      * @param Node\Stmt\ClassMethod $node
      *
-     * @return Generator<Node\Stmt\ClassMethod>
+     * @return iterable<Node\Stmt\ClassMethod>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\ClassMethod(
             $node->name,

--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Mutator;
 
 use DomainException;
-use Generator;
 use Infection\PhpParser\Visitor\ReflectionVisitor;
 use Infection\Reflection\ClassReflection;
 use PhpParser\Node;
@@ -97,9 +96,9 @@ final class IgnoreMutator implements Mutator
     }
 
     /**
-     * @return Generator<Node|Node[]>
+     * @return iterable<Node|Node[]>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         return $this->mutator->mutate($node);
     }

--- a/src/Mutator/Mutator.php
+++ b/src/Mutator/Mutator.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator;
 
-use Generator;
 use PhpParser\Node;
 
 /**
@@ -50,7 +49,7 @@ interface Mutator
     public function canMutate(Node $node): bool;
 
     /**
-     * @return Generator<Node|Node[]>
+     * @return iterable<Node|Node[]>
      */
-    public function mutate(Node $node): Generator;
+    public function mutate(Node $node): iterable;
 }

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Number;
 
-use Generator;
 use function in_array;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
@@ -71,9 +70,9 @@ final class DecrementInteger extends AbstractNumberMutator
     /**
      * @param Node\Scalar\LNumber $node
      *
-     * @return Generator<Node\Scalar\LNumber>
+     * @return iterable<Node\Scalar\LNumber>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Scalar\LNumber($node->value - 1);
     }

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Number;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\MutatorCategory;
@@ -60,9 +59,9 @@ final class IncrementInteger extends AbstractNumberMutator
     /**
      * @param Node\Scalar\LNumber $node
      *
-     * @return Generator<Node\Scalar\LNumber>
+     * @return iterable<Node\Scalar\LNumber>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Scalar\LNumber($node->value + 1);
     }

--- a/src/Mutator/Number/OneZeroFloat.php
+++ b/src/Mutator/Number/OneZeroFloat.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Number;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\MutatorCategory;
@@ -63,9 +62,9 @@ TXT
     /**
      * @param Node\Scalar\DNumber $node
      *
-     * @return Generator<Node\Scalar\DNumber>
+     * @return iterable<Node\Scalar\DNumber>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         if ($node->value === 0.0) {
             yield new Node\Scalar\DNumber(1.0);

--- a/src/Mutator/Number/OneZeroInteger.php
+++ b/src/Mutator/Number/OneZeroInteger.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Number;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\MutatorCategory;
@@ -63,9 +62,9 @@ TXT
     /**
      * @param Node\Scalar\LNumber $node
      *
-     * @return Generator<Node\Scalar\LNumber>
+     * @return iterable<Node\Scalar\LNumber>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         if ($node->value === 0) {
             yield new Node\Scalar\LNumber(1);

--- a/src/Mutator/Operator/AssignCoalesce.php
+++ b/src/Mutator/Operator/AssignCoalesce.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\AssignOp\Coalesce $node
      *
-     * @return Generator<Node\Expr\Assign>
+     * @return iterable<Node\Expr\Assign>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\Assign($node->var, $node->expr, $node->getAttributes());
     }

--- a/src/Mutator/Operator/Break_.php
+++ b/src/Mutator/Operator/Break_.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -65,9 +64,9 @@ TXT
     /**
      * @param Node\Stmt\Break_ $node
      *
-     * @return Generator<Node\Stmt\Continue_>
+     * @return iterable<Node\Stmt\Continue_>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\Continue_();
     }

--- a/src/Mutator/Operator/Coalesce.php
+++ b/src/Mutator/Operator/Coalesce.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -74,9 +73,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Coalesce $node
      *
-     * @return Generator<Node\Expr>
+     * @return iterable<Node\Expr>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield $node->right;
     }

--- a/src/Mutator/Operator/Continue_.php
+++ b/src/Mutator/Operator/Continue_.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -65,9 +64,9 @@ TXT
     /**
      * @param Node\Stmt\Continue_ $node
      *
-     * @return Generator<Node\Stmt\Break_>
+     * @return iterable<Node\Stmt\Break_>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\Break_();
     }

--- a/src/Mutator/Operator/Finally_.php
+++ b/src/Mutator/Operator/Finally_.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Mutator\Operator;
 
 use function count;
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -63,9 +62,9 @@ final class Finally_ implements Mutator
     /**
      * @param Node\Stmt\Finally_ $node
      *
-     * @return Generator<Node\Stmt\Nop>
+     * @return iterable<Node\Stmt\Nop>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\Nop();
     }

--- a/src/Mutator/Operator/Spread.php
+++ b/src/Mutator/Operator/Spread.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -74,9 +73,9 @@ TXT
     /**
      * @param Node\Expr\ArrayItem $node
      *
-     * @return Generator<Node\Expr\ArrayItem>
+     * @return iterable<Node\Expr\ArrayItem>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\ArrayItem(
             new Node\Expr\ArrayDimFetch(

--- a/src/Mutator/Operator/Throw_.php
+++ b/src/Mutator/Operator/Throw_.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Operator;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -77,9 +76,9 @@ TXT
      *
      * @param Node\Stmt\Throw_ $node
      *
-     * @return Generator<Node\Stmt\Expression>
+     * @return iterable<Node\Stmt\Expression>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\Expression($node->expr);
     }

--- a/src/Mutator/Regex/PregMatchMatches.php
+++ b/src/Mutator/Regex/PregMatchMatches.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Mutator\Regex;
 
 use function count;
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -80,9 +79,9 @@ TXT
     /**
      * @param Node\Expr\FuncCall $node
      *
-     * @return Generator<Node\Expr\Cast\Int_>
+     * @return iterable<Node\Expr\Cast\Int_>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\Cast\Int_(new Node\Expr\Assign($node->args[2]->value, new Node\Expr\Array_()));
     }

--- a/src/Mutator/Regex/PregQuote.php
+++ b/src/Mutator/Regex/PregQuote.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Regex;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -75,9 +74,9 @@ TXT
     /**
      * @param Node\Expr\FuncCall $node
      *
-     * @return Generator<Node\Arg>
+     * @return iterable<Node\Arg>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield $node->args[0];
     }

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Mutator\Removal;
 
 use function count;
-use Generator;
 use Infection\Mutator\ConfigurableMutator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetConfigClassName;
@@ -103,9 +102,9 @@ TXT
     /**
      * @param Node\Expr\Array_ $arrayNode
      *
-     * @return Generator<Node\Expr\Array_>
+     * @return iterable<Node\Expr\Array_>
      */
-    public function mutate(Node $arrayNode): Generator
+    public function mutate(Node $arrayNode): iterable
     {
         foreach ($this->getItemsIndexes($arrayNode->items) as $indexToRemove) {
             $newArrayNode = clone $arrayNode;

--- a/src/Mutator/Removal/CloneRemoval.php
+++ b/src/Mutator/Removal/CloneRemoval.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Removal;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class CloneRemoval implements Mutator
     /**
      * @param Node\Expr\Clone_ $node
      *
-     * @return Generator<Node\Expr>
+     * @return iterable<Node\Expr>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield $node->expr;
     }

--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Removal;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -63,9 +62,9 @@ final class FunctionCallRemoval implements Mutator
      *
      * @param Node\Stmt\Expression $node
      *
-     * @return Generator<Node\Stmt\Nop>
+     * @return iterable<Node\Stmt\Nop>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\Nop();
     }

--- a/src/Mutator/Removal/MethodCallRemoval.php
+++ b/src/Mutator/Removal/MethodCallRemoval.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Removal;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -61,9 +60,9 @@ final class MethodCallRemoval implements Mutator
     /**
      * @param Node\Stmt\Expression $node
      *
-     * @return Generator<Node\Stmt\Nop>
+     * @return iterable<Node\Stmt\Nop>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\Nop();
     }

--- a/src/Mutator/ReturnValue/ArrayOneItem.php
+++ b/src/Mutator/ReturnValue/ArrayOneItem.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -80,9 +79,9 @@ TXT
     /**
      * @param Node\Stmt\Return_ $node
      *
-     * @return Generator<Node\Stmt\Return_>
+     * @return iterable<Node\Stmt\Return_>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         /** @var Node\Expr\Variable $expression */
         $expression = $node->expr;

--- a/src/Mutator/ReturnValue/FloatNegation.php
+++ b/src/Mutator/ReturnValue/FloatNegation.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Stmt\Return_ $node
      *
-     * @return Generator<Node\Stmt\Return_>
+     * @return iterable<Node\Stmt\Return_>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\Return_(
             new Node\Scalar\DNumber(-1 * $this->getFloatValueOfNode($node), $node->getAttributes())

--- a/src/Mutator/ReturnValue/FunctionCall.php
+++ b/src/Mutator/ReturnValue/FunctionCall.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use Infection\Mutator\Util\AbstractValueToNullReturnValue;
@@ -84,9 +83,9 @@ TXT
     /**
      * @param Node\Stmt\Return_ $node
      *
-     * @return Generator<array<Node\Stmt\Expression|Node\Stmt\Return_>>
+     * @return iterable<array<Node\Stmt\Expression|Node\Stmt\Return_>>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         /** @var Node\Expr\New_ $expr */
         $expr = $node->expr;

--- a/src/Mutator/ReturnValue/IntegerNegation.php
+++ b/src/Mutator/ReturnValue/IntegerNegation.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Stmt\Return_ $node
      *
-     * @return Generator<Node\Stmt\Return_>
+     * @return iterable<Node\Stmt\Return_>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\Return_(
             new Node\Scalar\LNumber(-1 * $this->getIntegerValueOfNode($node), $node->getAttributes())

--- a/src/Mutator/ReturnValue/NewObject.php
+++ b/src/Mutator/ReturnValue/NewObject.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use Infection\Mutator\Util\AbstractValueToNullReturnValue;
@@ -84,9 +83,9 @@ TXT
     /**
      * @param Node\Stmt\Return_ $node
      *
-     * @return Generator<array<Node\Stmt\Expression|Node\Stmt\Return_>>
+     * @return iterable<array<Node\Stmt\Expression|Node\Stmt\Return_>>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         /** @var Node\Expr\New_ $expr */
         $expr = $node->expr;

--- a/src/Mutator/ReturnValue/This.php
+++ b/src/Mutator/ReturnValue/This.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use Infection\Mutator\Util\AbstractValueToNullReturnValue;
@@ -60,9 +59,9 @@ final class This extends AbstractValueToNullReturnValue
      *
      * @param Node\Stmt\Return_ $node
      *
-     * @return Generator<Node\Stmt\Return_>
+     * @return iterable<Node\Stmt\Return_>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\Return_(
             new Node\Expr\ConstFetch(new Node\Name('null'))

--- a/src/Mutator/Sort/Spaceship.php
+++ b/src/Mutator/Sort/Spaceship.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Sort;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -64,9 +63,9 @@ TXT
     /**
      * @param Node\Expr\BinaryOp\Spaceship $node
      *
-     * @return Generator<Node\Expr\BinaryOp\Spaceship>
+     * @return iterable<Node\Expr\BinaryOp\Spaceship>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Expr\BinaryOp\Spaceship($node->right, $node->left);
     }

--- a/src/Mutator/Unwrap/AbstractUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractUnwrapMutator.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Mutator\Unwrap;
 
 use function array_key_exists;
-use Generator;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use PhpParser\Node;
@@ -51,9 +50,9 @@ abstract class AbstractUnwrapMutator implements Mutator
     /**
      * @param Node\Expr\FuncCall $node
      *
-     * @return Generator<Node\Arg>
+     * @return iterable<Node\Arg>
      */
-    final public function mutate(Node $node): Generator
+    final public function mutate(Node $node): iterable
     {
         foreach ($this->getParameterIndexes($node) as $index) {
             if ($node->args[$index]->unpack) {
@@ -82,7 +81,7 @@ abstract class AbstractUnwrapMutator implements Mutator
     abstract protected function getFunctionName(): string;
 
     /**
-     * @return int[]|Generator
+     * @return iterable<int>
      */
-    abstract protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator;
+    abstract protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable;
 }

--- a/src/Mutator/Unwrap/UnwrapArrayChangeKeyCase.php
+++ b/src/Mutator/Unwrap/UnwrapArrayChangeKeyCase.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_change_key_case';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayChunk.php
+++ b/src/Mutator/Unwrap/UnwrapArrayChunk.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -73,7 +72,7 @@ TXT
         return 'array_chunk';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayColumn.php
+++ b/src/Mutator/Unwrap/UnwrapArrayColumn.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_column';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayCombine.php
+++ b/src/Mutator/Unwrap/UnwrapArrayCombine.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -79,7 +78,7 @@ TXT
         return 'array_combine';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
 

--- a/src/Mutator/Unwrap/UnwrapArrayDiff.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiff.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -73,7 +72,7 @@ TXT
         return 'array_diff';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffAssoc.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -73,7 +72,7 @@ TXT
         return 'array_diff_assoc';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffKey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffKey.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -73,7 +72,7 @@ TXT
         return 'array_diff_key';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffUassoc.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -73,7 +72,7 @@ TXT
         return 'array_diff_uassoc';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffUkey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffUkey.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -73,7 +72,7 @@ TXT
         return 'array_diff_ukey';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayFilter.php
+++ b/src/Mutator/Unwrap/UnwrapArrayFilter.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -73,7 +72,7 @@ TXT
         return 'array_filter';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayFlip.php
+++ b/src/Mutator/Unwrap/UnwrapArrayFlip.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -73,7 +72,7 @@ TXT
         return 'array_flip';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayIntersect.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersect.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -79,7 +78,7 @@ TXT
         return 'array_intersect';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectAssoc.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -79,7 +78,7 @@ TXT
         return 'array_intersect_assoc';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectKey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectKey.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -79,7 +78,7 @@ TXT
         return 'array_intersect_key';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectUassoc.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use function array_slice;
 use function count;
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -81,7 +80,7 @@ TXT
         return 'array_intersect_uassoc';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_slice(
             array_keys($node->args),

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectUkey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectUkey.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use function array_slice;
 use function count;
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -81,7 +80,7 @@ TXT
         return 'array_intersect_ukey';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_slice(
             array_keys($node->args),

--- a/src/Mutator/Unwrap/UnwrapArrayKeys.php
+++ b/src/Mutator/Unwrap/UnwrapArrayKeys.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_keys';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayMap.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMap.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Mutator\Unwrap;
 
 use function count;
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -73,7 +72,7 @@ TXT
         return 'array_map';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from range(1, count($node->args) - 1);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayMerge.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMerge.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -79,7 +78,7 @@ TXT
         return 'array_merge';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayMergeRecursive.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMergeRecursive.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -79,7 +78,7 @@ TXT
         return 'array_merge_recursive';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayPad.php
+++ b/src/Mutator/Unwrap/UnwrapArrayPad.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_pad';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayReduce.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReduce.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -78,7 +77,7 @@ TXT
         return 'array_reduce';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 2;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayReplace.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReplace.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -79,7 +78,7 @@ TXT
         return 'array_replace';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayReplaceRecursive.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReplaceRecursive.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_replace_recursive';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);
     }

--- a/src/Mutator/Unwrap/UnwrapArrayReverse.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReverse.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_reverse';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArraySlice.php
+++ b/src/Mutator/Unwrap/UnwrapArraySlice.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_slice';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArraySplice.php
+++ b/src/Mutator/Unwrap/UnwrapArraySplice.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_splice';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayUdiff.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUdiff.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_udiff';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayUdiffAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUdiffAssoc.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_udiff_assoc';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayUdiffUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUdiffUassoc.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_udiff_uassoc';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayUintersect.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUintersect.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use function array_slice;
 use function count;
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -85,7 +84,7 @@ TXT
         return 'array_uintersect';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_slice(
             array_keys($node->args),

--- a/src/Mutator/Unwrap/UnwrapArrayUintersectAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUintersectAssoc.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use function array_slice;
 use function count;
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -85,7 +84,7 @@ TXT
         return 'array_uintersect_assoc';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_slice(
             array_keys($node->args),

--- a/src/Mutator/Unwrap/UnwrapArrayUintersectUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUintersectUassoc.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use function array_slice;
 use function count;
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -86,7 +85,7 @@ TXT
         return 'array_uintersect_uassoc';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_slice(
             array_keys($node->args),

--- a/src/Mutator/Unwrap/UnwrapArrayUnique.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUnique.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_unique';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapArrayValues.php
+++ b/src/Mutator/Unwrap/UnwrapArrayValues.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'array_values';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapLcFirst.php
+++ b/src/Mutator/Unwrap/UnwrapLcFirst.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'lcfirst';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapStrRepeat.php
+++ b/src/Mutator/Unwrap/UnwrapStrRepeat.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'str_repeat';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapStrReplace.php
+++ b/src/Mutator/Unwrap/UnwrapStrReplace.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'str_replace';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 2;
     }

--- a/src/Mutator/Unwrap/UnwrapStrToLower.php
+++ b/src/Mutator/Unwrap/UnwrapStrToLower.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'strtolower';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapStrToUpper.php
+++ b/src/Mutator/Unwrap/UnwrapStrToUpper.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'strtoupper';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapTrim.php
+++ b/src/Mutator/Unwrap/UnwrapTrim.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'trim';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapUcFirst.php
+++ b/src/Mutator/Unwrap/UnwrapUcFirst.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'ucfirst';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/Unwrap/UnwrapUcWords.php
+++ b/src/Mutator/Unwrap/UnwrapUcWords.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Unwrap;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
@@ -72,7 +71,7 @@ TXT
         return 'ucwords';
     }
 
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): Generator
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;
     }

--- a/src/Mutator/ZeroIteration/For_.php
+++ b/src/Mutator/ZeroIteration/For_.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ZeroIteration;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -79,9 +78,9 @@ TXT
     /**
      * @param Node\Stmt\For_ $node
      *
-     * @return Generator<Node\Stmt\For_>
+     * @return iterable<Node\Stmt\For_>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\For_(
             [

--- a/src/Mutator/ZeroIteration/Foreach_.php
+++ b/src/Mutator/ZeroIteration/Foreach_.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\ZeroIteration;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -79,9 +78,9 @@ TXT
     /**
      * @param Node\Stmt\Foreach_ $node
      *
-     * @return Generator<Node\Stmt\Foreach_>
+     * @return iterable<Node\Stmt\Foreach_>
      */
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\Foreach_(
             new Node\Expr\Array_(),

--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\TestFramework\Coverage\JUnit;
 
 use function explode;
-use Generator;
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\Coverage\SourceFileData;
@@ -79,9 +78,9 @@ class JUnitTestExecutionInfoAdder
     /**
      * @param iterable<SourceFileData> $coverage
      *
-     * @return Generator<SourceFileData>
+     * @return iterable<SourceFileData>
      */
-    private function testExecutionInfoAdder(iterable $coverage): Generator
+    private function testExecutionInfoAdder(iterable $coverage): iterable
     {
         foreach ($coverage as $data) {
             foreach ($data->retrieveCoverageReport()->byLine as $linesCoverageData) {

--- a/src/TestFramework/PhpUnit/Coverage/XmlCoverageParser.php
+++ b/src/TestFramework/PhpUnit/Coverage/XmlCoverageParser.php
@@ -37,7 +37,6 @@ namespace Infection\TestFramework\PhpUnit\Coverage;
 
 use DOMElement;
 use DOMNodeList;
-use Generator;
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 use Infection\TestFramework\Coverage\CoverageReport;
 use Infection\TestFramework\Coverage\MethodLocationData;
@@ -63,9 +62,9 @@ final class XmlCoverageParser
     }
 
     /**
-     * @return Generator<CoverageReport>
+     * @return iterable<CoverageReport>
      */
-    private static function createCoverageReportGenerator(SafeDOMXPath $xPath): Generator
+    private static function createCoverageReportGenerator(SafeDOMXPath $xPath): iterable
     {
         yield self::retrieveCoverageReport($xPath);
     }

--- a/tests/phpunit/AutoReview/BuildConfigYmlTest.php
+++ b/tests/phpunit/AutoReview/BuildConfigYmlTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\AutoReview;
 
-use Generator;
 use PHPUnit\Framework\TestCase;
 use function Safe\file_get_contents;
 use function Safe\realpath;
@@ -70,7 +69,7 @@ final class BuildConfigYmlTest extends TestCase
         }
     }
 
-    public function providesYamlFilesForTesting(): Generator
+    public function providesYamlFilesForTesting(): iterable
     {
         $rootPath = __DIR__ . '/../../../';
 

--- a/tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulatorCodeDetectorTest.php
+++ b/tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulatorCodeDetectorTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\AutoReview\EnvVariableManipulation;
 
-use Generator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -53,7 +52,7 @@ final class EnvManipulatorCodeDetectorTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function codeProvider(): Generator
+    public function codeProvider(): iterable
     {
         yield 'empty' => [
             '',

--- a/tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
+++ b/tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
@@ -39,7 +39,6 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use function class_exists;
-use Generator;
 use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
 use Infection\Tests\AutoReview\SourceTestClassNameScheme;
 use function iterator_to_array;
@@ -64,7 +63,7 @@ final class EnvTestCasesProvider
      * it checks the source classes, but it is not excluded that a fixture file used in a test case
      * contains env writings. In this scenario, the current implementation would miss out that one.
      */
-    public static function provideEnvTestCaseTuple(): Generator
+    public static function provideEnvTestCaseTuple(): iterable
     {
         if (self::$envTestCaseClassesTuple !== null) {
             yield from self::$envTestCaseClassesTuple;
@@ -82,7 +81,7 @@ final class EnvTestCasesProvider
         yield from self::$envTestCaseClassesTuple;
     }
 
-    public static function envTestCaseTupleProvider(): Generator
+    public static function envTestCaseTupleProvider(): iterable
     {
         yield from self::provideEnvTestCaseTuple();
     }

--- a/tests/phpunit/AutoReview/Event/SubscriberProvider.php
+++ b/tests/phpunit/AutoReview/Event/SubscriberProvider.php
@@ -37,7 +37,6 @@ namespace Infection\Tests\AutoReview\Event;
 
 use function array_filter;
 use function array_values;
-use Generator;
 use Infection\Event\Subscriber\EventSubscriber;
 use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
 use function Infection\Tests\generator_to_phpunit_data_provider;
@@ -55,7 +54,7 @@ final class SubscriberProvider
     {
     }
 
-    public static function provideSubscriberClasses(): Generator
+    public static function provideSubscriberClasses(): iterable
     {
         if (self::$subscriberClasses !== null) {
             yield from self::$subscriberClasses;
@@ -75,7 +74,7 @@ final class SubscriberProvider
         yield from self::$subscriberClasses;
     }
 
-    public static function subscriberClassesProvider(): Generator
+    public static function subscriberClassesProvider(): iterable
     {
         yield from generator_to_phpunit_data_provider(self::provideSubscriberClasses());
     }

--- a/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
@@ -39,7 +39,6 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use function class_exists;
-use Generator;
 use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
 use Infection\Tests\AutoReview\SourceTestClassNameScheme;
 use Infection\Tests\Console\E2ETest;
@@ -75,7 +74,7 @@ final class IntegrationGroupProvider
      * it checks the source classes, but it is not excluded that a fixture file used in a test case
      * contains I/O operations. In this scenario, the current implementation would miss out that one.
      */
-    public static function provideIoTestCaseTuple(): Generator
+    public static function provideIoTestCaseTuple(): iterable
     {
         if (self::$ioTestCaseClassesTuple !== null) {
             yield from self::$ioTestCaseClassesTuple;
@@ -103,7 +102,7 @@ final class IntegrationGroupProvider
         yield from self::$ioTestCaseClassesTuple;
     }
 
-    public static function ioTestCaseTupleProvider(): Generator
+    public static function ioTestCaseTupleProvider(): iterable
     {
         yield from self::provideIoTestCaseTuple();
     }

--- a/tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetectorTest.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetectorTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\AutoReview\IntegrationGroup;
 
-use Generator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -53,7 +52,7 @@ final class IoCodeDetectorTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function codeProvider(): Generator
+    public function codeProvider(): iterable
     {
         yield 'empty' => [
             '',

--- a/tests/phpunit/AutoReview/Makefile/ParserTest.php
+++ b/tests/phpunit/AutoReview/Makefile/ParserTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\AutoReview\Makefile;
 
-use Generator;
 use PHPUnit\Framework\TestCase;
 
 final class ParserTest extends TestCase
@@ -50,7 +49,7 @@ final class ParserTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function makefileContentProvider(): Generator
+    public function makefileContentProvider(): iterable
     {
         yield [
             <<<'MAKEFILE'

--- a/tests/phpunit/AutoReview/Mutator/MutatorProvider.php
+++ b/tests/phpunit/AutoReview/Mutator/MutatorProvider.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\AutoReview\Mutator;
 
 use function array_column;
-use Generator;
 use function in_array;
 use Infection\Mutator\ConfigurableMutator;
 use Infection\Tests\AutoReview\ConcreteClassReflector;
@@ -75,7 +74,7 @@ final class MutatorProvider
     {
     }
 
-    public static function provideMutatorClasses(): Generator
+    public static function provideMutatorClasses(): iterable
     {
         if (self::$mutatorClasses === null) {
             self::$mutatorClasses = array_column(
@@ -87,7 +86,7 @@ final class MutatorProvider
         yield from self::$mutatorClasses;
     }
 
-    public static function provideConcreteMutatorClasses(): Generator
+    public static function provideConcreteMutatorClasses(): iterable
     {
         if (self::$concreteMutatorClasses === null) {
             self::$concreteMutatorClasses = ConcreteClassReflector::filterByConcreteClasses(
@@ -98,7 +97,7 @@ final class MutatorProvider
         yield from self::$concreteMutatorClasses;
     }
 
-    public static function provideConfigurableMutatorClasses(): Generator
+    public static function provideConfigurableMutatorClasses(): iterable
     {
         if (self::$configurableMutatorClasses === null) {
             self::$configurableMutatorClasses = [];
@@ -113,17 +112,17 @@ final class MutatorProvider
         yield from self::$configurableMutatorClasses;
     }
 
-    public static function mutatorClassesProvider(): Generator
+    public static function mutatorClassesProvider(): iterable
     {
         yield from generator_to_phpunit_data_provider(self::provideMutatorClasses());
     }
 
-    public static function concreteMutatorClassesProvider(): Generator
+    public static function concreteMutatorClassesProvider(): iterable
     {
         yield from generator_to_phpunit_data_provider(self::provideConcreteMutatorClasses());
     }
 
-    public static function configurableMutatorClassesProvider(): Generator
+    public static function configurableMutatorClassesProvider(): iterable
     {
         yield from generator_to_phpunit_data_provider(self::provideConfigurableMutatorClasses());
     }

--- a/tests/phpunit/AutoReview/PhpDoc/PHPDocParserTest.php
+++ b/tests/phpunit/AutoReview/PhpDoc/PHPDocParserTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\AutoReview\PhpDoc;
 
-use Generator;
 use PHPUnit\Framework\TestCase;
 
 final class PHPDocParserTest extends TestCase
@@ -50,7 +49,7 @@ final class PHPDocParserTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function phpDocProvider(): Generator
+    public function phpDocProvider(): iterable
     {
         yield 'empty' => [
             '',

--- a/tests/phpunit/AutoReview/ProjectCode/DocBlockParserTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/DocBlockParserTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\AutoReview\ProjectCode;
 
-use Generator;
 use PHPUnit\Framework\TestCase;
 
 final class DocBlockParserTest extends TestCase
@@ -50,7 +49,7 @@ final class DocBlockParserTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function docBlocksProvider(): Generator
+    public function docBlocksProvider(): iterable
     {
         yield ['', ''];
 

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\AutoReview\ProjectCode;
 
 use const DIRECTORY_SEPARATOR;
-use Generator;
 use function in_array;
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 use Infection\Command\ConfigureCommand;
@@ -150,7 +149,7 @@ final class ProjectCodeProvider
     {
     }
 
-    public static function provideSourceClasses(): Generator
+    public static function provideSourceClasses(): iterable
     {
         if (self::$sourceClasses !== null) {
             yield from self::$sourceClasses;
@@ -183,14 +182,14 @@ final class ProjectCodeProvider
         yield from self::$sourceClasses;
     }
 
-    public static function sourceClassesProvider(): Generator
+    public static function sourceClassesProvider(): iterable
     {
         yield from generator_to_phpunit_data_provider(
             self::provideSourceClasses()
         );
     }
 
-    public static function provideConcreteSourceClasses(): Generator
+    public static function provideConcreteSourceClasses(): iterable
     {
         yield from ConcreteClassReflector::filterByConcreteClasses(iterator_to_array(
             self::provideSourceClasses(),
@@ -198,14 +197,14 @@ final class ProjectCodeProvider
         ));
     }
 
-    public static function concreteSourceClassesProvider(): Generator
+    public static function concreteSourceClassesProvider(): iterable
     {
         yield from generator_to_phpunit_data_provider(
             self::provideConcreteSourceClasses()
         );
     }
 
-    public static function provideSourceClassesToCheckForPublicProperties(): Generator
+    public static function provideSourceClassesToCheckForPublicProperties(): iterable
     {
         if (self::$sourceClassesToCheckForPublicProperties !== null) {
             yield from self::$sourceClassesToCheckForPublicProperties;
@@ -237,14 +236,14 @@ final class ProjectCodeProvider
         yield from self::$sourceClassesToCheckForPublicProperties;
     }
 
-    public static function sourceClassesToCheckForPublicPropertiesProvider(): Generator
+    public static function sourceClassesToCheckForPublicPropertiesProvider(): iterable
     {
         yield from generator_to_phpunit_data_provider(
             self::provideSourceClassesToCheckForPublicProperties()
         );
     }
 
-    public static function provideTestClasses(): Generator
+    public static function provideTestClasses(): iterable
     {
         if (self::$testClasses !== null) {
             yield from self::$testClasses;
@@ -287,21 +286,21 @@ final class ProjectCodeProvider
 
     // "testClassesProvider" would be more correct but PHPUnit will then detect this method as a
     // test instead of a test provider.
-    public static function classesTestProvider(): Generator
+    public static function classesTestProvider(): iterable
     {
         yield from generator_to_phpunit_data_provider(
             self::provideTestClasses()
         );
     }
 
-    public static function nonTestedConcreteClassesProvider(): Generator
+    public static function nonTestedConcreteClassesProvider(): iterable
     {
         yield from generator_to_phpunit_data_provider(
             self::NON_TESTED_CONCRETE_CLASSES
         );
     }
 
-    public static function nonFinalExtensionClasses(): Generator
+    public static function nonFinalExtensionClasses(): iterable
     {
         yield from generator_to_phpunit_data_provider(
             self::NON_FINAL_EXTENSION_CLASSES

--- a/tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php
+++ b/tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Config\Guesser;
 
-use Generator;
 use Infection\Config\Guesser\PhpUnitPathGuesser;
 use PHPUnit\Framework\TestCase;
 use function Safe\json_decode;
@@ -52,7 +51,7 @@ final class PhpUnitPathGuesserTest extends TestCase
         $this->assertSame($directory, $guesser->guess());
     }
 
-    public function providesJsonComposerAndLocations(): Generator
+    public function providesJsonComposerAndLocations(): iterable
     {
         yield [
             <<<'JSON'

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Configuration;
 
-use Generator;
 use Infection\Configuration\ConfigurationFactory;
 use Infection\Configuration\Entry\Badge;
 use Infection\Configuration\Entry\Logs;
@@ -207,7 +206,7 @@ final class ConfigurationFactoryTest extends TestCase
         );
     }
 
-    public function valueProvider(): Generator
+    public function valueProvider(): iterable
     {
         yield 'minimal' => [
             new SchemaConfiguration(

--- a/tests/phpunit/Configuration/ConfigurationTest.php
+++ b/tests/phpunit/Configuration/ConfigurationTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Configuration;
 
-use Generator;
 use Infection\Configuration\Configuration;
 use Infection\Configuration\Entry\Badge;
 use Infection\Configuration\Entry\Logs;
@@ -140,7 +139,7 @@ final class ConfigurationTest extends TestCase
         );
     }
 
-    public function valueProvider(): Generator
+    public function valueProvider(): iterable
     {
         yield 'empty' => [
             10,

--- a/tests/phpunit/Configuration/Entry/LogsTest.php
+++ b/tests/phpunit/Configuration/Entry/LogsTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Configuration\Entry;
 
-use Generator;
 use Infection\Configuration\Entry\Badge;
 use Infection\Configuration\Entry\Logs;
 use PHPUnit\Framework\TestCase;
@@ -86,7 +85,7 @@ final class LogsTest extends TestCase
         );
     }
 
-    public function valuesProvider(): Generator
+    public function valuesProvider(): iterable
     {
         yield 'minimal' => [
             null,

--- a/tests/phpunit/Configuration/Entry/PhpUnitTest.php
+++ b/tests/phpunit/Configuration/Entry/PhpUnitTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Configuration\Entry;
 
-use Generator;
 use Infection\Configuration\Entry\PhpUnit;
 use PHPUnit\Framework\TestCase;
 
@@ -71,7 +70,7 @@ final class PhpUnitTest extends TestCase
         );
     }
 
-    public function valuesProvider(): Generator
+    public function valuesProvider(): iterable
     {
         yield 'minimal' => [
             null,

--- a/tests/phpunit/Configuration/Entry/SourceTest.php
+++ b/tests/phpunit/Configuration/Entry/SourceTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Configuration\Entry;
 
-use Generator;
 use Infection\Configuration\Entry\Source;
 use PHPUnit\Framework\TestCase;
 
@@ -57,7 +56,7 @@ final class SourceTest extends TestCase
         );
     }
 
-    public function valuesProvider(): Generator
+    public function valuesProvider(): iterable
     {
         yield 'minimal' => [
             [],

--- a/tests/phpunit/Configuration/Schema/InvalidFileTest.php
+++ b/tests/phpunit/Configuration/Schema/InvalidFileTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Configuration\Schema;
 
 use Error;
-use Generator;
 use Infection\Configuration\Schema\InvalidFile;
 use Infection\Configuration\Schema\SchemaConfigurationFile;
 use PHPUnit\Framework\TestCase;
@@ -102,7 +101,7 @@ final class InvalidFileTest extends TestCase
         $this->assertSame($previous, $exception->getPrevious());
     }
 
-    public function jsonErrorProvider(): Generator
+    public function jsonErrorProvider(): iterable
     {
         yield [
             new SchemaConfigurationFile('/path/to/config'),

--- a/tests/phpunit/Configuration/Schema/InvalidSchemaTest.php
+++ b/tests/phpunit/Configuration/Schema/InvalidSchemaTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Configuration\Schema;
 
-use Generator;
 use Infection\Configuration\Schema\InvalidSchema;
 use Infection\Configuration\Schema\SchemaConfigurationFile;
 use function Infection\Tests\normalizeLineReturn;
@@ -61,7 +60,7 @@ final class InvalidSchemaTest extends TestCase
         $this->assertNull($exception->getPrevious());
     }
 
-    public function configWithErrorsProvider(): Generator
+    public function configWithErrorsProvider(): iterable
     {
         $path = '/path/to/config';
 

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -41,7 +41,6 @@ use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_values;
-use Generator;
 use function implode;
 use Infection\Configuration\Entry\Badge;
 use Infection\Configuration\Entry\Logs;
@@ -113,7 +112,7 @@ final class SchemaConfigurationFactoryTest extends TestCase
         );
     }
 
-    public function provideRawConfig(): Generator
+    public function provideRawConfig(): iterable
     {
         // The schema is given as a JSON here to be closer to how the user configure the schema
         yield 'minimal' => [

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Configuration\Schema;
 
 use Exception;
-use Generator;
 use function get_class;
 use Infection\Configuration\Schema\InvalidFile;
 use Infection\Configuration\Schema\SchemaConfigurationFile;
@@ -138,7 +137,7 @@ final class SchemaConfigurationFileTest extends TestCase
         }
     }
 
-    public function invalidConfigContentsProvider(): Generator
+    public function invalidConfigContentsProvider(): iterable
     {
         yield 'unknown path' => [
             '/nowhere',

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Configuration\Schema;
 
-use Generator;
 use Infection\Configuration\Schema\SchemaConfiguration;
 use Infection\Configuration\Schema\SchemaConfigurationFileLoader;
 use Infection\Configuration\Schema\SchemaConfigurationLoader;
@@ -101,7 +100,7 @@ final class SchemaConfigurationLoaderTest extends TestCase
         $this->assertSame($expectedConfig, $actualConfig);
     }
 
-    public function configurationPathsProvider(): Generator
+    public function configurationPathsProvider(): iterable
     {
         $config = (new ReflectionClass(SchemaConfiguration::class))->newInstanceWithoutConstructor();
 

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Configuration\Schema;
 
-use Generator;
 use Infection\Configuration\Entry\Badge;
 use Infection\Configuration\Entry\Logs;
 use Infection\Configuration\Entry\PhpUnit;
@@ -97,7 +96,7 @@ final class SchemaConfigurationTest extends TestCase
         $this->assertSame($testFrameworkExtraOptions, $config->getTestFrameworkExtraOptions());
     }
 
-    public function valueProvider(): Generator
+    public function valueProvider(): iterable
     {
         yield 'minimal' => [
             '',

--- a/tests/phpunit/Configuration/Schema/SchemaValidatorTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaValidatorTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Configuration\Schema;
 
-use Generator;
 use Infection\Configuration\Schema\InvalidSchema;
 use Infection\Configuration\Schema\SchemaConfigurationFile;
 use Infection\Configuration\Schema\SchemaValidator;
@@ -75,7 +74,7 @@ final class SchemaValidatorTest extends TestCase
         }
     }
 
-    public function configProvider(): Generator
+    public function configProvider(): iterable
     {
         $path = '/path/to/config';
 

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -42,7 +42,6 @@ use const DIRECTORY_SEPARATOR;
 use function extension_loaded;
 use function file_exists;
 use function function_exists;
-use Generator;
 use function getenv;
 use function implode;
 use Infection\Command\ConfigureCommand;
@@ -170,7 +169,7 @@ final class E2ETest extends TestCase
         $this->runOnE2EFixture($fullPath);
     }
 
-    public function e2eTestSuiteDataProvider(): Generator
+    public function e2eTestSuiteDataProvider(): iterable
     {
         $directories = Finder::create()
             ->depth('== 0')

--- a/tests/phpunit/Differ/DifferTest.php
+++ b/tests/phpunit/Differ/DifferTest.php
@@ -37,7 +37,6 @@ namespace Infection\Tests\Differ;
 
 use function array_map;
 use function explode;
-use Generator;
 use function implode;
 use Infection\Differ\Differ;
 use PHPUnit\Framework\TestCase;
@@ -58,7 +57,7 @@ final class DifferTest extends TestCase
         $this->assertSame($expectedDiff, self::normalizeString($actualDiff));
     }
 
-    public function diffProvider(): Generator
+    public function diffProvider(): iterable
     {
         yield 'empty' => [
             '',

--- a/tests/phpunit/Environment/BuildContextResolverTest.php
+++ b/tests/phpunit/Environment/BuildContextResolverTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Environment;
 
-use Generator;
 use Infection\Environment\BuildContextResolver;
 use Infection\Environment\CouldNotResolveBuildContext;
 use OndraM\CiDetector\Ci\CiInterface;
@@ -176,7 +175,7 @@ final class BuildContextResolverTest extends TestCase
         $buildContextResolver->resolve();
     }
 
-    public function provideBlankOrEmptyString(): Generator
+    public function provideBlankOrEmptyString(): iterable
     {
         yield 'string-blank' => [' '];
 

--- a/tests/phpunit/FileSystem/Locator/FileNotFoundTest.php
+++ b/tests/phpunit/FileSystem/Locator/FileNotFoundTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\FileSystem\Locator;
 
-use Generator;
 use Infection\FileSystem\Locator\FileNotFound;
 use PHPUnit\Framework\TestCase;
 
@@ -76,7 +75,7 @@ final class FileNotFoundTest extends TestCase
         $this->assertNull($exception->getPrevious());
     }
 
-    public function nonExistentPathsProvider(): Generator
+    public function nonExistentPathsProvider(): iterable
     {
         yield [
             'unknown',
@@ -103,7 +102,7 @@ final class FileNotFoundTest extends TestCase
         ];
     }
 
-    public function multipleNonExistentPathsProvider(): Generator
+    public function multipleNonExistentPathsProvider(): iterable
     {
         yield [
             [],

--- a/tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php
+++ b/tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\FileSystem\Locator;
 
-use Generator;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use PHPUnit\Framework\TestCase;
 
@@ -88,7 +87,7 @@ final class FileOrDirectoryNotFoundTest extends TestCase
         $this->assertNull($exception->getPrevious());
     }
 
-    public function nonExistentPathsProvider(): Generator
+    public function nonExistentPathsProvider(): iterable
     {
         yield [
             'unknown',
@@ -115,7 +114,7 @@ final class FileOrDirectoryNotFoundTest extends TestCase
         ];
     }
 
-    public function multipleNonExistentPathsProvider(): Generator
+    public function multipleNonExistentPathsProvider(): iterable
     {
         yield [
             [],

--- a/tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php
+++ b/tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\FileSystem\Locator;
 
 use function defined;
-use Generator;
 use Infection\FileSystem\Locator\FileNotFound;
 use Infection\FileSystem\Locator\RootsFileLocator;
 use function Infection\Tests\normalizePath as p;
@@ -144,13 +143,13 @@ final class RootsFileLocatorTest extends TestCase
         }
     }
 
-    public function pathsProvider(): Generator
+    public function pathsProvider(): iterable
     {
         $root = realpath(self::FIXTURES_DIR);
 
         $generators = [];
 
-        $generators[] = static function () use ($root): Generator {
+        $generators[] = static function () use ($root): iterable {
             $title = 'one root';
             $case = 'locate root file';
 
@@ -178,7 +177,7 @@ final class RootsFileLocatorTest extends TestCase
             }
         };
 
-        $generators[] = static function () use ($root): Generator {
+        $generators[] = static function () use ($root): iterable {
             $title = 'one root';
             $case = 'locate sub-dir root file';
 
@@ -201,7 +200,7 @@ final class RootsFileLocatorTest extends TestCase
             }
         };
 
-        $generators[] = static function () use ($root): Generator {
+        $generators[] = static function () use ($root): iterable {
             $title = 'multiple roots';
             $case = 'locate root file';
 
@@ -231,7 +230,7 @@ final class RootsFileLocatorTest extends TestCase
             }
         };
 
-        $generators[] = static function () use ($root): Generator {
+        $generators[] = static function () use ($root): iterable {
             $title = 'multiple roots';
             $case = 'locate sub-dir root file';
 
@@ -258,7 +257,7 @@ final class RootsFileLocatorTest extends TestCase
         };
 
         if (!defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            $generators[] = static function () use ($root): Generator {
+            $generators[] = static function () use ($root): iterable {
                 $title = 'one root';
                 $case = 'locate symlinked file';
 
@@ -289,7 +288,7 @@ final class RootsFileLocatorTest extends TestCase
         }
     }
 
-    public function invalidPathsProvider(): Generator
+    public function invalidPathsProvider(): iterable
     {
         yield [
             ['/nowhere'],
@@ -323,7 +322,7 @@ final class RootsFileLocatorTest extends TestCase
         }
     }
 
-    public function multiplePathsProvider(): Generator
+    public function multiplePathsProvider(): iterable
     {
         $root = realpath(self::FIXTURES_DIR);
 
@@ -388,7 +387,7 @@ final class RootsFileLocatorTest extends TestCase
         ];
     }
 
-    public function multipleInvalidPathsProvider(): Generator
+    public function multipleInvalidPathsProvider(): iterable
     {
         $root1 = realpath(self::FIXTURES_DIR);
         $root2 = realpath(self::FIXTURES_DIR) . '/dir';

--- a/tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php
+++ b/tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\FileSystem\Locator;
 
 use function defined;
-use Generator;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\FileSystem\Locator\RootsFileOrDirectoryLocator;
 use function Infection\Tests\normalizePath as p;
@@ -131,13 +130,13 @@ final class RootsFileOrDirectoryLocatorTest extends TestCase
         }
     }
 
-    public function pathsProvider(): Generator
+    public function pathsProvider(): iterable
     {
         $root = realpath(self::FIXTURES_DIR);
 
         $generators = [];
 
-        $generators[] = static function () use ($root): Generator {
+        $generators[] = static function () use ($root): iterable {
             $title = 'one root';
             $case = 'locate root file';
 
@@ -165,7 +164,7 @@ final class RootsFileOrDirectoryLocatorTest extends TestCase
             }
         };
 
-        $generators[] = static function () use ($root): Generator {
+        $generators[] = static function () use ($root): iterable {
             $title = 'one root';
             $case = 'locate sub-dir root file';
 
@@ -188,7 +187,7 @@ final class RootsFileOrDirectoryLocatorTest extends TestCase
             }
         };
 
-        $generators[] = static function () use ($root): Generator {
+        $generators[] = static function () use ($root): iterable {
             $title = 'multiple roots';
             $case = 'locate root file';
 
@@ -218,7 +217,7 @@ final class RootsFileOrDirectoryLocatorTest extends TestCase
             }
         };
 
-        $generators[] = static function () use ($root): Generator {
+        $generators[] = static function () use ($root): iterable {
             $title = 'multiple roots';
             $case = 'locate sub-dir root file';
 
@@ -244,7 +243,7 @@ final class RootsFileOrDirectoryLocatorTest extends TestCase
             }
         };
 
-        $generators[] = static function () use ($root): Generator {
+        $generators[] = static function () use ($root): iterable {
             $title = 'one root';
             $case = 'locate root directory';
 
@@ -272,7 +271,7 @@ final class RootsFileOrDirectoryLocatorTest extends TestCase
         };
 
         if (!defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            $generators[] = static function () use ($root): Generator {
+            $generators[] = static function () use ($root): iterable {
                 $title = 'one root';
                 $case = 'locate symlinked file';
 
@@ -303,7 +302,7 @@ final class RootsFileOrDirectoryLocatorTest extends TestCase
         }
     }
 
-    public function invalidPathsProvider(): Generator
+    public function invalidPathsProvider(): iterable
     {
         yield [
             ['/nowhere'],
@@ -337,7 +336,7 @@ final class RootsFileOrDirectoryLocatorTest extends TestCase
         }
     }
 
-    public function multiplePathsProvider(): Generator
+    public function multiplePathsProvider(): iterable
     {
         $root = realpath(self::FIXTURES_DIR);
 
@@ -402,7 +401,7 @@ final class RootsFileOrDirectoryLocatorTest extends TestCase
         ];
     }
 
-    public function multipleInvalidPathsProvider(): Generator
+    public function multipleInvalidPathsProvider(): iterable
     {
         $root1 = realpath(self::FIXTURES_DIR);
         $root2 = realpath(self::FIXTURES_DIR) . '/dir';

--- a/tests/phpunit/FileSystem/SourceFileCollectorTest.php
+++ b/tests/phpunit/FileSystem/SourceFileCollectorTest.php
@@ -37,7 +37,6 @@ namespace Infection\Tests\FileSystem;
 
 use function array_map;
 use function array_values;
-use Generator;
 use Infection\FileSystem\SourceFileCollector;
 use PHPUnit\Framework\TestCase;
 use function Pipeline\take;
@@ -77,7 +76,7 @@ final class SourceFileCollectorTest extends TestCase
         }
     }
 
-    public function sourceFilesProvider(): Generator
+    public function sourceFilesProvider(): iterable
     {
         yield 'empty' => [
             [],

--- a/tests/phpunit/FileSystem/SourceFileFilterTest.php
+++ b/tests/phpunit/FileSystem/SourceFileFilterTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\FileSystem;
 
 use function array_values;
-use Generator;
 use Infection\FileSystem\SourceFileFilter;
 use IteratorIterator;
 use PHPUnit\Framework\TestCase;
@@ -61,7 +60,7 @@ final class SourceFileFilterTest extends TestCase
         $this->assertSame($expectedFilters, array_values($fileFilter->getFilters()));
     }
 
-    public function filterProvider(): Generator
+    public function filterProvider(): iterable
     {
         yield 'empty' => ['', []];
 
@@ -104,7 +103,7 @@ final class SourceFileFilterTest extends TestCase
         $this->assertCanFilterInput($filter, $input, $expected);
     }
 
-    public static function fileListProvider(): Generator
+    public static function fileListProvider(): iterable
     {
         yield [
             'src/Example',

--- a/tests/phpunit/FileSystem/TmpDirProviderTest.php
+++ b/tests/phpunit/FileSystem/TmpDirProviderTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\FileSystem;
 
-use Generator;
 use Infection\FileSystem\TmpDirProvider;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -111,7 +110,7 @@ final class TmpDirProviderTest extends TestCase
         }
     }
 
-    public function tmpDirProvider(): Generator
+    public function tmpDirProvider(): iterable
     {
         yield 'root dir path' => [
             '/',
@@ -129,7 +128,7 @@ final class TmpDirProviderTest extends TestCase
         ];
     }
 
-    public function invalidTmpDirProvider(): Generator
+    public function invalidTmpDirProvider(): iterable
     {
         yield 'empty dir path' => [
             '',

--- a/tests/phpunit/Fixtures/Mutator/FakeMutator.php
+++ b/tests/phpunit/Fixtures/Mutator/FakeMutator.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures\Mutator;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\Mutator;
 use LogicException;
@@ -58,7 +57,7 @@ final class FakeMutator implements Mutator
         throw new LogicException('Not expected to be called');
     }
 
-    public function mutate(Node $node): Generator
+    public function mutate(Node $node): iterable
     {
         throw new LogicException('Not expected to be called');
     }

--- a/tests/phpunit/Fixtures/TestFramework/PhpUnit/Coverage/XmlCoverageFixtures.php
+++ b/tests/phpunit/Fixtures/TestFramework/PhpUnit/Coverage/XmlCoverageFixtures.php
@@ -35,8 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures\TestFramework\PhpUnit\Coverage;
 
-use Generator;
-
 final class XmlCoverageFixtures
 {
     public const FIXTURES_SRC_DIR = __DIR__ . '/../../../Files/phpunit/coverage/src';
@@ -46,18 +44,18 @@ final class XmlCoverageFixtures
     public const FIXTURES_OLD_SRC_DIR = __DIR__ . '/../../../Files/phpunit/old-coverage/src';
 
     /**
-     * @return Generator<XmlCoverageFixture>
+     * @return iterable<XmlCoverageFixture>
      */
-    public static function provideAllFixtures(): Generator
+    public static function provideAllFixtures(): iterable
     {
         yield from self::provideFixtures();
         yield from self::providePhpUnit6Fixtures();
     }
 
     /**
-     * @return Generator<XmlCoverageFixture>
+     * @return iterable<XmlCoverageFixture>
      */
-    public static function provideFixtures(): Generator
+    public static function provideFixtures(): iterable
     {
         yield new XmlCoverageFixture(
             self::FIXTURES_COVERAGE_DIR,

--- a/tests/phpunit/Helpers.php
+++ b/tests/phpunit/Helpers.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests;
 
 use const DIRECTORY_SEPARATOR;
-use Generator;
 use function random_int;
 use function Safe\realpath;
 use function Safe\substr;
@@ -59,7 +58,7 @@ function normalizeLineReturn(string $value): string
     return str_replace(["\r\n", "\r"], "\n", $value);
 }
 
-function generator_to_phpunit_data_provider(iterable $source): Generator
+function generator_to_phpunit_data_provider(iterable $source): iterable
 {
     foreach ($source as $key => $value) {
         yield $key => [$value];

--- a/tests/phpunit/Http/ResponseTest.php
+++ b/tests/phpunit/Http/ResponseTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Http;
 
-use Generator;
 use Infection\Http\Response;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -67,7 +66,7 @@ final class ResponseTest extends TestCase
         }
     }
 
-    public function valueProvider(): Generator
+    public function valueProvider(): iterable
     {
         yield 'empty' => [200, ''];
 

--- a/tests/phpunit/Logger/DebugFileLoggerTest.php
+++ b/tests/phpunit/Logger/DebugFileLoggerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Logger;
 
-use Generator;
 use Infection\Logger\DebugFileLogger;
 use Infection\Mutant\MetricsCalculator;
 use PHPUnit\Framework\TestCase;
@@ -58,7 +57,7 @@ final class DebugFileLoggerTest extends TestCase
         $this->assertLoggedContentIs($expectedContents, $logger);
     }
 
-    public function metricsProvider(): Generator
+    public function metricsProvider(): iterable
     {
         yield 'no mutations' => [
             new MetricsCalculator(),

--- a/tests/phpunit/Logger/ExecutionResultSorterTest.php
+++ b/tests/phpunit/Logger/ExecutionResultSorterTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Logger;
 
-use Generator;
 use Infection\Logger\ExecutionResultSorter;
 use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
@@ -58,7 +57,7 @@ final class ExecutionResultSorterTest extends TestCase
         $this->assertSame($expectedResults, $executionResults);
     }
 
-    public function resultsProvider(): Generator
+    public function resultsProvider(): iterable
     {
         yield 'empty' => [[], []];
 

--- a/tests/phpunit/Logger/LoggerFactoryTest.php
+++ b/tests/phpunit/Logger/LoggerFactoryTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Logger;
 
 use function array_map;
-use Generator;
 use function get_class;
 use Infection\Configuration\Entry\Badge;
 use Infection\Configuration\Entry\Logs;
@@ -149,7 +148,7 @@ final class LoggerFactoryTest extends TestCase
         $this->assertRegisteredLoggersAre($expectedLoggerClasses, $logger);
     }
 
-    public function logsProvider(): Generator
+    public function logsProvider(): iterable
     {
         yield 'no logger' => [
             Logs::createEmpty(),

--- a/tests/phpunit/Logger/PerMutatorLoggerTest.php
+++ b/tests/phpunit/Logger/PerMutatorLoggerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Logger;
 
-use Generator;
 use Infection\Logger\PerMutatorLogger;
 use Infection\Mutant\MetricsCalculator;
 use PHPUnit\Framework\TestCase;
@@ -57,7 +56,7 @@ final class PerMutatorLoggerTest extends TestCase
         $this->assertLoggedContentIs($expectedContents, $logger);
     }
 
-    public function metricsProvider(): Generator
+    public function metricsProvider(): iterable
     {
         yield 'no mutations' => [
             new MetricsCalculator(),

--- a/tests/phpunit/Logger/SummaryFileLoggerTest.php
+++ b/tests/phpunit/Logger/SummaryFileLoggerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Logger;
 
-use Generator;
 use Infection\Logger\SummaryFileLogger;
 use Infection\Mutant\MetricsCalculator;
 use PHPUnit\Framework\TestCase;
@@ -57,7 +56,7 @@ final class SummaryFileLoggerTest extends TestCase
         $this->assertLoggedContentIs($expectedContents, $logger);
     }
 
-    public function metricsProvider(): Generator
+    public function metricsProvider(): iterable
     {
         yield 'no mutations' => [
             new MetricsCalculator(),

--- a/tests/phpunit/Logger/TextFileLoggerTest.php
+++ b/tests/phpunit/Logger/TextFileLoggerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Logger;
 
-use Generator;
 use Infection\Logger\TextFileLogger;
 use Infection\Mutant\MetricsCalculator;
 use PHPUnit\Framework\TestCase;
@@ -83,7 +82,7 @@ final class TextFileLoggerTest extends TestCase
         $this->assertLoggedContentIs($expectedContents, $logger);
     }
 
-    public function emptyMetricsProvider(): Generator
+    public function emptyMetricsProvider(): iterable
     {
         yield 'no debug verbosity; no debug mode' => [
             false,
@@ -234,7 +233,7 @@ TXT
         ];
     }
 
-    public function completeMetricsProvider(): Generator
+    public function completeMetricsProvider(): iterable
     {
         yield 'no debug verbosity; no debug mode' => [
             false,

--- a/tests/phpunit/Mutant/CalculatorTest.php
+++ b/tests/phpunit/Mutant/CalculatorTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutant;
 
 use function array_sum;
-use Generator;
 use Infection\Mutant\Calculator;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Tests\Logger\CreateMetricsCalculator;
@@ -99,7 +98,7 @@ final class CalculatorTest extends TestCase
         $this->assertSame($expectedCoveredMsi, $calculator->getCoveredCodeMutationScoreIndicator());
     }
 
-    public function metricsProvider(): Generator
+    public function metricsProvider(): iterable
     {
         yield 'empty' => [
             0,
@@ -146,7 +145,7 @@ final class CalculatorTest extends TestCase
         ];
     }
 
-    public function metricsCalculatorProvider(): Generator
+    public function metricsCalculatorProvider(): iterable
     {
         yield 'empty' => [
             new MetricsCalculator(),

--- a/tests/phpunit/Mutant/MutantCodeFactoryTest.php
+++ b/tests/phpunit/Mutant/MutantCodeFactoryTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutant;
 
-use Generator;
 use Infection\Mutant\MutantCodeFactory;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\Arithmetic\Plus;
@@ -84,7 +83,7 @@ final class MutantCodeFactoryTest extends TestCase
         $this->assertSame($originalNodesDump, $originalNodesDumpAfterMutation);
     }
 
-    public function mutationProvider(): Generator
+    public function mutationProvider(): iterable
     {
         yield [
             new Mutation(

--- a/tests/phpunit/Mutant/MutantTest.php
+++ b/tests/phpunit/Mutant/MutantTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutant;
 
-use Generator;
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 use Infection\Mutant\Mutant;
 use Infection\Mutation\Mutation;
@@ -75,7 +74,7 @@ final class MutantTest extends TestCase
         );
     }
 
-    public function valuesProvider(): Generator
+    public function valuesProvider(): iterable
     {
         $nominalAttributes = [
             'startLine' => 3,

--- a/tests/phpunit/Mutant/SortableMutantExecutionResultsTest.php
+++ b/tests/phpunit/Mutant/SortableMutantExecutionResultsTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutant;
 
-use Generator;
 use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutant\SortableMutantExecutionResults;
@@ -98,7 +97,7 @@ final class SortableMutantExecutionResultsTest extends TestCase
         );
     }
 
-    public function resultsProvider(): Generator
+    public function resultsProvider(): iterable
     {
         yield 'empty' => [[], []];
 

--- a/tests/phpunit/Mutation/FileMutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/FileMutationGeneratorTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutation;
 
 use function current;
-use Generator;
 use Infection\Mutation\FileMutationGenerator;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\Arithmetic\Plus;
@@ -218,7 +217,7 @@ final class FileMutationGeneratorTest extends TestCase
         $this->assertSame([], $mutations);
     }
 
-    public function parsedFilesProvider(): Generator
+    public function parsedFilesProvider(): iterable
     {
         foreach ($this->provideBoolean() as $hasTests) {
             $title = sprintf(
@@ -271,7 +270,7 @@ final class FileMutationGeneratorTest extends TestCase
         ];
     }
 
-    public function skippedFilesProvider(): Generator
+    public function skippedFilesProvider(): iterable
     {
         yield 'path - only covered: true - has tests: %s' => [
             $this->createSourceFileDataMock('/path/to/file', 'relativePath', 'relativePathName'),
@@ -284,7 +283,7 @@ final class FileMutationGeneratorTest extends TestCase
         ];
     }
 
-    public function provideBoolean(): Generator
+    public function provideBoolean(): iterable
     {
         yield from [true, false];
     }

--- a/tests/phpunit/Mutation/MutationTest.php
+++ b/tests/phpunit/Mutation/MutationTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutation;
 
 use function array_merge;
-use Generator;
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\Arithmetic\Plus;
@@ -94,7 +93,7 @@ final class MutationTest extends TestCase
         $this->assertSame($expectedHash, $mutation->getHash());
     }
 
-    public function valuesProvider(): Generator
+    public function valuesProvider(): iterable
     {
         $nominalAttributes = [
             'startLine' => $originalStartingLine = 3,

--- a/tests/phpunit/Mutator/Arithmetic/AssignmentEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/AssignmentEqualTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class AssignmentEqualTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class AssignmentEqualTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates a comparison to an assignment' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/AssignmentTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/AssignmentTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class AssignmentTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class AssignmentTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseAndTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseAndTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class BitwiseAndTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class BitwiseAndTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseNotTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseNotTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class BitwiseNotTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class BitwiseNotTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseOrTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseOrTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class BitwiseOrTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class BitwiseOrTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/BitwiseXorTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/BitwiseXorTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class BitwiseXorTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class BitwiseXorTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield[
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/DecrementTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/DecrementTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class DecrementTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class DecrementTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It replaces post decrement' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/DivEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/DivEqualTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class DivEqualTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class DivEqualTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It changes divison equals' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/DivisionTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/DivisionTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class DivisionTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class DivisionTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It changes regular divison' => [
                 <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/ExponentiationTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ExponentiationTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ExponentiationTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class ExponentiationTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/IncrementTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/IncrementTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class IncrementTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class IncrementTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It replaces post increment' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/MinusEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MinusEqualTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class MinusEqualTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class MinusEqualTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates minus equals' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/MinusTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MinusTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class MinusTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class MinusTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates normal minus' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/ModEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ModEqualTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ModEqualTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class ModEqualTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates mod equal' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/ModulusTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ModulusTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ModulusTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class ModulusTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates normal mod' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/MulEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MulEqualTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class MulEqualTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class MulEqualTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates multiply equal' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/MultiplicationTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/MultiplicationTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class MultiplicationTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class MultiplicationTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates normal multiplication' => [
                 <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/PlusEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/PlusEqualTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class PlusEqualTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class PlusEqualTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates plus equal' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/PlusTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/PlusTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
@@ -53,7 +52,7 @@ final class PlusTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates normal plus' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/PowEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/PowEqualTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class PowEqualTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class PowEqualTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates pow equal' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/RoundingFamilyTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/RoundingFamilyTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class RoundingFamilyTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class RoundingFamilyTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates round() to floor() and ceil()' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/ShiftLeftTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ShiftLeftTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ShiftLeftTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class ShiftLeftTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates shift left' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Arithmetic/ShiftRightTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ShiftRightTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Arithmetic;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ShiftRightTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class ShiftRightTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates shift right' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/ArrayItemTest.php
+++ b/tests/phpunit/Mutator/Boolean/ArrayItemTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ArrayItemTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class ArrayItemTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates double arrow operator to a greater than comparison when operands can have side-effects and left is property' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class EqualIdenticalTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class EqualIdenticalTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates with two variables' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/FalseValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/FalseValueTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name;
@@ -52,7 +51,7 @@ final class FalseValueTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates false to true' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class IdenticalEqualTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class IdenticalEqualTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates identical operator into equal operator with two variables' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/LogicalAndTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalAndTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LogicalAndTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class LogicalAndTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates logical and' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/LogicalLowerAndTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalLowerAndTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LogicalLowerAndTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class LogicalLowerAndTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates logical lower and' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/LogicalLowerOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalLowerOrTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LogicalLowerOrTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class LogicalLowerOrTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates logical lower or' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/LogicalNotTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalNotTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\ConstFetch;
@@ -53,7 +52,7 @@ final class LogicalNotTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes logical not' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LogicalOrTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class LogicalOrTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates logical or' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/NotEqualNotIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/NotEqualNotIdenticalTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class NotEqualNotIdenticalTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class NotEqualNotIdenticalTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates with two variables' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/NotIdenticalNotEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/NotIdenticalNotEqualTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class NotIdenticalNotEqualTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class NotIdenticalNotEqualTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates not identical operator into not equal operator with two variables' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/TrueValueConfigTest.php
+++ b/tests/phpunit/Mutator/Boolean/TrueValueConfigTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Mutator\Boolean\TrueValueConfig;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -80,7 +79,7 @@ final class TrueValueConfigTest extends TestCase
         }
     }
 
-    public function settingsProvider(): Generator
+    public function settingsProvider(): iterable
     {
         yield 'default' => [
             [],

--- a/tests/phpunit/Mutator/Boolean/TrueValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/TrueValueTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name;
@@ -53,7 +52,7 @@ final class TrueValueTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected, $settings);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates true to false' => [
                 <<<'PHP'

--- a/tests/phpunit/Mutator/Boolean/Yield_Test.php
+++ b/tests/phpunit/Mutator/Boolean/Yield_Test.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Boolean;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class Yield_Test extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class Yield_Test extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates a yield with a double arrow to a yield with a greater than comparison' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastArrayTest.php
+++ b/tests/phpunit/Mutator/Cast/CastArrayTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Cast;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class CastArrayTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class CastArrayTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes casting to array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastBoolTest.php
+++ b/tests/phpunit/Mutator/Cast/CastBoolTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Cast;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class CastBoolTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class CastBoolTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes casting to bool with "bool"' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastFloatTest.php
+++ b/tests/phpunit/Mutator/Cast/CastFloatTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Cast;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class CastFloatTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class CastFloatTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes casting to float' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastIntTest.php
+++ b/tests/phpunit/Mutator/Cast/CastIntTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Cast;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class CastIntTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class CastIntTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes casting to int' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastObjectTest.php
+++ b/tests/phpunit/Mutator/Cast/CastObjectTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Cast;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class CastObjectTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class CastObjectTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes casting to object' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Cast/CastStringTest.php
+++ b/tests/phpunit/Mutator/Cast/CastStringTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Cast;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class CastStringTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class CastStringTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes casting to string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanOrEqualToTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanOrEqualToTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalBoundary;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class GreaterThanOrEqualToTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class GreaterThanOrEqualToTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates greater than or equal to' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/GreaterThanTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalBoundary;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class GreaterThanTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class GreaterThanTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates greater than' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalBoundary/LessThanOrEqualToTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/LessThanOrEqualToTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalBoundary;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LessThanOrEqualToTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class LessThanOrEqualToTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates less than or equal to' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalBoundary/LessThanTest.php
+++ b/tests/phpunit/Mutator/ConditionalBoundary/LessThanTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalBoundary;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LessThanTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class LessThanTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates less than' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalNegotiation/EqualTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/EqualTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class EqualTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class EqualTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates not strict comparison' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanNegotiationTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class GreaterThanNegotiationTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class GreaterThanNegotiationTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates greater than' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiationTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class GreaterThanOrEqualToNegotiationTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class GreaterThanOrEqualToNegotiationTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates greater than or equal to' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalNegotiation/IdenticalTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/IdenticalTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class IdenticalTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class IdenticalTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates strict comparison' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalNegotiation/LessThanNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/LessThanNegotiationTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LessThanNegotiationTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class LessThanNegotiationTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates less than' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiationTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class LessThanOrEqualToNegotiationTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class LessThanOrEqualToNegotiationTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates less than or equal to' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalNegotiation/NotEqualTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/NotEqualTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class NotEqualTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class NotEqualTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates not strict comparison' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ConditionalNegotiation/NotIdenticalTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/NotIdenticalTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ConditionalNegotiation;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class NotIdenticalTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class NotIdenticalTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates strict comparison' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/DefinitionTest.php
+++ b/tests/phpunit/Mutator/DefinitionTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator;
 
-use Generator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
 use PHPUnit\Framework\TestCase;
@@ -57,7 +56,7 @@ final class DefinitionTest extends TestCase
         $this->assertSame($remedies, $definition->getRemedies());
     }
 
-    public function valuesProvider(): Generator
+    public function valuesProvider(): iterable
     {
         yield 'empty' => [
             '',

--- a/tests/phpunit/Mutator/Extensions/BCMathConfigTest.php
+++ b/tests/phpunit/Mutator/Extensions/BCMathConfigTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Extensions;
 
-use Generator;
 use Infection\Mutator\Extensions\BCMathConfig;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -80,7 +79,7 @@ final class BCMathConfigTest extends TestCase
         }
     }
 
-    public function settingsProvider(): Generator
+    public function settingsProvider(): iterable
     {
         yield 'default' => [
             [],

--- a/tests/phpunit/Mutator/Extensions/BCMathTest.php
+++ b/tests/phpunit/Mutator/Extensions/BCMathTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator\Extensions;
 
 use function array_map;
-use Generator;
 use function implode;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use function range;
@@ -53,7 +52,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected, $settings);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield from $this->mutationsProviderForBinaryOperator('bcadd', '+', 'summation');
 
@@ -74,7 +73,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         yield from $this->mutationsProviderForComparision();
     }
 
-    private function mutationsProviderForBinaryOperator(string $bcFunc, string $op, string $expression): Generator
+    private function mutationsProviderForBinaryOperator(string $bcFunc, string $op, string $expression): iterable
     {
         yield "It converts $bcFunc to $expression expression" => [
             "<?php \\$bcFunc('3', \$b);",
@@ -94,7 +93,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         yield from $this->provideCasesWhereMutatorShouldNotApply($bcFunc);
     }
 
-    private function mutationsProviderForPowerOperator(): Generator
+    private function mutationsProviderForPowerOperator(): iterable
     {
         yield 'It converts bcpow to power expression' => [
             '<?php \\bcpow(5, $b);',
@@ -114,7 +113,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         yield from $this->provideCasesWhereMutatorShouldNotApply('bcpow');
     }
 
-    private function mutationsProviderForSquareRoot(): Generator
+    private function mutationsProviderForSquareRoot(): iterable
     {
         yield 'It converts bcsqrt to sqrt call' => [
             '<?php \\bcsqrt(2);',
@@ -134,7 +133,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         yield from $this->provideCasesWhereMutatorShouldNotApply('bcsqrt', 1);
     }
 
-    private function mutationsProviderForPowerModulo(): Generator
+    private function mutationsProviderForPowerModulo(): iterable
     {
         yield 'It converts bcpowmod to power modulo expression' => [
             '<?php \\bcpowmod($a, $b, $mod);',
@@ -154,7 +153,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         yield from $this->provideCasesWhereMutatorShouldNotApply('bcpowmod', 3);
     }
 
-    private function mutationsProviderForComparision(): Generator
+    private function mutationsProviderForComparision(): iterable
     {
         yield 'It converts bccomp to spaceship expression' => [
             '<?php \\bccomp(\'3\', $b);',
@@ -174,7 +173,7 @@ final class BCMathTest extends AbstractMutatorTestCase
         yield from $this->provideCasesWhereMutatorShouldNotApply('bccomp', 2);
     }
 
-    private function provideCasesWhereMutatorShouldNotApply(string $bcFunc, int $requiredArgumentsCount = 2): Generator
+    private function provideCasesWhereMutatorShouldNotApply(string $bcFunc, int $requiredArgumentsCount = 2): iterable
     {
         $invalidArgumentsExpression = $this->generateArgumentsExpression($requiredArgumentsCount - 1);
         $validArgumentsExpression = $this->generateArgumentsExpression($requiredArgumentsCount);

--- a/tests/phpunit/Mutator/Extensions/MBStringConfigTest.php
+++ b/tests/phpunit/Mutator/Extensions/MBStringConfigTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Extensions;
 
-use Generator;
 use Infection\Mutator\Extensions\MBStringConfig;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -80,7 +79,7 @@ final class MBStringConfigTest extends TestCase
         }
     }
 
-    public function settingsProvider(): Generator
+    public function settingsProvider(): iterable
     {
         yield 'default' => [
             [],

--- a/tests/phpunit/Mutator/Extensions/MBStringTest.php
+++ b/tests/phpunit/Mutator/Extensions/MBStringTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator\Extensions;
 
 use function defined;
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use function Safe\define;
 
@@ -57,7 +56,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected, $settings);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It converts mb_strlen with leading slash' => [
             "<?php \mb_strlen('test');",
@@ -122,7 +121,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         yield from $this->mutationsProviderForStrSplit();
     }
 
-    private function mutationsProviderForChr(): Generator
+    private function mutationsProviderForChr(): iterable
     {
         yield 'It converts mb_chr to chr' => [
             '<?php mb_chr(74);',
@@ -144,7 +143,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForOrd(): Generator
+    private function mutationsProviderForOrd(): iterable
     {
         yield 'It converts mb_ord to ord' => [
             "<?php mb_ord('T');",
@@ -166,7 +165,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForParseStr(): Generator
+    private function mutationsProviderForParseStr(): iterable
     {
         yield 'It converts mb_parse_str to parse_str' => [
             "<?php mb_parse_str('T');",
@@ -188,7 +187,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForSendMail(): Generator
+    private function mutationsProviderForSendMail(): iterable
     {
         yield 'It converts mb_send_mail to mail' => [
             "<?php mb_send_mail('to', 'subject', 'msg');",
@@ -210,7 +209,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForStrCut(): Generator
+    private function mutationsProviderForStrCut(): iterable
     {
         yield 'It converts mb_strcut to substr' => [
             "<?php mb_strcut('subject', 1);",
@@ -237,7 +236,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForStrPos(): Generator
+    private function mutationsProviderForStrPos(): iterable
     {
         yield 'It converts mb_strpos to strpos' => [
             "<?php mb_strpos('subject', 'b');",
@@ -264,7 +263,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForStrIPos(): Generator
+    private function mutationsProviderForStrIPos(): iterable
     {
         yield 'It converts mb_stripos to stripos' => [
             "<?php mb_stripos('subject', 'b');",
@@ -291,7 +290,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForStrIStr(): Generator
+    private function mutationsProviderForStrIStr(): iterable
     {
         yield 'It converts mb_stristr to stristr' => [
             "<?php mb_stristr('subject', 'b');",
@@ -318,7 +317,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForStrRiPos(): Generator
+    private function mutationsProviderForStrRiPos(): iterable
     {
         yield 'It converts mb_strripos to strripos' => [
             "<?php mb_strripos('subject', 'b');",
@@ -345,7 +344,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForStrRPos(): Generator
+    private function mutationsProviderForStrRPos(): iterable
     {
         yield 'It converts mb_strrpos to strrpos' => [
             "<?php mb_strrpos('subject', 'b');",
@@ -372,7 +371,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForStrStr(): Generator
+    private function mutationsProviderForStrStr(): iterable
     {
         yield 'It converts mb_strstr to strstr' => [
             "<?php mb_strstr('subject', 'b');",
@@ -399,7 +398,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForStrToLower(): Generator
+    private function mutationsProviderForStrToLower(): iterable
     {
         yield 'It converts mb_strtolower to strtolower' => [
             "<?php mb_strtolower('test');",
@@ -421,7 +420,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForStrToUpper(): Generator
+    private function mutationsProviderForStrToUpper(): iterable
     {
         yield 'It converts mb_strtoupper to strtoupper' => [
             "<?php mb_strtoupper('test');",
@@ -443,7 +442,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForSubStrCount(): Generator
+    private function mutationsProviderForSubStrCount(): iterable
     {
         yield 'It converts mb_substr_count to substr_count' => [
             "<?php mb_substr_count('test', 't');",
@@ -465,7 +464,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForSubStr(): Generator
+    private function mutationsProviderForSubStr(): iterable
     {
         yield 'It converts mb_substr to substr' => [
             "<?php mb_substr('test', 2);",
@@ -492,7 +491,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForStrRChr(): Generator
+    private function mutationsProviderForStrRChr(): iterable
     {
         yield 'It converts mb_strrchr to strrchr' => [
             "<?php mb_strrchr('subject', 'b');",
@@ -519,7 +518,7 @@ final class MBStringTest extends AbstractMutatorTestCase
         ];
     }
 
-    private function mutationsProviderForConvertCase(): Generator
+    private function mutationsProviderForConvertCase(): iterable
     {
         yield 'It converts mb_convert_case with MB_CASE_UPPER mode to strtoupper' => [
             "<?php mb_convert_case('test', MB_CASE_UPPER);",

--- a/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\FunctionSignature;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use function Safe\file_get_contents;
 use function Safe\sprintf;
@@ -55,7 +54,7 @@ final class ProtectedVisibilityTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates protected to private' => [
             $this->getFileContent('pv-one-class.php'),

--- a/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\FunctionSignature;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use function Safe\file_get_contents;
 use function Safe\sprintf;
@@ -81,7 +80,7 @@ final class PublicVisibilityTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates public to protected' => [
             $this->getFileContent('pv-one-class.php'),

--- a/tests/phpunit/Mutator/IgnoreConfigTest.php
+++ b/tests/phpunit/Mutator/IgnoreConfigTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator;
 
-use Generator;
 use Infection\Mutator\IgnoreConfig;
 use PHPUnit\Framework\TestCase;
 
@@ -79,7 +78,7 @@ final class IgnoreConfigTest extends TestCase
         $this->assertFalse($config->isIgnored($class, $method, $lineNumber));
     }
 
-    public function ignoredValuesProvider(): Generator
+    public function ignoredValuesProvider(): iterable
     {
         foreach ([null, 50] as $lineNumber) {
             $titleSuffix = $lineNumber === null ? '' : ' with line number #' . $lineNumber;
@@ -135,7 +134,7 @@ final class IgnoreConfigTest extends TestCase
         ];
     }
 
-    public function nonIgnoredValuesProvider(): Generator
+    public function nonIgnoredValuesProvider(): iterable
     {
         foreach ([null, 50] as $lineNumber) {
             $titleSuffix = $lineNumber === null ? '' : ' with line number #' . $lineNumber;

--- a/tests/phpunit/Mutator/IgnoreMutatorTest.php
+++ b/tests/phpunit/Mutator/IgnoreMutatorTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator;
 
 use DomainException;
-use Generator;
 use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\IgnoreConfig;
 use Infection\Mutator\IgnoreMutator;
@@ -173,7 +172,7 @@ final class IgnoreMutatorTest extends TestCase
             ->expects($this->once())
             ->method('mutate')
             ->with($this->nodeMock)
-            ->willReturnCallback(static function () use ($mutatedNodeMock): Generator {
+            ->willReturnCallback(static function () use ($mutatedNodeMock): iterable {
                 yield $mutatedNodeMock;
             })
         ;

--- a/tests/phpunit/Mutator/MutatorParserTest.php
+++ b/tests/phpunit/Mutator/MutatorParserTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator;
 
-use Generator;
 use Infection\Mutator\MutatorParser;
 use PHPUnit\Framework\TestCase;
 
@@ -65,7 +64,7 @@ final class MutatorParserTest extends TestCase
         $this->assertSame($expectedMutators, $parsedMutators);
     }
 
-    public function mutatorInputProvider(): Generator
+    public function mutatorInputProvider(): iterable
     {
         yield 'empty string' => ['', []];
 

--- a/tests/phpunit/Mutator/MutatorRobustnessTest.php
+++ b/tests/phpunit/Mutator/MutatorRobustnessTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator;
 
 use function array_values;
-use Generator;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\ProfileList;
 use Infection\PhpParser\NodeTraverserFactory;
@@ -82,7 +81,7 @@ final class MutatorRobustnessTest extends TestCase
         }
     }
 
-    public function mutatorWithCodeCaseProvider(): Generator
+    public function mutatorWithCodeCaseProvider(): iterable
     {
         $mutatorFactory = SingletonContainer::getContainer()->getMutatorFactory();
 
@@ -99,7 +98,7 @@ final class MutatorRobustnessTest extends TestCase
         }
     }
 
-    private function provideCodeSamples(): Generator
+    private function provideCodeSamples(): iterable
     {
         if (self::$files !== null) {
             yield from self::$files;

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Number;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class DecrementIntegerTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class DecrementIntegerTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It does not decrement an integer in a comparison' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Number;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class IncrementIntegerTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class IncrementIntegerTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It increments an integer' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Number/OneZeroFloatTest.php
+++ b/tests/phpunit/Mutator/Number/OneZeroFloatTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Number;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class OneZeroFloatTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class OneZeroFloatTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates float one to zero' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Number/OneZeroIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/OneZeroIntegerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Number;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class OneZeroIntegerTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class OneZeroIntegerTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates int one to zero' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Operator/AssignCoalesceTest.php
+++ b/tests/phpunit/Mutator/Operator/AssignCoalesceTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Operator;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class AssignCoalesceTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class AssignCoalesceTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'Mutate coalesce when right part is a scalar value' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Operator/Break_Test.php
+++ b/tests/phpunit/Mutator/Operator/Break_Test.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Operator;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class Break_Test extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class Break_Test extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It replaces break with continue in while' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Operator/CoalesceTest.php
+++ b/tests/phpunit/Mutator/Operator/CoalesceTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Operator;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class CoalesceTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class CoalesceTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'Mutate coalesce with scalar values' => [
             <<<PHP

--- a/tests/phpunit/Mutator/Operator/Continue_Test.php
+++ b/tests/phpunit/Mutator/Operator/Continue_Test.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Operator;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class Continue_Test extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class Continue_Test extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It replaces continue with break in while' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Operator/Finally_Test.php
+++ b/tests/phpunit/Mutator/Operator/Finally_Test.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Operator;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class Finally_Test extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class Finally_Test extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes the finally statement' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Operator/SpreadTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Operator;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class SpreadTest extends AbstractMutatorTestCase
@@ -51,7 +50,7 @@ final class SpreadTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'Spread for a raw array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Operator/Throw_Test.php
+++ b/tests/phpunit/Mutator/Operator/Throw_Test.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Operator;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class Throw_Test extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class Throw_Test extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes the throw statement' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ProfileListProvider.php
+++ b/tests/phpunit/Mutator/ProfileListProvider.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\Mutator;
 use function array_filter;
 use const ARRAY_FILTER_USE_KEY;
 use function array_values;
-use Generator;
 use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\ProfileList;
@@ -69,14 +68,14 @@ final class ProfileListProvider
     {
     }
 
-    public static function mutatorNameAndClassProvider(): Generator
+    public static function mutatorNameAndClassProvider(): iterable
     {
         foreach (self::implementedMutatorProvider() as [$filePath, $className, $shortClassName]) {
             yield [$shortClassName, $className];
         }
     }
 
-    public static function implementedMutatorProvider(): Generator
+    public static function implementedMutatorProvider(): iterable
     {
         if (self::$mutators !== null) {
             yield from self::$mutators;
@@ -145,7 +144,7 @@ final class ProfileListProvider
         return self::$profileConstants;
     }
 
-    public static function profileProvider(): Generator
+    public static function profileProvider(): iterable
     {
         foreach (self::getProfiles() as $profile => $profileOrMutators) {
             yield $profile => [

--- a/tests/phpunit/Mutator/Regex/PregMatchMatchesTest.php
+++ b/tests/phpunit/Mutator/Regex/PregMatchMatchesTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Regex;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class PregMatchMatchesTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class PregMatchMatchesTest extends AbstractMutatorTestCase
         $this->doTest($input, $output);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates ' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Regex/PregQuoteTest.php
+++ b/tests/phpunit/Mutator/Regex/PregQuoteTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Regex;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class PregQuoteTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class PregQuoteTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Removal;
 
-use Generator;
 use Infection\Mutator\Removal\ArrayItemRemovalConfig;
 use InvalidArgumentException;
 use const PHP_INT_MAX;
@@ -99,7 +98,7 @@ final class ArrayItemRemovalConfigTest extends TestCase
         }
     }
 
-    public function settingsProvider(): Generator
+    public function settingsProvider(): iterable
     {
         yield 'default' => [
             [],

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Removal;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class ArrayItemRemovalTest extends AbstractMutatorTestCase
@@ -51,7 +50,7 @@ final class ArrayItemRemovalTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected, $settings);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It does not mutate empty arrays' => [
             '<?php $a = [];',

--- a/tests/phpunit/Mutator/Removal/CloneRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/CloneRemovalTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Removal;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class CloneRemovalTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class CloneRemovalTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes clone from expression clone-new' => [
           <<<'PHP'

--- a/tests/phpunit/Mutator/Removal/FunctionCallRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/FunctionCallRemovalTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Removal;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class FunctionCallRemovalTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class FunctionCallRemovalTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes a function call without parameters' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Removal/MethodCallRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/MethodCallRemovalTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Removal;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class MethodCallRemovalTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class MethodCallRemovalTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It removes a method call without parameters' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use function Safe\file_get_contents;
 use function Safe\sprintf;
@@ -55,7 +54,7 @@ final class ArrayOneItemTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates when return typehint is not nullable array' => [
             $this->getFileContent('mutates-not-nullable-array.php'),

--- a/tests/phpunit/Mutator/ReturnValue/FloatNegationTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/FloatNegationTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class FloatNegationTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class FloatNegationTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates negative float return to positive' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use function Safe\file_get_contents;
 use function Safe\sprintf;
@@ -55,7 +54,7 @@ final class FunctionCallTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It does not mutate with not nullable return typehint' => [
             $this->getFileContent('fc-not-mutates-with-not-nullable-typehint.php'),

--- a/tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt\Return_;
@@ -52,7 +51,7 @@ final class IntegerNegationTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates negative -1 int return to positive' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use function Safe\file_get_contents;
 use function Safe\sprintf;
@@ -58,7 +57,7 @@ final class NewObjectTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It does not mutate if no class name found' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ReturnValue/ThisTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/ThisTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ReturnValue;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 use function Safe\file_get_contents;
 use function Safe\sprintf;
@@ -55,7 +54,7 @@ final class ThisTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It does mutate with no typehint' => [
             $this->getFileContent('this_return-this.php'),

--- a/tests/phpunit/Mutator/Sort/SpaceshipTest.php
+++ b/tests/phpunit/Mutator/Sort/SpaceshipTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Sort;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class SpaceshipTest extends AbstractMutatorTestCase
@@ -55,7 +54,7 @@ final class SpaceshipTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It swaps spaceship operators' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayChangeKeyCaseTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayChangeKeyCaseTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayChangeKeyCaseTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayChangeKeyCaseTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayChunkTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayChunkTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayChunkTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayChunkTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayColumnTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayColumnTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayColumnTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayColumnTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayCombineTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayCombineTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayCombineTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayCombineTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffAssocTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayDiffAssocTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayDiffAssocTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffKeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffKeyTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayDiffKeyTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayDiffKeyTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayDiffTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayDiffTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUassocTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayDiffUassocTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayDiffUassocTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUkeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUkeyTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayDiffUkeyTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayDiffUkeyTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayFilterTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayFilterTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayFilterTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayFilterTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayFlipTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayFlipTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayFlipTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayFlipTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectAssocTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayIntersectAssocTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayIntersectAssocTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectKeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectKeyTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayIntersectKeyTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayIntersectKeyTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayIntersectTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayIntersectTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUassocTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayIntersectUassocTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayIntersectUassocTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUkeyTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUkeyTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayIntersectUkeyTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayIntersectUkeyTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayKeysTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayKeysTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayKeysTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayKeysTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayMapTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayMapTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayMapTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayMapTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeRecursiveTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeRecursiveTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayMergeRecursiveTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayMergeRecursiveTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayMergeTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayMergeTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayPadTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayPadTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayPadTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayPadTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReduceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReduceTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayReduceTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayReduceTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when the $initial parameter is provided as an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceRecursiveTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceRecursiveTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayReplaceRecursiveTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayReplaceRecursiveTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayReplaceTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayReplaceTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayReverseTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayReverseTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayReverseTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayReverseTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArraySliceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArraySliceTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArraySliceTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArraySliceTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArraySpliceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArraySpliceTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArraySpliceTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArraySpliceTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffAssocTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayUdiffAssocTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayUdiffAssocTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayUdiffTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayUdiffTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffUassocTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayUdiffUassocTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayUdiffUassocTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectAssocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectAssocTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayUintersectAssocTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayUintersectAssocTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayUintersectTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayUintersectTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectUassocTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectUassocTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayUintersectUassocTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayUintersectUassocTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayUniqueTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayUniqueTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayUniqueTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayUniqueTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapArrayValuesTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapArrayValuesTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapArrayValuesTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapArrayValuesTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an array' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapLcFirstTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapLcFirstTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapLcFirstTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapLcFirstTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrRepeatTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrRepeatTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapStrRepeatTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapStrRepeatTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrReplaceTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrReplaceTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapStrReplaceTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapStrReplaceTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrToLowerTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrToLowerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapStrToLowerTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapStrToLowerTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapStrToUpperTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapStrToUpperTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapStrToUpperTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapStrToUpperTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with an string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapTrimTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapTrimTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapTrimTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapTrimTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapUcFirstTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapUcFirstTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapUcFirstTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapUcFirstTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/Unwrap/UnwrapUcWordsTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapUcWordsTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\Unwrap;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class UnwrapUcWordsTest extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class UnwrapUcWordsTest extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates correctly when provided with a string' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ZeroIteration/For_Test.php
+++ b/tests/phpunit/Mutator/ZeroIteration/For_Test.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ZeroIteration;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class For_Test extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class For_Test extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates to false in for loop condition' => [
             <<<'PHP'

--- a/tests/phpunit/Mutator/ZeroIteration/Foreach_Test.php
+++ b/tests/phpunit/Mutator/ZeroIteration/Foreach_Test.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutator\ZeroIteration;
 
-use Generator;
 use Infection\Tests\Mutator\AbstractMutatorTestCase;
 
 final class Foreach_Test extends AbstractMutatorTestCase
@@ -50,7 +49,7 @@ final class Foreach_Test extends AbstractMutatorTestCase
         $this->doTest($input, $expected);
     }
 
-    public function mutationsProvider(): Generator
+    public function mutationsProvider(): iterable
     {
         yield 'It mutates to new array in foreach' => [
             <<<'PHP'

--- a/tests/phpunit/PhpParser/FileParserTest.php
+++ b/tests/phpunit/PhpParser/FileParserTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\PhpParser;
 
-use Generator;
 use Infection\PhpParser\FileParser;
 use Infection\PhpParser\UnparsableFile;
 use Infection\Tests\SingletonContainer;
@@ -129,7 +128,7 @@ final class FileParserTest extends TestCase
         }
     }
 
-    public function fileToParserProvider(): Generator
+    public function fileToParserProvider(): iterable
     {
         yield 'empty file' => [
             self::createFileInfo('/unknown', ''),

--- a/tests/phpunit/PhpParser/MutatedNodeTest.php
+++ b/tests/phpunit/PhpParser/MutatedNodeTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\PhpParser;
 
-use Generator;
 use Infection\PhpParser\MutatedNode;
 use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
@@ -54,7 +53,7 @@ final class MutatedNodeTest extends TestCase
         $this->assertSame($node, $mutatedNode->unwrap());
     }
 
-    public function nodeProvider(): Generator
+    public function nodeProvider(): iterable
     {
         yield 'single node' => [new Node\Scalar\LNumber(1)];
 

--- a/tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameVisitorTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\PhpParser\Visitor;
 
 use function array_map;
-use Generator;
 use Infection\PhpParser\Visitor\FullyQualifiedClassNameVisitor;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
@@ -76,7 +75,7 @@ final class FullyQualifiedClassNameVisitorTest extends BaseVisitorTest
         $this->assertSame($expectedProcessedNodesFqcn, $actualProcessedNodesFqcn);
     }
 
-    public function codeProvider(): Generator
+    public function codeProvider(): iterable
     {
         yield [
             'Fqcn/fqcn-empty-class.php',

--- a/tests/phpunit/PhpParser/Visitor/IgnoreNode/InterfaceIgnorerTest.php
+++ b/tests/phpunit/PhpParser/Visitor/IgnoreNode/InterfaceIgnorerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\PhpParser\Visitor\IgnoreNode;
 
-use Generator;
 use Infection\PhpParser\Visitor\IgnoreNode\InterfaceIgnorer;
 use Infection\PhpParser\Visitor\IgnoreNode\NodeIgnorer;
 
@@ -53,7 +52,7 @@ final class InterfaceIgnorerTest extends BaseNodeIgnorerTestCase
         $this->assertSame($count, $spy->nodeCounter);
     }
 
-    public function provideIgnoreCases(): Generator
+    public function provideIgnoreCases(): iterable
     {
         yield 'interfaces are ignored' => [
             <<<'PHP'

--- a/tests/phpunit/PhpParser/Visitor/IgnoreNode/PhpUnitCodeCoverageAnnotationIgnorerTest.php
+++ b/tests/phpunit/PhpParser/Visitor/IgnoreNode/PhpUnitCodeCoverageAnnotationIgnorerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\PhpParser\Visitor\IgnoreNode;
 
-use Generator;
 use Infection\PhpParser\Visitor\IgnoreNode\NodeIgnorer;
 use Infection\PhpParser\Visitor\IgnoreNode\PhpUnitCodeCoverageAnnotationIgnorer;
 
@@ -53,7 +52,7 @@ final class PhpUnitCodeCoverageAnnotationIgnorerTest extends BaseNodeIgnorerTest
         $this->assertSame($count, $spy->nodeCounter);
     }
 
-    public function provideIgnoreCases(): Generator
+    public function provideIgnoreCases(): iterable
     {
         yield 'classes with annotation are ignored' => [
             <<<'PHP'

--- a/tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\PhpParser\Visitor;
 
-use Generator;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
 use Infection\PhpParser\MutatedNode;
@@ -74,7 +73,7 @@ final class MutatorVisitorTest extends BaseVisitorTest
         $this->assertSame($expectedCodeOutput, StringNormalizer::normalizeString($output));
     }
 
-    public function providesMutationCases(): Generator
+    public function providesMutationCases(): iterable
     {
         yield 'it mutates the correct node' => (function () {
             return [

--- a/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\PhpParser\Visitor;
 
-use Generator;
 use Infection\PhpParser\Visitor\FullyQualifiedClassNameVisitor;
 use Infection\PhpParser\Visitor\ParentConnectorVisitor;
 use Infection\PhpParser\Visitor\ReflectionVisitor;
@@ -194,7 +193,7 @@ final class ReflectionVisitorTest extends BaseVisitorTest
         $this->assertSame(Bug2::class, $reflectionSpyVisitor->createAnonymousClassReflectionClass->getName());
     }
 
-    public function isPartOfSignatureFlagProvider(): Generator
+    public function isPartOfSignatureFlagProvider(): iterable
     {
         yield [Node\Stmt\ClassMethod::class, true];
 

--- a/tests/phpunit/Process/Runner/Parallel/ParallelProcessRunnerTest.php
+++ b/tests/phpunit/Process/Runner/Parallel/ParallelProcessRunnerTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Process\Runner\Parallel;
 
 use Closure;
-use Generator;
 use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\MutantProcessWasFinished;
 use Infection\Mutant\MutantExecutionResult;
@@ -71,7 +70,7 @@ final class ParallelProcessRunnerTest extends TestCase
 
     public function test_it_checks_for_timeout(): void
     {
-        $processes = (function (): Generator {
+        $processes = (function (): iterable {
             for ($i = 0; $i < 10; ++$i) {
                 yield $this->buildMutantProcessWithTimeout();
             }

--- a/tests/phpunit/Process/Runner/TestRunConstraintCheckerTest.php
+++ b/tests/phpunit/Process/Runner/TestRunConstraintCheckerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Process\Runner;
 
-use Generator;
 use Infection\Mutant\MetricsCalculator;
 use Infection\Process\Runner\TestRunConstraintChecker;
 use PHPUnit\Framework\TestCase;
@@ -240,7 +239,7 @@ final class TestRunConstraintCheckerTest extends TestCase
         $this->assertSame($expected, $constraintChecker->isActualOverRequired());
     }
 
-    public function isMsiOverMinimumMsiProvider(): Generator
+    public function isMsiOverMinimumMsiProvider(): iterable
     {
         $minMsi = 10.0;
 

--- a/tests/phpunit/Reflection/ClassReflectionTestCase.php
+++ b/tests/phpunit/Reflection/ClassReflectionTestCase.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Reflection;
 
-use Generator;
 use Infection\PhpParser\Visitor\CloneVisitor;
 use Infection\Reflection\ClassReflection;
 use Infection\Reflection\Visibility;
@@ -55,7 +54,7 @@ abstract class ClassReflectionTestCase extends TestCase
         $this->assertSame($hasParent, $reflection->hasParentMethodWithVisibility($method, $visibility));
     }
 
-    public function provideParentMethodCases(): Generator
+    public function provideParentMethodCases(): iterable
     {
         yield [
             $this->createFromName(CloneVisitor::class),

--- a/tests/phpunit/Resource/Memory/MemoryFormatterTest.php
+++ b/tests/phpunit/Resource/Memory/MemoryFormatterTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Resource\Memory;
 
-use Generator;
 use Infection\Resource\Memory\MemoryFormatter;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -76,7 +75,7 @@ final class MemoryFormatterTest extends TestCase
         }
     }
 
-    public function bytesProvider(): Generator
+    public function bytesProvider(): iterable
     {
         yield [0., '0.00B'];
 

--- a/tests/phpunit/Resource/Time/StopwatchTest.php
+++ b/tests/phpunit/Resource/Time/StopwatchTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Resource\Time;
 
-use Generator;
 use Infection\Resource\Time\Stopwatch;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -102,7 +101,7 @@ final class StopwatchTest extends TestCase
         }
     }
 
-    public function timeProvider(): Generator
+    public function timeProvider(): iterable
     {
         yield 'no time' => [0, 0.];
 

--- a/tests/phpunit/Resource/Time/TimeFormatterTest.php
+++ b/tests/phpunit/Resource/Time/TimeFormatterTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Resource\Time;
 
-use Generator;
 use Infection\Resource\Time\TimeFormatter;
 use PHPUnit\Framework\TestCase;
 
@@ -61,7 +60,7 @@ final class TimeFormatterTest extends TestCase
         $this->assertSame($expectedString, $timeString);
     }
 
-    public function timeProvider(): Generator
+    public function timeProvider(): iterable
     {
         foreach (self::secondsProvider() as $i => $set) {
             yield 'seconds#' . $i => $set;
@@ -76,7 +75,7 @@ final class TimeFormatterTest extends TestCase
         }
     }
 
-    private static function secondsProvider(): Generator
+    private static function secondsProvider(): iterable
     {
         yield [0, '0s'];
 
@@ -93,7 +92,7 @@ final class TimeFormatterTest extends TestCase
         yield [31.01, '31s'];
     }
 
-    private static function minutesProvider(): Generator
+    private static function minutesProvider(): iterable
     {
         yield [60, '1m'];
 
@@ -106,7 +105,7 @@ final class TimeFormatterTest extends TestCase
         yield [122.9, '2m 2s'];
     }
 
-    private static function hoursProvider(): Generator
+    private static function hoursProvider(): iterable
     {
         yield [3600, '1h'];
 

--- a/tests/phpunit/StrTest.php
+++ b/tests/phpunit/StrTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests;
 
-use Generator;
 use Infection\Str;
 use PHPUnit\Framework\TestCase;
 
@@ -52,7 +51,7 @@ final class StrTest extends TestCase
         );
     }
 
-    public function stringProvider(): Generator
+    public function stringProvider(): iterable
     {
         yield 'empty' => [
             '',

--- a/tests/phpunit/StringNormalizerTest.php
+++ b/tests/phpunit/StringNormalizerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests;
 
-use Generator;
 use PHPUnit\Framework\TestCase;
 
 final class StringNormalizerTest extends TestCase
@@ -50,7 +49,7 @@ final class StringNormalizerTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function stringValuesProvider(): Generator
+    public function stringValuesProvider(): iterable
     {
         yield 'empty' => ['', ''];
 

--- a/tests/phpunit/TestFramework/Coverage/CoverageHelperTest.php
+++ b/tests/phpunit/TestFramework/Coverage/CoverageHelperTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Coverage;
 
-use Generator;
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 use Infection\TestFramework\Coverage\CoverageReport;
 use Infection\TestFramework\Coverage\MethodLocationData;
@@ -53,7 +52,7 @@ final class CoverageHelperTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function coverageProvider(): Generator
+    public function coverageProvider(): iterable
     {
         yield 'empty' => [[], []];
 

--- a/tests/phpunit/TestFramework/Coverage/LineRangeCalculatorTest.php
+++ b/tests/phpunit/TestFramework/Coverage/LineRangeCalculatorTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Coverage;
 
-use Generator;
 use Infection\PhpParser\Visitor\ParentConnectorVisitor;
 use Infection\TestFramework\Coverage\LineRangeCalculator;
 use Infection\Tests\SingletonContainer;
@@ -65,7 +64,7 @@ final class LineRangeCalculatorTest extends TestCase
         $this->assertSame($nodeRange, $range);
     }
 
-    public function provideCodeAndRangeCases(): Generator
+    public function provideCodeAndRangeCases(): iterable
     {
         /* @see https://github.com/infection/infection/issues/815 */
         yield 'Code from original issue 815' => [

--- a/tests/phpunit/TestFramework/Coverage/NodeLineRangeDataTest.php
+++ b/tests/phpunit/TestFramework/Coverage/NodeLineRangeDataTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Coverage;
 
-use Generator;
 use Infection\TestFramework\Coverage\NodeLineRangeData;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -58,7 +57,7 @@ final class NodeLineRangeDataTest extends TestCase
         $this->assertSame($expected, $range->range);
     }
 
-    public function providesLineRanges(): Generator
+    public function providesLineRanges(): iterable
     {
         yield 'Single line range' => [10, 10, [10]];
 

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpUnit\Adapter;
 
 use function array_map;
-use Generator;
 use Infection\PhpParser\Visitor\IgnoreNode\PhpUnitCodeCoverageAnnotationIgnorer;
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 use Infection\TestFramework\CommandLineBuilder;
@@ -121,7 +120,7 @@ final class PhpUnitAdapterTest extends TestCase
         );
     }
 
-    public function outputProvider(): Generator
+    public function outputProvider(): iterable
     {
         yield ['OK, but incomplete, skipped, or risky tests!', true];
 
@@ -132,7 +131,7 @@ final class PhpUnitAdapterTest extends TestCase
         yield ['ERRORS!', false];
     }
 
-    public function memoryReportProvider(): Generator
+    public function memoryReportProvider(): iterable
     {
         yield ['Memory: 8.00MB', 8.0];
 

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\TestFramework\PhpUnit\Config\Builder;
 use DOMDocument;
 use DOMNodeList;
 use DOMXPath;
-use Generator;
 use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\InvalidPhpUnitConfiguration;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
@@ -363,7 +362,7 @@ XML
         );
     }
 
-    public function executionOrderProvider(): Generator
+    public function executionOrderProvider(): iterable
     {
         yield 'PHPUnit 7.1.99 runs without random test order' => [
             '7.1.99',

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -42,7 +42,6 @@ use DOMNodeList;
 use DOMXPath;
 use function escapeshellarg;
 use function exec;
-use Generator;
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 use Infection\StreamWrapper\IncludeInterceptor;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestCaseSorter;
@@ -526,7 +525,7 @@ PHP
         );
     }
 
-    public function coverageTestsProvider(): Generator
+    public function coverageTestsProvider(): iterable
     {
         yield [
             [

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpUnit\Config\Path;
 
 use DOMDocument;
-use Generator;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use function Infection\Tests\normalizePath as p;
 use PHPUnit\Framework\TestCase;
@@ -76,7 +75,7 @@ final class PathReplacerTest extends TestCase
         $this->assertSame($expectedPath, p($node->nodeValue));
     }
 
-    public function pathProvider(): Generator
+    public function pathProvider(): iterable
     {
         yield ['autoload.php', $this->projectPath . '/autoload.php'];
 

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\TestFramework\PhpUnit\Config;
 use Closure;
 use DOMDocument;
 use const E_ALL;
-use Generator;
 use Infection\TestFramework\PhpUnit\Config\InvalidPhpUnitConfiguration;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator;
@@ -669,14 +668,14 @@ XML
         );
     }
 
-    public function schemaProvider(): Generator
+    public function schemaProvider(): iterable
     {
         yield 'remote XSD' => ['https://raw.githubusercontent.com/sebastianbergmann/phpunit/7.4.0/phpunit.xsd'];
 
         yield 'local XSD' => ['./vendor/phpunit/phpunit/phpunit.xsd'];
     }
 
-    public function invalidSchemaProvider(): Generator
+    public function invalidSchemaProvider(): iterable
     {
         yield 'empty' => [
             '',

--- a/tests/phpunit/TestFramework/PhpUnit/Coverage/IndexXmlCoverageParserTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Coverage/IndexXmlCoverageParserTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpUnit\Coverage;
 
-use Generator;
 use Infection\TestFramework\Coverage\SourceFileData;
 use Infection\TestFramework\PhpUnit\Coverage\IndexXmlCoverageParser;
 use Infection\TestFramework\PhpUnit\Coverage\InvalidCoverage;
@@ -181,7 +180,7 @@ XML;
         $this->parser->parse('/path/to/index.xml', $xml);
     }
 
-    public function coverageProvider(): Generator
+    public function coverageProvider(): iterable
     {
         yield 'nominal' => [self::getXml()];
 
@@ -226,7 +225,7 @@ XML;
         }
     }
 
-    public function noCoveredLineReportProviders(): Generator
+    public function noCoveredLineReportProviders(): iterable
     {
         yield 'zero lines executed' => [<<<'XML'
 <?xml version="1.0"?>

--- a/tests/phpunit/TestFramework/TestFrameworkExtraOptionsFilterTest.php
+++ b/tests/phpunit/TestFramework/TestFrameworkExtraOptionsFilterTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework;
 
-use Generator;
 use Infection\TestFramework\TestFrameworkExtraOptionsFilter;
 use PHPUnit\Framework\TestCase;
 
@@ -53,7 +52,7 @@ final class TestFrameworkExtraOptionsFilterTest extends TestCase
         $this->assertSame($expectedExtraOptions, $filteredOptions);
     }
 
-    public function mutantProcessProvider(): Generator
+    public function mutantProcessProvider(): iterable
     {
         yield ['--filter=someTest#2 --a --b=value', '--a --b=value'];
 

--- a/tests/phpunit/TestFramework/VersionParserTest.php
+++ b/tests/phpunit/TestFramework/VersionParserTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework;
 
-use Generator;
 use Infection\TestFramework\VersionParser;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -76,7 +75,7 @@ final class VersionParserTest extends TestCase
         }
     }
 
-    public function versionProvider(): Generator
+    public function versionProvider(): iterable
     {
         yield 'nominal stable' => ['7.0.2', '7.0.2'];
 


### PR DESCRIPTION
`Generator` type declaration is, in principle, an implementation detail. Like all implementation details, it should not be exposed without a reason, e.g. when one wants a consumer to really use the return value as a generator by calling its methods. 

- If not, even for private APIs we inconvenience ourselves to mock generators in tests, where a simple array would be sufficient. For public APIs this is a definite inconvenience.
- Public APIs declaring this return type make a lock-in with a type one may not want to use in the future, e.g. we may need to return a custom iterator instead.  Using `iterable` avoids any BC breaks if you happen to want that.

Although this is not a big deal in tests, it will be inconsistent with other code where you normally try to avoid declaring generators due to above reasons. If we consider consistency is important, and if there isn't a specific reason to use this concrete return type, I propose to stick with the `iterable`.

(There's one place where we actually use return value as a Generator, and another, where PHPStan can't infer it's a generator from use of yield.)