### PR TITLE
Rename LineCodeCoverage to Trace

### DIFF
--- a/doc/nomenclature.md
+++ b/doc/nomenclature.md
@@ -1,0 +1,27 @@
+# Nomenclature
+
+## Table of Contents
+
+- [T](#t)
+  - [Tracer][tracer]
+  - [Trace][trace]
+
+
+## T
+
+### Tracer
+
+A tool responsible for creating a bound, a [_trace_][trace], between a piece of source code and the
+test source which executes it. The tracer can work one way, i.e. find the corresponding test(s) for
+a given piece of source code. It may also work the other way around or both ways.
+
+
+### Trace
+
+Artifact produced by a tracer: provides the piece of source code and its associated tests. 
+
+
+<hr />
+
+[tracer]: #tracer
+[trace]: #trace

--- a/doc/nomenclature.md
+++ b/doc/nomenclature.md
@@ -18,7 +18,7 @@ a given piece of source code. It may also work the other way around or both ways
 
 ### Trace
 
-Artifact produced by a tracer: provides the piece of source code and its associated tests. 
+Artifact produced by a tracer: provides the piece of source code and its associated tests.
 
 
 <hr />

--- a/src/Container.php
+++ b/src/Container.php
@@ -167,7 +167,7 @@ final class Container
             },
             FilteredEnrichedTraceProvider::class => static function (self $container): FilteredEnrichedTraceProvider {
                 return new FilteredEnrichedTraceProvider(
-                    $container->getPhpUnitXmlCoveredFileDataProvider(),
+                    $container->getPhpUnitXmlCoverageTraceProvider(),
                     $container->getJUnitTestExecutionInfoAdder(),
                     $container->getSourceFileFilter(),
                     $container->getConfiguration()->getSourceFiles(),
@@ -185,7 +185,7 @@ final class Container
                     $container->getMemoizedTestFileDataProvider()
                 );
             },
-            PhpUnitXmlCoverageTraceProvider::class => static function (self $container): PhpUnitXmlCoveredFileDataProvider {
+            PhpUnitXmlCoverageTraceProvider::class => static function (self $container): PhpUnitXmlCoverageTraceProvider {
                 return new PhpUnitXmlCoverageTraceProvider(
                     $container->getIndexXmlCoverageReader(),
                     $container->getIndexXmlCoverageParser(),
@@ -197,7 +197,7 @@ final class Container
                     $container->getConfiguration()->getCoveragePath()
                 );
             },
-            TestTraceProvider::class => static function (self $container): FileCodeCoverageProvider {
+            TestTraceProvider::class => static function (): TestTraceProvider {
                 return new TestTraceProvider();
             },
             RootsFileOrDirectoryLocator::class => static function (self $container): RootsFileOrDirectoryLocator {
@@ -433,7 +433,7 @@ final class Container
 
                 return new MutationGenerator(
                     $container->getFilteredEnrichedTraceProvider(),
-                    $container->getFileCodeCoverageProvider(),
+                    $container->getTestTraceProvider(),
                     $config->getMutators(),
                     $container->getEventDispatcher(),
                     $container->getFileMutationGenerator(),
@@ -600,7 +600,7 @@ final class Container
         return $this->get(JUnitTestExecutionInfoAdder::class);
     }
 
-    public function getPhpUnitXmlCoveredFileDataProvider(): PhpUnitXmlCoverageTraceProvider
+    public function getPhpUnitXmlCoverageTraceProvider(): PhpUnitXmlCoverageTraceProvider
     {
         return $this->get(PhpUnitXmlCoverageTraceProvider::class);
     }
@@ -610,7 +610,7 @@ final class Container
         return $this->get(IndexXmlCoverageReader::class);
     }
 
-    public function getFileCodeCoverageProvider(): TestTraceProvider
+    public function getTestTraceProvider(): TestTraceProvider
     {
         return $this->get(TestTraceProvider::class);
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -89,16 +89,16 @@ use Infection\TestFramework\AdapterInstaller;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use Infection\TestFramework\Coverage\CoverageChecker;
+use Infection\TestFramework\Coverage\FilteredEnrichedTraceProvider;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
 use Infection\TestFramework\Coverage\JUnit\MemoizedTestFileDataProvider;
 use Infection\TestFramework\Coverage\JUnit\TestFileDataProvider;
 use Infection\TestFramework\Coverage\LineRangeCalculator;
-use Infection\TestFramework\Coverage\SourceFileDataFactory;
-use Infection\TestFramework\Coverage\XmlReport\FileCodeCoverageProvider;
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser;
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageReader;
-use Infection\TestFramework\Coverage\XmlReport\PhpUnitXmlCoveredFileDataProvider;
+use Infection\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProvider;
+use Infection\TestFramework\Coverage\XmlReport\TestTraceProvider;
 use Infection\TestFramework\Coverage\XmlReport\XmlCoverageParser;
 use Infection\TestFramework\Factory;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
@@ -166,8 +166,8 @@ final class Container
                 // TODO XmlCoverageParser might want to notify ProcessRunner if it can't parse another file due to lack of RAM
                 return new XmlCoverageParser();
             },
-            SourceFileDataFactory::class => static function (self $container): SourceFileDataFactory {
-                return new SourceFileDataFactory(
+            FilteredEnrichedTraceProvider::class => static function (self $container): FilteredEnrichedTraceProvider {
+                return new FilteredEnrichedTraceProvider(
                     $container->getPhpUnitXmlCoveredFileDataProvider(),
                     $container->getJUnitTestExecutionInfoAdder(),
                     $container->getSourceFileFilter(),
@@ -186,8 +186,8 @@ final class Container
                     $container->getMemoizedTestFileDataProvider()
                 );
             },
-            PhpUnitXmlCoveredFileDataProvider::class => static function (self $container): PhpUnitXmlCoveredFileDataProvider {
-                return new PhpUnitXmlCoveredFileDataProvider(
+            PhpUnitXmlCoverageTraceProvider::class => static function (self $container): PhpUnitXmlCoverageTraceProvider {
+                return new PhpUnitXmlCoverageTraceProvider(
                     new IndexXmlCoverageReader(
                         $container->getConfiguration()->getCoveragePath()
                     ),
@@ -195,8 +195,8 @@ final class Container
                     $container->getXmlCoverageParser()
                 );
             },
-            FileCodeCoverageProvider::class => static function (self $container): FileCodeCoverageProvider {
-                return new FileCodeCoverageProvider();
+            TestTraceProvider::class => static function (self $container): TestTraceProvider {
+                return new TestTraceProvider();
             },
             RootsFileOrDirectoryLocator::class => static function (self $container): RootsFileOrDirectoryLocator {
                 return new RootsFileOrDirectoryLocator(
@@ -435,7 +435,7 @@ final class Container
                 $config = $container->getConfiguration();
 
                 return new MutationGenerator(
-                    $container->getSourceFileDataFactory(),
+                    $container->getFilteredEnrichedTraceProvider(),
                     $container->getFileCodeCoverageProvider(),
                     $config->getMutators(),
                     $container->getEventDispatcher(),
@@ -588,9 +588,9 @@ final class Container
         return $this->get(XmlCoverageParser::class);
     }
 
-    public function getSourceFileDataFactory(): SourceFileDataFactory
+    public function getFilteredEnrichedTraceProvider(): FilteredEnrichedTraceProvider
     {
-        return $this->get(SourceFileDataFactory::class);
+        return $this->get(FilteredEnrichedTraceProvider::class);
     }
 
     public function getSourceFileFilter(): SourceFileFilter
@@ -603,14 +603,14 @@ final class Container
         return $this->get(JUnitTestExecutionInfoAdder::class);
     }
 
-    public function getPhpUnitXmlCoveredFileDataProvider(): PhpUnitXmlCoveredFileDataProvider
+    public function getPhpUnitXmlCoveredFileDataProvider(): PhpUnitXmlCoverageTraceProvider
     {
-        return $this->get(PhpUnitXmlCoveredFileDataProvider::class);
+        return $this->get(PhpUnitXmlCoverageTraceProvider::class);
     }
 
-    public function getFileCodeCoverageProvider(): FileCodeCoverageProvider
+    public function getFileCodeCoverageProvider(): TestTraceProvider
     {
-        return $this->get(FileCodeCoverageProvider::class);
+        return $this->get(TestTraceProvider::class);
     }
 
     public function getRootsFileOrDirectoryLocator(): RootsFileOrDirectoryLocator

--- a/src/FileSystem/SourceFileFilter.php
+++ b/src/FileSystem/SourceFileFilter.php
@@ -39,7 +39,9 @@ use function array_filter;
 use function array_map;
 use function explode;
 use Infection\FileSystem\Finder\Iterator\RealPathFilterIterator;
+use Infection\TestFramework\Coverage\ProxyTrace;
 use Iterator;
+use SplFileInfo;
 
 /**
  * @internal
@@ -73,9 +75,9 @@ class SourceFileFilter
     }
 
     /**
-     * @param iterable<object> $input
+     * @param iterable<SplFileInfo&ProxyTrace> $input
      *
-     * @return iterable<object>
+     * @return iterable<SplFileInfo&ProxyTrace>
      */
     public function filter(iterable $input): iterable
     {
@@ -91,9 +93,9 @@ class SourceFileFilter
     }
 
     /**
-     * @param iterable<object> $input
+     * @param iterable<SplFileInfo&ProxyTrace> $input
      *
-     * @return Iterator<object>
+     * @return Iterator<SplFileInfo&ProxyTrace>
      */
     private function iterableToIterator(iterable $input): Iterator
     {

--- a/src/FileSystem/SourceFileFilter.php
+++ b/src/FileSystem/SourceFileFilter.php
@@ -41,7 +41,7 @@ use function explode;
 use Infection\FileSystem\Finder\Iterator\RealPathFilterIterator;
 use Infection\TestFramework\Coverage\ProxyTrace;
 use Iterator;
-use SplFileInfo;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @internal

--- a/src/FileSystem/SourceFileFilter.php
+++ b/src/FileSystem/SourceFileFilter.php
@@ -39,9 +39,7 @@ use function array_filter;
 use function array_map;
 use function explode;
 use Infection\FileSystem\Finder\Iterator\RealPathFilterIterator;
-use Infection\TestFramework\Coverage\SourceFileData;
 use Iterator;
-use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @internal
@@ -75,9 +73,9 @@ class SourceFileFilter
     }
 
     /**
-     * @param iterable<SplFileInfo&SourceFileData> $input
+     * @param iterable<object> $input
      *
-     * @return iterable<SplFileInfo&SourceFileData>
+     * @return iterable<object>
      */
     public function filter(iterable $input): iterable
     {
@@ -93,9 +91,9 @@ class SourceFileFilter
     }
 
     /**
-     * @param iterable<SplFileInfo&SourceFileData> $input
+     * @param iterable<object> $input
      *
-     * @return Iterator<SplFileInfo&SourceFileData>
+     * @return Iterator<object>
      */
     private function iterableToIterator(iterable $input): Iterator
     {

--- a/src/Mutation/FileMutationGenerator.php
+++ b/src/Mutation/FileMutationGenerator.php
@@ -42,9 +42,9 @@ use Infection\PhpParser\NodeTraverserFactory;
 use Infection\PhpParser\UnparsableFile;
 use Infection\PhpParser\Visitor\IgnoreNode\NodeIgnorer;
 use Infection\PhpParser\Visitor\MutationsCollectorVisitor;
-use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Infection\TestFramework\Coverage\LineRangeCalculator;
-use Infection\TestFramework\Coverage\SourceFileData;
+use Infection\TestFramework\Coverage\ProxyTrace;
+use Infection\TestFramework\Coverage\Trace;
 use Webmozart\Assert\Assert;
 
 /**
@@ -76,16 +76,17 @@ class FileMutationGenerator
      * @return iterable<Mutation>
      */
     public function generate(
-        SourceFileData $fileData,
+        // TODO: rename this one once the TODO in TestTrace has been taken care of
+        ProxyTrace $fileData,
         bool $onlyCovered,
-        LineCodeCoverage $codeCoverage,
+        Trace $trace,
         array $mutators,
         array $nodeIgnorers
     ): iterable {
         Assert::allIsInstanceOf($mutators, Mutator::class);
         Assert::allIsInstanceOf($nodeIgnorers, NodeIgnorer::class);
 
-        if ($onlyCovered && !$codeCoverage->hasTests()) {
+        if ($onlyCovered && !$trace->hasTests()) {
             return;
         }
 
@@ -98,7 +99,7 @@ class FileMutationGenerator
                 $mutators,
                 $fileInfo->getPathname(),
                 $initialStatements,
-                $codeCoverage,
+                $trace,
                 $onlyCovered,
                 $this->lineRangeCalculator
             )

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -40,8 +40,8 @@ use function get_class;
 use Infection\Mutation\Mutation;
 use Infection\PhpParser\MutatedNode;
 use Infection\PhpParser\Visitor\ReflectionVisitor;
-use Infection\TestFramework\Coverage\LineCodeCoverage;
 use Infection\TestFramework\Coverage\LineRangeCalculator;
+use Infection\TestFramework\Coverage\Trace;
 use function iterator_to_array;
 use PhpParser\Node;
 use function Pipeline\take;
@@ -58,7 +58,7 @@ class NodeMutationGenerator
     private $mutators;
     private $filePath;
     private $fileNodes;
-    private $codeCoverageData;
+    private $trace;
     private $onlyCovered;
     private $lineRangeCalculator;
 
@@ -70,7 +70,7 @@ class NodeMutationGenerator
         array $mutators,
         string $filePath,
         array $fileNodes,
-        LineCodeCoverage $codeCoverageData,
+        Trace $trace,
         bool $onlyCovered,
         LineRangeCalculator $lineRangeCalculator
     ) {
@@ -79,7 +79,7 @@ class NodeMutationGenerator
         $this->mutators = $mutators;
         $this->filePath = $filePath;
         $this->fileNodes = $fileNodes;
-        $this->codeCoverageData = $codeCoverageData;
+        $this->trace = $trace;
         $this->onlyCovered = $onlyCovered;
         $this->lineRangeCalculator = $lineRangeCalculator;
     }
@@ -119,7 +119,7 @@ class NodeMutationGenerator
             return;
         }
 
-        $tests = $this->codeCoverageData->getAllTestsForMutation(
+        $tests = $this->trace->getAllTestsForMutation(
             $this->lineRangeCalculator->calculateRange($node),
             $isOnFunctionSignature
         );

--- a/src/TestFramework/Coverage/FilteredEnrichedTraceProvider.php
+++ b/src/TestFramework/Coverage/FilteredEnrichedTraceProvider.php
@@ -89,6 +89,7 @@ final class FilteredEnrichedTraceProvider implements TraceProvider
      */
     public function provideTraces(): iterable
     {
+        /** @var iterable<ProxyTrace> $traces */
         $traces = $this->filter->filter(
             $this->primaryTraceProvider->provideTraces()
         );

--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -83,7 +83,7 @@ class JUnitTestExecutionInfoAdder
     private function testExecutionInfoAdder(iterable $traces): iterable
     {
         foreach ($traces as $trace) {
-            foreach ($trace->retrieveCoverageReport()->byLine as $linesCoverageData) {
+            foreach ($trace->retrieveTestLocations()->byLine as $linesCoverageData) {
                 foreach ($linesCoverageData as $test) {
                     self::updateTestExecutionInfo($test, $this->testFileDataProvider);
                 }

--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -38,7 +38,7 @@ namespace Infection\TestFramework\Coverage\JUnit;
 use function explode;
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
-use Infection\TestFramework\Coverage\SourceFileData;
+use Infection\TestFramework\Coverage\ProxyTrace;
 
 /**
  * Adds test execution info to selected covered file data object.
@@ -62,34 +62,34 @@ class JUnitTestExecutionInfoAdder
     }
 
     /**
-     * @param iterable<SourceFileData> $coverage
+     * @param iterable<ProxyTrace> $traces
      *
-     * @return iterable<SourceFileData>
+     * @return iterable<ProxyTrace>
      */
-    public function addTestExecutionInfo(iterable $coverage): iterable
+    public function addTestExecutionInfo(iterable $traces): iterable
     {
         if (!$this->adapter->hasJUnitReport()) {
-            return $coverage;
+            return $traces;
         }
 
-        return $this->testExecutionInfoAdder($coverage);
+        return $this->testExecutionInfoAdder($traces);
     }
 
     /**
-     * @param iterable<SourceFileData> $coverage
+     * @param iterable<ProxyTrace> $traces
      *
-     * @return iterable<SourceFileData>
+     * @return iterable<ProxyTrace>
      */
-    private function testExecutionInfoAdder(iterable $coverage): iterable
+    private function testExecutionInfoAdder(iterable $traces): iterable
     {
-        foreach ($coverage as $data) {
-            foreach ($data->retrieveCoverageReport()->byLine as $linesCoverageData) {
+        foreach ($traces as $trace) {
+            foreach ($trace->retrieveCoverageReport()->byLine as $linesCoverageData) {
                 foreach ($linesCoverageData as $test) {
                     self::updateTestExecutionInfo($test, $this->testFileDataProvider);
                 }
             }
 
-            yield $data;
+            yield $trace;
         }
     }
 

--- a/src/TestFramework/Coverage/SourceFileDataProvider.php
+++ b/src/TestFramework/Coverage/SourceFileDataProvider.php
@@ -37,15 +37,11 @@ namespace Infection\TestFramework\Coverage;
 
 /**
  * @internal
- *
- * TODO: rename to TraceProvider
  */
 interface SourceFileDataProvider
 {
     /**
-     * TODO: rename to provideTraces()
-     *
-     * @return iterable<SourceFileData>
+     * @return iterable<ProxyTrace>
      */
-    public function provideFiles(): iterable;
+    public function provideTraces(): iterable;
 }

--- a/src/TestFramework/Coverage/TestLocations.php
+++ b/src/TestFramework/Coverage/TestLocations.php
@@ -33,54 +33,54 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework\Coverage;
+namespace Infection\TestFramework\Coverage;
 
-use Infection\TestFramework\Coverage\CoverageReport;
-use function is_array;
-use function is_scalar;
-use function iterator_to_array;
-use Traversable;
+use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 
-final class CoverageHelper
+/**
+ * @internal
+ *
+ * ```
+ * 'byMethod' => [
+ *      'mutate' => MethodLocationData::['startLine' => 12, 'endLine' => 16],
+ *      ...
+ * ],
+ * 'byLine' => [
+ *     22 => [
+ *         CoverageLineData::[
+ *             'testMethod' => '\A\B\C::test_it_works',
+ *             'testFilePath' => '/path/to/A/B/C.php',
+ *             'time' => 0.34325,
+ *         ],
+ *         ...
+ *      ]
+ *  ]
+ * ```
+ */
+final class TestLocations
 {
-    private function __construct()
-    {
-    }
+    /**
+     * @var array<int, array<int, CoverageLineData>>
+     */
+    public $byLine = [];
 
     /**
-     * @param array<string, CoverageReport> $coverage
+     * TODO: use a getter "get"
      *
-     * @return array<string|int, mixed>
+     * @var array<string, MethodLocationData>
      */
-    public static function convertToArray(iterable $coverage): array
+    public $byMethod = [];
+
+    /**
+     * TODO: rename CoverageLineData to TestLocation
+     * TODO: rename MethodLocationData to SourceMethodRange
+     *
+     * @param array<int, array<int, CoverageLineData>> $byLine
+     * @param array<string, MethodLocationData> $byMethod
+     */
+    public function __construct(array $byLine = [], array $byMethod = [])
     {
-        if ($coverage instanceof Traversable) {
-            $coverage = iterator_to_array($coverage, false);
-        }
-
-        return self::serializeValue($coverage);
-    }
-
-    private static function serializeValue($mixed)
-    {
-        if ($mixed === null) {
-            return null;
-        }
-
-        if (is_scalar($mixed)) {
-            return $mixed;
-        }
-
-        if (is_array($mixed)) {
-            $convertedArray = [];
-
-            foreach ($mixed as $key => $value) {
-                $convertedArray[$key] = self::serializeValue($value);
-            }
-
-            return $convertedArray;
-        }
-
-        return self::serializeValue((array) $mixed);
+        $this->byLine = $byLine;
+        $this->byMethod = $byMethod;
     }
 }

--- a/src/TestFramework/Coverage/Trace.php
+++ b/src/TestFramework/Coverage/Trace.php
@@ -33,21 +33,19 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\Coverage\XmlReport;
+namespace Infection\TestFramework\Coverage;
 
-use Infection\TestFramework\Coverage\SourceFileData;
+use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 
 /**
  * @internal
- * @final
  */
-class FileCodeCoverageProvider
+interface Trace
 {
-    public function provideFor(SourceFileData $fileData): FileCodeCoverage
-    {
-        // TODO: I'm pretty sure this step can be simplified and maybe we can
-        //  find a way to merge SourceFileData & FileCodeCoverage: they implement the same interface
-        //  and one just decorate the other so I'm not convinced this is really needed
-        return new FileCodeCoverage($fileData->retrieveCoverageReport());
-    }
+    public function hasTests(): bool;
+
+    /**
+     * @return iterable<CoverageLineData>
+     */
+    public function getAllTestsForMutation(NodeLineRangeData $lineRange, bool $isOnFunctionSignature): iterable;
 }

--- a/src/TestFramework/Coverage/TraceProvider.php
+++ b/src/TestFramework/Coverage/TraceProvider.php
@@ -38,7 +38,7 @@ namespace Infection\TestFramework\Coverage;
 /**
  * @internal
  */
-interface SourceFileDataProvider
+interface TraceProvider
 {
     /**
      * @return iterable<ProxyTrace>

--- a/src/TestFramework/Coverage/XmlReport/TestTraceProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/TestTraceProvider.php
@@ -35,44 +35,19 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Coverage\XmlReport;
 
-use Infection\TestFramework\Coverage\SourceFileData;
-use Infection\TestFramework\Coverage\SourceFileDataProvider;
+use Infection\TestFramework\Coverage\ProxyTrace;
 
 /**
- * Source of primary coverage data. Used by SourceFileDataFactory.
- *
  * @internal
  * @final
- *
- * TODO: rename to PhpUnitXmlCoverageTraceProvider: Provides the traces based on the PHPUnit XML coverage collected
  */
-class PhpUnitXmlCoveredFileDataProvider implements SourceFileDataProvider
+class TestTraceProvider
 {
-    private $indexReader;
-    private $indexParser;
-    private $parser;
-
-    public function __construct(
-        IndexXmlCoverageReader $indexReader,
-        IndexXmlCoverageParser $indexCoverageXmlParser,
-        XmlCoverageParser $coverageXmlParser
-    ) {
-        $this->indexReader = $indexReader;
-        $this->indexParser = $indexCoverageXmlParser;
-        $this->parser = $coverageXmlParser;
-    }
-
-    /**
-     * @return iterable<SourceFileData>
-     */
-    public function provideFiles(): iterable
+    public function provideFor(ProxyTrace $trace): TestTrace
     {
-        foreach ($this->indexParser->parse(
-            $this->indexReader->getIndexXmlPath(),
-            $this->indexReader->getIndexXmlContent()
-        ) as $infoProvider) {
-            // TODO It might be benificial to filter files at this stage, rather than later. SourceFileDataFactory does that.
-            yield $this->parser->parse($infoProvider);
-        }
+        // TODO: I'm pretty sure this step can be simplified and maybe we can
+        //  find a way to merge SourceFileData & FileCodeCoverage: they implement the same interface
+        //  and one just decorate the other so I'm not convinced this is really needed
+        return new TestTrace($trace->retrieveTestLocations());
     }
 }

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -63,10 +63,10 @@ use Infection\Mutator\NodeMutationGenerator;
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
 use Infection\Resource\Memory\MemoryLimiterEnvironment;
 use Infection\TestFramework\AdapterInstaller;
-use Infection\TestFramework\Coverage\CoverageReport;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
 use Infection\TestFramework\Coverage\MethodLocationData;
 use Infection\TestFramework\Coverage\NodeLineRangeData;
+use Infection\TestFramework\Coverage\TestLocations;
 use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder as PhpUnitInitalConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder as PhpUnitMutationConfigBuilder;
 use Infection\TestFramework\TestFrameworkTypes;
@@ -221,7 +221,7 @@ final class ProjectCodeProvider
                     && !in_array(
                         $className,
                         [
-                            CoverageReport::class,
+                            TestLocations::class,
                             CoverageLineData::class,
                             MethodLocationData::class,
                             NodeLineRangeData::class,

--- a/tests/phpunit/ContainerTest.php
+++ b/tests/phpunit/ContainerTest.php
@@ -134,14 +134,14 @@ final class ContainerTest extends TestCase
             ''
         );
 
-        $files = $newContainer->getSourceFileDataFactory()->provideFiles();
+        $traces = $newContainer->getFilteredEnrichedTraceProvider()->provideTraces();
 
-        $this->assertIsIterable($files);
+        $this->assertIsIterable($traces);
 
         $this->expectException(Warning::class);
         $this->expectExceptionMessage('No such file or directory');
 
-        foreach ($files as $file) {
+        foreach ($traces as $trace) {
             $this->fail();
         }
     }

--- a/tests/phpunit/FileSystem/SourceFileFilterTest.php
+++ b/tests/phpunit/FileSystem/SourceFileFilterTest.php
@@ -43,9 +43,6 @@ use function Pipeline\take;
 use Symfony\Component\Finder\SplFileInfo;
 use Traversable;
 
-/**
- * @covers \Infection\FileSystem\SourceFileFilter
- */
 final class SourceFileFilterTest extends TestCase
 {
     /**

--- a/tests/phpunit/Mutation/MutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/MutationGeneratorTest.php
@@ -118,7 +118,7 @@ final class MutationGeneratorTest extends TestCase
         $fileDataProviderMock = $this->createMock(TraceProvider::class);
         $fileDataProviderMock
             ->expects($this->exactly(1))
-            ->method('provideFiles')
+            ->method('provideTraces')
             ->willReturn([
                 $proxyTraceA,
                 $proxyTraceB,
@@ -236,7 +236,7 @@ final class MutationGeneratorTest extends TestCase
     {
         $providerMock = $this->createMock(TraceProvider::class);
         $providerMock
-            ->method('provideFiles')
+            ->method('provideTraces')
             ->willReturn(take($files)->map(static function (SplFileInfo $fileInfo) {
                 return new ProxyTrace($fileInfo, [new TestLocations()]);
             }))

--- a/tests/phpunit/Mutation/MutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/MutationGeneratorTest.php
@@ -44,11 +44,11 @@ use Infection\Mutation\Mutation;
 use Infection\Mutation\MutationGenerator;
 use Infection\Mutator\IgnoreConfig;
 use Infection\Mutator\IgnoreMutator;
-use Infection\TestFramework\Coverage\CoverageReport;
-use Infection\TestFramework\Coverage\SourceFileData;
-use Infection\TestFramework\Coverage\SourceFileDataProvider;
-use Infection\TestFramework\Coverage\XmlReport\FileCodeCoverage;
-use Infection\TestFramework\Coverage\XmlReport\FileCodeCoverageProvider;
+use Infection\TestFramework\Coverage\ProxyTrace;
+use Infection\TestFramework\Coverage\TestLocations;
+use Infection\TestFramework\Coverage\TraceProvider;
+use Infection\TestFramework\Coverage\XmlReport\TestTrace;
+use Infection\TestFramework\Coverage\XmlReport\TestTraceProvider;
 use Infection\Tests\Fixtures\Mutator\FakeMutator;
 use Infection\Tests\Fixtures\PhpParser\FakeIgnorer;
 use PHPUnit\Framework\TestCase;
@@ -63,10 +63,11 @@ final class MutationGeneratorTest extends TestCase
         $fileInfo = $this->createMock(SplFileInfo::class);
 
         // Prophecy compares arguments on equality, therefore these have to be somewhat unique
-        $fileInfoA = new SourceFileData($fileInfo, [1]);
-        $fileInfoB = new SourceFileData($fileInfo, [2]);
+        $proxyTraceA = new ProxyTrace($fileInfo, [1]);
+        $proxyTraceB = new ProxyTrace($fileInfo, [2]);
 
-        $codeCoverageMock = $this->createMock(FileCodeCoverage::class);
+        // TODO: check name and should only require to mock Trace itself
+        $testTraceMock = $this->createMock(TestTrace::class);
         $mutators = ['Fake' => new IgnoreMutator(new IgnoreConfig([]), new FakeMutator())];
         $eventDispatcherMock = $this->createMock(EventDispatcher::class);
         $onlyCovered = true;
@@ -79,7 +80,7 @@ final class MutationGeneratorTest extends TestCase
         /** @var FileMutationGenerator|ObjectProphecy $fileMutationGeneratorProphecy */
         $fileMutationGeneratorProphecy = $this->prophesize(FileMutationGenerator::class);
         $fileMutationGeneratorProphecy
-            ->generate($fileInfoA, $onlyCovered, $codeCoverageMock, $mutators, $nodeIgnorers)
+            ->generate($proxyTraceA, $onlyCovered, $testTraceMock, $mutators, $nodeIgnorers)
             ->shouldBeCalledTimes(1)
             ->willReturn([
                 $mutation0,
@@ -88,7 +89,7 @@ final class MutationGeneratorTest extends TestCase
         ;
 
         $fileMutationGeneratorProphecy
-            ->generate($fileInfoB, $onlyCovered, $codeCoverageMock, $mutators, $nodeIgnorers)
+            ->generate($proxyTraceB, $onlyCovered, $testTraceMock, $mutators, $nodeIgnorers)
             ->shouldBeCalledTimes(1)
             ->willReturn([
                 $mutation1,
@@ -96,15 +97,15 @@ final class MutationGeneratorTest extends TestCase
             ])
         ;
 
-        $providerMock = $this->createMock(FileCodeCoverageProvider::class);
+        $providerMock = $this->createMock(TestTraceProvider::class);
         $providerMock
             ->expects($this->exactly(2))
             ->method('provideFor')
             ->withConsecutive(
-                [$fileInfoA],
-                [$fileInfoB]
+                [$proxyTraceA],
+                [$proxyTraceB]
              )
-            ->willReturn($codeCoverageMock)
+            ->willReturn($testTraceMock)
         ;
 
         $expectedMutations = [
@@ -114,13 +115,13 @@ final class MutationGeneratorTest extends TestCase
             $mutation2,
         ];
 
-        $fileDataProviderMock = $this->createMock(SourceFileDataProvider::class);
+        $fileDataProviderMock = $this->createMock(TraceProvider::class);
         $fileDataProviderMock
             ->expects($this->exactly(1))
             ->method('provideFiles')
             ->willReturn([
-                $fileInfoA,
-                $fileInfoB,
+                $proxyTraceA,
+                $proxyTraceB,
             ])
         ;
 
@@ -171,7 +172,7 @@ final class MutationGeneratorTest extends TestCase
             )
         ;
 
-        $providerMock = $this->createMock(FileCodeCoverageProvider::class);
+        $providerMock = $this->createMock(TestTraceProvider::class);
 
         $mutationGenerator = new MutationGenerator(
             $this->createSourceFileDataProviderMock($sourceFiles),
@@ -216,7 +217,7 @@ final class MutationGeneratorTest extends TestCase
             )
         ;
 
-        $providerMock = $this->createMock(FileCodeCoverageProvider::class);
+        $providerMock = $this->createMock(TestTraceProvider::class);
 
         $mutationGenerator = new MutationGenerator(
             $this->createSourceFileDataProviderMock($sourceFiles),
@@ -231,13 +232,13 @@ final class MutationGeneratorTest extends TestCase
         }
     }
 
-    private function createSourceFileDataProviderMock(iterable $files): SourceFileDataProvider
+    private function createSourceFileDataProviderMock(iterable $files): TraceProvider
     {
-        $providerMock = $this->createMock(SourceFileDataProvider::class);
+        $providerMock = $this->createMock(TraceProvider::class);
         $providerMock
             ->method('provideFiles')
             ->willReturn(take($files)->map(static function (SplFileInfo $fileInfo) {
-                return new SourceFileData($fileInfo, [new CoverageReport()]);
+                return new ProxyTrace($fileInfo, [new TestLocations()]);
             }))
         ;
 

--- a/tests/phpunit/TestFramework/Coverage/FilteredEnrichedTraceProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/FilteredEnrichedTraceProviderTest.php
@@ -155,7 +155,7 @@ final class FilteredEnrichedTraceProviderTest extends TestCase
         $traceProviderMock = $this->createMock(TraceProvider::class);
         $traceProviderMock
             ->expects($this->once())
-            ->method('provideFiles')
+            ->method('provideTraces')
             ->willReturn($canary)
         ;
 

--- a/tests/phpunit/TestFramework/Coverage/FilteredEnrichedTraceProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/FilteredEnrichedTraceProviderTest.php
@@ -36,35 +36,32 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage;
 
 use Infection\FileSystem\SourceFileFilter;
+use Infection\TestFramework\Coverage\FilteredEnrichedTraceProvider;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder;
-use Infection\TestFramework\Coverage\SourceFileData;
-use Infection\TestFramework\Coverage\SourceFileDataFactory;
-use Infection\TestFramework\Coverage\SourceFileDataProvider;
+use Infection\TestFramework\Coverage\ProxyTrace;
+use Infection\TestFramework\Coverage\TraceProvider;
 use PHPUnit\Framework\TestCase;
 use function Pipeline\take;
 use Symfony\Component\Finder\SplFileInfo;
 use Traversable;
 
-/**
- * @covers \Infection\TestFramework\Coverage\SourceFileDataFactory
- */
-final class SourceFileDataFactoryTest extends TestCase
+final class FilteredEnrichedTraceProviderTest extends TestCase
 {
-    public function test_it_provides_files(): void
+    public function test_it_provides_traces(): void
     {
         $canary = [1, 2, 3];
 
-        $providedFiles = $this->factoryProvidesFiles(
+        $traces = $this->createTraces(
             $canary,
             [$this->createMock(SplFileInfo::class)],
             true
         );
 
-        $this->assertSame($canary, $providedFiles);
+        $this->assertSame($canary, $traces);
         $this->assertCount(3, $canary);
     }
 
-    public function test_it_adds_source_files_to_provided_files(): void
+    public function test_it_takes_its_traces_from_the_decorated_trace_provider_and_not_the_provided_source_files(): void
     {
         $inputFileNames = [
             'src/Foo.php',
@@ -78,42 +75,45 @@ final class SourceFileDataFactoryTest extends TestCase
             'src/Test/Foo.php',
         ];
 
-        $providedFiles = $this->factoryProvidesFiles(
+        $traces = $this->createTraces(
             take($inputFileNames)->map(function (string $filename) {
-                return $this->createSourceFileDataMock($filename);
+                return $this->createProxyTraceMock($filename);
             }),
             take($expectedFileNames)->map(function (string $filename) {
-                return $this->createSplFileInfoMock($filename);
+                return $this->createFileInfoMock($filename);
             }),
             false
         );
 
-        $actualFileNames = take($providedFiles)->map(static function (SourceFileData $data) {
-            return $data->getSplFileInfo()->getRealPath();
-        })->toArray();
+        $actualFileNames = take($traces)
+            ->map(static function (ProxyTrace $trace) {
+                return $trace->getSplFileInfo()->getRealPath();
+            })
+            ->toArray()
+        ;
 
         $this->assertSame($expectedFileNames, $actualFileNames);
     }
 
-    public function test_it_provides_added_source_files_with_no_coverage(): void
+    public function test_it_appends_the_missing_source_files_as_uncovered_traces(): void
     {
-        $providedFiles = $this->factoryProvidesFiles(
+        $traces = $this->createTraces(
             [],
-            [$this->createSplFileInfoMock('src/Foo.php')],
+            [$this->createFileInfoMock('src/Foo.php')],
             false
         );
 
-        if ($providedFiles instanceof Traversable) {
-            $providedFiles = iterator_to_array($providedFiles);
+        if ($traces instanceof Traversable) {
+            $traces = iterator_to_array($traces);
         }
 
-        /** @var SourceFileData $fileWithoutCoverage */
-        $fileWithoutCoverage = $providedFiles[0];
+        /** @var ProxyTrace $uncoveredTrace */
+        $uncoveredTrace = $traces[0];
 
-        $this->assertFalse($fileWithoutCoverage->hasTests());
+        $this->assertFalse($uncoveredTrace->hasTests());
     }
 
-    public function test_it_ignores_source_files_when_only_covered(): void
+    public function test_it_does_not_append_missing_sources_files_as_uncovered_traces_if_only_covered_is_enabled(): void
     {
         $expectedFileNames = [
             'src/Foo.php',
@@ -127,30 +127,33 @@ final class SourceFileDataFactoryTest extends TestCase
             'src/Test/Foo.php',
         ];
 
-        $providedFiles = $this->factoryProvidesFiles(
+        $providedFiles = $this->createTraces(
             take($expectedFileNames)->map(function (string $filename) {
-                return $this->createSourceFileDataMock($filename);
+                return $this->createProxyTraceMock($filename);
             }),
             take($inputFileNames)->map(function (string $filename) {
-                return $this->createSplFileInfoMock($filename);
+                return $this->createFileInfoMock($filename);
             }),
             true
         );
 
-        $actualFileNames = take($providedFiles)->map(static function (SourceFileData $data) {
-            return $data->getSplFileInfo()->getRealPath();
-        })->toArray();
+        $traces = take($providedFiles)
+            ->map(static function (ProxyTrace $trace) {
+                return $trace->getSplFileInfo()->getRealPath();
+            })
+            ->toArray()
+        ;
 
-        $this->assertSame($expectedFileNames, $actualFileNames);
+        $this->assertSame($expectedFileNames, $traces);
     }
 
-    private function factoryProvidesFiles(
+    private function createTraces(
         iterable $canary,
         iterable $sourceFiles,
         bool $onlyCovered
     ): iterable {
-        $sourceFileDataProvider = $this->createMock(SourceFileDataProvider::class);
-        $sourceFileDataProvider
+        $traceProviderMock = $this->createMock(TraceProvider::class);
+        $traceProviderMock
             ->expects($this->once())
             ->method('provideFiles')
             ->willReturn($canary)
@@ -172,38 +175,38 @@ final class SourceFileDataFactoryTest extends TestCase
             ->willReturn($canary)
         ;
 
-        $factory = new SourceFileDataFactory(
-            $sourceFileDataProvider,
+        $provider = new FilteredEnrichedTraceProvider(
+            $traceProviderMock,
             $testFileDataAdder,
             $filter,
             $sourceFiles,
             $onlyCovered
         );
 
-        return $factory->provideFiles();
+        return $provider->provideTraces();
     }
 
-    private function createSplFileInfoMock(string $filename): SplFileInfo
+    private function createFileInfoMock(string $filename): SplFileInfo
     {
-        $splFileInfoMock = $this->createMock(SplFileInfo::class);
-        $splFileInfoMock
+        $fileInfoMock = $this->createMock(SplFileInfo::class);
+        $fileInfoMock
             ->method('getRealPath')
             ->willReturn($filename)
         ;
 
-        return $splFileInfoMock;
+        return $fileInfoMock;
     }
 
-    private function createSourceFileDataMock(string $filename): SourceFileData
+    private function createProxyTraceMock(string $filename): ProxyTrace
     {
-        $splFileInfoMock = $this->createSplFileInfoMock($filename);
+        $splFileInfoMock = $this->createFileInfoMock($filename);
 
-        $codeCoverageMock = $this->createMock(SourceFileData::class);
-        $codeCoverageMock
+        $proxyTraceMock = $this->createMock(ProxyTrace::class);
+        $proxyTraceMock
             ->method('getSplFileInfo')
             ->willReturn($splFileInfoMock)
         ;
 
-        return $codeCoverageMock;
+        return $proxyTraceMock;
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php
@@ -37,11 +37,11 @@ namespace Infection\Tests\TestFramework\Coverage\JUnit;
 
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
-use Infection\TestFramework\Coverage\CoverageReport;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder;
 use Infection\TestFramework\Coverage\JUnit\TestFileDataProvider;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
-use Infection\TestFramework\Coverage\SourceFileData;
+use Infection\TestFramework\Coverage\ProxyTrace;
+use Infection\TestFramework\Coverage\TestLocations;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -68,7 +68,6 @@ final class JUnitTestExecutionInfoAdderTest extends TestCase
 
         $expected = [1, 2, 3];
 
-        /** @var array $actual */
         $actual = $adder->addTestExecutionInfo($expected);
 
         $this->assertSame($expected, $actual);
@@ -98,23 +97,21 @@ final class JUnitTestExecutionInfoAdderTest extends TestCase
 
         $lineData = CoverageLineData::withTestMethod('Acme\FooTest::test_it_can_be_instantiated');
 
-        $fileData = new CoverageReport();
-        $fileData->byLine = [
+        $tests = new TestLocations();
+        $tests->byLine = [
             11 => [
                 $lineData,
             ],
         ];
 
-        $sourceFileDataMock = $this->createMock(SourceFileData::class);
-        $sourceFileDataMock
+        $proxyTraceMock = $this->createMock(ProxyTrace::class);
+        $proxyTraceMock
             ->expects($this->once())
             ->method('retrieveCoverageReport')
-            ->willReturn($fileData)
+            ->willReturn($tests)
         ;
 
-        $expected = [
-            $sourceFileDataMock,
-        ];
+        $expected = [$proxyTraceMock];
 
         $actual = $adder->addTestExecutionInfo($expected);
         $actual = iterator_to_array($actual, false);
@@ -125,6 +122,6 @@ final class JUnitTestExecutionInfoAdderTest extends TestCase
         $this->assertSame('/path/to/acme/FooTest.php', $lineData->testFilePath);
         $this->assertSame(0.000234, $lineData->time);
 
-        $this->assertSame($lineData, $fileData->byLine[11][0]);
+        $this->assertSame($lineData, $tests->byLine[11][0]);
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php
@@ -44,9 +44,6 @@ use Infection\TestFramework\Coverage\ProxyTrace;
 use Infection\TestFramework\Coverage\TestLocations;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder
- */
 final class JUnitTestExecutionInfoAdderTest extends TestCase
 {
     public function test_it_does_not_add_if_junit_is_not_provided(): void
@@ -66,11 +63,13 @@ final class JUnitTestExecutionInfoAdderTest extends TestCase
 
         $adder = new JUnitTestExecutionInfoAdder($adapter, $testFileDataProvider);
 
-        $expected = [1, 2, 3];
+        $proxyTraceMock = $this->createMock(ProxyTrace::class);
+        $proxyTraceMock
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
 
-        $actual = $adder->addTestExecutionInfo($expected);
-
-        $this->assertSame($expected, $actual);
+        $adder->addTestExecutionInfo([$proxyTraceMock]);
     }
 
     public function test_it_adds_if_junit_is_provided(): void
@@ -107,7 +106,7 @@ final class JUnitTestExecutionInfoAdderTest extends TestCase
         $proxyTraceMock = $this->createMock(ProxyTrace::class);
         $proxyTraceMock
             ->expects($this->once())
-            ->method('retrieveCoverageReport')
+            ->method('retrieveTestLocations')
             ->willReturn($tests)
         ;
 

--- a/tests/phpunit/TestFramework/Coverage/TestLocationsNormalizer.php
+++ b/tests/phpunit/TestFramework/Coverage/TestLocationsNormalizer.php
@@ -33,56 +33,54 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\Coverage;
+namespace Infection\Tests\TestFramework\Coverage;
 
-use Infection\AbstractTestFramework\Coverage\CoverageLineData;
+use Infection\TestFramework\Coverage\TestLocations;
+use function is_array;
+use function is_scalar;
+use function iterator_to_array;
+use Traversable;
 
-/**
- * @internal
- *
- * ```
- * 'byMethod' => [
- *      'mutate' => MethodLocationData::['startLine' => 12, 'endLine' => 16],
- *      ...
- * ],
- * 'byLine' => [
- *     22 => [
- *         CoverageLineData::[
- *             'testMethod' => '\A\B\C::test_it_works',
- *             'testFilePath' => '/path/to/A/B/C.php',
- *             'time' => 0.34325,
- *         ],
- *         ...
- *      ]
- *  ]
- * ```
- *
- * TODO: rename to TestLocations
- */
-final class CoverageReport
+final class TestLocationsNormalizer
 {
-    /**
-     * @var array<int, array<int, CoverageLineData>>
-     */
-    public $byLine = [];
-
-    /**
-     * TODO: use a getter "get"
-     *
-     * @var array<string, MethodLocationData>
-     */
-    public $byMethod = [];
-
-    /**
-     * TODO: rename CoverageLineData to TestLocation
-     * TODO: rename MethodLocationData to SourceMethodRange
-     *
-     * @param array<int, array<int, CoverageLineData>> $byLine
-     * @param array<string, MethodLocationData> $byMethod
-     */
-    public function __construct(array $byLine = [], array $byMethod = [])
+    private function __construct()
     {
-        $this->byLine = $byLine;
-        $this->byMethod = $byMethod;
+    }
+
+    /**
+     * @param array<string, TestLocations> $coverage
+     *
+     * @return array<string|int, mixed>
+     */
+    public static function normalize(iterable $coverage): array
+    {
+        if ($coverage instanceof Traversable) {
+            $coverage = iterator_to_array($coverage, false);
+        }
+
+        return self::serializeValue($coverage);
+    }
+
+    private static function serializeValue($mixed)
+    {
+        if ($mixed === null) {
+            return null;
+        }
+
+        if (is_scalar($mixed)) {
+            return $mixed;
+        }
+
+        if (is_array($mixed)) {
+            $convertedArray = [];
+
+            foreach ($mixed as $key => $value) {
+                $convertedArray[$key] = self::serializeValue($value);
+            }
+
+            return $convertedArray;
+        }
+
+        return self::serializeValue((array) $mixed);
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/TestLocationsNormalizerTest.php
+++ b/tests/phpunit/TestFramework/Coverage/TestLocationsNormalizerTest.php
@@ -43,7 +43,7 @@ use PHPUnit\Framework\TestCase;
 final class TestLocationsNormalizerTest extends TestCase
 {
     /**
-     * @dataProvider testLocationsProvider
+     * @dataProvider locationsProvider
      */
     public function test_it_can_convert_an_associative_array_of_test_locations_into_an_associative_array_of_scalar_values(array $coverage, array $expected): void
     {
@@ -52,7 +52,7 @@ final class TestLocationsNormalizerTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function test_locations_provider(): iterable
+    public function locationsProvider(): iterable
     {
         yield 'empty' => [[], []];
 

--- a/tests/phpunit/TestFramework/Coverage/TestLocationsNormalizerTest.php
+++ b/tests/phpunit/TestFramework/Coverage/TestLocationsNormalizerTest.php
@@ -36,29 +36,29 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage;
 
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
-use Infection\TestFramework\Coverage\CoverageReport;
 use Infection\TestFramework\Coverage\MethodLocationData;
+use Infection\TestFramework\Coverage\TestLocations;
 use PHPUnit\Framework\TestCase;
 
-final class CoverageHelperTest extends TestCase
+final class TestLocationsNormalizerTest extends TestCase
 {
     /**
-     * @dataProvider coverageProvider
+     * @dataProvider testLocationsProvider
      */
-    public function test_it_can_convert_a_coverage_into_array(array $coverage, array $expected): void
+    public function test_it_can_convert_an_associative_array_of_test_locations_into_an_associative_array_of_scalar_values(array $coverage, array $expected): void
     {
-        $actual = CoverageHelper::convertToArray($coverage);
+        $actual = TestLocationsNormalizer::normalize($coverage);
 
         $this->assertSame($expected, $actual);
     }
 
-    public function coverageProvider(): iterable
+    public function test_locations_provider(): iterable
     {
         yield 'empty' => [[], []];
 
         yield 'empty coverage file data' => [
             [
-                '/path/to/file' => new CoverageReport(),
+                '/path/to/file' => new TestLocations(),
             ],
             [
                 '/path/to/file' => [
@@ -70,7 +70,7 @@ final class CoverageHelperTest extends TestCase
 
         yield 'coverage file data with byLine data' => [
             [
-                '/path/to/acme/Foo.php' => new CoverageReport(
+                '/path/to/acme/Foo.php' => new TestLocations(
                     [
                         11 => [
                             CoverageLineData::with(
@@ -100,7 +100,7 @@ final class CoverageHelperTest extends TestCase
 
         yield 'coverage coverage file data with byMethod data' => [
             [
-                '/path/to/acme/Foo.php' => new CoverageReport(
+                '/path/to/acme/Foo.php' => new TestLocations(
                     [],
                     [
                         '__construct' => new MethodLocationData(
@@ -125,7 +125,7 @@ final class CoverageHelperTest extends TestCase
 
         yield 'nominal' => [
             [
-                '/path/to/acme/Foo.php' => new CoverageReport(
+                '/path/to/acme/Foo.php' => new TestLocations(
                     [
                         11 => [
                             CoverageLineData::with(

--- a/tests/phpunit/TestFramework/Coverage/TestLocationsTest.php
+++ b/tests/phpunit/TestFramework/Coverage/TestLocationsTest.php
@@ -36,30 +36,30 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage;
 
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
-use Infection\TestFramework\Coverage\CoverageReport;
 use Infection\TestFramework\Coverage\MethodLocationData;
+use Infection\TestFramework\Coverage\TestLocations;
 use PHPUnit\Framework\TestCase;
 
-final class CoverageReportTest extends TestCase
+final class TestLocationsTest extends TestCase
 {
     public function test_it_has_default_values(): void
     {
-        $coverageReport = new CoverageReport();
+        $tests = new TestLocations();
 
-        $this->assertSame([], $coverageReport->byMethod);
-        $this->assertSame([], $coverageReport->byLine);
+        $this->assertSame([], $tests->byMethod);
+        $this->assertSame([], $tests->byLine);
     }
 
     public function test_it_creates_self_object_with_named_constructor(): void
     {
         $pathToTest = '/path/to/Test.php';
 
-        $coverageReport = new CoverageReport(
+        $tests = new TestLocations(
             [1 => [CoverageLineData::withTestMethod($pathToTest)]],
             ['method' => new MethodLocationData(1, 3)]
         );
 
-        $this->assertSame($pathToTest, $coverageReport->byLine[1][0]->testMethod);
-        $this->assertSame(1, $coverageReport->byMethod['method']->startLine);
+        $this->assertSame($pathToTest, $tests->byLine[1][0]->testMethod);
+        $this->assertSame(1, $tests->byMethod['method']->startLine);
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/FileCodeCoverageTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/FileCodeCoverageTest.php
@@ -36,24 +36,24 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage\XmlReport;
 
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
-use Infection\TestFramework\Coverage\CoverageReport;
 use Infection\TestFramework\Coverage\MethodLocationData;
 use Infection\TestFramework\Coverage\NodeLineRangeData;
-use Infection\TestFramework\Coverage\XmlReport\FileCodeCoverage;
-use Infection\Tests\TestFramework\Coverage\CoverageHelper;
+use Infection\TestFramework\Coverage\TestLocations;
+use Infection\TestFramework\Coverage\XmlReport\TestTrace;
+use Infection\Tests\TestFramework\Coverage\TestLocationsNormalizer;
 use function iterator_to_array;
 use PHPUnit\Framework\TestCase;
 use Traversable;
 
 final class FileCodeCoverageTest extends TestCase
 {
+    private static $testsLocations;
+
     public function test_it_correctly_sets_coverage_information_for_method_body(): void
     {
         $filePath = '/path/to/acme/Foo.php';
 
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
-
-        $tests = $codeCoverageData->getAllTestsForMutation(
+        $tests = $this->createTestTrace($filePath)->getAllTestsForMutation(
             new NodeLineRangeData(34, 34),
             false
         );
@@ -66,7 +66,7 @@ final class FileCodeCoverageTest extends TestCase
                     'time' => 0.123,
                 ],
             ],
-            CoverageHelper::convertToArray($tests)
+            TestLocationsNormalizer::normalize($tests)
         );
     }
 
@@ -74,9 +74,7 @@ final class FileCodeCoverageTest extends TestCase
     {
         $filePath = '/path/to/acme/Foo.php';
 
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
-
-        $tests = $codeCoverageData->getAllTestsForMutation(
+        $tests = $this->createTestTrace($filePath)->getAllTestsForMutation(
             new NodeLineRangeData(24, 24),
             true
         );
@@ -114,103 +112,130 @@ final class FileCodeCoverageTest extends TestCase
                     'time' => 0.123,
                 ],
             ],
-            CoverageHelper::convertToArray($tests)
+            TestLocationsNormalizer::normalize($tests)
         );
     }
 
     public function test_it_determines_method_was_not_executed_from_coverage_report(): void
     {
         $filePath = '/path/to/acme/Foo.php';
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
+        $trace = $this->createTestTrace($filePath);
 
-        $this->assertCount(0, $codeCoverageData->getAllTestsForMutation(
-            new NodeLineRangeData(19, 19),
-            true
-        ));
-        $this->assertCount(0, $codeCoverageData->getAllTestsForMutation(
-            new NodeLineRangeData(21, 21),
-            false
-        ));
+        $this->assertCount(
+            0,
+            $trace->getAllTestsForMutation(
+                new NodeLineRangeData(19, 19),
+                true
+            )
+        );
+
+        $this->assertCount(
+            0,
+            $trace->getAllTestsForMutation(
+                new NodeLineRangeData(21, 21),
+                false
+            )
+        );
     }
 
     public function test_it_determines_line_was_not_executed_from_coverage_report(): void
     {
         $filePath = '/path/to/acme/Foo.php';
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
+        $trace = $this->createTestTrace($filePath);
 
-        $this->assertCount(0, $codeCoverageData->getAllTestsForMutation(
-            new NodeLineRangeData(27, 27),
-            false
-        ));
-        $this->assertCount(0, $codeCoverageData->getAllTestsForMutation(
-            new NodeLineRangeData(32, 32),
-            false
-        ));
+        $this->assertCount(
+            0,
+            $trace->getAllTestsForMutation(
+                new NodeLineRangeData(27, 27),
+                false
+            )
+        );
+
+        $this->assertCount(
+            0,
+            $trace->getAllTestsForMutation(
+                new NodeLineRangeData(32, 32),
+                false
+            )
+        );
     }
 
     public function test_it_determines_file_is_not_covered_for_unknown_path(): void
     {
         $filePath = '/path/to/unknown-file';
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
 
-        $this->assertFalse($codeCoverageData->hasTests());
+        $this->assertFalse($this->createTestTrace($filePath)->hasTests());
     }
 
     public function test_it_determines_file_is_covered(): void
     {
         $filePath = '/path/to/acme/Foo.php';
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
 
-        $this->assertTrue($codeCoverageData->hasTests());
+        $this->assertTrue($this->createTestTrace($filePath)->hasTests());
     }
 
     public function test_it_determines_file_does_not_have_tests_on_line_for_unknown_file(): void
     {
         $filePath = '/path/to/unknown-file';
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
+        $trace = $this->createTestTrace($filePath);
 
-        $this->assertCount(0, $codeCoverageData->getAllTestsForMutation(
-            new NodeLineRangeData(34, 34),
-            true
-        ));
-        $this->assertCount(0, $codeCoverageData->getAllTestsForMutation(
-            new NodeLineRangeData(34, 34),
-            false
-        ));
+        $this->assertCount(
+            0,
+            $trace->getAllTestsForMutation(
+                new NodeLineRangeData(34, 34),
+                true
+            )
+        );
+
+        $this->assertCount(
+            0,
+            $trace->getAllTestsForMutation(
+                new NodeLineRangeData(34, 34),
+                false
+            )
+        );
     }
 
     public function test_it_determines_file_does_not_have_tests_for_line(): void
     {
         $filePath = '/path/to/acme/Foo.php';
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
 
-        $this->assertCount(0, $codeCoverageData->getAllTestsForMutation(
-            new NodeLineRangeData(1, 1),
-            true
-        ));
-        $this->assertCount(0, $codeCoverageData->getAllTestsForMutation(
-            new NodeLineRangeData(1, 1),
-            false
-        ));
+        $trace = $this->createTestTrace($filePath);
+
+        $this->assertCount(
+            0,
+            $trace->getAllTestsForMutation(
+                new NodeLineRangeData(1, 1),
+                true
+            )
+        );
+
+        $this->assertCount(
+            0,
+            $trace->getAllTestsForMutation(
+                new NodeLineRangeData(1, 1),
+                false
+            )
+        );
     }
 
     public function test_it_returns_zero_tests_for_not_covered_function_body_mutator(): void
     {
         $filePath = '/path/to/acme/Foo.php';
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
-
-        $this->assertCount(0, $codeCoverageData->getAllTestsForMutation(
-            new NodeLineRangeData(1, 1),
-            false
-        ));
+        $this->assertCount(
+            0,
+            $this->createTestTrace($filePath)->getAllTestsForMutation(
+                new NodeLineRangeData(1, 1),
+                false
+            )
+        );
     }
 
     public function test_it_returns_tests_for_covered_function_body_mutator(): void
     {
         $filePath = '/path/to/acme/Foo.php';
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
 
-        $tests = $codeCoverageData->getAllTestsForMutation(
+        $tests = $this->createTestTrace($filePath)->getAllTestsForMutation(
             new NodeLineRangeData(26, 26),
             false
         );
@@ -227,19 +252,20 @@ final class FileCodeCoverageTest extends TestCase
     public function test_it_returns_zero_tests_for_not_covered_function_signature_mutator(): void
     {
         $filePath = '/path/to/acme/Foo.php';
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
 
-        $this->assertCount(0, $codeCoverageData->getAllTestsForMutation(
-            new NodeLineRangeData(1, 1), true
-        ));
+        $this->assertCount(
+            0,
+            $this->createTestTrace($filePath)->getAllTestsForMutation(
+                new NodeLineRangeData(1, 1), true
+            )
+        );
     }
 
     public function test_it_returns_tests_for_covered_function_signature_mutator(): void
     {
         $filePath = '/path/to/acme/Foo.php';
-        $codeCoverageData = $this->createCodeCoverageData($filePath);
 
-        $tests = $codeCoverageData->getAllTestsForMutation(
+        $tests = $this->createTestTrace($filePath)->getAllTestsForMutation(
             new NodeLineRangeData(24, 24),
             true
         );
@@ -247,10 +273,21 @@ final class FileCodeCoverageTest extends TestCase
         $this->assertCount(6, $tests);
     }
 
-    private function getParsedCodeCoverageData(): array
+    private function createTestTrace(string $filePath): TestTrace
     {
-        return [
-            '/path/to/acme/Foo.php' => new CoverageReport(
+        $testsLocations = $this->getTestsLocations();
+
+        if (!array_key_exists($filePath, $testsLocations)) {
+            return new TestTrace(new TestLocations());
+        }
+
+        return new TestTrace($testsLocations[$filePath]);
+    }
+
+    private function getTestsLocations(): array
+    {
+        return self::$testsLocations ?? [
+            '/path/to/acme/Foo.php' => new TestLocations(
                 [
                     26 => [
                         CoverageLineData::with(
@@ -298,16 +335,5 @@ final class FileCodeCoverageTest extends TestCase
                 ]
             ),
         ];
-    }
-
-    private function createCodeCoverageData(string $filePath): FileCodeCoverage
-    {
-        $parsedData = $this->getParsedCodeCoverageData();
-
-        if (!array_key_exists($filePath, $parsedData)) {
-            return new FileCodeCoverage(new CoverageReport());
-        }
-
-        return new FileCodeCoverage($parsedData[$filePath]);
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php
@@ -35,15 +35,15 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Coverage\XmlReport;
 
-use Infection\TestFramework\Coverage\SourceFileData;
+use Infection\TestFramework\Coverage\ProxyTrace;
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser;
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageReader;
-use Infection\TestFramework\Coverage\XmlReport\PhpUnitXmlCoveredFileDataProvider;
+use Infection\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProvider;
 use Infection\TestFramework\Coverage\XmlReport\SourceFileInfoProvider;
 use Infection\TestFramework\Coverage\XmlReport\XmlCoverageParser;
 use PHPUnit\Framework\TestCase;
 
-final class PhpUnitXmlCoveredFileDataProviderTest extends TestCase
+final class PhpUnitXmlCoverageTraceProviderTest extends TestCase
 {
     public function test_it_can_parse_coverage_data(): void
     {
@@ -70,24 +70,24 @@ final class PhpUnitXmlCoveredFileDataProviderTest extends TestCase
             ->willReturn([$providerMock])
         ;
 
-        $sourceFileDataMock = $this->createMock(SourceFileData::class);
+        $proxyTraceMock = $this->createMock(ProxyTrace::class);
 
         $coverageXmlParserMock = $this->createMock(XmlCoverageParser::class);
         $coverageXmlParserMock
             ->expects($this->once())
             ->method('parse')
             ->with($providerMock)
-            ->willReturn($sourceFileDataMock)
+            ->willReturn($proxyTraceMock)
         ;
 
-        $coverageProvider = new PhpUnitXmlCoveredFileDataProvider(
+        $provider = new PhpUnitXmlCoverageTraceProvider(
             $reader,
             $indexXmlParserMock,
             $coverageXmlParserMock
         );
 
-        $coverage = $coverageProvider->provideFiles();
+        $traces = $provider->provideTraces();
 
-        $this->assertSame([$sourceFileDataMock], iterator_to_array($coverage));
+        $this->assertSame([$proxyTraceMock], iterator_to_array($traces));
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/TestTraceProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/TestTraceProviderTest.php
@@ -36,28 +36,25 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage\XmlReport;
 
 use Infection\AbstractTestFramework\Coverage\CoverageLineData;
-use Infection\TestFramework\Coverage\CoverageReport;
 use Infection\TestFramework\Coverage\MethodLocationData;
-use Infection\TestFramework\Coverage\SourceFileData;
-use Infection\TestFramework\Coverage\XmlReport\FileCodeCoverageProvider;
+use Infection\TestFramework\Coverage\ProxyTrace;
+use Infection\TestFramework\Coverage\TestLocations;
+use Infection\TestFramework\Coverage\XmlReport\TestTraceProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\SplFileInfo;
 
-final class FileCodeCoverageProviderTest extends TestCase
+final class TestTraceProviderTest extends TestCase
 {
-    public function test_it_determines_file_is_covered(): void
+    public function test_it_determines_if_trace_is_covered(): void
     {
-        $filePath = '/path/to/acme/Foo.php';
+        $trace = (new TestTraceProvider())->provideFor($this->createProxyTrace());
 
-        $provider = $this->createCodeCoverageDataProvider();
-        $codeCoverageData = $provider->provideFor($this->createSourceFileData($filePath));
-
-        $this->assertTrue($codeCoverageData->hasTests());
+        $this->assertTrue($trace->hasTests());
     }
 
-    private function getParsedCodeCoverageData(): CoverageReport
+    private function getParsedTestLocations(): TestLocations
     {
-        return new CoverageReport(
+        return new TestLocations(
             [
                 26 => [
                     CoverageLineData::with(
@@ -106,15 +103,15 @@ final class FileCodeCoverageProviderTest extends TestCase
         );
     }
 
-    private function createSourceFileData(string $filePath): SourceFileData
+    private function createProxyTrace(): ProxyTrace
     {
-        return new SourceFileData(
-            $this->createSplFileInfo($filePath),
-            [$this->getParsedCodeCoverageData()]
+        return new ProxyTrace(
+            $this->createFileInfoMock(),
+            [$this->getParsedTestLocations()]
         );
     }
 
-    private function createSplFileInfo(string $filePath): SplFileInfo
+    private function createFileInfoMock(): SplFileInfo
     {
         $splFileInfoMock = $this->createMock(SplFileInfo::class);
         $splFileInfoMock
@@ -128,10 +125,5 @@ final class FileCodeCoverageProviderTest extends TestCase
         ;
 
         return $splFileInfoMock;
-    }
-
-    private function createCodeCoverageDataProvider(): FileCodeCoverageProvider
-    {
-        return new FileCodeCoverageProvider();
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/TestTraceTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/TestTraceTest.php
@@ -45,7 +45,7 @@ use function iterator_to_array;
 use PHPUnit\Framework\TestCase;
 use Traversable;
 
-final class FileCodeCoverageTest extends TestCase
+final class TestTraceTest extends TestCase
 {
     private static $testsLocations;
 

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParserTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParserTest.php
@@ -39,7 +39,7 @@ use Infection\TestFramework\Coverage\XmlReport\SourceFileInfoProvider;
 use Infection\TestFramework\Coverage\XmlReport\XmlCoverageParser;
 use Infection\TestFramework\Coverage\XmlReport\XPathFactory;
 use Infection\Tests\Fixtures\TestFramework\PhpUnit\Coverage\XmlCoverageFixtures;
-use Infection\Tests\TestFramework\Coverage\CoverageHelper;
+use Infection\Tests\TestFramework\Coverage\TestLocationsNormalizer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\SplFileInfo;
@@ -75,11 +75,11 @@ final class XmlCoverageParserTest extends TestCase
             $provider->provideFileInfo()->getRealPath()
         );
 
-        $coverageData = $fileData->retrieveCoverageReport();
+        $coverageData = $fileData->retrieveTestLocations();
 
         $this->assertSame(
             $expectedCoverage,
-            CoverageHelper::convertToArray([$coverageData])[0]
+            TestLocationsNormalizer::normalize([$coverageData])[0]
         );
     }
 
@@ -100,7 +100,7 @@ XML;
 
         $coverageData = $this->parser
             ->parse($this->createSourceFileInfoProvider($xml))
-            ->retrieveCoverageReport()
+            ->retrieveTestLocations()
         ;
 
         $this->assertSame([], $coverageData->byLine);
@@ -127,7 +127,7 @@ XML;
 
         $coverageData = $this->parser
             ->parse($this->createSourceFileInfoProvider($xml))
-            ->retrieveCoverageReport()
+            ->retrieveTestLocations()
         ;
 
         $this->assertArrayHasKey(11, $coverageData->byLine);
@@ -153,7 +153,7 @@ XML;
 
         $coverageData = $this->parser
             ->parse($this->createSourceFileInfoProvider($xml))
-            ->retrieveCoverageReport()
+            ->retrieveTestLocations()
         ;
 
         $this->assertArrayNotHasKey(11, $coverageData->byLine);


### PR DESCRIPTION
After @sanmai 's PR #1106, I think it is time to introduce this new Tracer terminology. Reasons:

- It is a term used in mutant (at least the private version) so it provides common grounds with other mutation testing tools (well at least one...)
- I think it the term is understable enable enough: a trace is the association between a piece of source code and its associated tests
- It provides a good alternative to "covered" which is in our case horribly confusing: covered by tests, covered from a coverage report, covered by the mutation testing tool... And all the usages of "coverage" and "covered" coming from manipulating coverage reports

**This PR contains only naming changes.** There might be a few CS tweaks here and there, but no class has been removed, methods parameters changed or others.

There is a big TODO worth reading if you get confused as to why we have `ProxyTrace` in some places: IMO this is a leaking implementation detail that could be removed by slightly tweaking the `Trace` interface.

There is also a renaming change to do in the test framework adapter package. An update of it in infection/infection can be later though so it's not blocking for this PR.

I invite everyone to review this and I hope that you share the feeling that it helps to clarify some elements. At least to me, it revealed a few axes of improvements, e.g. the fact that we have currently two traces implementations depending on one another with a leaking abstraction.

I also added the nomenclature file, it's by no means finished, in fact I only added the tracing related terms. I think however I'll complete it more and more here instead of a random file locally. So for now it's more for internal usage and we can decide to publish it later, either to the website or to have it peer-reviewed with other mutation testing tool maintainers