### PR TITLE
Mutant & Mutation tweaks

### DIFF
--- a/src/Metrics/MetricsCalculator.php
+++ b/src/Metrics/MetricsCalculator.php
@@ -68,7 +68,7 @@ class MetricsCalculator
     /**
      * @var int
      */
-    private $notCoveredByTestsCount = 0;
+    private $notExecutedByTestsCount = 0;
 
     /**
      * @var int
@@ -110,7 +110,7 @@ class MetricsCalculator
                     break;
 
                 case DetectionStatus::NOT_COVERED:
-                    $this->notCoveredByTestsCount++;
+                    $this->notExecutedByTestsCount++;
                     $this->notCoveredExecutionResults->add($executionResult);
 
                     break;
@@ -164,7 +164,7 @@ class MetricsCalculator
 
     public function getNotTestedCount(): int
     {
-        return $this->notCoveredByTestsCount;
+        return $this->notExecutedByTestsCount;
     }
 
     public function getTotalMutantsCount(): int

--- a/src/Mutant/Mutant.php
+++ b/src/Mutant/Mutant.php
@@ -81,11 +81,6 @@ class Mutant
         return $this->diff;
     }
 
-    public function isCoveredByTest(): bool
-    {
-        return $this->mutation->isCoveredByTest();
-    }
-
     /**
      * @return TestLocation[]
      */

--- a/src/Mutant/Mutant.php
+++ b/src/Mutant/Mutant.php
@@ -86,6 +86,6 @@ class Mutant
      */
     public function getTests(): array
     {
-        return $this->mutation->getAllTests();
+        return $this->mutation->getTests();
     }
 }

--- a/src/Mutant/MutantExecutionResultFactory.php
+++ b/src/Mutant/MutantExecutionResultFactory.php
@@ -86,7 +86,7 @@ class MutantExecutionResultFactory
 
     private function retrieveDetectionStatus(MutantProcess $mutantProcess): string
     {
-        if (!$mutantProcess->getMutant()->isCoveredByTest()) {
+        if (!$mutantProcess->getMutant()->getMutation()->hasTests()) {
             return DetectionStatus::NOT_COVERED;
         }
 

--- a/src/Mutation/Mutation.php
+++ b/src/Mutation/Mutation.php
@@ -158,7 +158,7 @@ class Mutation
     /**
      * @return TestLocation[]
      */
-    public function getAllTests(): array
+    public function getTests(): array
     {
         return $this->tests;
     }

--- a/src/Mutation/Mutation.php
+++ b/src/Mutation/Mutation.php
@@ -70,7 +70,7 @@ class Mutation
     private $attributes;
     private $originalFileAst;
     private $tests;
-    private $coveredByTests;
+    private $executedByTests;
 
     /**
      * @var string|null
@@ -106,7 +106,7 @@ class Mutation
         $this->mutatedNode = $mutatedNode;
         $this->mutationByMutatorIndex = $mutationByMutatorIndex;
         $this->tests = $tests;
-        $this->coveredByTests = count($tests) > 0;
+        $this->executedByTests = count($tests) > 0;
     }
 
     public function getOriginalFilePath(): string
@@ -150,10 +150,9 @@ class Mutation
         return $this->mutatedNode;
     }
 
-    // TODO: hasTest()?
-    public function isCoveredByTest(): bool
+    public function hasTests(): bool
     {
-        return $this->coveredByTests;
+        return $this->executedByTests;
     }
 
     /**

--- a/src/Process/Builder/MutantProcessBuilder.php
+++ b/src/Process/Builder/MutantProcessBuilder.php
@@ -70,12 +70,14 @@ class MutantProcessBuilder
 
     public function createProcessForMutant(Mutant $mutant, string $testFrameworkExtraOptions = ''): MutantProcess
     {
+        $mutation = $mutant->getMutation();
+
         $process = new Process(
             $this->testFrameworkAdapter->getMutantCommandLine(
-                $mutant->getTests(),
+                $mutation->getTests(),
                 $mutant->getFilePath(),
-                $mutant->getMutation()->getHash(),
-                $mutant->getMutation()->getOriginalFilePath(),
+                $mutation->getHash(),
+                $mutation->getOriginalFilePath(),
                 $testFrameworkExtraOptions
             )
         );

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -89,8 +89,11 @@ final class MutationTestingRunner
                 return $this->mutantFactory->create($mutation);
             })
             ->filter(function (Mutant $mutant) {
-                // It's a proxy call to Mutation, can be done one stage up
-                if ($mutant->isCoveredByTest()) {
+                // The filtering is done here since with a mutant and not earlier with a mutation
+                // since:
+                // - if pass the filtering, the mutant is going to be used
+                // - if does not pass the filtering, the mutant is used for the reports
+                if ($mutant->getMutation()->hasTests()) {
                     return true;
                 }
 

--- a/tests/phpunit/Mutant/MutantAssertions.php
+++ b/tests/phpunit/Mutant/MutantAssertions.php
@@ -50,14 +50,12 @@ trait MutantAssertions
         Mutation $expectedMutation,
         string $expectedMutatedCode,
         string $expectedDiff,
-        bool $expectedCoveredByTests,
         array $expectedTests
     ): void {
         $this->assertSame($expectedFilePath, $mutant->getFilePath());
         $this->assertSame($expectedMutation, $mutant->getMutation());
         $this->assertSame($expectedMutatedCode, $mutant->getMutatedCode());
         $this->assertSame($expectedDiff, $mutant->getDiff());
-        $this->assertSame($expectedCoveredByTests, $mutant->isCoveredByTest());
         $this->assertSame($expectedTests, $mutant->getTests());
     }
 }

--- a/tests/phpunit/Mutant/MutantAssertions.php
+++ b/tests/phpunit/Mutant/MutantAssertions.php
@@ -35,27 +35,21 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Mutant;
 
-use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\Mutant\Mutant;
 use Infection\Mutation\Mutation;
 
 trait MutantAssertions
 {
-    /**
-     * @param TestLocation[] $expectedTests
-     */
     public function assertMutantStateIs(
         Mutant $mutant,
         string $expectedFilePath,
         Mutation $expectedMutation,
         string $expectedMutatedCode,
-        string $expectedDiff,
-        array $expectedTests
+        string $expectedDiff
     ): void {
         $this->assertSame($expectedFilePath, $mutant->getFilePath());
         $this->assertSame($expectedMutation, $mutant->getMutation());
         $this->assertSame($expectedMutatedCode, $mutant->getMutatedCode());
         $this->assertSame($expectedDiff, $mutant->getDiff());
-        $this->assertSame($expectedTests, $mutant->getTests());
     }
 }

--- a/tests/phpunit/Mutant/MutantFactoryTest.php
+++ b/tests/phpunit/Mutant/MutantFactoryTest.php
@@ -98,13 +98,7 @@ final class MutantFactoryTest extends TestCase
                 new Node\Name('Acme'),
                 [new Node\Scalar\LNumber(0)]
             )],
-            $tests = [
-                new TestLocation(
-                    'FooTest::test_it_can_instantiate',
-                    '/path/to/acme/FooTest.php',
-                    0.01
-                ),
-            ]
+            []
         );
 
         $expectedMutantFilePath = sprintf(
@@ -140,8 +134,7 @@ final class MutantFactoryTest extends TestCase
             $expectedMutantFilePath,
             $mutation,
             'mutated code',
-            'code diff',
-            $tests
+            'code diff'
         );
     }
 

--- a/tests/phpunit/Mutant/MutantFactoryTest.php
+++ b/tests/phpunit/Mutant/MutantFactoryTest.php
@@ -141,7 +141,6 @@ final class MutantFactoryTest extends TestCase
             $mutation,
             'mutated code',
             'code diff',
-            true,
             $tests
         );
     }

--- a/tests/phpunit/Mutant/MutantTest.php
+++ b/tests/phpunit/Mutant/MutantTest.php
@@ -58,7 +58,6 @@ final class MutantTest extends TestCase
         Mutation $mutation,
         string $mutatedCode,
         string $diff,
-        bool $expectedCoveredByTests,
         array $expectedTests
     ): void {
         $mutant = new Mutant($filePath, $mutation, $mutatedCode, $diff);
@@ -69,7 +68,6 @@ final class MutantTest extends TestCase
             $mutation,
             $mutatedCode,
             $diff,
-            $expectedCoveredByTests,
             $expectedTests
         );
     }
@@ -110,7 +108,6 @@ final class MutantTest extends TestCase
             ),
             'mutated code',
             'diff value',
-            true,
             $tests,
         ];
 
@@ -131,7 +128,6 @@ final class MutantTest extends TestCase
             ),
             'mutated code',
             'diff value',
-            false,
             [],
         ];
     }

--- a/tests/phpunit/Mutant/MutantTest.php
+++ b/tests/phpunit/Mutant/MutantTest.php
@@ -50,15 +50,12 @@ final class MutantTest extends TestCase
 
     /**
      * @dataProvider valuesProvider
-     *
-     * @param TestLocation[] $expectedTests
      */
     public function test_it_can_be_instantiated(
         string $filePath,
         Mutation $mutation,
         string $mutatedCode,
-        string $diff,
-        array $expectedTests
+        string $diff
     ): void {
         $mutant = new Mutant($filePath, $mutation, $mutatedCode, $diff);
 
@@ -67,8 +64,7 @@ final class MutantTest extends TestCase
             $filePath,
             $mutation,
             $mutatedCode,
-            $diff,
-            $expectedTests
+            $diff
         );
     }
 
@@ -108,7 +104,6 @@ final class MutantTest extends TestCase
             ),
             'mutated code',
             'diff value',
-            $tests,
         ];
 
         yield 'nominal without tests' => [
@@ -128,7 +123,6 @@ final class MutantTest extends TestCase
             ),
             'mutated code',
             'diff value',
-            [],
         ];
     }
 }

--- a/tests/phpunit/Mutation/MutationTest.php
+++ b/tests/phpunit/Mutation/MutationTest.php
@@ -87,7 +87,7 @@ final class MutationTest extends TestCase
         $this->assertSame($expectedOriginalStartingLine, $mutation->getOriginalStartingLine());
         $this->assertSame($mutatedNodeClass, $mutation->getMutatedNodeClass());
         $this->assertSame($mutatedNode, $mutation->getMutatedNode());
-        $this->assertSame($tests, $mutation->getAllTests());
+        $this->assertSame($tests, $mutation->getTests());
         $this->assertSame($expectedHasTests, $mutation->hasTests());
         $this->assertSame($expectedHash, $mutation->getHash());
     }

--- a/tests/phpunit/Mutation/MutationTest.php
+++ b/tests/phpunit/Mutation/MutationTest.php
@@ -66,7 +66,7 @@ final class MutationTest extends TestCase
         array $tests,
         array $expectedAttributes,
         int $expectedOriginalStartingLine,
-        bool $expectedCoveredByTests,
+        bool $expectedHasTests,
         string $expectedHash
     ): void {
         $mutation = new Mutation(
@@ -88,7 +88,7 @@ final class MutationTest extends TestCase
         $this->assertSame($mutatedNodeClass, $mutation->getMutatedNodeClass());
         $this->assertSame($mutatedNode, $mutation->getMutatedNode());
         $this->assertSame($tests, $mutation->getAllTests());
-        $this->assertSame($expectedCoveredByTests, $mutation->isCoveredByTest());
+        $this->assertSame($expectedHasTests, $mutation->hasTests());
         $this->assertSame($expectedHash, $mutation->getHash());
     }
 


### PR DESCRIPTION
I don't think there is a need to keep a duplicated method hence the removal of: 

- `Mutant::isCoveredByTests()`
- `Mutant::getTests()`

I also propose to rename `Mutation::isCoveredByTests()` to `hasTests()` or alternatively `isExecutedByTests()` to avoid the "coverage" notion confusion.

`Mutation::getAllTests()` also has been renamed `getTests()`, since it's unclear otherwise whether it's all the tests for the mutations or all the tests in general. Removing just implies the tests for the mutation