### PR TITLE
Add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,8 @@
+# Core team members as per https://github.com/orgs/infection/teams/core/members
+github:
+  - sanmai
+  - localheinz
+  - sidz
+  - maks-rafalko
+  - theofidry
+  - BackEndTea


### PR DESCRIPTION
Poor man's way to fix #1346

This PR:

- [x] Adds FUNDING.yml with core team members in the same order [as in the list](https://github.com/orgs/infection/teams/core/members).

If you don't want to see yourself in the list, or if there are other concerns, please leave a review.