### PR TITLE
Add `ignoreSourceCodeByRegex` key for custom mutator definitions

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -199,6 +199,12 @@
                                         "type": "string"
                                     }
                                 },
+                                "ignoreSourceCodeByRegex": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
                                 "settings": {
                                     "type": "object",
                                     "additionalProperties": false,
@@ -253,6 +259,12 @@
                             "additionalProperties": false,
                             "properties": {
                                 "ignore": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "ignoreSourceCodeByRegex": {
                                     "type": "array",
                                     "items": {
                                         "type": "string"
@@ -358,6 +370,12 @@
                                         "type": "string"
                                     }
                                 },
+                                "ignoreSourceCodeByRegex": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
                                 "settings": {
                                     "type": "object",
                                     "additionalProperties": false,
@@ -405,6 +423,12 @@
                             "additionalProperties": false,
                             "properties": {
                                 "ignore": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "ignoreSourceCodeByRegex": {
                                     "type": "array",
                                     "items": {
                                         "type": "string"

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -1005,6 +1005,32 @@ JSON
             ]),
         ];
 
+        yield '[mutators][TrueValue] ignoreSourceCodeByRegex' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "mutators": {
+        "TrueValue": {
+            "ignoreSourceCodeByRegex": [".*test.*"]
+        }
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mutators' => [
+                    'TrueValue' => (object) [
+                        'ignoreSourceCodeByRegex' => [
+                            '.*test.*',
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
         yield '[mutators][TrueValue] empty & untrimmed ignore' => [
             <<<'JSON'
 {
@@ -1181,6 +1207,32 @@ JSON
                         'ignore' => [
                             'fileA',
                             'fileB',
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield '[mutators][ArrayItemRemoval] ignoreSourceCodeByRegex' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "mutators": {
+        "ArrayItemRemoval": {
+            "ignoreSourceCodeByRegex": [".*test.*"]
+        }
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mutators' => [
+                    'ArrayItemRemoval' => (object) [
+                        'ignoreSourceCodeByRegex' => [
+                            '.*test.*',
                         ],
                     ],
                 ],
@@ -1369,6 +1421,32 @@ JSON
             ]),
         ];
 
+        yield '[mutators][BCMath] ignoreSourceCodeByRegex' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "mutators": {
+        "BCMath": {
+            "ignoreSourceCodeByRegex": [".*test.*"]
+        }
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mutators' => [
+                    'BCMath' => (object) [
+                        'ignoreSourceCodeByRegex' => [
+                            '.*test.*',
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
         yield '[mutators][BCMath] empty & untrimmed ignore' => [
             <<<'JSON'
 {
@@ -1547,6 +1625,32 @@ JSON
                         'ignore' => [
                             'fileA',
                             'fileB',
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield '[mutators][MBString] ignoreSourceCodeByRegex' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "mutators": {
+        "MBString": {
+            "ignoreSourceCodeByRegex": [".*test.*"]
+        }
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mutators' => [
+                    'MBString' => (object) [
+                        'ignoreSourceCodeByRegex' => [
+                            '.*test.*',
                         ],
                     ],
                 ],


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/1384

The root error from 1384:

```
[mutators.ArrayItemRemoval] Object value found, but a boolean is required 
[mutators.ArrayItemRemoval] The property ignoreSourceCodeByRegex is not defined and the definition does not allow additional properties [mutators.ArrayItemRemoval] Failed to match at least one schema 
```

Currently, we have the following issue: when we add a new key to `default-mutator-config` definition, we have to add such key for *every* custom definition. This is what I forget to do, and this is what this PR does.

It fixes the issue, but we will definitely have the same issue in the future because someone will forget to add new key to custom definitions as well.

I tried to fix this second issue by using [Extending](https://json-schema.org/understanding-json-schema/structuring.html#extending) in JSON schema, but this brings new issues.

Let's get it merged to fix the issue, and discuss extending [in a separate PR](https://github.com/infection/infection/pull/1386).