### PR TITLE
Move threadCount to Configuration

### DIFF
--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -29,6 +29,10 @@ parameters:
             message: '#^Method Infection\\Container::get.*\(\) should return .* but returns object\.$#'
             count: 1
         -
+            path: '../src/Container.php'
+            message: '#^Parameter \#1 \$processHandler of class Infection\\Process\\Runner\\Parallel\\ParallelProcessRunner constructor expects Closure\(Infection\\Process\\Runner\\Parallel\\ProcessBearer\)\: void\, Closure\(Infection\\Process\\MutantProcess\): void given\.$#'
+            count: 1
+        -
             path: '../src/TestFramework/Coverage/JUnit/JUnitTestCaseSorter.php'
             message: '#array_key_exists expects int\|string, string\|null given#'
             count: 1

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -213,7 +213,7 @@ final class InfectionCommand extends BaseCommand
             $this->container->getTestFrameworkExtraOptionsFilter()
         );
 
-        $result = $engine->execute((int) $this->input->getOption('threads'));
+        $result = $engine->execute();
 
         return $result === true ? 0 : 1;
     }

--- a/src/Command/InfectionCommand.php
+++ b/src/Command/InfectionCommand.php
@@ -306,7 +306,8 @@ final class InfectionCommand extends BaseCommand
             $minCoveredMsi === null ? null : (float) $minCoveredMsi,
             $testFramework === '' ? null : $testFramework,
             $testFrameworkExtraOptions === '' ? null : $testFrameworkExtraOptions,
-            trim((string) $input->getOption('filter'))
+            trim((string) $input->getOption('filter')),
+            (int) $this->input->getOption('threads')
         );
     }
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -83,6 +83,7 @@ class Configuration
     private $minMsi;
     private $showMutations;
     private $minCoveredMsi;
+    private $threads;
 
     /**
      * @param string[] $sourceDirectories
@@ -113,7 +114,8 @@ class Configuration
         bool $ignoreMsiWithNoMutations,
         ?float $minMsi,
         bool $showMutations,
-        ?float $minCoveredMsi
+        ?float $minCoveredMsi,
+        int $threads
     ) {
         Assert::nullOrGreaterThanEq($timeout, 1);
         Assert::allString($sourceDirectories);
@@ -122,6 +124,7 @@ class Configuration
         Assert::nullOrOneOf($testFramework, TestFrameworkTypes::TYPES);
         Assert::oneOf($formatter, self::FORMATTER);
         Assert::nullOrGreaterThanEq($minMsi, 0.);
+        Assert::greaterThanEq($threads, 0);
 
         $this->timeout = $timeout;
         $this->sourceDirectories = $sourceDirectories;
@@ -147,6 +150,7 @@ class Configuration
         $this->minMsi = $minMsi;
         $this->showMutations = $showMutations;
         $this->minCoveredMsi = $minCoveredMsi;
+        $this->threads = $threads;
     }
 
     public function getProcessTimeout(): int
@@ -276,5 +280,10 @@ class Configuration
     public function getMinCoveredMsi(): ?float
     {
         return $this->minCoveredMsi;
+    }
+
+    public function getThreads(): int
+    {
+        return $this->threads;
     }
 }

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -83,7 +83,7 @@ class Configuration
     private $minMsi;
     private $showMutations;
     private $minCoveredMsi;
-    private $threads;
+    private $threadsCount;
 
     /**
      * @param string[] $sourceDirectories
@@ -115,7 +115,7 @@ class Configuration
         ?float $minMsi,
         bool $showMutations,
         ?float $minCoveredMsi,
-        int $threads
+        int $threadsCount
     ) {
         Assert::nullOrGreaterThanEq($timeout, 1);
         Assert::allString($sourceDirectories);
@@ -124,7 +124,7 @@ class Configuration
         Assert::nullOrOneOf($testFramework, TestFrameworkTypes::TYPES);
         Assert::oneOf($formatter, self::FORMATTER);
         Assert::nullOrGreaterThanEq($minMsi, 0.);
-        Assert::greaterThanEq($threads, 0);
+        Assert::greaterThanEq($threadsCount, 0);
 
         $this->timeout = $timeout;
         $this->sourceDirectories = $sourceDirectories;
@@ -150,7 +150,7 @@ class Configuration
         $this->minMsi = $minMsi;
         $this->showMutations = $showMutations;
         $this->minCoveredMsi = $minCoveredMsi;
-        $this->threads = $threads;
+        $this->threadsCount = $threadsCount;
     }
 
     public function getProcessTimeout(): int
@@ -282,8 +282,8 @@ class Configuration
         return $this->minCoveredMsi;
     }
 
-    public function getThreads(): int
+    public function getThreadsCount(): int
     {
-        return $this->threads;
+        return $this->threadsCount;
     }
 }

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -83,7 +83,7 @@ class Configuration
     private $minMsi;
     private $showMutations;
     private $minCoveredMsi;
-    private $threadsCount;
+    private $threadCount;
 
     /**
      * @param string[] $sourceDirectories
@@ -115,7 +115,7 @@ class Configuration
         ?float $minMsi,
         bool $showMutations,
         ?float $minCoveredMsi,
-        int $threadsCount
+        int $threadCount
     ) {
         Assert::nullOrGreaterThanEq($timeout, 1);
         Assert::allString($sourceDirectories);
@@ -124,7 +124,7 @@ class Configuration
         Assert::nullOrOneOf($testFramework, TestFrameworkTypes::TYPES);
         Assert::oneOf($formatter, self::FORMATTER);
         Assert::nullOrGreaterThanEq($minMsi, 0.);
-        Assert::greaterThanEq($threadsCount, 0);
+        Assert::greaterThanEq($threadCount, 0);
 
         $this->timeout = $timeout;
         $this->sourceDirectories = $sourceDirectories;
@@ -150,7 +150,7 @@ class Configuration
         $this->minMsi = $minMsi;
         $this->showMutations = $showMutations;
         $this->minCoveredMsi = $minCoveredMsi;
-        $this->threadsCount = $threadsCount;
+        $this->threadCount = $threadCount;
     }
 
     public function getProcessTimeout(): int
@@ -282,8 +282,8 @@ class Configuration
         return $this->minCoveredMsi;
     }
 
-    public function getThreadsCount(): int
+    public function getThreadCount(): int
     {
-        return $this->threadsCount;
+        return $this->threadCount;
     }
 }

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -107,7 +107,7 @@ class ConfigurationFactory
         ?string $testFramework,
         ?string $testFrameworkExtraOptions,
         string $filter,
-        int $threads
+        int $threadsCount
     ): Configuration {
         $configDir = dirname($schema->getFile());
 
@@ -151,7 +151,7 @@ class ConfigurationFactory
             self::retrieveMinMsi($minMsi, $schema),
             $showMutations,
             self::retrieveMinCoveredMsi($minCoveredMsi, $schema),
-            $threads
+            $threadsCount
         );
     }
 

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -107,7 +107,7 @@ class ConfigurationFactory
         ?string $testFramework,
         ?string $testFrameworkExtraOptions,
         string $filter,
-        int $threadsCount
+        int $threadCount
     ): Configuration {
         $configDir = dirname($schema->getFile());
 
@@ -151,7 +151,7 @@ class ConfigurationFactory
             self::retrieveMinMsi($minMsi, $schema),
             $showMutations,
             self::retrieveMinCoveredMsi($minCoveredMsi, $schema),
-            $threadsCount
+            $threadCount
         );
     }
 

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -106,7 +106,8 @@ class ConfigurationFactory
         string $mutatorsInput,
         ?string $testFramework,
         ?string $testFrameworkExtraOptions,
-        string $filter
+        string $filter,
+        int $threads
     ): Configuration {
         $configDir = dirname($schema->getFile());
 
@@ -149,7 +150,8 @@ class ConfigurationFactory
             self::retrieveIgnoreMsiWithNoMutations($ignoreMsiWithNoMutations, $schema),
             self::retrieveMinMsi($minMsi, $schema),
             $showMutations,
-            self::retrieveMinCoveredMsi($minCoveredMsi, $schema)
+            self::retrieveMinCoveredMsi($minCoveredMsi, $schema),
+            $threads
         );
     }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -239,7 +239,7 @@ final class Container
                             MutantExecutionResult::createFromProcess($mutantProcess)
                         ));
                     },
-                    $container->getConfiguration()->getThreadsCount()
+                    $container->getConfiguration()->getThreadCount()
                 );
             },
             TestFrameworkConfigLocator::class => static function (self $container): TestFrameworkConfigLocator {
@@ -484,7 +484,7 @@ final class Container
         ?string $testFramework,
         ?string $testFrameworkExtraOptions,
         string $filter,
-        int $threads
+        int $threadCount
     ): self {
         $clone = clone $this;
 
@@ -522,7 +522,7 @@ final class Container
                 $testFramework,
                 $testFrameworkExtraOptions,
                 $filter,
-                $threads
+                $threadCount
             ): Configuration {
                 return $container->getConfigurationFactory()->create(
                     $container->getSchemaConfiguration(),
@@ -542,7 +542,7 @@ final class Container
                     $testFramework,
                     $testFrameworkExtraOptions,
                     $filter,
-                    $threads
+                    $threadCount
                 );
             }
         );

--- a/src/Container.php
+++ b/src/Container.php
@@ -480,7 +480,8 @@ final class Container
         ?float $minCoveredMsi,
         ?string $testFramework,
         ?string $testFrameworkExtraOptions,
-        string $filter
+        string $filter,
+        int $threads
     ): self {
         $clone = clone $this;
 
@@ -517,7 +518,8 @@ final class Container
                 $mutatorsInput,
                 $testFramework,
                 $testFrameworkExtraOptions,
-                $filter
+                $filter,
+                $threads
             ): Configuration {
                 return $container->getConfigurationFactory()->create(
                     $container->getSchemaConfiguration(),
@@ -536,7 +538,8 @@ final class Container
                     $mutatorsInput,
                     $testFramework,
                     $testFrameworkExtraOptions,
-                    $filter
+                    $filter,
+                    $threads
                 );
             }
         );

--- a/src/Container.php
+++ b/src/Container.php
@@ -233,11 +233,14 @@ final class Container
                 return new SyncEventDispatcher();
             },
             ParallelProcessRunner::class => static function (self $container): ParallelProcessRunner {
-                return new ParallelProcessRunner(static function (MutantProcess $mutantProcess) use ($container): void {
-                    $container->getEventDispatcher()->dispatch(new MutantProcessWasFinished(
-                        MutantExecutionResult::createFromProcess($mutantProcess)
-                    ));
-                });
+                return new ParallelProcessRunner(
+                    static function (MutantProcess $mutantProcess) use ($container): void {
+                        $container->getEventDispatcher()->dispatch(new MutantProcessWasFinished(
+                            MutantExecutionResult::createFromProcess($mutantProcess)
+                        ));
+                    },
+                    $container->getConfiguration()->getThreadsCount()
+                );
             },
             TestFrameworkConfigLocator::class => static function (self $container): TestFrameworkConfigLocator {
                 return new TestFrameworkConfigLocator(

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -99,10 +99,10 @@ final class Engine
         $this->testFrameworkExtraOptionsFilter = $testFrameworkExtraOptionsFilter;
     }
 
-    public function execute(int $threads): bool
+    public function execute(): bool
     {
         $this->runInitialTestSuite();
-        $this->runMutationAnalysis($threads);
+        $this->runMutationAnalysis();
 
         return $this->checkMetrics();
     }
@@ -134,7 +134,7 @@ final class Engine
         $this->memoryLimitApplier->applyMemoryLimitFromProcess($initialTestSuitProcess, $this->adapter);
     }
 
-    private function runMutationAnalysis(int $threads): void
+    private function runMutationAnalysis(): void
     {
         $mutations = $this->mutationGenerator->generate(
             $this->config->mutateOnlyCoveredCode(),
@@ -149,7 +149,7 @@ final class Engine
             ? $this->testFrameworkExtraOptionsFilter->filterForMutantProcess($actualExtraOptions, $this->adapter->getInitialRunOnlyOptions())
             : $actualExtraOptions;
 
-        $this->mutationTestingRunner->run($mutations, $threads, $filteredExtraOptionsForMutant);
+        $this->mutationTestingRunner->run($mutations, $filteredExtraOptionsForMutant);
     }
 
     private function checkMetrics(): bool

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -81,7 +81,7 @@ final class MutationTestingRunner
     /**
      * @param iterable<Mutation> $mutations
      */
-    public function run(iterable $mutations, int $threadCount, string $testFrameworkExtraOptions): void
+    public function run(iterable $mutations, string $testFrameworkExtraOptions): void
     {
         $numberOfMutants = IterableCounter::bufferAndCountIfNeeded($mutations, $this->runConcurrently);
         $this->eventDispatcher->dispatch(new MutationTestingWasStarted($numberOfMutants));
@@ -110,7 +110,7 @@ final class MutationTestingRunner
             })
         ;
 
-        $this->parallelProcessManager->run($processes, $threadCount);
+        $this->parallelProcessManager->run($processes);
 
         $this->eventDispatcher->dispatch(new MutationTestingWasFinished());
     }

--- a/tests/benchmark/MutationGenerator/generate-mutations-closure.php
+++ b/tests/benchmark/MutationGenerator/generate-mutations-closure.php
@@ -62,7 +62,8 @@ $container = Container::create()->withDynamicParameters(
     .0,
     'phpunit',
     '',
-    ''
+    '',
+    0
 );
 
 $files = Finder::create()

--- a/tests/benchmark/Tracing/provide-traces-closure.php
+++ b/tests/benchmark/Tracing/provide-traces-closure.php
@@ -58,7 +58,8 @@ $container = Container::create()->withDynamicParameters(
     .0,
     'phpunit',
     '',
-    ''
+    '',
+    0
 );
 
 $generateTraces = static function (?int $maxCount) use ($container): Generator {

--- a/tests/phpunit/Configuration/ConfigurationAssertions.php
+++ b/tests/phpunit/Configuration/ConfigurationAssertions.php
@@ -77,7 +77,8 @@ trait ConfigurationAssertions
         bool $expectedIgnoreMsiWithNoMutations,
         ?float $expectedMinMsi,
         bool $expectedShowMutations,
-        ?float $expectedMinCoveredMsi
+        ?float $expectedMinCoveredMsi,
+        int $expectedThreads
     ): void {
         $this->assertSame($expectedTimeout, $configuration->getProcessTimeout());
         $this->assertSame($expectedSourceDirectories, $configuration->getSourceDirectories());
@@ -120,6 +121,7 @@ trait ConfigurationAssertions
         $this->assertSame($expectedMinMsi, $configuration->getMinMsi());
         $this->assertSame($expectedShowMutations, $configuration->showMutations());
         $this->assertSame($expectedMinCoveredMsi, $configuration->getMinCoveredMsi());
+        $this->assertSame($expectedThreads, $configuration->getThreads());
     }
 
     /**

--- a/tests/phpunit/Configuration/ConfigurationAssertions.php
+++ b/tests/phpunit/Configuration/ConfigurationAssertions.php
@@ -78,7 +78,7 @@ trait ConfigurationAssertions
         ?float $expectedMinMsi,
         bool $expectedShowMutations,
         ?float $expectedMinCoveredMsi,
-        int $expectedThreadsCount
+        int $expectedThreadCount
     ): void {
         $this->assertSame($expectedTimeout, $configuration->getProcessTimeout());
         $this->assertSame($expectedSourceDirectories, $configuration->getSourceDirectories());
@@ -121,7 +121,7 @@ trait ConfigurationAssertions
         $this->assertSame($expectedMinMsi, $configuration->getMinMsi());
         $this->assertSame($expectedShowMutations, $configuration->showMutations());
         $this->assertSame($expectedMinCoveredMsi, $configuration->getMinCoveredMsi());
-        $this->assertSame($expectedThreadsCount, $configuration->getThreadsCount());
+        $this->assertSame($expectedThreadCount, $configuration->getThreadCount());
     }
 
     /**

--- a/tests/phpunit/Configuration/ConfigurationAssertions.php
+++ b/tests/phpunit/Configuration/ConfigurationAssertions.php
@@ -78,7 +78,7 @@ trait ConfigurationAssertions
         ?float $expectedMinMsi,
         bool $expectedShowMutations,
         ?float $expectedMinCoveredMsi,
-        int $expectedThreads
+        int $expectedThreadsCount
     ): void {
         $this->assertSame($expectedTimeout, $configuration->getProcessTimeout());
         $this->assertSame($expectedSourceDirectories, $configuration->getSourceDirectories());
@@ -121,7 +121,7 @@ trait ConfigurationAssertions
         $this->assertSame($expectedMinMsi, $configuration->getMinMsi());
         $this->assertSame($expectedShowMutations, $configuration->showMutations());
         $this->assertSame($expectedMinCoveredMsi, $configuration->getMinCoveredMsi());
-        $this->assertSame($expectedThreads, $configuration->getThreads());
+        $this->assertSame($expectedThreadsCount, $configuration->getThreadsCount());
     }
 
     /**

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -132,7 +132,7 @@ final class ConfigurationFactoryTest extends TestCase
         ?string $inputTestFramework,
         ?string $inputTestFrameworkExtraOptions,
         string $inputFilter,
-        int $inputThreads,
+        int $inputThreadsCount,
         int $expectedTimeout,
         array $expectedSourceDirectories,
         array $expectedSourceFiles,
@@ -176,7 +176,7 @@ final class ConfigurationFactoryTest extends TestCase
             $inputTestFramework,
             $inputTestFrameworkExtraOptions,
             $inputFilter,
-            $inputThreads
+            $inputThreadsCount
         );
 
         $this->assertConfigurationStateIs(
@@ -205,7 +205,7 @@ final class ConfigurationFactoryTest extends TestCase
             $expectedMinMsi,
             $expectedShowMutations,
             $expectedMinCoveredMsi,
-            $inputThreads
+            $inputThreadsCount
         );
     }
 

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -132,6 +132,7 @@ final class ConfigurationFactoryTest extends TestCase
         ?string $inputTestFramework,
         ?string $inputTestFrameworkExtraOptions,
         string $inputFilter,
+        int $inputThreads,
         int $expectedTimeout,
         array $expectedSourceDirectories,
         array $expectedSourceFiles,
@@ -174,7 +175,8 @@ final class ConfigurationFactoryTest extends TestCase
             $inputMutators,
             $inputTestFramework,
             $inputTestFrameworkExtraOptions,
-            $inputFilter
+            $inputFilter,
+            $inputThreads
         );
 
         $this->assertConfigurationStateIs(
@@ -202,7 +204,8 @@ final class ConfigurationFactoryTest extends TestCase
             $expectedIgnoreMsiWithNoMutations,
             $expectedMinMsi,
             $expectedShowMutations,
-            $expectedMinCoveredMsi
+            $expectedMinCoveredMsi,
+            $inputThreads
         );
     }
 
@@ -241,6 +244,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             '',
+            0,
             10,
             [],
             [],
@@ -620,6 +624,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             'src/Foo.php, src/Bar.php',
+            0,
             10,
             ['src/'],
             [
@@ -691,6 +696,7 @@ final class ConfigurationFactoryTest extends TestCase
             'phpspec',
             '--stop-on-failure',
             'src/Foo.php, src/Bar.php',
+            4,
             10,
             ['src/'],
             [
@@ -774,6 +780,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             '',
+            0,
             $expectedTimeOut,
             [],
             [],
@@ -838,6 +845,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             '',
+            0,
             10,
             [],
             [],
@@ -903,6 +911,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             '',
+            0,
             10,
             [],
             [],
@@ -967,6 +976,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             '',
+            0,
             10,
             [],
             [],
@@ -1032,6 +1042,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             '',
+            0,
             10,
             [],
             [],
@@ -1097,6 +1108,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             '',
+            0,
             10,
             [],
             [],
@@ -1162,6 +1174,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             '',
+            0,
             10,
             [],
             [],
@@ -1229,6 +1242,7 @@ final class ConfigurationFactoryTest extends TestCase
             $inputTestFramework,
             null,
             '',
+            0,
             10,
             [],
             [],
@@ -1294,6 +1308,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             '',
+            0,
             10,
             [],
             [],
@@ -1361,6 +1376,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             $inputTestFrameworkExtraOptions,
             '',
+            0,
             10,
             [],
             [],
@@ -1427,6 +1443,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             $inputTestFrameworkExtraOptions,
             '',
+            0,
             10,
             [],
             [],
@@ -1495,6 +1512,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             '',
+            0,
             10,
             [],
             [],

--- a/tests/phpunit/Configuration/ConfigurationTest.php
+++ b/tests/phpunit/Configuration/ConfigurationTest.php
@@ -81,7 +81,8 @@ final class ConfigurationTest extends TestCase
         bool $ignoreMsiWithNoMutations,
         ?float $minMsi,
         bool $showMutations,
-        ?float $minCoveredMsi
+        ?float $minCoveredMsi,
+        int $threads
     ): void {
         $config = new Configuration(
             $timeout,
@@ -107,7 +108,8 @@ final class ConfigurationTest extends TestCase
             $ignoreMsiWithNoMutations,
             $minMsi,
             $showMutations,
-            $minCoveredMsi
+            $minCoveredMsi,
+            $threads
         );
 
         $this->assertConfigurationStateIs(
@@ -135,7 +137,8 @@ final class ConfigurationTest extends TestCase
             $ignoreMsiWithNoMutations,
             $minMsi,
             $showMutations,
-            $minCoveredMsi
+            $minCoveredMsi,
+            $threads
         );
     }
 
@@ -166,6 +169,7 @@ final class ConfigurationTest extends TestCase
             null,
             false,
             null,
+            0,
         ];
 
         yield 'nominal' => [
@@ -204,6 +208,7 @@ final class ConfigurationTest extends TestCase
             43.,
             true,
             43.,
+            4,
         ];
     }
 }

--- a/tests/phpunit/Configuration/ConfigurationTest.php
+++ b/tests/phpunit/Configuration/ConfigurationTest.php
@@ -82,7 +82,7 @@ final class ConfigurationTest extends TestCase
         ?float $minMsi,
         bool $showMutations,
         ?float $minCoveredMsi,
-        int $threads
+        int $threadsCount
     ): void {
         $config = new Configuration(
             $timeout,
@@ -109,7 +109,7 @@ final class ConfigurationTest extends TestCase
             $minMsi,
             $showMutations,
             $minCoveredMsi,
-            $threads
+            $threadsCount
         );
 
         $this->assertConfigurationStateIs(
@@ -138,7 +138,7 @@ final class ConfigurationTest extends TestCase
             $minMsi,
             $showMutations,
             $minCoveredMsi,
-            $threads
+            $threadsCount
         );
     }
 

--- a/tests/phpunit/ContainerTest.php
+++ b/tests/phpunit/ContainerTest.php
@@ -103,7 +103,8 @@ final class ContainerTest extends TestCase
             .0,
             'phpunit',
             '',
-            ''
+            '',
+            0
         );
 
         $newContainer->getSchemaConfiguration();
@@ -114,6 +115,7 @@ final class ContainerTest extends TestCase
     public function test_it_can_build_lazy_source_file_data_factory_that_fails_on_use(): void
     {
         $container = SingletonContainer::getContainer();
+
         $newContainer = $container->withDynamicParameters(
             null,
             '',
@@ -131,7 +133,8 @@ final class ContainerTest extends TestCase
             .0,
             'phpunit',
             '',
-            ''
+            '',
+            0
         );
 
         $traces = $newContainer->getFilteredEnrichedTraceProvider()->provideTraces();

--- a/tests/phpunit/Fixtures/Process/DummyProcessBearer.php
+++ b/tests/phpunit/Fixtures/Process/DummyProcessBearer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Fixtures\Process;
+
+use Infection\Process\Runner\Parallel\ProcessBearer;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Process\Process;
+use function Safe\sprintf;
+
+final class DummyProcessBearer implements ProcessBearer
+{
+    private $process;
+    private $expectTimeOut;
+
+    public function __construct(Process $process, bool $expectTimeOut)
+    {
+        $this->process = $process;
+        $this->expectTimeOut = $expectTimeOut;
+    }
+
+    public function getProcess(): Process
+    {
+        return $this->process;
+    }
+
+    public function markAsTimedOut(): void
+    {
+        if (!$this->expectTimeOut) {
+            Assert::fail(sprintf(
+                'Did not expect "%s()" to be called',
+                __FUNCTION__
+            ));
+        }
+    }
+}

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -118,16 +118,15 @@ final class MutationTestingRunnerTest extends TestCase
     public function test_it_does_not_create_processes_when_there_is_not_mutations(): void
     {
         $mutations = [];
-        $threadCount = 4;
         $testFrameworkExtraOptions = '--filter=acme/FooTest.php';
 
         $this->parallelProcessRunnerMock
             ->expects($this->once())
             ->method('run')
-            ->with($this->emptyIterable(), $threadCount)
+            ->with($this->emptyIterable())
         ;
 
-        $this->runner->run($mutations, $threadCount, $testFrameworkExtraOptions);
+        $this->runner->run($mutations, $testFrameworkExtraOptions);
 
         $this->assertAreSameEvents(
             [
@@ -144,7 +143,6 @@ final class MutationTestingRunnerTest extends TestCase
             $mutation0 = $this->createMutation(0),
             $mutation1 = $this->createMutation(1),
         ];
-        $threadCount = 4;
         $testFrameworkExtraOptions = '--filter=acme/FooTest.php';
 
         $this->mutantFactoryMock
@@ -193,10 +191,10 @@ final class MutationTestingRunnerTest extends TestCase
         $this->parallelProcessRunnerMock
             ->expects($this->once())
             ->method('run')
-            ->with($this->iterableContaining([$process0, $process1]), $threadCount)
+            ->with($this->iterableContaining([$process0, $process1]))
         ;
 
-        $this->runner->run($mutations, $threadCount, $testFrameworkExtraOptions);
+        $this->runner->run($mutations, $testFrameworkExtraOptions);
 
         $this->assertAreSameEvents(
             [
@@ -214,7 +212,6 @@ final class MutationTestingRunnerTest extends TestCase
             $mutation1 = $this->createMutation(1),
         ]);
 
-        $threadCount = 4;
         $testFrameworkExtraOptions = '--filter=acme/FooTest.php';
 
         $this->mutantFactoryMock
@@ -263,7 +260,7 @@ final class MutationTestingRunnerTest extends TestCase
         $this->parallelProcessRunnerMock
             ->expects($this->once())
             ->method('run')
-            ->with($this->iterableContaining([$process0, $process1]), $threadCount)
+            ->with($this->iterableContaining([$process0, $process1]), )
         ;
 
         $this->runner = new MutationTestingRunner(
@@ -275,7 +272,7 @@ final class MutationTestingRunnerTest extends TestCase
             true
         );
 
-        $this->runner->run($mutations, $threadCount, $testFrameworkExtraOptions);
+        $this->runner->run($mutations, $testFrameworkExtraOptions);
 
         $this->assertAreSameEvents(
             [
@@ -294,8 +291,6 @@ final class MutationTestingRunnerTest extends TestCase
             ->method($this->anything())
         ;
 
-        $threadCount = 4;
-
         $this->mutantFactoryMock
             ->expects($this->never())
             ->method($this->anything())
@@ -309,7 +304,7 @@ final class MutationTestingRunnerTest extends TestCase
         $this->parallelProcessRunnerMock
             ->expects($this->once())
             ->method('run')
-            ->with($this->someIterable(), $threadCount)
+            ->with($this->someIterable())
         ;
 
         $this->runner = new MutationTestingRunner(
@@ -321,13 +316,12 @@ final class MutationTestingRunnerTest extends TestCase
             true
         );
 
-        $this->runner->run($mutations, $threadCount, '');
+        $this->runner->run($mutations, '');
     }
 
     public function test_it_dispatches_events_even_when_no_mutations_is_given(): void
     {
         $mutations = [];
-        $threadCount = 4;
         $testFrameworkExtraOptions = '--filter=acme/FooTest.php';
 
         $this->processBuilderMock
@@ -343,10 +337,10 @@ final class MutationTestingRunnerTest extends TestCase
         $this->parallelProcessRunnerMock
             ->expects($this->once())
             ->method('run')
-            ->with($this->emptyIterable(), $threadCount)
+            ->with($this->emptyIterable())
         ;
 
-        $this->runner->run($mutations, $threadCount, $testFrameworkExtraOptions);
+        $this->runner->run($mutations, $testFrameworkExtraOptions);
 
         $this->assertAreSameEvents(
             [

--- a/tests/phpunit/Process/Runner/Parallel/ParallelProcessRunnerTest.php
+++ b/tests/phpunit/Process/Runner/Parallel/ParallelProcessRunnerTest.php
@@ -36,11 +36,14 @@ declare(strict_types=1);
 namespace Infection\Tests\Process\Runner\Parallel;
 
 use Closure;
+use Generator;
 use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\MutantProcessWasFinished;
 use Infection\Mutant\MutantExecutionResult;
-use Infection\Process\MutantProcess;
 use Infection\Process\Runner\Parallel\ParallelProcessRunner;
+use Infection\Process\Runner\Parallel\ProcessBearer;
+use Infection\Tests\Fixtures\Process\DummyProcessBearer;
+use const PHP_INT_MAX;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
@@ -48,136 +51,160 @@ use Symfony\Component\Process\Process;
 
 final class ParallelProcessRunnerTest extends TestCase
 {
-    public function test_it_does_nothing_when_nothing_to_do(): void
+    public function test_it_does_nothing_when_no_process_is_given(): void
     {
-        $eventDispatcher = $this->buildEventDispatcherWithEventCount(0);
-        $runner = new ParallelProcessRunner(self::makeEventAccounter($eventDispatcher));
-        $runner->run([], 4, 0);
+        $eventDispatcher = $this->createEventDispatcherWithEventCount(0);
+
+        $runner = new ParallelProcessRunner(
+            $this->createProcessHandler($eventDispatcher),
+            4,
+            0
+        );
+
+        $runner->run([]);
     }
 
-    public function test_it_starts_processes_for_covered_mutants(): void
+    public function test_it_starts_the_given_processes(): void
     {
-        $processes = [];
-
-        for ($i = 0; $i < 10; ++$i) {
-            $processes[] = $this->buildMutantProcess();
-        }
-
-        $eventDispatcher = $this->buildEventDispatcherWithEventCount(10);
-        $runner = new ParallelProcessRunner(self::makeEventAccounter($eventDispatcher));
-        $runner->run($processes, 4, 0);
-    }
-
-    public function test_it_checks_for_timeout(): void
-    {
-        $processes = (function (): iterable {
+        $processes = (function (): Generator {
             for ($i = 0; $i < 10; ++$i) {
-                yield $this->buildMutantProcessWithTimeout();
+                yield $this->createProcessBearer();
             }
         })();
 
-        $eventDispatcher = $this->buildEventDispatcherWithEventCount(10);
-        $runner = new ParallelProcessRunner(self::makeEventAccounter($eventDispatcher));
-        $runner->run($processes, 4, 0);
+        $eventDispatcher = $this->createEventDispatcherWithEventCount(10);
+
+        $runner = new ParallelProcessRunner(
+            $this->createProcessHandler($eventDispatcher),
+            4,
+            0
+        );
+
+        $runner->run($processes);
     }
 
-    public function test_it_handles_all_kids_of_processes_with_infinite_threads(): void
+    public function test_it_checks_if_the_executed_processes_time_out(): void
     {
-        $this->runWithAllKindsOfProcesses(PHP_INT_MAX);
+        $processes = (function (): Generator {
+            for ($i = 0; $i < 10; ++$i) {
+                yield $this->createTimeOutProcessBearer();
+            }
+        })();
+
+        $eventDispatcher = $this->createEventDispatcherWithEventCount(10);
+
+        $runner = new ParallelProcessRunner(
+            $this->createProcessHandler($eventDispatcher),
+            4,
+            0
+        );
+
+        $runner->run($processes);
     }
 
-    public function test_it_handles_all_kids_of_processes(): void
+    /**
+     * @dataProvider threadCountProvider
+     */
+    public function test_it_handles_all_kids_of_processes_with_infinite_threads(int $threadCount): void
     {
-        $this->runWithAllKindsOfProcesses(4);
+        $this->runWithAllKindsOfProcesses($threadCount);
     }
 
-    public function test_it_handles_all_kids_of_processes_in_one_thread(): void
+    public function threadCountProvider(): iterable
     {
-        $this->runWithAllKindsOfProcesses(1);
+        yield 'no threads' => [0];
+
+        yield 'one thread' => [1];
+
+        yield 'invalid thread' => [-1];
+
+        yield 'nominal' => [4];
+
+        yield 'infinite' => [PHP_INT_MAX];
     }
 
-    public function test_it_still_runs_with_zero_threads(): void
+    /**
+     * @return EventDispatcher|MockObject
+     */
+    private function createEventDispatcherWithEventCount(int $eventCount): EventDispatcher
     {
-        $this->runWithAllKindsOfProcesses(0);
-    }
-
-    public function test_it_still_runs_with_negative_thread_count(): void
-    {
-        $this->runWithAllKindsOfProcesses(-1);
-    }
-
-    private function buildEventDispatcherWithEventCount(int $eventCount)
-    {
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher->expects($this->exactly($eventCount))
+        $eventDispatcherMock = $this->createMock(EventDispatcher::class);
+        $eventDispatcherMock
+            ->expects($this->exactly($eventCount))
             ->method('dispatch')
-            ->with(new MutantProcessWasFinished($this->createMock(MutantExecutionResult::class)));
+            ->with(new MutantProcessWasFinished(
+                $this->createMock(MutantExecutionResult::class))
+            )
+        ;
 
-        return $eventDispatcher;
+        return $eventDispatcherMock;
     }
 
-    private function buildMutantProcess(): MutantProcess
+    private function createProcessBearer(): ProcessBearer
     {
-        $process = $this->createMock(Process::class);
-        $process->expects($this->once())
-            ->method('start');
-        $process->expects($this->once())
-            ->method('checkTimeout');
-        $process->expects($this->once())
-            ->method('isRunning')
-            ->willReturn(false);
-
-        /** @var MockObject|MutantProcess $mutantProcess */
-        $mutantProcess = $this->createMock(MutantProcess::class);
-        $mutantProcess->expects($this->exactly(2))
-            ->method('getProcess')
-            ->willReturn($process);
-
-        return $mutantProcess;
-    }
-
-    private function buildMutantProcessWithTimeout(): MutantProcess
-    {
-        $process = $this->createMock(Process::class);
-        $process->expects($this->once())
-            ->method('start');
-        $process->expects($this->once())
+        $processMock = $this->createMock(Process::class);
+        $processMock
+            ->expects($this->once())
+            ->method('start')
+        ;
+        $processMock
+            ->expects($this->once())
             ->method('checkTimeout')
-            ->will($this->throwException(new ProcessTimedOutException($process, 1)));
-        $process->expects($this->once())
+        ;
+        $processMock
+            ->expects($this->once())
             ->method('isRunning')
-            ->willReturn(false);
+            ->willReturn(false)
+        ;
 
-        /** @var MockObject|MutantProcess $mutantProcess */
-        $mutantProcess = $this->createMock(MutantProcess::class);
-        $mutantProcess->expects($this->exactly(2))
-            ->method('getProcess')
-            ->willReturn($process);
-        $mutantProcess->expects($this->once())
-            ->method('markAsTimedOut');
+        return new DummyProcessBearer($processMock, false);
+    }
 
-        return $mutantProcess;
+    private function createTimeOutProcessBearer(): ProcessBearer
+    {
+        $processMock = $this->createMock(Process::class);
+        $processMock
+            ->expects($this->once())
+            ->method('start')
+        ;
+        $processMock
+            ->expects($this->once())
+            ->method('checkTimeout')
+            ->willThrowException(new ProcessTimedOutException($processMock, 1))
+        ;
+        $processMock
+            ->expects($this->once())
+            ->method('isRunning')
+            ->willReturn(false)
+        ;
+
+        return new DummyProcessBearer($processMock, true);
     }
 
     private function runWithAllKindsOfProcesses(int $threadCount): void
     {
-        $processes = [];
+        $processes = (function (): Generator {
+            for ($i = 0; $i < 5; ++$i) {
+                yield $this->createProcessBearer();
 
-        for ($i = 0; $i < 4; ++$i) {
-            $processes[] = $this->buildMutantProcess();
-            $processes[] = $this->buildMutantProcess();
-            $processes[] = $this->buildMutantProcessWithTimeout();
-        }
+                yield $this->createTimeOutProcessBearer();
+            }
+        })();
 
-        $eventDispatcher = $this->buildEventDispatcherWithEventCount(12);
+        $eventDispatcher = $this->createEventDispatcherWithEventCount(10);
 
-        $runner = new ParallelProcessRunner(self::makeEventAccounter($eventDispatcher));
-        $runner->run($processes, $threadCount, 0);
+        $runner = new ParallelProcessRunner(
+            $this->createProcessHandler($eventDispatcher),
+            $threadCount,
+            0
+        );
+
+        $runner->run($processes);
     }
 
-    private function makeEventAccounter(EventDispatcher $eventDispatcher): Closure
+    private function createProcessHandler(EventDispatcher $eventDispatcher): Closure
     {
-        return function (MutantProcess $mutantProcess) use ($eventDispatcher): void {
+        return function (ProcessBearer $processBearer) use ($eventDispatcher): void {
             $eventDispatcher->dispatch(new MutantProcessWasFinished(
                 // We're not testing MutantExecutionResult::createFromProcess() here
                 $this->createMock(MutantExecutionResult::class)


### PR DESCRIPTION
As I was looking into #1150, I was blocked by this question: where should this parameter go? Should it stored in the `Configuration` be part of service constructor(s) or passed around as a parameter?

If we take a closer look at Infection, the reality is as follows:

- we have a lot of parameters (see `Configuration`)
- most services depends on those parameters (i.e. depends on `Configuration`)

And it totally makes sense. As much as `Container::withDynamicParameters()` might be a bit confusing at first, it's neither an out of ordinary pattern and neither a bad fit: the alternative means passing the config to 3/4 of our services and that does not make any sense.

So back to the initial question. I think the best way to approach this is to ask ourselves: is that parameter an implementation detail of this class, or a generic parameter? For better clarity let's take our example here from this PR:

```php
// Prior to this PR
class ParallelProcessRunner {
    function run($processes, $threadCount)
}
```

`ParallelProcessRunner` is a concrete class without any parents. But if we imagined it had an interface, e.g. `ProcessRunner`, do the parameters `$processes` and `$threadCount` have a place there or are they an implementation detail of `ParallelProcessRunner`? IMO `$process` has a place yes, but not `$threadCount`.

Another example: `MutationTestingResultsLogger`:

```php
interface MutationTestingResultsLogger
{
    /**
     * Logs results of Mutation Testing to somewhere
     */
    public function log(): void;
}
```

Would it make sense to have a config object passed to `log()` for each type of logger? IMO while doable, it does not really makes sense either here (it could in other contexts maybe?).

I might revisit some similar cases in the future, but for now I'm fixing this one and I will add the `dryRun` parameter to `Configuration` in a similar fashion