### PR TITLE
Drop support for PHP 7.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,10 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.3', '7.4']
+        php-version: ['7.4']
         dependencies: ['']
         include:
-          - { php-version: '7.3', dependencies: '--prefer-lowest' }
+          - { php-version: '7.4', dependencies: '--prefer-lowest' }
           - { php-version: '8.0', dependencies: '--ignore-platform-req=php' }
 
     continue-on-error: ${{ matrix.php-version == '8.0' }}

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.3
+          php-version: 7.4
           tools: php-cs-fixer:${{ env.PHP_CS_FIXER_VERSION }}
 
       - name: Restore PHP-CS-Fixer cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 jobs:
   include:
     - stage: Static Code Analysis
-      php: 7.3
+      php: 7.4
       install:
         - composer install $COMPOSER_FLAGS
       script:
@@ -41,7 +41,7 @@ jobs:
 
     - &STANDARD_TEST_JOB
       stage: Test
-      php: 7.3
+      php: 7.4
       env: DRIVER="none"
       install:
         - |
@@ -86,25 +86,6 @@ jobs:
             phpdbg -qrr bin/infection $INFECTION_FLAGS;
           fi
 
-    - <<: *STANDARD_TEST_JOB
-      php: 7.3
-      env: DRIVER="pcov"
-      after_success:
-        - bash <(curl -s https://codecov.io/bash)
-
-    - <<: *STANDARD_TEST_JOB
-      php: 7.3
-      env: DRIVER="xdebug"
-
-    - <<: *STANDARD_TEST_JOB
-      php: 7.3
-      env: DRIVER="phpdbg"
-
-    -
-      <<: *STANDARD_TEST_JOB
-      php: 7.3
-      env: DEPS="LOW" DRIVER="xdebug"
-
     -
       <<: *STANDARD_TEST_JOB
       php: 7.4
@@ -134,7 +115,7 @@ jobs:
         - phpdbg -qrr bin/infection $INFECTION_FLAGS
 
     - stage: Deploy
-      php: 7.3
+      php: 7.4
       env:
         - secure: KPHUzOeWLeCWzcyPrnrDaR6grVUEXj48KlSQhJiubdkyKtGcvEs+TzZNYa2v+mSZsvrBHez9MRu4itcx05fNrb7/6M23uppv+fENH7tgZi8PXktlEXvD+Iqc9DIaDS1hQKpsnOhOZLlDNQ/kyE6TJAvoBMcbG6RfLqwLP1Abdz11t9Z65SIL7l2YpTjLjgmZUctpEVkivnQ3VQojd3soFTKZ8s9jNhdyUL2F+Rab4wu26Dy+q9xEd5y1tj2242nmVU7U/OD/spTkxRivuUPNM7jEnUvUcdEHd5DIBki702OrSkgsjrxlOlqOWcIRzVZA+A54GiE8qpnLSPN1qbc68ifXhd4lw4zKrE9KfvI8gnnFHtwQP0lhQuwG+j/VtbQRYrb0ufX1sAOUpOIDGMxYrh+Hn6j/nZnBiBh3NRF0u6PLfnAuph5TybylY0cuiGfGOWFf8UG7yz/EH+Br/D5M/IkObU8b9e3YJlUQPcjTi0BSa/+lkLpQMOOVOlQZk+LTVVRjXwSO10JcWhpqwWX74dsa5b2N/XbXOEQldVsYuQZz7re8e5Nwm5dx+B/KF/ohv2GDkQdqAA35ogOAABI3rvGlfOESDeZyGYOiJqBWX+KLKNRQ6l/KRkHNflX5J+0xeRlK4L84n0YwesyEAEFnYrYtQ+/VNd9ZP2+xXyTrePI=
         - secure: gto1Cg/FEurmKP+JNi7G7MBxJx9KX+WzM9VlLnu0x1Hq+2n8dEgNCBc9gvNrdpPPWHdke23uYXxM3XaKh6f/KXNRmYskJwAUP/jWTwkAc9dIz6qo3ObcS3M6WPnohkjhTJjJJH/dbUknR9gbstTvGsan7JysUnast6uyAhuP81ago0BoiCshTGPa7gZkD4dPPvDrUr70kRzgOd2ZJQZcuoCfL00q4Yu0OkjM9VMBxaBKkL8EE7594aYDjFtGbJuvWmZ36qqtUxzc3ly+G3IHfQVMQqN8+H0VB4ULwE1JOzWMsj5gpJtVeyPY5BTcAOE3je5/+1eq14VVnf3iSgMu3DbF1o/KuMxdes5vDadoZaVQmtLtNHvgu/UDCicBKk3BnLtlQe1bFfEsoSDRr+zCVkO5ypcbERxQzVCGdZdHsXLFZSxdLsEqSqD5ItZe1ZXv4K8bsDDY5rJgjyaiQs/FT/G4dlf61MHqzKtErgsNQ99ilV4iWqHGHnbMISyYdiLWTG8z/nhE34M+08J0gpSDfVrs1pvoUIzhD8KvjlU2QC2IXuE38aXTZm4IeTA7P6vZbUoCCcgOxIRqzS0UX9M1ddOUmy6prc3CGgiEgn6ey/eWmfyRQSbuL07aRH7MEzW4ESAJbdjHsuZoIUXGC9okLvk2pKfQxCjV86akPub7BZ8=

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ PHPUNIT=vendor/bin/phpunit
 INFECTION=./build/infection.phar
 
 DOCKER_RUN=docker run --tty --rm --volume "$$PWD":/opt/infection --workdir /opt/infection
-DOCKER_RUN_73=$(FLOCK) devTools/*php73*.json $(DOCKER_RUN) infection_php73
-DOCKER_RUN_73_IMAGE=devTools/Dockerfile-php73-xdebug.json
 DOCKER_RUN_74=$(FLOCK) devTools/*php74*.json $(DOCKER_RUN) infection_php74
 DOCKER_RUN_74_IMAGE=devTools/Dockerfile-php74-xdebug.json
 
@@ -108,11 +106,7 @@ test-unit: $(PHPUNIT)
 
 .PHONY: test-unit-docker
 test-unit-docker:	## Runs the unit tests on the different Docker platforms
-test-unit-docker: test-unit-73-docker test-unit-74-docker
-
-.PHONY: test-unit-73-docker
-test-unit-73-docker: $(DOCKER_RUN_73_IMAGE) $(PHPUNIT)
-	$(DOCKER_RUN_73) $(PHPUNIT) --group default
+test-unit-docker: test-unit-74-docker
 
 .PHONY: test-unit-74-docker
 test-unit-74-docker: $(DOCKER_RUN_74_IMAGE) $(PHPUNIT)
@@ -132,12 +126,7 @@ test-e2e-docker: 	## Runs the end-to-end tests on the different Docker platforms
 test-e2e-docker: test-e2e-phpdbg-docker test-e2e-xdebug-docker
 
 .PHONY: test-e2e-phpdbg-docker
-test-e2e-phpdbg-docker: test-e2e-phpdbg-73-docker test-e2e-phpdbg-74-docker
-
-.PHONY: test-e2e-phpdbg-73-docker
-test-e2e-phpdbg-73-docker: $(DOCKER_RUN_73_IMAGE) $(INFECTION)
-	$(DOCKER_RUN_73) $(PHPUNIT) --group integration,e2e
-	$(DOCKER_RUN_73) env PHPDBG=1 ./tests/e2e_tests $(INFECTION)
+test-e2e-phpdbg-docker: test-e2e-phpdbg-74-docker
 
 .PHONY: test-e2e-phpdbg-74-docker
 test-e2e-phpdbg-74-docker: $(DOCKER_RUN_74_IMAGE) $(INFECTION)
@@ -145,12 +134,7 @@ test-e2e-phpdbg-74-docker: $(DOCKER_RUN_74_IMAGE) $(INFECTION)
 	$(DOCKER_RUN_74) env PHPDBG=1 ./tests/e2e_tests $(INFECTION)
 
 .PHONY: test-e2e-xdebug-docker
-test-e2e-xdebug-docker: test-e2e-xdebug-73-docker test-e2e-xdebug-74-docker
-
-.PHONY: test-e2e-xdebug-73-docker
-test-e2e-xdebug-73-docker: $(DOCKER_RUN_73_IMAGE) $(INFECTION)
-	$(DOCKER_RUN_73) $(PHPUNIT) --group integration,e2e
-	$(DOCKER_RUN_73) ./tests/e2e_tests $(INFECTION)
+test-e2e-xdebug-docker: test-e2e-xdebug-74-docker
 
 .PHONY: test-e2e-xdebug-74-docker
 test-e2e-xdebug-74-docker: $(DOCKER_RUN_74_IMAGE) $(INFECTION)
@@ -167,22 +151,14 @@ test-infection-docker:	## Runs Infection against itself on the different Docker 
 test-infection-docker: test-infection-phpdbg-docker test-infection-xdebug-docker
 
 .PHONY: test-infection-phpdbg-docker
-test-infection-phpdbg-docker: test-infection-phpdbg-73-docker test-infection-phpdbg-74-docker
-
-.PHONY: test-infection-phpdbg-73-docker
-test-infection-phpdbg-73-docker: $(DOCKER_RUN_73_IMAGE)
-	$(DOCKER_RUN_73) phpdbg -qrr bin/infection --threads=4
+test-infection-phpdbg-docker: test-infection-phpdbg-74-docker
 
 .PHONY: test-infection-phpdbg-74-docker
 test-infection-phpdbg-74-docker: $(DOCKER_RUN_74_IMAGE)
 	$(DOCKER_RUN_74) phpdbg -qrr bin/infection --threads=4
 
 .PHONY: test-infection-xdebug-docker
-test-infection-xdebug-docker: test-infection-xdebug-73-docker test-infection-xdebug-74-docker
-
-.PHONY: test-infection-xdebug-73-docker
-test-infection-xdebug-73-docker: $(DOCKER_RUN_73_IMAGE)
-	$(DOCKER_RUN_73) ./bin/infection --threads=4
+test-infection-xdebug-docker: test-infection-xdebug-74-docker
 
 .PHONY: test-infection-xdebug-74-docker
 test-infection-xdebug-74-docker: $(DOCKER_RUN_74_IMAGE)
@@ -227,11 +203,6 @@ $(PHPUNIT): vendor phpunit.xml.dist
 phpunit.xml.dist:
 	# Not updating phpunit.xml with:
 	# phpunit --migrate-configuration || true
-
-$(DOCKER_RUN_73_IMAGE): devTools/Dockerfile-php73-xdebug
-	docker build --tag infection_php73 --file devTools/Dockerfile-php73-xdebug .
-	docker image inspect infection_php73 > $(DOCKER_RUN_73_IMAGE)
-	touch $@
 
 $(DOCKER_RUN_74_IMAGE): devTools/Dockerfile-php74-xdebug
 	docker build --tag infection_php74 --file devTools/Dockerfile-php74-xdebug .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,11 @@ clone_folder: c:\projects\workspace
 environment:
   matrix:
   - dependencies: highest
-    php_ver_target: 7.3.15
-    xdebug_ver: '2.9.2-7.3-vc15'
+    php_ver_target: 7.4.11
+    xdebug_ver: '2.9.2-7.4-vc15'
   - dependencies: current
-    php_ver_target: 7.3.15
-    xdebug_ver: '2.9.2-7.3-vc15'
+    php_ver_target: 7.4.11
+    xdebug_ver: '2.9.2-7.4-vc15'
 
 cache: # cache is cleared when linked file is modified
     - '%LOCALAPPDATA%\Composer\files -> composer.lock'

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.4",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",
@@ -84,7 +84,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.3.12"
+            "php": "7.4.0"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0737624599a9a46f462721e2837ad2b7",
+    "content-hash": "73c3213b7ebe77f6e5f55cb6b5e25771",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -4222,7 +4222,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3",
+        "php": "^7.4",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*"
@@ -4231,7 +4231,7 @@
         "ext-simplexml": "*"
     },
     "platform-overrides": {
-        "php": "7.3.12"
+        "php": "7.4.0"
     },
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
![php_roadmap](https://user-images.githubusercontent.com/3725595/96331652-a15f8600-1067-11eb-92dd-bba36c0c34bd.png)

Active support for PHP 7.3 is finished on 6 Dec 2020. Here is the first of several PRs to drop support for PHP 7.3 in Infection.

Infection 0.18, which I will release soon, will be the last Infection version with PHP 7.3 support.

Nexts PRs:

- Update the docs (https://github.com/infection/site/pull/178)
- Run Rector to upgrade to PHP 7.4 features (typed properties / short functions, etc.)