### PR TITLE
Do not mutate openssl_free_key()

### DIFF
--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -55,8 +55,8 @@ final class FunctionCallRemoval implements Mutator
         'curl_close',
         'curl_multi_close',
         'fclose',
-        'mysqli_free_result',
         'mysqli_close',
+        'mysqli_free_result',
         'socket_close',
     ];
 

--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -57,6 +57,7 @@ final class FunctionCallRemoval implements Mutator
         'fclose',
         'mysqli_close',
         'mysqli_free_result',
+        'openssl_free_key',
         'socket_close',
     ];
 

--- a/tests/phpunit/Mutator/Removal/FunctionCallRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/FunctionCallRemovalTest.php
@@ -179,6 +179,7 @@ fclose();
 mysqli_free_result();
 mysqli_close();
 socket_close();
+openssl_free_key();
 
 $a = 3;
 PHP


### PR DESCRIPTION
This PR:

- [x] Extends list of excluded functions from function removal mutator (like https://github.com/infection/infection/pull/1285)
- [x] Covered by tests

As per @maks-rafalko's [request](https://github.com/infection/infection/pull/1285#issuecomment-675889801) this adds `openssl_free_result()` to the list of function not to remove.