### PR TITLE
Check ignoreSourceCodeByRegex and global-ignoreSourceCodeByRegex have valid syntax

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -129,7 +129,8 @@
                 "global-ignoreSourceCodeByRegex": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "regex"
                     }
                 },
 
@@ -206,7 +207,8 @@
                                 "ignoreSourceCodeByRegex": {
                                     "type": "array",
                                     "items": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "format": "regex"
                                     }
                                 },
                                 "settings": {
@@ -272,7 +274,8 @@
                                 "ignoreSourceCodeByRegex": {
                                     "type": "array",
                                     "items": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "format": "regex"
                                     }
                                 },
                                 "settings": {
@@ -385,7 +388,8 @@
                                 "ignoreSourceCodeByRegex": {
                                     "type": "array",
                                     "items": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "format": "regex"
                                     }
                                 },
                                 "settings": {
@@ -443,7 +447,8 @@
                                 "ignoreSourceCodeByRegex": {
                                     "type": "array",
                                     "items": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "format": "regex"
                                     }
                                 },
                                 "settings": {
@@ -553,7 +558,8 @@
                         "ignoreSourceCodeByRegex": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "format": "regex"
                             }
                         }
                     }


### PR DESCRIPTION
PR implemented https://github.com/infection/infection/issues/1406 request.

Check `ignoreSourceCodeByRegex` and `global-ignoreSourceCodeByRegex` config options that both have valid syntax.

`global-ignoreSourceCodeByRegex` is invalid:
![image](https://user-images.githubusercontent.com/1302230/97982144-62aa2980-1de4-11eb-95df-7416cc841970.png)
`ignoreSourceCodeByRegex`  is invalid:
![image](https://user-images.githubusercontent.com/1302230/97982401-c896b100-1de4-11eb-924a-ed05d0958aea.png)