### PR TITLE
Lazify ProxyTrace with Deferred

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "nikic/php-parser": "^4.10.2",
         "ocramius/package-versions": "^1.2 || ^2.0",
         "ondram/ci-detector": "^3.3.0",
+        "sanmai/later": "^0.1.1",
         "sanmai/pipeline": "^3.1 || ^5.0",
         "sebastian/diff": "^3.0.2 || ^4.0",
         "seld/jsonlint": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "956a7f651410672f7485130b4cd962a2",
+    "content-hash": "0c171d3b66a8475134d8ffad35618cf2",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -589,6 +589,64 @@
                 "source": "https://github.com/php-fig/log/tree/1.1.3"
             },
             "time": "2020-03-23T09:12:05+00:00"
+        },
+        {
+            "name": "sanmai/later",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sanmai/later.git",
+                "reference": "d42e29e587fbac5a7a64e4081348206c2fb0987c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sanmai/later/zipball/d42e29e587fbac5a7a64e4081348206c2fb0987c",
+                "reference": "d42e29e587fbac5a7a64e4081348206c2fb0987c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.13",
+                "infection/infection": ">=0.10.5",
+                "phan/phan": "^2.0",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpstan/phpstan": ">=0.10",
+                "phpunit/phpunit": "^7.4 || ^8.1 || ^9.3",
+                "vimeo/psalm": "^2.0 || ^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Later\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Alexey Kopytko",
+                    "email": "alexey@kopytko.com"
+                }
+            ],
+            "description": "Later: deferred wrapper object",
+            "support": {
+                "issues": "https://github.com/sanmai/later/issues",
+                "source": "https://github.com/sanmai/later/tree/0.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sanmai",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-14T14:07:41+00:00"
         },
         {
             "name": "sanmai/pipeline",

--- a/src/TestFramework/Coverage/UncoveredTraceProvider.php
+++ b/src/TestFramework/Coverage/UncoveredTraceProvider.php
@@ -35,6 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Coverage;
 
+use function Later\now;
+
 /**
  * Adds empty coverage report to uncovered files provided by BufferedSourceFileFilter.
  *
@@ -55,7 +57,7 @@ final class UncoveredTraceProvider implements TraceProvider
     public function provideTraces(): iterable
     {
         foreach ($this->bufferedFilter->getUnseenInCoverageReportFiles() as $splFileInfo) {
-            yield new ProxyTrace($splFileInfo, [new TestLocations()]);
+            yield new ProxyTrace($splFileInfo, now(new TestLocations()));
         }
     }
 }

--- a/src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php
+++ b/src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php
@@ -43,6 +43,7 @@ use Infection\TestFramework\Coverage\SourceMethodLineRange;
 use Infection\TestFramework\Coverage\TestLocations;
 use Infection\TestFramework\Coverage\Trace;
 use Infection\TestFramework\SafeDOMXPath;
+use function Later\lazy;
 use Webmozart\Assert\Assert;
 
 /**
@@ -59,7 +60,7 @@ class XmlCoverageParser
     {
         return new ProxyTrace(
             $provider->provideFileInfo(),
-            self::createTestLocationsGenerator($provider->provideXPath())
+            lazy(self::createTestLocationsGenerator($provider->provideXPath()))
         );
     }
 

--- a/tests/phpunit/Mutation/MutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/MutationGeneratorTest.php
@@ -48,6 +48,7 @@ use Infection\TestFramework\Coverage\ProxyTrace;
 use Infection\TestFramework\Coverage\TraceProvider;
 use Infection\Tests\Fixtures\Mutator\FakeMutator;
 use Infection\Tests\Fixtures\PhpParser\FakeIgnorer;
+use function Later\now;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -62,8 +63,8 @@ final class MutationGeneratorTest extends TestCase
         $fileInfo = $this->createMock(SplFileInfo::class);
 
         // Prophecy compares arguments on equality, therefore these have to be somewhat unique
-        $proxyTraceA = new ProxyTrace($fileInfo, [1]);
-        $proxyTraceB = new ProxyTrace($fileInfo, [2]);
+        $proxyTraceA = new ProxyTrace($fileInfo, now(1));
+        $proxyTraceB = new ProxyTrace($fileInfo, now(2));
 
         $mutators = ['Fake' => new IgnoreMutator(new IgnoreConfig([]), new FakeMutator())];
         $eventDispatcherMock = $this->createMock(EventDispatcher::class);
@@ -162,16 +163,14 @@ final class MutationGeneratorTest extends TestCase
                         'fileA',
                         'relativePathToFileA',
                         'relativePathnameToFileA'
-                    ),
-                    []
+                    )
                 ),
                 new ProxyTrace(
                     new SplFileInfo(
                         'fileB',
                         'relativePathToFileB',
                         'relativePathnameToFileB'
-                    ),
-                    []
+                    )
                 ),
             ])
         ;
@@ -223,16 +222,14 @@ final class MutationGeneratorTest extends TestCase
                         'fileA',
                         'relativePathToFileA',
                         'relativePathnameToFileA'
-                    ),
-                    []
+                    )
                 ),
                 new ProxyTrace(
                     new SplFileInfo(
                         'fileB',
                         'relativePathToFileB',
                         'relativePathnameToFileB'
-                    ),
-                    []
+                    )
                 ),
             ])
         ;

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php
@@ -43,6 +43,7 @@ use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
 use Infection\TestFramework\Coverage\ProxyTrace;
 use Infection\TestFramework\Coverage\TestLocations;
 use Infection\Tests\TestFramework\Coverage\TestLocationsNormalizer;
+use function Later\now;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -107,7 +108,7 @@ final class JUnitTestExecutionInfoAdderTest extends TestCase
 
         $proxyTrace = new ProxyTrace(
             new SplFileInfo('/path/to/Foo.php', 'Foo.php', 'Foo.php'),
-            [$tests]
+            now($tests)
         );
 
         $expected = [$proxyTrace];

--- a/tests/phpunit/TestFramework/Coverage/ProxyTraceTest.php
+++ b/tests/phpunit/TestFramework/Coverage/ProxyTraceTest.php
@@ -40,6 +40,7 @@ use Infection\TestFramework\Coverage\NodeLineRangeData;
 use Infection\TestFramework\Coverage\ProxyTrace;
 use Infection\TestFramework\Coverage\SourceMethodLineRange;
 use Infection\TestFramework\Coverage\TestLocations;
+use function Later\now;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -49,7 +50,7 @@ final class ProxyTraceTest extends TestCase
     {
         $fileInfoMock = $this->createMock(SplFileInfo::class);
 
-        $actual = (new ProxyTrace($fileInfoMock, []))->getSourceFileInfo();
+        $actual = (new ProxyTrace($fileInfoMock))->getSourceFileInfo();
 
         $this->assertSame(
             $fileInfoMock,
@@ -67,7 +68,7 @@ final class ProxyTraceTest extends TestCase
             ->willReturn($expected)
         ;
 
-        $actual = (new ProxyTrace($fileInfoMock, []))->getRealPath();
+        $actual = (new ProxyTrace($fileInfoMock))->getRealPath();
 
         $this->assertSame($expected, $actual);
     }
@@ -77,7 +78,7 @@ final class ProxyTraceTest extends TestCase
         $fileInfoMock = $this->createMock(SplFileInfo::class);
         $tests = new TestLocations();
 
-        $trace = new ProxyTrace($fileInfoMock, [$tests]);
+        $trace = new ProxyTrace($fileInfoMock, now($tests));
 
         $actual = $trace->getTests();
         $this->assertSame($tests, $actual);
@@ -91,7 +92,7 @@ final class ProxyTraceTest extends TestCase
     {
         $fileInfoMock = $this->createMock(SplFileInfo::class);
 
-        $trace = new ProxyTrace($fileInfoMock, [new TestLocations()]);
+        $trace = new ProxyTrace($fileInfoMock, now(new TestLocations()));
 
         $this->assertFalse($trace->hasTests());
     }
@@ -114,7 +115,7 @@ final class ProxyTraceTest extends TestCase
             ]
         );
 
-        $trace = new ProxyTrace($fileInfoMock, [$tests]);
+        $trace = new ProxyTrace($fileInfoMock, now($tests));
 
         $this->assertTrue($trace->hasTests());
 


### PR DESCRIPTION
This PR:

- [x] Attempts to lazify ProxyTrace [with Deferred](https://github.com/sanmai/later#use)
- [x] Covered by tests

`sanmai/later` is a small, fully type-transparent library (with generics, under PHPStan/Psalm/Phan) from yours truly (full disclosure), invented this spring during the original work on ProxyTrace. I let it lay for several months, used here and there, and I think it's time for a wider adoption. It is quite easy to lazify/deferify almost everything with this library. What is ongoing in #1420.

In this particular case we employed about the same pattern before, therefore, outside of having to manage less code, there will be no speed bump, but I envy #1420 comes with at least some improvement in this regards (and _there is_ some!). 