### PR TITLE
Bugproof: fails in @dataProvider not recognised as such

### DIFF
--- a/tests/e2e/PhpUnit_DataProvider/README.md
+++ b/tests/e2e/PhpUnit_DataProvider/README.md
@@ -1,0 +1,5 @@
+# Title
+
+## Summary
+
+TODO

--- a/tests/e2e/PhpUnit_DataProvider/composer.json
+++ b/tests/e2e/PhpUnit_DataProvider/composer.json
@@ -1,0 +1,17 @@
+{
+    "autoload": {
+        "psr-4": {
+            "PhpUnit_DataProvider\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PhpUnit_DataProvider\\Test\\": "tests/"
+        }
+    },
+    "require": {
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8"
+    }
+}

--- a/tests/e2e/PhpUnit_DataProvider/expected-output.txt
+++ b/tests/e2e/PhpUnit_DataProvider/expected-output.txt
@@ -1,0 +1,7 @@
+Total: 3
+
+Killed: 2
+Errored: 0
+Escaped: 1
+Timed Out: 0
+Not Covered: 0

--- a/tests/e2e/PhpUnit_DataProvider/infection.json
+++ b/tests/e2e/PhpUnit_DataProvider/infection.json
@@ -1,0 +1,16 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": ".",
+    "mutators": {
+        "TrueValue": true,
+        "PublicVisibility": true
+    }
+}

--- a/tests/e2e/PhpUnit_DataProvider/phpunit.xml
+++ b/tests/e2e/PhpUnit_DataProvider/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/e2e/PhpUnit_DataProvider/src/SourceClass.php
+++ b/tests/e2e/PhpUnit_DataProvider/src/SourceClass.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PhpUnit_DataProvider;
+
+class SourceClass
+{
+    /**
+     * @var bool
+     */
+    private $value;
+
+    private function __construct(bool $value)
+    {
+        $this->value = $value;
+    }
+
+    public static function factoryMethod(): self
+    {
+        return new self(true);
+    }
+
+    public function getValue(): bool
+    {
+        return $this->value;
+    }
+}

--- a/tests/e2e/PhpUnit_DataProvider/tests/SourceClassTest.php
+++ b/tests/e2e/PhpUnit_DataProvider/tests/SourceClassTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpUnit_DataProvider\Test;
+
+use PhpUnit_DataProvider\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    /**
+     * @dataProvider instancesProvider
+     */
+    public function testAlwaysTrueFromFactoryMethod(SourceClass $class)
+    {
+        // $class = SourceClass::factoryMethod();
+        self::assertTrue($class->getValue());
+    }
+
+    public function instancesProvider(): array
+    {
+        return [
+            [SourceClass::factoryMethod()],
+        ];
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Covered by tests

References: https://github.com/psr7-sessions/storageless/pull/119#issuecomment-611368754

Hi, I would expect that a mutation affecting `@dataProvider` would be same as the same mutation affecting the test itself, but it is not so.

Is this expected or a bug?