### PR TITLE
Move RunCommand specific behaviour from the Application to the command

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -43,6 +43,7 @@ use Infection\Console\ConsoleOutput;
 use Infection\Console\Exception\ConfigurationException;
 use Infection\Console\Input\MsiParser;
 use Infection\Console\LogVerbosity;
+use Infection\Console\XdebugHandler;
 use Infection\Container;
 use Infection\Engine;
 use Infection\Event\ApplicationExecutionWasStarted;
@@ -55,6 +56,7 @@ use function Safe\sprintf;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use function trim;
@@ -226,6 +228,8 @@ final class RunCommand extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        XdebugHandler::check(new ConsoleLogger($output));
+
         $io = new SymfonyStyle($input, $output);
 
         $this->startUp();

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Console;
 
-use Composer\XdebugHandler\XdebugHandler;
 use function extension_loaded;
 use Infection\Command\ConfigureCommand;
 use Infection\Command\RunCommand;
@@ -63,8 +62,6 @@ final class Application extends BaseApplication
     private const NAME = 'Infection - PHP Mutation Testing Framework';
 
     private const PACKAGE_NAME = 'infection/infection';
-
-    private const INFECTION_PREFIX = 'INFECTION';
 
     private const LOGO = '
     ____      ____          __  _
@@ -129,10 +126,6 @@ final class Application extends BaseApplication
 
             return parent::run($input, $output);
         }
-
-        (new XdebugHandler(self::INFECTION_PREFIX, '--ansi'))
-            ->setPersistent()
-            ->check();
 
         return parent::run($input, $output);
     }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -35,24 +35,20 @@ declare(strict_types=1);
 
 namespace Infection\Console;
 
-use function extension_loaded;
+use function array_merge;
 use Infection\Command\ConfigureCommand;
 use Infection\Command\RunCommand;
-use Infection\Console\ConsoleOutput as InfectionConsoleOutput;
 use Infection\Container;
 use OutOfBoundsException;
 use PackageVersions\Versions;
-use const PHP_SAPI;
 use function preg_quote;
 use function Safe\preg_match;
+use function Safe\sprintf;
 use Symfony\Component\Console\Application as BaseApplication;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
-use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
+use function trim;
 
 /**
  * @internal
@@ -69,14 +65,10 @@ final class Application extends BaseApplication
    / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \
  _/ // / / / __/  __/ /__/ /_/ / /_/ / / / /
 /___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/
+
 ';
 
     private $container;
-
-    /**
-     * @var InfectionConsoleOutput
-     */
-    private $consoleOutput;
 
     public function __construct(Container $container)
     {
@@ -99,60 +91,34 @@ final class Application extends BaseApplication
         $this->setDefaultCommand('run');
     }
 
-    public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
-    {
-        if ($input === null) {
-            $input = new ArgvInput();
-        }
-
-        if ($output === null) {
-            $output = new ConsoleOutput();
-        }
-
-        $this->consoleOutput = new InfectionConsoleOutput(new SymfonyStyle($input, $output));
-
-        if ($input->hasParameterOption(['--quiet', '-q'], true)) {
-            $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
-        }
-
-        $this->logRunningWithDebugger();
-
-        if (!$this->isAutoExitEnabled()) {
-            // When we're not in control of exit codes, that means it's the caller
-            // responsibility to disable xdebug if it isn't needed. As of writing
-            // that's only the case during E2E testing. Show a warning nevertheless.
-
-            $this->consoleOutput->logNotInControlOfExitCodes();
-
-            return parent::run($input, $output);
-        }
-
-        return parent::run($input, $output);
-    }
-
     public function getContainer(): Container
     {
         return $this->container;
     }
 
-    public function getConsoleOutput(): InfectionConsoleOutput
+    public function getLongVersion(): string
     {
-        return $this->consoleOutput;
+        return trim(sprintf(
+            '<info>%s</info> version <comment>%s</comment>',
+            $this->getName(),
+            $this->getVersion()
+        ));
     }
 
-    protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
+    public function getHelp(): string
     {
-        $output->writeln([self::LOGO, $this->getLongVersion()]);
-
-        return parent::doRunCommand($command, $input, $output);
+        return self::LOGO . parent::getHelp();
     }
 
     protected function getDefaultCommands()
     {
-        $commands = array_merge(parent::getDefaultCommands(), [
-            new ConfigureCommand(),
-            new RunCommand(),
-        ]);
+        $commands = array_merge(
+            parent::getDefaultCommands(),
+            [
+                new ConfigureCommand(),
+                new RunCommand(),
+            ]
+        );
 
         return $commands;
     }
@@ -174,16 +140,5 @@ final class Application extends BaseApplication
         $output->getFormatter()->setStyle('low', new OutputFormatterStyle('red', null, ['bold']));
         $output->getFormatter()->setStyle('medium', new OutputFormatterStyle('yellow', null, ['bold']));
         $output->getFormatter()->setStyle('high', new OutputFormatterStyle('green', null, ['bold']));
-    }
-
-    private function logRunningWithDebugger(): void
-    {
-        if (PHP_SAPI === 'phpdbg') {
-            $this->consoleOutput->logRunningWithDebugger(PHP_SAPI);
-        } elseif (extension_loaded('xdebug')) {
-            $this->consoleOutput->logRunningWithDebugger('Xdebug');
-        } elseif (extension_loaded('pcov')) {
-            $this->consoleOutput->logRunningWithDebugger('PCOV');
-        }
     }
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -110,7 +110,7 @@ final class Application extends BaseApplication
         return self::LOGO . parent::getHelp();
     }
 
-    protected function getDefaultCommands()
+    protected function getDefaultCommands(): array
     {
         $commands = array_merge(
             parent::getDefaultCommands(),

--- a/src/Console/XdebugHandler.php
+++ b/src/Console/XdebugHandler.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Console;
+
+use Composer\XdebugHandler\XdebugHandler as ComposerXdebugHandler;
+use Infection\CannotBeInstantiated;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @internal
+ */
+final class XdebugHandler
+{
+    use CannotBeInstantiated;
+
+    private const PREFIX = 'INFECTION';
+
+    public static function check(LoggerInterface $logger): void
+    {
+        // We force the color option unconditionally since it is able to detect the --no-ansi option
+        // to disable it if necessary
+        (new ComposerXdebugHandler(self::PREFIX, '--ansi'))
+            ->setLogger($logger)
+            ->setPersistent()
+            ->check()
+        ;
+    }
+}

--- a/src/Resource/Memory/MemoryLimiterEnvironment.php
+++ b/src/Resource/Memory/MemoryLimiterEnvironment.php
@@ -41,6 +41,7 @@ use function Safe\ini_get;
 
 /**
  * @internal
+ * @final
  */
 class MemoryLimiterEnvironment
 {

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -63,7 +63,6 @@ use Infection\Mutant\DetectionStatus;
 use Infection\Mutation\MutationAttributeKeys;
 use Infection\Mutator\NodeMutationGenerator;
 use Infection\Process\Builder\InitialTestRunProcessBuilder;
-use Infection\Resource\Memory\MemoryLimiterEnvironment;
 use Infection\TestFramework\AdapterInstaller;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
 use Infection\TestFramework\Coverage\NodeLineRangeData;
@@ -123,7 +122,6 @@ final class ProjectCodeProvider
         InitialTestRunProcessBuilder::class,
         PhpUnitInitalConfigBuilder::class,
         PhpUnitMutationConfigBuilder::class,
-        MemoryLimiterEnvironment::class,
     ];
 
     /**

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -49,6 +49,7 @@ use Infection\Console\Application;
 use Infection\Console\OutputFormatter\OutputFormatter;
 use Infection\Console\OutputFormatter\ProgressFormatter;
 use Infection\Console\Util\PhpProcess;
+use Infection\Console\XdebugHandler;
 use Infection\Engine;
 use Infection\Event\Subscriber\MutationGeneratingConsoleLoggerSubscriber;
 use Infection\FileSystem\DummyFileSystem;
@@ -106,6 +107,7 @@ final class ProjectCodeProvider
         DetectionStatus::class,
         DummyFileSystem::class,
         MutationAttributeKeys::class,
+        XdebugHandler::class,
     ];
 
     /**


### PR DESCRIPTION
When looking at the `Application`, you might find a couple of intriguing things:

- we restart the process. This means even for a simple help or configure command
- we have some logging that is only relevant for the run command, but are here because otherwise would not fit nicely with the logo displayed

So I propose to change that and move the behaviour that is aimed for the `RunCommand` inside the `RunCommand`, leaving the help, configure or any future commands alone.

A few other notable changes:

- I moved the XdebugHandler related code in a small adapter utility
- Configure the logger for the XdebugHandler, see the diff bellow for seeing what it looks like

Note that another benefit, is that we no longer need to override the `Application::run()` which was always a tricky part since there is no easy automated way to know when we need to adapt that code depending of the parent.

<details>

<summary>After – configure</summary>

```
$ bin/infection configure


  Welcome to the Infection config generator



We did not find a configuration file. The following questions will help us to generate it for you.


Which source directories do you want to include (comma separated)? [src]:
  [0] .
  [1] adr
  [2] bin
  [3] build
  [4] devTools
  [5] doc
  [6] resources
  [7] src
  [8] tests
  [9] vendor
 >
```
</details>

<details>

<summary>After – run without verbosity</summary>

```
$ bin/infection

    ____      ____          __  _
   /  _/___  / __/__  _____/ /_(_)___  ____
   / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \
 _/ // / / / __/  __/ /__/ /_/ / /_/ / / / /
/___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/

Infection - PHP Mutation Testing Framework version dev-pr/2020-03/ExpressionRepeat@95ddae9a20db74830c88e5554bcbb17ecedbaff7

You are running Infection with PCOV enabled.

Running initial test suite...

PHPUnit version: 8.3.5
```

</details>

<details>

<summary>After – run with verbosity</summary>

```
bin/infection -vvv                                                                      tfidry@Theos-MacBook-Pro
[debug] Checking INFECTION_ALLOW_XDEBUG
[debug] The Xdebug extension is loaded (2.9.2)
[debug] Process restarting (INFECTION_ALLOW_XDEBUG=internal|2.9.2|1|*|*)
[debug] Running '/Users/tfidry/.phpbrew/php/php-7.3.15/bin/php' 'bin/infection' '-vvv' '--ansi'
[debug] Checking INFECTION_ALLOW_XDEBUG
[debug] Restarted (99 ms). The Xdebug extension is not loaded

    ____      ____          __  _
   /  _/___  / __/__  _____/ /_(_)___  ____
   / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \
 _/ // / / / __/  __/ /__/ /_/ / /_/ / / / /
/___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/

Infection - PHP Mutation Testing Framework version dev-pr/2020-03/ExpressionRepeat@95ddae9a20db74830c88e5554bcbb17ecedbaff7

You are running Infection with PCOV enabled.

Running initial test suite...

PHPUnit version: 8.3.5
```

</details>