### PR TITLE
Use not included delimiter

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1954,16 +1954,16 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.5.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "f220a51458bf4dd0dedebb171ac3457813c72bbc"
+                "reference": "ecdc3c476b3ccff02f8e5d5bcc04f7ccfd18751c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/f220a51458bf4dd0dedebb171ac3457813c72bbc",
-                "reference": "f220a51458bf4dd0dedebb171ac3457813c72bbc",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/ecdc3c476b3ccff02f8e5d5bcc04f7ccfd18751c",
+                "reference": "ecdc3c476b3ccff02f8e5d5bcc04f7ccfd18751c",
                 "shasum": ""
             },
             "require": {
@@ -2031,7 +2031,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/master"
+                "source": "https://github.com/amphp/amp/tree/v2.5.1"
             },
             "funding": [
                 {
@@ -2039,7 +2039,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-14T21:47:18+00:00"
+            "time": "2020-11-03T16:23:45+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -3064,16 +3064,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.53",
+            "version": "0.12.54",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "dbbdb0d7c2434ecd5289f6114d16473e694caa67"
+                "reference": "45c7b999a4b7dd9ac5558bdaaf23dcebbef88223"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dbbdb0d7c2434ecd5289f6114d16473e694caa67",
-                "reference": "dbbdb0d7c2434ecd5289f6114d16473e694caa67",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/45c7b999a4b7dd9ac5558bdaaf23dcebbef88223",
+                "reference": "45c7b999a4b7dd9ac5558bdaaf23dcebbef88223",
                 "shasum": ""
             },
             "require": {
@@ -3104,7 +3104,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.53"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.54"
             },
             "funding": [
                 {
@@ -3120,7 +3120,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-01T14:51:50+00:00"
+            "time": "2020-11-05T13:36:26+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/src/Differ/DiffSourceCodeMatcher.php
+++ b/src/Differ/DiffSourceCodeMatcher.php
@@ -42,10 +42,29 @@ use function Safe\preg_match;
  */
 final class DiffSourceCodeMatcher
 {
+    private const POSSIBLE_DELIMITERS = [
+            '#', '%', ':', ';', '=', '?', '@', '^', '~',
+    ];
+
     public function matches(string $diff, string $sourceCodeRegex): bool
     {
-        $regexWithEscapedDelimiters = str_replace('/', '\/', $sourceCodeRegex);
+        // https://www.php.net/manual/en/regexp.reference.delimiters.php
 
-        return preg_match("/^-\s*{$regexWithEscapedDelimiters}$/mu", $diff) === 1;
+        $delimiter = $this->findDelimiter($sourceCodeRegex);
+        // There's no need to escape delimiters since we're assuming there's none.
+
+        return preg_match("{$delimiter}^-\s*{$sourceCodeRegex}\${$delimiter}mu", $diff) === 1;
+    }
+
+    private function findDelimiter(string $sourceCodeRegex): string
+    {
+        foreach (self::POSSIBLE_DELIMITERS as $possibleDelimiter) {
+            if (strpos($sourceCodeRegex, $possibleDelimiter) === false) {
+                return $possibleDelimiter;
+            }
+        }
+
+        // Let it fail naturally, for now
+        return $possibleDelimiter;
     }
 }

--- a/src/Differ/DiffSourceCodeMatcher.php
+++ b/src/Differ/DiffSourceCodeMatcher.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Differ;
 
 use function Safe\preg_match;
+use function strpos;
 
 /**
  * @internal
@@ -64,7 +65,7 @@ final class DiffSourceCodeMatcher
             }
         }
 
-        // Let it fail naturally, for now
-        return $possibleDelimiter;
+        // Let it fail naturally, for now. Later this might be a good place to throw an exception.
+        return '/';
     }
 }

--- a/tests/phpunit/Differ/DiffSourceCodeMatcherTest.php
+++ b/tests/phpunit/Differ/DiffSourceCodeMatcherTest.php
@@ -170,17 +170,32 @@ DIFF
             false,
         ];
 
-        yield 'Regex contains delimiters should not lead to syntax error' => [
-            '/getString/',
+        yield 'Regex containing common delimiters should not lead to syntax error' => [
+            '.*# comment\s*',
             <<<'DIFF'
 --- Original
 +++ New
 @@ @@
 
-+ $a - 2 + $this->getString();
+- $a - 2 + $this->getString() / 2; # comment
++ $a - 2 + $this->getString(); # comment
 DIFF
             ,
-            false,
+                true,
+        ];
+
+        yield 'Regex containing less common delimiters should not lead to syntax error' => [
+            '.*%.*',
+                <<<'DIFF'
+--- Original
++++ New
+@@ @@
+
+- $a % 2;
++ $a % 3;
+DIFF
+                ,
+                true,
         ];
     }
 }


### PR DESCRIPTION
This PR:

- [x] Changes DiffSourceCodeMatcher to use a delimiter that isn't included in the regex, instead of escaping the default one. 
- [x] Covered by tests
- [x] Fixes #1414
