### PR TITLE
Avoid decorating mutators with IgnoreMutator unless required

### DIFF
--- a/devTools/phpstan-tests.neon
+++ b/devTools/phpstan-tests.neon
@@ -10,6 +10,7 @@ parameters:
     ignoreErrors:
         - '#Return type \(void\) of method .*(Visitor|Traverser).* should be compatible with return type .* of method PhpParser\\Node.*#'
         - '#^Cannot call method (willReturn|shouldBeCalledTimes)\(\) on iterable<Infection\\Mutation\\Mutation>\.$#'
+        - '#Offset .*\\.* does not exist on array<class-string<.*>.*#'
         - '#^PHPDoc tag @var for variable \$sourceFilesCollectorProphecy contains unresolvable type#'
         -
             path: '../tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php'

--- a/src/Mutator/MutatorResolver.php
+++ b/src/Mutator/MutatorResolver.php
@@ -57,7 +57,7 @@ final class MutatorResolver
      *
      * @param array<string, bool|stdClass> $mutatorSettings
      *
-     * @return array<string, mixed[]>
+     * @return array<class-string<Mutator&ConfigurableMutator>, mixed[]>
      */
     public function resolve(array $mutatorSettings): array
     {

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -572,14 +572,8 @@ final class ConfigurationFactoryTest extends TestCase
             'AssignmentEqual,EqualIdentical',
             (static function (): array {
                 return [
-                    'AssignmentEqual' => new IgnoreMutator(
-                        new IgnoreConfig([]),
-                        new AssignmentEqual()
-                    ),
-                    'EqualIdentical' => new IgnoreMutator(
-                        new IgnoreConfig([]),
-                        new EqualIdentical()
-                    ),
+                    'AssignmentEqual' => new AssignmentEqual(),
+                    'EqualIdentical' => new EqualIdentical(),
                 ];
             })()
         );
@@ -719,10 +713,7 @@ final class ConfigurationFactoryTest extends TestCase
             ),
             (static function (): array {
                 return [
-                    'TrueValue' => new IgnoreMutator(
-                        new IgnoreConfig([]),
-                        new TrueValue(new TrueValueConfig([]))
-                    ),
+                    'TrueValue' => new TrueValue(new TrueValueConfig([])),
                 ];
             })(),
             'phpspec',

--- a/tests/phpunit/Mutator/MutatorFactoryTest.php
+++ b/tests/phpunit/Mutator/MutatorFactoryTest.php
@@ -96,6 +96,7 @@ final class MutatorFactoryTest extends TestCase
             ],
         ]);
 
+        $this->assertContainsOnlyInstancesOf(IgnoreMutator::class, $mutators);
         $this->assertSameMutatorsByClass([TrueValue::class], $mutators);
 
         /** @var MockObject|ClassReflection $reflectionMock */
@@ -155,12 +156,12 @@ final class MutatorFactoryTest extends TestCase
     public function test_it_cannot_create_an_unknown_mutator(): void
     {
         try {
-            $this->mutatorFactory->create(['Unknwon\Mutator' => []]);
+            $this->mutatorFactory->create(['Unknown\Mutator' => []]);
 
             $this->fail();
         } catch (InvalidArgumentException $exception) {
             $this->assertSame(
-                'Unknown mutator "Unknwon\Mutator"',
+                'Unknown mutator "Unknown\Mutator"',
                 $exception->getMessage()
             );
         }
@@ -191,10 +192,14 @@ final class MutatorFactoryTest extends TestCase
         $decoratedMutatorReflection->setAccessible(true);
 
         foreach (array_values($actualMutators) as $index => $mutator) {
-            $this->assertInstanceOf(IgnoreMutator::class, $mutator);
+            $this->assertInstanceOf(Mutator::class, $mutator);
 
             $expectedMutatorClass = $expectedMutatorClassNames[$index];
-            $actualMutatorClass = get_class($decoratedMutatorReflection->getValue($mutator));
+            $actualMutatorClass = get_class(
+                $mutator instanceof IgnoreMutator ?
+                    $decoratedMutatorReflection->getValue($mutator) :
+                    $mutator
+            );
 
             $this->assertSame(
                 $expectedMutatorClass,


### PR DESCRIPTION
This PR:

- [x] Makes `MutatorFactory` more clever about use of `IgnoreMutator`
- [x] Covered by tests
