### PR TITLE
Builds without embedded XDebug should be able to continue

### DIFF
--- a/.ci/travis-functions.sh
+++ b/.ci/travis-functions.sh
@@ -25,7 +25,7 @@ readonly XDEBUG_DISABLED_INI_FILE="/tmp/xdebug.ini"
 #######################################
 function xdebug_disable() {
     if ! [[ -f $XDEBUG_ENABLED_INI_FILE ]]; then
-        exit
+        return 0
     fi
 
     cp "$XDEBUG_ENABLED_INI_FILE" "$XDEBUG_DISABLED_INI_FILE"


### PR DESCRIPTION
Which is currently not so with PHP 8.

Fix ported from #1309