### PR TITLE
Slim down Docker image by using shared Composer executable

### DIFF
--- a/devTools/Dockerfile-php74-xdebug
+++ b/devTools/Dockerfile-php74-xdebug
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     expect git zip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl --silent --show-error https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 RUN useradd --home-dir /opt/infection --shell /bin/bash infection
 


### PR DESCRIPTION
Check the current size:

```
docker system df -v | grep -E 'infection_php74|REPOSITORY'
```
Note size displayed in UNIQUE SIZE column. That's what the image itself takes.

Recompile and compare again:

```
make devTools/Dockerfile-php74-xdebug.json
docker system df -v | grep -E 'infection_php74|REPOSITORY'
```

Reports:
```
UNIQUE SIZE
2.323MB    
```

For #1349 it reports 28.27MB.