### PR TITLE
Replace non utf-8 characters before `json_encode`'ing to avoid failure in JsonLogger 

### DIFF
--- a/src/Logger/JsonLogger.php
+++ b/src/Logger/JsonLogger.php
@@ -40,6 +40,7 @@ use Infection\Mutant\MutantExecutionResult;
 use Infection\Str;
 use function json_encode;
 use const JSON_THROW_ON_ERROR;
+use function mb_convert_encoding;
 
 /**
  * @internal
@@ -103,11 +104,16 @@ final class JsonLogger implements LineMutationTestingResultsLogger
                     'originalFilePath' => $mutantProcess->getOriginalFilePath(),
                     'originalStartLine' => $mutantProcess->getOriginalStartingLine(),
                 ],
-                'diff' => Str::trimLineReturns($mutantProcess->getMutantDiff()),
-                'processOutput' => Str::trimLineReturns($mutantProcess->getProcessOutput()),
+                'diff' => $this->convertToUtf8(Str::trimLineReturns($mutantProcess->getMutantDiff())),
+                'processOutput' => $this->convertToUtf8(Str::trimLineReturns($mutantProcess->getProcessOutput())),
             ];
         }
 
         return $mutatorRows;
+    }
+
+    private function convertToUtf8(string $string): string
+    {
+        return mb_convert_encoding($string, 'UTF-8', 'UTF-8');
     }
 }


### PR DESCRIPTION
Replace non utf-8 characters before `json_encode`ing to avoid failure in JsonLogger  with `Malformed UTF-8 characters` error

Fixes https://github.com/infection/infection/issues/1316
