### PR TITLE
Optimize NodeMutationGenerator

### DIFF
--- a/devTools/phpstan-src-baseline.neon
+++ b/devTools/phpstan-src-baseline.neon
@@ -516,16 +516,6 @@ parameters:
 			path: ../src/Mutator/NodeMutationGenerator.php
 
 		-
-			message: "#^Anonymous function should have native return typehint \"Generator\"\\.$#"
-			count: 1
-			path: ../src/Mutator/NodeMutationGenerator.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
-			count: 2
-			path: ../src/Mutator/NodeMutationGenerator.php
-
-		-
 			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Scalar\\\\LNumber\\) of method Infection\\\\Mutator\\\\Number\\\\DecrementInteger\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
 			count: 2
 			path: ../src/Mutator/Number/DecrementInteger.php


### PR DESCRIPTION
This PR:

- [x] Optimizes `NodeMutationGenerator` to run fastest checks first
- [x] Covered by tests
- [x] [Blackfire diff](https://blackfire.io/profiles/compare/7339bfb2-76f7-4c7b-9023-af765e8b7358/graph) shows 12% time reduction.

 `NodeMutationGenerator` is one of the hottest places we have. Infections spends about _two thirds_ of the time in it. And it operates with O(n<sup>2</sup>) complexity, which we can't really do anything about (best guess). Therefore any small optimization we can make is worth it.

<details>
  <summary>Cachegrind reports</summary>

Here's a screenshot of a Cachegrind report from before this change:

![NodeMutationGenerator](https://user-images.githubusercontent.com/139488/98646248-78849500-2376-11eb-943a-abefca4e6e9b.png)

And here's after:

![NodeMutationGenerator2](https://user-images.githubusercontent.com/139488/98651108-23984d00-237d-11eb-90a3-484e538566b2.png)

</details>