### PR TITLE
Use Composer 1.x on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
       - expect
 
 before_install:
-  - composer self-update -1
+  - composer self-update --1
   - source .ci/travis-functions.sh
   - xdebug_disable
   # Since the Makefile timestamp is used in the Makefile as a dependency, we must

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
       - expect
 
 before_install:
+  - composer self-update -1
   - source .ci/travis-functions.sh
   - xdebug_disable
   # Since the Makefile timestamp is used in the Makefile as a dependency, we must

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
       - expect
 
 before_install:
+  - composer self-update --1
   - source .ci/travis-functions.sh
   - xdebug_disable
   # Since the Makefile timestamp is used in the Makefile as a dependency, we must

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ addons:
       - expect
 
 before_install:
-  - composer self-update --1
   - source .ci/travis-functions.sh
   - xdebug_disable
   # Since the Makefile timestamp is used in the Makefile as a dependency, we must

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
       - expect
 
 before_install:
-  - composer self-update --1
+  - composer self-update --1 # v2 needs Box 3.9.0+ 
   - source .ci/travis-functions.sh
   - xdebug_disable
   # Since the Makefile timestamp is used in the Makefile as a dependency, we must
@@ -124,4 +124,3 @@ jobs:
         on:
           tags: true
           repo: infection/infection
-

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 # Variables
 #---------------------------------------------------------------------------
 BOX=./.tools/box
-BOX_URL="https://github.com/humbug/box/releases/download/3.8.5/box.phar"
+BOX_URL="https://github.com/humbug/box/releases/download/3.9.0/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
 PHP_CS_FIXER_URL="https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 # Variables
 #---------------------------------------------------------------------------
 BOX=./.tools/box
-BOX_URL="https://github.com/humbug/box/releases/download/3.9.0/box.phar"
+BOX_URL="https://github.com/humbug/box/releases/download/3.8.5/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
 PHP_CS_FIXER_URL="https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar"


### PR DESCRIPTION
This PR:

- [x] Changes Travis CI to use Composer 1.x due to pending incompatibility with Box.
- [x] Travis CI's build is green
