### PR TITLE
Update TestFrameworkFinderTest 

### DIFF
--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -115,7 +115,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $frameworkFinder = new TestFrameworkFinder();
 
         $this->expectException(FinderException::class);
-        $this->expectExceptionMessageRegExp('/custom path/');
+        $this->expectExceptionMessage('custom path');
 
         $frameworkFinder->find('not-used', $filename);
     }


### PR DESCRIPTION
This PR:

- [x] Updates TestFrameworkFinderTest to do not use deprecated expectExceptionMessageRegExp

Ported over from #1309
