### PR TITLE
Restrict installing with faulty versions of PHPUnit's coverage package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
         "webmozart/path-util": "^2.3"
     },
     "conflict": {
+        "phpunit/php-code-coverage": ">9 <9.1.4",
         "symfony/console": "=4.1.5"
     },
     "require-dev": {
@@ -96,8 +97,12 @@
             "Infection\\Benchmark\\": "tests/benchmark",
             "Infection\\Tests\\": "tests/phpunit"
         },
-        "classmap": ["tests/autoloaded"],
-        "files": ["tests/phpunit/Helpers.php"]
+        "classmap": [
+            "tests/autoloaded"
+        ],
+        "files": [
+            "tests/phpunit/Helpers.php"
+        ]
     },
     "bin": [
         "bin/infection"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a6277ac6f4270174033923b9b68e6d5",
+    "content-hash": "21109e4835cff9b6dd32b9160549cc9e",
     "packages": [
         {
             "name": "composer/xdebug-handler",


### PR DESCRIPTION
This PR:

- [x] Fixes #1289 so we don't have to deal with this for time being

`phpunit/php-code-coverage` starting with 9.0 and up to including 9.1.3 had an annoying issue where [lines with `::class` constant were not covered](https://github.com/sebastianbergmann/php-code-coverage/issues/793) as per coverage report. 

This PR restricts installing Infection with these versions.

Coding standards issues are not related to this PR: no code change is assumed.