### PR TITLE
Address NodeMutationGenerator review

### DIFF
--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -130,7 +130,7 @@ class NodeMutationGenerator
             );
         }
 
-        $tests = $this->getAllTestsCurrentNode();
+        $tests = $this->getAllTestsForCurrentNode();
 
         if ($this->onlyCovered && count($tests) === 0) {
             return;
@@ -169,7 +169,7 @@ class NodeMutationGenerator
     /**
      * @return TestLocation[]
      */
-    private function getAllTestsCurrentNode(): array
+    private function getAllTestsForCurrentNode(): array
     {
         if ($this->testsMemoized !== null) {
             return $this->testsMemoized;

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -130,7 +130,7 @@ class NodeMutationGenerator
             );
         }
 
-        $tests = $this->getAllTestsForMutation();
+        $tests = $this->getAllTestsCurrentNode();
 
         if ($this->onlyCovered && count($tests) === 0) {
             return;
@@ -169,7 +169,7 @@ class NodeMutationGenerator
     /**
      * @return TestLocation[]
      */
-    private function getAllTestsForMutation(): array
+    private function getAllTestsCurrentNode(): array
     {
         if ($this->testsMemoized !== null) {
             return $this->testsMemoized;


### PR DESCRIPTION
`getAllTestsForCurrentNode()` is not concerned with a mutator or mutation, only with the current node.

Follow-up to #1423 
