### PR TITLE
Remove PHPDBG from the build matrix on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,22 +88,6 @@ jobs:
         - DRIVER="pcov"
         - MIN_MSI_CHECK="true"
 
-    -
-      <<: *STANDARD_TEST_JOB
-      php: 7.4
-      env: DRIVER="phpdbg"
-
-    -
-      <<: *STANDARD_TEST_JOB
-      php: nightly
-      env: DRIVER="phpdbg"
-      script:
-        # We don't have Xdebug on the nightly build, so we always run with phpdbg
-        - make compile
-        - ./tests/e2e_tests build/infection.phar
-        - phpdbg -qrr $PHPUNIT_BIN
-        - phpdbg -qrr bin/infection $INFECTION_FLAGS
-
     - stage: Deploy
       php: 7.4
       env:
@@ -128,9 +112,3 @@ jobs:
         on:
           tags: true
           repo: infection/infection
-
-  allow_failures:
-    - php: nightly
-      env: DRIVER="phpdbg"
-    - php: 7.4
-      env: DRIVER="phpdbg"


### PR DESCRIPTION
This PR:

- [ ] Removes PHPDBG from the build matrix on Travis CI
