### PR TITLE
Add native types to class properties, by Rector PHP

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -47,10 +47,7 @@ use Webmozart\Assert\Assert;
  */
 abstract class BaseCommand extends Command
 {
-    /**
-     * @var IO|null
-     */
-    private $io;
+    private ?IO $io = null;
 
     final public function getApplication(): Application
     {

--- a/src/Config/ConsoleHelper.php
+++ b/src/Config/ConsoleHelper.php
@@ -44,7 +44,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ConsoleHelper
 {
-    private $formatterHelper;
+    private FormatterHelper $formatterHelper;
 
     public function __construct(FormatterHelper $formatterHelper)
     {

--- a/src/Config/Guesser/PhpUnitPathGuesser.php
+++ b/src/Config/Guesser/PhpUnitPathGuesser.php
@@ -44,7 +44,7 @@ final class PhpUnitPathGuesser
 {
     private const CURRENT_DIR_PATH = '.';
 
-    private $composerJsonContent;
+    private stdClass $composerJsonContent;
 
     public function __construct(stdClass $composerJsonContent)
     {

--- a/src/Config/Guesser/SourceDirGuesser.php
+++ b/src/Config/Guesser/SourceDirGuesser.php
@@ -48,7 +48,7 @@ use stdClass;
  */
 class SourceDirGuesser
 {
-    private $composerJsonContent;
+    private stdClass $composerJsonContent;
 
     public function __construct(stdClass $composerJsonContent)
     {

--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -55,9 +55,9 @@ final class ExcludeDirsProvider
 {
     public const EXCLUDED_ROOT_DIRS = ['vendor', 'tests', 'test'];
 
-    private $consoleHelper;
-    private $questionHelper;
-    private $filesystem;
+    private ConsoleHelper $consoleHelper;
+    private QuestionHelper $questionHelper;
+    private Filesystem $filesystem;
 
     public function __construct(ConsoleHelper $consoleHelper, QuestionHelper $questionHelper, Filesystem $filesystem)
     {

--- a/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
+++ b/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
@@ -55,9 +55,9 @@ use function trim;
  */
 final class PhpUnitCustomExecutablePathProvider
 {
-    private $phpUnitExecutableFinder;
-    private $consoleHelper;
-    private $questionHelper;
+    private TestFrameworkFinder $phpUnitExecutableFinder;
+    private ConsoleHelper $consoleHelper;
+    private QuestionHelper $questionHelper;
 
     public function __construct(TestFrameworkFinder $phpUnitExecutableFinder, ConsoleHelper $consoleHelper, QuestionHelper $questionHelper)
     {

--- a/src/Config/ValueProvider/SourceDirsProvider.php
+++ b/src/Config/ValueProvider/SourceDirsProvider.php
@@ -53,9 +53,9 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
  */
 final class SourceDirsProvider
 {
-    private $consoleHelper;
-    private $questionHelper;
-    private $sourceDirGuesser;
+    private ConsoleHelper $consoleHelper;
+    private QuestionHelper $questionHelper;
+    private SourceDirGuesser $sourceDirGuesser;
 
     public function __construct(
         ConsoleHelper $consoleHelper,

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -55,9 +55,9 @@ use Symfony\Component\Console\Question\Question;
  */
 final class TestFrameworkConfigPathProvider
 {
-    private $testFrameworkConfigLocator;
-    private $consoleHelper;
-    private $questionHelper;
+    private TestFrameworkConfigLocatorInterface $testFrameworkConfigLocator;
+    private ConsoleHelper $consoleHelper;
+    private QuestionHelper $questionHelper;
 
     public function __construct(TestFrameworkConfigLocatorInterface $testFrameworkConfigLocator, ConsoleHelper $consoleHelper, QuestionHelper $questionHelper)
     {

--- a/src/Config/ValueProvider/TextLogFileProvider.php
+++ b/src/Config/ValueProvider/TextLogFileProvider.php
@@ -47,8 +47,8 @@ final class TextLogFileProvider
 {
     public const TEXT_LOG_FILE_NAME = 'infection.log';
 
-    private $consoleHelper;
-    private $questionHelper;
+    private ConsoleHelper $consoleHelper;
+    private QuestionHelper $questionHelper;
 
     public function __construct(ConsoleHelper $consoleHelper, QuestionHelper $questionHelper)
     {

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -54,34 +54,39 @@ class Configuration
         'default',
     ];
 
-    private $timeout;
-    private $sourceDirectories;
-    private $sourceFiles;
-    private $sourceFilesFilter;
-    private $sourceFilesExcludes;
-    private $logs;
-    private $logVerbosity;
-    private $tmpDir;
-    private $phpUnit;
-    private $mutators;
-    private $testFramework;
-    private $bootstrap;
-    private $initialTestsPhpOptions;
-    private $testFrameworkExtraOptions;
-    private $coveragePath;
-    private $skipCoverage;
-    private $skipInitialTests;
-    private $debug;
-    private $onlyCovered;
-    private $noProgress;
-    private $ignoreMsiWithNoMutations;
-    private $minMsi;
-    private $showMutations;
-    private $minCoveredMsi;
-    private $msiPrecision;
-    private $threadCount;
-    private $dryRun;
-    private $ignoreSourceCodeMutatorsMap;
+    private float $timeout;
+    /** @var string[] */
+    private array $sourceDirectories;
+    /** @var iterable<SplFileInfo> */
+    private iterable $sourceFiles;
+    private string $sourceFilesFilter;
+    /** @var string[] */
+    private array $sourceFilesExcludes;
+    private Logs $logs;
+    private string $logVerbosity;
+    private string $tmpDir;
+    private PhpUnit $phpUnit;
+    /** @var array<string, Mutator> */
+    private array $mutators;
+    private string $testFramework;
+    private ?string $bootstrap = null;
+    private ?string $initialTestsPhpOptions = null;
+    private string $testFrameworkExtraOptions;
+    private string $coveragePath;
+    private bool $skipCoverage;
+    private bool $skipInitialTests;
+    private bool $debug;
+    private bool $onlyCovered;
+    private bool $noProgress;
+    private bool $ignoreMsiWithNoMutations;
+    private ?float $minMsi = null;
+    private bool $showMutations;
+    private ?float $minCoveredMsi = null;
+    private int $msiPrecision;
+    private int $threadCount;
+    private bool $dryRun;
+    /** @var array<string, array<int, string>> */
+    private array $ignoreSourceCodeMutatorsMap;
 
     /**
      * @param string[] $sourceDirectories

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -65,12 +65,12 @@ class ConfigurationFactory
      */
     private const DEFAULT_TIMEOUT = 10;
 
-    private $tmpDirProvider;
-    private $mutatorResolver;
-    private $mutatorFactory;
-    private $mutatorParser;
-    private $sourceFileCollector;
-    private $ciDetector;
+    private TmpDirProvider $tmpDirProvider;
+    private MutatorResolver $mutatorResolver;
+    private MutatorFactory $mutatorFactory;
+    private MutatorParser $mutatorParser;
+    private SourceFileCollector $sourceFileCollector;
+    private CiDetector $ciDetector;
 
     public function __construct(
         TmpDirProvider $tmpDirProvider,

--- a/src/Configuration/Entry/Badge.php
+++ b/src/Configuration/Entry/Badge.php
@@ -40,7 +40,7 @@ namespace Infection\Configuration\Entry;
  */
 final class Badge
 {
-    private $branch;
+    private string $branch;
 
     public function __construct(string $branch)
     {

--- a/src/Configuration/Entry/Logs.php
+++ b/src/Configuration/Entry/Logs.php
@@ -40,12 +40,12 @@ namespace Infection\Configuration\Entry;
  */
 final class Logs
 {
-    private $textLogFilePath;
-    private $summaryLogFilePath;
-    private $jsonLogFilePath;
-    private $debugLogFilePath;
-    private $perMutatorFilePath;
-    private $badge;
+    private ?string $textLogFilePath;
+    private ?string $summaryLogFilePath;
+    private ?string $jsonLogFilePath;
+    private ?string $debugLogFilePath;
+    private ?string $perMutatorFilePath;
+    private ?Badge $badge;
 
     public function __construct(
         ?string $textLogFilePath,

--- a/src/Configuration/Entry/PhpUnit.php
+++ b/src/Configuration/Entry/PhpUnit.php
@@ -40,8 +40,8 @@ namespace Infection\Configuration\Entry;
  */
 final class PhpUnit
 {
-    private $configDir;
-    private $customPath;
+    private ?string $configDir;
+    private ?string $customPath;
 
     public function __construct(?string $configDir, ?string $executablePath)
     {

--- a/src/Configuration/Entry/Source.php
+++ b/src/Configuration/Entry/Source.php
@@ -42,8 +42,10 @@ use Webmozart\Assert\Assert;
  */
 final class Source
 {
-    private $directories;
-    private $excludes;
+    /** @var string[] */
+    private array $directories;
+    /** @var string[] */
+    private array $excludes;
 
     /**
      * @param string[] $directories

--- a/src/Configuration/Schema/SchemaConfiguration.php
+++ b/src/Configuration/Schema/SchemaConfiguration.php
@@ -46,20 +46,21 @@ use Webmozart\Assert\Assert;
  */
 final class SchemaConfiguration
 {
-    private $file;
-    private $timeout;
-    private $source;
-    private $logs;
-    private $tmpDir;
-    private $phpUnit;
-    private $ignoreMsiWithNoMutations;
-    private $minMsi;
-    private $minCoveredMsi;
-    private $mutators;
-    private $testFramework;
-    private $bootstrap;
-    private $initialTestsPhpOptions;
-    private $testFrameworkExtraOptions;
+    private string $file;
+    private ?float $timeout;
+    private Source $source;
+    private Logs $logs;
+    private ?string $tmpDir;
+    private PhpUnit $phpUnit;
+    private ?bool $ignoreMsiWithNoMutations;
+    private ?float $minMsi;
+    private ?float $minCoveredMsi;
+    /** @var array<string, mixed> */
+    private array $mutators;
+    private ?string $testFramework;
+    private ?string $bootstrap;
+    private ?string $initialTestsPhpOptions;
+    private ?string $testFrameworkExtraOptions;
 
     /**
      * @param array<string, mixed> $mutators

--- a/src/Configuration/Schema/SchemaConfigurationFile.php
+++ b/src/Configuration/Schema/SchemaConfigurationFile.php
@@ -47,12 +47,9 @@ use stdClass;
  */
 final class SchemaConfigurationFile
 {
-    private $path;
+    private string $path;
 
-    /**
-     * @var stdClass|null
-     */
-    private $decodedContents;
+    private ?stdClass $decodedContents = null;
 
     public function __construct(string $path)
     {

--- a/src/Configuration/Schema/SchemaConfigurationFileLoader.php
+++ b/src/Configuration/Schema/SchemaConfigurationFileLoader.php
@@ -40,8 +40,8 @@ namespace Infection\Configuration\Schema;
  */
 class SchemaConfigurationFileLoader
 {
-    private $schemaValidator;
-    private $factory;
+    private SchemaValidator $schemaValidator;
+    private SchemaConfigurationFactory $factory;
 
     public function __construct(SchemaValidator $schemaValidator, SchemaConfigurationFactory $factory)
     {

--- a/src/Configuration/Schema/SchemaConfigurationLoader.php
+++ b/src/Configuration/Schema/SchemaConfigurationLoader.php
@@ -45,8 +45,8 @@ final class SchemaConfigurationLoader
     public const DEFAULT_DIST_CONFIG_FILE = 'infection.json.dist';
     public const DEFAULT_CONFIG_FILE = 'infection.json';
 
-    private $locator;
-    private $fileLoader;
+    private Locator $locator;
+    private SchemaConfigurationFileLoader $fileLoader;
 
     public function __construct(Locator $locator, SchemaConfigurationFileLoader $fileLoader)
     {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -67,7 +67,7 @@ final class Application extends BaseApplication
 
 ';
 
-    private $container;
+    private Container $container;
 
     public function __construct(Container $container)
     {

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -49,7 +49,7 @@ class ConsoleOutput
     private const RUNNING_WITH_DEBUGGER_NOTE = 'You are running Infection with %s enabled.';
     private const MIN_MSI_CAN_GET_INCREASED_NOTICE = 'The %s is %s%% percentage points over the required %s. Consider increasing the required %s percentage the next time you run Infection.';
 
-    private $logger;
+    private ConsoleLogger $logger;
 
     public function __construct(ConsoleLogger $logger)
     {

--- a/src/Console/IO.php
+++ b/src/Console/IO.php
@@ -46,8 +46,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 final class IO extends SymfonyStyle
 {
-    private $input;
-    private $output;
+    private InputInterface $input;
+    private OutputInterface $output;
 
     public function __construct(InputInterface $input, OutputInterface $output)
     {

--- a/src/Console/OutputFormatter/AbstractOutputFormatter.php
+++ b/src/Console/OutputFormatter/AbstractOutputFormatter.php
@@ -49,10 +49,7 @@ abstract class AbstractOutputFormatter implements OutputFormatter
      */
     public const UNKNOWN_COUNT = 0;
 
-    /**
-     * @var int
-     */
-    protected $callsCount = 0;
+    protected int $callsCount = 0;
 
     public function start(int $mutationCount): void
     {

--- a/src/Console/OutputFormatter/DotFormatter.php
+++ b/src/Console/OutputFormatter/DotFormatter.php
@@ -49,7 +49,7 @@ final class DotFormatter extends AbstractOutputFormatter
 {
     private const DOTS_PER_ROW = 50;
 
-    private $output;
+    private OutputInterface $output;
 
     public function __construct(OutputInterface $output)
     {

--- a/src/Console/OutputFormatter/FormatterFactory.php
+++ b/src/Console/OutputFormatter/FormatterFactory.php
@@ -47,7 +47,7 @@ use Webmozart\Assert\Assert;
  */
 final class FormatterFactory
 {
-    private $output;
+    private OutputInterface $output;
 
     public function __construct(OutputInterface $output)
     {

--- a/src/Console/OutputFormatter/ProgressFormatter.php
+++ b/src/Console/OutputFormatter/ProgressFormatter.php
@@ -43,7 +43,7 @@ use Symfony\Component\Console\Helper\ProgressBar;
  */
 final class ProgressFormatter extends AbstractOutputFormatter
 {
-    private $progressBar;
+    private ProgressBar $progressBar;
 
     public function __construct(ProgressBar $progressBar)
     {

--- a/src/Container.php
+++ b/src/Container.php
@@ -172,22 +172,19 @@ final class Container
     /**
      * @var array<class-string<object>, true>
      */
-    private $keys = [];
+    private array $keys = [];
 
     /**
      * @var array<class-string<object>, object>
      */
-    private $values = [];
+    private array $values = [];
 
     /**
      * @var array<class-string<object>, Closure(self): object>
      */
-    private $factories = [];
+    private array $factories = [];
 
-    /**
-     * @var string|null
-     */
-    private $defaultJUnitPath;
+    private ?string $defaultJUnitPath = null;
 
     /**
      * @param array<class-string<object>, Closure(self): object> $values

--- a/src/Differ/Differ.php
+++ b/src/Differ/Differ.php
@@ -47,7 +47,7 @@ use SebastianBergmann\Diff\Differ as BaseDiffer;
  */
 class Differ
 {
-    private $differ;
+    private BaseDiffer $differ;
 
     public function __construct(BaseDiffer $differ)
     {

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -60,18 +60,18 @@ use Infection\TestFramework\TestFrameworkExtraOptionsFilter;
  */
 final class Engine
 {
-    private $config;
-    private $adapter;
-    private $coverageChecker;
-    private $eventDispatcher;
-    private $initialTestsRunner;
-    private $memoryLimiter;
-    private $mutationGenerator;
-    private $mutationTestingRunner;
-    private $minMsiChecker;
-    private $consoleOutput;
-    private $metricsCalculator;
-    private $testFrameworkExtraOptionsFilter;
+    private Configuration $config;
+    private TestFrameworkAdapter $adapter;
+    private CoverageChecker $coverageChecker;
+    private EventDispatcher $eventDispatcher;
+    private InitialTestsRunner $initialTestsRunner;
+    private MemoryLimiter $memoryLimiter;
+    private MutationGenerator $mutationGenerator;
+    private MutationTestingRunner $mutationTestingRunner;
+    private MinMsiChecker $minMsiChecker;
+    private ConsoleOutput $consoleOutput;
+    private MetricsCalculator $metricsCalculator;
+    private TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter;
 
     public function __construct(
         Configuration $config,

--- a/src/Environment/BuildContext.php
+++ b/src/Environment/BuildContext.php
@@ -40,8 +40,8 @@ namespace Infection\Environment;
  */
 final class BuildContext
 {
-    private $repositorySlug;
-    private $branch;
+    private string $repositorySlug;
+    private string $branch;
 
     public function __construct(string $repositorySlug, string $branch)
     {

--- a/src/Environment/BuildContextResolver.php
+++ b/src/Environment/BuildContextResolver.php
@@ -44,7 +44,7 @@ use function trim;
  */
 final class BuildContextResolver
 {
-    private $ciDetector;
+    private CiDetector $ciDetector;
 
     public function __construct(CiDetector $ciDetector)
     {

--- a/src/Event/EventDispatcher/SyncEventDispatcher.php
+++ b/src/Event/EventDispatcher/SyncEventDispatcher.php
@@ -50,7 +50,7 @@ final class SyncEventDispatcher implements EventDispatcher
     /**
      * @var callable[][]
      */
-    private $listeners = [];
+    private array $listeners = [];
 
     public function dispatch(object $event): void
     {

--- a/src/Event/InitialTestSuiteWasFinished.php
+++ b/src/Event/InitialTestSuiteWasFinished.php
@@ -40,7 +40,7 @@ namespace Infection\Event;
  */
 final class InitialTestSuiteWasFinished
 {
-    private $outputText;
+    private string $outputText;
 
     public function __construct(string $outputText)
     {

--- a/src/Event/MutantProcessWasFinished.php
+++ b/src/Event/MutantProcessWasFinished.php
@@ -43,7 +43,7 @@ use Infection\Mutant\MutantExecutionResult;
  */
 class MutantProcessWasFinished
 {
-    private $executionResult;
+    private MutantExecutionResult $executionResult;
 
     public function __construct(MutantExecutionResult $executionResult)
     {

--- a/src/Event/MutationGenerationWasStarted.php
+++ b/src/Event/MutationGenerationWasStarted.php
@@ -40,7 +40,7 @@ namespace Infection\Event;
  */
 final class MutationGenerationWasStarted
 {
-    private $mutableFilesCount;
+    private int $mutableFilesCount;
 
     public function __construct(int $mutableFilesCount)
     {

--- a/src/Event/MutationTestingWasStarted.php
+++ b/src/Event/MutationTestingWasStarted.php
@@ -40,7 +40,7 @@ namespace Infection\Event;
  */
 final class MutationTestingWasStarted
 {
-    private $mutationCount;
+    private int $mutationCount;
 
     public function __construct(int $mutationCount)
     {

--- a/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
@@ -46,8 +46,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class CiInitialTestsConsoleLoggerSubscriber implements EventSubscriber
 {
-    private $output;
-    private $testFrameworkAdapter;
+    private OutputInterface $output;
+    private TestFrameworkAdapter $testFrameworkAdapter;
 
     public function __construct(OutputInterface $output, TestFrameworkAdapter $testFrameworkAdapter)
     {

--- a/src/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriber.php
@@ -44,7 +44,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class CiMutationGeneratingConsoleLoggerSubscriber implements EventSubscriber
 {
-    private $output;
+    private OutputInterface $output;
 
     public function __construct(OutputInterface $output)
     {

--- a/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php
+++ b/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php
@@ -43,8 +43,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class CleanUpAfterMutationTestingFinishedSubscriber implements EventSubscriber
 {
-    private $filesystem;
-    private $tmpDir;
+    private Filesystem $filesystem;
+    private string $tmpDir;
 
     public function __construct(Filesystem $filesystem, string $tmpDir)
     {

--- a/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactory.php
+++ b/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactory.php
@@ -43,9 +43,9 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class CleanUpAfterMutationTestingFinishedSubscriberFactory implements SubscriberFactory
 {
-    private $debug;
-    private $fileSystem;
-    private $tmpDir;
+    private bool $debug;
+    private Filesystem $fileSystem;
+    private string $tmpDir;
 
     public function __construct(bool $debug, Filesystem $fileSystem, string $tmpDir)
     {

--- a/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriber.php
@@ -49,10 +49,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class InitialTestsConsoleLoggerSubscriber implements EventSubscriber
 {
-    private $output;
-    private $progressBar;
-    private $testFrameworkAdapter;
-    private $debug;
+    private OutputInterface $output;
+    private ProgressBar $progressBar;
+    private TestFrameworkAdapter $testFrameworkAdapter;
+    private bool $debug;
 
     public function __construct(OutputInterface $output, TestFrameworkAdapter $testFrameworkAdapter, bool $debug)
     {

--- a/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriberFactory.php
@@ -43,9 +43,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class InitialTestsConsoleLoggerSubscriberFactory implements SubscriberFactory
 {
-    private $skipProgressBar;
-    private $testFrameworkAdapter;
-    private $debug;
+    private bool $skipProgressBar;
+    private TestFrameworkAdapter $testFrameworkAdapter;
+    private bool $debug;
 
     public function __construct(
         bool $skipProgressBar,

--- a/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriber.php
@@ -46,8 +46,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutationGeneratingConsoleLoggerSubscriber implements EventSubscriber
 {
-    private $output;
-    private $progressBar;
+    private OutputInterface $output;
+    private ProgressBar $progressBar;
 
     public function __construct(OutputInterface $output)
     {

--- a/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriberFactory.php
@@ -42,7 +42,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutationGeneratingConsoleLoggerSubscriberFactory implements SubscriberFactory
 {
-    private $skipProgressBar;
+    private bool $skipProgressBar;
 
     public function __construct(bool $skipProgressBar)
     {

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -56,16 +56,13 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
 {
     private const PAD_LENGTH = 8;
 
-    private $output;
-    private $outputFormatter;
-    private $metricsCalculator;
-    private $showMutations;
-    private $diffColorizer;
+    private OutputInterface $output;
+    private OutputFormatter $outputFormatter;
+    private MetricsCalculator $metricsCalculator;
+    private bool $showMutations;
+    private DiffColorizer $diffColorizer;
 
-    /**
-     * @var int
-     */
-    private $mutationCount = 0;
+    private int $mutationCount = 0;
 
     public function __construct(
         OutputInterface $output,

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
@@ -45,10 +45,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutationTestingConsoleLoggerSubscriberFactory implements SubscriberFactory
 {
-    private $metricsCalculator;
-    private $diffColorizer;
-    private $showMutations;
-    private $formatter;
+    private MetricsCalculator $metricsCalculator;
+    private DiffColorizer $diffColorizer;
+    private bool $showMutations;
+    private OutputFormatter $formatter;
 
     public function __construct(
         MetricsCalculator $metricsCalculator,

--- a/src/Event/Subscriber/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingResultsLoggerSubscriber.php
@@ -43,7 +43,7 @@ use Infection\Logger\MutationTestingResultsLogger;
  */
 final class MutationTestingResultsLoggerSubscriber implements EventSubscriber
 {
-    private $logger;
+    private MutationTestingResultsLogger $logger;
 
     public function __construct(MutationTestingResultsLogger $logger)
     {

--- a/src/Event/Subscriber/MutationTestingResultsLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingResultsLoggerSubscriberFactory.php
@@ -44,8 +44,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutationTestingResultsLoggerSubscriberFactory implements SubscriberFactory
 {
-    private $loggerFactory;
-    private $logsConfig;
+    private LoggerFactory $loggerFactory;
+    private Logs $logsConfig;
 
     public function __construct(LoggerFactory $loggerFactory, Logs $logsConfig)
     {

--- a/src/Event/Subscriber/PerformanceLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/PerformanceLoggerSubscriberFactory.php
@@ -46,9 +46,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class PerformanceLoggerSubscriberFactory implements SubscriberFactory
 {
-    private $stopwatch;
-    private $timeFormatter;
-    private $memoryFormatter;
+    private Stopwatch $stopwatch;
+    private TimeFormatter $timeFormatter;
+    private MemoryFormatter $memoryFormatter;
 
     public function __construct(
         Stopwatch $stopwatch,

--- a/src/Event/Subscriber/SubscriberRegisterer.php
+++ b/src/Event/Subscriber/SubscriberRegisterer.php
@@ -43,8 +43,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class SubscriberRegisterer
 {
-    private $eventDispatcher;
-    private $subscriberRegistry;
+    private EventDispatcher $eventDispatcher;
+    private ChainSubscriberFactory $subscriberRegistry;
 
     public function __construct(
         EventDispatcher $eventDispatcher,

--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -63,7 +63,7 @@ class TestFrameworkFinder
     /**
      * @var array<string, string>
      */
-    private $cachedPath = [];
+    private array $cachedPath = [];
 
     public function find(string $testFrameworkName, string $customPath = ''): string
     {

--- a/src/FileSystem/Locator/RootsFileLocator.php
+++ b/src/FileSystem/Locator/RootsFileLocator.php
@@ -48,8 +48,9 @@ use Webmozart\PathUtil\Path;
  */
 final class RootsFileLocator implements Locator
 {
-    private $roots;
-    private $filesystem;
+    /** @var string[] */
+    private array $roots;
+    private \Symfony\Component\Filesystem\Filesystem $filesystem;
 
     /**
      * @param string[] $roots

--- a/src/FileSystem/Locator/RootsFileOrDirectoryLocator.php
+++ b/src/FileSystem/Locator/RootsFileOrDirectoryLocator.php
@@ -47,8 +47,9 @@ use Webmozart\PathUtil\Path;
  */
 final class RootsFileOrDirectoryLocator implements Locator
 {
-    private $roots;
-    private $filesystem;
+    /** @var string[] */
+    private array $roots;
+    private Filesystem $filesystem;
 
     /**
      * @param string[] $roots

--- a/src/FileSystem/SourceFileFilter.php
+++ b/src/FileSystem/SourceFileFilter.php
@@ -53,12 +53,12 @@ class SourceFileFilter implements FileFilter
     /**
      * @var string[]
      */
-    private $filters;
+    private array $filters;
 
     /**
      * @var string[]
      */
-    private $excludeDirectories;
+    private array $excludeDirectories;
 
     /**
      * @param string[] $excludeDirectories

--- a/src/Logger/BadgeLogger.php
+++ b/src/Logger/BadgeLogger.php
@@ -49,12 +49,12 @@ use function Safe\sprintf;
  */
 final class BadgeLogger implements MutationTestingResultsLogger
 {
-    private $buildContextResolver;
-    private $strykerApiKeyResolver;
-    private $strykerDashboardClient;
-    private $metricsCalculator;
-    private $branch;
-    private $logger;
+    private BuildContextResolver $buildContextResolver;
+    private StrykerApiKeyResolver $strykerApiKeyResolver;
+    private StrykerDashboardClient $strykerDashboardClient;
+    private MetricsCalculator $metricsCalculator;
+    private string $branch;
+    private LoggerInterface $logger;
 
     public function __construct(
         BuildContextResolver $buildContextResolver,

--- a/src/Logger/ConsoleLogger.php
+++ b/src/Logger/ConsoleLogger.php
@@ -86,7 +86,7 @@ final class ConsoleLogger extends AbstractLogger
         LogLevel::NOTICE => 'note',
     ];
 
-    private \Infection\Console\IO $io;
+    private IO $io;
 
     public function __construct(IO $io)
     {

--- a/src/Logger/ConsoleLogger.php
+++ b/src/Logger/ConsoleLogger.php
@@ -86,7 +86,7 @@ final class ConsoleLogger extends AbstractLogger
         LogLevel::NOTICE => 'note',
     ];
 
-    private $io;
+    private \Infection\Console\IO $io;
 
     public function __construct(IO $io)
     {

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -51,8 +51,8 @@ use function strlen;
  */
 final class DebugFileLogger implements LineMutationTestingResultsLogger
 {
-    private $metricsCalculator;
-    private $onlyCoveredMode;
+    private MetricsCalculator $metricsCalculator;
+    private bool $onlyCoveredMode;
 
     public function __construct(MetricsCalculator $metricsCalculator, bool $onlyCoveredMode)
     {

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -50,10 +50,10 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class FileLogger implements MutationTestingResultsLogger
 {
-    private $filePath;
-    private $fileSystem;
-    private $lineLogger;
-    private $logger;
+    private string $filePath;
+    private Filesystem $fileSystem;
+    private LineMutationTestingResultsLogger $lineLogger;
+    private LoggerInterface $logger;
 
     public function __construct(
         string $filePath,

--- a/src/Logger/Http/Response.php
+++ b/src/Logger/Http/Response.php
@@ -44,8 +44,8 @@ final class Response
 {
     public const CREATED_RESPONSE_CODE = 201;
 
-    private $statusCode;
-    private $body;
+    private int $statusCode;
+    private string $body;
 
     public function __construct(int $statusCode, string $body)
     {

--- a/src/Logger/Http/StrykerDashboardClient.php
+++ b/src/Logger/Http/StrykerDashboardClient.php
@@ -44,8 +44,8 @@ use function Safe\sprintf;
  */
 class StrykerDashboardClient
 {
-    private $client;
-    private $logger;
+    private StrykerCurlClient $client;
+    private LoggerInterface $logger;
 
     public function __construct(StrykerCurlClient $client, LoggerInterface $logger)
     {

--- a/src/Logger/JsonLogger.php
+++ b/src/Logger/JsonLogger.php
@@ -47,8 +47,8 @@ use function mb_convert_encoding;
  */
 final class JsonLogger implements LineMutationTestingResultsLogger
 {
-    private $metricsCalculator;
-    private $onlyCoveredMode;
+    private MetricsCalculator $metricsCalculator;
+    private bool $onlyCoveredMode;
 
     public function __construct(
         MetricsCalculator $metricsCalculator,

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -54,13 +54,13 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class LoggerFactory
 {
-    private $metricsCalculator;
-    private $filesystem;
-    private $logVerbosity;
-    private $debugMode;
-    private $onlyCoveredCode;
-    private $ciDetector;
-    private $logger;
+    private MetricsCalculator $metricsCalculator;
+    private Filesystem $filesystem;
+    private string $logVerbosity;
+    private bool $debugMode;
+    private bool $onlyCoveredCode;
+    private CiDetector $ciDetector;
+    private LoggerInterface $logger;
 
     public function __construct(
         MetricsCalculator $metricsCalculator,

--- a/src/Logger/PerMutatorLogger.php
+++ b/src/Logger/PerMutatorLogger.php
@@ -56,7 +56,7 @@ use function strlen;
  */
 final class PerMutatorLogger implements LineMutationTestingResultsLogger
 {
-    private $metricsCalculator;
+    private MetricsCalculator $metricsCalculator;
 
     public function __construct(MetricsCalculator $metricsCalculator)
     {

--- a/src/Logger/SummaryFileLogger.php
+++ b/src/Logger/SummaryFileLogger.php
@@ -45,7 +45,7 @@ use Infection\Metrics\MetricsCalculator;
  */
 final class SummaryFileLogger implements LineMutationTestingResultsLogger
 {
-    private $metricsCalculator;
+    private MetricsCalculator $metricsCalculator;
 
     public function __construct(MetricsCalculator $metricsCalculator)
     {

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -51,10 +51,10 @@ use function strlen;
  */
 final class TextFileLogger implements LineMutationTestingResultsLogger
 {
-    private $metricsCalculator;
-    private $debugVerbosity;
-    private $onlyCoveredMode;
-    private $debugMode;
+    private MetricsCalculator $metricsCalculator;
+    private bool $debugVerbosity;
+    private bool $onlyCoveredMode;
+    private bool $debugMode;
 
     public function __construct(
         MetricsCalculator $metricsCalculator,

--- a/src/Metrics/Calculator.php
+++ b/src/Metrics/Calculator.php
@@ -43,27 +43,18 @@ use function round;
  */
 final class Calculator
 {
-    private $roundingPrecision;
-    private $killedCount;
-    private $errorCount;
-    private $timedOutCount;
-    private $notTestedCount;
-    private $totalCount;
+    private int $roundingPrecision;
+    private int $killedCount;
+    private int $errorCount;
+    private int $timedOutCount;
+    private int $notTestedCount;
+    private int $totalCount;
 
-    /**
-     * @var float|null
-     */
-    private $mutationScoreIndicator;
+    private ?float $mutationScoreIndicator = null;
 
-    /**
-     * @var float|null
-     */
-    private $coverageRate;
+    private ?float $coverageRate = null;
 
-    /**
-     * @var float|null
-     */
-    private $coveredMutationScoreIndicator;
+    private ?float $coveredMutationScoreIndicator = null;
 
     public function __construct(
         int $roundingPrecision,

--- a/src/Metrics/MetricsCalculator.php
+++ b/src/Metrics/MetricsCalculator.php
@@ -46,54 +46,30 @@ use function Safe\sprintf;
  */
 class MetricsCalculator
 {
-    private $roundingPrecision;
-    private $killedExecutionResults;
-    private $errorExecutionResults;
-    private $escapedExecutionResults;
-    private $timedOutExecutionResults;
-    private $skippedExecutionResults;
-    private $notCoveredExecutionResults;
-    private $allExecutionResults;
+    private int $roundingPrecision;
+    private SortableMutantExecutionResults $killedExecutionResults;
+    private SortableMutantExecutionResults $errorExecutionResults;
+    private SortableMutantExecutionResults $escapedExecutionResults;
+    private SortableMutantExecutionResults $timedOutExecutionResults;
+    private SortableMutantExecutionResults $skippedExecutionResults;
+    private SortableMutantExecutionResults $notCoveredExecutionResults;
+    private SortableMutantExecutionResults $allExecutionResults;
 
-    /**
-     * @var int
-     */
-    private $killedCount = 0;
+    private int $killedCount = 0;
 
-    /**
-     * @var int
-     */
-    private $errorCount = 0;
+    private int $errorCount = 0;
 
-    /**
-     * @var int
-     */
-    private $skippedCount = 0;
+    private int $skippedCount = 0;
 
-    /**
-     * @var int
-     */
-    private $escapedCount = 0;
+    private int $escapedCount = 0;
 
-    /**
-     * @var int
-     */
-    private $timedOutCount = 0;
+    private int $timedOutCount = 0;
 
-    /**
-     * @var int
-     */
-    private $notCoveredByTestsCount = 0;
+    private int $notCoveredByTestsCount = 0;
 
-    /**
-     * @var int
-     */
-    private $totalMutantsCount = 0;
+    private int $totalMutantsCount = 0;
 
-    /**
-     * @var Calculator|null
-     */
-    private $calculator;
+    private ?\Infection\Metrics\Calculator $calculator = null;
 
     public function __construct(int $roundingPrecision)
     {

--- a/src/Metrics/MetricsCalculator.php
+++ b/src/Metrics/MetricsCalculator.php
@@ -69,7 +69,7 @@ class MetricsCalculator
 
     private int $totalMutantsCount = 0;
 
-    private ?\Infection\Metrics\Calculator $calculator = null;
+    private ?Calculator $calculator = null;
 
     public function __construct(int $roundingPrecision)
     {

--- a/src/Metrics/MinMsiChecker.php
+++ b/src/Metrics/MinMsiChecker.php
@@ -45,9 +45,9 @@ class MinMsiChecker
 {
     private const VALUE_OVER_REQUIRED_TOLERANCE = 2;
 
-    private $ignoreMsiWithNoMutations;
-    private $minMsi;
-    private $minCoveredCodeMsi;
+    private bool $ignoreMsiWithNoMutations;
+    private float $minMsi;
+    private float $minCoveredCodeMsi;
 
     public function __construct(
         bool $ignoreMsiWithNoMutations,

--- a/src/Metrics/SortableMutantExecutionResults.php
+++ b/src/Metrics/SortableMutantExecutionResults.php
@@ -46,12 +46,9 @@ final class SortableMutantExecutionResults
     /**
      * @var MutantExecutionResult[]
      */
-    private $executionResults = [];
+    private array $executionResults = [];
 
-    /**
-     * @var bool
-     */
-    private $sorted = false;
+    private bool $sorted = false;
 
     public function add(MutantExecutionResult $executionResult): void
     {

--- a/src/Mutant/Mutant.php
+++ b/src/Mutant/Mutant.php
@@ -44,11 +44,11 @@ use Infection\Mutation\Mutation;
  */
 class Mutant
 {
-    private $mutantFilePath;
-    private $mutation;
-    private $mutatedCode;
-    private $diff;
-    private $prettyPrintedOriginalCode;
+    private string $mutantFilePath;
+    private Mutation $mutation;
+    private string $mutatedCode;
+    private string $diff;
+    private string $prettyPrintedOriginalCode;
 
     public function __construct(
         string $mutantFilePath,

--- a/src/Mutant/MutantCodeFactory.php
+++ b/src/Mutant/MutantCodeFactory.php
@@ -47,7 +47,7 @@ use PhpParser\PrettyPrinterAbstract;
  */
 class MutantCodeFactory
 {
-    private $printer;
+    private PrettyPrinterAbstract $printer;
 
     public function __construct(PrettyPrinterAbstract $prettyPrinter)
     {

--- a/src/Mutant/MutantExecutionResult.php
+++ b/src/Mutant/MutantExecutionResult.php
@@ -45,15 +45,15 @@ use Webmozart\Assert\Assert;
  */
 class MutantExecutionResult
 {
-    private $processCommandLine;
-    private $processOutput;
-    private $detectionStatus;
-    private $mutantDiff;
-    private $mutatorName;
-    private $originalFilePath;
-    private $originalStartingLine;
-    private $originalCode;
-    private $mutatedCode;
+    private string $processCommandLine;
+    private string $processOutput;
+    private string $detectionStatus;
+    private string $mutantDiff;
+    private string $mutatorName;
+    private string $originalFilePath;
+    private int $originalStartingLine;
+    private string $originalCode;
+    private string $mutatedCode;
 
     public function __construct(
         string $processCommandLine,

--- a/src/Mutant/MutantExecutionResultFactory.php
+++ b/src/Mutant/MutantExecutionResultFactory.php
@@ -47,7 +47,7 @@ use Webmozart\Assert\Assert;
  */
 class MutantExecutionResultFactory
 {
-    private $testFrameworkAdapter;
+    private TestFrameworkAdapter $testFrameworkAdapter;
 
     public function __construct(TestFrameworkAdapter $testFrameworkAdapter)
     {

--- a/src/Mutant/MutantFactory.php
+++ b/src/Mutant/MutantFactory.php
@@ -47,15 +47,15 @@ use function Safe\sprintf;
  */
 class MutantFactory
 {
-    private $tmpDir;
-    private $differ;
-    private $printer;
+    private string $tmpDir;
+    private Differ $differ;
+    private PrettyPrinterAbstract $printer;
 
     /**
      * @var string[]
      */
-    private $printedFileCache = [];
-    private $mutantCodeFactory;
+    private array $printedFileCache = [];
+    private MutantCodeFactory $mutantCodeFactory;
 
     public function __construct(
         string $tmpDir,

--- a/src/Mutation/FileMutationGenerator.php
+++ b/src/Mutation/FileMutationGenerator.php
@@ -52,9 +52,9 @@ use Webmozart\Assert\Assert;
  */
 class FileMutationGenerator
 {
-    private $parser;
-    private $traverserFactory;
-    private $lineRangeCalculator;
+    private FileParser $parser;
+    private NodeTraverserFactory $traverserFactory;
+    private LineRangeCalculator $lineRangeCalculator;
 
     public function __construct(
         FileParser $parser,

--- a/src/Mutation/Mutation.php
+++ b/src/Mutation/Mutation.php
@@ -53,24 +53,21 @@ use Webmozart\Assert\Assert;
  */
 class Mutation
 {
-    private $originalFilePath;
-    private $mutatorName;
-    private $mutatedNodeClass;
-    private $mutatedNode;
-    private $mutationByMutatorIndex;
-    private $attributes;
-    private $originalFileAst;
-    private $tests;
-    private $coveredByTests;
-    /**
-     * @var float|null
-     */
-    private $nominalTimeToTest;
+    private string $originalFilePath;
+    private string $mutatorName;
+    private string $mutatedNodeClass;
+    private MutatedNode $mutatedNode;
+    private int $mutationByMutatorIndex;
+    /** @var array<string|int|float> */
+    private array $attributes;
+    /** @var Node[] */
+    private array $originalFileAst;
+    /** @var TestLocation[] */
+    private array $tests;
+    private bool $coveredByTests;
+    private ?float $nominalTimeToTest = null;
 
-    /**
-     * @var string|null
-     */
-    private $hash;
+    private ?string $hash = null;
 
     /**
      * @param Node[] $originalFileAst

--- a/src/Mutation/MutationGenerator.php
+++ b/src/Mutation/MutationGenerator.php
@@ -53,11 +53,12 @@ use Webmozart\Assert\Assert;
  */
 class MutationGenerator
 {
-    private $traceProvider;
-    private $mutators;
-    private $eventDispatcher;
-    private $fileMutationGenerator;
-    private $runConcurrently;
+    private TraceProvider $traceProvider;
+    /** @var Mutator[] */
+    private array $mutators;
+    private EventDispatcher $eventDispatcher;
+    private FileMutationGenerator $fileMutationGenerator;
+    private bool $runConcurrently;
 
     /**
      * @param Mutator[] $mutators

--- a/src/Mutator/AllowedFunctionsConfig.php
+++ b/src/Mutator/AllowedFunctionsConfig.php
@@ -48,7 +48,7 @@ abstract class AllowedFunctionsConfig
     /**
      * @var string[]
      */
-    private $allowedFunctions;
+    private array $allowedFunctions;
 
     /**
      * @param array<string, bool> $settings

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -56,7 +56,7 @@ final class TrueValue implements ConfigurableMutator
     /**
      * @var array<string, int>
      */
-    private $allowedFunctions;
+    private array $allowedFunctions;
 
     public function __construct(TrueValueConfig $config)
     {

--- a/src/Mutator/Boolean/TrueValueConfig.php
+++ b/src/Mutator/Boolean/TrueValueConfig.php
@@ -52,7 +52,7 @@ final class TrueValueConfig implements MutatorConfig
     /**
      * @var string[]
      */
-    private $allowedFunctions = [];
+    private array $allowedFunctions = [];
 
     /**
      * @param array<string, bool> $settings

--- a/src/Mutator/Definition.php
+++ b/src/Mutator/Definition.php
@@ -42,9 +42,9 @@ use Webmozart\Assert\Assert;
  */
 final class Definition
 {
-    private $description;
-    private $category;
-    private $remedies;
+    private string $description;
+    private string $category;
+    private ?string $remedies;
 
     /**
      * @param string $description Explanation on what the mutator is about

--- a/src/Mutator/Extensions/BCMath.php
+++ b/src/Mutator/Extensions/BCMath.php
@@ -57,7 +57,7 @@ final class BCMath implements ConfigurableMutator
     /**
      * @var array<string, Closure(Node\Expr\FuncCall): iterable<Node\Expr>>
      */
-    private $converters;
+    private array $converters;
 
     public function __construct(BCMathConfig $config)
     {

--- a/src/Mutator/Extensions/MBString.php
+++ b/src/Mutator/Extensions/MBString.php
@@ -62,7 +62,7 @@ final class MBString implements ConfigurableMutator
     /**
      * @var array<string, Closure(Node\Expr\FuncCall): iterable<Node\Expr\FuncCall>>
      */
-    private $converters;
+    private array $converters;
 
     public function __construct(MBStringConfig $config)
     {

--- a/src/Mutator/IgnoreConfig.php
+++ b/src/Mutator/IgnoreConfig.php
@@ -46,9 +46,10 @@ use function Safe\array_flip;
  */
 class IgnoreConfig
 {
-    private $patterns;
+    /** @var string[] */
+    private array $patterns;
     /** @var array<string, int> */
-    private $hashtable = [];
+    private array $hashtable = [];
 
     /**
      * @param string[] $ignored

--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -55,8 +55,8 @@ use function Safe\sprintf;
  */
 final class IgnoreMutator implements Mutator
 {
-    private $config;
-    private $mutator;
+    private IgnoreConfig $config;
+    private Mutator $mutator;
 
     public function __construct(IgnoreConfig $config, Mutator $mutator)
     {

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -55,12 +55,14 @@ use Webmozart\Assert\Assert;
  */
 class NodeMutationGenerator
 {
-    private $mutators;
-    private $filePath;
-    private $fileNodes;
-    private $trace;
-    private $onlyCovered;
-    private $lineRangeCalculator;
+    /** @var Mutator[] */
+    private array $mutators;
+    private string $filePath;
+    /** @var Node[] */
+    private array $fileNodes;
+    private Trace $trace;
+    private bool $onlyCovered;
+    private LineRangeCalculator $lineRangeCalculator;
 
     /**
      * @param Mutator[] $mutators

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -436,10 +436,8 @@ final class ProfileList
         'MBString' => Mutator\Extensions\MBString::class,
     ];
 
-    /**
-     * @var array<string, string>|null
-     */
-    private static $defaultProfileMutators;
+    /** @var array<int, string>|null  */
+    private static ?array $defaultProfileMutators = null;
 
     /**
      * @return array<int, string>

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -436,7 +436,7 @@ final class ProfileList
         'MBString' => Mutator\Extensions\MBString::class,
     ];
 
-    /** @var array<int, string>|null  */
+    /** @var array<int, string>|null */
     private static ?array $defaultProfileMutators = null;
 
     /**

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -56,7 +56,7 @@ final class ArrayItemRemoval implements ConfigurableMutator
     use GetMutatorName;
     use GetConfigClassName;
 
-    private $config;
+    private ArrayItemRemovalConfig $config;
 
     public function __construct(ArrayItemRemovalConfig $config)
     {

--- a/src/Mutator/Removal/ArrayItemRemovalConfig.php
+++ b/src/Mutator/Removal/ArrayItemRemovalConfig.php
@@ -50,8 +50,8 @@ final class ArrayItemRemovalConfig implements MutatorConfig
         'all',
     ];
 
-    private $remove;
-    private $limit;
+    private string $remove;
+    private int $limit;
 
     /**
      * @param array{remove: string|null, limit: int|null} $settings

--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -49,7 +49,7 @@ final class FunctionCallRemoval implements Mutator
     use GetMutatorName;
 
     /** @var string[] */
-    private $doNotRemoveFunctions = [
+    private array $doNotRemoveFunctions = [
         'assert',
         'closedir',
         'curl_close',

--- a/src/PhpParser/FileParser.php
+++ b/src/PhpParser/FileParser.php
@@ -46,7 +46,7 @@ use Throwable;
  */
 class FileParser
 {
-    private $parser;
+    private Parser $parser;
 
     public function __construct(Parser $parser)
     {

--- a/src/PhpParser/Visitor/FullyQualifiedClassNameVisitor.php
+++ b/src/PhpParser/Visitor/FullyQualifiedClassNameVisitor.php
@@ -45,10 +45,7 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class FullyQualifiedClassNameVisitor extends NodeVisitorAbstract
 {
-    /**
-     * @var Node\Name|null
-     */
-    private $namespace;
+    private ?Node\Name $namespace = null;
 
     public function enterNode(Node $node): ?Node
     {

--- a/src/PhpParser/Visitor/MutationCollectorVisitor.php
+++ b/src/PhpParser/Visitor/MutationCollectorVisitor.php
@@ -48,9 +48,9 @@ final class MutationCollectorVisitor extends NodeVisitorAbstract
     /**
      * @var array<iterable<Mutation>>
      */
-    private $mutationChunks = [];
+    private array $mutationChunks = [];
 
-    private $mutationGenerator;
+    private NodeMutationGenerator $mutationGenerator;
 
     public function __construct(NodeMutationGenerator $mutationGenerator)
     {

--- a/src/PhpParser/Visitor/MutatorVisitor.php
+++ b/src/PhpParser/Visitor/MutatorVisitor.php
@@ -46,7 +46,7 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class MutatorVisitor extends NodeVisitorAbstract
 {
-    private $mutation;
+    private Mutation $mutation;
 
     public function __construct(Mutation $mutation)
     {

--- a/src/PhpParser/Visitor/NonMutableNodesIgnorerVisitor.php
+++ b/src/PhpParser/Visitor/NonMutableNodesIgnorerVisitor.php
@@ -48,7 +48,7 @@ final class NonMutableNodesIgnorerVisitor extends NodeVisitorAbstract
     /**
      * @var NodeIgnorer[]
      */
-    private $nodeIgnorers;
+    private array $nodeIgnorers;
 
     /**
      * @param NodeIgnorer[] $nodeIgnorers

--- a/src/PhpParser/Visitor/ParentConnectorVisitor.php
+++ b/src/PhpParser/Visitor/ParentConnectorVisitor.php
@@ -48,7 +48,7 @@ final class ParentConnectorVisitor implements NodeVisitor
     /**
      * @var Node[]
      */
-    private $stack = [];
+    private array $stack = [];
 
     public function beforeTraverse(array $nodes): ?array
     {

--- a/src/PhpParser/Visitor/ReflectionVisitor.php
+++ b/src/PhpParser/Visitor/ReflectionVisitor.php
@@ -57,7 +57,7 @@ final class ReflectionVisitor extends NodeVisitorAbstract
     public const FUNCTION_SCOPE_KEY = 'functionScope';
     public const FUNCTION_NAME = 'functionName';
 
-    /** @var array<int, Node>  */
+    /** @var array<int, Node> */
     private array $functionScopeStack = [];
 
     /**

--- a/src/PhpParser/Visitor/ReflectionVisitor.php
+++ b/src/PhpParser/Visitor/ReflectionVisitor.php
@@ -57,20 +57,15 @@ final class ReflectionVisitor extends NodeVisitorAbstract
     public const FUNCTION_SCOPE_KEY = 'functionScope';
     public const FUNCTION_NAME = 'functionName';
 
-    /**
-     * @var Node\Expr\Closure[]|Node\Stmt\ClassMethod[]|Node[]
-     */
-    private $functionScopeStack = [];
+    /** @var array<int, Node>  */
+    private array $functionScopeStack = [];
 
     /**
      * @var ClassReflection[]
      */
-    private $classScopeStack = [];
+    private array $classScopeStack = [];
 
-    /**
-     * @var string|null
-     */
-    private $methodName;
+    private ?string $methodName = null;
 
     public function beforeTraverse(array $nodes): ?array
     {

--- a/src/Process/Factory/InitialTestsRunProcessFactory.php
+++ b/src/Process/Factory/InitialTestsRunProcessFactory.php
@@ -46,7 +46,7 @@ use Symfony\Component\Process\Process;
  */
 class InitialTestsRunProcessFactory
 {
-    private $testFrameworkAdapter;
+    private TestFrameworkAdapter $testFrameworkAdapter;
 
     public function __construct(TestFrameworkAdapter $testFrameworkAdapter)
     {

--- a/src/Process/Factory/MutantProcessFactory.php
+++ b/src/Process/Factory/MutantProcessFactory.php
@@ -50,10 +50,10 @@ use Symfony\Component\Process\Process;
  */
 class MutantProcessFactory
 {
-    private $testFrameworkAdapter;
-    private $timeout;
-    private $eventDispatcher;
-    private $resultFactory;
+    private TestFrameworkAdapter $testFrameworkAdapter;
+    private float $timeout;
+    private EventDispatcher $eventDispatcher;
+    private MutantExecutionResultFactory $resultFactory;
 
     // TODO: is it necessary for the timeout to be an int?
     public function __construct(

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -46,14 +46,11 @@ use Symfony\Component\Process\Process;
  */
 class MutantProcess implements ProcessBearer
 {
-    private $process;
-    private $mutant;
-    private $callback;
+    private Process $process;
+    private Mutant $mutant;
+    private Closure $callback;
 
-    /**
-     * @var bool
-     */
-    private $timedOut = false;
+    private bool $timedOut = false;
 
     public function __construct(Process $process, Mutant $mutant)
     {

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -48,8 +48,8 @@ use Symfony\Component\Process\Process;
  */
 class InitialTestsRunner
 {
-    private $processBuilder;
-    private $eventDispatcher;
+    private InitialTestsRunProcessFactory $processBuilder;
+    private EventDispatcher $eventDispatcher;
 
     public function __construct(
         InitialTestsRunProcessFactory $processFactory,

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -56,16 +56,16 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class MutationTestingRunner
 {
-    private $processFactory;
-    private $mutantFactory;
-    private $processRunner;
-    private $eventDispatcher;
-    private $fileSystem;
-    private $diffSourceCodeMatcher;
-    private $runConcurrently;
-    private $timeout;
+    private MutantProcessFactory $processFactory;
+    private MutantFactory $mutantFactory;
+    private ProcessRunner $processRunner;
+    private EventDispatcher $eventDispatcher;
+    private Filesystem $fileSystem;
+    private DiffSourceCodeMatcher $diffSourceCodeMatcher;
+    private bool $runConcurrently;
+    private float $timeout;
     /** @var array<string, array<int, string>> */
-    private $ignoreSourceCodeMutatorsMap;
+    private array $ignoreSourceCodeMutatorsMap;
 
     /**
      * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap

--- a/src/Process/Runner/ParallelProcessRunner.php
+++ b/src/Process/Runner/ParallelProcessRunner.php
@@ -51,10 +51,10 @@ final class ParallelProcessRunner implements ProcessRunner
     /**
      * @var ProcessBearer[]
      */
-    private $runningProcesses = [];
+    private array $runningProcesses = [];
 
-    private $threadCount;
-    private $poll;
+    private int $threadCount;
+    private int $poll;
 
     /**
      * @param int $poll Delay (in milliseconds) to wait in-between two polls

--- a/src/Reflection/AnonymousClassReflection.php
+++ b/src/Reflection/AnonymousClassReflection.php
@@ -42,10 +42,7 @@ use ReflectionClass;
  */
 final class AnonymousClassReflection implements ClassReflection
 {
-    /**
-     * @var ReflectionClass
-     */
-    private $reflectionClass;
+    private ReflectionClass $reflectionClass;
 
     private function __construct(ReflectionClass $reflectionClass)
     {

--- a/src/Reflection/CoreClassReflection.php
+++ b/src/Reflection/CoreClassReflection.php
@@ -43,7 +43,7 @@ use ReflectionException;
  */
 final class CoreClassReflection implements ClassReflection
 {
-    private $reflectionClass;
+    private ReflectionClass $reflectionClass;
 
     private function __construct(ReflectionClass $reflectionClass)
     {

--- a/src/Reflection/Visibility.php
+++ b/src/Reflection/Visibility.php
@@ -43,10 +43,7 @@ final class Visibility
     public const PUBLIC = 'public';
     public const PROTECTED = 'protected';
 
-    /**
-     * @var string
-     */
-    private $variant;
+    private string $variant;
 
     private function __construct(string $variant)
     {

--- a/src/Resource/Listener/PerformanceLoggerSubscriber.php
+++ b/src/Resource/Listener/PerformanceLoggerSubscriber.php
@@ -50,10 +50,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class PerformanceLoggerSubscriber implements EventSubscriber
 {
-    private $stopwatch;
-    private $output;
-    private $timeFormatter;
-    private $memoryFormatter;
+    private Stopwatch $stopwatch;
+    private OutputInterface $output;
+    private TimeFormatter $timeFormatter;
+    private MemoryFormatter $memoryFormatter;
 
     public function __construct(
         Stopwatch $stopwatch,

--- a/src/Resource/Memory/MemoryLimiter.php
+++ b/src/Resource/Memory/MemoryLimiter.php
@@ -48,9 +48,9 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class MemoryLimiter
 {
-    private $fileSystem;
-    private $phpIniPath;
-    private $environment;
+    private Filesystem $fileSystem;
+    private string $phpIniPath;
+    private MemoryLimiterEnvironment $environment;
 
     public function __construct(
         Filesystem $fileSystem,

--- a/src/Resource/Time/Stopwatch.php
+++ b/src/Resource/Time/Stopwatch.php
@@ -45,10 +45,7 @@ use Webmozart\Assert\Assert;
  */
 final class Stopwatch
 {
-    /**
-     * @var float|null
-     */
-    private $microTime;
+    private ?float $microTime = null;
 
     public function start(): void
     {

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -47,13 +47,13 @@ use Symfony\Component\Process\Process;
  */
 abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
 {
-    private $testFrameworkExecutable;
-    private $argumentsAndOptionsBuilder;
-    private $initialConfigBuilder;
-    private $mutationConfigBuilder;
-    private $versionParser;
-    private $commandLineBuilder;
-    private $version;
+    private string $testFrameworkExecutable;
+    private CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder;
+    private InitialConfigBuilder $initialConfigBuilder;
+    private MutationConfigBuilder $mutationConfigBuilder;
+    private VersionParser $versionParser;
+    private CommandLineBuilder $commandLineBuilder;
+    private ?string $version;
 
     public function __construct(
         string $testFrameworkExecutable,

--- a/src/TestFramework/AdapterInstallationDecider.php
+++ b/src/TestFramework/AdapterInstallationDecider.php
@@ -52,7 +52,7 @@ final class AdapterInstallationDecider
         TestFrameworkTypes::PHPSPEC => 'Infection\TestFramework\PhpSpec\PhpSpecAdapter',
     ];
 
-    private $questionHelper;
+    private QuestionHelper $questionHelper;
 
     public function __construct(QuestionHelper $questionHelper)
     {

--- a/src/TestFramework/AdapterInstaller.php
+++ b/src/TestFramework/AdapterInstaller.php
@@ -52,7 +52,7 @@ final class AdapterInstaller
 
     private const TIMEOUT = 120.0; // 2 minutes
 
-    private $composerExecutableFinder;
+    private ComposerExecutableFinder $composerExecutableFinder;
 
     public function __construct(ComposerExecutableFinder $composerExecutableFinder)
     {

--- a/src/TestFramework/CommandLineBuilder.php
+++ b/src/TestFramework/CommandLineBuilder.php
@@ -49,10 +49,8 @@ use Symfony\Component\Process\PhpExecutableFinder;
  */
 class CommandLineBuilder
 {
-    /**
-     * @var string[]|null
-     */
-    private $cachedPhpCmdLine;
+    /** @var string[]|null */
+    private ?array $cachedPhpCmdLine = null;
 
     /**
      * @param string[] $frameworkArgs

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -54,10 +54,7 @@ final class TestFrameworkConfigLocator implements TestFrameworkConfigLocatorInte
         'dist.yml',
     ];
 
-    /**
-     * @var string
-     */
-    private $configDir;
+    private string $configDir;
 
     public function __construct(string $configDir)
     {

--- a/src/TestFramework/Coverage/BufferedSourceFileFilter.php
+++ b/src/TestFramework/Coverage/BufferedSourceFileFilter.php
@@ -56,14 +56,14 @@ use Webmozart\Assert\Assert;
  */
 class BufferedSourceFileFilter implements FileFilter
 {
-    private $filter;
+    private FileFilter $filter;
 
     /**
      * An associative array mapping real paths to SplFileInfo objects.
      *
      * @var array<string, SplFileInfo>
      */
-    private $sourceFiles = [];
+    private array $sourceFiles = [];
 
     /**
      * @param SourceFileFilter|FileFilter $filter

--- a/src/TestFramework/Coverage/CoverageChecker.php
+++ b/src/TestFramework/Coverage/CoverageChecker.php
@@ -57,14 +57,14 @@ class CoverageChecker
     private const PHPUNIT = 'phpunit';
     private const CODECEPTION = 'codeception';
 
-    private $skipCoverage;
-    private $skipInitialTests;
-    private $initialTestPhpOptions;
-    private $coveragePath;
-    private $jUnitReport;
-    private $jUnitReportLocator;
-    private $frameworkAdapterName;
-    private $indexXmlCoverageLocator;
+    private bool $skipCoverage;
+    private bool $skipInitialTests;
+    private string $initialTestPhpOptions;
+    private string $coveragePath;
+    private bool $jUnitReport;
+    private JUnitReportLocator $jUnitReportLocator;
+    private string $frameworkAdapterName;
+    private IndexXmlCoverageLocator $indexXmlCoverageLocator;
 
     public function __construct(
         bool $skipCoverage,

--- a/src/TestFramework/Coverage/CoveredTraceProvider.php
+++ b/src/TestFramework/Coverage/CoveredTraceProvider.php
@@ -46,14 +46,11 @@ use Infection\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProvider;
  */
 final class CoveredTraceProvider implements TraceProvider
 {
-    /**
-     * @var TraceProvider
-     */
-    private $primaryTraceProvider;
+    private TraceProvider $primaryTraceProvider;
 
-    private $testFileDataAdder;
+    private JUnitTestExecutionInfoAdder $testFileDataAdder;
 
-    private $bufferedFilter;
+    private FileFilter $bufferedFilter;
 
     /**
      * @param PhpUnitXmlCoverageTraceProvider|TraceProvider $primaryTraceProvider

--- a/src/TestFramework/Coverage/JUnit/JUnitReportLocator.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitReportLocator.php
@@ -53,13 +53,10 @@ use Webmozart\PathUtil\Path;
  */
 class JUnitReportLocator
 {
-    private $coveragePath;
-    private $defaultJUnitPath;
+    private string $coveragePath;
+    private string $defaultJUnitPath;
 
-    /**
-     * @var string|null
-     */
-    private $jUnitPath;
+    private ?string $jUnitPath = null;
 
     public function __construct(string $coveragePath, string $defaultJUnitPath)
     {

--- a/src/TestFramework/Coverage/JUnit/JUnitTestCaseTimeAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestCaseTimeAdder.php
@@ -48,7 +48,7 @@ final class JUnitTestCaseTimeAdder
     /**
      * @var TestLocation[]
      */
-    private $tests;
+    private array $tests;
 
     /**
      * @param TestLocation[] $tests

--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -48,12 +48,9 @@ use Infection\TestFramework\Coverage\Trace;
  */
 class JUnitTestExecutionInfoAdder
 {
-    /**
-     * @var TestFileDataProvider
-     */
-    private $testFileDataProvider;
+    private TestFileDataProvider $testFileDataProvider;
 
-    private $adapter;
+    private TestFrameworkAdapter $adapter;
 
     public function __construct(
         TestFrameworkAdapter $adapter,

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -48,12 +48,9 @@ use Webmozart\Assert\Assert;
  */
 final class JUnitTestFileDataProvider implements TestFileDataProvider
 {
-    private $jUnitLocator;
+    private JUnitReportLocator $jUnitLocator;
 
-    /**
-     * @var SafeDOMXPath|null
-     */
-    private $xPath;
+    private ?SafeDOMXPath $xPath = null;
 
     public function __construct(JUnitReportLocator $jUnitLocator)
     {

--- a/src/TestFramework/Coverage/JUnit/MemoizedTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/MemoizedTestFileDataProvider.php
@@ -42,12 +42,12 @@ use function array_key_exists;
  */
 final class MemoizedTestFileDataProvider implements TestFileDataProvider
 {
-    private $provider;
+    private TestFileDataProvider $provider;
 
     /**
      * @var array<string, TestFileTimeData>
      */
-    private $cache = [];
+    private array $cache = [];
 
     public function __construct(TestFileDataProvider $decoratedProvider)
     {

--- a/src/TestFramework/Coverage/JUnit/TestFileTimeData.php
+++ b/src/TestFramework/Coverage/JUnit/TestFileTimeData.php
@@ -40,15 +40,9 @@ namespace Infection\TestFramework\Coverage\JUnit;
  */
 final class TestFileTimeData
 {
-    /**
-     * @var string
-     */
-    public $path;
+    public string $path;
 
-    /**
-     * @var float
-     */
-    public $time;
+    public float $time;
 
     public function __construct(string $path, float $time)
     {

--- a/src/TestFramework/Coverage/NodeLineRangeData.php
+++ b/src/TestFramework/Coverage/NodeLineRangeData.php
@@ -55,7 +55,7 @@ final class NodeLineRangeData
     /**
      * @var array<int, int>
      */
-    public $range;
+    public array $range;
 
     public function __construct(int $start, int $end)
     {

--- a/src/TestFramework/Coverage/ProxyTrace.php
+++ b/src/TestFramework/Coverage/ProxyTrace.php
@@ -48,25 +48,16 @@ use Webmozart\Assert\Assert;
  */
 class ProxyTrace implements Trace
 {
-    /**
-     * @var SplFileInfo
-     */
-    private $sourceFile;
+    private SplFileInfo $sourceFile;
 
-    /**
-     * @var TestLocations|null
-     */
-    private $testLocations;
+    private ?TestLocations $testLocations = null;
 
     /**
      * @var iterable<TestLocations>
      */
-    private $lazyTestLocations;
+    private iterable $lazyTestLocations;
 
-    /**
-     * @var TestLocator|null
-     */
-    private $tests;
+    private ?TestLocator $tests = null;
 
     /**
      * @param iterable<TestLocations> $lazyTestLocations

--- a/src/TestFramework/Coverage/SourceMethodLineRange.php
+++ b/src/TestFramework/Coverage/SourceMethodLineRange.php
@@ -40,8 +40,8 @@ namespace Infection\TestFramework\Coverage;
  */
 final class SourceMethodLineRange
 {
-    private $startLine;
-    private $endLine;
+    private int $startLine;
+    private int $endLine;
 
     public function __construct(int $startLine, int $endLine)
     {

--- a/src/TestFramework/Coverage/TestLocations.php
+++ b/src/TestFramework/Coverage/TestLocations.php
@@ -42,8 +42,10 @@ use Infection\AbstractTestFramework\Coverage\TestLocation;
  */
 final class TestLocations
 {
-    private $byLine;
-    private $byMethod;
+    /** @var array<int, array<int, TestLocation>> */
+    private array $byLine;
+    /** @var array<string, SourceMethodLineRange> */
+    private array $byMethod;
 
     /**
      * @param array<int, array<int, TestLocation>> $testLocationsBySourceLine

--- a/src/TestFramework/Coverage/UncoveredTraceProvider.php
+++ b/src/TestFramework/Coverage/UncoveredTraceProvider.php
@@ -42,7 +42,7 @@ namespace Infection\TestFramework\Coverage;
  */
 final class UncoveredTraceProvider implements TraceProvider
 {
-    private $bufferedFilter;
+    private BufferedSourceFileFilter $bufferedFilter;
 
     public function __construct(BufferedSourceFileFilter $bufferedFilter)
     {

--- a/src/TestFramework/Coverage/UnionTraceProvider.php
+++ b/src/TestFramework/Coverage/UnionTraceProvider.php
@@ -43,14 +43,11 @@ namespace Infection\TestFramework\Coverage;
  */
 final class UnionTraceProvider implements TraceProvider
 {
-    /**
-     * @var TraceProvider
-     */
-    private $coveredTraceProvider;
+    private TraceProvider $coveredTraceProvider;
 
-    private $uncoveredTraceProvider;
+    private TraceProvider $uncoveredTraceProvider;
 
-    private $onlyCovered;
+    private bool $onlyCovered;
 
     /**
      * @param CoveredTraceProvider|TraceProvider $coveredTraceProvider

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php
@@ -53,13 +53,10 @@ use Webmozart\PathUtil\Path;
  */
 class IndexXmlCoverageLocator
 {
-    private $coveragePath;
-    private $defaultIndexPath;
+    private string $coveragePath;
+    private string $defaultIndexPath;
 
-    /**
-     * @var string|null
-     */
-    private $indexPath;
+    private ?string $indexPath = null;
 
     public function __construct(string $coveragePath)
     {

--- a/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProvider.php
@@ -48,9 +48,9 @@ use function Safe\file_get_contents;
  */
 class PhpUnitXmlCoverageTraceProvider implements TraceProvider
 {
-    private $indexLocator;
-    private $indexParser;
-    private $parser;
+    private IndexXmlCoverageLocator $indexLocator;
+    private IndexXmlCoverageParser $indexParser;
+    private XmlCoverageParser $parser;
 
     public function __construct(
         IndexXmlCoverageLocator $indexCoverageLocator,

--- a/src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
@@ -54,15 +54,12 @@ use Webmozart\PathUtil\Path;
  */
 class SourceFileInfoProvider
 {
-    private $coverageIndexPath;
-    private $coverageDir;
-    private $relativeCoverageFilePath;
-    private $projectSource;
+    private string $coverageIndexPath;
+    private string $coverageDir;
+    private string $relativeCoverageFilePath;
+    private string $projectSource;
 
-    /**
-     * @var SafeDOMXPath|null
-     */
-    private $xPath;
+    private ?SafeDOMXPath $xPath = null;
 
     public function __construct(
         string $coverageIndexPath,

--- a/src/TestFramework/Coverage/XmlReport/TestLocator.php
+++ b/src/TestFramework/Coverage/XmlReport/TestLocator.php
@@ -47,7 +47,7 @@ use Infection\TestFramework\Coverage\TestLocations;
  */
 class TestLocator
 {
-    private $testLocations;
+    private TestLocations $testLocations;
 
     public function __construct(TestLocations $testLocations)
     {

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -51,17 +51,17 @@ use Webmozart\Assert\Assert;
  */
 final class Factory
 {
-    private $tmpDir;
-    private $projectDir;
-    private $configLocator;
-    private $testFrameworkFinder;
-    private $jUnitFilePath;
-    private $infectionConfig;
+    private string $tmpDir;
+    private string $projectDir;
+    private TestFrameworkConfigLocatorInterface $configLocator;
+    private TestFrameworkFinder $testFrameworkFinder;
+    private string $jUnitFilePath;
+    private Configuration $infectionConfig;
 
     /**
      * @var array<string, array<string, mixed>>
      */
-    private $installedExtensions;
+    private array $installedExtensions;
 
     /**
      * @param array<string, array<string, mixed>> $installedExtensions

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -57,9 +57,9 @@ class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements IgnoresAddi
 {
     public const COVERAGE_DIR = 'coverage-xml';
 
-    private $tmpDir;
+    private string $tmpDir;
 
-    private $jUnitFilePath;
+    private string $jUnitFilePath;
 
     public function __construct(
         string $testFrameworkExecutable,

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -50,11 +50,12 @@ use Webmozart\Assert\Assert;
  */
 class InitialConfigBuilder implements ConfigBuilder
 {
-    private $tmpDir;
-    private $originalXmlConfigContent;
-    private $configManipulator;
-    private $versionProvider;
-    private $srcDirs;
+    private string $tmpDir;
+    private string $originalXmlConfigContent;
+    private XmlConfigurationManipulator $configManipulator;
+    private XmlConfigurationVersionProvider $versionProvider;
+    /** @var string[] */
+    private array $srcDirs;
 
     /**
      * @param string[] $srcDirs

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -53,21 +53,15 @@ use Webmozart\Assert\Assert;
  */
 class MutationConfigBuilder extends ConfigBuilder
 {
-    private $tmpDir;
-    private $projectDir;
-    private $originalXmlConfigContent;
-    private $configManipulator;
-    private $jUnitTestCaseSorter;
+    private string $tmpDir;
+    private string $projectDir;
+    private string $originalXmlConfigContent;
+    private XmlConfigurationManipulator $configManipulator;
+    private JUnitTestCaseSorter $jUnitTestCaseSorter;
 
-    /**
-     * @var string|null
-     */
-    private $originalBootstrapFile;
+    private ?string $originalBootstrapFile = null;
 
-    /**
-     * @var DOMDocument|null
-     */
-    private $dom;
+    private ?\DOMDocument $dom = null;
 
     public function __construct(
         string $tmpDir,

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -61,7 +61,7 @@ class MutationConfigBuilder extends ConfigBuilder
 
     private ?string $originalBootstrapFile = null;
 
-    private ?\DOMDocument $dom = null;
+    private ?DOMDocument $dom = null;
 
     public function __construct(
         string $tmpDir,

--- a/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
+++ b/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
@@ -47,8 +47,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class PathReplacer
 {
-    private $filesystem;
-    private $phpUnitConfigDir;
+    private Filesystem $filesystem;
+    private ?string $phpUnitConfigDir = null;
 
     public function __construct(Filesystem $filesystem, ?string $phpUnitConfigDir = null)
     {

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -57,8 +57,8 @@ use Webmozart\Assert\Assert;
  */
 final class XmlConfigurationManipulator
 {
-    private $pathReplacer;
-    private $phpUnitConfigDir;
+    private PathReplacer $pathReplacer;
+    private string $phpUnitConfigDir;
 
     public function __construct(PathReplacer $pathReplacer, string $phpUnitConfigDir)
     {

--- a/src/TestFramework/SafeDOMXPath.php
+++ b/src/TestFramework/SafeDOMXPath.php
@@ -48,9 +48,9 @@ use Webmozart\Assert\Assert;
  */
 final class SafeDOMXPath
 {
-    private \DOMDocument $document;
+    private DOMDocument $document;
 
-    private \DOMXPath $xPath;
+    private DOMXPath $xPath;
 
     public function __construct(DOMDocument $document)
     {

--- a/src/TestFramework/SafeDOMXPath.php
+++ b/src/TestFramework/SafeDOMXPath.php
@@ -48,11 +48,9 @@ use Webmozart\Assert\Assert;
  */
 final class SafeDOMXPath
 {
-    /** @var DOMDocument */
-    private $document;
+    private \DOMDocument $document;
 
-    /** @var DOMXPath */
-    private $xPath;
+    private \DOMXPath $xPath;
 
     public function __construct(DOMDocument $document)
     {

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php
@@ -76,9 +76,9 @@ final class ArrayItemRemovalConfigTest extends TestCase
             new ArrayItemRemovalConfig(['limit' => 'foo']);
 
             $this->fail();
-        } catch (InvalidArgumentException $exception) {
+        } catch (\TypeError $exception) {
             $this->assertSame(
-                'Expected the limit to be an integer. Got "string" instead',
+                'Typed property Infection\Mutator\Removal\ArrayItemRemovalConfig::$limit must be int, string used',
                 $exception->getMessage()
             );
         }

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php
@@ -78,10 +78,11 @@ final class ArrayItemRemovalConfigTest extends TestCase
 
             $this->fail();
         } catch (TypeError $exception) {
-            $this->assertSame(
-                'Typed property Infection\Mutator\Removal\ArrayItemRemovalConfig::$limit must be int, string used',
-                $exception->getMessage()
-            );
+            $message = PHP_VERSION_ID < 80000
+                ? 'Typed property Infection\Mutator\Removal\ArrayItemRemovalConfig::$limit must be int, string used'
+                : 'Cannot assign string to property Infection\Mutator\Removal\ArrayItemRemovalConfig::$limit of type int';
+
+            $this->assertSame($message, $exception->getMessage());
         }
     }
 

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php
@@ -39,6 +39,7 @@ use Infection\Mutator\Removal\ArrayItemRemovalConfig;
 use InvalidArgumentException;
 use const PHP_INT_MAX;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 final class ArrayItemRemovalConfigTest extends TestCase
 {
@@ -76,7 +77,7 @@ final class ArrayItemRemovalConfigTest extends TestCase
             new ArrayItemRemovalConfig(['limit' => 'foo']);
 
             $this->fail();
-        } catch (\TypeError $exception) {
+        } catch (TypeError $exception) {
             $this->assertSame(
                 'Typed property Infection\Mutator\Removal\ArrayItemRemovalConfig::$limit must be int, string used',
                 $exception->getMessage()


### PR DESCRIPTION
This is a follow up for https://github.com/infection/infection/pull/1340

```bash
./rector.phar process src --config=rector.php
```

`rector.php` config:

```php
<?php

declare(strict_types=1);

use Rector\Core\Configuration\Option;
use Rector\Core\ValueObject\PhpVersionFeature;
use Rector\Php74\Rector\Property\TypedPropertyRector;
use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;

return static function (ContainerConfigurator $containerConfigurator): void {
    $services = $containerConfigurator->services();

    $services->set(TypedPropertyRector::class);

    $parameters = $containerConfigurator->parameters();

    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersionFeature::TYPED_PROPERTIES);
};
```

Next steps:

- update CI to fail the build when native type is missed (another PR)