### PR TITLE
Use GitHub Actions to test on Windows

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -30,14 +30,19 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2
 
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.cache/composer
-          key: composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}-${{ matrix.dependencies }}
           restore-keys: |
-            composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}-
-            composer-${{ matrix.php-version }}-
+            composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}-
+            composer-${{ runner.os }}-${{ matrix.php-version }}-
+            composer-${{ runner.os }}-
             composer-
 
       - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         run: |
           composer update --no-interaction --prefer-dist --no-progress ${{ matrix.dependencies }}
 
-      - name: Run tests
+      - name: Run tests using Makefile
         if: runner.os != 'Windows'
         run: |
           make test-unit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,11 @@ jobs:
         run: |
           make test-unit
 
+      - name: Run tests without Makefile
+        if: runner.os == 'Windows'
+        run: |
+          vendor/bin/phpunit --group default
+
       - name: Run Infection
         run: |
           php bin/infection -j2 --test-framework-options="--group=default" --ignore-msi-with-no-mutations

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Run Infection
         run: |
-          ./bin/infection -j$(nproc) --test-framework-options="--group=default" --only-covered --ignore-msi-with-no-mutations
+          ./bin/infection -j2 --test-framework-options="--group=default" --only-covered --ignore-msi-with-no-mutations

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,13 +57,10 @@ jobs:
         run: |
           composer update --no-interaction --prefer-dist --no-progress ${{ matrix.dependencies }}
 
-      - name: Setup WSL on Windows
-        uses: Vampire/setup-wsl@v1
-        if: runner.os == 'Windows'
-
       - name: Run tests
+        if: runner.os != 'Windows'
         run: |
-          php vendor/bin/phpunit --group default
+          make test-unit
 
       - name: Run Infection
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        operating-system: [ubuntu-latest, windows-latest]
         php-version: ['7.4']
         dependencies: ['']
         coverage-driver: [pcov, xdebug]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,18 +12,20 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating-system }}
 
     strategy:
       matrix:
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
         php-version: ['7.4']
         dependencies: ['']
+        coverage-driver: [pcov, xdebug]
         include:
-          - { php-version: '7.4', dependencies: '--prefer-lowest' }
-          - { php-version: '8.0', dependencies: '--ignore-platform-req=php' }
+          - { operating-system: 'ubuntu-latest', php-version: '7.4', dependencies: '--prefer-lowest', coverage-driver: 'pcov' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.0', dependencies: '--ignore-platform-req=php', coverage-driver: 'pcov' }
 
     continue-on-error: ${{ matrix.php-version == '8.0' }}
-    name: CI with PHP ${{ matrix.php-version }} ${{ matrix.dependencies }}
+    name: ${{ matrix.operating-system }} CI with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }} ${{ matrix.dependencies }}
 
     steps:
       - name: Checkout code
@@ -33,27 +35,36 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: pcov
+          coverage: ${{ matrix.coverage-driver }}
           tools: composer:v2
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.cache/composer
-          key: composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}-${{ matrix.dependencies }}
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}-${{ matrix.dependencies }}
           restore-keys: |
-            composer-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}-
-            composer-${{ matrix.php-version }}-
+            composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}-
+            composer-${{ runner.os }}-${{ matrix.php-version }}-
+            composer-${{ runner.os }}-
             composer-
 
       - name: Install dependencies
         run: |
           composer update --no-interaction --prefer-dist --no-progress ${{ matrix.dependencies }}
 
+      - name: Setup WSL on Windows
+        uses: Vampire/setup-wsl@v1
+        if: runner.os == 'Windows'
+
       - name: Run tests
         run: |
-          make test-unit
+          ./vendor/bin/phpunit --group default
 
       - name: Run Infection
         run: |
-          ./bin/infection -j$(nproc) --test-framework-options="--group=default"
+          ./bin/infection -j$(nproc) --test-framework-options="--group=default" --only-covered --ignore-msi-with-no-mutations

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           - { operating-system: 'ubuntu-latest', php-version: '8.0', dependencies: '--ignore-platform-req=php', coverage-driver: 'pcov' }
 
     continue-on-error: ${{ matrix.php-version == '8.0' }}
-    name: ${{ matrix.operating-system }} CI with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }} ${{ matrix.dependencies }}
+    name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }} ${{ matrix.dependencies }}
 
     steps:
       - name: Checkout code
@@ -63,8 +63,8 @@ jobs:
 
       - name: Run tests
         run: |
-          ./vendor/bin/phpunit --group default
+          php vendor/bin/phpunit --group default
 
       - name: Run Infection
         run: |
-          ./bin/infection -j2 --test-framework-options="--group=default" --only-covered --ignore-msi-with-no-mutations
+          php bin/infection -j2 --test-framework-options="--group=default" --only-covered --ignore-msi-with-no-mutations

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,4 +64,4 @@ jobs:
 
       - name: Run Infection
         run: |
-          php bin/infection -j2 --test-framework-options="--group=default" --only-covered --ignore-msi-with-no-mutations
+          php bin/infection -j2 --test-framework-options="--group=default" --ignore-msi-with-no-mutations


### PR DESCRIPTION
The number one reason to do this is the extreme slowness of AppVeyor builds. They take almost forever to queue, and as long to execute one after another. That's a free service so one can't really complain, but for GH workflows there's no such issue. And it's a free service too.

This PR:

- [x] Uses GitHub Actions to test on Windows
- [x] ~~And on macOS, for good measure~~
- [x] And with both Xdebug and PCOV

FWIW PHPUnit takes the same approach, [though in a much more elaborate way](https://github.com/sebastianbergmann/phpunit/blob/b2a9914fd2057a72ec65bc9b3cd963c831a1b14b/.github/workflows/ci.yml#L88-L118).
