### PR TITLE
Introduce UnsupportedMethod

### DIFF
--- a/src/UnsupportedMethod.php
+++ b/src/UnsupportedMethod.php
@@ -33,33 +33,21 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Fixtures\Mutator;
+namespace Infection;
 
-use Infection\Mutator\Definition;
-use Infection\Mutator\Mutator;
-use Infection\UnsupportedMethod;
-use LogicException;
-use PhpParser\Node;
+use DomainException;
 
-final class FakeMutator implements Mutator
+/**
+ * @internal
+ */
+final class UnsupportedMethod extends DomainException
 {
-    public static function getDefinition(): ?Definition
+    public static function method(string $class, string $method): self
     {
-        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
-    }
-
-    public function getName(): string
-    {
-        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
-    }
-
-    public function canMutate(Node $node): bool
-    {
-        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
-    }
-
-    public function mutate(Node $node): iterable
-    {
-        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
+        return new self(sprintf(
+            'Did not expect "%s::%s()" to be called',
+            $class,
+            $method
+        ));
     }
 }

--- a/tests/phpunit/Fixtures/Event/UnknownEventSubscriber.php
+++ b/tests/phpunit/Fixtures/Event/UnknownEventSubscriber.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Infection\Tests\Fixtures\Event;
 
 use Infection\Event\Subscriber\EventSubscriber;
+use Infection\UnsupportedMethod;
 use LogicException;
 
 final class UnknownEventSubscriber implements EventSubscriber
 {
     public function onUnknownEventSubscriber(UnknownEventSubscriber $event): void
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 }

--- a/tests/phpunit/Fixtures/Event/UnknownEventSubscriber.php
+++ b/tests/phpunit/Fixtures/Event/UnknownEventSubscriber.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Fixtures\Event;
 
 use Infection\Event\Subscriber\EventSubscriber;
-use Infection\UnsupportedMethod;
-use LogicException;
+use Infection\Tests\UnsupportedMethod;
 
 final class UnknownEventSubscriber implements EventSubscriber
 {

--- a/tests/phpunit/Fixtures/Mutation/FakeNodeTraverser.php
+++ b/tests/phpunit/Fixtures/Mutation/FakeNodeTraverser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures\Mutation;
 
+use Infection\UnsupportedMethod;
 use LogicException;
 use PhpParser\Node;
 use PhpParser\NodeTraverserInterface;
@@ -13,28 +14,16 @@ final class FakeNodeTraverser implements NodeTraverserInterface
 {
     public function addVisitor(NodeVisitor $visitor)
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
-    /**
-     * Removes an added visitor.
-     *
-     * @param NodeVisitor $visitor
-     */
     public function removeVisitor(NodeVisitor $visitor)
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
-    /**
-     * Traverses an array of nodes using the registered visitors.
-     *
-     * @param Node[] $nodes Array of nodes
-     *
-     * @return Node[] Traversed array of nodes
-     */
     public function traverse(array $nodes): array
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 }

--- a/tests/phpunit/Fixtures/Mutation/FakeNodeTraverser.php
+++ b/tests/phpunit/Fixtures/Mutation/FakeNodeTraverser.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures\Mutation;
 
-use Infection\UnsupportedMethod;
-use LogicException;
-use PhpParser\Node;
+use Infection\Tests\UnsupportedMethod;
 use PhpParser\NodeTraverserInterface;
 use PhpParser\NodeVisitor;
 

--- a/tests/phpunit/Fixtures/Mutator/FakeMutator.php
+++ b/tests/phpunit/Fixtures/Mutator/FakeMutator.php
@@ -37,8 +37,7 @@ namespace Infection\Tests\Fixtures\Mutator;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\Mutator;
-use Infection\UnsupportedMethod;
-use LogicException;
+use Infection\Tests\UnsupportedMethod;
 use PhpParser\Node;
 
 final class FakeMutator implements Mutator

--- a/tests/phpunit/Fixtures/PhpParser/FakeIgnorer.php
+++ b/tests/phpunit/Fixtures/PhpParser/FakeIgnorer.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Fixtures\PhpParser;
 
 use Infection\PhpParser\Visitor\IgnoreNode\NodeIgnorer;
-use Infection\UnsupportedMethod;
-use LogicException;
+use Infection\Tests\UnsupportedMethod;
 use PhpParser\Node;
 
 final class FakeIgnorer implements NodeIgnorer

--- a/tests/phpunit/Fixtures/PhpParser/FakeIgnorer.php
+++ b/tests/phpunit/Fixtures/PhpParser/FakeIgnorer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Fixtures\PhpParser;
 
 use Infection\PhpParser\Visitor\IgnoreNode\NodeIgnorer;
+use Infection\UnsupportedMethod;
 use LogicException;
 use PhpParser\Node;
 
@@ -12,6 +13,6 @@ final class FakeIgnorer implements NodeIgnorer
 {
     public function ignores(Node $node): bool
     {
-       throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 }

--- a/tests/phpunit/Fixtures/PhpParser/FakeNode.php
+++ b/tests/phpunit/Fixtures/PhpParser/FakeNode.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures\PhpParser;
 
-use Infection\UnsupportedMethod;
-use LogicException;
+use Infection\Tests\UnsupportedMethod;
 use PhpParser\Comment;
 use PhpParser\Node;
 

--- a/tests/phpunit/Fixtures/PhpParser/FakeNode.php
+++ b/tests/phpunit/Fixtures/PhpParser/FakeNode.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures\PhpParser;
 
+use Infection\UnsupportedMethod;
 use LogicException;
 use PhpParser\Comment;
 use PhpParser\Node;
@@ -12,86 +13,86 @@ final class FakeNode implements Node
 {
     public function getType(): string
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getSubNodeNames(): array
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getLine(): int
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getStartLine(): int
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getEndLine(): int
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getStartTokenPos(): int
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getEndTokenPos(): int
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getStartFilePos(): int
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getEndFilePos(): int
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getComments(): array
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getDocComment()
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function setDocComment(Comment\Doc $docComment)
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function setAttribute(string $key, $value)
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function hasAttribute(string $key): bool
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getAttribute(string $key, $default = null)
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function getAttributes(): array
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function setAttributes(array $attributes)
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 }

--- a/tests/phpunit/Fixtures/PhpParser/FakeVisitor.php
+++ b/tests/phpunit/Fixtures/PhpParser/FakeVisitor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures\PhpParser;
 
+use Infection\UnsupportedMethod;
 use LogicException;
 use PhpParser\Node;
 use PhpParser\NodeVisitor;
@@ -12,21 +13,21 @@ final class FakeVisitor implements NodeVisitor
 {
     public function beforeTraverse(array $nodes)
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function enterNode(Node $node)
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function leaveNode(Node $node)
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function afterTraverse(array $nodes)
     {
-        throw new LogicException();
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 }

--- a/tests/phpunit/Fixtures/PhpParser/FakeVisitor.php
+++ b/tests/phpunit/Fixtures/PhpParser/FakeVisitor.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Fixtures\PhpParser;
 
-use Infection\UnsupportedMethod;
-use LogicException;
+use Infection\Tests\UnsupportedMethod;
 use PhpParser\Node;
 use PhpParser\NodeVisitor;
 

--- a/tests/phpunit/Fixtures/Process/FakeProcessBearer.php
+++ b/tests/phpunit/Fixtures/Process/FakeProcessBearer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Fixtures\Process;
 
 use Infection\Process\Runner\ProcessBearer;
+use Infection\UnsupportedMethod;
 use LogicException;
 use Symfony\Component\Process\Process;
 
@@ -12,11 +13,11 @@ final class FakeProcessBearer implements ProcessBearer
 {
     public function getProcess(): Process
     {
-        throw new LogicException('Did no expect to be called');
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 
     public function markAsTimedOut(): void
     {
-        throw new LogicException('Did no expect to be called');
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
     }
 }

--- a/tests/phpunit/Fixtures/Process/FakeProcessBearer.php
+++ b/tests/phpunit/Fixtures/Process/FakeProcessBearer.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Fixtures\Process;
 
 use Infection\Process\Runner\ProcessBearer;
-use Infection\UnsupportedMethod;
-use LogicException;
+use Infection\Tests\UnsupportedMethod;
 use Symfony\Component\Process\Process;
 
 final class FakeProcessBearer implements ProcessBearer

--- a/tests/phpunit/UnsupportedMethod.php
+++ b/tests/phpunit/UnsupportedMethod.php
@@ -33,7 +33,7 @@
 
 declare(strict_types=1);
 
-namespace Infection;
+namespace Infection\Tests;
 
 use DomainException;
 

--- a/tests/phpunit/UnsupportedMethod.php
+++ b/tests/phpunit/UnsupportedMethod.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests;
 
 use DomainException;
+use function Safe\sprintf;
 
 /**
  * @internal

--- a/tests/phpunit/UnsupportedMethodTest.php
+++ b/tests/phpunit/UnsupportedMethodTest.php
@@ -35,9 +35,11 @@ declare(strict_types=1);
 
 namespace Infection\Tests;
 
-use Infection\UnsupportedMethod;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Infection\Tests\UnsupportedMethod
+ */
 final class UnsupportedMethodTest extends TestCase
 {
     public function test_it_can_be_instantiated_for_a_method(): void

--- a/tests/phpunit/UnsupportedMethodTest.php
+++ b/tests/phpunit/UnsupportedMethodTest.php
@@ -33,33 +33,19 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Fixtures\Mutator;
+namespace Infection\Tests;
 
-use Infection\Mutator\Definition;
-use Infection\Mutator\Mutator;
 use Infection\UnsupportedMethod;
-use LogicException;
-use PhpParser\Node;
+use PHPUnit\Framework\TestCase;
 
-final class FakeMutator implements Mutator
+final class UnsupportedMethodTest extends TestCase
 {
-    public static function getDefinition(): ?Definition
+    public function test_it_can_be_instantiated_for_a_method(): void
     {
-        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
-    }
+        $exception = UnsupportedMethod::method('Acme\Foo', 'foo');
 
-    public function getName(): string
-    {
-        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
-    }
-
-    public function canMutate(Node $node): bool
-    {
-        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
-    }
-
-    public function mutate(Node $node): iterable
-    {
-        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
+        $this->assertSame('Did not expect "Acme\Foo::foo()" to be called', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
     }
 }


### PR DESCRIPTION
Small exception to be a bit more expressive when throwing an exception in a method when the method is not supported, e.g. in our "fake implementations".