### PR TITLE
Refactor InitialConfigBuilder

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/schema/9.2.xsd"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
          colors="true"
          executionOrder="random"
@@ -23,11 +23,11 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
     <groups>
         <exclude>

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -44,6 +44,7 @@ use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator;
+use Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider;
 use Infection\TestFramework\VersionParser;
 use function Safe\file_get_contents;
 use Symfony\Component\Filesystem\Filesystem;
@@ -87,6 +88,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
                 $tmpDir,
                 $testFrameworkConfigContent,
                 $configManipulator,
+                new XmlConfigurationVersionProvider(),
                 $sourceDirectories
             ),
             new MutationConfigBuilder(

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -36,10 +36,9 @@ declare(strict_types=1);
 namespace Infection\TestFramework\PhpUnit\Config\Builder;
 
 use DOMDocument;
-use DOMElement;
-use DOMNode;
 use Infection\TestFramework\Config\InitialConfigBuilder as ConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator;
+use Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider;
 use Infection\TestFramework\SafeDOMXPath;
 use function Safe\file_put_contents;
 use function Safe\sprintf;
@@ -54,6 +53,7 @@ class InitialConfigBuilder implements ConfigBuilder
     private $tmpDir;
     private $originalXmlConfigContent;
     private $configManipulator;
+    private $versionProvider;
     private $srcDirs;
 
     /**
@@ -63,6 +63,7 @@ class InitialConfigBuilder implements ConfigBuilder
         string $tmpDir,
         string $originalXmlConfigContent,
         XmlConfigurationManipulator $configManipulator,
+        XmlConfigurationVersionProvider $versionProvider,
         array $srcDirs
     ) {
         Assert::notEmpty(
@@ -73,6 +74,7 @@ class InitialConfigBuilder implements ConfigBuilder
         $this->tmpDir = $tmpDir;
         $this->originalXmlConfigContent = $originalXmlConfigContent;
         $this->configManipulator = $configManipulator;
+        $this->versionProvider = $versionProvider;
         $this->srcDirs = $srcDirs;
     }
 
@@ -91,7 +93,7 @@ class InitialConfigBuilder implements ConfigBuilder
 
         $this->configManipulator->validate($path, $xPath);
 
-        $this->addCoverageFilterWhitelistIfDoesNotExist($xPath);
+        $this->addCoverageNodes($version, $xPath);
         $this->addRandomTestsOrderAttributesIfNotSet($version, $xPath);
         $this->addFailOnAttributesIfNotSet($version, $xPath);
         $this->configManipulator->replaceWithAbsolutePaths($xPath);
@@ -112,50 +114,28 @@ class InitialConfigBuilder implements ConfigBuilder
         return $this->tmpDir . '/phpunitConfiguration.initial.infection.xml';
     }
 
-    private function addCoverageFilterWhitelistIfDoesNotExist(SafeDOMXPath $xPath): void
+    private function addCoverageNodes(string $version, SafeDOMXPath $xPath): void
     {
-        $filterWhitelistNode = $this->getNode($xPath, 'filter/whitelist');
-        $coverageIncludeNode = $this->getNode($xPath, 'coverage/include');
+        if (version_compare($version, '10', '>=')) {
+            $this->configManipulator->addCoverageIncludeNodesUnlessTheyExist($xPath, $this->srcDirs);
 
-        if ($filterWhitelistNode || $coverageIncludeNode) {
             return;
         }
 
-        $filterNode = $this->createNode($xPath->document, 'filter');
+        if (version_compare($version, '9.3', '<')) {
+            $this->configManipulator->addLegacyCoverageWhitelistNodesUnlessTheyExist($xPath, $this->srcDirs);
 
-        $whiteListNode = $xPath->document->createElement('whitelist');
-
-        foreach ($this->srcDirs as $srcDir) {
-            $directoryNode = $xPath->document->createElement(
-                'directory',
-                $srcDir
-            );
-
-            $whiteListNode->appendChild($directoryNode);
+            return;
         }
 
-        $filterNode->appendChild($whiteListNode);
-    }
+        // For versions between 9.3 and 10.0, fallback to version provider
+        if (version_compare($this->versionProvider->provide($xPath), '9.3', '>=')) {
+            $this->configManipulator->addCoverageIncludeNodesUnlessTheyExist($xPath, $this->srcDirs);
 
-    private function getNode(SafeDOMXPath $xPath, string $nodeName): ?DOMNode
-    {
-        $nodeList = $xPath->query(sprintf('/phpunit/%s', $nodeName));
-
-        if ($nodeList->length) {
-            return $nodeList->item(0);
+            return;
         }
 
-        return null;
-    }
-
-    private function createNode(DOMDocument $dom, string $nodeName): DOMElement
-    {
-        $node = $dom->createElement($nodeName);
-        $document = $dom->documentElement;
-        Assert::isInstanceOf($document, DOMElement::class);
-        $document->appendChild($node);
-
-        return $node;
+        $this->configManipulator->addLegacyCoverageWhitelistNodesUnlessTheyExist($xPath, $this->srcDirs);
     }
 
     private function addRandomTestsOrderAttributesIfNotSet(string $version, SafeDOMXPath $xPath): void

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\TestFramework\PhpUnit\Config;
+
+use Infection\TestFramework\SafeDOMXPath;
+use function Safe\preg_match;
+
+/**
+ * @internal
+ */
+final class XmlConfigurationVersionProvider
+{
+    private const LAST_LEGACY_VERSION = '9.2';
+    private const NEXT_MAINSTREAM_VERSION = '9.3';
+
+    public function provide(SafeDOMXPath $xPath): string
+    {
+        // <coverage>
+        if ($xPath->query('/phpunit/coverage')->length) {
+            return self::NEXT_MAINSTREAM_VERSION;
+        }
+
+        // <logging><log type="*">
+        if ($xPath->query('/phpunit/logging/log')->length) {
+            return self::LAST_LEGACY_VERSION;
+        }
+
+        // <logging><*> where <*> isn't <log>
+        if ($xPath->query('/phpunit/logging/*[name(.) != "log"]')->length) {
+            return self::NEXT_MAINSTREAM_VERSION;
+        }
+
+        // <filter><whitelist>
+        if ($xPath->query('/phpunit/filter')->length) {
+            return self::LAST_LEGACY_VERSION;
+        }
+
+        foreach ([
+            'disableCodeCoverageIgnore', // <phpunit disableCodeCoverageIgnore="true">
+            'ignoreDeprecatedCodeUnitsFromCodeCoverage', // <phpunit ignoreDeprecatedCodeUnitsFromCodeCoverage="true">
+        ] as $legacyAttribute) {
+            if ($xPath->query("/phpunit[@{$legacyAttribute}]")->length) {
+                return self::LAST_LEGACY_VERSION;
+            }
+        }
+
+        $schemaUri = $this->getSchemaURI($xPath);
+
+        if ($schemaUri === null) {
+            // Best guess it is a legacy version: config upgrader will add a path to XSD
+            return self::LAST_LEGACY_VERSION;
+        }
+
+        /*
+         * We're looking for these:
+         *
+         * vendor/phpunit/phpunit/schema/9.2.xsd
+         * http://schema.phpunit.de/6.0/phpunit.xsd
+         * https://schema.phpunit.de/9.3/phpunit.xsd
+         */
+        $match = [];
+
+        if (preg_match('#(\d+\.\d)(/phpunit)?\.xsd$#', $schemaUri, $match)) {
+            return $match[1];
+        }
+
+        // Without any clues we assume it's a legacy version: it's most prevalent
+        return self::LAST_LEGACY_VERSION;
+    }
+
+    private function getSchemaURI(SafeDOMXPath $xPath): ?string
+    {
+        if ($xPath->query('namespace::xsi')->length === 0) {
+            return null;
+        }
+
+        $schema = $xPath->query('/phpunit/@xsi:noNamespaceSchemaLocation');
+
+        if ($schema->length === 0) {
+            return null;
+        }
+
+        return $schema[0]->nodeValue;
+    }
+}

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -146,6 +146,30 @@ XML
         );
     }
 
+    public function test_it_adds_coverage_whitelist_to_pre_93_configuration(): void
+    {
+        $this->assertItChangesXML(
+            <<<'XML'
+<phpunit cacheTokens="true">
+</phpunit>
+XML
+            ,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->addLegacyCoverageWhitelistNodesUnlessTheyExist($xPath, ['src/', 'examples/']);
+            },
+            <<<'XML'
+<phpunit cacheTokens="true">
+  <filter>
+    <whitelist>
+      <directory>src/</directory>
+      <directory>examples/</directory>
+    </whitelist>
+  </filter>
+</phpunit>
+XML
+            );
+    }
+
     public function test_it_removes_existing_loggers_from_post_93_configuration(): void
     {
         $this->assertItChangesPostPHPUnit93Configuration(
@@ -740,7 +764,7 @@ EOF
 
     private function assertItChangesPostPHPUnit93Configuration(Closure $changeXml, string $expectedXml): void
     {
-        $xPath = $this->createXPath(<<<'XML'
+        $this->assertItChangesXML(<<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
@@ -778,19 +802,15 @@ EOF
     </logging>
 </phpunit>
 XML
-            );
-
-        $changeXml($this->configManipulator, $xPath);
-
-        $actualXml = $xPath->document->saveXML();
-
-        $this->assertNotFalse($actualXml);
-        $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
+            ,
+            $changeXml,
+            $expectedXml
+        );
     }
 
     private function assertItChangesPrePHPUnit93Configuration(Closure $changeXml, string $expectedXml): void
     {
-        $xPath = $this->createXPath(<<<'XML'
+        $this->assertItChangesXML(<<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     backupGlobals="false"
@@ -822,14 +842,10 @@ XML
     </logging>
 </phpunit>
 XML
+        ,
+            $changeXml,
+            $expectedXml
         );
-
-        $changeXml($this->configManipulator, $xPath);
-
-        $actualXml = $xPath->document->saveXML();
-
-        $this->assertNotFalse($actualXml);
-        $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
 
     private function assertItChangesXML(string $inputXml, Closure $changeXml, string $expectedXml): void

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestFramework\PhpUnit\Config;
+
+use Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider;
+use Infection\TestFramework\SafeDOMXPath;
+use PHPUnit\Framework\TestCase;
+use function Pipeline\take;
+use function version_compare;
+
+final class XmlConfigurationVersionProviderTest extends TestCase
+{
+    /**
+     * @var XmlConfigurationVersionProvider
+     */
+    private $versionProvider;
+
+    protected function setUp(): void
+    {
+        $this->versionProvider = new XmlConfigurationVersionProvider();
+    }
+
+    public function configurationsProvider()
+    {
+        yield from take($this->legacyConfigurationsProvider())
+            ->map(static function (string $xml) {
+                yield $xml => [
+                    SafeDOMXPath::fromString($xml),
+                    false,
+                ];
+            });
+
+        yield from take($this->mainlineConfigurationsProvider())
+            ->map(static function (string $xml) {
+                yield $xml => [
+                    SafeDOMXPath::fromString($xml),
+                    true,
+                ];
+            });
+    }
+
+    /**
+     * @dataProvider configurationsProvider
+     */
+    public function test_it_finds_correct_version(SafeDOMXPath $xPath, bool $mainline): void
+    {
+        $version = $this->versionProvider->provide($xPath);
+
+        $this->assertSame($mainline, version_compare($version, '9.3', '>='));
+    }
+
+    protected function legacyConfigurationsProvider()
+    {
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="/app/autoload2.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    printerClass="Fake\Printer\Class"
+    processIsolation="false"
+    syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>/*Bundle</directory>
+            <exclude>/*Bundle/Fixtures</exclude>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>/src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-html" target="/path/to/tmp"/>
+    </logging>
+</phpunit>
+XML;
+
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit>
+    <logging>
+        <log type="coverage-html" target="/path/to/tmp"/>
+    </logging>
+</phpunit>
+XML;
+
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit>
+    <filter>
+        <whitelist>
+            <directory>/src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>
+XML;
+
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit disableCodeCoverageIgnore="true"></phpunit>
+XML;
+
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit ignoreDeprecatedCodeUnitsFromCodeCoverage="true"></phpunit>
+XML;
+
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit></phpunit>
+XML;
+
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"></phpunit>
+XML;
+
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.0/phpunit.xsd">
+</phpunit>
+XML;
+
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/schema/9.2.xsd">
+</phpunit>
+XML;
+
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./phpunit.xsd">
+</phpunit>
+XML;
+    }
+
+    protected function mainlineConfigurationsProvider()
+    {
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+</phpunit>
+XML;
+
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit>
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>
+XML;
+
+        yield <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit>
+    <logging>
+        <text outputFile="logfile.txt"/>
+    </logging>
+</phpunit>
+XML;
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds heuristics to detect used PHPUnit configuration format.
- [x] Add a method to update PHPUnit configuration with appropriate coverage whitelist/include directives.
- [x] Fixes #1283 to the point we're using Infection with the newest PHPUnit configuration.
