### PR TITLE
Tweak MutationCollectorVisitor

### DIFF
--- a/devTools/phpstan-tests.neon
+++ b/devTools/phpstan-tests.neon
@@ -10,10 +10,6 @@ parameters:
         - '#^Cannot call method (willReturn|shouldBeCalledTimes)\(\) on iterable<Infection\\Mutation\\Mutation>\.$#'
         - '#^PHPDoc tag @var for variable \$sourceFilesCollectorProphecy contains unresolvable type#'
         -
-            path: '../tests/phpunit/PhpParser/Visitor/MutationsCollectorVisitorTest.php'
-            message: '#Call to method PHPUnit\\Framework\\Assert::assertSame\(\)#'
-            count: 2
-        -
             path: '../tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php'
             message: '#Function simplexml_load_string is unsafe to use#'
             count: 1

--- a/src/Mutation/FileMutationGenerator.php
+++ b/src/Mutation/FileMutationGenerator.php
@@ -41,7 +41,7 @@ use Infection\PhpParser\FileParser;
 use Infection\PhpParser\NodeTraverserFactory;
 use Infection\PhpParser\UnparsableFile;
 use Infection\PhpParser\Visitor\IgnoreNode\NodeIgnorer;
-use Infection\PhpParser\Visitor\MutationsCollectorVisitor;
+use Infection\PhpParser\Visitor\MutationCollectorVisitor;
 use Infection\TestFramework\Coverage\LineRangeCalculator;
 use Infection\TestFramework\Coverage\Trace;
 use Webmozart\Assert\Assert;
@@ -91,7 +91,7 @@ class FileMutationGenerator
 
         $initialStatements = $this->parser->parse($fileInfo);
 
-        $mutationsCollectorVisitor = new MutationsCollectorVisitor(
+        $mutationCollectorVisitor = new MutationCollectorVisitor(
             new NodeMutationGenerator(
                 $mutators,
                 $fileInfo->getPathname(),
@@ -102,10 +102,10 @@ class FileMutationGenerator
             )
         );
 
-        $traverser = $this->traverserFactory->create($mutationsCollectorVisitor, $nodeIgnorers);
+        $traverser = $this->traverserFactory->create($mutationCollectorVisitor, $nodeIgnorers);
 
         $traverser->traverse($initialStatements);
 
-        yield from $mutationsCollectorVisitor->getMutations();
+        yield from $mutationCollectorVisitor->getMutations();
     }
 }

--- a/src/PhpParser/Visitor/MutationCollectorVisitor.php
+++ b/src/PhpParser/Visitor/MutationCollectorVisitor.php
@@ -43,10 +43,10 @@ use PhpParser\NodeVisitorAbstract;
 /**
  * @internal
  */
-final class MutationsCollectorVisitor extends NodeVisitorAbstract
+final class MutationCollectorVisitor extends NodeVisitorAbstract
 {
     /**
-     * @var iterable[]
+     * @var iterable<Mutation>[]
      */
     private $mutationChunks = [];
 
@@ -76,8 +76,8 @@ final class MutationsCollectorVisitor extends NodeVisitorAbstract
      */
     public function getMutations(): iterable
     {
-        foreach ($this->mutationChunks as $mutationChunk) {
-            yield from $mutationChunk;
+        foreach ($this->mutationChunks as $mutations) {
+            yield from $mutations;
         }
     }
 }

--- a/tests/phpunit/Mutation/FileMutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/FileMutationGeneratorTest.php
@@ -43,7 +43,7 @@ use Infection\Mutator\IgnoreConfig;
 use Infection\Mutator\IgnoreMutator;
 use Infection\PhpParser\FileParser;
 use Infection\PhpParser\NodeTraverserFactory;
-use Infection\PhpParser\Visitor\MutationsCollectorVisitor;
+use Infection\PhpParser\Visitor\MutationCollectorVisitor;
 use Infection\TestFramework\Coverage\LineRangeCalculator;
 use Infection\TestFramework\Coverage\Trace;
 use Infection\Tests\Fixtures\PhpParser\FakeIgnorer;
@@ -161,7 +161,7 @@ final class FileMutationGeneratorTest extends TestCase
         $this->traverserFactoryMock
             ->expects($this->once())
             ->method('create')
-            ->with($this->isInstanceOf(MutationsCollectorVisitor::class), $nodeIgnorers)
+            ->with($this->isInstanceOf(MutationCollectorVisitor::class), $nodeIgnorers)
             ->willReturn($traverserMock)
         ;
 


### PR DESCRIPTION
- Rename `MutationsCollectorVisitor` to `MutationCollectorVisitor` which is more consistent with `FileMutationGenerator` (which is not called `FileMutationsGenerator`)
- Update the test to use `Mutation` instead of `stdClass`
- Update the test to use PHPUnit's mock instead of prophecy