### PR TITLE
Add mutator to remove shared cases

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -276,6 +276,7 @@
                 "FunctionCallRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "MethodCallRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "CloneRemoval": { "$ref": "#/definitions/default-mutator-config" },
+                "SharedCaseRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "ArrayOneItem": { "$ref": "#/definitions/default-mutator-config" },
                 "FloatNegation": { "$ref": "#/definitions/default-mutator-config" },
                 "FunctionCall": { "$ref": "#/definitions/default-mutator-config" },

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -170,6 +170,7 @@ final class ProfileList
         Mutator\Removal\CloneRemoval::class,
         Mutator\Removal\FunctionCallRemoval::class,
         Mutator\Removal\MethodCallRemoval::class,
+        Mutator\Removal\SharedCaseRemoval::class,
     ];
 
     public const RETURN_VALUE_PROFILE = [
@@ -354,6 +355,7 @@ final class ProfileList
         'CloneRemoval' => Mutator\Removal\CloneRemoval::class,
         'FunctionCallRemoval' => Mutator\Removal\FunctionCallRemoval::class,
         'MethodCallRemoval' => Mutator\Removal\MethodCallRemoval::class,
+        'SharedCaseRemoval' => Mutator\Removal\SharedCaseRemoval::class,
 
         // Return Value
         'ArrayOneItem' => Mutator\ReturnValue\ArrayOneItem::class,

--- a/src/Mutator/Removal/SharedCaseRemoval.php
+++ b/src/Mutator/Removal/SharedCaseRemoval.php
@@ -79,11 +79,11 @@ final class SharedCaseRemoval implements Mutator
      */
     public function mutate(Node $node): iterable
     {
-        $lastWasEmpty = false;
+        $previousWasEmpty = false;
 
         foreach ($node->cases as $i => $case) {
             if ($case->stmts === []) {
-                $lastWasEmpty = true;
+                $previousWasEmpty = true;
                 $cases = $node->cases;
                 unset($cases[$i]);
 
@@ -92,8 +92,12 @@ final class SharedCaseRemoval implements Mutator
                     $cases,
                     $node->getAttributes()
                 );
-            } elseif ($lastWasEmpty) {
-                $lastWasEmpty = false;
+
+                continue;
+            }
+
+            if ($previousWasEmpty) {
+                $previousWasEmpty = false;
                 $cases = $node->cases;
                 unset($cases[$i]);
                 $lastCase = $cases[$i - 1];

--- a/src/Mutator/Removal/SharedCaseRemoval.php
+++ b/src/Mutator/Removal/SharedCaseRemoval.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Removal;
+
+use Infection\Mutator\Definition;
+use Infection\Mutator\GetMutatorName;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\MutatorCategory;
+use PhpParser\Node;
+
+/**
+ * @internal
+ */
+final class SharedCaseRemoval implements Mutator
+{
+    use GetMutatorName;
+
+    public static function getDefinition(): ?Definition
+    {
+        return new Definition(
+            'Removes `case`s from `switch`.',
+            MutatorCategory::SEMANTIC_REDUCTION,
+            null
+        );
+    }
+
+    public function canMutate(Node $node): bool
+    {
+        if (!$node instanceof Node\Stmt\Switch_) {
+            return false;
+        }
+
+        foreach ($node->cases as $case) {
+            if ($case->stmts === []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Node\Stmt\Switch_ $node
+     *
+     * @return iterable<Node\Stmt\Switch_>
+     */
+    public function mutate(Node $node): iterable
+    {
+        $lastWasEmpty = false;
+
+        foreach ($node->cases as $i => $case) {
+            if ($case->stmts === []) {
+                $lastWasEmpty = true;
+                $cases = $node->cases;
+                unset($cases[$i]);
+
+                yield new Node\Stmt\Switch_(
+                    $node->cond,
+                    $cases,
+                    $node->getAttributes()
+                );
+            } elseif ($lastWasEmpty) {
+                $lastWasEmpty = false;
+                $cases = $node->cases;
+                unset($cases[$i]);
+                $lastCase = $cases[$i - 1];
+                $cases[$i - 1] = new Node\Stmt\Case_(
+                    $lastCase->cond,
+                    $case->stmts,
+                    $lastCase->getAttributes()
+                );
+
+                yield new Node\Stmt\Switch_(
+                    $node->cond,
+                    $cases,
+                    $node->getAttributes()
+                );
+            }
+        }
+    }
+}

--- a/tests/phpunit/Mutator/Removal/SharedCaseRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/SharedCaseRemovalTest.php
@@ -53,11 +53,30 @@ final class SharedCaseRemovalTest extends BaseMutatorTestCase
     public function mutationsProvider(): iterable
     {
         yield 'It does not mutate single cases with a body' => [
-            '<?php switch(true) {case true: $a = [];break; case false: $a = [];break;};',
+            '<?php
+
+ switch(true) {
+    case true:
+        $a = [];
+        break;
+    case false:
+        $a = [];
+        break;
+}',
         ];
 
         yield 'It removes cases that share a body' => [
-            '<?php switch(true) {case true: case false: $a = [];break; case null: $a = []; break;};',
+            '<?php
+
+switch(true) {
+    case true:
+    case false:
+        $a = [];
+        break;
+    case null:
+        $a = [];
+        break;
+}',
             [
                 '<?php
 
@@ -83,7 +102,17 @@ switch (true) {
         ];
 
         yield 'It removes default if it shares a body with a case' => [
-            '<?php switch(true) {case true: $a = [];break; case false: default: $b = []; break;};',
+            '<?php
+
+switch(true) {
+    case true:
+        $a = [];
+        break;
+    case false:
+    default:
+        $b = [];
+        break;
+}',
             [
                 '<?php
 

--- a/tests/phpunit/Mutator/Removal/SharedCaseRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/SharedCaseRemovalTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Removal;
+
+use Infection\Tests\Mutator\BaseMutatorTestCase;
+
+final class SharedCaseRemovalTest extends BaseMutatorTestCase
+{
+    /**
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
+     * @param mixed[] $settings
+     */
+    public function test_it_can_mutate(string $input, $expected = [], array $settings = []): void
+    {
+        $this->doTest($input, $expected, $settings);
+    }
+
+    public function mutationsProvider(): iterable
+    {
+        yield 'It does not mutate single cases with a body' => [
+            '<?php switch(true) {case true: $a = [];break; case false: $a = [];break;};',
+        ];
+
+        yield 'It removes cases that share a body' => [
+            '<?php switch(true) {case true: case false: $a = [];break; case null: $a = []; break;};',
+            [
+                '<?php
+
+switch (true) {
+    case false:
+        $a = [];
+        break;
+    case null:
+        $a = [];
+        break;
+}',
+                '<?php
+
+switch (true) {
+    case true:
+        $a = [];
+        break;
+    case null:
+        $a = [];
+        break;
+}',
+            ],
+        ];
+
+        yield 'It removes default if it shares a body with a case' => [
+            '<?php switch(true) {case true: $a = [];break; case false: default: $b = []; break;};',
+            [
+                '<?php
+
+switch (true) {
+    case true:
+        $a = [];
+        break;
+    default:
+        $b = [];
+        break;
+}',
+                '<?php
+
+switch (true) {
+    case true:
+        $a = [];
+        break;
+    case false:
+        $b = [];
+        break;
+}',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR:
- [x] Adds a new mutator to remove `case`s from `switch`-statments that share a body
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/173

Closes #1290

Code like this:
```
switch ($value) {
  case 'a':
    doSomething();
    break;
  case 'b':
  case 'c':
  default:
    doSomethingElse();
    break;
}
```
Creates the following mutants:
```diff
switch ($value) {
  case 'a':
    doSomething();
    break;
-  case 'b':
  case 'c':
  default:
    doSomethingElse();
    break;
}
```
```diff
switch ($value) {
  case 'a':
    doSomething();
    break;
  case 'b':
-  case 'c':
  default:
    doSomethingElse();
    break;
}
```
```diff
switch ($value) {
  case 'a':
    doSomething();
    break;
  case 'b':
  case 'c':
-  default:
    doSomethingElse();
    break;
}
```