### PR TITLE
Improve usage of IndexXmlCoverageReader

### DIFF
--- a/src/TestFramework/Coverage/CoverageChecker.php
+++ b/src/TestFramework/Coverage/CoverageChecker.php
@@ -46,7 +46,6 @@ use const PHP_SAPI;
 use function Safe\preg_match;
 use function Safe\sprintf;
 use function strtolower;
-use Webmozart\PathUtil\Path;
 
 /**
  * @internal
@@ -62,6 +61,7 @@ final class CoverageChecker
     private $coveragePath;
     private $jUnitPath;
     private $frameworkAdapterName;
+    private $indexXmlCoverageReader;
 
     public function __construct(
         bool $skipCoverage,
@@ -69,7 +69,8 @@ final class CoverageChecker
         string $initialTestPhpOptions,
         string $coveragePath,
         ?string $jUnitPath,
-        string $testFrameworkAdapterName
+        string $testFrameworkAdapterName,
+        IndexXmlCoverageReader $indexXmlCoverageReader
     ) {
         $this->skipCoverage = $skipCoverage;
         $this->skipInitialTests = $skipInitialTests;
@@ -77,6 +78,7 @@ final class CoverageChecker
         $this->coveragePath = $coveragePath;
         $this->jUnitPath = $jUnitPath;
         $this->frameworkAdapterName = strtolower($testFrameworkAdapterName);
+        $this->indexXmlCoverageReader = $indexXmlCoverageReader;
     }
 
     public function checkCoverageRequirements(): void
@@ -106,7 +108,7 @@ TXT
 
     public function checkCoverageExists(): void
     {
-        $coverageIndexFilePath = $this->getCoverageIndexFilePath();
+        $coverageIndexFilePath = $this->indexXmlCoverageReader->getIndexXmlPath();
 
         if (!file_exists($coverageIndexFilePath)) {
             $message = sprintf(
@@ -156,7 +158,7 @@ TXT
     ): void {
         $errors = [];
 
-        $coverageIndexFilePath = $this->getCoverageIndexFilePath();
+        $coverageIndexFilePath = $this->indexXmlCoverageReader->getIndexXmlPath();
 
         if (!file_exists($coverageIndexFilePath)) {
             $errors[] = sprintf('- The file "%s" could not be found', $coverageIndexFilePath);
@@ -215,13 +217,6 @@ TXT
         return (bool) preg_match(
             '/(extension\s*=.*pcov.*)/mi',
             $this->initialTestPhpOptions
-        );
-    }
-
-    private function getCoverageIndexFilePath(): string
-    {
-        return Path::canonicalize(
-            (new IndexXmlCoverageReader($this->coveragePath))->getIndexXmlPath()
         );
     }
 }

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageReader.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageReader.php
@@ -37,6 +37,7 @@ namespace Infection\TestFramework\Coverage\XmlReport;
 
 use const DIRECTORY_SEPARATOR;
 use function Safe\file_get_contents;
+use Webmozart\PathUtil\Path;
 
 /**
  * @internal
@@ -46,20 +47,22 @@ class IndexXmlCoverageReader
 {
     private const COVERAGE_INDEX_FILE_NAME = 'index.xml';
 
-    private $coverageDir;
+    private $path;
 
     public function __construct(string $coverageDir)
     {
-        $this->coverageDir = $coverageDir;
+        $this->path = Path::canonicalize(
+            $coverageDir . DIRECTORY_SEPARATOR . self::COVERAGE_INDEX_FILE_NAME
+        );
     }
 
     public function getIndexXmlPath(): string
     {
-        return $this->coverageDir . DIRECTORY_SEPARATOR . self::COVERAGE_INDEX_FILE_NAME;
+        return $this->path;
     }
 
     public function getIndexXmlContent(): string
     {
-        return file_get_contents($this->getIndexXmlPath());
+        return file_get_contents($this->path);
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/CoverageCheckerTest.php
+++ b/tests/phpunit/TestFramework/Coverage/CoverageCheckerTest.php
@@ -36,9 +36,9 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage;
 
 use function extension_loaded;
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\TestFramework\Coverage\CoverageChecker;
 use Infection\TestFramework\Coverage\CoverageNotFound;
+use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageReader;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
 use const PHP_SAPI;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -68,14 +68,19 @@ final class CoverageCheckerTest extends TestCase
     private static $jUnit;
 
     /**
-     * @var TestFrameworkAdapter|MockObject
+     * @var IndexXmlCoverageReader|MockObject
      */
-    private $testFrameworkAdapterMock;
+    private $indexXmlCoverageReaderMock;
 
     public static function setUpBeforeClass(): void
     {
         self::$coveragePath = Path::canonicalize(__DIR__ . '/../../Fixtures/Files/phpunit/coverage/coverage-xml');
         self::$jUnit = Path::canonicalize(__DIR__ . '/../../Fixtures/Files/phpunit/junit.xml');
+    }
+
+    protected function setUp(): void
+    {
+        $this->indexXmlCoverageReaderMock = $this->createMock(IndexXmlCoverageReader::class);
     }
 
     public function test_it_needs_coverage_to_be_provided_if_initial_tests_are_skipped_without_JUnit_report(): void
@@ -86,8 +91,14 @@ final class CoverageCheckerTest extends TestCase
             '',
             '',
             null,
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
 
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage(
@@ -106,8 +117,14 @@ final class CoverageCheckerTest extends TestCase
             '',
             '',
             '/path/to/junit.xml',
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
 
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage(
@@ -130,8 +147,14 @@ final class CoverageCheckerTest extends TestCase
             '',
             '',
             '',
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
 
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage(<<<TXT
@@ -155,8 +178,14 @@ TXT
             '',
             self::$coveragePath,
             self::$jUnit,
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn(self::$coveragePath . '/index.xml')
+        ;
 
         $checker->checkCoverageExists();
 
@@ -171,8 +200,14 @@ TXT
             '',
             self::$coveragePath,
             self::$jUnit,
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn(self::$coveragePath . '/index.xml')
+        ;
 
         $checker->checkCoverageExists();
 
@@ -187,8 +222,14 @@ TXT
             '',
             '/nowhere',
             self::$jUnit,
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn('/nowhere/index.xml')
+        ;
 
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage(
@@ -207,8 +248,14 @@ TXT
             '',
             '/nowhere',
             self::$jUnit,
-            'phpunit'
+            'phpunit',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn('/nowhere/index.xml')
+        ;
 
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage(
@@ -228,8 +275,14 @@ TXT
             '',
             '/nowhere',
             self::$jUnit,
-            'codeception'
+            'codeception',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn('/nowhere/index.xml')
+        ;
 
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage(
@@ -249,8 +302,14 @@ TXT
             '',
             self::$coveragePath,
             null,
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn(self::$coveragePath . '/index.xml')
+        ;
 
         $checker->checkCoverageExists();
 
@@ -265,8 +324,14 @@ TXT
             '',
             self::$coveragePath,
             '/invalid/path/to/junit.xml',
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn(self::$coveragePath . '/index.xml')
+        ;
 
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage(sprintf(
@@ -289,8 +354,14 @@ TXT
             '',
             self::$coveragePath,
             '/invalid/path/to/junit.xml',
-            'phpunit'
+            'phpunit',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn(self::$coveragePath . '/index.xml')
+        ;
 
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage(sprintf(
@@ -311,8 +382,14 @@ TXT
             '',
             self::$coveragePath,
             '/invalid/path/to/junit.xml',
-            'codeception'
+            'codeception',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn(self::$coveragePath . '/index.xml')
+        ;
 
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage('Could not find the file "/invalid/path/to/junit.xml". Please'
@@ -331,8 +408,14 @@ TXT
             '',
             self::$coveragePath,
             self::$jUnit,
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn(self::$coveragePath . '/index.xml')
+        ;
 
         $checker->checkCoverageHasBeenGenerated(
             'bin/phpunit --coverage-xml=coverage/coverage-xml --log-junit=coverage=junit.xml',
@@ -350,8 +433,14 @@ TXT
             '',
             self::$coveragePath,
             self::$jUnit,
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn(self::$coveragePath . '/index.xml')
+        ;
 
         $checker->checkCoverageHasBeenGenerated(
             'bin/phpunit --coverage-xml=coverage/coverage-xml --log-junit=coverage=junit.xml',
@@ -369,8 +458,14 @@ TXT
             '',
             '/nowhere',
             self::$jUnit,
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn('/nowhere/index.xml')
+        ;
 
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage(<<<'TXT'
@@ -403,8 +498,14 @@ TXT
             '',
             $coveragePath,
             '/invalid/path/to/junit.xml',
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn(self::$coveragePath . '/index.xml')
+        ;
 
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage(<<<'TXT'
@@ -435,8 +536,14 @@ TXT
             '',
             self::$coveragePath,
             null,
-            'unknown'
+            'unknown',
+            $this->indexXmlCoverageReaderMock
         );
+
+        $this->indexXmlCoverageReaderMock
+            ->method('getIndexXmlPath')
+            ->willReturn(self::$coveragePath . '/index.xml')
+        ;
 
         $checker->checkCoverageHasBeenGenerated(
             'bin/phpunit --coverage-xml=coverage/coverage-xml --log-junit=coverage=junit.xml',

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageReaderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageReaderTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\TestFramework\Coverage\XmlReport;
 
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageReader;
 use PHPUnit\Framework\TestCase;
+use function Infection\Tests\normalizePath;
 use function Safe\file_get_contents;
 use function Safe\realpath;
 
@@ -51,7 +52,7 @@ final class IndexXmlCoverageReaderTest extends TestCase
     {
         $reader = new IndexXmlCoverageReader(self::COVERAGE_DIR);
 
-        $expectedIndexPath = realpath(self::COVERAGE_DIR . '/index.xml');
+        $expectedIndexPath = normalizePath(realpath(self::COVERAGE_DIR . '/index.xml'));
 
         $this->assertSame(
             $expectedIndexPath,

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageReaderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageReaderTest.php
@@ -37,6 +37,8 @@ namespace Infection\Tests\TestFramework\Coverage\XmlReport;
 
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageReader;
 use PHPUnit\Framework\TestCase;
+use function Safe\file_get_contents;
+use function Safe\realpath;
 
 /**
  * @group integration
@@ -45,13 +47,31 @@ final class IndexXmlCoverageReaderTest extends TestCase
 {
     private const COVERAGE_DIR = __DIR__ . '/../../../Fixtures/Files/phpunit/coverage/coverage-xml';
 
-    public function test_it(): void
+    public function test_it_can_provide_the_PHPUnit_XML_report_index_file_path(): void
     {
         $reader = new IndexXmlCoverageReader(self::COVERAGE_DIR);
 
-        $this->assertStringStartsWith(self::COVERAGE_DIR, $reader->getIndexXmlPath());
-        $this->assertStringEndsWith('index.xml', $reader->getIndexXmlPath());
+        $expectedIndexPath = realpath(self::COVERAGE_DIR . '/index.xml');
 
-        $this->assertStringEqualsFile(self::COVERAGE_DIR . '/index.xml', $reader->getIndexXmlContent());
+        $this->assertSame(
+            $expectedIndexPath,
+            $reader->getIndexXmlPath()
+        );
+    }
+
+    public function test_it_does_not_check_the_file_existence_when_retrieving_the_index_file_path(): void
+    {
+        $reader = new IndexXmlCoverageReader('/nowhere');
+
+        $this->assertSame('/nowhere/index.xml', $reader->getIndexXmlPath());
+    }
+
+    public function test_it_can_provide_the_PHPUnit_XML_report_index_file_content(): void
+    {
+        $reader = new IndexXmlCoverageReader(self::COVERAGE_DIR);
+
+        $expectedContents = file_get_contents(self::COVERAGE_DIR . '/index.xml');
+
+        $this->assertSame($expectedContents, $reader->getIndexXmlContent());
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageReaderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageReaderTest.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage\XmlReport;
 
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageReader;
-use PHPUnit\Framework\TestCase;
 use function Infection\Tests\normalizePath;
+use PHPUnit\Framework\TestCase;
 use function Safe\file_get_contents;
 use function Safe\realpath;
 


### PR DESCRIPTION
- Inject the `IndexXmlCoverageReader`
- Canonicalize the index file path
- Calculate the index file path only once