### PR TITLE
Use most favorable non-buffering consumption in benchmarks

### DIFF
--- a/tests/benchmark/MutationGenerator/generate-mutations-closure.php
+++ b/tests/benchmark/MutationGenerator/generate-mutations-closure.php
@@ -38,7 +38,6 @@ namespace Infection\Benchmark\MutationGenerator;
 use function array_map;
 use Infection\Container;
 use Infection\TestFramework\Coverage\Trace;
-use function is_array;
 use function iterator_to_array;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -98,8 +97,9 @@ return static function () use ($fileMutationGenerator, $traces, $mutators): void
             []
         );
 
-        if (!is_array($mutations)) {
-            iterator_to_array($mutations, false);
+        // avoid all possible buffering
+        foreach ($mutations as $_) {
+            // discard
         }
     }
 };


### PR DESCRIPTION
Follow-up to #1178

When someone says they have some performance issues with Infection, I'd suggest to try with `--no-progress` because it offers most favorable conditions for Infection to run in. Likewise, when running benchmarks best to use similar, most favorable, conditions. Else we'll be testing PHP's efficiency with memory allocations, not what Infection is doing.

E.g. `iterator_to_array` [puts a strain](https://blackfire.io/profiles/d8e5faa7-7a92-4e11-85f2-e7dd8213bad9/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=iterator_to_array&callname=main()) on the PHP's memory allocator, which, I believe, is not what we after here with the benchmarks. All the while it excludes GC from the involvement, which might be detrimental for the performance of a long-running program—area we have yet to explore.