### PR TITLE
Rename MutantProcessBuilder to MutantProcessFactory

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -449,7 +449,7 @@ final class Container
             },
             MutationTestingRunner::class => static function (self $container): MutationTestingRunner {
                 return new MutationTestingRunner(
-                    $container->getMutantFactoryBuilder(),
+                    $container->getMutantProcessFactory(),
                     $container->getMutantFactory(),
                     $container->getProcessRunner(),
                     $container->getEventDispatcher(),
@@ -828,7 +828,7 @@ final class Container
         return $this->get(InitialTestsRunner::class);
     }
 
-    public function getMutantFactoryBuilder(): MutantProcessFactory
+    public function getMutantProcessFactory(): MutantProcessFactory
     {
         return $this->get(MutantProcessFactory::class);
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -74,7 +74,7 @@ use Infection\Mutator\MutatorResolver;
 use Infection\PhpParser\FileParser;
 use Infection\PhpParser\NodeTraverserFactory;
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
-use Infection\Process\Builder\MutantProcessBuilder;
+use Infection\Process\Builder\MutantProcessFactory;
 use Infection\Process\Builder\SubscriberBuilder;
 use Infection\Process\Runner\DryProcessRunner;
 use Infection\Process\Runner\InitialTestsRunner;
@@ -417,8 +417,8 @@ final class Container
                     $container->getEventDispatcher()
                 );
             },
-            MutantProcessBuilder::class => static function (self $container): MutantProcessBuilder {
-                return new MutantProcessBuilder(
+            MutantProcessFactory::class => static function (self $container): MutantProcessFactory {
+                return new MutantProcessFactory(
                     $container->getTestFrameworkAdapter(),
                     $container->getConfiguration()->getProcessTimeout(),
                     $container->getEventDispatcher(),
@@ -438,7 +438,7 @@ final class Container
             },
             MutationTestingRunner::class => static function (self $container): MutationTestingRunner {
                 return new MutationTestingRunner(
-                    $container->getMutantProcessBuilder(),
+                    $container->getMutantFactoryBuilder(),
                     $container->getMutantFactory(),
                     $container->getProcessRunner(),
                     $container->getEventDispatcher(),
@@ -812,9 +812,9 @@ final class Container
         return $this->get(InitialTestsRunner::class);
     }
 
-    public function getMutantProcessBuilder(): MutantProcessBuilder
+    public function getMutantFactoryBuilder(): MutantProcessFactory
     {
-        return $this->get(MutantProcessBuilder::class);
+        return $this->get(MutantProcessFactory::class);
     }
 
     public function getMutationGenerator(): MutationGenerator

--- a/src/Process/Builder/MutantProcessFactory.php
+++ b/src/Process/Builder/MutantProcessFactory.php
@@ -48,7 +48,7 @@ use Symfony\Component\Process\Process;
  * @internal
  * @final
  */
-class MutantProcessBuilder
+class MutantProcessFactory
 {
     private $testFrameworkAdapter;
     private $timeout;

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -44,7 +44,7 @@ use Infection\Mutant\Mutant;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutant\MutantFactory;
 use Infection\Mutation\Mutation;
-use Infection\Process\Builder\MutantProcessBuilder;
+use Infection\Process\Builder\MutantProcessFactory;
 use function Pipeline\take;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -53,7 +53,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class MutationTestingRunner
 {
-    private $processBuilder;
+    private $processFactory;
     private $mutantFactory;
     private $processRunner;
     private $eventDispatcher;
@@ -61,14 +61,14 @@ final class MutationTestingRunner
     private $runConcurrently;
 
     public function __construct(
-        MutantProcessBuilder $mutantProcessBuilder,
+        MutantProcessFactory $processFactory,
         MutantFactory $mutantFactory,
         ProcessRunner $processRunner,
         EventDispatcher $eventDispatcher,
         Filesystem $fileSystem,
         bool $runConcurrently
     ) {
-        $this->processBuilder = $mutantProcessBuilder;
+        $this->processFactory = $processFactory;
         $this->mutantFactory = $mutantFactory;
         $this->processRunner = $processRunner;
         $this->eventDispatcher = $eventDispatcher;
@@ -103,7 +103,7 @@ final class MutationTestingRunner
             ->map(function (Mutant $mutant) use ($testFrameworkExtraOptions): ProcessBearer {
                 $this->fileSystem->dumpFile($mutant->getFilePath(), $mutant->getMutatedCode());
 
-                $process = $this->processBuilder->createProcessForMutant($mutant, $testFrameworkExtraOptions);
+                $process = $this->processFactory->createProcessForMutant($mutant, $testFrameworkExtraOptions);
 
                 return $process;
             })

--- a/tests/phpunit/Process/Builder/MutantProcessFactoryTest.php
+++ b/tests/phpunit/Process/Builder/MutantProcessFactoryTest.php
@@ -45,14 +45,14 @@ use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\ZeroIteration\For_;
 use Infection\PhpParser\MutatedNode;
-use Infection\Process\Builder\MutantProcessBuilder;
+use Infection\Process\Builder\MutantProcessFactory;
 use Infection\Tests\Fixtures\Event\EventDispatcherCollector;
 use Infection\Tests\Mutator\MutatorName;
 use const PHP_OS_FAMILY;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\TestCase;
 
-final class MutantProcessBuilderTest extends TestCase
+final class MutantProcessFactoryTest extends TestCase
 {
     public function test_it_creates_a_process_with_timeout(): void
     {
@@ -123,14 +123,14 @@ DIFF
             ->willReturn($executionResultMock)
         ;
 
-        $builder = new MutantProcessBuilder(
+        $factory = new MutantProcessFactory(
             $testFrameworkAdapterMock,
             100,
             $eventDispatcher,
             $resultFactoryMock
         );
 
-        $mutantProcess = $builder->createProcessForMutant($mutant, $testFrameworkExtraOptions);
+        $mutantProcess = $factory->createProcessForMutant($mutant, $testFrameworkExtraOptions);
 
         $process = $mutantProcess->getProcess();
 

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -48,7 +48,7 @@ use Infection\Mutant\MutantFactory;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\ZeroIteration\For_;
 use Infection\PhpParser\MutatedNode;
-use Infection\Process\Builder\MutantProcessBuilder;
+use Infection\Process\Builder\MutantProcessFactory;
 use Infection\Process\MutantProcess;
 use Infection\Process\Runner\MutationTestingRunner;
 use Infection\Process\Runner\ProcessRunner;
@@ -68,9 +68,9 @@ use Symfony\Component\Filesystem\Filesystem;
 final class MutationTestingRunnerTest extends TestCase
 {
     /**
-     * @var MutantProcessBuilder|MockObject
+     * @var MutantProcessFactory|MockObject
      */
-    private $processBuilderMock;
+    private $processFactoryMock;
 
     /**
      * @var MutantFactory|MockObject
@@ -99,14 +99,14 @@ final class MutationTestingRunnerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->processBuilderMock = $this->createMock(MutantProcessBuilder::class);
+        $this->processFactoryMock = $this->createMock(MutantProcessFactory::class);
         $this->mutantFactoryMock = $this->createMock(MutantFactory::class);
         $this->processRunnerMock = $this->createMock(ProcessRunner::class);
         $this->eventDispatcher = new EventDispatcherCollector();
         $this->fileSystemMock = $this->createMock(Filesystem::class);
 
         $this->runner = new MutationTestingRunner(
-            $this->processBuilderMock,
+            $this->processFactoryMock,
             $this->mutantFactoryMock,
             $this->processRunnerMock,
             $this->eventDispatcher,
@@ -176,7 +176,7 @@ final class MutationTestingRunnerTest extends TestCase
             )
         ;
 
-        $this->processBuilderMock
+        $this->processFactoryMock
             ->method('createProcessForMutant')
             ->withConsecutive(
                 [$mutant0, $testFrameworkExtraOptions],
@@ -245,7 +245,7 @@ final class MutationTestingRunnerTest extends TestCase
             )
         ;
 
-        $this->processBuilderMock
+        $this->processFactoryMock
             ->method('createProcessForMutant')
             ->withConsecutive(
                 [$mutant0, $testFrameworkExtraOptions],
@@ -264,7 +264,7 @@ final class MutationTestingRunnerTest extends TestCase
         ;
 
         $this->runner = new MutationTestingRunner(
-            $this->processBuilderMock,
+            $this->processFactoryMock,
             $this->mutantFactoryMock,
             $this->processRunnerMock,
             $this->eventDispatcher,
@@ -296,7 +296,7 @@ final class MutationTestingRunnerTest extends TestCase
             ->method($this->anything())
         ;
 
-        $this->processBuilderMock
+        $this->processFactoryMock
             ->expects($this->never())
             ->method($this->anything())
         ;
@@ -308,7 +308,7 @@ final class MutationTestingRunnerTest extends TestCase
         ;
 
         $this->runner = new MutationTestingRunner(
-            $this->processBuilderMock,
+            $this->processFactoryMock,
             $this->mutantFactoryMock,
             $this->processRunnerMock,
             $this->eventDispatcher,
@@ -324,7 +324,7 @@ final class MutationTestingRunnerTest extends TestCase
         $mutations = [];
         $testFrameworkExtraOptions = '--filter=acme/FooTest.php';
 
-        $this->processBuilderMock
+        $this->processFactoryMock
             ->expects($this->never())
             ->method($this->anything())
         ;


### PR DESCRIPTION
I think it is more appropriate to call it `Factory` than `Builder`, since it's:

- closer to what it does
- a more standard name for that role/pattern
- can be confusion with the actual [builder pattern](https://en.wikipedia.org/wiki/Builder_pattern)