### PR TITLE
Don't mutate $limit argument from 0 to -1 and from -1 to 0 in `preg_split` function

### DIFF
--- a/src/Mutator/Number/AbstractNumberMutator.php
+++ b/src/Mutator/Number/AbstractNumberMutator.php
@@ -51,6 +51,13 @@ abstract class AbstractNumberMutator implements Mutator
         return $this->isSizeComparison($parent);
     }
 
+    protected function isPartOfComparison(Node $node): bool
+    {
+        $parent = ParentConnector::getParent($node);
+
+        return $this->isComparison($parent);
+    }
+
     private function isSizeComparison(?Node $node): bool
     {
         if ($node === null) {
@@ -61,10 +68,33 @@ abstract class AbstractNumberMutator implements Mutator
             return $this->isSizeComparison(ParentConnector::findParent($node));
         }
 
+        return $this->isSizeNode($node);
+    }
+
+    private function isSizeNode(Node $node): bool
+    {
         return $node instanceof Node\Expr\BinaryOp\Greater
             || $node instanceof Node\Expr\BinaryOp\GreaterOrEqual
             || $node instanceof Node\Expr\BinaryOp\Smaller
             || $node instanceof Node\Expr\BinaryOp\SmallerOrEqual
+        ;
+    }
+
+    private function isComparison(?Node $node): bool
+    {
+        if ($node === null) {
+            return false;
+        }
+
+        if ($node instanceof Node\Expr\UnaryMinus) {
+            return $this->isComparison(ParentConnector::findParent($node));
+        }
+
+        return $node instanceof Node\Expr\BinaryOp\Identical
+            || $node instanceof Node\Expr\BinaryOp\NotIdentical
+            || $node instanceof Node\Expr\BinaryOp\Equal
+            || $node instanceof Node\Expr\BinaryOp\NotEqual
+            || $this->isSizeNode($node)
         ;
     }
 }

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -87,7 +87,14 @@ final class DecrementInteger extends AbstractNumberMutator
 
     public function canMutate(Node $node): bool
     {
-        if (!$node instanceof Node\Scalar\LNumber || $node->value === 1) {
+        if (!$node instanceof Node\Scalar\LNumber) {
+            return false;
+        }
+
+        if (
+            $node->value === 1
+            && ($this->isPartOfComparison($node) || ParentConnector::getParent($node) instanceof Node\Expr\Assign)
+        ) {
             return false;
         }
 
@@ -96,6 +103,10 @@ final class DecrementInteger extends AbstractNumberMutator
         }
 
         if ($this->isPartOfSizeComparison($node)) {
+            return false;
+        }
+
+        if ($this->isPregSplitLimitZeroOrMinusOneArgument($node)) {
             return false;
         }
 
@@ -108,11 +119,12 @@ final class DecrementInteger extends AbstractNumberMutator
             return true;
         }
 
-        $parentNode = ParentConnector::getParent($node);
-
-        if (!$this->isComparison($parentNode)) {
+        if (!$this->isPartOfComparison($node)) {
             return true;
         }
+
+        $parentNode = ParentConnector::getParent($node);
+
         /** @var Node\Expr\BinaryOp $parentNode */
         if ($parentNode->left instanceof Node\Expr\FuncCall && $parentNode->left->name instanceof Node\Name
             && in_array(
@@ -137,26 +149,8 @@ final class DecrementInteger extends AbstractNumberMutator
         return true;
     }
 
-    private function isComparison(Node $parentNode): bool
+    private function isArrayZeroIndexAccess(Node\Scalar\LNumber $node): bool
     {
-        return $parentNode instanceof Node\Expr\BinaryOp\Identical
-            || $parentNode instanceof Node\Expr\BinaryOp\NotIdentical
-            || $parentNode instanceof Node\Expr\BinaryOp\Equal
-            || $parentNode instanceof Node\Expr\BinaryOp\NotEqual
-            || $parentNode instanceof Node\Expr\BinaryOp\Greater
-            || $parentNode instanceof Node\Expr\BinaryOp\GreaterOrEqual
-            || $parentNode instanceof Node\Expr\BinaryOp\Smaller
-            || $parentNode instanceof Node\Expr\BinaryOp\SmallerOrEqual
-        ;
-    }
-
-    private function isArrayZeroIndexAccess(Node $node): bool
-    {
-        if (!$node instanceof Node\Scalar\LNumber) {
-            return false;
-        }
-
-        /** @var Node\Scalar\LNumber $node */
         if ($node->value !== 0) {
             return false;
         }
@@ -166,5 +160,33 @@ final class DecrementInteger extends AbstractNumberMutator
         }
 
         return false;
+    }
+
+    private function isPregSplitLimitZeroOrMinusOneArgument(Node\Scalar\LNumber $node): bool
+    {
+        if ($node->value !== 0) {
+            return false;
+        }
+
+        $parentNode = ParentConnector::getParent($node);
+
+        if (!$parentNode instanceof Node\Arg) {
+            if (!$parentNode instanceof Node\Expr\UnaryMinus) {
+                return false;
+            }
+
+            $parentNode = ParentConnector::getParent($node);
+
+            if (!$parentNode instanceof Node\Arg) {
+                return false;
+            }
+        }
+
+        $parentNode = ParentConnector::getParent($parentNode);
+
+        return $parentNode instanceof Node\Expr\FuncCall
+            && $parentNode->name instanceof Node\Name
+            && $parentNode->name->toLowerString() === 'preg_split'
+        ;
     }
 }

--- a/tests/e2e/Exec_Path/expected-output.txt
+++ b/tests/e2e/Exec_Path/expected-output.txt
@@ -1,6 +1,6 @@
-Total: 6
+Total: 7
 
-Killed: 5
+Killed: 6
 Errored: 0
 Escaped: 0
 Timed Out: 0

--- a/tests/e2e/TimeoutSkipped/expected-output.txt
+++ b/tests/e2e/TimeoutSkipped/expected-output.txt
@@ -1,8 +1,8 @@
-Total: 5
+Total: 6
 
 Killed: 2
 Errored: 0
-Escaped: 2
+Escaped: 3
 Timed Out: 1
 Skipped: 0
 Not Covered: 0

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -470,5 +470,41 @@ PHP
 $b = $a[0];
 PHP
         ];
+
+        yield 'It does not decrement limit argument of preg_split function when it equals to 0' => [
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', 0);
+PHP
+        ];
+
+        yield 'It does decrement limit argument of preg_split function when it greater than 0' => [
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', 1);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', 0);
+PHP
+        ];
+
+        yield 'It does decrement limit argument of preg_split function when it equal to -1' => [
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', -1);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', -2);
+PHP
+        ];
     }
 }

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -206,5 +206,40 @@ if ($foo === -9) {
 PHP
             ,
         ];
+
+        yield 'It does not increment limit argument of preg_split function when it equals to -1' => [
+            <<<'PHP'
+<?php
+preg_split('//', 'string', -1);
+PHP
+        ];
+
+        yield 'It does increment limit argument of preg_split function when it equals to 0' => [
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', 0);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', 1);
+PHP
+        ];
+
+        yield 'It does increment limit argument of preg_split function when it equals to -2' => [
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', -2);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', -1);
+PHP
+        ];
     }
 }

--- a/tests/phpunit/Mutator/Number/OneZeroIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/OneZeroIntegerTest.php
@@ -442,5 +442,27 @@ if ($foo !== -0) {
 }
 PHP
         ];
+
+        yield 'It does not mutates limit argument of preg_split function when it equal to -1' => [
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', -1);
+PHP
+        ];
+
+        yield 'It mutates limit argument of preg_split function when it equal to 1' => [
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', 1);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+preg_split('//', 'string', 0);
+PHP
+        ];
     }
 }


### PR DESCRIPTION
This PR stops mutate $limit argument from 0 to -1 and from -1 to 0 in `preg_split` function.

Requested in https://github.com/infection/infection/issues/1345
