### PR TITLE
Add JSON logger, useful for CI and analyzing results of Infection programmatically

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -51,6 +51,10 @@
                     "type": "string",
                     "definition": "Summary log file, which display the amount of mutants per category, (Killed, Errored, Escaped, Timed Out & Not Covered). More intended for internal purposes."
                 },
+                "json": {
+                    "type": "string",
+                    "definition": "JSON log file, which contains information about all mutants, as well as the source and mutated code and test framework output. Useful for using on CI servers to be able to programmatically analyze it."
+                },
                 "debug": {
                     "type": "string",
                     "description": "Debug log file, which displays what mutations were found on what line, per category. More intended for internal purposes."

--- a/src/Configuration/Entry/Logs.php
+++ b/src/Configuration/Entry/Logs.php
@@ -42,6 +42,7 @@ final class Logs
 {
     private $textLogFilePath;
     private $summaryLogFilePath;
+    private $jsonLogFilePath;
     private $debugLogFilePath;
     private $perMutatorFilePath;
     private $badge;
@@ -49,12 +50,14 @@ final class Logs
     public function __construct(
         ?string $textLogFilePath,
         ?string $summaryLogFilePath,
+        ?string $jsonLogFilePath,
         ?string $debugLogFilePath,
         ?string $perMutatorFilePath,
         ?Badge $badge
     ) {
         $this->textLogFilePath = $textLogFilePath;
         $this->summaryLogFilePath = $summaryLogFilePath;
+        $this->jsonLogFilePath = $jsonLogFilePath;
         $this->debugLogFilePath = $debugLogFilePath;
         $this->perMutatorFilePath = $perMutatorFilePath;
         $this->badge = $badge;
@@ -63,6 +66,7 @@ final class Logs
     public static function createEmpty(): self
     {
         return new self(
+            null,
             null,
             null,
             null,
@@ -79,6 +83,11 @@ final class Logs
     public function getSummaryLogFilePath(): ?string
     {
         return $this->summaryLogFilePath;
+    }
+
+    public function getJsonLogFilePath(): ?string
+    {
+        return $this->jsonLogFilePath;
     }
 
     public function getDebugLogFilePath(): ?string

--- a/src/Configuration/Schema/SchemaConfigurationFactory.php
+++ b/src/Configuration/Schema/SchemaConfigurationFactory.php
@@ -83,6 +83,7 @@ class SchemaConfigurationFactory
         return new Logs(
             self::normalizeString($logs->text ?? null),
             self::normalizeString($logs->summary ?? null),
+            self::normalizeString($logs->json ?? null),
             self::normalizeString($logs->debug ?? null),
             self::normalizeString($logs->perMutator ?? null),
             self::createBadge($logs->badge ?? null)

--- a/src/Logger/JsonLogger.php
+++ b/src/Logger/JsonLogger.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Logger;
+
+use Infection\Metrics\MetricsCalculator;
+use Infection\Mutant\MutantExecutionResult;
+use Infection\Str;
+use function json_encode;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * @internal
+ */
+final class JsonLogger implements LineMutationTestingResultsLogger
+{
+    private $metricsCalculator;
+    private $onlyCoveredMode;
+
+    public function __construct(
+        MetricsCalculator $metricsCalculator,
+        bool $onlyCoveredMode
+    ) {
+        $this->metricsCalculator = $metricsCalculator;
+        $this->onlyCoveredMode = $onlyCoveredMode;
+    }
+
+    /**
+     * @return array{0: string}
+     */
+    public function getLogLines(): array
+    {
+        $data = [
+            'stats' => [
+                'totalMutantsCount' => $this->metricsCalculator->getTotalMutantsCount(),
+                'killedCount' => $this->metricsCalculator->getKilledCount(),
+                'notCoveredCount' => $this->metricsCalculator->getNotTestedCount(),
+                'escapedCount' => $this->metricsCalculator->getEscapedCount(),
+                'errorCount' => $this->metricsCalculator->getErrorCount(),
+                'timeOutCount' => $this->metricsCalculator->getTimedOutCount(),
+                'msi' => $this->metricsCalculator->getMutationScoreIndicator(),
+                'mutationCodeCoverage' => $this->metricsCalculator->getCoverageRate(),
+                'coveredCodeMsi' => $this->metricsCalculator->getCoveredCodeMutationScoreIndicator(),
+            ],
+            'escaped' => $this->getResultsLine($this->metricsCalculator->getEscapedExecutionResults()),
+            'timeouted' => $this->getResultsLine($this->metricsCalculator->getTimedOutExecutionResults()),
+            'killed' => $this->getResultsLine($this->metricsCalculator->getKilledExecutionResults()),
+            'errored' => $this->getResultsLine($this->metricsCalculator->getErrorExecutionResults()),
+            'uncovered' => $this->onlyCoveredMode ? [] : $this->getResultsLine($this->metricsCalculator->getNotCoveredExecutionResults()),
+        ];
+
+        return [json_encode($data, JSON_THROW_ON_ERROR)];
+    }
+
+    /**
+     * @param MutantExecutionResult[] $executionResults
+     *
+     * @return array<int, array{mutator: array, diff: string, processOutput: string}>
+     */
+    private function getResultsLine(array $executionResults): array
+    {
+        $mutatorRows = [];
+
+        foreach ($executionResults as $index => $mutantProcess) {
+            $mutatorRows[] = [
+                'mutator' => [
+                    'mutatorName' => $mutantProcess->getMutatorName(),
+                    'originalSourceCode' => $mutantProcess->getOriginalCode(),
+                    'mutatedSourceCode' => $mutantProcess->getMutatedCode(),
+                    'originalFilePath' => $mutantProcess->getOriginalFilePath(),
+                    'originalStartLine' => $mutantProcess->getOriginalStartingLine(),
+                ],
+                'diff' => Str::trimLineReturns($mutantProcess->getMutantDiff()),
+                'processOutput' => Str::trimLineReturns($mutantProcess->getProcessOutput()),
+            ];
+        }
+
+        return $mutatorRows;
+    }
+}

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -87,6 +87,7 @@ class LoggerFactory
                 [
                     $this->createTextLogger($logConfig->getTextLogFilePath()),
                     $this->createSummaryLogger($logConfig->getSummaryLogFilePath()),
+                    $this->createJsonLogger($logConfig->getJsonLogFilePath()),
                     $this->createDebugLogger($logConfig->getDebugLogFilePath()),
                     $this->createPerMutatorLogger($logConfig->getPerMutatorFilePath()),
                     $this->createBadgeLogger($logConfig->getBadge()),
@@ -124,6 +125,19 @@ class LoggerFactory
                 $filePath,
                 $this->filesystem,
                 new SummaryFileLogger($this->metricsCalculator),
+                $this->logger
+            )
+        ;
+    }
+
+    private function createJsonLogger(?string $filePath): ?FileLogger
+    {
+        return $filePath === null
+            ? null
+            : new FileLogger(
+                $filePath,
+                $this->filesystem,
+                new JsonLogger($this->metricsCalculator, $this->onlyCoveredCode),
                 $this->logger
             )
         ;

--- a/src/Mutant/Mutant.php
+++ b/src/Mutant/Mutant.php
@@ -48,17 +48,20 @@ class Mutant
     private $mutation;
     private $mutatedCode;
     private $diff;
+    private $prettyPrintedOriginalCode;
 
     public function __construct(
         string $mutantFilePath,
         Mutation $mutation,
         string $mutatedCode,
-        string $diff
+        string $diff,
+        string $prettyPrintedOriginalCode
     ) {
         $this->mutantFilePath = $mutantFilePath;
         $this->mutation = $mutation;
         $this->mutatedCode = $mutatedCode;
         $this->diff = $diff;
+        $this->prettyPrintedOriginalCode = $prettyPrintedOriginalCode;
     }
 
     public function getFilePath(): string
@@ -74,6 +77,11 @@ class Mutant
     public function getMutatedCode(): string
     {
         return $this->mutatedCode;
+    }
+
+    public function getPrettyPrintedOriginalCode(): string
+    {
+        return $this->prettyPrintedOriginalCode;
     }
 
     public function getDiff(): string

--- a/src/Mutant/MutantExecutionResult.php
+++ b/src/Mutant/MutantExecutionResult.php
@@ -52,6 +52,8 @@ class MutantExecutionResult
     private $mutatorName;
     private $originalFilePath;
     private $originalStartingLine;
+    private $originalCode;
+    private $mutatedCode;
 
     public function __construct(
         string $processCommandLine,
@@ -60,7 +62,9 @@ class MutantExecutionResult
         string $mutantDiff,
         string $mutatorName,
         string $originalFilePath,
-        int $originalStartingLine
+        int $originalStartingLine,
+        string $originalCode,
+        string $mutatedCode
     ) {
         Assert::oneOf($detectionStatus, DetectionStatus::ALL);
         Assert::oneOf($mutatorName, array_keys(ProfileList::ALL_MUTATORS));
@@ -72,6 +76,8 @@ class MutantExecutionResult
         $this->mutatorName = $mutatorName;
         $this->originalFilePath = $originalFilePath;
         $this->originalStartingLine = $originalStartingLine;
+        $this->originalCode = $originalCode;
+        $this->mutatedCode = $mutatedCode;
     }
 
     public static function createFromNonCoveredMutant(Mutant $mutant): self
@@ -85,7 +91,9 @@ class MutantExecutionResult
             $mutant->getDiff(),
             $mutant->getMutation()->getMutatorName(),
             $mutation->getOriginalFilePath(),
-            $mutation->getOriginalStartingLine()
+            $mutation->getOriginalStartingLine(),
+            $mutant->getPrettyPrintedOriginalCode(),
+            $mutant->getMutatedCode()
         );
     }
 
@@ -122,5 +130,15 @@ class MutantExecutionResult
     public function getOriginalStartingLine(): int
     {
         return $this->originalStartingLine;
+    }
+
+    public function getOriginalCode(): string
+    {
+        return $this->originalCode;
+    }
+
+    public function getMutatedCode(): string
+    {
+        return $this->mutatedCode;
     }
 }

--- a/src/Mutant/MutantExecutionResultFactory.php
+++ b/src/Mutant/MutantExecutionResultFactory.php
@@ -67,7 +67,9 @@ class MutantExecutionResultFactory
             $mutant->getDiff(),
             $mutation->getMutatorName(),
             $mutation->getOriginalFilePath(),
-            $mutation->getOriginalStartingLine()
+            $mutation->getOriginalStartingLine(),
+            $mutant->getPrettyPrintedOriginalCode(),
+            $mutant->getMutatedCode()
         );
     }
 

--- a/src/Mutant/MutantFactory.php
+++ b/src/Mutant/MutantFactory.php
@@ -83,7 +83,8 @@ class MutantFactory
             $mutantFilePath,
             $mutation,
             $mutatedCode,
-            $this->createMutantDiff($mutation, $mutatedCode)
+            $this->createMutantDiff($mutation, $mutatedCode),
+            $this->getOriginalPrettyPrintedFile($mutation->getOriginalFilePath(), $mutation->getOriginalFileAst())
         );
     }
 

--- a/tests/phpunit/Configuration/ConfigurationAssertions.php
+++ b/tests/phpunit/Configuration/ConfigurationAssertions.php
@@ -95,6 +95,7 @@ trait ConfigurationAssertions
             $configuration->getLogs(),
             $expectedLogs->getTextLogFilePath(),
             $expectedLogs->getSummaryLogFilePath(),
+            $expectedLogs->getJsonLogFilePath(),
             $expectedLogs->getDebugLogFilePath(),
             $expectedLogs->getPerMutatorFilePath(),
             $expectedLogs->getBadge()

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -658,6 +658,7 @@ final class ConfigurationFactoryTest extends TestCase
                 new Logs(
                     'text.log',
                     'summary.log',
+                    'json.log',
                     'debug.log',
                     'mutator.log',
                     new Badge('master')
@@ -705,6 +706,7 @@ final class ConfigurationFactoryTest extends TestCase
             new Logs(
                 'text.log',
                 'summary.log',
+                'json.log',
                 'debug.log',
                 'mutator.log',
                 new Badge('master')

--- a/tests/phpunit/Configuration/ConfigurationTest.php
+++ b/tests/phpunit/Configuration/ConfigurationTest.php
@@ -193,6 +193,7 @@ final class ConfigurationTest extends TestCase
             new Logs(
                 'text.log',
                 'summary.log',
+                'json.log',
                 'debug.log',
                 'mutator.log',
                 new Badge('master')

--- a/tests/phpunit/Configuration/Entry/LogsAssertions.php
+++ b/tests/phpunit/Configuration/Entry/LogsAssertions.php
@@ -46,12 +46,14 @@ trait LogsAssertions
         Logs $logs,
         ?string $expectedTextLogFilePath,
         ?string $expectedSummaryLogFilePath,
+        ?string $expectedJsonLogFilePath,
         ?string $expectedDebugLogFilePath,
         ?string $expectedPerMutatorFilePath,
         ?Badge $expectedBadge
     ): void {
         $this->assertSame($expectedTextLogFilePath, $logs->getTextLogFilePath());
         $this->assertSame($expectedSummaryLogFilePath, $logs->getSummaryLogFilePath());
+        $this->assertSame($expectedJsonLogFilePath, $logs->getJsonLogFilePath());
         $this->assertSame($expectedDebugLogFilePath, $logs->getDebugLogFilePath());
         $this->assertSame($expectedPerMutatorFilePath, $logs->getPerMutatorFilePath());
 

--- a/tests/phpunit/Configuration/Entry/LogsTest.php
+++ b/tests/phpunit/Configuration/Entry/LogsTest.php
@@ -49,6 +49,7 @@ final class LogsTest extends TestCase
     public function test_it_can_be_instantiated(
         ?string $textLogFilePath,
         ?string $summaryLogFilePath,
+        ?string $jsonLogFilePath,
         ?string $debugLogFilePath,
         ?string $perMutatorFilePath,
         ?Badge $badge
@@ -56,6 +57,7 @@ final class LogsTest extends TestCase
         $logs = new Logs(
             $textLogFilePath,
             $summaryLogFilePath,
+            $jsonLogFilePath,
             $debugLogFilePath,
             $perMutatorFilePath,
             $badge
@@ -65,6 +67,7 @@ final class LogsTest extends TestCase
             $logs,
             $textLogFilePath,
             $summaryLogFilePath,
+            $jsonLogFilePath,
             $debugLogFilePath,
             $perMutatorFilePath,
             $badge
@@ -81,6 +84,7 @@ final class LogsTest extends TestCase
             null,
             null,
             null,
+            null,
             null
         );
     }
@@ -93,11 +97,13 @@ final class LogsTest extends TestCase
             null,
             null,
             null,
+            null,
         ];
 
         yield 'complete' => [
             'text.log',
             'summary.log',
+            'json.log',
             'debug.log',
             'perMutator.log',
             new Badge('master'),

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -229,6 +229,7 @@ JSON
                     null,
                     null,
                     null,
+                    null,
                     null
                 ),
             ]),
@@ -253,6 +254,32 @@ JSON
                     'summary.log',
                     null,
                     null,
+                    null,
+                    null
+                ),
+            ]),
+        ];
+
+        yield '[logs][json] nominal' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "logs": {
+        "json": "json.log"
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'logs' => new Logs(
+                    null,
+                    null,
+                    'json.log',
+                    null,
+                    null,
                     null
                 ),
             ]),
@@ -273,6 +300,7 @@ JSON
             self::createConfig([
                 'source' => new Source(['src'], []),
                 'logs' => new Logs(
+                    null,
                     null,
                     null,
                     'debug.log',
@@ -297,6 +325,7 @@ JSON
             self::createConfig([
                 'source' => new Source(['src'], []),
                 'logs' => new Logs(
+                    null,
                     null,
                     null,
                     null,
@@ -327,6 +356,7 @@ JSON
                     null,
                     null,
                     null,
+                    null,
                     new Badge('master')
                 ),
             ]),
@@ -341,6 +371,7 @@ JSON
     "logs": {
         "text": "text.log",
         "summary": "summary.log",
+        "json": "json.log",
         "debug": "debug.log",
         "perMutator": "perMutator.log",
         "badge": {
@@ -355,6 +386,7 @@ JSON
                 'logs' => new Logs(
                     'text.log',
                     'summary.log',
+                    'json.log',
                     'debug.log',
                     'perMutator.log',
                     new Badge('master')
@@ -395,6 +427,7 @@ JSON
     "logs": {
         "text": " text.log ",
         "summary": " summary.log ",
+        "json": " json.log ",
         "debug": " debug.log ",
         "perMutator": " perMutator.log ",
         "badge": {
@@ -409,6 +442,7 @@ JSON
                 'logs' => new Logs(
                     'text.log',
                     'summary.log',
+                    'json.log',
                     'debug.log',
                     'perMutator.log',
                     new Badge('master')
@@ -1935,6 +1969,7 @@ JSON
     "logs": {
         "text": "text.log",
         "summary": "summary.log",
+        "json": "json.log",
         "debug": "debug.log",
         "perMutator": "perMutator.log",
         "badge": {
@@ -2172,6 +2207,7 @@ JSON
                 'logs' => new Logs(
                     'text.log',
                     'summary.log',
+                    'json.log',
                     'debug.log',
                     'perMutator.log',
                     new Badge('master')

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationTest.php
@@ -122,6 +122,7 @@ final class SchemaConfigurationTest extends TestCase
             new Logs(
                 'text.log',
                 'summary.log',
+                'json.log',
                 'debug.log',
                 'mutator.log',
                 new Badge('master')

--- a/tests/phpunit/Logger/CreateMetricsCalculator.php
+++ b/tests/phpunit/Logger/CreateMetricsCalculator.php
@@ -141,7 +141,9 @@ DIFF
             ),
             MutatorName::getName($mutatorClassName),
             'foo/bar',
-            10 - $i
+            10 - $i,
+            '<?php $a = 1;',
+            '<?php $a = 2;'
         );
     }
 }

--- a/tests/phpunit/Logger/JsonLoggerTest.php
+++ b/tests/phpunit/Logger/JsonLoggerTest.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Logger;
+
+use Infection\Logger\JsonLogger;
+use Infection\Metrics\MetricsCalculator;
+use Infection\Mutant\DetectionStatus;
+use Infection\Mutator\ZeroIteration\For_;
+use const JSON_THROW_ON_ERROR;
+use const PHP_EOL;
+use PHPUnit\Framework\TestCase;
+use function Safe\json_decode;
+use function str_replace;
+
+/**
+ * @group integration
+ */
+final class JsonLoggerTest extends TestCase
+{
+    use CreateMetricsCalculator;
+
+    /**
+     * @dataProvider metricsProvider
+     */
+    public function test_it_logs_correctly_with_mutations(
+        bool $onlyCovered,
+        MetricsCalculator $metricsCalculator,
+        array $expectedContents
+    ): void {
+        $logger = new JsonLogger($metricsCalculator, $onlyCovered);
+
+        $this->assertLoggedContentIs($expectedContents, $logger);
+    }
+
+    public function metricsProvider(): iterable
+    {
+        yield 'no mutations; only covered' => [
+            true,
+            new MetricsCalculator(2),
+            [
+                'stats' => [
+                    'totalMutantsCount' => 0,
+                    'killedCount' => 0,
+                    'notCoveredCount' => 0,
+                    'escapedCount' => 0,
+                    'errorCount' => 0,
+                    'timeOutCount' => 0,
+                    'msi' => 0,
+                    'mutationCodeCoverage' => 0,
+                    'coveredCodeMsi' => 0,
+                ],
+                'escaped' => [],
+                'timeouted' => [],
+                'killed' => [],
+                'errored' => [],
+                'uncovered' => [],
+            ],
+        ];
+
+        yield 'all mutations; only covered' => [
+            true,
+            $this->createCompleteMetricsCalculator(),
+            [
+                'stats' => [
+                    'totalMutantsCount' => 10,
+                    'killedCount' => 2,
+                    'notCoveredCount' => 2,
+                    'escapedCount' => 2,
+                    'errorCount' => 2,
+                    'timeOutCount' => 2,
+                    'msi' => 60,
+                    'mutationCodeCoverage' => 80,
+                    'coveredCodeMsi' => 75,
+                ],
+                'escaped' => [
+                    [
+                        'mutator' => [
+                            'mutatorName' => 'PregQuote',
+                            'originalSourceCode' => '<?php $a = 1;',
+                            'mutatedSourceCode' => '<?php $a = 2;',
+                            'originalFilePath' => 'foo/bar',
+                            'originalStartLine' => 9,
+                        ],
+                        'diff' => str_replace("\n", PHP_EOL, "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'escaped#1';"),
+                        'processOutput' => 'process output',
+                    ],
+                    [
+                        'mutator' => [
+                            'mutatorName' => 'For_',
+                            'originalSourceCode' => '<?php $a = 1;',
+                            'mutatedSourceCode' => '<?php $a = 2;',
+                            'originalFilePath' => 'foo/bar',
+                            'originalStartLine' => 10,
+                        ],
+                        'diff' => str_replace("\n", PHP_EOL, "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'escaped#0';"),
+                        'processOutput' => 'process output',
+                    ],
+                ],
+                'timeouted' => [
+                    [
+                        'mutator' => [
+                            'mutatorName' => 'PregQuote',
+                            'originalSourceCode' => '<?php $a = 1;',
+                            'mutatedSourceCode' => '<?php $a = 2;',
+                            'originalFilePath' => 'foo/bar',
+                            'originalStartLine' => 9,
+                        ],
+                        'diff' => str_replace("\n", PHP_EOL, "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'timedOut#1';"),
+                        'processOutput' => 'process output',
+                    ],
+                    [
+                        'mutator' => [
+                            'mutatorName' => 'For_',
+                            'originalSourceCode' => '<?php $a = 1;',
+                            'mutatedSourceCode' => '<?php $a = 2;',
+                            'originalFilePath' => 'foo/bar',
+                            'originalStartLine' => 10,
+                        ],
+                        'diff' => str_replace("\n", PHP_EOL, "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'timedOut#0';"),
+                        'processOutput' => 'process output',
+                    ],
+                ],
+                'killed' => [
+                    [
+                        'mutator' => [
+                            'mutatorName' => 'PregQuote',
+                            'originalSourceCode' => '<?php $a = 1;',
+                            'mutatedSourceCode' => '<?php $a = 2;',
+                            'originalFilePath' => 'foo/bar',
+                            'originalStartLine' => 9,
+                        ],
+                        'diff' => str_replace("\n", PHP_EOL, "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'killed#1';"),
+                        'processOutput' => 'process output',
+                    ],
+                    [
+                        'mutator' => [
+                            'mutatorName' => 'For_',
+                            'originalSourceCode' => '<?php $a = 1;',
+                            'mutatedSourceCode' => '<?php $a = 2;',
+                            'originalFilePath' => 'foo/bar',
+                            'originalStartLine' => 10,
+                        ],
+                        'diff' => str_replace("\n", PHP_EOL, "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'killed#0';"),
+                        'processOutput' => 'process output',
+                    ],
+                ],
+                'errored' => [
+                    [
+                        'mutator' => [
+                            'mutatorName' => 'PregQuote',
+                            'originalSourceCode' => '<?php $a = 1;',
+                            'mutatedSourceCode' => '<?php $a = 2;',
+                            'originalFilePath' => 'foo/bar',
+                            'originalStartLine' => 9,
+                        ],
+                        'diff' => str_replace("\n", PHP_EOL, "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'error#1';"),
+                        'processOutput' => 'process output',
+                    ],
+                    [
+                        'mutator' => [
+                            'mutatorName' => 'For_',
+                            'originalSourceCode' => '<?php $a = 1;',
+                            'mutatedSourceCode' => '<?php $a = 2;',
+                            'originalFilePath' => 'foo/bar',
+                            'originalStartLine' => 10,
+                        ],
+                        'diff' => str_replace("\n", PHP_EOL, "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'error#0';"),
+                        'processOutput' => 'process output',
+                    ],
+                ],
+                'uncovered' => [],
+            ],
+        ];
+
+        yield 'uncovered mutations' => [
+            false,
+            $this->createUncoveredMetricsCalculator(),
+            [
+                'stats' => [
+                    'totalMutantsCount' => 1,
+                    'killedCount' => 0,
+                    'notCoveredCount' => 1,
+                    'escapedCount' => 0,
+                    'errorCount' => 0,
+                    'timeOutCount' => 0,
+                    'msi' => 0,
+                    'mutationCodeCoverage' => 0,
+                    'coveredCodeMsi' => 0,
+                ],
+                'escaped' => [],
+                'timeouted' => [],
+                'killed' => [],
+                'errored' => [],
+                'uncovered' => [
+                    [
+                        'mutator' => [
+                            'mutatorName' => 'For_',
+                            'originalSourceCode' => '<?php $a = 1;',
+                            'mutatedSourceCode' => '<?php $a = 2;',
+                            'originalFilePath' => 'foo/bar',
+                            'originalStartLine' => 10,
+                        ],
+                        'diff' => str_replace("\n", PHP_EOL, "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'uncovered#0';"),
+                        'processOutput' => 'process output',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function assertLoggedContentIs(array $expectedJson, JsonLogger $logger): void
+    {
+        $this->assertSame($expectedJson, json_decode($logger->getLogLines()[0], true, JSON_THROW_ON_ERROR));
+    }
+
+    private function createUncoveredMetricsCalculator(): MetricsCalculator
+    {
+        $calculator = new MetricsCalculator(2);
+
+        $calculator->collect(
+            $this->createMutantExecutionResult(
+                0,
+                For_::class,
+                DetectionStatus::NOT_COVERED,
+                'uncovered#0'
+            ),
+        );
+
+        return $calculator;
+    }
+}

--- a/tests/phpunit/Logger/LoggerFactoryTest.php
+++ b/tests/phpunit/Logger/LoggerFactoryTest.php
@@ -43,6 +43,7 @@ use Infection\Console\LogVerbosity;
 use Infection\Logger\BadgeLogger;
 use Infection\Logger\DebugFileLogger;
 use Infection\Logger\FileLogger;
+use Infection\Logger\JsonLogger;
 use Infection\Logger\LoggerFactory;
 use Infection\Logger\LoggerRegistry;
 use Infection\Logger\MutationTestingResultsLogger;
@@ -92,6 +93,7 @@ final class LoggerFactoryTest extends TestCase
                 '/a/file',
                 '/a/file',
                 '/a/file',
+                '/a/file',
                 null
             )
         );
@@ -109,6 +111,7 @@ final class LoggerFactoryTest extends TestCase
 
         $logger = $factory->createFromLogEntries(
             new Logs(
+                null,
                 null,
                 null,
                 null,
@@ -151,6 +154,7 @@ final class LoggerFactoryTest extends TestCase
                 null,
                 null,
                 null,
+                null,
                 null
             ),
             [TextFileLogger::class],
@@ -162,6 +166,7 @@ final class LoggerFactoryTest extends TestCase
                 'summary_file',
                 null,
                 null,
+                null,
                 null
             ),
             [SummaryFileLogger::class],
@@ -171,6 +176,7 @@ final class LoggerFactoryTest extends TestCase
             new Logs(
                 null,
                 null,
+                null,
                 'debug_file',
                 null,
                 null
@@ -178,8 +184,21 @@ final class LoggerFactoryTest extends TestCase
             [DebugFileLogger::class],
         ];
 
+        yield 'json logger' => [
+            new Logs(
+                null,
+                null,
+                'json_file',
+                null,
+                null,
+                null
+            ),
+            [JsonLogger::class],
+        ];
+
         yield 'per mutator logger' => [
             new Logs(
+                null,
                 null,
                 null,
                 null,
@@ -195,6 +214,7 @@ final class LoggerFactoryTest extends TestCase
                 null,
                 null,
                 null,
+                null,
                 new Badge('foo')
             ),
             [BadgeLogger::class],
@@ -204,6 +224,7 @@ final class LoggerFactoryTest extends TestCase
             new Logs(
                 'text',
                 'summary',
+                'json',
                 'debug',
                 'per_mutator',
                 new Badge('branch')
@@ -211,6 +232,7 @@ final class LoggerFactoryTest extends TestCase
             [
                 TextFileLogger::class,
                 SummaryFileLogger::class,
+                JsonLogger::class,
                 DebugFileLogger::class,
                 PerMutatorLogger::class,
                 BadgeLogger::class,

--- a/tests/phpunit/Metrics/MetricsCalculatorTest.php
+++ b/tests/phpunit/Metrics/MetricsCalculatorTest.php
@@ -196,7 +196,9 @@ DIFF
             ),
             MutatorName::getName(For_::class),
             'foo/bar',
-            $id
+            $id,
+            '<?php $a = 1;',
+            '<?php $a = 1;'
         );
     }
 }

--- a/tests/phpunit/Metrics/SortableMutantExecutionResultsTest.php
+++ b/tests/phpunit/Metrics/SortableMutantExecutionResultsTest.php
@@ -194,7 +194,9 @@ final class SortableMutantExecutionResultsTest extends TestCase
             '#' . $id,
             MutatorName::getName(For_::class),
             $originalFilePath,
-            $originalStartingLine
+            $originalStartingLine,
+            '<?php $a = 1;',
+            '<?php $a = 1;'
         );
     }
 }

--- a/tests/phpunit/Mutant/MutantAssertions.php
+++ b/tests/phpunit/Mutant/MutantAssertions.php
@@ -51,7 +51,8 @@ trait MutantAssertions
         string $expectedMutatedCode,
         string $expectedDiff,
         bool $expectedCoveredByTests,
-        array $expectedTests
+        array $expectedTests,
+        string $originalCode
     ): void {
         $this->assertSame($expectedFilePath, $mutant->getFilePath());
         $this->assertSame($expectedMutation, $mutant->getMutation());
@@ -59,5 +60,6 @@ trait MutantAssertions
         $this->assertSame($expectedDiff, $mutant->getDiff());
         $this->assertSame($expectedCoveredByTests, $mutant->isCoveredByTest());
         $this->assertSame($expectedTests, $mutant->getTests());
+        $this->assertSame($originalCode, $mutant->getPrettyPrintedOriginalCode());
     }
 }

--- a/tests/phpunit/Mutant/MutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/Mutant/MutantExecutionResultFactoryTest.php
@@ -124,7 +124,8 @@ final class MutantExecutionResultFactoryTest extends TestCase
 - echo 'original';
 + echo 'notCovered#0';
 
-DIFF
+DIFF,
+                '<?php $a = 1;'
             )
         );
 
@@ -199,7 +200,8 @@ DIFF
 - echo 'original';
 + echo 'timedOut#0';
 
-DIFF
+DIFF,
+                '<?php $a = 1;'
             )
         );
         $mutantProcess->markAsTimedOut();
@@ -280,7 +282,8 @@ DIFF
 - echo 'original';
 + echo 'errored#0';
 
-DIFF
+DIFF,
+                '<?php $a = 1;'
             )
         );
 
@@ -362,7 +365,8 @@ DIFF
 - echo 'original';
 + echo 'escaped#0';
 
-DIFF
+DIFF,
+                '<?php $a = 1;'
             )
         );
 
@@ -444,7 +448,8 @@ DIFF
 - echo 'original';
 + echo 'killed#0';
 
-DIFF
+DIFF,
+                '<?php $a = 1;'
             )
         );
 

--- a/tests/phpunit/Mutant/MutantExecutionResultTest.php
+++ b/tests/phpunit/Mutant/MutantExecutionResultTest.php
@@ -68,6 +68,8 @@ DIFF;
         $mutatorName = MutatorName::getName(For_::class);
         $originalFilePath = 'path/to/Foo.php';
         $originalStartingLine = 10;
+        $originalCode = '<php $a = 1;';
+        $mutatedCode = '<php $a = 2;';
 
         $result = new MutantExecutionResult(
             $processCommandLine,
@@ -76,7 +78,9 @@ DIFF;
             $mutantDiff,
             $mutatorName,
             $originalFilePath,
-            $originalStartingLine
+            $originalStartingLine,
+            $originalCode,
+            $mutatedCode
         );
 
         $this->assertResultStateIs(
@@ -87,12 +91,17 @@ DIFF;
             $mutantDiff,
             $mutatorName,
             $originalFilePath,
-            $originalStartingLine
+            $originalStartingLine,
+            $originalCode,
+            $mutatedCode
         );
     }
 
     public function test_it_can_be_instantiated_from_a_non_covered_mutant(): void
     {
+        $originalCode = '<?php $a = 1;';
+        $mutatedCode = '<?php $a = 1;';
+
         $mutant = new Mutant(
             '/path/to/mutant',
             new Mutation(
@@ -118,7 +127,7 @@ DIFF;
                     ),
                 ]
             ),
-            'notCovered#0',
+            $mutatedCode,
             $mutantDiff = <<<'DIFF'
 --- Original
 +++ New
@@ -127,7 +136,8 @@ DIFF;
 - echo 'original';
 + echo 'notCovered#0';
 
-DIFF
+DIFF,
+            $originalCode
         );
 
         $this->assertResultStateIs(
@@ -138,7 +148,9 @@ DIFF
             $mutantDiff,
             $mutatorName,
             $originalFilePath,
-            $originalStartingLine
+            $originalStartingLine,
+            $originalCode,
+            $mutatedCode
         );
     }
 
@@ -150,7 +162,9 @@ DIFF
         string $expectedMutantDiff,
         string $expectedMutatorName,
         string $expectedOriginalFilePath,
-        int $expectedOriginalStartingLine
+        int $expectedOriginalStartingLine,
+        string $originalCode,
+        string $mutatedCode
     ): void {
         $this->assertSame($expectedProcessCommandLine, $result->getProcessCommandLine());
         $this->assertSame($expectedProcessOutput, $result->getProcessOutput());
@@ -159,5 +173,7 @@ DIFF
         $this->assertSame($expectedMutatorName, $result->getMutatorName());
         $this->assertSame($expectedOriginalFilePath, $result->getOriginalFilePath());
         $this->assertSame($expectedOriginalStartingLine, $result->getOriginalStartingLine());
+        $this->assertSame($originalCode, $result->getOriginalCode());
+        $this->assertSame($mutatedCode, $result->getMutatedCode());
     }
 }

--- a/tests/phpunit/Mutant/MutantFactoryTest.php
+++ b/tests/phpunit/Mutant/MutantFactoryTest.php
@@ -119,11 +119,12 @@ final class MutantFactoryTest extends TestCase
             ->willReturn('mutated code')
         ;
 
+        $originalCode = 'original code';
         $this->printerMock
             ->expects($this->once())
             ->method('prettyPrintFile')
             ->with($originalNodes)
-            ->willReturn('original code')
+            ->willReturn($originalCode)
         ;
 
         $this->differMock
@@ -142,7 +143,8 @@ final class MutantFactoryTest extends TestCase
             'mutated code',
             'code diff',
             true,
-            $tests
+            $tests,
+            $originalCode
         );
     }
 

--- a/tests/phpunit/Mutant/MutantTest.php
+++ b/tests/phpunit/Mutant/MutantTest.php
@@ -59,9 +59,10 @@ final class MutantTest extends TestCase
         string $mutatedCode,
         string $diff,
         bool $expectedCoveredByTests,
-        array $expectedTests
+        array $expectedTests,
+        string $originalCode
     ): void {
-        $mutant = new Mutant($filePath, $mutation, $mutatedCode, $diff);
+        $mutant = new Mutant($filePath, $mutation, $mutatedCode, $diff, $originalCode);
 
         $this->assertMutantStateIs(
             $mutant,
@@ -70,7 +71,8 @@ final class MutantTest extends TestCase
             $mutatedCode,
             $diff,
             $expectedCoveredByTests,
-            $expectedTests
+            $expectedTests,
+            $originalCode
         );
     }
 
@@ -93,6 +95,8 @@ final class MutantTest extends TestCase
             ),
         ];
 
+        $originalCode = '<?php $a = 1';
+
         yield 'nominal with tests' => [
             '/path/to/tmp/mutant.Foo.infection.php',
             new Mutation(
@@ -112,6 +116,7 @@ final class MutantTest extends TestCase
             'diff value',
             true,
             $tests,
+            $originalCode,
         ];
 
         yield 'nominal without tests' => [
@@ -133,6 +138,7 @@ final class MutantTest extends TestCase
             'diff value',
             false,
             [],
+            $originalCode,
         ];
     }
 }

--- a/tests/phpunit/Process/Factory/MutantProcessFactoryTest.php
+++ b/tests/phpunit/Process/Factory/MutantProcessFactoryTest.php
@@ -90,7 +90,8 @@ final class MutantProcessFactoryTest extends TestCase
 - echo 'original';
 + echo 'killed#0';
 
-DIFF
+DIFF,
+            '<?php $a = 1;'
         );
 
         $testFrameworkExtraOptions = '--verbose';

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -156,13 +156,15 @@ final class MutationTestingRunnerTest extends TestCase
                     '/path/to/mutant0',
                     $mutation0,
                     'mutated code 0',
-                    'diff0'
+                    'diff0',
+                    '<?php $a = 1;'
                 ),
                 $mutant1 = new Mutant(
                     '/path/to/mutant1',
                     $mutation1,
                     'mutated code 1',
-                    'diff1'
+                    'diff1',
+                    '<?php $a = 1;'
                 )
             )
         ;
@@ -225,13 +227,15 @@ final class MutationTestingRunnerTest extends TestCase
                     '/path/to/mutant0',
                     $mutation0,
                     'mutated code 0',
-                    'diff0'
+                    'diff0',
+                    '<?php $a = 1;'
                 ),
                 $mutant1 = new Mutant(
                     '/path/to/mutant1',
                     $mutation1,
                     'mutated code 1',
-                    'diff1'
+                    'diff1',
+                    '<?php $a = 1;'
                 )
             )
         ;


### PR DESCRIPTION
This PR:

- [x] adds new `json` report type (file logger)
- [x] covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/166

<details>
<summary>Example of report JSON file</summary>

```json
{
    "stats": {
        "totalMutantsCount": 10,
        "killedCount": 2,
        "notTestedCount": 2,
        "escapedCount": 2,
        "errorCount": 2,
        "timeOutCount": 2,
        "msi": 60,
        "mutationCodeCoverage": 80,
        "coveredCodeMsi": 75
    },
    "escaped": [
        {
            "mutator": {
                "mutatorName": "PregQuote",
                "originalSourceCode": "<?php $a = 1;",
                "mutatedSourceCode": "<?php $a = 2;",
                "originalFilePath": "foo\/bar",
                "originalStartLine": 9
            },
            "diff": "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'escaped#1';",
            "processOutput": "process output"
        },
        {
            "mutator": {
                "mutatorName": "For_",
                "originalSourceCode": "<?php $a = 1;",
                "mutatedSourceCode": "<?php $a = 2;",
                "originalFilePath": "foo\/bar",
                "originalStartLine": 10
            },
            "diff": "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'escaped#0';",
            "processOutput": "process output"
        }
    ],
    "timeouted": [
        {
            "mutator": {
                "mutatorName": "PregQuote",
                "originalSourceCode": "<?php $a = 1;",
                "mutatedSourceCode": "<?php $a = 2;",
                "originalFilePath": "foo\/bar",
                "originalStartLine": 9
            },
            "diff": "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'timedOut#1';",
            "processOutput": "process output"
        },
        {
            "mutator": {
                "mutatorName": "For_",
                "originalSourceCode": "<?php $a = 1;",
                "mutatedSourceCode": "<?php $a = 2;",
                "originalFilePath": "foo\/bar",
                "originalStartLine": 10
            },
            "diff": "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'timedOut#0';",
            "processOutput": "process output"
        }
    ],
    "killed": [
        {
            "mutator": {
                "mutatorName": "PregQuote",
                "originalSourceCode": "<?php $a = 1;",
                "mutatedSourceCode": "<?php $a = 2;",
                "originalFilePath": "foo\/bar",
                "originalStartLine": 9
            },
            "diff": "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'killed#1';",
            "processOutput": "process output"
        },
        {
            "mutator": {
                "mutatorName": "For_",
                "originalSourceCode": "<?php $a = 1;",
                "mutatedSourceCode": "<?php $a = 2;",
                "originalFilePath": "foo\/bar",
                "originalStartLine": 10
            },
            "diff": "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'killed#0';",
            "processOutput": "process output"
        }
    ],
    "errored": [
        {
            "mutator": {
                "mutatorName": "PregQuote",
                "originalSourceCode": "<?php $a = 1;",
                "mutatedSourceCode": "<?php $a = 2;",
                "originalFilePath": "foo\/bar",
                "originalStartLine": 9
            },
            "diff": "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'error#1';",
            "processOutput": "process output"
        },
        {
            "mutator": {
                "mutatorName": "For_",
                "originalSourceCode": "<?php $a = 1;",
                "mutatedSourceCode": "<?php $a = 2;",
                "originalFilePath": "foo\/bar",
                "originalStartLine": 10
            },
            "diff": "--- Original\n+++ New\n@@ @@\n\n- echo 'original';\n+ echo 'error#0';",
            "processOutput": "process output"
        }
    ],
    "uncovered": []
}x

```
</details>

Can be useful for CI and any other place where results of Mutation Testing need to be analyzed programmatically.

Personally, I'm building something new for Infection, so this report covers 100% of my needs. This report is used to build such UI

<img width="1634" alt="example" src="https://user-images.githubusercontent.com/3725595/86491869-b80df580-bd74-11ea-8363-0b428c42cdae.png">
