### PR TITLE
Move no-progress detection to the ConfigurationFactory

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -47,6 +47,7 @@ use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\MutatorParser;
 use Infection\Mutator\MutatorResolver;
 use Infection\TestFramework\TestFrameworkTypes;
+use function getenv;
 use function Safe\sprintf;
 use function sys_get_temp_dir;
 use Webmozart\PathUtil\Path;
@@ -142,7 +143,7 @@ class ConfigurationFactory
             $debug,
             $onlyCovered,
             $formatter,
-            $noProgress,
+            self::retrieveNoProgress($noProgress),
             self::retrieveIgnoreMsiWithNoMutations($ignoreMsiWithNoMutations, $schema),
             self::retrieveMinMsi($minMsi, $schema),
             $showMutations,
@@ -230,6 +231,14 @@ class ConfigurationFactory
         SchemaConfiguration $schema
     ): string {
         return $testFrameworkExtraOptions ?? $schema->getTestFrameworkExtraOptions() ?? '';
+    }
+
+    private static function retrieveNoProgress(bool $noProgress): bool
+    {
+        return $noProgress
+            || getenv('CI') === 'true'
+            || getenv('CONTINUOUS_INTEGRATION') === 'true'
+        ;
     }
 
     private static function retrieveIgnoreMsiWithNoMutations(

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -61,19 +61,22 @@ class LoggerFactory
     private $logVerbosity;
     private $debugMode;
     private $onlyCoveredCode;
+    private $ciDetector;
 
     public function __construct(
         MetricsCalculator $metricsCalculator,
         Filesystem $filesystem,
         string $logVerbosity,
         bool $debugMode,
-        bool $onlyCoveredCode
+        bool $onlyCoveredCode,
+        CiDetector $ciDetector
     ) {
         $this->metricsCalculator = $metricsCalculator;
         $this->filesystem = $filesystem;
         $this->logVerbosity = $logVerbosity;
         $this->debugMode = $debugMode;
         $this->onlyCoveredCode = $onlyCoveredCode;
+        $this->ciDetector = $ciDetector;
     }
 
     public function createFromLogEntries(Logs $logConfig, OutputInterface $output): MutationTestingResultsLogger
@@ -166,7 +169,7 @@ class LoggerFactory
         return $badge === null
             ? null
             : new BadgeLogger(
-                new BuildContextResolver(new CiDetector()),
+                new BuildContextResolver($this->ciDetector),
                 new StrykerApiKeyResolver(),
                 new StrykerDashboardClient(
                     new StrykerCurlClient(),

--- a/tests/phpunit/Fixtures/DummyCiDetector.php
+++ b/tests/phpunit/Fixtures/DummyCiDetector.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Fixtures;
+
+use Infection\Tests\UnsupportedMethod;
+use OndraM\CiDetector\Ci\CiInterface;
+use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\Env;
+
+final class DummyCiDetector extends CiDetector
+{
+    private $ciDetected;
+
+    public function __construct(bool $ciDetected)
+    {
+        $this->ciDetected = $ciDetected;
+    }
+
+    public static function fromEnvironment(Env $environment): CiDetector
+    {
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
+    }
+
+    public function isCiDetected(): bool
+    {
+        return $this->ciDetected;
+    }
+
+    public function detect(): CiInterface
+    {
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
+    }
+}

--- a/tests/phpunit/Fixtures/FakeCiDetector.php
+++ b/tests/phpunit/Fixtures/FakeCiDetector.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Fixtures;
+
+use Infection\Tests\UnsupportedMethod;
+use OndraM\CiDetector\Ci\CiInterface;
+use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\Env;
+
+final class FakeCiDetector extends CiDetector
+{
+    public static function fromEnvironment(Env $environment): CiDetector
+    {
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
+    }
+
+    public function isCiDetected(): bool
+    {
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
+    }
+
+    public function detect(): CiInterface
+    {
+        throw UnsupportedMethod::method(__CLASS__, __FUNCTION__);
+    }
+}

--- a/tests/phpunit/Logger/LoggerFactoryTest.php
+++ b/tests/phpunit/Logger/LoggerFactoryTest.php
@@ -50,6 +50,7 @@ use Infection\Logger\PerMutatorLogger;
 use Infection\Logger\SummaryFileLogger;
 use Infection\Logger\TextFileLogger;
 use Infection\Metrics\MetricsCalculator;
+use Infection\Tests\Fixtures\FakeCiDetector;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -238,7 +239,8 @@ final class LoggerFactoryTest extends TestCase
             $this->fileSystemMock,
             $logVerbosity,
             $debugMode,
-            $onlyCoveredCode
+            $onlyCoveredCode,
+            new FakeCiDetector()
         );
     }
 


### PR DESCRIPTION
- A few subscribers are relying on `skipProgressBar` which currently is detected in their factories (when registering them in `Container`)
- `skipProgressBar` was relying on an "old" way to detect the CI environment, this PR now leverages the `CiDetector` introduced instead
- The `MutationGenerator` and `MutationTestingRunner` are relying on `noProgress` in order to know if they should run concurrently or not. With this PR, they will run concurrently if a CI environment is detected as well