### PR TITLE
Improve Makefile, E2E tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,3 +256,4 @@ clean:
 	rm -fr tests/benchmark/MutationGenerator/sources
 	rm -fr tests/benchmark/Tracing/coverage
 	rm -fr tests/benchmark/Tracing/sources
+	git clean -f -X tests/e2e/

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -75,7 +75,7 @@ final class Application extends BaseApplication
             $version = Versions::getVersion(self::PACKAGE_NAME);
             // @codeCoverageIgnoreStart
         } catch (OutOfBoundsException $e) {
-            if (preg_match('#package .*' . preg_quote(self::PACKAGE_NAME, '#') . '.* not installed#', $e->getMessage()) === 0) {
+            if (preg_match('#package .*' . preg_quote(self::PACKAGE_NAME, '#') . '.* not installed#i', $e->getMessage()) === 0) {
                 throw $e;
             }
 

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -84,9 +84,10 @@ final class MakefileTest extends TestCase
 [33mtest-docker:[0m		 Runs all the tests on the different Docker platforms
 [33mtest-unit:[0m	 	 Runs the unit tests
 [33mtest-unit-docker:[0m	 Runs the unit tests on the different Docker platforms
-[33mtest-e2e:[0m 	 	 Runs the end-to-end tests on the different Docker platforms
+[33mtest-e2e:[0m 	 	 Runs the end-to-end tests
+[33mtest-e2e-phpunit:[0m	 Runs PHPUnit-enabled subset of end-to-end tests
 [33mtest-e2e-docker:[0m 	 Runs the end-to-end tests on the different Docker platforms
-[33mtest-infection:[0m		 Runs Infection against itself
+[33mtest-infection:[0m	 Runs Infection against itself
 [33mtest-infection-docker:[0m	 Runs Infection against itself on the different Docker platforms
 
 EOF;

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -326,8 +326,8 @@ final class E2ETest extends TestCase
 
     private function runInfection(int $expectedExitCode, array $argvExtra = []): string
     {
-        if (!extension_loaded('xdebug') && PHP_SAPI !== 'phpdbg') {
-            $this->markTestSkipped("Infection from within PHPUnit won't run without xdebug or phpdbg");
+        if (!extension_loaded('xdebug') && !extension_loaded('pcov') && PHP_SAPI !== 'phpdbg') {
+            $this->markTestSkipped("Infection from within PHPUnit won't run without Xdebug or PCOV or PHPDBG");
         }
 
         /*

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -326,8 +326,8 @@ final class E2ETest extends TestCase
 
     private function runInfection(int $expectedExitCode, array $argvExtra = []): string
     {
-        if (!extension_loaded('xdebug') && !extension_loaded('pcov') && PHP_SAPI !== 'phpdbg') {
-            $this->markTestSkipped("Infection from within PHPUnit won't run without Xdebug or PCOV or PHPDBG");
+        if (!extension_loaded('xdebug') && PHP_SAPI !== 'phpdbg') {
+            $this->markTestSkipped("Infection from within PHPUnit won't run without Xdebug or PHPDBG");
         }
 
         /*


### PR DESCRIPTION
This PR:

- [x] Extracts PHPUnit-compatible rule from `test-e2e` into `test-e2e-phpunit` (needed for #1365)
- [x] Help message alignment (it was skewed)
- [x] ~~Allows E2E tests with PCOV~~ Causes build failures: not in this PR.
- [x] Adds a rule to clean benchmark fixtures
- [x] Add an option to clean all ignored files from e2e tests (like vendor or composer.lock)
- [x] Extends bogus exception check to check without case (the message may start with a capital P)
