### PR TITLE
ignore-msi-with-no-mutations option should work for skipped mutations

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -110,7 +110,7 @@ final class Engine
         $this->runMutationAnalysis();
 
         $this->minMsiChecker->checkMetrics(
-            $this->metricsCalculator->getTotalMutantsCount(),
+            $this->metricsCalculator->getTestedMutantsCount(),
             $this->metricsCalculator->getMutationScoreIndicator(),
             $this->metricsCalculator->getCoveredCodeMutationScoreIndicator(),
             $this->consoleOutput


### PR DESCRIPTION
This PR:

- [x] Fixes an issue where builds with `--filter` will fail even if no mutations were tested.

Example build: https://travis-ci.com/github/infection/infection/jobs/384367264#L796