### PR TITLE
ArrayItemRemoval should not mutate lists

### DIFF
--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -41,6 +41,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetConfigClassName;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\MutatorCategory;
+use Infection\PhpParser\Visitor\ParentConnector;
 use function min;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayItem;
@@ -119,7 +120,22 @@ TXT
 
     public function canMutate(Node $node): bool
     {
-        return $node instanceof Node\Expr\Array_ && count($node->items);
+        if (!$node instanceof Node\Expr\Array_) {
+            return false;
+        }
+
+        if (!count($node->items)) {
+            return false;
+        }
+
+        $parent = ParentConnector::findParent($node);
+
+        // Arrays to the left of an assignments are not arrays but lists.
+        if ($parent instanceof Node\Expr\Assign && $parent->var === $node) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -124,7 +124,7 @@ TXT
             return false;
         }
 
-        if (!count($node->items)) {
+        if (count($node->items) === 0) {
             return false;
         }
 

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -124,7 +124,7 @@ TXT
             return false;
         }
 
-        if (count($node->items) === 0) {
+        if ($node->items === []) {
             return false;
         }
 

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
@@ -102,5 +102,17 @@ final class ArrayItemRemovalTest extends BaseMutatorTestCase
             ],
             ['remove' => 'all', 'limit' => 1],
         ];
+
+        yield 'It does not mutate lists with missing elements' => [
+            '<?php [, $a] = [];',
+        ];
+
+        yield 'It does not mutate lists with one element' => [
+            '<?php [$a] = [];',
+        ];
+
+        yield 'It does not mutate lists with any number of elements' => [
+            '<?php [$a, $b] = [];',
+        ];
     }
 }


### PR DESCRIPTION
This PR:

- [x] Ensures ArrayItemRemoval does not mutate lists (arrays to the left of an assignment)
- [x] Covered by tests
- [x] Fixes #1357
