### PR TITLE
Introduce our own ConsoleLogger

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
 
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
+        <env name="COLUMNS" value="100" />
     </php>
 
     <testsuites>

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -51,6 +51,7 @@ use Infection\Event\ApplicationExecutionWasStarted;
 use Infection\FileSystem\Locator\FileNotFound;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\FileSystem\Locator\Locator;
+use Infection\Logger\ConsoleLogger;
 use Infection\Metrics\MinMsiCheckFailed;
 use Infection\Process\Runner\InitialTestsFailed;
 use Infection\TestFramework\TestFrameworkTypes;
@@ -59,7 +60,6 @@ use Psr\Log\LoggerInterface;
 use function Safe\sprintf;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Logger\ConsoleLogger;
 use function trim;
 
 /**
@@ -215,9 +215,9 @@ final class RunCommand extends BaseCommand
 
     protected function executeCommand(IO $io): void
     {
-        $logger = new ConsoleLogger($io->getOutput());
+        $logger = new ConsoleLogger($io);
         $container = $this->createContainer($io, $logger);
-        $consoleOutput = new ConsoleOutput($io);
+        $consoleOutput = new ConsoleOutput($logger);
 
         $this->startUp($container, $consoleOutput, $logger, $io);
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -35,32 +35,41 @@ declare(strict_types=1);
 
 namespace Infection\Console;
 
+use function implode;
+use Infection\Logger\ConsoleLogger;
+use const PHP_EOL;
 use function Safe\sprintf;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @internal
+ * @final
  */
-final class ConsoleOutput
+class ConsoleOutput
 {
     private const RUNNING_WITH_DEBUGGER_NOTE = 'You are running Infection with %s enabled.';
     private const MIN_MSI_CAN_GET_INCREASED_NOTICE = 'The %s is %s%% percent points over the required %s. Consider increasing the required %s percentage the next time you run infection.';
 
-    private $io;
+    private $logger;
 
-    public function __construct(SymfonyStyle $io)
+    public function __construct(ConsoleLogger $logger)
     {
-        $this->io = $io;
+        $this->logger = $logger;
     }
 
     public function logVerbosityDeprecationNotice(string $valueToUse): void
     {
-        $this->io->note('Numeric versions of log-verbosity have been deprecated, please use, ' . $valueToUse . ' to keep the same result');
+        $this->logger->notice(
+            'Numeric versions of log-verbosity have been deprecated, please use, ' . $valueToUse . ' to keep the same result',
+            ['block' => true]
+        );
     }
 
     public function logUnknownVerbosityOption(string $default): void
     {
-        $this->io->note('Running infection with an unknown log-verbosity option, falling back to ' . $default . ' option');
+        $this->logger->notice(
+            'Running infection with an unknown log-verbosity option, falling back to ' . $default . ' option',
+            ['block' => true]
+        );
     }
 
     public function logMinMsiCanGetIncreasedNotice(float $minMsi, float $msi): void
@@ -68,14 +77,15 @@ final class ConsoleOutput
         $typeString = 'MSI';
         $msiDifference = $msi - $minMsi;
 
-        $this->io->note(
+        $this->logger->notice(
             sprintf(
                 self::MIN_MSI_CAN_GET_INCREASED_NOTICE,
                 $typeString,
                 $msiDifference,
                 $typeString,
                 $typeString
-            )
+            ),
+            ['block' => true]
         );
     }
 
@@ -84,36 +94,41 @@ final class ConsoleOutput
         $typeString = 'Covered Code MSI';
         $msiDifference = $coveredCodeMsi - $minMsi;
 
-        $this->io->note(
+        $this->logger->notice(
             sprintf(
                 self::MIN_MSI_CAN_GET_INCREASED_NOTICE,
                 $typeString,
                 $msiDifference,
                 $typeString,
                 $typeString
-            )
+            ),
+            ['block' => true]
         );
     }
 
     public function logRunningWithDebugger(string $debugger): void
     {
-        $this->io->writeln(sprintf(self::RUNNING_WITH_DEBUGGER_NOTE, $debugger));
+        $this->logger->notice(sprintf(self::RUNNING_WITH_DEBUGGER_NOTE, $debugger));
     }
 
     public function logNotInControlOfExitCodes(): void
     {
-        $this->io->warning([
+        $this->logger->warning(
             'Infection cannot control exit codes and unable to relaunch itself.' . PHP_EOL .
             'It is your responsibility to disable xdebug/phpdbg unless needed.',
-        ]);
+            ['block' => true]
+        );
     }
 
     public function logSkippingInitialTests(): void
     {
-        $this->io->warning([
-            'Skipping the initial test run can be very dangerous.',
-            'It is your responsibility to ensure the tests are in a passing state to begin.',
-            'If this is not done then mutations may report as caught when they are not.',
-        ]);
+        $this->logger->warning(implode(
+            PHP_EOL,
+            [
+                'Skipping the initial test run can be very dangerous.',
+                'It is your responsibility to ensure the tests are in a passing state to begin.',
+                'If this is not done then mutations may report as caught when they are not.',
+            ]
+        ));
     }
 }

--- a/src/Console/LogVerbosity.php
+++ b/src/Console/LogVerbosity.php
@@ -76,7 +76,7 @@ final class LogVerbosity
     {
         $verbosityLevel = $input->getOption('log-verbosity');
 
-        if (in_array($verbosityLevel, self::ALLOWED_OPTIONS)) {
+        if (in_array($verbosityLevel, self::ALLOWED_OPTIONS, true)) {
             return;
         }
 

--- a/src/Logger/ConsoleLogger.php
+++ b/src/Logger/ConsoleLogger.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Logger;
+
+use DateTime;
+use DateTimeInterface;
+use function get_class;
+use Infection\Console\IO;
+use function is_object;
+use function is_scalar;
+use function method_exists;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+use function Safe\sprintf;
+use function strpos;
+use function strtr;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * @internal
+ */
+final class ConsoleLogger extends AbstractLogger
+{
+    private const INFO = 'info';
+    private const ERROR = 'error';
+
+    private const VERBOSITY_LEVEL_MAP = [
+        LogLevel::EMERGENCY => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::ALERT => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::CRITICAL => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::ERROR => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::WARNING => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::INFO => OutputInterface::VERBOSITY_VERBOSE,
+        LogLevel::DEBUG => OutputInterface::VERBOSITY_DEBUG,
+    ];
+
+    private const FORMAT_LEVEL_MAP = [
+        LogLevel::EMERGENCY => self::ERROR,
+        LogLevel::ALERT => self::ERROR,
+        LogLevel::CRITICAL => self::ERROR,
+        LogLevel::ERROR => self::ERROR,
+        LogLevel::WARNING => self::INFO,
+        LogLevel::NOTICE => self::INFO,
+        LogLevel::INFO => self::INFO,
+        LogLevel::DEBUG => self::INFO,
+    ];
+
+    private const IO_MAP = [
+        LogLevel::ERROR => 'error',
+        LogLevel::WARNING => 'warning',
+        LogLevel::NOTICE => 'note',
+    ];
+
+    private $io;
+
+    public function __construct(IO $io)
+    {
+        $this->io = $io;
+    }
+
+    /**
+     * @param string $level
+     * @param string $message
+     * @param mixed[] $context
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        Assert::keyExists(
+            self::VERBOSITY_LEVEL_MAP,
+            $level,
+            'The log level %s does not exist'
+        );
+
+        $output = $this->io->getOutput();
+
+        // The if condition check isn't necessary per se – it's the same one that $output will do
+        // internally anyway. We only do it for efficiency here as the message formatting is
+        // relatively expensive
+        if ($output->getVerbosity() < self::VERBOSITY_LEVEL_MAP[$level]) {
+            return;
+        }
+
+        $interpolatedMessage = $this->interpolate($message, $context);
+
+        if (!isset($context['block'])) {
+            $output->writeln(
+                sprintf(
+                    '<%1$s>[%2$s] %3$s</%1$s>',
+                    self::FORMAT_LEVEL_MAP[$level],
+                    $level,
+                    $interpolatedMessage
+                ),
+                self::VERBOSITY_LEVEL_MAP[$level]
+            );
+
+            return;
+        }
+
+        Assert::keyExists(
+            self::IO_MAP,
+            $level,
+            'The log level "%s" does not exist for the IO mapping'
+        );
+
+        $this->io->{self::IO_MAP[$level]}($interpolatedMessage);
+    }
+
+    /**
+     * Interpolates context values into the message placeholders.
+     *
+     * @param mixed[] $context
+     *
+     * @author PHP Framework Interoperability Group
+     */
+    private function interpolate(string $message, array $context): string
+    {
+        if (strpos($message, '{') === false) {
+            return $message;
+        }
+
+        $replacements = [];
+
+        foreach ($context as $key => $val) {
+            if ($val === null
+                || is_scalar($val)
+                || (is_object($val) && method_exists($val, '__toString'))
+            ) {
+                $replacements["{{$key}}"] = $val;
+            } elseif ($val instanceof DateTimeInterface) {
+                $replacements["{{$key}}"] = $val->format(DateTime::RFC3339);
+            } elseif (is_object($val)) {
+                $replacements["{{$key}}"] = '[object ' . get_class($val) . ']';
+            } else {
+                $replacements["{{$key}}"] = '[' . gettype($val) . ']';
+            }
+        }
+
+        return strtr($message, $replacements);
+    }
+}

--- a/tests/phpunit/Console/ConsoleOutputTest.php
+++ b/tests/phpunit/Console/ConsoleOutputTest.php
@@ -73,7 +73,8 @@ final class ConsoleOutputTest extends TestCase
         $this->assertSame(
             <<<'TXT'
 
- ! [NOTE] Numeric versions of log-verbosity have been deprecated, please use, all to keep the same result
+ ! [NOTE] Numeric versions of log-verbosity have been deprecated, please use, all to keep the same
+ !        result
 
 
 TXT
@@ -139,8 +140,8 @@ TXT
         $this->assertSame(
             <<<'TXT'
 
- ! [NOTE] The MSI is 5% percent points over the required MSI. Consider increasing the required MSI percentage the next
- !        time you run infection.
+ ! [NOTE] The MSI is 5% percent points over the required MSI. Consider increasing the required MSI
+ !        percentage the next time you run infection.
 
 
 TXT
@@ -159,8 +160,8 @@ TXT
         $this->assertSame(
             <<<'TXT'
 
- ! [NOTE] The Covered Code MSI is 5% percent points over the required Covered Code MSI. Consider increasing the required
- !        Covered Code MSI percentage the next time you run infection.
+ ! [NOTE] The Covered Code MSI is 5% percent points over the required Covered Code MSI. Consider
+ !        increasing the required Covered Code MSI percentage the next time you run infection.
 
 
 TXT

--- a/tests/phpunit/Console/ConsoleOutputTest.php
+++ b/tests/phpunit/Console/ConsoleOutputTest.php
@@ -36,101 +36,136 @@ declare(strict_types=1);
 namespace Infection\Tests\Console;
 
 use Infection\Console\ConsoleOutput;
+use Infection\Console\IO;
+use Infection\Logger\ConsoleLogger;
+use function Infection\Tests\normalize_trailing_spaces;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 final class ConsoleOutputTest extends TestCase
 {
+    /**
+     * @var BufferedOutput
+     */
+    private $output;
+
+    /**
+     * @var ConsoleOutput
+     */
+    private $consoleOutput;
+
+    protected function setUp(): void
+    {
+        $this->output = new BufferedOutput();
+
+        $this->consoleOutput = new ConsoleOutput(
+            new ConsoleLogger(
+                new IO(new StringInput(''), $this->output)
+            )
+        );
+    }
+
     public function test_log_verbosity_deprecation_notice(): void
     {
-        $option = 'all';
-        $io = $this->createMock(SymfonyStyle::class);
-        $io->expects($this->once())->method('note')
-            ->with(
-                'Numeric versions of log-verbosity have been deprecated, please use, ' . $option . ' to keep the same result'
-            );
+        $this->consoleOutput->logVerbosityDeprecationNotice('all');
 
-        $consoleOutput = new ConsoleOutput($io);
-        $consoleOutput->logVerbosityDeprecationNotice($option);
+        $this->assertSame(
+            <<<'TXT'
+
+ ! [NOTE] Numeric versions of log-verbosity have been deprecated, please use, all to keep the same result
+
+
+TXT
+            ,
+            normalize_trailing_spaces($this->output->fetch())
+        );
     }
 
     public function test_log_unknown_verbosity_option(): void
     {
-        $option = 'default';
-        $io = $this->createMock(SymfonyStyle::class);
-        $io->expects($this->once())->method('note')
-            ->with(
-                'Running infection with an unknown log-verbosity option, falling back to ' . $option . ' option'
-            );
+        $this->consoleOutput->logUnknownVerbosityOption('default');
 
-        $consoleOutput = new ConsoleOutput($io);
-        $consoleOutput->logUnknownVerbosityOption($option);
+        $this->assertSame(
+            <<<'TXT'
+
+ ! [NOTE] Running infection with an unknown log-verbosity option, falling back to default option
+
+
+TXT
+            ,
+            normalize_trailing_spaces($this->output->fetch())
+        );
     }
 
     public function test_log_running_with_debugger(): void
     {
-        $io = $this->createMock(SymfonyStyle::class);
-        $io->expects($this->once())->method('writeln')
-            ->with('You are running Infection with foo enabled.');
+        $this->consoleOutput->logRunningWithDebugger('foo');
 
-        $consoleOutput = new ConsoleOutput($io);
-        $consoleOutput->logRunningWithDebugger('foo');
+        $this->assertSame(
+            <<<'TXT'
+[notice] You are running Infection with foo enabled.
+
+TXT
+            ,
+            normalize_trailing_spaces($this->output->fetch())
+        );
     }
 
     public function test_log_not_in_control_of_exit_codes(): void
     {
-        $io = $this->createMock(SymfonyStyle::class);
-        $io->expects($this->once())->method('warning')
-            ->with([
-                'Infection cannot control exit codes and unable to relaunch itself.' . PHP_EOL .
-                'It is your responsibility to disable xdebug/phpdbg unless needed.',
-            ]);
+        $this->consoleOutput->logNotInControlOfExitCodes();
 
-        $consoleOutput = new ConsoleOutput($io);
-        $consoleOutput->logNotInControlOfExitCodes();
+        $this->assertSame(
+            <<<'TXT'
+
+ [WARNING] Infection cannot control exit codes and unable to relaunch itself.
+           It is your responsibility to disable xdebug/phpdbg unless needed.
+
+
+TXT
+            ,
+            normalize_trailing_spaces($this->output->fetch())
+        );
     }
 
     public function test_log_min_msi_can_get_increased_notice_for_msi(): void
     {
-        $actualMsi = 10.0;
-        $minMsi = 5.0;
-        $msiDifference = $actualMsi - $minMsi;
+        $this->consoleOutput->logMinMsiCanGetIncreasedNotice(
+            5.0,
+            10.0
+        );
 
-        $ioMock = $this->createMock(SymfonyStyle::class);
-        $ioMock
-            ->expects($this->once())
-            ->method('note')
-            ->with(
-                'The MSI is ' . $msiDifference . '% percent points over the required MSI. ' .
-                'Consider increasing the required MSI percentage the next time you run infection.'
-            )
-        ;
+        $this->assertSame(
+            <<<'TXT'
 
-        (new ConsoleOutput($ioMock))->logMinMsiCanGetIncreasedNotice(
-            $minMsi,
-            $actualMsi
+ ! [NOTE] The MSI is 5% percent points over the required MSI. Consider increasing the required MSI percentage the next
+ !        time you run infection.
+
+
+TXT
+            ,
+            normalize_trailing_spaces($this->output->fetch())
         );
     }
 
     public function test_log_min_msi_can_get_increased_notice_for_covered_msi(): void
     {
-        $actualCoveredCodeMsi = 10.0;
-        $minCoveredCodeMsi = 5.0;
-        $msiDifference = $actualCoveredCodeMsi - $minCoveredCodeMsi;
+        $this->consoleOutput->logMinCoveredCodeMsiCanGetIncreasedNotice(
+            5.0,
+            10.0
+        );
 
-        $ioMock = $this->createMock(SymfonyStyle::class);
-        $ioMock
-            ->expects($this->once())
-            ->method('note')
-            ->with(
-                'The Covered Code MSI is ' . $msiDifference . '% percent points over the required Covered Code MSI. ' .
-                'Consider increasing the required Covered Code MSI percentage the next time you run infection.'
-            )
-        ;
+        $this->assertSame(
+            <<<'TXT'
 
-        (new ConsoleOutput($ioMock))->logMinCoveredCodeMsiCanGetIncreasedNotice(
-            $minCoveredCodeMsi,
-            $actualCoveredCodeMsi
+ ! [NOTE] The Covered Code MSI is 5% percent points over the required Covered Code MSI. Consider increasing the required
+ !        Covered Code MSI percentage the next time you run infection.
+
+
+TXT
+            ,
+            normalize_trailing_spaces($this->output->fetch())
         );
     }
 }

--- a/tests/phpunit/Console/LogVerbosityTest.php
+++ b/tests/phpunit/Console/LogVerbosityTest.php
@@ -49,7 +49,7 @@ final class LogVerbosityTest extends TestCase
     private $inputMock;
 
     /**
-     * @var ConsoleOutput
+     * @var ConsoleOutput|MockObject
      */
     private $consoleOutputMock;
 

--- a/tests/phpunit/Helpers.php
+++ b/tests/phpunit/Helpers.php
@@ -35,7 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\Tests;
 
+use function array_map;
 use const DIRECTORY_SEPARATOR;
+use function explode;
+use function implode;
 use function random_int;
 use function Safe\realpath;
 use function Safe\substr;
@@ -56,6 +59,17 @@ function normalizePath(string $value): string
 function normalizeLineReturn(string $value): string
 {
     return str_replace(["\r\n", "\r"], "\n", $value);
+}
+
+function normalize_trailing_spaces(string $value): string
+{
+    return implode(
+        "\n",
+        array_map(
+            'rtrim',
+            explode("\n", normalizeLineReturn($value))
+        )
+    );
 }
 
 function generator_to_phpunit_data_provider(iterable $source): iterable

--- a/tests/phpunit/Logger/ConsoleLoggerTest.php
+++ b/tests/phpunit/Logger/ConsoleLoggerTest.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Logger;
+
+use Infection\Console\IO;
+use Infection\Logger\ConsoleLogger;
+use function Infection\Tests\normalize_trailing_spaces;
+use InvalidArgumentException;
+use const PHP_EOL;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+use Safe\DateTime;
+use Safe\DateTimeImmutable;
+use function Safe\fopen;
+use stdClass;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @group integration
+ */
+final class ConsoleLoggerTest extends TestCase
+{
+    public function test_it_throws_a_friendly_error_on_invalid_log_level(): void
+    {
+        $logger = new ConsoleLogger(IO::createNull());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The log level "unknownLogLevel" does not exist');
+
+        $logger->log('unknownLogLevel', 'foo bar');
+    }
+
+    /**
+     * @dataProvider outputMappingProvider
+     */
+    public function test_the_log_level_is_added_to_the_message(
+        string $logLevel,
+        int $outputVerbosity,
+        bool $outputsMessage
+    ): void {
+        $output = new BufferedOutput($outputVerbosity);
+
+        $logger = new ConsoleLogger(new IO(new StringInput(''), $output));
+        $logger->log($logLevel, 'foo bar');
+
+        $logs = $output->fetch();
+
+        $this->assertSame($outputsMessage ? "[$logLevel] foo bar" . PHP_EOL : '', $logs);
+    }
+
+    public function test_it_interpolates_the_message_with_the_context(): void
+    {
+        $output = new BufferedOutput();
+
+        $logger = new ConsoleLogger(new IO(new StringInput(''), $output));
+
+        $logger->log(
+            LogLevel::ERROR,
+            '{foo} {bar} baz',
+            [
+                'foo' => 'oof',
+                'bar' => 'rab',
+                'baz' => 'zab',
+            ]
+        );
+
+        $this->assertSame(
+            '[error] oof rab baz' . PHP_EOL,
+            $output->fetch()
+        );
+    }
+
+    /**
+     * @dataProvider valueToCastProvider
+     */
+    public function test_it_casts_the_context_values_into_strings($value, string $expected): void
+    {
+        $output = new BufferedOutput();
+
+        $logger = new ConsoleLogger(new IO(new StringInput(''), $output));
+
+        $logger->log(
+            LogLevel::ERROR,
+            '{value}',
+            ['value' => $value]
+        );
+
+        $this->assertSame(
+            '[error] ' . $expected . PHP_EOL,
+            $output->fetch()
+        );
+    }
+
+    public function test_it_uses_the_io_blocks_when_passing_the_block_context(): void
+    {
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL);
+
+        $logger = new ConsoleLogger(new IO(new StringInput(''), $output));
+
+        $logger->log(LogLevel::NOTICE, 'message', ['block' => true]);
+
+        $this->assertSame(
+            <<<'TXT'
+
+ ! [NOTE] message
+
+
+TXT
+            ,
+            normalize_trailing_spaces($output->fetch())
+        );
+
+        $logger->log(LogLevel::WARNING, 'message', ['block' => true]);
+
+        $this->assertSame(
+            <<<'TXT'
+ [WARNING] message
+
+
+TXT
+            ,
+            normalize_trailing_spaces($output->fetch())
+        );
+
+        $logger->log(LogLevel::ERROR, 'message', ['block' => true]);
+
+        $this->assertSame(
+            <<<'TXT'
+ [ERROR] message
+
+
+TXT
+            ,
+            normalize_trailing_spaces($output->fetch())
+        );
+    }
+
+    public static function valueToCastProvider(): iterable
+    {
+        yield 'string' => ['oof', 'oof'];
+
+        yield 'bool' => [true, '1'];
+
+        yield 'null' => ['null', 'null'];
+
+        yield 'int' => [10, '10'];
+
+        yield 'float' => [10.8, '10.8'];
+
+        yield 'object' => [new stdClass(), '[object stdClass]'];
+
+        yield 'datetime' => [
+            DateTimeImmutable::createFromFormat(
+                DateTime::ATOM,
+                '2020-04-26T07:32:25+00:00'
+            ),
+            '2020-04-26T07:32:25+00:00',
+        ];
+
+        yield 'nested' => [
+            ['with object' => new stdClass()],
+            '[array]',
+        ];
+
+        yield 'resource' => [
+            fopen('php://memory', 'rb'),
+            '[resource]',
+        ];
+
+        yield 'callable' => [
+            static function (): void {},
+            '[object Closure]',
+        ];
+    }
+
+    public static function outputMappingProvider(): iterable
+    {
+        yield [LogLevel::EMERGENCY, OutputInterface::VERBOSITY_NORMAL, true];
+
+        yield [LogLevel::WARNING, OutputInterface::VERBOSITY_NORMAL, true];
+
+        yield [LogLevel::INFO, OutputInterface::VERBOSITY_NORMAL, false];
+
+        yield [LogLevel::DEBUG, OutputInterface::VERBOSITY_NORMAL, false];
+
+        yield [LogLevel::INFO, OutputInterface::VERBOSITY_VERBOSE, true];
+
+        yield [LogLevel::DEBUG, OutputInterface::VERBOSITY_VERY_VERBOSE, false];
+
+        yield [LogLevel::DEBUG, OutputInterface::VERBOSITY_DEBUG, true];
+
+        yield [LogLevel::ALERT, OutputInterface::VERBOSITY_QUIET, false];
+
+        yield [LogLevel::EMERGENCY, OutputInterface::VERBOSITY_QUIET, false];
+    }
+}

--- a/tests/phpunit/Metrics/MinMsiCheckerTest.php
+++ b/tests/phpunit/Metrics/MinMsiCheckerTest.php
@@ -113,8 +113,8 @@ final class MinMsiCheckerTest extends TestCase
         $this->assertSame(
             <<<'TXT'
 
- ! [NOTE] The MSI is 70% percent points over the required MSI. Consider increasing the required MSI percentage the next
- !        time you run infection.
+ ! [NOTE] The MSI is 70% percent points over the required MSI. Consider increasing the required MSI
+ !        percentage the next time you run infection.
 
 
 TXT
@@ -132,8 +132,8 @@ TXT
         $this->assertSame(
             <<<'TXT'
 
- ! [NOTE] The Covered Code MSI is 70% percent points over the required Covered Code MSI. Consider increasing the
- !        required Covered Code MSI percentage the next time you run infection.
+ ! [NOTE] The Covered Code MSI is 70% percent points over the required Covered Code MSI. Consider
+ !        increasing the required Covered Code MSI percentage the next time you run infection.
 
 
 TXT
@@ -151,11 +151,11 @@ TXT
         $this->assertSame(
             <<<'TXT'
 
- ! [NOTE] The MSI is 70% percent points over the required MSI. Consider increasing the required MSI percentage the next
- !        time you run infection.
+ ! [NOTE] The MSI is 70% percent points over the required MSI. Consider increasing the required MSI
+ !        percentage the next time you run infection.
 
- ! [NOTE] The Covered Code MSI is 70% percent points over the required Covered Code MSI. Consider increasing the
- !        required Covered Code MSI percentage the next time you run infection.
+ ! [NOTE] The Covered Code MSI is 70% percent points over the required Covered Code MSI. Consider
+ !        increasing the required Covered Code MSI percentage the next time you run infection.
 
 
 TXT

--- a/tests/phpunit/Metrics/MinMsiCheckerTest.php
+++ b/tests/phpunit/Metrics/MinMsiCheckerTest.php
@@ -36,135 +36,158 @@ declare(strict_types=1);
 namespace Infection\Tests\Metrics;
 
 use Infection\Console\ConsoleOutput;
+use Infection\Console\IO;
+use Infection\Logger\ConsoleLogger;
 use Infection\Metrics\MinMsiChecker;
 use Infection\Metrics\MinMsiCheckFailed;
-use PHPUnit\Framework\MockObject\MockObject;
+use function Infection\Tests\normalize_trailing_spaces;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 final class MinMsiCheckerTest extends TestCase
 {
     /**
-     * @var SymfonyStyle|MockObject
+     * @var BufferedOutput
      */
-    private $ioMock;
+    private $output;
 
     /**
      * @var ConsoleOutput
      */
-    private $output;
+    private $consoleOutput;
 
     protected function setUp(): void
     {
-        $this->ioMock = $this->createMock(SymfonyStyle::class);
-        $this->output = new ConsoleOutput($this->ioMock);
+        $this->output = new BufferedOutput();
+
+        $this->consoleOutput = new ConsoleOutput(
+            new ConsoleLogger(
+                new IO(new StringInput(''), $this->output)
+            )
+        );
     }
 
     public function test_it_fails_the_check_if_the_msi_is_lower_than_the_min_msi(): void
     {
         $msiChecker = new MinMsiChecker(false, 10., 5.);
 
-        $this->ioMock
-            ->expects($this->never())
-            ->method($this->anything())
-        ;
+        try {
+            $msiChecker->checkMetrics(2, 8., 10., $this->consoleOutput);
 
-        $this->expectException(MinMsiCheckFailed::class);
-        $this->expectExceptionMessage('The minimum required MSI percentage should be 10%, but actual is 8%. Improve your tests!');
+            $this->fail();
+        } catch (MinMsiCheckFailed $exception) {
+            $this->assertSame(
+                'The minimum required MSI percentage should be 10%, but actual is 8%. Improve your tests!',
+                $exception->getMessage()
+            );
 
-        $msiChecker->checkMetrics(2, 8., 10., $this->output);
+            $this->assertSame('', $this->output->fetch());
+        }
     }
 
     public function test_it_fails_the_check_if_the_covered_code_msi_is_lower_than_the_min_covered_code_msi(): void
     {
         $msiChecker = new MinMsiChecker(false, 5., 10.);
 
-        $this->ioMock
-            ->expects($this->never())
-            ->method($this->anything())
-        ;
+        try {
+            $msiChecker->checkMetrics(2, 12., 8., $this->consoleOutput);
 
-        $this->expectException(MinMsiCheckFailed::class);
-        $this->expectExceptionMessage('The minimum required Covered Code MSI percentage should be 10%, but actual is 8%. Improve your tests!');
+            $this->fail();
+        } catch (MinMsiCheckFailed $exception) {
+            $this->assertSame(
+                'The minimum required Covered Code MSI percentage should be 10%, but actual is 8%. Improve your tests!',
+                $exception->getMessage()
+            );
 
-        $msiChecker->checkMetrics(2, 12., 8., $this->output);
+            $this->assertSame('', $this->output->fetch());
+        }
     }
 
     public function test_it_suggests_to_increase_the_min_msi_if_above_the_limit(): void
     {
         $msiChecker = new MinMsiChecker(false, 10., 10.);
 
-        $this->ioMock
-            ->expects($this->once())
-            ->method('note')
-            ->with('The MSI is 70% percent points over the required MSI. Consider increasing the required MSI percentage the next time you run infection.')
-        ;
+        $msiChecker->checkMetrics(2, 80., 10., $this->consoleOutput);
 
-        $msiChecker->checkMetrics(2, 80., 10., $this->output);
+        $this->assertSame(
+            <<<'TXT'
+
+ ! [NOTE] The MSI is 70% percent points over the required MSI. Consider increasing the required MSI percentage the next
+ !        time you run infection.
+
+
+TXT
+            ,
+            normalize_trailing_spaces($this->output->fetch())
+        );
     }
 
     public function test_it_suggests_to_increase_the_min_covered_code_msi_if_above_the_limit(): void
     {
         $msiChecker = new MinMsiChecker(false, 10., 10.);
 
-        $this->ioMock
-            ->expects($this->once())
-            ->method('note')
-            ->with('The Covered Code MSI is 70% percent points over the required Covered Code MSI. Consider increasing the required Covered Code MSI percentage the next time you run infection.')
-        ;
+        $msiChecker->checkMetrics(2, 10., 80., $this->consoleOutput);
 
-        $msiChecker->checkMetrics(2, 10., 80., $this->output);
+        $this->assertSame(
+            <<<'TXT'
+
+ ! [NOTE] The Covered Code MSI is 70% percent points over the required Covered Code MSI. Consider increasing the
+ !        required Covered Code MSI percentage the next time you run infection.
+
+
+TXT
+            ,
+            normalize_trailing_spaces($this->output->fetch())
+        );
     }
 
     public function test_it_suggests_to_increase_the_min_msi_and_min_covered_code_msi_if_above_the_limit(): void
     {
         $msiChecker = new MinMsiChecker(false, 10., 10.);
 
-        $this->ioMock
-            ->expects($this->exactly(2))
-            ->method('note')
-            ->withConsecutive(
-                ['The MSI is 70% percent points over the required MSI. Consider increasing the required MSI percentage the next time you run infection.'],
-                ['The Covered Code MSI is 70% percent points over the required Covered Code MSI. Consider increasing the required Covered Code MSI percentage the next time you run infection.']
-            )
-        ;
+        $msiChecker->checkMetrics(2, 80., 80., $this->consoleOutput);
 
-        $msiChecker->checkMetrics(2, 80., 80., $this->output);
+        $this->assertSame(
+            <<<'TXT'
+
+ ! [NOTE] The MSI is 70% percent points over the required MSI. Consider increasing the required MSI percentage the next
+ !        time you run infection.
+
+ ! [NOTE] The Covered Code MSI is 70% percent points over the required Covered Code MSI. Consider increasing the
+ !        required Covered Code MSI percentage the next time you run infection.
+
+
+TXT
+            ,
+            normalize_trailing_spaces($this->output->fetch())
+        );
     }
 
     public function test_it_does_nothing_if_the_scores_barely_passes(): void
     {
         $msiChecker = new MinMsiChecker(false, 10., 10.);
 
-        $this->ioMock
-            ->expects($this->never())
-            ->method($this->anything())
-        ;
+        $msiChecker->checkMetrics(2, 10.2, 10.2, $this->consoleOutput);
 
-        $msiChecker->checkMetrics(2, 10.2, 10.2, $this->output);
+        $this->assertSame('', $this->output->fetch());
     }
 
     public function test_it_does_nothing_if_the_scores_barely_passes_with_no_mutation(): void
     {
         $msiChecker = new MinMsiChecker(false, 10., 10.);
 
-        $this->ioMock
-            ->expects($this->never())
-            ->method($this->anything())
-        ;
+        $msiChecker->checkMetrics(0, 10.2, 10.2, $this->consoleOutput);
 
-        $msiChecker->checkMetrics(0, 10.2, 10.2, $this->output);
+        $this->assertSame('', $this->output->fetch());
     }
 
     public function test_it_does_nothing_if_the_msis_are_too_low_but_we_ignore_it_with_no_mutations_and_there_is_no_mutations(): void
     {
         $msiChecker = new MinMsiChecker(true, 10., 10.);
 
-        $this->ioMock
-            ->expects($this->never())
-            ->method($this->anything())
-        ;
+        $msiChecker->checkMetrics(0, 2, 2, $this->consoleOutput);
 
-        $msiChecker->checkMetrics(0, 2, 2, $this->output);
+        $this->assertSame('', $this->output->fetch());
     }
 }


### PR DESCRIPTION
The Symfony `ConsoleLogger` is great to be able to make use of the `LoggerInterface` whilst forwarding everything to the output. It however is a bit lacking when it comes to extensibility in regards to:

- easily rewire the log verbosity to a different one
- interpret the context differently for styling options
- is coupled to `OutputInterface`, cannot make use of `SymfonyStyle` or our own `IO`

As a result I initially started with a copy paste of the Symfony one and tweaked it for our needs. Besides introducing this new logger, this PR:

- Replaces the usage of the Symfony one by this new one
- Make `ConsoleOutput` leverage this logger instead of `SymfonyStyle`

There is no behaviour change intended.