### PR TITLE
Extend (reuse) JSON definitions to avoid issues where we have to duplicate part of the definitions

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -190,34 +190,25 @@
                             "type": "boolean"
                         },
                         {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "ignore": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "ignoreSourceCodeByRegex": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "settings": {
-                                    "type": "object",
-                                    "additionalProperties": false,
+                            "allOf": [
+                                { "$ref": "#/definitions/default-mutator-subconfig" },
+                                {
                                     "properties": {
-                                        "in_array": {
-                                            "type": "boolean"
-                                        },
-                                        "array_search": {
-                                            "type": "boolean"
+                                        "settings": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "in_array": {
+                                                    "type": "boolean"
+                                                },
+                                                "array_search": {
+                                                    "type": "boolean"
+                                                }
+                                            }
                                         }
                                     }
                                 }
-                            }
+                            ]
                         }
                     ]
                 },
@@ -255,40 +246,31 @@
                             "type": "boolean"
                         },
                         {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "ignore": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "ignoreSourceCodeByRegex": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "settings": {
-                                    "type": "object",
-                                    "additionalProperties": false,
+                            "allOf": [
+                                { "$ref": "#/definitions/default-mutator-subconfig" },
+                                {
                                     "properties": {
-                                        "remove": {
-                                            "type": "string",
-                                            "enum": [
-                                                "first",
-                                                "last",
-                                                "all"
-                                            ]
-                                        },
-                                        "limit": {
-                                            "type": "integer",
-                                            "minimum": 1
+                                        "settings": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "remove": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "first",
+                                                        "last",
+                                                        "all"
+                                                    ]
+                                                },
+                                                "limit": {
+                                                    "type": "integer",
+                                                    "minimum": 1
+                                                }
+                                            }
                                         }
                                     }
                                 }
-                            }
+                            ]
                         }
                     ]
                 },
@@ -361,55 +343,46 @@
                             "type": "boolean"
                         },
                         {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "ignore": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "ignoreSourceCodeByRegex": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "settings": {
-                                    "type": "object",
-                                    "additionalProperties": false,
+                            "allOf": [
+                                { "$ref": "#/definitions/default-mutator-subconfig" },
+                                {
                                     "properties": {
-                                        "bcadd": {
-                                            "type": "boolean"
-                                        },
-                                        "bccomp": {
-                                            "type": "boolean"
-                                        },
-                                        "bcdiv": {
-                                            "type": "boolean"
-                                        },
-                                        "bcmod": {
-                                            "type": "boolean"
-                                        },
-                                        "bcmul": {
-                                            "type": "boolean"
-                                        },
-                                        "bcpow": {
-                                            "type": "boolean"
-                                        },
-                                        "bcsub": {
-                                            "type": "boolean"
-                                        },
-                                        "bcsqrt": {
-                                            "type": "boolean"
-                                        },
-                                        "bcpowmod": {
-                                            "type": "boolean"
+                                        "settings": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "bcadd": {
+                                                    "type": "boolean"
+                                                },
+                                                "bccomp": {
+                                                    "type": "boolean"
+                                                },
+                                                "bcdiv": {
+                                                    "type": "boolean"
+                                                },
+                                                "bcmod": {
+                                                    "type": "boolean"
+                                                },
+                                                "bcmul": {
+                                                    "type": "boolean"
+                                                },
+                                                "bcpow": {
+                                                    "type": "boolean"
+                                                },
+                                                "bcsub": {
+                                                    "type": "boolean"
+                                                },
+                                                "bcsqrt": {
+                                                    "type": "boolean"
+                                                },
+                                                "bcpowmod": {
+                                                    "type": "boolean"
+                                                }
+                                            }
                                         }
                                     }
                                 }
-                            }
+                            ]
                         }
                     ]
                 },
@@ -419,82 +392,73 @@
                             "type": "boolean"
                         },
                         {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "ignore": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "ignoreSourceCodeByRegex": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "settings": {
-                                    "type": "object",
-                                    "additionalProperties": false,
+                            "allOf": [
+                                { "$ref": "#/definitions/default-mutator-subconfig" },
+                                {
                                     "properties": {
-                                        "mb_chr": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_ord": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_parse_str": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_send_mail": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_strcut": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_stripos": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_stristr": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_strlen": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_strpos": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_strrchr": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_strripos": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_strrpos": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_strstr": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_strtolower": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_strtoupper": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_substr_count": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_substr": {
-                                            "type": "boolean"
-                                        },
-                                        "mb_convert_case": {
-                                            "type": "boolean"
+                                        "settings": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "mb_chr": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_ord": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_parse_str": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_send_mail": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_strcut": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_stripos": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_stristr": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_strlen": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_strpos": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_strrchr": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_strripos": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_strrpos": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_strstr": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_strtolower": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_strtoupper": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_substr_count": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_substr": {
+                                                    "type": "boolean"
+                                                },
+                                                "mb_convert_case": {
+                                                    "type": "boolean"
+                                                }
+                                            }
                                         }
                                     }
                                 }
-                            }
+                            ]
                         }
                     ]
                 }
@@ -528,25 +492,25 @@
                 {
                     "type": "boolean"
                 },
-                {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ignore": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "ignoreSourceCodeByRegex": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
+                { "$ref": "#/definitions/default-mutator-subconfig" }
+            ]
+        },
+        "default-mutator-subconfig": {
+            "type": "object",
+            "properties": {
+                "ignore": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ignoreSourceCodeByRegex": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
-            ]
+            }
         }
     }
 }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -199,6 +199,12 @@
                                         "type": "string"
                                     }
                                 },
+                                "ignoreSourceCodeByRegex": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
                                 "settings": {
                                     "type": "object",
                                     "additionalProperties": false,
@@ -253,6 +259,12 @@
                             "additionalProperties": false,
                             "properties": {
                                 "ignore": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "ignoreSourceCodeByRegex": {
                                     "type": "array",
                                     "items": {
                                         "type": "string"
@@ -358,6 +370,12 @@
                                         "type": "string"
                                     }
                                 },
+                                "ignoreSourceCodeByRegex": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
                                 "settings": {
                                     "type": "object",
                                     "additionalProperties": false,
@@ -405,6 +423,12 @@
                             "additionalProperties": false,
                             "properties": {
                                 "ignore": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "ignoreSourceCodeByRegex": {
                                     "type": "array",
                                     "items": {
                                         "type": "string"

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -1005,6 +1005,32 @@ JSON
             ]),
         ];
 
+        yield '[mutators][TrueValue] ignoreSourceCodeByRegex' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "mutators": {
+        "TrueValue": {
+            "ignoreSourceCodeByRegex": [".*test.*"]
+        }
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mutators' => [
+                    'TrueValue' => (object) [
+                        'ignoreSourceCodeByRegex' => [
+                            '.*test.*',
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
         yield '[mutators][TrueValue] empty & untrimmed ignore' => [
             <<<'JSON'
 {
@@ -1181,6 +1207,32 @@ JSON
                         'ignore' => [
                             'fileA',
                             'fileB',
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield '[mutators][ArrayItemRemoval] ignoreSourceCodeByRegex' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "mutators": {
+        "ArrayItemRemoval": {
+            "ignoreSourceCodeByRegex": [".*test.*"]
+        }
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mutators' => [
+                    'ArrayItemRemoval' => (object) [
+                        'ignoreSourceCodeByRegex' => [
+                            '.*test.*',
                         ],
                     ],
                 ],
@@ -1369,6 +1421,32 @@ JSON
             ]),
         ];
 
+        yield '[mutators][BCMath] ignoreSourceCodeByRegex' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "mutators": {
+        "BCMath": {
+            "ignoreSourceCodeByRegex": [".*test.*"]
+        }
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mutators' => [
+                    'BCMath' => (object) [
+                        'ignoreSourceCodeByRegex' => [
+                            '.*test.*',
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
         yield '[mutators][BCMath] empty & untrimmed ignore' => [
             <<<'JSON'
 {
@@ -1547,6 +1625,32 @@ JSON
                         'ignore' => [
                             'fileA',
                             'fileB',
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        yield '[mutators][MBString] ignoreSourceCodeByRegex' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "mutators": {
+        "MBString": {
+            "ignoreSourceCodeByRegex": [".*test.*"]
+        }
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mutators' => [
+                    'MBString' => (object) [
+                        'ignoreSourceCodeByRegex' => [
+                            '.*test.*',
                         ],
                     ],
                 ],


### PR DESCRIPTION
This PR is to show how we can reuse definitions and [extend them](https://json-schema.org/understanding-json-schema/structuring.html#extending), by adding custom keys. (follow up to https://github.com/infection/infection/pull/1385)

But here we have a big issue from my POV:

when we are using extending via `allOf`, we can't use `"additionalProperties": false,`, because sub-schemas are applied one by one and the object gets rejected.

So, when we are using `allOf` - we have to remove `additionalProperties`, which introduces a potential bug when users can add not supported key.

More about it: http://json-schema.org/understanding-json-schema/reference/combining.html#allof

---

I don't know how to resolve it. From the link above:

>  There are some proposals to address this in the next version of the JSON schema specification.

Seems like we can't use `allOf` in our case, unfortunately.

But if someone knows how to do it - please let me know.