### PR TITLE
Install test framework adapters as dev dependencies

### DIFF
--- a/src/TestFramework/AdapterInstaller.php
+++ b/src/TestFramework/AdapterInstaller.php
@@ -66,6 +66,7 @@ final class AdapterInstaller
         $process = new Process([
             $this->composerExecutableFinder->find(),
             'require',
+            '--dev',
             self::OFFICIAL_ADAPTERS_MAP[$adapterName],
         ]);
 


### PR DESCRIPTION
Since Infection is for development purposes, adapter must be installed as `dev` dependencies as well.

php-cs-fixer's failure is unrelated and fixed in master