### PR TITLE
Optimize JUnitTestCaseTimeAdder

### DIFF
--- a/src/TestFramework/Coverage/JUnit/JUnitTestCaseTimeAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestCaseTimeAdder.php
@@ -75,6 +75,8 @@ final class JUnitTestCaseTimeAdder
      */
     private function uniqueTestLocations(): Traversable
     {
+        $seenTestSuites = [];
+
         foreach ($this->tests as $testLocation) {
             $methodName = $testLocation->getMethod();
             $methodSeparatorPos = strpos($methodName, '::');
@@ -85,7 +87,15 @@ final class JUnitTestCaseTimeAdder
             }
 
             // For each test we discard method name, and return a single timing for an entire suite
-            yield substr($methodName, 0, $methodSeparatorPos) => $testLocation->getExecutionTime();
+            $testSuiteName = substr($methodName, 0, $methodSeparatorPos);
+
+            if (array_key_exists($testSuiteName, $seenTestSuites)) {
+                continue;
+            }
+
+            $seenTestSuites[$testSuiteName] = true;
+
+            yield $testLocation->getExecutionTime();
         }
     }
 }

--- a/src/TestFramework/Coverage/JUnit/JUnitTestCaseTimeAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestCaseTimeAdder.php
@@ -71,7 +71,7 @@ final class JUnitTestCaseTimeAdder
     /**
      * Returns unique'd test cases with timings. Timings are per test suite, not per test, therefore we have to unique by test suite name.
      *
-     * @return Traversable<string, float|null>
+     * @return Traversable<float|null>
      */
     private function uniqueTestLocations(): Traversable
     {


### PR DESCRIPTION
This PR:

- [x] Optimizes JUnitTestCaseTimeAdder (~50% savings, from 1.65 to 0.7 of a second on my test bench)

Turns out it is cheaper not to yield things you want to discard.

Timings are only for the work of the added. Full run takes about 20 seconds, e.g. it's a 3% boost.