### PR TITLE
Return back `$finder->notPath($excludedDir)` to filter out excluded files configured in `infection.json`

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -178,7 +178,8 @@ final class Container
             },
             SourceFileFilter::class => static function (self $container): SourceFileFilter {
                 return new SourceFileFilter(
-                    $container->getConfiguration()->getSourceFilesFilter()
+                    $container->getConfiguration()->getSourceFilesFilter(),
+                    $container->getSchemaConfiguration()->getSource()->getExcludes()
                 );
             },
             JUnitTestExecutionInfoAdder::class => static function (self $container): JUnitTestExecutionInfoAdder {

--- a/src/FileSystem/SourceFileCollector.php
+++ b/src/FileSystem/SourceFileCollector.php
@@ -66,6 +66,10 @@ class SourceFileCollector
             ->name('*.php')
         ;
 
+        foreach ($excludeDirectories as $excludeDirectory) {
+            $finder->notPath($excludeDirectory);
+        }
+
         // Generator here to make sure these files used only once
         yield from $finder;
     }

--- a/src/TestFramework/Coverage/ProxyTrace.php
+++ b/src/TestFramework/Coverage/ProxyTrace.php
@@ -93,6 +93,11 @@ class ProxyTrace implements Trace
         return $realPath;
     }
 
+    public function getRelativePathname(): string
+    {
+        return $this->sourceFile->getRelativePathname();
+    }
+
     public function hasTests(): bool
     {
         return $this->getTestLocator()->hasTests();

--- a/src/TestFramework/Coverage/Trace.php
+++ b/src/TestFramework/Coverage/Trace.php
@@ -60,6 +60,8 @@ interface Trace
      */
     public function getRealPath(): string;
 
+    public function getRelativePathname(): string;
+
     public function hasTests(): bool;
 
     public function getTests(): TestLocations;

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
@@ -37,7 +37,6 @@ namespace Infection\TestFramework\Coverage\XmlReport;
 
 use DOMElement;
 use Infection\TestFramework\SafeDOMXPath;
-use function strpos;
 
 /**
  * @internal
@@ -79,11 +78,6 @@ class IndexXmlCoverageParser
 
         foreach ($xPath->query('//file') as $node) {
             $relativeCoverageFilePath = $node->getAttribute('href');
-
-            // TODO here we need somehow to respect excluded files. Below is not a solid solution, just to check it works
-            if (strpos($relativeCoverageFilePath, 'Kernel.php') !== false) {
-                continue;
-            }
 
             yield new SourceFileInfoProvider(
                 $coverageIndexPath,

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
@@ -37,6 +37,7 @@ namespace Infection\TestFramework\Coverage\XmlReport;
 
 use DOMElement;
 use Infection\TestFramework\SafeDOMXPath;
+use function strpos;
 
 /**
  * @internal
@@ -78,6 +79,11 @@ class IndexXmlCoverageParser
 
         foreach ($xPath->query('//file') as $node) {
             $relativeCoverageFilePath = $node->getAttribute('href');
+
+            // TODO here we need somehow to respect excluded files. Below is not a solid solution, just to check it works
+            if (strpos($relativeCoverageFilePath, 'Kernel.php') !== false) {
+                continue;
+            }
 
             yield new SourceFileInfoProvider(
                 $coverageIndexPath,

--- a/tests/benchmark/MutationGenerator/PartialTrace.php
+++ b/tests/benchmark/MutationGenerator/PartialTrace.php
@@ -59,6 +59,11 @@ final class PartialTrace implements Trace
         return $this->sourceFileInfo->getRealPath();
     }
 
+    public function getRelativePathname(): string
+    {
+        return $this->sourceFileInfo->getRelativePathname();
+    }
+
     public function hasTests(): bool
     {
         return false;

--- a/tests/e2e/Exclude_by_file_name/README.md
+++ b/tests/e2e/Exclude_by_file_name/README.md
@@ -1,0 +1,6 @@
+This test ensures `source.excludes` key in `infection.json` works as expected
+
+## Summary
+
+Related to the following bug: https://github.com/infection/infection/issues/1238
+

--- a/tests/e2e/Exclude_by_file_name/composer.json
+++ b/tests/e2e/Exclude_by_file_name/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^8"
+    },
+    "autoload": {
+        "psr-4": {
+            "Exclude_by_file_name\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Exclude_by_file_name\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/e2e/Exclude_by_file_name/expected-output.txt
+++ b/tests/e2e/Exclude_by_file_name/expected-output.txt
@@ -1,0 +1,7 @@
+Total: 1
+
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Not Covered: 0

--- a/tests/e2e/Exclude_by_file_name/infection.json
+++ b/tests/e2e/Exclude_by_file_name/infection.json
@@ -1,0 +1,15 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ],
+        "excludes": [
+            "Kernel.php"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/Exclude_by_file_name/phpunit.xml
+++ b/tests/e2e/Exclude_by_file_name/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/e2e/Exclude_by_file_name/src/Kernel.php
+++ b/tests/e2e/Exclude_by_file_name/src/Kernel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Exclude_by_file_name;
+
+class Kernel
+{
+    public function fooKernel(): int
+    {
+        return 1 + 2;
+    }
+}

--- a/tests/e2e/Exclude_by_file_name/src/SourceClass.php
+++ b/tests/e2e/Exclude_by_file_name/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Exclude_by_file_name;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/e2e/Exclude_by_file_name/tests/SourceClassTest.php
+++ b/tests/e2e/Exclude_by_file_name/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Exclude_by_file_name\Test;
+
+use Exclude_by_file_name\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/phpunit/FileSystem/SourceFileCollectorTest.php
+++ b/tests/phpunit/FileSystem/SourceFileCollectorTest.php
@@ -140,6 +140,14 @@ final class SourceFileCollectorTest extends TestCase
                 'case1/a.php',
             ],
         ];
+
+        yield 'exclude file by its name' => [
+            [self::FIXTURES . '/case1'],
+            ['a.php'],
+            [
+                'case1/sub-dir/b.php',
+            ],
+        ];
     }
 
     /**

--- a/tests/phpunit/FileSystem/SourceFileFilterTest.php
+++ b/tests/phpunit/FileSystem/SourceFileFilterTest.php
@@ -55,7 +55,7 @@ final class SourceFileFilterTest extends TestCase
         string $filter,
         array $expectedFilters
     ): void {
-        $fileFilter = new SourceFileFilter($filter);
+        $fileFilter = new SourceFileFilter($filter, []);
 
         $this->assertSame($expectedFilters, array_values($fileFilter->getFilters()));
     }
@@ -206,7 +206,7 @@ final class SourceFileFilterTest extends TestCase
         iterable $input,
         array $expectedFilePaths
     ): void {
-        $actual = (new SourceFileFilter($filter))->filter($input);
+        $actual = (new SourceFileFilter($filter, []))->filter($input);
 
         $actual = take($actual)
             ->map(static function ($traceOrFileInfo) {


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/1238

Unfortunately, 2 issues here:

1. Here https://github.com/infection/infection/commit/b2f6ddb4eb752d271d5e359c7e5d3d4016b72af6 `$finder->notPath(..)` was removed and it caused finder not respect excluded files from `infection.json`

2. Here https://github.com/infection/infection/pull/1106 we introduced another issue: when we get the files from coverage report, we don't respect `source.excludes` config from `infection.json`, and mutate all files that present in the coverage report regardless of the exclusion configuration

I have fixed the first item here, but have difficulties with the second, so @sanmai I need your help here.

I believe the best (from performance POV) place to filter out excluded files is in this file where I left `TODO` https://github.com/infection/infection/compare/bugfix/exclude-file?expand=1#diff-feed5b44802aab03ea332afc7740b86dR83

Since calling `SourceFileInfoProvider::provideFileInfo()` is quite an expensive thing, we need to filter out files here to reduce the result array of files (iterator).

However, I'm not sure how to do it better. In Symfony's finder we just call `->notPath($excludedFirOrFile)`, but here we have only path that we read from the XML coverage report.

Any ideas?

PS

1. The first issue is unit tested (pass)
2. For the second point, I've added a functional test you can play with (or at least have a look at). It's currently failing, obviously.