### PR TITLE
Introduce FilteringResultsCollector

### DIFF
--- a/devTools/phpstan-tests.neon
+++ b/devTools/phpstan-tests.neon
@@ -14,7 +14,7 @@ parameters:
         - '#Return type \((void|mixed)\) of method .*(Visitor|Traverser).* should be compatible with return type .* of method PhpParser\\Node.*#'
         - '#^Cannot call method (willReturn|shouldBeCalledTimes)\(\) on iterable<Infection\\Mutation\\Mutation>\.$#'
         - '#Offset .*\\.* does not exist on array<class-string<.*>.*#'
-        - '#Dynamic call to static method PHPUnit\\Framework\\Assert::(.*)#'
+        - '#Dynamic call to static method PHPUnit\\Framework\\.*::.*#'
         - '#Call to method PHPUnit\\Framework\\Assert::.* with array.* and array.* will always evaluate to false#'
         - '#^PHPDoc tag @var for variable \$sourceFilesCollectorProphecy contains unresolvable type#'
         -

--- a/src/Configuration/Entry/Logs.php
+++ b/src/Configuration/Entry/Logs.php
@@ -37,8 +37,9 @@ namespace Infection\Configuration\Entry;
 
 /**
  * @internal
+ * @final
  */
-final class Logs
+class Logs
 {
     private ?string $textLogFilePath;
     private ?string $summaryLogFilePath;

--- a/src/Container.php
+++ b/src/Container.php
@@ -545,7 +545,7 @@ final class Container
                 $config = $container->getConfiguration();
 
                 return new TargetDetectionStatusesProvider(
-                    $container->getConfiguration()->getLogs(),
+                    $config->getLogs(),
                     $config->getLogVerbosity(),
                     $config->mutateOnlyCoveredCode()
                 );

--- a/src/Container.php
+++ b/src/Container.php
@@ -547,7 +547,8 @@ final class Container
                 return new TargetDetectionStatusesProvider(
                     $config->getLogs(),
                     $config->getLogVerbosity(),
-                    $config->mutateOnlyCoveredCode()
+                    $config->mutateOnlyCoveredCode(),
+                    $config->showMutations()
                 );
             },
             FilteringResultsCollectorFactory::class => static function (self $container): FilteringResultsCollectorFactory {

--- a/src/Metrics/FilteringResultsCollector.php
+++ b/src/Metrics/FilteringResultsCollector.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Metrics;
+
+use function array_filter;
+use function array_key_exists;
+use Infection\Mutant\MutantExecutionResult;
+
+/**
+ * @internal
+ * @final
+ */
+class FilteringResultsCollector implements Collector
+{
+    private Collector $targetCollector;
+    private array $targetDetectionStatuses;
+
+    /**
+     * @param array<string, mixed> $targetDetectionStatuses
+     */
+    public function __construct(Collector $targetCollector, array $targetDetectionStatuses)
+    {
+        $this->targetCollector = $targetCollector;
+        $this->targetDetectionStatuses = $targetDetectionStatuses;
+    }
+
+    public function collect(MutantExecutionResult ...$executionResults): void
+    {
+        $executionResults = array_filter(
+            $executionResults,
+            function (MutantExecutionResult $executionResults): bool {
+                return array_key_exists($executionResults->getDetectionStatus(), $this->targetDetectionStatuses);
+            }
+        );
+
+        if ($executionResults !== []) {
+            $this->targetCollector->collect(...$executionResults);
+        }
+    }
+}

--- a/src/Metrics/FilteringResultsCollector.php
+++ b/src/Metrics/FilteringResultsCollector.php
@@ -46,6 +46,7 @@ use Infection\Mutant\MutantExecutionResult;
 class FilteringResultsCollector implements Collector
 {
     private Collector $targetCollector;
+    /** @var array<string, mixed> */
     private array $targetDetectionStatuses;
 
     /**

--- a/src/Metrics/TargetDetectionStatusesProvider.php
+++ b/src/Metrics/TargetDetectionStatusesProvider.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Metrics;
+
+use Infection\Configuration\Entry\Logs;
+use Infection\Console\LogVerbosity;
+use Infection\Logger\TextFileLogger;
+use Infection\Mutant\DetectionStatus;
+
+/**
+ * @internal
+ */
+final class TargetDetectionStatusesProvider
+{
+    private Logs $logConfig;
+    private string $logVerbosity;
+    private bool $onlyCoveredMode;
+
+    public function __construct(
+        Logs $logConfig,
+        string $logVerbosity,
+        bool $onlyCoveredMode
+    ) {
+        $this->logConfig = $logConfig;
+        $this->logVerbosity = $logVerbosity;
+        $this->onlyCoveredMode = $onlyCoveredMode;
+    }
+
+    /**
+     * Implementation follows the logic in TextFileLogger.
+     *
+     * @see TextFileLogger
+     *
+     * @return array<string, mixed>
+     */
+    public function get(): array
+    {
+        $targetDetectionStatuses = array_flip(DetectionStatus::ALL);
+
+        if ($this->logConfig->getDebugLogFilePath() !== null) {
+            return $targetDetectionStatuses;
+        }
+
+        if ($this->logVerbosity !== LogVerbosity::DEBUG) {
+            unset($targetDetectionStatuses[DetectionStatus::KILLED]);
+            unset($targetDetectionStatuses[DetectionStatus::ERROR]);
+        }
+
+        if ($this->onlyCoveredMode) {
+            unset($targetDetectionStatuses[DetectionStatus::NOT_COVERED]);
+        }
+
+        return $targetDetectionStatuses;
+    }
+}

--- a/src/Metrics/TargetDetectionStatusesProvider.php
+++ b/src/Metrics/TargetDetectionStatusesProvider.php
@@ -39,6 +39,7 @@ use Infection\Configuration\Entry\Logs;
 use Infection\Console\LogVerbosity;
 use Infection\Logger\TextFileLogger;
 use Infection\Mutant\DetectionStatus;
+use function Safe\array_flip;
 
 /**
  * @internal

--- a/src/Metrics/TargetDetectionStatusesProvider.php
+++ b/src/Metrics/TargetDetectionStatusesProvider.php
@@ -81,6 +81,9 @@ class TargetDetectionStatusesProvider
     /**
      * TODO This has to be a responsibility of loggers.
      *
+     * @see https://github.com/infection/infection/pull/1430#pullrequestreview-535715334
+     * @deprecated
+     *
      * @return Generator<string>
      */
     private function findRequired(): Generator

--- a/src/Metrics/TargetDetectionStatusesProvider.php
+++ b/src/Metrics/TargetDetectionStatusesProvider.php
@@ -74,6 +74,11 @@ final class TargetDetectionStatusesProvider
             return $targetDetectionStatuses;
         }
 
+        // Per mutator logger uses mutation results to make a summary
+        if ($this->logConfig->getPerMutatorFilePath() !== null) {
+            return $targetDetectionStatuses;
+        }
+
         if ($this->logVerbosity !== LogVerbosity::DEBUG) {
             unset($targetDetectionStatuses[DetectionStatus::KILLED]);
             unset($targetDetectionStatuses[DetectionStatus::ERROR]);

--- a/src/Metrics/TargetDetectionStatusesProvider.php
+++ b/src/Metrics/TargetDetectionStatusesProvider.php
@@ -97,10 +97,14 @@ class TargetDetectionStatusesProvider
     /**
      * TODO This has to be a responsibility of loggers.
      *
-     * @return iterable<string>
+     * @return Generator<string>
      */
     private function findRequired(): Generator
     {
+        if ($this->showMutations) {
+            yield DetectionStatus::ESCAPED;
+        }
+
         if ($this->logConfig->getUseGitHubAnnotationsLogger()) {
             yield DetectionStatus::ESCAPED;
         }

--- a/tests/phpunit/Metrics/CreateMutantExecutionResult.php
+++ b/tests/phpunit/Metrics/CreateMutantExecutionResult.php
@@ -51,7 +51,7 @@ trait CreateMutantExecutionResult
     private function addMutantExecutionResult(
         Collector $collector,
         string $detectionStatus,
-        int $count
+        int $count = 1
     ): array {
         $executionResults = [];
 

--- a/tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php
+++ b/tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Metrics;
 
-use function array_flip;
 use Infection\Metrics\Collector;
 use Infection\Metrics\FilteringResultsCollector;
 use Infection\Metrics\FilteringResultsCollectorFactory;
 use Infection\Metrics\TargetDetectionStatusesProvider;
 use Infection\Mutant\DetectionStatus;
 use PHPUnit\Framework\TestCase;
+use function Safe\array_flip;
 
 final class FilteringResultsCollectorFactoryTest extends TestCase
 {

--- a/tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php
+++ b/tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Metrics;
+
+use function array_flip;
+use Infection\Metrics\Collector;
+use Infection\Metrics\FilteringResultsCollector;
+use Infection\Metrics\FilteringResultsCollectorFactory;
+use Infection\Metrics\TargetDetectionStatusesProvider;
+use Infection\Mutant\DetectionStatus;
+use PHPUnit\Framework\TestCase;
+
+final class FilteringResultsCollectorFactoryTest extends TestCase
+{
+    use CreateMutantExecutionResult;
+
+    public function test_it_makes_non_filtering_collector(): void
+    {
+        $statusesProvider = $this->createMock(TargetDetectionStatusesProvider::class);
+        $statusesProvider
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn(array_flip(DetectionStatus::ALL));
+
+        $factory = new FilteringResultsCollectorFactory($statusesProvider);
+
+        $targetCollector = $this->createMock(Collector::class);
+
+        $filteringCollector = $factory->create($targetCollector);
+
+        $this->assertSame($targetCollector, $filteringCollector);
+    }
+
+    public function test_it_makes_non_collector(): void
+    {
+        $statusesProvider = $this->createMock(TargetDetectionStatusesProvider::class);
+        $statusesProvider
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn([]);
+
+        $factory = new FilteringResultsCollectorFactory($statusesProvider);
+
+        $targetCollector = $this->createMock(Collector::class);
+
+        $filteringCollector = $factory->create($targetCollector);
+
+        $this->assertNull($filteringCollector);
+    }
+
+    public function test_it_makes_filtering_collector(): void
+    {
+        $statusesProvider = $this->createMock(TargetDetectionStatusesProvider::class);
+        $statusesProvider
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn([
+                DetectionStatus::ESCAPED => true,
+            ]);
+
+        $factory = new FilteringResultsCollectorFactory($statusesProvider);
+
+        $targetCollector = $this->createMock(Collector::class);
+
+        $filteringCollector = $factory->create($targetCollector);
+
+        $this->assertInstanceOf(FilteringResultsCollector::class, $filteringCollector);
+
+        $targetCollector
+            ->expects($this->once())
+            ->method('collect')
+        ;
+
+        $this->addMutantExecutionResult(
+            $filteringCollector,
+            DetectionStatus::ESCAPED
+        );
+
+        $this->addMutantExecutionResult(
+            $filteringCollector,
+            DetectionStatus::KILLED
+        );
+    }
+}

--- a/tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php
+++ b/tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php
@@ -70,7 +70,8 @@ final class FilteringResultsCollectorFactoryTest extends TestCase
         $statusesProvider
             ->expects($this->once())
             ->method('get')
-            ->willReturn([]);
+            ->willReturn([])
+        ;
 
         $factory = new FilteringResultsCollectorFactory($statusesProvider);
 
@@ -89,7 +90,8 @@ final class FilteringResultsCollectorFactoryTest extends TestCase
             ->method('get')
             ->willReturn([
                 DetectionStatus::ESCAPED => true,
-            ]);
+            ])
+        ;
 
         $factory = new FilteringResultsCollectorFactory($statusesProvider);
 

--- a/tests/phpunit/Metrics/FilteringResultsCollectorTest.php
+++ b/tests/phpunit/Metrics/FilteringResultsCollectorTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Metrics;
+
+use function array_flip;
+use Infection\Metrics\Collector;
+use Infection\Metrics\FilteringResultsCollector;
+use Infection\Mutant\DetectionStatus;
+use PHPUnit\Framework\TestCase;
+
+final class FilteringResultsCollectorTest extends TestCase
+{
+    use CreateMutantExecutionResult;
+
+    public function test_it_collects_nothing_by_default(): void
+    {
+        $targetCollector = $this->createMock(Collector::class);
+        $targetCollector
+            ->expects($this->never())
+            ->method('collect')
+        ;
+
+        $collector = new FilteringResultsCollector($targetCollector, []);
+
+        $this->addMutantExecutionResult(
+            $collector,
+            DetectionStatus::ESCAPED,
+            2
+        );
+    }
+
+    public function test_it_collects_everything_when_told_to(): void
+    {
+        $targetCollector = $this->createMock(Collector::class);
+        $targetCollector
+            ->expects($this->exactly(5))
+            ->method('collect')
+        ;
+
+        $targetDetectionStatuses = array_flip(DetectionStatus::ALL);
+
+        $collector = new FilteringResultsCollector($targetCollector, $targetDetectionStatuses);
+
+        $this->addSeveralMutantExecutionResults($collector);
+    }
+
+    public function test_it_does_not_collect_everything_when_told_to(): void
+    {
+        $targetCollector = $this->createMock(Collector::class);
+        $targetCollector
+            ->expects($this->exactly(4))
+            ->method('collect')
+        ;
+
+        $targetDetectionStatuses = array_flip(DetectionStatus::ALL);
+        unset($targetDetectionStatuses[DetectionStatus::KILLED]);
+
+        $collector = new FilteringResultsCollector($targetCollector, $targetDetectionStatuses);
+
+        $this->addSeveralMutantExecutionResults($collector);
+    }
+
+    private function addSeveralMutantExecutionResults(Collector $collector): void
+    {
+        $this->addMutantExecutionResult(
+            $collector,
+            DetectionStatus::KILLED,
+            7
+        );
+
+        $this->addMutantExecutionResult(
+            $collector,
+            DetectionStatus::ERROR,
+            2
+        );
+
+        $this->addMutantExecutionResult(
+            $collector,
+            DetectionStatus::ESCAPED,
+            2
+        );
+
+        $this->addMutantExecutionResult(
+            $collector,
+            DetectionStatus::TIMED_OUT,
+            2
+        );
+
+        $this->addMutantExecutionResult(
+            $collector,
+            DetectionStatus::NOT_COVERED,
+            1
+        );
+    }
+}

--- a/tests/phpunit/Metrics/FilteringResultsCollectorTest.php
+++ b/tests/phpunit/Metrics/FilteringResultsCollectorTest.php
@@ -35,11 +35,11 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Metrics;
 
-use function array_flip;
 use Infection\Metrics\Collector;
 use Infection\Metrics\FilteringResultsCollector;
 use Infection\Mutant\DetectionStatus;
 use PHPUnit\Framework\TestCase;
+use function Safe\array_flip;
 
 final class FilteringResultsCollectorTest extends TestCase
 {

--- a/tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php
+++ b/tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php
@@ -35,12 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Metrics;
 
-use function array_flip;
 use Infection\Configuration\Entry\Logs;
 use Infection\Console\LogVerbosity;
 use Infection\Metrics\TargetDetectionStatusesProvider;
 use Infection\Mutant\DetectionStatus;
 use PHPUnit\Framework\TestCase;
+use function Safe\array_flip;
 
 final class TargetDetectionStatusesProviderTest extends TestCase
 {

--- a/tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php
+++ b/tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Metrics;
+
+use function array_flip;
+use Infection\Configuration\Entry\Logs;
+use Infection\Console\LogVerbosity;
+use Infection\Metrics\TargetDetectionStatusesProvider;
+use Infection\Mutant\DetectionStatus;
+use PHPUnit\Framework\TestCase;
+
+final class TargetDetectionStatusesProviderTest extends TestCase
+{
+    public function test_it_provides_all_statuses_when_debugging_log_is_enabled(): void
+    {
+        $logs = $this->createMock(Logs::class);
+        $logs
+            ->expects($this->once())
+            ->method('getDebugLogFilePath')
+            ->willReturn('debug.log')
+        ;
+
+        $provider = new TargetDetectionStatusesProvider($logs, LogVerbosity::NORMAL, false);
+
+        $this->assertSame(
+            $this->getDetectionStatusesIndexExcluding([]),
+            $provider->get()
+        );
+    }
+
+    public function test_it_provides_all_statuses_when_per_mutator_report_is_expected(): void
+    {
+        $logs = $this->createMock(Logs::class);
+        $logs
+            ->expects($this->once())
+            ->method('getPerMutatorFilePath')
+            ->willReturn('per_mutator.md')
+        ;
+
+        $provider = new TargetDetectionStatusesProvider($logs, LogVerbosity::NORMAL, false);
+
+        $this->assertSame(
+            $this->getDetectionStatusesIndexExcluding([]),
+            $provider->get()
+        );
+    }
+
+    public function test_it_provides_all_statuses_when_debugging_is_enabled(): void
+    {
+        $logs = $this->createMock(Logs::class);
+
+        $provider = new TargetDetectionStatusesProvider($logs, LogVerbosity::DEBUG, false);
+
+        $this->assertSame(
+            $this->getDetectionStatusesIndexExcluding([]),
+            $provider->get()
+        );
+    }
+
+    public function test_it_ignores_some_statuses_when_debugging_is_not_enabled(): void
+    {
+        $logs = $this->createMock(Logs::class);
+
+        $provider = new TargetDetectionStatusesProvider($logs, LogVerbosity::NORMAL, false);
+
+        $this->assertSame(
+            $this->getDetectionStatusesIndexExcluding([
+                DetectionStatus::KILLED,
+                DetectionStatus::ERROR,
+            ]),
+            $provider->get()
+        );
+    }
+
+    public function test_it_ignores_more_statuses_when_running_in_only_covered_mode(): void
+    {
+        $logs = $this->createMock(Logs::class);
+
+        $provider = new TargetDetectionStatusesProvider($logs, LogVerbosity::NORMAL, true);
+
+        $this->assertSame(
+            $this->getDetectionStatusesIndexExcluding([
+                DetectionStatus::KILLED,
+                DetectionStatus::ERROR,
+                DetectionStatus::NOT_COVERED,
+            ]),
+            $provider->get()
+        );
+    }
+
+    private function getDetectionStatusesIndexExcluding(array $excludeList): array
+    {
+        $detectionStatuses = array_flip(DetectionStatus::ALL);
+
+        foreach ($excludeList as $exclude) {
+            unset($detectionStatuses[$exclude]);
+        }
+
+        return $detectionStatuses;
+    }
+}

--- a/tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php
+++ b/tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php
@@ -179,7 +179,7 @@ final class TargetDetectionStatusesProviderTest extends TestCase
         ], $provider->get());
     }
 
-    public function test_it_provides_certain_statuses_includin_not_covered_for_json_logger(): void
+    public function test_it_provides_certain_statuses_including_not_covered_for_json_logger(): void
     {
         $logs = $this->createMock(Logs::class);
         $logs


### PR DESCRIPTION
This PR:

- [x] Adds `FilteringResultsCollector` that excludes unneeded mutation results depending on logging/debugging configuration.
- [x] Covered by tests
- [x] Benchmarks
  - From current `master` build [there's a 66% memory reduction](https://blackfire.io/profiles/compare/9c9a7a2e-231f-46be-85df-76c710eb95e5/graph).
  - From 0.20.1 [a diff shows](https://blackfire.io/profiles/compare/cc3fb3b9-0d33-4406-82a3-65009dfcaf0c/graph) -46% time reduction, -23% memory reduction.

I'm not too happy about `TargetDetectionStatusesProvider` because it does what individual loggers should provide, but that should do it for now. Changing the loggers to supply this information to `TargetDetectionStatusesProvider` will require fairly substantial refactoring with otherwise uncertain benefits.

Follow-up to #1425 

<details>
  <summary>Blackfire is a bit flacky, here are the screenshots</summary>
  
![vs current master](https://user-images.githubusercontent.com/139488/99816071-8912e780-2b8e-11eb-8ebb-6b30a81217a5.png)
![vs 0.20.1](https://user-images.githubusercontent.com/139488/99816076-8a441480-2b8e-11eb-8135-89cd36c66b9b.png)
  
</details>
