### PR TITLE
Do not mutate clean up functions

### DIFF
--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -48,6 +48,18 @@ final class FunctionCallRemoval implements Mutator
 {
     use GetMutatorName;
 
+    /** @var string[] */
+    private $doNotRemoveFunctions = [
+        'assert',
+        'closedir',
+        'curl_close',
+        'curl_multi_close',
+        'fclose',
+        'mysqli_free_result',
+        'mysqli_close',
+        'socket_close',
+    ];
+
     public static function getDefinition(): ?Definition
     {
         return new Definition(
@@ -85,6 +97,6 @@ final class FunctionCallRemoval implements Mutator
             return true;
         }
 
-        return $name->toLowerString() !== 'assert';
+        return !in_array($name->toLowerString(), $this->doNotRemoveFunctions);
     }
 }

--- a/tests/phpunit/Mutator/Removal/FunctionCallRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/FunctionCallRemovalTest.php
@@ -165,13 +165,21 @@ $a = 3;
 PHP
         ];
 
-        yield 'It does not remove an assert() call' => [
+        yield 'It does not remove disallowed calls' => [
             <<<'PHP'
 <?php
 
 assert(true === true);
 aSsert(true === true);
 \assert(true === true);
+fclose($fileHandle);
+closedir($close);
+curl_close($curlHandle);
+fclose();
+mysqli_free_result();
+mysqli_close();
+socket_close();
+
 $a = 3;
 PHP
         ];


### PR DESCRIPTION
Functions like Close and Free should not be removed by the function call
removals. Removing them does not change the tested behavior, but does
free the memory before the script finished / garbage collection is
invoked

This PR:

- [ ] Adds new feature ...
- [x] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

