### PR TITLE
Add accepted ADR entries

### DIFF
--- a/adr/0001-inheritdoc.md
+++ b/adr/0001-inheritdoc.md
@@ -13,14 +13,10 @@ A number of points:
 Also it has a very limited value.
 
 
-### Consequences
-
-`@inheritdoc` tags and its variants must be removed when submitting pull requests.
-
-
 ### Decision
 
-Do not use `@inheritdoc` tags or any of its variants.
+Do not use `@inheritdoc` tags or any of its variants. The `@inheritdoc` tags and its variants must 
+be removed when submitting pull requests.
 
 
 ### Status

--- a/adr/0001-inheritdoc.md
+++ b/adr/0001-inheritdoc.md
@@ -1,14 +1,4 @@
-# Inheritdoc usage [(#860)](https://github.com/infection/infection/issues/860)
-
-### Decision
-
-Do not use `@inheritdoc` tags or any of its variants.
-
-
-### Status
-
-Accepted
-
+# Inheritdoc usage
 
 ### Context
 
@@ -17,9 +7,8 @@ systematically or remove it systematically had to be done.
 
 A number of points:
 
-- [PHPDoc](https://docs.phpdoc.org/guides/inheritance.html) provides inheritance of the docblocks
-  by default when appropriate
-- Static analysers such as PHPStan or Psalm can do without at the time of writting
+- [PHPDoc][phpdoc-inheritance] provides inheritance of the docblocks by default when appropriate
+- Static analysers such as PHPStan or Psalm can do without at the time of writing
 
 Also it has a very limited value.
 
@@ -27,3 +16,17 @@ Also it has a very limited value.
 ### Consequences
 
 `@inheritdoc` tags and its variants must be removed when submitting pull requests.
+
+
+### Decision
+
+Do not use `@inheritdoc` tags or any of its variants.
+
+
+### Status
+
+Accepted ([#860][860])
+
+
+[phpdoc-inheritance]: https://docs.phpdoc.org/guides/inheritance.html
+[860]: https://github.com/infection/infection/issues/860

--- a/adr/0002-@covers-annotations.md
+++ b/adr/0002-@covers-annotations.md
@@ -10,10 +10,10 @@ another settings as well?
 ### Decision
 
 Since we are using the [`symfony/phpunit-bridge`][phpunit-bridge], we decide to leverage the
-`Symfony\Bridge\PhpUnit\CoverageListener` in `phpunit.xml.dist` in order to avoid to require the
+[`Symfony\Bridge\PhpUnit\CoverageListener`][code-coverage-listener] in `phpunit.xml.dist` in order to avoid to require the
 `@covers` annotations whilst still benefit from it.
 
-This however does not allows to completely forgo its usage due to the following cases:
+This however does not allow to completely forgo its usage due to the following cases:
 
 - A test testing more than one class, requiring multiple `@covers` annotations
 - A test case testing a "test class", i.e. code reserved for testing purposes
@@ -21,7 +21,7 @@ This however does not allows to completely forgo its usage due to the following 
 For this reason, the proposal to remove the `@covers` annotations via the [PHP-CS-Fixer][php-cs-fixer]
 setting `general_phpdoc_annotation_remove` has been refused.
 
-Since no one came up with an easy or acceptable proposal to automate the process of whether an
+Since no one came up with an easy or acceptable proposal to automate the process of whether a
 `@covers` annotation is necessary or not, no further action has been voted for automating this 
 process.
 
@@ -31,6 +31,7 @@ process.
 Accepted ([#1060][1060])
 
 
+[code-coverage-listener]: https://symfony.com/doc/current/components/phpunit_bridge.html#code-coverage-listener
 [phpunit-bridge]: https://packagist.org/packages/symfony/phpunit-bridge
 [php-cs-fixer]: https://github.com/FriendsOfPHP/PHP-CS-Fixer
 [1060]: https://github.com/infection/infection/pull/1060

--- a/adr/0002-@covers-annotations.md
+++ b/adr/0002-@covers-annotations.md
@@ -1,0 +1,40 @@
+# `@covers` annotations usage
+
+### Context
+
+PHPUnit offers a range of `@covers` annotations with the possible to enforce a strict mode or to
+enforce them. The question is when should those annotations be enforced and/or if we need to enable
+another settings as well?
+
+
+### Decision
+
+Since we are using the [`symfony/phpunit-bridge`][phpunit-bridge], we decide to leverage the
+`Symfony\Bridge\PhpUnit\CoverageListener` in `phpunit.xml.dist` in order to avoid to require the
+`@covers` annotations whilst still benefit from it.
+
+This however does not allows to completely forgo its usage due to the following cases:
+
+- A test testing more than one class, requiring multiple `@covers` annotations
+- A test case testing a "test class", i.e. code reserved for testing purposes
+
+For this reason, the proposal to remove the `@covers` annotations via the [PHP-CS-Fixer][php-cs-fixer]
+setting `general_phpdoc_annotation_remove` has been refused.
+
+Since no one came up with an easy or acceptable proposal to automate the process of whether an
+`@covers` annotation is necessary or not, no further action has been voted for automating this 
+process.
+
+
+### Status
+
+Accepted ([#1060][1060])
+
+
+### Consequences
+
+We should omit the `@covers` annotation when unnecessary
+
+[phpunit-bridge]: https://packagist.org/packages/symfony/phpunit-bridge
+[php-cs-fixer]: https://github.com/FriendsOfPHP/PHP-CS-Fixer
+[1060]: https://github.com/infection/infection/pull/1060

--- a/adr/0002-@covers-annotations.md
+++ b/adr/0002-@covers-annotations.md
@@ -31,10 +31,6 @@ process.
 Accepted ([#1060][1060])
 
 
-### Consequences
-
-We should omit the `@covers` annotation when unnecessary
-
 [phpunit-bridge]: https://packagist.org/packages/symfony/phpunit-bridge
 [php-cs-fixer]: https://github.com/FriendsOfPHP/PHP-CS-Fixer
 [1060]: https://github.com/infection/infection/pull/1060

--- a/adr/0003-PHPUnit-this-over-self.md
+++ b/adr/0003-PHPUnit-this-over-self.md
@@ -1,0 +1,35 @@
+# Use `$this` instead of `self` for PHPUnit assertions
+
+### Context
+
+PHPUnit assertions are static methods, yet in our code base we call them with `$this` instead of
+`self`.
+
+Whilst "incorrect", this usage does not break anything. Besides:
+
+- [PHUnit documentation][phpunit-doc] itself uses this by default
+- `$this` is much more widely used than `self` in this context in the community
+- all Infection code uses `$this`
+- `phpstan-strict-rules` itself (we use PHPStan in Infection) recommends this
+
+There is not much shortcomings from using this other than the "incorrectness" of using a static
+method as a non-static one.
+
+
+### Decision
+
+Since there is no clear benefits of adopting `self` over `$this` and given the context of its usage,
+the decision is to keep the usage of `$this` over `self` in the codebase.
+
+
+### Status
+
+Accepted ([#1061][1061])
+
+
+### Consequences
+
+We should omit the `@covers` annotation when unnecessary
+
+[phpunit-doc]: https://phpunit.de/manual/6.5/en/appendixes.assertions.html
+[1061]: https://github.com/infection/infection/pull/1061

--- a/adr/0003-PHPUnit-this-over-self.md
+++ b/adr/0003-PHPUnit-this-over-self.md
@@ -27,9 +27,5 @@ the decision is to keep the usage of `$this` over `self` in the codebase.
 Accepted ([#1061][1061])
 
 
-### Consequences
-
-We should omit the `@covers` annotation when unnecessary
-
 [phpunit-doc]: https://phpunit.de/manual/6.5/en/appendixes.assertions.html
 [1061]: https://github.com/infection/infection/pull/1061

--- a/adr/0003-PHPUnit-this-over-self.md
+++ b/adr/0003-PHPUnit-this-over-self.md
@@ -10,7 +10,6 @@ Whilst "incorrect", this usage does not break anything. Besides:
 - [PHUnit documentation][phpunit-doc] itself uses this by default
 - `$this` is much more widely used than `self` in this context in the community
 - all Infection code uses `$this`
-- `phpstan-strict-rules` itself (we use PHPStan in Infection) recommends this
 
 There is not much shortcomings from using this other than the "incorrectness" of using a static
 method as a non-static one.

--- a/adr/0004-PHPUnit-expect-exception-over-try-catch.md
+++ b/adr/0004-PHPUnit-expect-exception-over-try-catch.md
@@ -1,0 +1,50 @@
+# Use PHPUnit `expectException*()` API over `try-catch`
+
+### Context
+
+When executing code that is expected to fail in a test case, there is two ways to do this:
+
+```php
+function test_something(): void {
+    // ...
+
+    try {
+        // the statement that fail
+        $this->fail();
+    } catch (Exception $e) {
+        // ...
+    }
+}
+```
+
+Or:
+
+```php
+function test_something(): void {
+    // ...
+
+    $this->expectException($exception)
+
+    // the statement that fail
+}
+```
+
+
+### Decision
+
+As recommended by [Sebastian Bergmann][sebastian-bergmann] in 
+[this article][phpunit-exception-best-practices], since in both cases a PHPUnit specific API is
+necessary, the decision taken is to leverage the `expectException*()` API when possible.
+
+A pull request to fix this practice in the whole codebase may be done but has not been made 
+mandatory. New pull requests though should stick to this practice.
+
+
+### Status
+
+Accepted ([#1090][1090])
+
+
+[sebastian-bergmann]: https://thephp.cc/company/consultants/sebastian-bergmann
+[phpunit-exception-best-practices]: https://thephp.cc/news/2016/02/questioning-phpunit-best-practices
+[1090]: https://github.com/infection/infection/pull/1061


### PR DESCRIPTION
Add ADR entries for some conventions or practices that have been discussed in the course of the last few months.

This PR is not an attempt or invitation to challenge any of those decisions: those are decisions _already_ made. If you wish to challenge or change one, this should be discussed and done in a separate issue/PR.