### PR TITLE
Ensure Mutator::mutate() is mutations-free

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ PHP_CS_FIXER_CACHE=build/cache/.php_cs.cache
 
 PHPSTAN=./vendor/bin/phpstan
 
+PSALM=./vendor/bin/psalm
+
 PHPUNIT=vendor/phpunit/phpunit/phpunit
 
 INFECTION=./build/infection.phar
@@ -67,6 +69,10 @@ phpstan: vendor $(PHPSTAN)
 	$(PHPSTAN) analyse --configuration devTools/phpstan-src.neon --no-interaction --no-progress
 	$(PHPSTAN) analyse --configuration devTools/phpstan-tests.neon --no-interaction --no-progress
 
+.PHONY: psalm
+psalm: vendor $(PSALM)
+	$(PSALM)
+
 .PHONY: validate
 validate:
 	composer validate --strict
@@ -90,7 +96,7 @@ profile: vendor $(BENCHMARK_SOURCES)
 
 .PHONY: autoreview
 autoreview: 	 	## Runs various checks (static analysis & AutoReview test suite)
-autoreview: phpstan validate test-autoreview
+autoreview: phpstan psalm validate test-autoreview
 
 .PHONY: test
 test:		 	## Runs all the tests
@@ -207,6 +213,8 @@ $(PHP_CS_FIXER): Makefile
 	touch $@
 
 $(PHPSTAN): vendor
+
+$(PSALM): vendor
 
 $(INFECTION): vendor $(shell find bin/ src/ -type f) $(BOX) box.json.dist .git/HEAD
 	composer require infection/codeception-adapter infection/phpspec-adapter

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,8 @@
         "phpunit/phpunit": "^9.3.11",
         "symfony/phpunit-bridge": "^4.4.14 || ^5.1.6",
         "symfony/yaml": "^5.0",
-        "thecodingmachine/phpstan-safe-rule": "^1.0"
+        "thecodingmachine/phpstan-safe-rule": "^1.0",
+        "vimeo/psalm": "^4.0"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,81 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "073f27049eec4f625621e1111a95c6fc",
+    "content-hash": "57ef6889a2b20e4c77ae0c2f42a10c5c",
     "packages": [
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855",
+                "reference": "c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-25T05:50:16+00:00"
+        },
         {
             "name": "composer/xdebug-handler",
             "version": "1.4.4",
@@ -341,71 +414,6 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.2"
             },
             "time": "2020-09-26T10:30:38+00:00"
-        },
-        {
-            "name": "ocramius/package-versions",
-            "version": "1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "94c9d42a466c57f91390cdd49c81313264f49d85"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/94c9d42a466c57f91390cdd49c81313264f49d85",
-                "reference": "94c9d42a466c57f91390cdd49c81313264f49d85",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1.0 || ^2.0",
-                "php": "^7.4.0"
-            },
-            "require-dev": {
-                "composer/composer": "^1.9.3 || ^2.0@dev",
-                "doctrine/coding-standard": "^7.0.2",
-                "ext-zip": "^1.15.0",
-                "infection/infection": "^0.15.3",
-                "phpunit/phpunit": "^9.1.1",
-                "vimeo/psalm": "^3.9.3"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "1.99.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "support": {
-                "issues": "https://github.com/Ocramius/PackageVersions/issues",
-                "source": "https://github.com/Ocramius/PackageVersions/tree/1.9.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/Ocramius",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/ocramius/package-versions",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-06-22T14:15:44+00:00"
         },
         {
             "name": "ondram/ci-detector",
@@ -1964,6 +1972,284 @@
     ],
     "packages-dev": [
         {
+            "name": "amphp/amp",
+            "version": "v2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "f220a51458bf4dd0dedebb171ac3457813c72bbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/f220a51458bf4dd0dedebb171ac3457813c72bbc",
+                "reference": "f220a51458bf4dd0dedebb171ac3457813c72bbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6.0.9 | ^7",
+                "psalm/phar": "^3.11@dev",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "http://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-14T21:47:18+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
+                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.4",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "psalm/phar": "^3.11.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/master"
+            },
+            "time": "2020-06-29T18:35:05+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "4089fddb67bcf6bf860d91b979e95be303835002"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/4089fddb67bcf6bf860d91b979e95be303835002",
+                "reference": "4089fddb67bcf6bf860d91b979e95be303835002",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.19",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-14T08:51:15+00:00"
+        },
+        {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.3.1",
             "source": {
@@ -2036,6 +2322,107 @@
                 }
             ],
             "time": "2020-05-29T17:27:14+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "0ed363f8de17d284d479ec813c9ad3f6834b5c40"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/0ed363f8de17d284d479ec813c9ad3f6834b5c40",
+                "reference": "0ed363f8de17d284d479ec813c9ad3f6834b5c40",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0",
+                "php": ">=7.0",
+                "phpdocumentor/reflection-docblock": "^4.0.0 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/master"
+            },
+            "time": "2020-03-11T15:21:41+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "85e83cacd2ed573238678c6875f8f0d7ec699541"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/85e83cacd2ed573238678c6875f8f0d7ec699541",
+                "reference": "85e83cacd2ed573238678c6875f8f0d7ec699541",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.0"
+            },
+            "time": "2020-10-23T13:55:30+00:00"
         },
         {
             "name": "helmich/phpunit-json-assert",
@@ -2152,6 +2539,110 @@
                 }
             ],
             "time": "2020-06-29T13:22:24+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4 || ~7.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/master"
+            },
+            "time": "2020-04-16T18:48:43+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -4486,6 +4977,162 @@
                 }
             ],
             "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "vimeo/psalm",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "b1e2e30026936ef8d5bf6a354d1c3959b6231f44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/b1e2e30026936ef8d5bf6a354d1c3959b6231f44",
+                "reference": "b1e2e30026936ef8d5bf6a354d1c3959b6231f44",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.1",
+                "amphp/byte-stream": "^1.5",
+                "composer/package-versions-deprecated": "^1.8.0",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.1",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.4",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0",
+                "nikic/php-parser": "^4.10.1",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.3|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "webmozart/glob": "^4.1",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.4.2",
+                "bamarni/composer-bin-plugin": "^1.2",
+                "brianium/paratest": "^4.0.0",
+                "ext-curl": "*",
+                "phpdocumentor/reflection-docblock": "^5",
+                "phpmyadmin/sql-parser": "5.1.0",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpunit/phpunit": "^9.0",
+                "psalm/plugin-phpunit": "^0.13",
+                "slevomat/coding-standard": "^5.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "ext-igbinary": "^2.0.5"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                },
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm/tree/4.0.1"
+            },
+            "time": "2020-10-20T13:40:17+00:00"
+        },
+        {
+            "name": "webmozart/glob",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/glob.git",
+                "reference": "3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/glob/zipball/3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe",
+                "reference": "3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0",
+                "webmozart/path-util": "^2.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1",
+                "symfony/filesystem": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Glob\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A PHP implementation of Ant's glob.",
+            "support": {
+                "issues": "https://github.com/webmozart/glob/issues",
+                "source": "https://github.com/webmozart/glob/tree/master"
+            },
+            "time": "2015-12-29T11:14:33+00:00"
         }
     ],
     "aliases": [],

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="8"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src/Mutator" />
+        <ignoreFiles>
+            <directory name="vendor" />
+           <directory name="src/PhpParser" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/src/Mutator/Arithmetic/Assignment.php
+++ b/src/Mutator/Arithmetic/Assignment.php
@@ -62,6 +62,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\AssignOp $node
      *
      * @return iterable<Node\Expr\Assign>

--- a/src/Mutator/Arithmetic/AssignmentEqual.php
+++ b/src/Mutator/Arithmetic/AssignmentEqual.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Equal $node
      *
      * @return iterable<Node\Expr\Assign>

--- a/src/Mutator/Arithmetic/BitwiseAnd.php
+++ b/src/Mutator/Arithmetic/BitwiseAnd.php
@@ -58,6 +58,8 @@ final class BitwiseAnd implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\BooleanAnd $node
      *
      * @return iterable<Node\Expr\BinaryOp\BitwiseOr>

--- a/src/Mutator/Arithmetic/BitwiseNot.php
+++ b/src/Mutator/Arithmetic/BitwiseNot.php
@@ -58,6 +58,8 @@ final class BitwiseNot implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BitwiseNot $node
      *
      * @return iterable<Node\Expr>

--- a/src/Mutator/Arithmetic/BitwiseOr.php
+++ b/src/Mutator/Arithmetic/BitwiseOr.php
@@ -58,6 +58,8 @@ final class BitwiseOr implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\BitwiseOr $node
      *
      * @return iterable<Node\Expr\BinaryOp\BitwiseAnd>

--- a/src/Mutator/Arithmetic/BitwiseXor.php
+++ b/src/Mutator/Arithmetic/BitwiseXor.php
@@ -58,6 +58,8 @@ final class BitwiseXor implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\BitwiseXor $node
      *
      * @return iterable<Node\Expr\BinaryOp\BitwiseAnd>

--- a/src/Mutator/Arithmetic/Decrement.php
+++ b/src/Mutator/Arithmetic/Decrement.php
@@ -62,6 +62,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\PreDec|Node\Expr\PostDec $node
      *
      * @return iterable<Node\Expr\PreInc|Node\Expr\PostInc>

--- a/src/Mutator/Arithmetic/DivEqual.php
+++ b/src/Mutator/Arithmetic/DivEqual.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\AssignOp\Div $node
      *
      * @return iterable<Node\Expr\AssignOp\Mul>

--- a/src/Mutator/Arithmetic/Division.php
+++ b/src/Mutator/Arithmetic/Division.php
@@ -58,6 +58,8 @@ final class Division implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Div $node
      *
      * @return iterable<Node\Expr\BinaryOp\Mul>

--- a/src/Mutator/Arithmetic/Exponentiation.php
+++ b/src/Mutator/Arithmetic/Exponentiation.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Pow $node
      *
      * @return iterable<Node\Expr\BinaryOp\Div>

--- a/src/Mutator/Arithmetic/Increment.php
+++ b/src/Mutator/Arithmetic/Increment.php
@@ -62,6 +62,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\PostInc|Node\Expr\PreInc $node
      *
      * @return iterable<Node\Expr\PreDec|Node\Expr\PostDec>

--- a/src/Mutator/Arithmetic/Minus.php
+++ b/src/Mutator/Arithmetic/Minus.php
@@ -58,6 +58,8 @@ final class Minus implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Minus $node
      *
      * @return iterable<Node\Expr\BinaryOp\Plus>

--- a/src/Mutator/Arithmetic/MinusEqual.php
+++ b/src/Mutator/Arithmetic/MinusEqual.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\AssignOp\Minus $node
      *
      * @return iterable<Node\Expr\AssignOp\Plus>

--- a/src/Mutator/Arithmetic/ModEqual.php
+++ b/src/Mutator/Arithmetic/ModEqual.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\AssignOp\Mod $node
      *
      * @return iterable<Node\Expr\AssignOp\Mul>

--- a/src/Mutator/Arithmetic/Modulus.php
+++ b/src/Mutator/Arithmetic/Modulus.php
@@ -58,6 +58,8 @@ final class Modulus implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Mod $node
      *
      * @return iterable<Node\Expr\BinaryOp\Mul>

--- a/src/Mutator/Arithmetic/MulEqual.php
+++ b/src/Mutator/Arithmetic/MulEqual.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\AssignOp\Mul $node
      *
      * @return iterable<Node\Expr\AssignOp\Div>

--- a/src/Mutator/Arithmetic/Multiplication.php
+++ b/src/Mutator/Arithmetic/Multiplication.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Mul $node
      *
      * @return iterable<Node\Expr\BinaryOp\Div>

--- a/src/Mutator/Arithmetic/Plus.php
+++ b/src/Mutator/Arithmetic/Plus.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Plus $node
      *
      * @return iterable<Node\Expr\BinaryOp\Minus>

--- a/src/Mutator/Arithmetic/PlusEqual.php
+++ b/src/Mutator/Arithmetic/PlusEqual.php
@@ -63,6 +63,8 @@ TXT
     /**
      * Replaces "+=" with "-="
      *
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\AssignOp\Plus $node
      *
      * @return iterable<Node\Expr\AssignOp\Minus>

--- a/src/Mutator/Arithmetic/PowEqual.php
+++ b/src/Mutator/Arithmetic/PowEqual.php
@@ -63,6 +63,8 @@ TXT
     /**
      * Replaces "**=" with "/="
      *
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\AssignOp\Pow $node
      *
      * @return iterable<Node\Expr\AssignOp\Div>

--- a/src/Mutator/Arithmetic/RoundingFamily.php
+++ b/src/Mutator/Arithmetic/RoundingFamily.php
@@ -68,6 +68,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Expr\FuncCall>
@@ -76,6 +78,7 @@ TXT
     {
         /** @var Node\Name $name */
         $name = $node->name;
+        /** @psalm-suppress ImpureMethodCall */
         $currentFunctionName = $name->toLowerString();
 
         $mutateToFunctions = array_diff(self::MUTATORS_MAP, [$currentFunctionName]);

--- a/src/Mutator/Arithmetic/ShiftLeft.php
+++ b/src/Mutator/Arithmetic/ShiftLeft.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\ShiftLeft $node
      *
      * @return iterable<Node\Expr\BinaryOp\ShiftRight>

--- a/src/Mutator/Arithmetic/ShiftRight.php
+++ b/src/Mutator/Arithmetic/ShiftRight.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\ShiftRight $node
      *
      * @return iterable<Node\Expr\BinaryOp\ShiftLeft>

--- a/src/Mutator/Boolean/ArrayItem.php
+++ b/src/Mutator/Boolean/ArrayItem.php
@@ -67,6 +67,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\ArrayItem $node
      *
      * @return iterable<Node\Expr\BinaryOp\Greater>

--- a/src/Mutator/Boolean/EqualIdentical.php
+++ b/src/Mutator/Boolean/EqualIdentical.php
@@ -62,6 +62,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Equal $node
      *
      * @return iterable<Node\Expr\BinaryOp\Identical>

--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -58,6 +58,8 @@ final class FalseValue implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\ConstFetch $node
      *
      * @return iterable<Node\Expr\ConstFetch>

--- a/src/Mutator/Boolean/IdenticalEqual.php
+++ b/src/Mutator/Boolean/IdenticalEqual.php
@@ -64,6 +64,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Identical $node
      *
      * @return iterable<Node\Expr\BinaryOp\Equal>

--- a/src/Mutator/Boolean/InstanceOf_.php
+++ b/src/Mutator/Boolean/InstanceOf_.php
@@ -58,6 +58,8 @@ final class InstanceOf_ implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @return iterable<Node\Expr\ConstFetch>
      */
     public function mutate(Node $node): iterable

--- a/src/Mutator/Boolean/LogicalAnd.php
+++ b/src/Mutator/Boolean/LogicalAnd.php
@@ -58,6 +58,8 @@ final class LogicalAnd implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\LogicalOr $node
      *
      * @return iterable<Node\Expr\BinaryOp\BooleanOr>

--- a/src/Mutator/Boolean/LogicalLowerAnd.php
+++ b/src/Mutator/Boolean/LogicalLowerAnd.php
@@ -58,6 +58,8 @@ final class LogicalLowerAnd implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * Replaces "and" with "or"
      *
      * @param Node\Expr\BinaryOp\LogicalAnd $node

--- a/src/Mutator/Boolean/LogicalLowerOr.php
+++ b/src/Mutator/Boolean/LogicalLowerOr.php
@@ -58,6 +58,8 @@ final class LogicalLowerOr implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\LogicalOr $node
      *
      * @return iterable<Node\Expr\BinaryOp\LogicalAnd>

--- a/src/Mutator/Boolean/LogicalNot.php
+++ b/src/Mutator/Boolean/LogicalNot.php
@@ -58,6 +58,8 @@ final class LogicalNot implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BooleanNot $node
      *
      * @return iterable<Node\Expr>

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -58,6 +58,8 @@ final class LogicalOr implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * Replaces "||" with "&&"
      *
      * @param Node\Expr\BinaryOp\BooleanOr $node

--- a/src/Mutator/Boolean/NotEqualNotIdentical.php
+++ b/src/Mutator/Boolean/NotEqualNotIdentical.php
@@ -62,6 +62,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\NotEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\NotIdentical>

--- a/src/Mutator/Boolean/NotIdenticalNotEqual.php
+++ b/src/Mutator/Boolean/NotIdenticalNotEqual.php
@@ -64,6 +64,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\NotIdentical $node
      *
      * @return iterable<Node\Expr\BinaryOp\NotEqual>

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -73,6 +73,8 @@ final class TrueValue implements ConfigurableMutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\ConstFetch $node
      *
      * @return iterable<Node\Expr\ConstFetch>

--- a/src/Mutator/Boolean/Yield_.php
+++ b/src/Mutator/Boolean/Yield_.php
@@ -67,6 +67,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\Yield_ $node
      *
      * @return iterable<Node\Expr\Yield_>
@@ -78,10 +80,7 @@ TXT
         /** @var Node\Expr $value */
         $value = $node->value;
 
-        $node->value = new Node\Expr\BinaryOp\Greater($key, $value, $node->getAttributes());
-        $node->key = null;
-
-        yield $node;
+        yield new Node\Expr\Yield_(new Node\Expr\BinaryOp\Greater($key, $value, $node->getAttributes()));
     }
 
     public function canMutate(Node $node): bool

--- a/src/Mutator/Cast/AbstractCastMutator.php
+++ b/src/Mutator/Cast/AbstractCastMutator.php
@@ -47,6 +47,8 @@ abstract class AbstractCastMutator implements Mutator
     use GetMutatorName;
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\Cast $node
      *
      * @return iterable<Node\Expr>

--- a/src/Mutator/ConditionalBoundary/GreaterThan.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThan.php
@@ -63,6 +63,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Greater $node
      *
      * @return iterable<Node\Expr\BinaryOp\GreaterOrEqual>

--- a/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\GreaterOrEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\Greater>

--- a/src/Mutator/ConditionalBoundary/LessThan.php
+++ b/src/Mutator/ConditionalBoundary/LessThan.php
@@ -63,6 +63,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Smaller $node
      *
      * @return iterable<Node\Expr\BinaryOp\SmallerOrEqual>

--- a/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\SmallerOrEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\Smaller>

--- a/src/Mutator/ConditionalNegotiation/Equal.php
+++ b/src/Mutator/ConditionalNegotiation/Equal.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Equal $node
      *
      * @return iterable<Node\Expr\BinaryOp\NotEqual>

--- a/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Greater $node
      *
      * @return iterable<Node\Expr\BinaryOp\SmallerOrEqual>

--- a/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\GreaterOrEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\Smaller>

--- a/src/Mutator/ConditionalNegotiation/Identical.php
+++ b/src/Mutator/ConditionalNegotiation/Identical.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Identical $node
      *
      * @return iterable<Node\Expr\BinaryOp\NotIdentical>

--- a/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Smaller $node
      *
      * @return iterable<Node\Expr\BinaryOp\GreaterOrEqual>

--- a/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\SmallerOrEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\Greater>

--- a/src/Mutator/ConditionalNegotiation/NotEqual.php
+++ b/src/Mutator/ConditionalNegotiation/NotEqual.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\NotEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\Equal>

--- a/src/Mutator/ConditionalNegotiation/NotIdentical.php
+++ b/src/Mutator/ConditionalNegotiation/NotIdentical.php
@@ -63,6 +63,8 @@ TXT
     /**
      * Replaces "!==" with "==="
      *
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\NotIdentical $node
      *
      * @return iterable<Node\Expr\BinaryOp\Identical>

--- a/src/Mutator/Extensions/BCMath.php
+++ b/src/Mutator/Extensions/BCMath.php
@@ -87,6 +87,9 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     * @psalm-suppress ImpureMethodCall
+     *
      * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Expr>

--- a/src/Mutator/Extensions/MBString.php
+++ b/src/Mutator/Extensions/MBString.php
@@ -93,6 +93,9 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     * @psalm-suppress ImpureMethodCall
+     *
      * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Expr\FuncCall>

--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -61,6 +61,8 @@ final class ProtectedVisibility implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\ClassMethod $node
      *
      * @return iterable<Node\Stmt\ClassMethod>

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -61,6 +61,8 @@ final class PublicVisibility implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\ClassMethod $node
      *
      * @return iterable<Node\Stmt\ClassMethod>

--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -96,6 +96,8 @@ final class IgnoreMutator implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @return iterable<Node|Node[]>
      */
     public function mutate(Node $node): iterable

--- a/src/Mutator/Mutator.php
+++ b/src/Mutator/Mutator.php
@@ -49,6 +49,8 @@ interface Mutator
     public function canMutate(Node $node): bool;
 
     /**
+     * @psalm-mutation-free
+     *
      * @return iterable<Node|Node[]>
      */
     public function mutate(Node $node): iterable;

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -68,6 +68,8 @@ final class DecrementInteger extends AbstractNumberMutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Scalar\LNumber $node
      *
      * @return iterable<Node\Scalar\LNumber>

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -58,6 +58,8 @@ final class IncrementInteger extends AbstractNumberMutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Scalar\LNumber $node
      *
      * @return iterable<Node\Scalar\LNumber>

--- a/src/Mutator/Number/OneZeroFloat.php
+++ b/src/Mutator/Number/OneZeroFloat.php
@@ -60,6 +60,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Scalar\DNumber $node
      *
      * @return iterable<Node\Scalar\DNumber>

--- a/src/Mutator/Number/OneZeroInteger.php
+++ b/src/Mutator/Number/OneZeroInteger.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Scalar\LNumber $node
      *
      * @return iterable<Node\Scalar\LNumber>

--- a/src/Mutator/Operator/AssignCoalesce.php
+++ b/src/Mutator/Operator/AssignCoalesce.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\AssignOp\Coalesce $node
      *
      * @return iterable<Node\Expr\Assign>

--- a/src/Mutator/Operator/Break_.php
+++ b/src/Mutator/Operator/Break_.php
@@ -62,6 +62,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Break_ $node
      *
      * @return iterable<Node\Stmt\Continue_>

--- a/src/Mutator/Operator/Coalesce.php
+++ b/src/Mutator/Operator/Coalesce.php
@@ -71,6 +71,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Coalesce $node
      *
      * @return iterable<Node\Expr>

--- a/src/Mutator/Operator/Continue_.php
+++ b/src/Mutator/Operator/Continue_.php
@@ -62,6 +62,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Continue_ $node
      *
      * @return iterable<Node\Stmt\Break_>

--- a/src/Mutator/Operator/Finally_.php
+++ b/src/Mutator/Operator/Finally_.php
@@ -61,6 +61,8 @@ final class Finally_ implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Finally_ $node
      *
      * @return iterable<Node\Stmt\Nop>

--- a/src/Mutator/Operator/Spread.php
+++ b/src/Mutator/Operator/Spread.php
@@ -71,6 +71,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\ArrayItem $node
      *
      * @return iterable<Node\Expr\ArrayItem>

--- a/src/Mutator/Operator/Throw_.php
+++ b/src/Mutator/Operator/Throw_.php
@@ -72,6 +72,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * Replaces "throw new Exception();" with "new Exception();"
      *
      * @param Node\Stmt\Throw_ $node

--- a/src/Mutator/Regex/PregMatchMatches.php
+++ b/src/Mutator/Regex/PregMatchMatches.php
@@ -77,6 +77,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Expr\Cast\Int_>

--- a/src/Mutator/Regex/PregQuote.php
+++ b/src/Mutator/Regex/PregQuote.php
@@ -72,6 +72,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Arg>

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -102,6 +102,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\Array_ $arrayNode
      *
      * @return iterable<Node\Expr\Array_>
@@ -139,6 +141,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param ArrayItem[] $items
      *
      * @return int[]

--- a/src/Mutator/Removal/ArrayItemRemovalConfig.php
+++ b/src/Mutator/Removal/ArrayItemRemovalConfig.php
@@ -73,11 +73,17 @@ final class ArrayItemRemovalConfig implements MutatorConfig
         );
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     public function getRemove(): string
     {
         return $this->remove;
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     public function getLimit(): int
     {
         return $this->limit;

--- a/src/Mutator/Removal/CloneRemoval.php
+++ b/src/Mutator/Removal/CloneRemoval.php
@@ -58,6 +58,8 @@ final class CloneRemoval implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\Clone_ $node
      *
      * @return iterable<Node\Expr>

--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -71,6 +71,8 @@ final class FunctionCallRemoval implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * Replaces "doSmth()" with ""
      *
      * @param Node\Stmt\Expression $node

--- a/src/Mutator/Removal/MethodCallRemoval.php
+++ b/src/Mutator/Removal/MethodCallRemoval.php
@@ -58,6 +58,8 @@ final class MethodCallRemoval implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Expression $node
      *
      * @return iterable<Node\Stmt\Nop>

--- a/src/Mutator/Removal/SharedCaseRemoval.php
+++ b/src/Mutator/Removal/SharedCaseRemoval.php
@@ -73,6 +73,8 @@ final class SharedCaseRemoval implements Mutator
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Switch_ $node
      *
      * @return iterable<Node\Stmt\Switch_>

--- a/src/Mutator/ReturnValue/ArrayOneItem.php
+++ b/src/Mutator/ReturnValue/ArrayOneItem.php
@@ -77,6 +77,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Return_ $node
      *
      * @return iterable<Node\Stmt\Return_>

--- a/src/Mutator/ReturnValue/FloatNegation.php
+++ b/src/Mutator/ReturnValue/FloatNegation.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Return_ $node
      *
      * @return iterable<Node\Stmt\Return_>
@@ -96,6 +98,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Return_ $node
      */
     private function getFloatValueOfNode(Node $node): float

--- a/src/Mutator/ReturnValue/FunctionCall.php
+++ b/src/Mutator/ReturnValue/FunctionCall.php
@@ -81,6 +81,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Return_ $node
      *
      * @return iterable<array<Node\Stmt\Expression|Node\Stmt\Return_>>

--- a/src/Mutator/ReturnValue/IntegerNegation.php
+++ b/src/Mutator/ReturnValue/IntegerNegation.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Return_ $node
      *
      * @return iterable<Node\Stmt\Return_>
@@ -96,6 +98,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Return_ $node
      */
     private function getIntegerValueOfNode(Node $node): int

--- a/src/Mutator/ReturnValue/NewObject.php
+++ b/src/Mutator/ReturnValue/NewObject.php
@@ -81,6 +81,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Return_ $node
      *
      * @return iterable<array<Node\Stmt\Expression|Node\Stmt\Return_>>

--- a/src/Mutator/ReturnValue/This.php
+++ b/src/Mutator/ReturnValue/This.php
@@ -57,6 +57,8 @@ final class This extends AbstractValueToNullReturnValue
     /**
      * Replaces "return $this;" with "return null;"
      *
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Return_ $node
      *
      * @return iterable<Node\Stmt\Return_>

--- a/src/Mutator/ReturnValue/YieldValue.php
+++ b/src/Mutator/ReturnValue/YieldValue.php
@@ -64,19 +64,19 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\Yield_ $node
      *
      * @return iterable<Node\Expr\Yield_>
      */
     public function mutate(Node $node): iterable
     {
-        $node->key = null;
-
-        yield $node;
+        yield new Node\Expr\Yield_($node->value);
     }
 
     public function canMutate(Node $node): bool
     {
-        return $node instanceof Node\Expr\Yield_ && $node->key;
+        return $node instanceof Node\Expr\Yield_ && $node->key !== null;
     }
 }

--- a/src/Mutator/Sort/Spaceship.php
+++ b/src/Mutator/Sort/Spaceship.php
@@ -61,6 +61,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\BinaryOp\Spaceship $node
      *
      * @return iterable<Node\Expr\BinaryOp\Spaceship>

--- a/src/Mutator/Unwrap/AbstractUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractUnwrapMutator.php
@@ -48,6 +48,8 @@ abstract class AbstractUnwrapMutator implements Mutator
     use GetMutatorName;
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Arg>
@@ -81,7 +83,12 @@ abstract class AbstractUnwrapMutator implements Mutator
     abstract protected function getFunctionName(): string;
 
     /**
+     * @psalm-mutation-free
+     *
      * @return iterable<int>
      */
-    abstract protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable;
+    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
+    {
+        yield 0;
+    }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayChangeKeyCase.php
+++ b/src/Mutator/Unwrap/UnwrapArrayChangeKeyCase.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_change_key_case';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayChunk.php
+++ b/src/Mutator/Unwrap/UnwrapArrayChunk.php
@@ -72,6 +72,9 @@ TXT
         return 'array_chunk';
     }
 
+    /**
+     * @psalm-pure
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;

--- a/src/Mutator/Unwrap/UnwrapArrayChunk.php
+++ b/src/Mutator/Unwrap/UnwrapArrayChunk.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -70,13 +69,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_chunk';
-    }
-
-    /**
-     * @psalm-pure
-     */
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayColumn.php
+++ b/src/Mutator/Unwrap/UnwrapArrayColumn.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,13 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_column';
-    }
-
-    /**
-     * @psalm-pure
-     */
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayColumn.php
+++ b/src/Mutator/Unwrap/UnwrapArrayColumn.php
@@ -71,6 +71,9 @@ TXT
         return 'array_column';
     }
 
+    /**
+     * @psalm-pure
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;

--- a/src/Mutator/Unwrap/UnwrapArrayCombine.php
+++ b/src/Mutator/Unwrap/UnwrapArrayCombine.php
@@ -78,6 +78,9 @@ TXT
         return 'array_combine';
     }
 
+    /**
+     * @psalm-pure
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 0;

--- a/src/Mutator/Unwrap/UnwrapArrayDiff.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiff.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -70,10 +69,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_diff';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffAssoc.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -70,10 +69,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_diff_assoc';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffKey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffKey.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -70,10 +69,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_diff_key';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffUassoc.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -70,10 +69,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_diff_uassoc';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayDiffUkey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayDiffUkey.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -70,10 +69,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_diff_ukey';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayFilter.php
+++ b/src/Mutator/Unwrap/UnwrapArrayFilter.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -70,10 +69,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_filter';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayFlip.php
+++ b/src/Mutator/Unwrap/UnwrapArrayFlip.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -70,10 +69,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_flip';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayIntersect.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersect.php
@@ -78,6 +78,9 @@ TXT
         return 'array_intersect';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectAssoc.php
@@ -78,6 +78,9 @@ TXT
         return 'array_intersect_assoc';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectKey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectKey.php
@@ -78,6 +78,9 @@ TXT
         return 'array_intersect_key';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectUassoc.php
@@ -80,6 +80,9 @@ TXT
         return 'array_intersect_uassoc';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_slice(

--- a/src/Mutator/Unwrap/UnwrapArrayIntersectUkey.php
+++ b/src/Mutator/Unwrap/UnwrapArrayIntersectUkey.php
@@ -80,6 +80,9 @@ TXT
         return 'array_intersect_ukey';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_slice(

--- a/src/Mutator/Unwrap/UnwrapArrayKeys.php
+++ b/src/Mutator/Unwrap/UnwrapArrayKeys.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_keys';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayMap.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMap.php
@@ -72,6 +72,9 @@ TXT
         return 'array_map';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from range(1, count($node->args) - 1);

--- a/src/Mutator/Unwrap/UnwrapArrayMerge.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMerge.php
@@ -78,6 +78,9 @@ TXT
         return 'array_merge';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);

--- a/src/Mutator/Unwrap/UnwrapArrayMergeRecursive.php
+++ b/src/Mutator/Unwrap/UnwrapArrayMergeRecursive.php
@@ -78,6 +78,9 @@ TXT
         return 'array_merge_recursive';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);

--- a/src/Mutator/Unwrap/UnwrapArrayPad.php
+++ b/src/Mutator/Unwrap/UnwrapArrayPad.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_pad';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayReduce.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReduce.php
@@ -77,6 +77,9 @@ TXT
         return 'array_reduce';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 2;

--- a/src/Mutator/Unwrap/UnwrapArrayReplace.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReplace.php
@@ -78,6 +78,9 @@ TXT
         return 'array_replace';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);

--- a/src/Mutator/Unwrap/UnwrapArrayReplaceRecursive.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReplaceRecursive.php
@@ -71,6 +71,9 @@ TXT
         return 'array_replace_recursive';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_keys($node->args);

--- a/src/Mutator/Unwrap/UnwrapArrayReverse.php
+++ b/src/Mutator/Unwrap/UnwrapArrayReverse.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_reverse';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArraySlice.php
+++ b/src/Mutator/Unwrap/UnwrapArraySlice.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_slice';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArraySplice.php
+++ b/src/Mutator/Unwrap/UnwrapArraySplice.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_splice';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayUdiff.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUdiff.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_udiff';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayUdiffAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUdiffAssoc.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_udiff_assoc';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayUdiffUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUdiffUassoc.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_udiff_uassoc';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayUintersect.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUintersect.php
@@ -84,6 +84,9 @@ TXT
         return 'array_uintersect';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_slice(

--- a/src/Mutator/Unwrap/UnwrapArrayUintersectAssoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUintersectAssoc.php
@@ -84,6 +84,9 @@ TXT
         return 'array_uintersect_assoc';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_slice(

--- a/src/Mutator/Unwrap/UnwrapArrayUintersectUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUintersectUassoc.php
@@ -85,6 +85,9 @@ TXT
         return 'array_uintersect_uassoc';
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield from array_slice(

--- a/src/Mutator/Unwrap/UnwrapArrayUnique.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUnique.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_unique';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapArrayValues.php
+++ b/src/Mutator/Unwrap/UnwrapArrayValues.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'array_values';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapLcFirst.php
+++ b/src/Mutator/Unwrap/UnwrapLcFirst.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'lcfirst';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapStrRepeat.php
+++ b/src/Mutator/Unwrap/UnwrapStrRepeat.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'str_repeat';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapStrReplace.php
+++ b/src/Mutator/Unwrap/UnwrapStrReplace.php
@@ -71,6 +71,9 @@ TXT
         return 'str_replace';
     }
 
+    /**
+     * @psalm-pure
+     */
     protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
     {
         yield 2;

--- a/src/Mutator/Unwrap/UnwrapStrToLower.php
+++ b/src/Mutator/Unwrap/UnwrapStrToLower.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'strtolower';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapStrToUpper.php
+++ b/src/Mutator/Unwrap/UnwrapStrToUpper.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'strtoupper';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapTrim.php
+++ b/src/Mutator/Unwrap/UnwrapTrim.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'trim';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapUcFirst.php
+++ b/src/Mutator/Unwrap/UnwrapUcFirst.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'ucfirst';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/Unwrap/UnwrapUcWords.php
+++ b/src/Mutator/Unwrap/UnwrapUcWords.php
@@ -37,7 +37,6 @@ namespace Infection\Mutator\Unwrap;
 
 use Infection\Mutator\Definition;
 use Infection\Mutator\MutatorCategory;
-use PhpParser\Node;
 
 /**
  * @internal
@@ -69,10 +68,5 @@ TXT
     protected function getFunctionName(): string
     {
         return 'ucwords';
-    }
-
-    protected function getParameterIndexes(Node\Expr\FuncCall $node): iterable
-    {
-        yield 0;
     }
 }

--- a/src/Mutator/ZeroIteration/For_.php
+++ b/src/Mutator/ZeroIteration/For_.php
@@ -76,6 +76,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\For_ $node
      *
      * @return iterable<Node\Stmt\For_>

--- a/src/Mutator/ZeroIteration/Foreach_.php
+++ b/src/Mutator/ZeroIteration/Foreach_.php
@@ -76,6 +76,8 @@ TXT
     }
 
     /**
+     * @psalm-mutation-free
+     *
      * @param Node\Stmt\Foreach_ $node
      *
      * @return iterable<Node\Stmt\Foreach_>

--- a/src/PhpParser/Visitor/ParentConnector.php
+++ b/src/PhpParser/Visitor/ParentConnector.php
@@ -53,6 +53,9 @@ final class ParentConnector
         $node->setAttribute(self::PARENT_ATTRIBUTE, $parent);
     }
 
+    /**
+     * @psalm-mutation-free
+     */
     public static function getParent(Node $node): Node
     {
         Assert::true($node->hasAttribute(self::PARENT_ATTRIBUTE));

--- a/tests/e2e/YieldValue/README.md
+++ b/tests/e2e/YieldValue/README.md
@@ -1,0 +1,9 @@
+# Title
+
+* Link to github ticket if relevant
+
+## Summary
+Short summary of the ticket
+
+## Full Ticket
+Full github ticket

--- a/tests/e2e/YieldValue/README.md
+++ b/tests/e2e/YieldValue/README.md
@@ -1,9 +1,3 @@
-# Title
+# YieldValue mutator does not work properly
 
-* Link to github ticket if relevant
-
-## Summary
-Short summary of the ticket
-
-## Full Ticket
-Full github ticket
+* Related to https://github.com/infection/infection/issues/1380

--- a/tests/e2e/YieldValue/composer.json
+++ b/tests/e2e/YieldValue/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.3.11"
+    },
+    "autoload": {
+        "psr-4": {
+            "YieldValue\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "YieldValue\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/e2e/YieldValue/expected-output.txt
+++ b/tests/e2e/YieldValue/expected-output.txt
@@ -1,0 +1,8 @@
+Total: 1
+
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Skipped: 0
+Not Covered: 0

--- a/tests/e2e/YieldValue/expected-output.txt
+++ b/tests/e2e/YieldValue/expected-output.txt
@@ -1,6 +1,6 @@
 # Effects per Mutator
 
-| Mutator          | Mutations | Killed | Escaped | Errors | Timed Out | Skipped | MSI (%s) | Covered MSI (%s) |
-| ---------------- | --------- | ------ | ------- | ------ | --------- | ------- | -------- | ---------------- |
-| PublicVisibility |         1 |      1 |       0 |      0 |         0 |       0 |   100.00 |           100.00 |
-| Yield_           |         2 |      1 |       0 |      0 |         0 |       0 |    50.00 |           100.00 |
+| Mutator    | Mutations | Killed | Escaped | Errors | Timed Out | Skipped | MSI (%s) | Covered MSI (%s) |
+| ---------- | --------- | ------ | ------- | ------ | --------- | ------- | -------- | ---------------- |
+| YieldValue |         2 |      1 |       0 |      0 |         0 |       0 |    50.00 |           100.00 |
+| Yield_     |         2 |      1 |       0 |      0 |         0 |       0 |    50.00 |           100.00 |

--- a/tests/e2e/YieldValue/expected-output.txt
+++ b/tests/e2e/YieldValue/expected-output.txt
@@ -1,8 +1,6 @@
-Total: 1
+# Effects per Mutator
 
-Killed: 1
-Errored: 0
-Escaped: 0
-Timed Out: 0
-Skipped: 0
-Not Covered: 0
+| Mutator          | Mutations | Killed | Escaped | Errors | Timed Out | Skipped | MSI (%s) | Covered MSI (%s) |
+| ---------------- | --------- | ------ | ------- | ------ | --------- | ------- | -------- | ---------------- |
+| PublicVisibility |         1 |      1 |       0 |      0 |         0 |       0 |   100.00 |           100.00 |
+| Yield_           |         2 |      1 |       0 |      0 |         0 |       0 |    50.00 |           100.00 |

--- a/tests/e2e/YieldValue/infection.json
+++ b/tests/e2e/YieldValue/infection.json
@@ -5,6 +5,10 @@
             "src"
         ]
     },
+    "mutators": {
+        "Yield_": true,
+        "YieldValue": true
+    },
     "logs": {
         "perMutator": "infection.log"
     },

--- a/tests/e2e/YieldValue/infection.json
+++ b/tests/e2e/YieldValue/infection.json
@@ -1,0 +1,13 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log",
+        "text": "infection.txt"
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/YieldValue/infection.json
+++ b/tests/e2e/YieldValue/infection.json
@@ -6,8 +6,7 @@
         ]
     },
     "logs": {
-        "summary": "infection.log",
-        "text": "infection.txt"
+        "perMutator": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/e2e/YieldValue/phpunit.xml
+++ b/tests/e2e/YieldValue/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/schema/9.2.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/e2e/YieldValue/src/SourceClass.php
+++ b/tests/e2e/YieldValue/src/SourceClass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace YieldValue;
+
+class SourceClass
+{
+    public function hello(): \Generator
+    {
+        $key = 'key';
+        $value = 'value';
+
+        $a = function () {
+            $a = 'a';
+            $b = 'b';
+            (yield $a => $b);
+        };
+
+        yield $key => $value;
+    }
+}

--- a/tests/e2e/YieldValue/tests/SourceClassTest.php
+++ b/tests/e2e/YieldValue/tests/SourceClassTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace YieldValue\Test;
+
+use YieldValue\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $result = $sourceClass->hello();
+
+        foreach ($result as $key => $value) {
+            self::assertSame('key', $key);
+            self::assertSame('value', $value);
+        }
+    }
+}


### PR DESCRIPTION
This PR:

 - [x] Adds Psalm to the pipeline to ensure `Mutator::mutate()` methods are [mutations-free AKA pure](https://psalm.dev/articles/immutability-and-beyond).
 - [x] Fixes existing issues with `YieldValue` and `Yield_`
 - [x] Refactors this and that
 - [x] Covered by tests
 - [x] Fixes #1380

