### PR TITLE
Restrict Docker build context to only what is needed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!devTools

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 /.box_dump/
 /.ci/keys.asc
 /.composer/
-/.dockerignore
 /.idea
 /.php_cs.cache
 /.tools/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.box_dump/
 /.ci/keys.asc
 /.composer/
+/.dockerignore
 /.idea
 /.php_cs.cache
 /.tools/


### PR DESCRIPTION
Try running something on Docker:

```
make test-infection-xdebug-74-docker
```
Observe "Sending build context..." counting hundreds of megabytes. This PR makes sure this does not happen, because Docker only needs one directory for the context, nothing else.
