### PR TITLE
Optimize JUnit test lookups to stop on the first element

### DIFF
--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -48,6 +48,9 @@ use Infection\TestFramework\Coverage\Trace;
  */
 class JUnitTestExecutionInfoAdder
 {
+    /**
+     * @var TestFileDataProvider|MemoizedTestFileDataProvider|JUnitTestFileDataProvider
+     */
     private $testFileDataProvider;
 
     private $adapter;

--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -49,7 +49,7 @@ use Infection\TestFramework\Coverage\Trace;
 class JUnitTestExecutionInfoAdder
 {
     /**
-     * @var TestFileDataProvider|MemoizedTestFileDataProvider|JUnitTestFileDataProvider
+     * @var TestFileDataProvider
      */
     private $testFileDataProvider;
 

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -80,6 +80,8 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
             );
         }
 
+        Assert::same($nodes->length, 1);
+
         return new TestFileTimeData(
             $nodes[0]->getAttribute('file'),
             (float) $nodes[0]->getAttribute('time')

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -78,6 +78,8 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
             }
         }
 
+        Assert::notNull($nodes);
+
         if ($nodes->length === 0) {
             throw TestFileNameNotFoundException::notFoundFromFQN(
                 $fullyQualifiedClassName,

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -90,14 +90,14 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
 
     private static function testCaseMapGenerator(string $fullyQualifiedClassName): iterable
     {
-        // Similar format for <testsuite>
-        yield '(//testsuite[@name="%s"])[1]' => $fullyQualifiedClassName;
+        // A default format for <testsuite>
+        yield '//testsuite[@name="%s"][1]' => $fullyQualifiedClassName;
 
         // A format where the class name is inside `class` attribute of `testcase` tag
-        yield '(//testcase[@class="%s"])[1]' => $fullyQualifiedClassName;
+        yield '//testcase[@class="%s"][1]' => $fullyQualifiedClassName;
 
         // A format where the class name is inside `file` attribute of `testcase` tag
-        yield '(//testcase[contains(@file, "%s")])[1]' => preg_replace('/^(.*):+.*$/', '$1.feature', $fullyQualifiedClassName);
+        yield '//testcase[contains(@file, "%s")][1]' => preg_replace('/^(.*):+.*$/', '$1.feature', $fullyQualifiedClassName);
     }
 
     private function getXPath(): SafeDOMXPath

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -36,6 +36,8 @@ declare(strict_types=1);
 namespace Infection\TestFramework\Coverage\JUnit;
 
 use DOMDocument;
+use DOMElement;
+use DOMNodeList;
 use Infection\TestFramework\SafeDOMXPath;
 use function Safe\preg_replace;
 use function Safe\sprintf;
@@ -65,6 +67,9 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
     {
         $xPath = $this->getXPath();
 
+        /** @var DOMNodeList<DOMElement> $nodes */
+        $nodes = null;
+
         foreach (self::testCaseMapGenerator($fullyQualifiedClassName) as $queryString => $placeholder) {
             $nodes = $xPath->query(sprintf($queryString, $placeholder));
 
@@ -88,6 +93,9 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
         );
     }
 
+    /**
+     * @return iterable<string, string>
+     */
     private static function testCaseMapGenerator(string $fullyQualifiedClassName): iterable
     {
         // A default format for <testsuite>

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProviderTest.php
@@ -110,4 +110,43 @@ final class JUnitTestFileDataProviderTest extends TestCase
 
         $this->assertSame('/codeception/tests/bdd/FeatureA.feature', $testFileInfo->path);
     }
+
+    /**
+     * @dataProvider xmlProvider
+     */
+    public function test_it_does_not_trigger_count_assertion(string $xml): void
+    {
+        file_put_contents($this->tempfile, $xml);
+
+        $provider = new JUnitTestFileDataProvider($this->tempfile);
+        $provider->getTestFileInfo('ExampleTest');
+        $this->addToAssertionCount(1);
+    }
+
+    public static function xmlProvider(): iterable
+    {
+        yield [<<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="ExampleTest"/>
+    <testsuite name="ExampleTest"/>
+</testsuites>
+XML];
+
+        yield [<<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testcase class="ExampleTest"/>
+    <testcase class="ExampleTest"/>
+</testsuites>
+XML];
+
+        yield [<<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testcase file="foo/ExampleTest.feature"/>
+    <testcase file="foo/ExampleTest.feature"/>
+</testsuites>
+XML];
+    }
 }

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProviderTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\TestFramework\Coverage\JUnit;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use function Safe\file_put_contents;
 use function Safe\tempnam;
 use function Safe\unlink;
 


### PR DESCRIPTION
Offers modest [3.5% improvement](https://blackfire.io/profiles/compare/6022a84b-a6f0-4f3d-865e-1443cbc69585/graph) on an example project with 1.4M junit.xml.
