### PR TITLE
Set `failOnRisky`, `failOnWarning` to `true` if parameters are not already set

### DIFF
--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -100,6 +100,7 @@ class InitialConfigBuilder implements ConfigBuilder
 
         $this->addCoverageFilterWhitelistIfDoesNotExist($xPath);
         $this->addRandomTestsOrderAttributesIfNotSet($version, $xPath);
+        $this->addFailOnAttributesIfNotSet($version, $xPath);
         $this->configManipulator->replaceWithAbsolutePaths($xPath);
         $this->configManipulator->setStopOnFailure($xPath);
         $this->configManipulator->deactivateColours($xPath);
@@ -202,13 +203,23 @@ class InitialConfigBuilder implements ConfigBuilder
 
     private function addRandomTestsOrderAttributesIfNotSet(string $version, SafeDOMXPath $xPath): void
     {
-        if (!version_compare($version, '7.2', '>=')) {
+        if (version_compare($version, '7.2', '<')) {
             return;
         }
 
         if ($this->addAttributeIfNotSet('executionOrder', 'random', $xPath)) {
             $this->addAttributeIfNotSet('resolveDependencies', 'true', $xPath);
         }
+    }
+
+    private function addFailOnAttributesIfNotSet(string $version, SafeDOMXPath $xPath): void
+    {
+        if (version_compare($version, '5.2', '<')) {
+            return;
+        }
+
+        $this->addAttributeIfNotSet('failOnRisky', 'true', $xPath);
+        $this->addAttributeIfNotSet('failOnWarning', 'true', $xPath);
     }
 
     private function addAttributeIfNotSet(string $attribute, string $value, SafeDOMXPath $xPath): bool

--- a/tests/phpunit/Fixtures/Files/phpunit/format-whitespace/expected-phpunit.xml
+++ b/tests/phpunit/Fixtures/Files/phpunit/format-whitespace/expected-phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit cacheResult="false" colors="false" stderr="false" stopOnFailure="true">
+<phpunit cacheResult="false" colors="false" stderr="false" stopOnFailure="true" failOnRisky="true" failOnWarning="true">
   <testsuites>
     <testsuite name="Application Test Suite">
       <directory>/path/to/src</directory>

--- a/tests/phpunit/Fixtures/Files/phpunit/phpunit_with_fail_on_risky_set.xml
+++ b/tests/phpunit/Fixtures/Files/phpunit/phpunit_with_fail_on_risky_set.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="app/autoload2.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         syntaxCheck="false"
+         executionOrder="reverse"
+         failOnRisky="true"
+>
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>./*Bundle</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/phpunit/Fixtures/Files/phpunit/phpunit_with_fail_on_warning_set.xml
+++ b/tests/phpunit/Fixtures/Files/phpunit/phpunit_with_fail_on_warning_set.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="app/autoload2.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         syntaxCheck="false"
+         executionOrder="reverse"
+         failOnWarning="true"
+>
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>./*Bundle</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -315,8 +315,53 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
 
         $resolveDependencies = $this->queryXpath($xml, sprintf('/phpunit/@%s', 'resolveDependencies'));
 
-        $this->assertInstanceOf(DOMNodeList::class, $executionOrder);
+        $this->assertInstanceOf(DOMNodeList::class, $resolveDependencies);
         $this->assertSame(0, $resolveDependencies->length);
+    }
+
+    /**
+     * @dataProvider failOnProvider
+     */
+    public function test_it_adds_fail_on_risky_and_warning_for_proper_phpunit_versions(
+        string $version,
+        string $attributeName,
+        int $expectedNodeCount
+    ): void {
+        $xml = file_get_contents($this->builder->build($version));
+
+        $nodes = $this->queryXpath($xml, sprintf('/phpunit/@%s', $attributeName));
+
+        $this->assertInstanceOf(DOMNodeList::class, $nodes);
+
+        $this->assertSame($expectedNodeCount, $nodes->length);
+    }
+
+    public function test_it_does_not_update_fail_on_risky_attributes_if_it_is_already_set(): void
+    {
+        $phpunitXmlPath = self::FIXTURES . '/phpunit_with_fail_on_risky_set.xml';
+
+        $builder = $this->createConfigBuilder($phpunitXmlPath);
+
+        $xml = file_get_contents($builder->build('5.2'));
+
+        $failOnRisky = $this->queryXpath($xml, sprintf('/phpunit/@%s', 'failOnRisky'));
+
+        $this->assertInstanceOf(DOMNodeList::class, $failOnRisky);
+        $this->assertSame('true', $failOnRisky[0]->value);
+    }
+
+    public function test_it_does_not_update_fail_on_warning_attributes_if_it_is_already_set(): void
+    {
+        $phpunitXmlPath = self::FIXTURES . '/phpunit_with_fail_on_warning_set.xml';
+
+        $builder = $this->createConfigBuilder($phpunitXmlPath);
+
+        $xml = file_get_contents($builder->build('5.2'));
+
+        $failOnRisky = $this->queryXpath($xml, sprintf('/phpunit/@%s', 'failOnWarning'));
+
+        $this->assertInstanceOf(DOMNodeList::class, $failOnRisky);
+        $this->assertSame('true', $failOnRisky[0]->value);
     }
 
     public function test_it_creates_a_configuration(): void
@@ -338,7 +383,7 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
   ~
   ~ License: https://opensource.org/licenses/BSD-3-Clause New BSD License
   -->
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="$projectPath/app/autoload2.php" colors="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" defaultTestSuite="unit" stopOnFailure="true" cacheResult="false" stderr="false">
+<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="$projectPath/app/autoload2.php" colors="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" syntaxCheck="false" defaultTestSuite="unit" failOnRisky="true" failOnWarning="true" stopOnFailure="true" cacheResult="false" stderr="false">
   <testsuites>
     <testsuite name="Application Test Suite">
       <directory>$projectPath/*Bundle</directory>
@@ -397,6 +442,45 @@ XML
         yield 'PHPUnit 7.3.1 runs dependency resolver' => [
             '7.3.1',
             'resolveDependencies',
+            1,
+        ];
+    }
+
+    public function failOnProvider(): iterable
+    {
+        yield 'PHPUnit 5.1.99 runs without failOnRisky' => [
+            '5.1.99',
+            'failOnRisky',
+            0,
+        ];
+
+        yield 'PHPUnit 5.2 runs with failOnRisky' => [
+            '5.2',
+            'failOnRisky',
+            1,
+        ];
+
+        yield 'PHPUnit 5.3.1 runs with failOnRisky' => [
+            '5.3.1',
+            'failOnRisky',
+            1,
+        ];
+
+        yield 'PHPUnit 5.1.99 runs without resolveDependencies' => [
+            '5.1.99',
+            'failOnWarning',
+            0,
+        ];
+
+        yield 'PHPUnit 5.2 runs with resolveDependencies' => [
+            '5.2',
+            'failOnWarning',
+            1,
+        ];
+
+        yield 'PHPUnit 5.3.1 runs resolveDependencies' => [
+            '5.3.1',
+            'failOnWarning',
             1,
         ];
     }


### PR DESCRIPTION
Fixes #1274

> Since PHPUnit won't treat new risky tests as failures by default, and since this behavior causes an unnecessary confusion even for experienced users (see #1273), we add failOnRisky="true" and failOnWarning="true" by default unless a conflicting directive is present, just like we do with executionOrder="random".

> That is, if there's already failOnRisky="false" then it should not be changed.