### PR TITLE
Request coverage reports with command line args

### DIFF
--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -53,10 +53,6 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
     private $mutationConfigBuilder;
     private $versionParser;
     private $commandLineBuilder;
-
-    /**
-     * @var string|null
-     */
     private $version;
 
     public function __construct(
@@ -65,7 +61,8 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         MutationConfigBuilder $mutationConfigBuilder,
         CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder,
         VersionParser $versionParser,
-        CommandLineBuilder $commandLineBuilder
+        CommandLineBuilder $commandLineBuilder,
+        ?string $version = null
     ) {
         $this->testFrameworkExecutable = $testFrameworkExecutable;
         $this->initialConfigBuilder = $initialConfigBuilder;
@@ -73,6 +70,7 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         $this->argumentsAndOptionsBuilder = $argumentsAndOptionsBuilder;
         $this->versionParser = $versionParser;
         $this->commandLineBuilder = $commandLineBuilder;
+        $this->version = $version;
     }
 
     abstract public function testsPass(string $output): bool;
@@ -82,7 +80,7 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
     abstract public function hasJUnitReport(): bool;
 
     /**
-     * Returns array of arguments to pass them into the Initial Run Symfony Process
+     * Returns array of arguments to pass them into the Initial Run Process
      *
      * @param string[] $phpExtraArgs
      *
@@ -97,7 +95,7 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
     }
 
     /**
-     * Returns array of arguments to pass them into the Mutant Symfony Process
+     * Returns array of arguments to pass them into the Mutant Process
      *
      * @param TestLocation[] $tests
      *

--- a/src/TestFramework/CommandLineBuilder.php
+++ b/src/TestFramework/CommandLineBuilder.php
@@ -45,8 +45,9 @@ use Symfony\Component\Process\PhpExecutableFinder;
 
 /**
  * @internal
+ * @final
  */
-final class CommandLineBuilder
+class CommandLineBuilder
 {
     /**
      * @var string[]|null

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -99,7 +99,7 @@ class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements IgnoresAddi
             $extraOptions = trim(sprintf(
                 '%s --coverage-xml=%s --log-junit=%s',
                 $extraOptions,
-                $this->tmpDir . DIRECTORY_SEPARATOR . self::COVERAGE_DIR,
+                $this->tmpDir . '/' . self::COVERAGE_DIR,
                 $this->jUnitFilePath // escapeshellarg() is done up the stack in ArgumentsAndOptionsBuilder
             ));
         }

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -81,13 +81,13 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
 
         return new PhpUnitAdapter(
             $testFrameworkExecutable,
+            $tmpDir,
+            $jUnitFilePath,
             new InitialConfigBuilder(
                 $tmpDir,
                 $testFrameworkConfigContent,
                 $configManipulator,
-                $jUnitFilePath,
-                $sourceDirectories,
-                $skipCoverage
+                $sourceDirectories
             ),
             new MutationConfigBuilder(
                 $tmpDir,

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -52,7 +52,7 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
                 '--configuration',
                 $configPath,
             ],
-            explode(' ', $extraOptions)
+            explode(' ', $extraOptions) // FIXME might break space-containing paths
         );
 
         return array_filter($options);

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -82,9 +82,11 @@ final class XmlConfigurationManipulator
     public function removeExistingLoggers(SafeDOMXPath $xPath): void
     {
         foreach ($xPath->query('/phpunit/logging') as $node) {
-            $document = $xPath->document->documentElement;
-            Assert::isInstanceOf($document, DOMElement::class);
-            $document->removeChild($node);
+            $node->parentNode->removeChild($node);
+        }
+
+        foreach ($xPath->query('/phpunit/coverage/report') as $node) {
+            $node->parentNode->removeChild($node);
         }
     }
 

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -79,6 +79,9 @@ final class XmlConfigurationManipulator
         }
     }
 
+    /**
+     * Removes existing loggers to improve throughput during MT. Initial test loggers are added through CLI arguments.
+     */
     public function removeExistingLoggers(SafeDOMXPath $xPath): void
     {
         foreach ($xPath->query('/phpunit/logging') as $node) {

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -103,8 +103,7 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
         }
 
         $builder = $this->createConfigBuilder(
-            self::FIXTURES . '/format-whitespace/original-phpunit.xml',
-            true
+            self::FIXTURES . '/format-whitespace/original-phpunit.xml'
         );
 
         $configurationPath = $builder->build('6.5');
@@ -119,8 +118,7 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
     {
         try {
             $this->createConfigBuilder(
-                self::FIXTURES . '/invalid/empty-phpunit.xml',
-                true
+                self::FIXTURES . '/invalid/empty-phpunit.xml'
             );
 
             $this->fail('Expected an exception to be thrown.');
@@ -135,8 +133,7 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
     public function test_the_original_xml_config_must_be_a_valid_phpunit_config_file(): void
     {
         $builder = $this->createConfigBuilder(
-            self::FIXTURES . '/invalid/invalid-phpunit.xml',
-            true
+            self::FIXTURES . '/invalid/invalid-phpunit.xml'
         );
 
         try {
@@ -220,30 +217,9 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
         $this->assertSame(0, $logEntries->length);
     }
 
-    public function test_it_adds_needed_loggers(): void
+    public function test_it_does_not_add_loggers_ever(): void
     {
         $xml = file_get_contents($this->builder->build('6.5'));
-
-        $logEntries = $this->queryXpath($xml, '/phpunit/logging/log');
-
-        $this->assertInstanceOf(DOMNodeList::class, $logEntries);
-
-        $this->assertSame(2, $logEntries->length);
-
-        // XML coverage logger
-        $this->assertSame($this->tmp . '/coverage-xml', $logEntries[0]->getAttribute('target'));
-        $this->assertSame('coverage-xml', $logEntries[0]->getAttribute('type'));
-
-        // JUnit coverage logger
-        $this->assertSame('junit', $logEntries[1]->getAttribute('type'));
-        $this->assertSame('/path/to/junit.xml', $logEntries[1]->getAttribute('target'));
-    }
-
-    public function test_it_does_not_add_coverage_loggers_if_should_be_skipped(): void
-    {
-        $builder = $this->createConfigBuilder(null, true);
-
-        $xml = file_get_contents($builder->build('6.5'));
 
         $logEntries = $this->queryXpath($xml, '/phpunit/logging/log');
 
@@ -371,8 +347,7 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
     public function test_it_creates_a_configuration(): void
     {
         $builder = $this->createConfigBuilder(
-            self::FIXTURES . '/phpunit.xml',
-            true
+            self::FIXTURES . '/phpunit.xml'
         );
 
         $configurationPath = $builder->build('6.5');
@@ -498,12 +473,10 @@ XML
     }
 
     private function createConfigBuilder(
-        ?string $originalPhpUnitXmlConfigPath = null,
-        bool $skipCoverage = false
+        ?string $originalPhpUnitXmlConfigPath = null
     ): InitialConfigBuilder {
         $phpunitXmlPath = $originalPhpUnitXmlConfigPath ?: self::FIXTURES . '/phpunit.xml';
 
-        $jUnitFilePath = '/path/to/junit.xml';
         $srcDirs = ['src', 'app'];
 
         $replacer = new PathReplacer(new Filesystem(), $this->projectPath);
@@ -512,9 +485,7 @@ XML
             $this->tmp,
             file_get_contents($phpunitXmlPath),
             new XmlConfigurationManipulator($replacer, ''),
-            $jUnitFilePath,
-            $srcDirs,
-            $skipCoverage
+            $srcDirs
         );
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -217,7 +217,7 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
         $this->assertSame(0, $logEntries->length);
     }
 
-    public function test_it_does_not_add_loggers_ever(): void
+    public function test_it_does_not_add_coverage_loggers_ever(): void
     {
         $xml = file_get_contents($this->builder->build('6.5'));
 


### PR DESCRIPTION
This PR:

- [x] Request coverage reports from PHPUnit with command line args, thus avoiding working [with the new schema](https://github.com/sebastianbergmann/phpunit/blob/a0d6b21c6c8f6564212a1a14292d230ee35eba6d/ChangeLog-9.3.md#configuration-of-code-coverage-and-logging-in-phpunitxml).
- [x] Removes new-style loggers from the configuration
- [x] Replaces the bulk of #1294
- [x] Covered by tests

What left to do with #1283:

- There has to be a test with new schema.
- New-style coverage "whitelist" adder has to be dealt with (`addCoverageFilterWhitelistIfDoesNotExist`).
