### PR TITLE
Change DecrementInteger and IncrementInteger mutators behaviour

### DIFF
--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -74,7 +74,15 @@ final class DecrementInteger extends AbstractNumberMutator
      */
     public function mutate(Node $node): iterable
     {
-        yield new Node\Scalar\LNumber($node->value - 1);
+        $parentNode = ParentConnector::getParent($node);
+
+        $value = $node->value - 1;
+
+        if ($parentNode instanceof Node\Expr\UnaryMinus) {
+            $value = $node->value + 1;
+        }
+
+        yield new Node\Scalar\LNumber($value);
     }
 
     public function canMutate(Node $node): bool

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -38,6 +38,7 @@ namespace Infection\Mutator\Number;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\MutatorCategory;
+use Infection\PhpParser\Visitor\ParentConnector;
 use PhpParser\Node;
 
 /**
@@ -63,7 +64,15 @@ final class IncrementInteger extends AbstractNumberMutator
      */
     public function mutate(Node $node): iterable
     {
-        yield new Node\Scalar\LNumber($node->value + 1);
+        $parentNode = ParentConnector::getParent($node);
+
+        $value = $node->value + 1;
+
+        if ($parentNode instanceof Node\Expr\UnaryMinus) {
+            $value = $node->value - 1;
+        }
+
+        yield new Node\Scalar\LNumber($value);
     }
 
     public function canMutate(Node $node): bool

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -300,7 +300,7 @@ PHP
             <<<'PHP'
 <?php
 
-if ($foo === -9) {
+if ($foo === -11) {
     echo 'bar';
 }
 PHP

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -110,7 +110,7 @@ if ($foo === 1.0) {
 PHP
         ];
 
-        yield 'It decrements a negative integer' => [
+        yield 'It increments a negative integer' => [
             <<<'PHP'
 <?php
 
@@ -122,7 +122,7 @@ PHP
             <<<'PHP'
 <?php
 
-if ($foo === -11) {
+if ($foo === -9) {
     echo 'bar';
 }
 PHP


### PR DESCRIPTION
Found an interesting issues while worked with https://github.com/infection/infection/pull/1347 that:

- DecrementInteger mutator generates wrong mutation with negative values: -1 was mutated to -0 instead of -2
- IncrementIngeger mutator generates wrong mutation with negative values: -1 was mutated to -2 instead of 0

This PR fixes behavior for both mutators and now DecrementInteger will return -2 for case when original value is -1 and IncrementIngeger returns 0 for case when original value is -1