### PR TITLE
Infection must return appropriate exit status when failing

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -75,7 +75,7 @@ abstract class BaseCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        return $this->executeCommand($this->getIO()) ? self::SUCCESS : self::FAILURE;
+        return $this->executeCommand($this->getIO()) ? 0 : 1;
     }
 
     abstract protected function executeCommand(IO $io): bool;

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -75,12 +75,10 @@ abstract class BaseCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->executeCommand($this->getIO());
-
-        return 0;
+        return $this->executeCommand($this->getIO()) ? self::SUCCESS : self::FAILURE;
     }
 
-    abstract protected function executeCommand(IO $io): void;
+    abstract protected function executeCommand(IO $io): bool;
 
     final protected function getIO(): IO
     {

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -84,7 +84,7 @@ final class ConfigureCommand extends BaseCommand
             );
     }
 
-    protected function executeCommand(IO $io): void
+    protected function executeCommand(IO $io): bool
     {
         if (!$io->isInteractive()) {
             $io->writeln(self::NONINTERACTIVE_MODE_ERROR);
@@ -156,6 +156,8 @@ final class ConfigureCommand extends BaseCommand
             SchemaConfigurationLoader::DEFAULT_DIST_CONFIG_FILE
         ));
         $io->newLine();
+
+        return true;
     }
 
     /**

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -213,7 +213,7 @@ final class RunCommand extends BaseCommand
         ;
     }
 
-    protected function executeCommand(IO $io): void
+    protected function executeCommand(IO $io): bool
     {
         $logger = new ConsoleLogger($io);
         $container = $this->createContainer($io, $logger);
@@ -238,10 +238,14 @@ final class RunCommand extends BaseCommand
 
         try {
             $engine->execute();
+
+            return true;
         } catch (InitialTestsFailed | MinMsiCheckFailed $exception) {
             // TODO: we can move that in a dedicated logger later and handle those cases in the
             // Engine instead
             $io->error($exception->getMessage());
+
+            return false;
         }
     }
 


### PR DESCRIPTION
This PR fixes the unfortunate issue where Infection wouldn't exit with an error status in case of an error (e.g. low MSI).

Tests pending.