### PR TITLE
Add Flip Coalesce operator mutator

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -247,6 +247,7 @@
                 "Throw_": { "$ref": "#/definitions/default-mutator-config" },
                 "Finally_": { "$ref": "#/definitions/default-mutator-config" },
                 "Coalesce": { "$ref": "#/definitions/default-mutator-config" },
+                "FlipCoalesce": { "$ref": "#/definitions/default-mutator-config" },
                 "PregQuote": { "$ref": "#/definitions/default-mutator-config" },
                 "PregMatchMatches": { "$ref": "#/definitions/default-mutator-config" },
                 "ArrayItemRemoval": {

--- a/src/Mutator/Operator/FlipCoalesce.php
+++ b/src/Mutator/Operator/FlipCoalesce.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Operator;
+
+use Infection\Mutator\Definition;
+use Infection\Mutator\GetMutatorName;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\MutatorCategory;
+use PhpParser\Node;
+
+/**
+ * @internal
+ */
+final class FlipCoalesce implements Mutator
+{
+    use GetMutatorName;
+
+    public static function getDefinition(): ?Definition
+    {
+        return new Definition(
+            <<<'TXT'
+Swaps the coalesce operator (`??`) operands,
+e.g. replaces `$a ?? $b` with `$b ?? $a` or `$a ?? $b ?? $c` with `$b ?? $a ?? $c` and `$a ?? $c ?? $b`.
+TXT
+            ,
+            MutatorCategory::ORTHOGONAL_REPLACEMENT,
+            null
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @param Node\Expr\BinaryOp\Coalesce $node
+     *
+     * @return iterable<Node\Expr>
+     */
+    public function mutate(Node $node): iterable
+    {
+        $left = $node->left;
+        $right = $node->right;
+
+        if ($right instanceof Node\Expr\BinaryOp\Coalesce) {
+            $left = new Node\Expr\BinaryOp\Coalesce($node->left, $right->right, $right->getAttributes());
+            $right = $right->left;
+        }
+
+        yield new Node\Expr\BinaryOp\Coalesce($right, $left, $node->getAttributes());
+    }
+
+    public function canMutate(Node $node): bool
+    {
+        return $node instanceof Node\Expr\BinaryOp\Coalesce;
+    }
+}

--- a/src/Mutator/Operator/FlipCoalesce.php
+++ b/src/Mutator/Operator/FlipCoalesce.php
@@ -83,6 +83,8 @@ TXT
 
     public function canMutate(Node $node): bool
     {
-        return $node instanceof Node\Expr\BinaryOp\Coalesce;
+        return $node instanceof Node\Expr\BinaryOp\Coalesce
+            && !$node->left instanceof Node\Expr\ConstFetch
+            && !$node->left instanceof Node\Expr\ClassConstFetch;
     }
 }

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -156,6 +156,7 @@ final class ProfileList
         Mutator\Operator\Coalesce::class,
         Mutator\Operator\Continue_::class,
         Mutator\Operator\Finally_::class,
+        Mutator\Operator\FlipCoalesce::class,
         Mutator\Operator\Spread::class,
         Mutator\Operator\Throw_::class,
     ];
@@ -344,6 +345,7 @@ final class ProfileList
         'Coalesce' => Mutator\Operator\Coalesce::class,
         'Continue_' => Mutator\Operator\Continue_::class,
         'Finally_' => Mutator\Operator\Finally_::class,
+        'FlipCoalesce' => Mutator\Operator\FlipCoalesce::class,
         'Spread' => Mutator\Operator\Spread::class,
         'Throw_' => Mutator\Operator\Throw_::class,
 

--- a/tests/phpunit/Mutator/Operator/FlipCoalesceTest.php
+++ b/tests/phpunit/Mutator/Operator/FlipCoalesceTest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Operator;
+
+use Infection\Tests\Mutator\BaseMutatorTestCase;
+
+final class FlipCoalesceTest extends BaseMutatorTestCase
+{
+    /**
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
+     */
+    public function test_it_can_mutate(string $input, $expected = []): void
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function mutationsProvider(): iterable
+    {
+        yield 'Mutate coalesce and flip operands' => [
+            <<<'PHP'
+<?php
+
+$foo = 'foo';
+$bar = 'bar';
+$foo ?? $bar;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$foo = 'foo';
+$bar = 'bar';
+$bar ?? $foo;
+PHP
+        ];
+
+        yield 'Mutate more than one coalesce operators and flip operands' => [
+            <<<'PHP'
+<?php
+
+$foo = 'foo';
+$bar = 'bar';
+$baz = 'baz';
+$foo ?? $bar ?? $baz;
+PHP
+            ,
+            [
+                <<<'PHP'
+<?php
+
+$foo = 'foo';
+$bar = 'bar';
+$baz = 'baz';
+$foo ?? $baz ?? $bar;
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$foo = 'foo';
+$bar = 'bar';
+$baz = 'baz';
+$bar ?? $foo ?? $baz;
+PHP
+            ],
+        ];
+
+        yield 'Mutate more than two coalesce operators and flip operands' => [
+            <<<'PHP'
+<?php
+
+$foo = 'foo';
+$bar = 'bar';
+$baz = 'baz';
+$foo ?? $bar ?? $baz ?? 'oof';
+PHP
+            ,
+            [
+                <<<'PHP'
+<?php
+
+$foo = 'foo';
+$bar = 'bar';
+$baz = 'baz';
+$foo ?? $bar ?? 'oof' ?? $baz;
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$foo = 'foo';
+$bar = 'bar';
+$baz = 'baz';
+$foo ?? $baz ?? $bar ?? 'oof';
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$foo = 'foo';
+$bar = 'bar';
+$baz = 'baz';
+$bar ?? $foo ?? $baz ?? 'oof';
+PHP
+            ],
+        ];
+    }
+}

--- a/tests/phpunit/Mutator/Operator/FlipCoalesceTest.php
+++ b/tests/phpunit/Mutator/Operator/FlipCoalesceTest.php
@@ -139,5 +139,29 @@ $bar ?? $foo ?? $baz ?? 'oof';
 PHP
             ],
         ];
+
+        yield 'It does not mutate when left operator is constant defined through `define` function' => [
+            <<<'PHP'
+<?php
+
+define('FOO', 'foo');
+FOO ?? 'bar';
+PHP
+        ];
+
+        yield 'It does not mutate when left operator is constant defined in class' => [
+            <<<'PHP'
+<?php
+
+new class {
+    private const FOO = 'foo';
+
+    public function getFoo(): string
+    {
+        return self::FOO ?? 'bar';
+    }
+};
+PHP
+        ];
     }
 }


### PR DESCRIPTION
This PR:

- [x] Adds new FlipCoalesce mutator
- [x] Covered by tests
- [x] Schema needs an update
- [x] Doc PR: https://github.com/infection/site/pull/185

Mutates:
```diff
$foo = 'foo';
$bar = 'bar';
- $foo ?? $bar;
+ $bar ?? $foo;
```
```diff
$foo = 'foo';
$bar = 'bar';
$baz = 'baz';
- $foo ?? $bar ?? $baz;
+ $foo ?? $baz ?? $bar;
```
```diff
$foo = 'foo';
$bar = 'bar';
$baz = 'baz';
- $foo ?? $bar ?? $baz;
+ $bar ?? $foo ?? $baz;
```

Requested in https://github.com/infection/infection/issues/1387

p.s. From my POV `Infection\Mutator\Operator\Coalesce` mutator is redundant when this PR is merged. Thoughts?