### PR TITLE
Use alpine CLI instead of ubuntu. Significantly decreases image size.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test-unit: $(PHPUNIT)
 
 .PHONY: test-unit-docker
 test-unit-docker:	## Runs the unit tests on the different Docker platforms
-test-unit-docker: test-unit-80-docker
+test-unit-docker: test-unit-74-docker test-unit-80-docker
 
 .PHONY: test-unit-74-docker
 test-unit-74-docker: $(DOCKER_RUN_74_IMAGE) $(PHPUNIT)

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ test-e2e-xdebug-80-docker: $(DOCKER_RUN_80_IMAGE) $(INFECTION)
 
 .PHONY: test-infection
 test-infection:		## Runs Infection against itself
-test-infection:MakefileTes
+test-infection:
 	$(INFECTION) --threads=4
 
 .PHONY: test-infection-docker

--- a/devTools/Dockerfile-php74-xdebug
+++ b/devTools/Dockerfile-php74-xdebug
@@ -1,13 +1,31 @@
-FROM php:7.4-cli
+FROM php:7.4-cli-alpine
 
-RUN pecl install xdebug-beta && docker-php-ext-enable xdebug
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    expect git zip \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+        bash \
+        expect \
+        git \
+        zip
+
+RUN set -eux; \
+    apk add --no-cache --virtual .build-deps \
+        ${PHPIZE_DEPS} \
+        build-base \
+    ; \
+    pecl install xdebug; \
+    pecl clear-cache; \
+    docker-php-ext-enable xdebug ;\
+    runDeps="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )"; \
+    apk add --no-cache --virtual .phpexts-rundeps ${runDeps}; \
+    apk del .build-deps
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
-RUN useradd --home-dir /opt/infection --shell /bin/bash infection
+RUN adduser -h /opt/infection -s /bin/bash -D infection
 
 COPY devTools/memory-limit.ini /usr/local/etc/php/conf.d/memory-limit.ini
 

--- a/devTools/Dockerfile-php80-xdebug
+++ b/devTools/Dockerfile-php80-xdebug
@@ -1,4 +1,4 @@
-reFROM php:8.0-rc-cli-alpine
+FROM php:8.0-rc-cli-alpine
 
 RUN apk add --no-cache \
         bash \

--- a/devTools/Dockerfile-php80-xdebug
+++ b/devTools/Dockerfile-php80-xdebug
@@ -1,17 +1,19 @@
-FROM php:7.4-cli-alpine
+reFROM php:8.0-rc-cli-alpine
 
 RUN apk add --no-cache \
         bash \
         expect \
         zip
 
+ARG XDEBUG_VERSION=3.0.0beta1
+
 RUN set -eux; \
     apk add --no-cache --virtual .build-deps \
         ${PHPIZE_DEPS} \
         build-base \
     ; \
-    pecl install xdebug; \
-    pecl clear-cache; \
+    mkdir -p /usr/src/php/ext/xdebug && curl -fsSL https://pecl.php.net/get/xdebug-${XDEBUG_VERSION} | tar -xvz -C "/usr/src/php/ext/xdebug" --strip 1; \
+    docker-php-ext-install -j$(nproc) xdebug; \
     docker-php-ext-enable xdebug ;\
     runDeps="$( \
         scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
@@ -19,6 +21,7 @@ RUN set -eux; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
+    rm -rf /usr/src/php; \
     apk add --no-cache --virtual .phpexts-rundeps ${runDeps}; \
     apk del .build-deps
 

--- a/devTools/memory-limit.ini
+++ b/devTools/memory-limit.ini
@@ -1,2 +1,1 @@
 memory_limit = 512M
-


### PR DESCRIPTION
Use alpine CLI instead of ubuntu in the devTools. Significantly decreases image size.

Additional improvements:
- Add PHP 8 container.
- Switch from Ubuntu to Alpine
- Drop `git` as dependency
- switch to `--prefer-dist` instead of `--prefer-source`

p.s. Does anybody use these containers?