### PR TITLE
Make coverage path more tolerant

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -63,12 +63,6 @@ class ConfigurationFactory
      */
     private const DEFAULT_TIMEOUT = 10;
 
-    private const TEST_FRAMEWORK_COVERAGE_DIRECTORY = [
-        TestFrameworkTypes::PHPUNIT => 'coverage-xml',
-        TestFrameworkTypes::PHPSPEC => TestFrameworkTypes::PHPSPEC . '-coverage-xml',
-        TestFrameworkTypes::CODECEPTION => TestFrameworkTypes::CODECEPTION . '-coverage-xml',
-    ];
-
     private $tmpDirProvider;
     private $mutatorResolver;
     private $mutatorFactory;
@@ -142,7 +136,7 @@ class ConfigurationFactory
             $schema->getBootstrap(),
             $initialTestsPhpOptions ?? $schema->getInitialTestsPhpOptions(),
             self::retrieveTestFrameworkExtraOptions($testFrameworkExtraOptions, $schema),
-            self::retrieveCoveragePath($coverageBasePath, $testFramework),
+            $coverageBasePath,
             $skipCoverage,
             $skipInitialTests,
             $debug,
@@ -212,19 +206,6 @@ class ConfigurationFactory
 
         return $this->mutatorFactory->create(
             $this->mutatorResolver->resolve($mutatorsList)
-        );
-    }
-
-    private static function retrieveCoveragePath(
-        string $coverageBasePath,
-        string $testFramework
-    ): string {
-        Assert::keyExists(self::TEST_FRAMEWORK_COVERAGE_DIRECTORY, $testFramework);
-
-        return sprintf(
-            '%s/%s',
-            $coverageBasePath,
-            self::TEST_FRAMEWORK_COVERAGE_DIRECTORY[$testFramework]
         );
     }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -162,10 +162,8 @@ final class Container
             TmpDirProvider::class => static function (): TmpDirProvider {
                 return new TmpDirProvider();
             },
-            IndexXmlCoverageParser::class => static function (self $container): IndexXmlCoverageParser {
-                return new IndexXmlCoverageParser(
-                    $container->getConfiguration()->getCoveragePath(),
-                );
+            IndexXmlCoverageParser::class => static function (): IndexXmlCoverageParser {
+                return new IndexXmlCoverageParser();
             },
             XmlCoverageParser::class => static function (): XmlCoverageParser {
                 // TODO XmlCoverageParser might want to notify ProcessRunner if it can't parse another file due to lack of RAM
@@ -590,7 +588,7 @@ final class Container
         return $this->defaultJUnitPath ?? $this->defaultJUnitPath = sprintf(
             '%s/%s',
             Path::canonicalize(
-                $this->getConfiguration()->getCoveragePath() . '/..'
+                $this->getConfiguration()->getCoveragePath()
             ),
             'junit.xml'
         );

--- a/src/TestFramework/Coverage/JUnit/JUnitReportLocator.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitReportLocator.php
@@ -63,7 +63,7 @@ class JUnitReportLocator
 
     public function __construct(string $coveragePath, string $defaultJUnitPath)
     {
-        $this->coveragePath = Path::canonicalize($coveragePath . '/..');
+        $this->coveragePath = $coveragePath;
         $this->defaultJUnitPath = Path::canonicalize($defaultJUnitPath);
     }
 

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php
@@ -63,8 +63,8 @@ class IndexXmlCoverageLocator
 
     public function __construct(string $coveragePath)
     {
-        $this->coveragePath = Path::canonicalize($coveragePath . '/..');
-        $this->defaultIndexPath = Path::canonicalize($coveragePath . '/index.xml');
+        $this->coveragePath = $coveragePath;
+        $this->defaultIndexPath = Path::canonicalize($coveragePath . '/coverage-xml/index.xml');
     }
 
     /**

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
@@ -44,13 +44,6 @@ use Infection\TestFramework\SafeDOMXPath;
  */
 class IndexXmlCoverageParser
 {
-    private $coverageDir;
-
-    public function __construct(string $coverageDir)
-    {
-        $this->coverageDir = $coverageDir;
-    }
-
     /**
      * Parses the given PHPUnit XML coverage index report (index.xml) to collect the information
      * needed to parse general coverage data. Note that this data is likely incomplete an will
@@ -60,20 +53,26 @@ class IndexXmlCoverageParser
      *
      * @return iterable<SourceFileInfoProvider>
      */
-    public function parse(string $coverageIndexPath, string $xmlIndexCoverageContent): iterable
-    {
+    public function parse(
+        string $coverageIndexPath,
+        string $xmlIndexCoverageContent,
+        string $coverageBasePath
+    ): iterable {
         $xPath = XPathFactory::createXPath($xmlIndexCoverageContent);
 
         self::assertHasExecutedLines($xPath);
 
-        return $this->parseNodes($coverageIndexPath, $xPath);
+        return $this->parseNodes($coverageIndexPath, $coverageBasePath, $xPath);
     }
 
     /**
      * @return iterable<SourceFileInfoProvider>
      */
-    private function parseNodes(string $coverageIndexPath, SafeDOMXPath $xPath): iterable
-    {
+    private function parseNodes(
+        string $coverageIndexPath,
+        string $coverageBasePath,
+        SafeDOMXPath $xPath
+    ): iterable {
         $projectSource = self::getProjectSource($xPath);
 
         foreach ($xPath->query('//file') as $node) {
@@ -81,7 +80,7 @@ class IndexXmlCoverageParser
 
             yield new SourceFileInfoProvider(
                 $coverageIndexPath,
-                $this->coverageDir,
+                $coverageBasePath,
                 $relativeCoverageFilePath,
                 $projectSource
             );

--- a/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProvider.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Coverage\XmlReport;
 
+use function dirname;
 use Infection\TestFramework\Coverage\Trace;
 use Infection\TestFramework\Coverage\TraceProvider;
 use function Safe\file_get_contents;
@@ -69,11 +70,13 @@ class PhpUnitXmlCoverageTraceProvider implements TraceProvider
         // The existence of the file should have already been checked. Hence in theory we should not
         // have to deal with a FileNotFound exception here so we skip any friendly error handling
         $indexPath = $this->indexLocator->locate();
+        $coverageBasePath = dirname($indexPath);
         $indexContents = file_get_contents($indexPath);
 
         foreach ($this->indexParser->parse(
             $indexPath,
-            $indexContents
+            $indexContents,
+            $coverageBasePath
         ) as $infoProvider) {
             // TODO It might be beneficial to filter files at this stage, rather than later. SourceFileDataFactory does that.
             yield $this->parser->parse($infoProvider);

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -267,7 +267,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             '',
-            sys_get_temp_dir() . '/infection/coverage-xml',
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,
@@ -312,19 +312,19 @@ final class ConfigurationFactoryTest extends TestCase
         yield 'no existing base path for code coverage' => self::createValueForCoveragePath(
             null,
             false,
-            sys_get_temp_dir() . '/infection/coverage-xml'
+            sys_get_temp_dir() . '/infection'
         );
 
         yield 'absolute base path for code coverage' => self::createValueForCoveragePath(
             '/path/to/coverage',
             true,
-            '/path/to/coverage/coverage-xml'
+            '/path/to/coverage'
         );
 
         yield 'relative base path for code coverage' => self::createValueForCoveragePath(
             'relative/path/to/coverage',
             true,
-            '/path/to/relative/path/to/coverage/coverage-xml'
+            '/path/to/relative/path/to/coverage'
         );
 
         yield 'no PHPUnit config dir' => self::createValueForPhpUnitConfigDir(
@@ -436,32 +436,28 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             'phpunit',
-            '',
-            sys_get_temp_dir() . '/infection/coverage-xml'
+            ''
         );
 
         yield 'test framework from config' => self::createValueForTestFramework(
             'phpspec',
             null,
             'phpspec',
-            '',
-            sys_get_temp_dir() . '/infection/phpspec-coverage-xml'
+            ''
         );
 
         yield 'test framework from input' => self::createValueForTestFramework(
             null,
             'phpspec',
             'phpspec',
-            '',
-            sys_get_temp_dir() . '/infection/phpspec-coverage-xml'
+            ''
         );
 
         yield 'test framework from config & input' => self::createValueForTestFramework(
             'phpunit',
             'phpspec',
             'phpspec',
-            '',
-            sys_get_temp_dir() . '/infection/phpspec-coverage-xml'
+            ''
         );
 
         yield 'test no test PHP options' => self::createValueForInitialTestsPhpOptions(
@@ -492,61 +488,53 @@ final class ConfigurationFactoryTest extends TestCase
             'phpunit',
             null,
             null,
-            '',
-            sys_get_temp_dir() . '/infection/coverage-xml'
+            ''
         );
 
         yield 'test framework PHP options from config' => self::createValueForTestFrameworkExtraOptions(
             'phpunit',
             '--debug',
             null,
-            '--debug',
-            sys_get_temp_dir() . '/infection/coverage-xml'
+            '--debug'
         );
 
         yield 'test framework PHP options from input' => self::createValueForTestFrameworkExtraOptions(
             'phpunit',
             null,
             '--debug',
-            '--debug',
-            sys_get_temp_dir() . '/infection/coverage-xml'
+            '--debug'
         );
 
         yield 'test framework PHP options from config & input' => self::createValueForTestFrameworkExtraOptions(
             'phpunit',
             '--stop-on-failure',
             '--debug',
-            '--debug',
-            sys_get_temp_dir() . '/infection/coverage-xml'
+            '--debug'
         );
 
         yield 'test framework PHP options from config with phpspec framework' => self::createValueForTestFrameworkExtraOptions(
             'phpspec',
             '--debug',
             null,
-            '--debug',
-            sys_get_temp_dir() . '/infection/phpspec-coverage-xml'
+            '--debug'
         );
 
         yield 'PHPUnit test framework' => self::createValueForTestFrameworkKey(
             'phpunit',
             '--debug',
-            '--debug',
-            sys_get_temp_dir() . '/infection/coverage-xml'
+            '--debug'
         );
 
         yield 'phpSpec test framework' => self::createValueForTestFrameworkKey(
             'phpspec',
             '--debug',
-            '--debug',
-            sys_get_temp_dir() . '/infection/phpspec-coverage-xml'
+            '--debug'
         );
 
         yield 'codeception test framework' => self::createValueForTestFrameworkKey(
             'codeception',
             '--debug',
-            '--debug',
-            sys_get_temp_dir() . '/infection/codeception-coverage-xml'
+            '--debug'
         );
 
         yield 'no mutator' => self::createValueForMutators(
@@ -652,7 +640,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             '',
-            sys_get_temp_dir() . '/infection/coverage-xml',
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,
@@ -664,7 +652,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
         ];
 
-        yield 'ee' => [
+        yield 'complete' => [
             new SchemaConfiguration(
                 '/path/to/infection.json',
                 10,
@@ -742,7 +730,7 @@ final class ConfigurationFactoryTest extends TestCase
             '-d zend_extension=xdebug.so',
             false,
             '--stop-on-failure',
-            '/path/to/dist/coverage/phpspec-coverage-xml',
+            '/path/to/dist/coverage',
             true,
             true,
             true,
@@ -809,7 +797,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             '',
-            sys_get_temp_dir() . '/infection/coverage-xml',
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,
@@ -876,7 +864,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             '',
-            $expectedTmpDir . '/coverage-xml',
+            $expectedTmpDir,
             false,
             false,
             false,
@@ -1011,7 +999,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             '',
-            sys_get_temp_dir() . '/infection/coverage-xml',
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,
@@ -1079,7 +1067,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             '',
-            sys_get_temp_dir() . '/infection/coverage-xml',
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,
@@ -1147,7 +1135,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             '',
-            sys_get_temp_dir() . '/infection/coverage-xml',
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,
@@ -1215,7 +1203,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             '',
-            sys_get_temp_dir() . '/infection/coverage-xml',
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,
@@ -1232,8 +1220,7 @@ final class ConfigurationFactoryTest extends TestCase
         ?string $configTestFramework,
         ?string $inputTestFramework,
         string $expectedTestFramework,
-        string $expectedTestFrameworkExtraOptions,
-        string $expectedCoveragePath
+        string $expectedTestFrameworkExtraOptions
     ): array {
         return [
             new SchemaConfiguration(
@@ -1285,7 +1272,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             $expectedTestFrameworkExtraOptions,
-            $expectedCoveragePath,
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,
@@ -1353,7 +1340,7 @@ final class ConfigurationFactoryTest extends TestCase
             $expectedInitialTestPhpOptions,
             false,
             '',
-            sys_get_temp_dir() . '/infection/coverage-xml',
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,
@@ -1370,8 +1357,7 @@ final class ConfigurationFactoryTest extends TestCase
         string $configTestFramework,
         ?string $configTestFrameworkExtraOptions,
         ?string $inputTestFrameworkExtraOptions,
-        string $expectedTestFrameworkExtraOptions,
-        string $expectedCoveragePath
+        string $expectedTestFrameworkExtraOptions
     ): array {
         return [
             new SchemaConfiguration(
@@ -1423,7 +1409,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             $expectedTestFrameworkExtraOptions,
-            $expectedCoveragePath,
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,
@@ -1439,8 +1425,7 @@ final class ConfigurationFactoryTest extends TestCase
     private static function createValueForTestFrameworkKey(
         string $configTestFramework,
         string $inputTestFrameworkExtraOptions,
-        string $expectedTestFrameworkExtraOptions,
-        string $expectedCoveragePath
+        string $expectedTestFrameworkExtraOptions
     ): array {
         return [
             new SchemaConfiguration(
@@ -1492,7 +1477,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             $expectedTestFrameworkExtraOptions,
-            $expectedCoveragePath,
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,
@@ -1563,7 +1548,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             '',
-            sys_get_temp_dir() . '/infection/coverage-xml',
+            sys_get_temp_dir() . '/infection',
             false,
             false,
             false,

--- a/tests/phpunit/TestFramework/Coverage/CoverageCheckerTest.php
+++ b/tests/phpunit/TestFramework/Coverage/CoverageCheckerTest.php
@@ -71,7 +71,7 @@ final class CoverageCheckerTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$coveragePath = Path::canonicalize(__DIR__ . '/../../Fixtures/Files/phpunit/coverage/coverage-xml');
+        self::$coveragePath = Path::canonicalize(__DIR__ . '/../../Fixtures/Files/phpunit/coverage');
         self::$jUnit = Path::canonicalize(__DIR__ . '/../../Fixtures/Files/phpunit/junit.xml');
     }
 

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php
@@ -66,7 +66,7 @@ final class JUnitReportLocatorTest extends FileSystemTestCase
         chdir($this->tmp);
 
         $this->locator = new JUnitReportLocator(
-            $this->tmp . '/coverage-xml',
+            $this->tmp,
             $this->tmp . '/junit.xml'
         );
     }
@@ -147,14 +147,14 @@ final class JUnitReportLocatorTest extends FileSystemTestCase
     public function test_it_cannot_locate_the_JUnit_file_in_a_non_existent_coverage_directory(): void
     {
         $locator = new JUnitReportLocator(
-            $this->tmp . '/unknown/sub-dir',
+            $this->tmp . '/unknown-dir',
             $this->tmp . '/junit.xml'
         );
 
         $this->expectException(FileNotFound::class);
         $this->expectExceptionMessage(sprintf(
             'Could not find any file with the pattern "*.junit.xml" in "%s"',
-            $this->tmp . '/unknown'
+            $this->tmp . '/unknown-dir'
         ));
 
         $locator->locate();

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParserTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParserTest.php
@@ -68,9 +68,7 @@ final class IndexXmlCoverageParserTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->parser = new IndexXmlCoverageParser(
-            XmlCoverageFixtures::FIXTURES_COVERAGE_DIR,
-        );
+        $this->parser = new IndexXmlCoverageParser();
     }
 
     /**
@@ -78,7 +76,11 @@ final class IndexXmlCoverageParserTest extends TestCase
      */
     public function test_it_collects_data_recursively_for_all_files(string $xml): void
     {
-        $sourceFilesData = $this->parser->parse('/path/to/index.xml', $xml);
+        $sourceFilesData = $this->parser->parse(
+            '/path/to/index.xml',
+            $xml,
+            XmlCoverageFixtures::FIXTURES_COVERAGE_DIR
+        );
 
         // zeroLevel + noPercentage + firstLevel + secondLevel
         $this->assertCount(5, $sourceFilesData);
@@ -92,7 +94,8 @@ final class IndexXmlCoverageParserTest extends TestCase
                 '/percent=".*"/',
                 '',
                 self::getXml()
-            )
+            ),
+            XmlCoverageFixtures::FIXTURES_COVERAGE_DIR
         );
 
         $this->assertCoverageFixtureSame(
@@ -125,22 +128,25 @@ final class IndexXmlCoverageParserTest extends TestCase
 </phpunit>
 XML;
 
-        $sourceFilesData = $this->parser->parse('/path/to/index.xml', $xml);
+        $sourceFilesData = $this->parser->parse(
+            '/path/to/index.xml',
+            $xml,
+            XmlCoverageFixtures::FIXTURES_COVERAGE_DIR
+        );
 
         $this->assertCoverageFixtureSame([], $sourceFilesData);
     }
 
     public function test_it_has_correct_coverage_data_for_each_file_for_old_phpunit_versions(): void
     {
-        $sourceFilesData = (new IndexXmlCoverageParser(
-            XmlCoverageFixtures::FIXTURES_OLD_COVERAGE_DIR
-        ))->parse(
+        $sourceFilesData = $this->parser->parse(
             '/path/to/index.xml',
             str_replace(
                 '/path/to/src',
                 realpath(XmlCoverageFixtures::FIXTURES_OLD_SRC_DIR),
                 file_get_contents(XmlCoverageFixtures::FIXTURES_OLD_COVERAGE_DIR . '/index.xml')
-            )
+            ),
+            XmlCoverageFixtures::FIXTURES_OLD_COVERAGE_DIR
         );
 
         $this->assertCoverageFixtureSame(
@@ -156,7 +162,11 @@ XML;
     {
         $this->expectException(NoLineExecuted::class);
 
-        $this->parser->parse('/path/to/index.xml', $xml);
+        $this->parser->parse(
+            '/path/to/index.xml',
+            $xml,
+            XmlCoverageFixtures::FIXTURES_COVERAGE_DIR
+        );
     }
 
     public function coverageProvider(): iterable

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php
@@ -67,7 +67,7 @@ final class PhpUnitXmlCoverageTraceProviderTest extends FileSystemTestCase
         $indexXmlParserMock = $this->createMock(IndexXmlCoverageParser::class);
         $indexXmlParserMock
             ->method('parse')
-            ->with($indexPath, $indexContents)
+            ->with($indexPath, $indexContents, $this->tmp)
             ->willReturn([$sourceFileInfoProviderMock])
         ;
 


### PR DESCRIPTION
This PR completes the journey started with #1193 and #1194. Now you can provide `--coverage=build/coverage`, it does not matter what path you gave for the XML coverage report or the name for the JUnit report as long as:

- both are in the the given coverage path
- the junit report has a `(.+\.)?junit.xml` pattern

Infection will find the necessary files and figure it out. The previously required path are still suggested and are the "default paths" which are checked first, so there will not be any performance degradation for this feature if you are using the suggested layout