### PR TITLE
Add an ability to ignore Mutators for source code line(s) by regular expression

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -122,6 +122,12 @@
                         "type": "string"
                     }
                 },
+                "global-ignoreSourceCodeByRegex": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
 
                 "@arithmetic": { "$ref": "#/definitions/default-mutator-config" },
                 "@boolean": { "$ref": "#/definitions/default-mutator-config" },
@@ -502,6 +508,12 @@
                     "additionalProperties": false,
                     "properties": {
                         "ignore": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "ignoreSourceCodeByRegex": {
                             "type": "array",
                             "items": {
                                 "type": "string"

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -81,12 +81,14 @@ class Configuration
     private $msiPrecision;
     private $threadCount;
     private $dryRun;
+    private $ignoreSourceCodeMutatorsMap;
 
     /**
      * @param string[] $sourceDirectories
      * @param string[] $sourceFilesExcludes
      * @param iterable<SplFileInfo> $sourceFiles
      * @param array<string, Mutator> $mutators
+     * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
      */
     public function __construct(
         float $timeout,
@@ -115,7 +117,8 @@ class Configuration
         ?float $minCoveredMsi,
         int $msiPrecision,
         int $threadCount,
-        bool $dryRun
+        bool $dryRun,
+        array $ignoreSourceCodeMutatorsMap
     ) {
         Assert::nullOrGreaterThanEq($timeout, 0);
         Assert::allString($sourceDirectories);
@@ -152,6 +155,7 @@ class Configuration
         $this->msiPrecision = $msiPrecision;
         $this->threadCount = $threadCount;
         $this->dryRun = $dryRun;
+        $this->ignoreSourceCodeMutatorsMap = $ignoreSourceCodeMutatorsMap;
     }
 
     public function getProcessTimeout(): float
@@ -299,5 +303,13 @@ class Configuration
     public function isDryRun(): bool
     {
         return $this->dryRun;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function getIgnoreSourceCodeMutatorsMap(): array
+    {
+        return $this->ignoreSourceCodeMutatorsMap;
     }
 }

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -37,7 +37,6 @@ namespace Infection\Configuration;
 
 use function array_fill_keys;
 use function array_key_exists;
-use function count;
 use function dirname;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Schema\SchemaConfiguration;
@@ -169,9 +168,9 @@ class ConfigurationFactory
      *
      * @return array<class-string<Mutator&ConfigurableMutator>, mixed[]>
      */
-    public function resolveMutators(array $schemaMutators, string $mutatorsInput): array
+    private function resolveMutators(array $schemaMutators, string $mutatorsInput): array
     {
-        if (count($schemaMutators) === 0) {
+        if ($schemaMutators === []) {
             $schemaMutators = ['@default' => true];
         }
 

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -39,11 +39,12 @@ use function array_fill_keys;
 use function array_key_exists;
 use function count;
 use function dirname;
-use function explode;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Schema\SchemaConfiguration;
 use Infection\FileSystem\SourceFileCollector;
 use Infection\FileSystem\TmpDirProvider;
+use Infection\Mutator\ConfigurableMutator;
+use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\MutatorParser;
 use Infection\Mutator\MutatorResolver;
@@ -166,7 +167,7 @@ class ConfigurationFactory
     /**
      * @param array<string, mixed> $schemaMutators
      *
-     * @return array<string, mixed[]>
+     * @return array<class-string<Mutator&ConfigurableMutator>, mixed[]>
      */
     public function resolveMutators(array $schemaMutators, string $mutatorsInput): array
     {
@@ -273,10 +274,8 @@ class ConfigurationFactory
 
         foreach ($resolvedMutatorsMap as $mutatorClassName => $config) {
             if (array_key_exists('ignoreSourceCodeByRegex', $config)) {
-                $classNameParts = explode('\\', $mutatorClassName);
-                $mutatorName = end($classNameParts);
+                $mutatorName = MutatorFactory::getMutatorNameForClassName($mutatorClassName);
 
-                Assert::string($mutatorName);
                 Assert::isArray($config['ignoreSourceCodeByRegex']);
 
                 $map[$mutatorName] = $config['ignoreSourceCodeByRegex'];

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -36,13 +36,14 @@ declare(strict_types=1);
 namespace Infection\Configuration;
 
 use function array_fill_keys;
+use function array_key_exists;
 use function count;
 use function dirname;
+use function explode;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Schema\SchemaConfiguration;
 use Infection\FileSystem\SourceFileCollector;
 use Infection\FileSystem\TmpDirProvider;
-use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\MutatorParser;
 use Infection\Mutator\MutatorResolver;
@@ -50,6 +51,7 @@ use Infection\TestFramework\TestFrameworkTypes;
 use OndraM\CiDetector\CiDetector;
 use function Safe\sprintf;
 use function sys_get_temp_dir;
+use Webmozart\Assert\Assert;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -121,6 +123,11 @@ class ConfigurationFactory
             $namespacedTmpDir
         );
 
+        $resolvedMutatorsArray = $this->resolveMutators($schema->getMutators(), $mutatorsInput);
+
+        $mutators = $this->mutatorFactory->create($resolvedMutatorsArray);
+        $ignoreSourceCodeMutatorsMap = $this->retrieveIgnoreSourceCodeMutatorsMap($resolvedMutatorsArray);
+
         return new Configuration(
             $schema->getTimeout() ?? self::DEFAULT_TIMEOUT,
             $schema->getSource()->getDirectories(),
@@ -134,7 +141,7 @@ class ConfigurationFactory
             $logVerbosity,
             $namespacedTmpDir,
             $this->retrievePhpUnit($schema, $configDir),
-            $this->retrieveMutators($schema->getMutators(), $mutatorsInput),
+            $mutators,
             $testFramework,
             $schema->getBootstrap(),
             $initialTestsPhpOptions ?? $schema->getInitialTestsPhpOptions(),
@@ -151,8 +158,31 @@ class ConfigurationFactory
             self::retrieveMinCoveredMsi($minCoveredMsi, $schema),
             $msiPrecision,
             $threadCount,
-            $dryRun
+            $dryRun,
+            $ignoreSourceCodeMutatorsMap
         );
+    }
+
+    /**
+     * @param array<string, mixed> $schemaMutators
+     *
+     * @return array<string, mixed[]>
+     */
+    public function resolveMutators(array $schemaMutators, string $mutatorsInput): array
+    {
+        if (count($schemaMutators) === 0) {
+            $schemaMutators = ['@default' => true];
+        }
+
+        $parsedMutatorsInput = $this->mutatorParser->parse($mutatorsInput);
+
+        if ($parsedMutatorsInput === []) {
+            $mutatorsList = $schemaMutators;
+        } else {
+            $mutatorsList = array_fill_keys($parsedMutatorsInput, true);
+        }
+
+        return $this->mutatorResolver->resolve($mutatorsList);
     }
 
     private function retrieveTmpDir(
@@ -185,30 +215,6 @@ class ConfigurationFactory
         }
 
         return $phpUnit;
-    }
-
-    /**
-     * @param array<string, mixed> $schemaMutators
-     *
-     * @return array<string, Mutator>
-     */
-    private function retrieveMutators(array $schemaMutators, string $mutatorsInput): array
-    {
-        if (count($schemaMutators) === 0) {
-            $schemaMutators = ['@default' => true];
-        }
-
-        $parsedMutatorsInput = $this->mutatorParser->parse($mutatorsInput);
-
-        if ($parsedMutatorsInput === []) {
-            $mutatorsList = $schemaMutators;
-        } else {
-            $mutatorsList = array_fill_keys($parsedMutatorsInput, true);
-        }
-
-        return $this->mutatorFactory->create(
-            $this->mutatorResolver->resolve($mutatorsList)
-        );
     }
 
     private static function retrieveCoverageBasePath(
@@ -254,5 +260,29 @@ class ConfigurationFactory
     private static function retrieveMinCoveredMsi(?float $minCoveredMsi, SchemaConfiguration $schema): ?float
     {
         return $minCoveredMsi ?? $schema->getMinCoveredMsi();
+    }
+
+    /**
+     * @param array<string, mixed[]> $resolvedMutatorsMap
+     *
+     * @return array<string, array<int, string>>
+     */
+    private function retrieveIgnoreSourceCodeMutatorsMap(array $resolvedMutatorsMap): array
+    {
+        $map = [];
+
+        foreach ($resolvedMutatorsMap as $mutatorClassName => $config) {
+            if (array_key_exists('ignoreSourceCodeByRegex', $config)) {
+                $classNameParts = explode('\\', $mutatorClassName);
+                $mutatorName = end($classNameParts);
+
+                Assert::string($mutatorName);
+                Assert::isArray($config['ignoreSourceCodeByRegex']);
+
+                $map[$mutatorName] = $config['ignoreSourceCodeByRegex'];
+            }
+        }
+
+        return $map;
     }
 }

--- a/src/Differ/DiffSourceCodeMatcher.php
+++ b/src/Differ/DiffSourceCodeMatcher.php
@@ -44,6 +44,8 @@ final class DiffSourceCodeMatcher
 {
     public function matches(string $diff, string $sourceCodeRegex): bool
     {
-        return preg_match("/^-\s*{$sourceCodeRegex}$/mu", $diff) === 1;
+        $regexWithEscapedDelimiters = str_replace('/', '\/', $sourceCodeRegex);
+
+        return preg_match("/^-\s*{$regexWithEscapedDelimiters}$/mu", $diff) === 1;
     }
 }

--- a/src/Differ/DiffSourceCodeMatcher.php
+++ b/src/Differ/DiffSourceCodeMatcher.php
@@ -33,60 +33,17 @@
 
 declare(strict_types=1);
 
-namespace Infection\Mutator;
+namespace Infection\Differ;
 
-use function array_key_exists;
-use const FNM_NOESCAPE;
-use function fnmatch;
-use function Safe\array_flip;
+use function Safe\preg_match;
 
 /**
  * @internal
- * @final
  */
-class IgnoreConfig
+final class DiffSourceCodeMatcher
 {
-    private $patterns;
-    /** @var array<string, int> */
-    private $hashtable = [];
-
-    /**
-     * @param string[] $ignored
-     */
-    public function __construct(array $ignored)
+    public function matches(string $diff, string $sourceCodeRegex): bool
     {
-        $this->patterns = $ignored;
-
-        if ($ignored !== []) {
-            $this->hashtable = array_flip($ignored);
-        }
-    }
-
-    public function isIgnored(string $class, string $method, ?int $lineNumber): bool
-    {
-        if ($this->patterns === []) {
-            return false;
-        }
-
-        if (array_key_exists($class, $this->hashtable)) {
-            return true;
-        }
-
-        $classMethod = $class . '::' . $method;
-
-        if (array_key_exists($classMethod, $this->hashtable)) {
-            return true;
-        }
-
-        foreach ($this->patterns as $ignorePattern) {
-            if (fnmatch($ignorePattern, $class, FNM_NOESCAPE)
-                || fnmatch($ignorePattern, $classMethod, FNM_NOESCAPE)
-                || ($lineNumber !== null && fnmatch($ignorePattern, $classMethod . '::' . $lineNumber, FNM_NOESCAPE))
-            ) {
-                return true;
-            }
-        }
-
-        return false;
+        return preg_match("/^-\s*{$sourceCodeRegex}$/mu", $diff) === 1;
     }
 }

--- a/src/Mutator/MutatorResolver.php
+++ b/src/Mutator/MutatorResolver.php
@@ -49,6 +49,7 @@ use stdClass;
 final class MutatorResolver
 {
     private const GLOBAL_IGNORE_SETTING = 'global-ignore';
+    private const GLOBAL_IGNORE_SOURCE_CODE_BY_REGEX_SETTING = 'global-ignoreSourceCodeByRegex';
 
     /**
      * Resolves the given hashmap of enabled, disabled or configured mutators
@@ -72,6 +73,16 @@ final class MutatorResolver
 
                 $globalSettings = ['ignore' => $globalSetting];
                 unset($mutatorSettings[self::GLOBAL_IGNORE_SETTING]);
+
+                break;
+            }
+
+            if ($mutatorOrProfileOrGlobalSettingKey === self::GLOBAL_IGNORE_SOURCE_CODE_BY_REGEX_SETTING) {
+                /** @var string[] $globalSetting */
+                $globalSetting = $setting;
+
+                $globalSettings = ['ignoreSourceCodeByRegex' => $globalSetting];
+                unset($mutatorSettings[self::GLOBAL_IGNORE_SOURCE_CODE_BY_REGEX_SETTING]);
 
                 break;
             }

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -35,6 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Process\Runner;
 
+use function array_key_exists;
+use Infection\Differ\DiffSourceCodeMatcher;
 use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\MutantProcessWasFinished;
 use Infection\Event\MutationTestingWasFinished;
@@ -59,25 +61,35 @@ class MutationTestingRunner
     private $processRunner;
     private $eventDispatcher;
     private $fileSystem;
+    private $diffSourceCodeMatcher;
     private $runConcurrently;
     private $timeout;
+    /** @var array<string, array<int, string>> */
+    private $ignoreSourceCodeMutatorsMap;
 
+    /**
+     * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
+     */
     public function __construct(
         MutantProcessFactory $processFactory,
         MutantFactory $mutantFactory,
         ProcessRunner $processRunner,
         EventDispatcher $eventDispatcher,
         Filesystem $fileSystem,
+        DiffSourceCodeMatcher $diffSourceCodeMatcher,
         bool $runConcurrently,
-        float $timeout
+        float $timeout,
+        array $ignoreSourceCodeMutatorsMap
     ) {
         $this->processFactory = $processFactory;
         $this->mutantFactory = $mutantFactory;
         $this->processRunner = $processRunner;
         $this->eventDispatcher = $eventDispatcher;
         $this->fileSystem = $fileSystem;
+        $this->diffSourceCodeMatcher = $diffSourceCodeMatcher;
         $this->runConcurrently = $runConcurrently;
         $this->timeout = $timeout;
+        $this->ignoreSourceCodeMutatorsMap = $ignoreSourceCodeMutatorsMap;
     }
 
     /**
@@ -103,6 +115,21 @@ class MutationTestingRunner
                 ));
 
                 return false;
+            })
+            ->filter(function (Mutant $mutant) {
+                $mutatorName = $mutant->getMutation()->getMutatorName();
+
+                if (!array_key_exists($mutatorName, $this->ignoreSourceCodeMutatorsMap)) {
+                    return true;
+                }
+
+                foreach ($this->ignoreSourceCodeMutatorsMap[$mutatorName] as $sourceCodeRegex) {
+                    if ($this->diffSourceCodeMatcher->matches($mutant->getDiff(), $sourceCodeRegex)) {
+                        return false;
+                    }
+                }
+
+                return true;
             })
             ->filter(function (Mutant $mutant) {
                 if ($mutant->getMutation()->getNominalTestExecutionTime() < $this->timeout) {

--- a/tests/e2e/Exclude_Mutations_By_Regex/README.md
+++ b/tests/e2e/Exclude_Mutations_By_Regex/README.md
@@ -1,0 +1,34 @@
+## Summary
+
+* Support test for the feature that fixes https://github.com/infection/infection/issues/697
+
+Allows to avoid mutating such lines of code as:
+
+```diff
+- Assert::notNull($variable);
+```
+
+or
+
+```diff
+- $this->logger->error($message, ['user' => $user]);
++ $this->logger->error($message, []);
+```
+
+and so on.
+
+Example of new config setting usage:
+
+```json
+{
+    "mutators": {
+        "MethodCallRemoval": {
+            "ignoreSourceCodeByRegex": [
+                "Assert::.*",
+                "\\$this->logger.*"
+            ]
+        }
+    }
+}
+```
+

--- a/tests/e2e/Exclude_Mutations_By_Regex/composer.json
+++ b/tests/e2e/Exclude_Mutations_By_Regex/composer.json
@@ -1,0 +1,18 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^8"
+    },
+    "autoload": {
+        "psr-4": {
+            "Exclude_Mutations_By_Regex\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Exclude_Mutations_By_Regex\\Test\\": "tests/"
+        }
+    },
+    "require": {
+        "webmozart/assert": "^1.9"
+    }
+}

--- a/tests/e2e/Exclude_Mutations_By_Regex/expected-output.txt
+++ b/tests/e2e/Exclude_Mutations_By_Regex/expected-output.txt
@@ -1,0 +1,8 @@
+Total: 0
+
+Killed: 0
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Skipped: 0
+Not Covered: 0

--- a/tests/e2e/Exclude_Mutations_By_Regex/infection.json
+++ b/tests/e2e/Exclude_Mutations_By_Regex/infection.json
@@ -1,0 +1,31 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": ".",
+    "mutators": {
+        "global-ignoreSourceCodeByRegex": [
+            ".*hello.*"
+        ],
+        "PublicVisibility": {
+            "ignore": [
+                "App\\*"
+            ],
+            "ignoreSourceCodeByRegex": [
+                ".*getString.*"
+            ]
+        },
+        "MethodCallRemoval": {
+            "ignoreSourceCodeByRegex": [
+                "Assert::.*",
+                "\\$this->getString\\(\\);"
+            ]
+        }
+    }
+}

--- a/tests/e2e/Exclude_Mutations_By_Regex/phpunit.xml
+++ b/tests/e2e/Exclude_Mutations_By_Regex/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/e2e/Exclude_Mutations_By_Regex/src/SourceClass.php
+++ b/tests/e2e/Exclude_Mutations_By_Regex/src/SourceClass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Exclude_Mutations_By_Regex;
+
+use Webmozart\Assert\Assert;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        Assert::numeric('1');
+
+        $this->getString();
+
+        return 'hello';
+    }
+
+    public function getString()
+    {
+        return 'string';
+    }
+}

--- a/tests/e2e/Exclude_Mutations_By_Regex/tests/SourceClassTest.php
+++ b/tests/e2e/Exclude_Mutations_By_Regex/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Exclude_Mutations_By_Regex\Test;
+
+use Exclude_Mutations_By_Regex\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/phpunit/Configuration/ConfigurationAssertions.php
+++ b/tests/phpunit/Configuration/ConfigurationAssertions.php
@@ -52,6 +52,7 @@ trait ConfigurationAssertions
      * @param string[] $expectedSourceDirectories
      * @param string[] $expectedSourceFilesExcludes
      * @param SplFileInfo[] $expectedSourceFiles
+     * @param array<string, array<int, string>> $expectedIgnoreSourceCodeMutatorsMap
      */
     private function assertConfigurationStateIs(
         Configuration $configuration,
@@ -81,7 +82,8 @@ trait ConfigurationAssertions
         ?float $expectedMinCoveredMsi,
         int $expectedMsiPrecision,
         int $expectedThreadCount,
-        bool $expectedDryRyn
+        bool $expectedDryRyn,
+        array $expectedIgnoreSourceCodeMutatorsMap
     ): void {
         $this->assertSame($expectedTimeout, $configuration->getProcessTimeout());
         $this->assertSame($expectedSourceDirectories, $configuration->getSourceDirectories());
@@ -128,6 +130,7 @@ trait ConfigurationAssertions
         $this->assertSame($expectedMsiPrecision, $configuration->getMsiPrecision());
         $this->assertSame($expectedThreadCount, $configuration->getThreadCount());
         $this->assertSame($expectedDryRyn, $configuration->isDryRun());
+        $this->assertSame($expectedIgnoreSourceCodeMutatorsMap, $configuration->getIgnoreSourceCodeMutatorsMap());
     }
 
     /**

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -1701,10 +1701,7 @@ final class ConfigurationFactoryTest extends TestCase
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
             [
-                'MethodCallRemoval' => new IgnoreMutator(
-                    new IgnoreConfig([]),
-                    new MethodCallRemoval()
-                ),
+                'MethodCallRemoval' => new MethodCallRemoval(),
             ],
             'phpunit',
             null,

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -129,7 +129,8 @@ final class ConfigurationFactoryTest extends TestCase
         bool $expectedIgnoreMsiWithNoMutations,
         ?float $expectedMinMsi,
         bool $expectedShowMutations,
-        ?float $expectedMinCoveredMsi
+        ?float $expectedMinCoveredMsi,
+        array $expectedIgnoreSourceCodeMutatorsMap
     ): void {
         $config = $this
             ->createConfigurationFactory($ciDetected)
@@ -184,7 +185,8 @@ final class ConfigurationFactoryTest extends TestCase
             $expectedMinCoveredMsi,
             $inputMsiPrecision,
             $inputThreadsCount,
-            $inputDryRun
+            $inputDryRun,
+            $expectedIgnoreSourceCodeMutatorsMap
         );
     }
 
@@ -250,6 +252,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
 
         yield 'null timeout' => self::createValueForTimeout(
@@ -560,6 +563,16 @@ final class ConfigurationFactoryTest extends TestCase
             ]
         );
 
+        yield 'ignore source code by regex' => self::createValueForIgnoreSourceCodeByRegex(
+            [
+                '@default' => false,
+                'MethodCallRemoval' => (object) [
+                    'ignoreSourceCodeByRegex' => ['Assert::.*'],
+                ],
+            ],
+            ['MethodCallRemoval' => ['Assert::.*']]
+        );
+
         yield 'mutators from config & input' => self::createValueForMutators(
             [
                 '@default' => true,
@@ -641,6 +654,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
 
         yield 'complete' => [
@@ -730,6 +744,7 @@ final class ConfigurationFactoryTest extends TestCase
             72.3,
             true,
             81.5,
+            [],
         ];
     }
 
@@ -797,6 +812,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
     }
 
@@ -864,6 +880,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
     }
 
@@ -932,6 +949,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
     }
 
@@ -999,6 +1017,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
     }
 
@@ -1067,6 +1086,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
     }
 
@@ -1135,6 +1155,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
     }
 
@@ -1203,6 +1224,7 @@ final class ConfigurationFactoryTest extends TestCase
             $expectedMinMsi,
             false,
             null,
+            [],
         ];
     }
 
@@ -1271,6 +1293,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             $expectedMinCoveredMsi,
+            [],
         ];
     }
 
@@ -1340,6 +1363,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
     }
 
@@ -1408,6 +1432,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
     }
 
@@ -1477,6 +1502,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
     }
 
@@ -1545,6 +1571,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
         ];
     }
 
@@ -1616,6 +1643,84 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
+            [],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $configMutators
+     * @param array<string, array<int, string>> $expectedIgnoreSourceCodeMutatorsMap
+     */
+    private static function createValueForIgnoreSourceCodeByRegex(
+        array $configMutators,
+        array $expectedIgnoreSourceCodeMutatorsMap
+    ): array {
+        return [
+            false,
+            new SchemaConfiguration(
+                '/path/to/infection.json',
+                null,
+                new Source([], []),
+                Logs::createEmpty(),
+                null,
+                new PhpUnit(null, null),
+                null,
+                null,
+                null,
+                $configMutators,
+                null,
+                null,
+                null,
+                null
+            ),
+            null,
+            null,
+            false,
+            'none',
+            false,
+            false,
+            false,
+            false,
+            null,
+            false,
+            null,
+            '',
+            null,
+            null,
+            '',
+            0,
+            false,
+            2,
+            10,
+            [],
+            [],
+            '',
+            [],
+            Logs::createEmpty(),
+            'none',
+            sys_get_temp_dir() . '/infection',
+            new PhpUnit('/path/to', null),
+            [
+                'MethodCallRemoval' => new IgnoreMutator(
+                    new IgnoreConfig([]),
+                    new MethodCallRemoval()
+                ),
+            ],
+            'phpunit',
+            null,
+            null,
+            false,
+            '',
+            sys_get_temp_dir() . '/infection',
+            false,
+            false,
+            false,
+            false,
+            false,
+            null,
+            false,
+            null,
+            $expectedIgnoreSourceCodeMutatorsMap,
         ];
     }
 

--- a/tests/phpunit/Configuration/ConfigurationTest.php
+++ b/tests/phpunit/Configuration/ConfigurationTest.php
@@ -57,6 +57,7 @@ final class ConfigurationTest extends TestCase
      * @param string[] $sourceFilesExcludes
      * @param SplFileInfo[] $sourceFiles
      * @param Mutator[] $mutators
+     * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
      */
     public function test_it_can_be_instantiated(
         float $timeout,
@@ -85,7 +86,8 @@ final class ConfigurationTest extends TestCase
         ?float $minCoveredMsi,
         int $msiPrecision,
         int $threadsCount,
-        bool $dryRun
+        bool $dryRun,
+        array $ignoreSourceCodeMutatorsMap
     ): void {
         $config = new Configuration(
             $timeout,
@@ -114,7 +116,8 @@ final class ConfigurationTest extends TestCase
             $minCoveredMsi,
             $msiPrecision,
             $threadsCount,
-            $dryRun
+            $dryRun,
+            $ignoreSourceCodeMutatorsMap
         );
 
         $this->assertConfigurationStateIs(
@@ -145,7 +148,8 @@ final class ConfigurationTest extends TestCase
             $minCoveredMsi,
             $msiPrecision,
             $threadsCount,
-            $dryRun
+            $dryRun,
+            $ignoreSourceCodeMutatorsMap
         );
     }
 
@@ -179,6 +183,7 @@ final class ConfigurationTest extends TestCase
             2,
             0,
             false,
+            [],
         ];
 
         yield 'nominal' => [
@@ -221,6 +226,9 @@ final class ConfigurationTest extends TestCase
             2,
             4,
             true,
+            [
+                'For_' => ['.*someMethod.*'],
+            ],
         ];
     }
 }

--- a/tests/phpunit/Differ/DiffSourceCodeMatcherTest.php
+++ b/tests/phpunit/Differ/DiffSourceCodeMatcherTest.php
@@ -169,5 +169,18 @@ DIFF
             ,
             false,
         ];
+
+        yield 'Regex contains delimiters should not lead to syntax error' => [
+            '/getString/',
+            <<<'DIFF'
+--- Original
++++ New
+@@ @@
+
++ $a - 2 + $this->getString();
+DIFF
+            ,
+            false,
+        ];
     }
 }

--- a/tests/phpunit/Differ/DiffSourceCodeMatcherTest.php
+++ b/tests/phpunit/Differ/DiffSourceCodeMatcherTest.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Differ;
+
+use Generator;
+use Infection\Differ\DiffSourceCodeMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class DiffSourceCodeMatcherTest extends TestCase
+{
+    /** @var DiffSourceCodeMatcher */
+    private $diffSourceCodeMatcher;
+
+    protected function setUp(): void
+    {
+        $this->diffSourceCodeMatcher = new DiffSourceCodeMatcher();
+    }
+
+    /**
+     * @dataProvider diffRegexProvider
+     */
+    public function test_it_matches_diff_with_provided_regex(string $regex, string $diff, bool $expectedMatches): void
+    {
+        $matches = $this->diffSourceCodeMatcher->matches($diff, $regex);
+
+        $this->assertSame($expectedMatches, $matches, 'Provided regex does not match the Mutant\'s diff');
+    }
+
+    public function diffRegexProvider(): Generator
+    {
+        yield 'Method name with PublicVisibility mutator' => [
+            '.*getString.*',
+            <<<'DIFF'
+--- Original
++++ New
+@@ @@
+         $this->getString();
+         return 'hello';
+     }
+-    public function getString()
++    protected function getString()
+     {
+         return 'string';
+     }
+ }
+DIFF
+            ,
+            true,
+        ];
+
+        yield 'Method name with MethodCallRemoval mutator' => [
+            '.*getString.*',
+            <<<'DIFF'
+--- Original
++++ New
+@@ @@
+     public function hello() : string
+     {
+         Assert::numeric('1');
+-        $this->getString();
++
+         return 'hello';
+     }
+     public function getString()
+DIFF
+            ,
+            true,
+        ];
+
+        yield 'Method name with not related PublicVisibility mutator' => [
+            'getString',
+            <<<'DIFF'
+--- Original
++++ New
+@@ @@
+ use Webmozart\Assert\Assert;
+ class SourceClass
+ {
+-    public function hello() : string
++    protected function hello() : string
+     {
+         Assert::numeric('1');
+         $this->getString();
+DIFF
+            ,
+            false,
+        ];
+
+        yield 'Method call on object with MethodCallRemoval mutator' => [
+            '\$this->getString\(\);',
+            <<<'DIFF'
+--- Original
++++ New
+@@ @@
+     public function hello() : string
+     {
+         Assert::numeric('1');
+-        $this->getString();
++
+         return 'hello';
+     }
+     public function getString()
+DIFF
+            ,
+            true,
+        ];
+
+        yield 'All methods of static class calls with MethodCallRemoval mutator' => [
+            'Assert::.*',
+            <<<'DIFF'
+--- Original
++++ New
+@@ @@
+ {
+     public function hello() : string
+     {
+-        Assert::numeric('1');
++
+         $this->getString();
+         return 'hello';
+     }
+DIFF
+            ,
+            true,
+        ];
+
+        yield 'Method name with the minus operator' => [
+            '.*getString.*',
+            <<<'DIFF'
+--- Original
++++ New
+@@ @@
+
++ $a - 2 + $this->getString();
+DIFF
+            ,
+            false,
+        ];
+    }
+}

--- a/tests/phpunit/Mutator/MutatorResolverTest.php
+++ b/tests/phpunit/Mutator/MutatorResolverTest.php
@@ -265,6 +265,29 @@ final class MutatorResolverTest extends TestCase
         $this->assertSame(['ignore' => ['A::B', 'B::C']], $resolvedMutators[IdenticalEqual::class]);
     }
 
+    public function test_it_can_resolve_mutators_with_global_ignore_source_code_by_regex_setting(): void
+    {
+        $resolvedMutators = $this->mutatorResolver->resolve([
+            'global-ignoreSourceCodeByRegex' => ['A::B'],
+            MutatorName::getName(Plus::class) => true,
+            MutatorName::getName(For_::class) => false,
+            MutatorName::getName(IdenticalEqual::class) => [
+                'ignoreSourceCodeByRegex' => ['B::C'],
+            ],
+        ]);
+
+        $this->assertSameMutatorsByClass(
+            [
+                Plus::class,
+                IdenticalEqual::class,
+            ],
+            $resolvedMutators
+        );
+
+        $this->assertSame(['ignoreSourceCodeByRegex' => ['A::B']], $resolvedMutators[Plus::class]);
+        $this->assertSame(['ignoreSourceCodeByRegex' => ['A::B', 'B::C']], $resolvedMutators[IdenticalEqual::class]);
+    }
+
     public function test_it_always_enrich_global_settings_for_a_mutator_regardless_of_the_order(): void
     {
         $resolvedMutators = $this->mutatorResolver->resolve([


### PR DESCRIPTION
- [x] Fixes https://github.com/infection/infection/issues/697
- [x] Covered by tests 
- [x] Doc PR: https://github.com/infection/site/pull/177


Allows to avoid mutating such lines of code as:

```diff
- Assert::notNull($variable);
```

or

```diff
- $this->logger->error($message, ['user' => $user]);
+ $this->logger->error($message, []);
```

and similar if developers are not interested in them.

Example of new config setting usage:

```json
{
    "mutators": {
        "MethodCallRemoval": {
            "ignoreSourceCodeByRegex": [
                "Assert::.*",
                "\\$this->logger.*"
            ]
        }
    }
}
```

Also, there is a new setting for `mutators` - `global-ignoreSourceCodeByRegex` that will be added to *all* enabled mutators if present. Works similar to [`global-ignore`](https://infection.github.io/guide/profiles.html#main)

```json
{
    "mutators": {
        "global-ignoreSourceCodeByRegex": [
            "Assert::.*"
        ]
    }
}
```

From an implementation point of view, it's not possible to use `IgnoreConfig` and `IgnoreMutator` to ignore mutators for configured lines of code by regex, because, at the step of applying Mutator, we don't have any information about the source line of code. 

While we technically can get it (using PrettyPrinter's [`prettyPrintExpr($expression)`](https://github.com/nikic/PHP-Parser/blob/f66a32e2df7866d593fa7a1bb582348f772511b0/lib/PhpParser/PrettyPrinterAbstract.php#L211) function or by passing source code to each mutator and finding the needed line), for me it seems like not the right solution.

This PR tries to filter out mutants before creating Mutant processes, similar to what is being discussed in `pre-`/`post-` hooks here https://github.com/infection/infection/issues/1323

So, before deciding whether we need to ignore mutator or no, we are applying regular expression (if any) to the diff of Mutant. Easy, yet so powerful.

I will continue adding tests/docs after we agree with the implementation.

I see this feature is most requested during the last months, so I would like to release it asap.

Regarding the suggested plugin system - https://github.com/infection/infection/issues/1323. When we will do it, this implementation can be redeveloped using plugin system/hooks, while for users configuration will be the same, so no BC here.

PS I'm aware of the failed build, it's ok for now since no tests have been updated