### PR TITLE
Private methods cannot be final as they are never overridden

### DIFF
--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -87,6 +87,10 @@ final class ProtectedVisibility implements Mutator
             return false;
         }
 
+        if ($node->isFinal()) {
+            return false;
+        }
+
         if ($node->isAbstract()) {
             return false;
         }

--- a/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -76,21 +76,6 @@ PHP
 
         yield 'It does not mutate final flag' => [
             MutatorFixturesProvider::getFixtureFileContent($this, 'pv-final.php'),
-            <<<'PHP'
-<?php
-
-namespace ProtectedVisibilityFinal;
-
-class Test
-{
-    private final function &foo(int $param, $test = 1) : bool
-    {
-        echo 1;
-        return false;
-    }
-}
-PHP
-            ,
         ];
 
         yield 'It does not mutate abstract protected to private' => [


### PR DESCRIPTION
This PR:

- [x] Fixes PHP 8 bug where this is a warning.

https://3v4l.org/Q0B8T
