### PR TITLE
Refactor ProxyTrace/JUnitTestExecutionInfoAdder to skip uncovered traces

### DIFF
--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -84,7 +84,13 @@ class JUnitTestExecutionInfoAdder
     {
         /** @var Trace $trace */
         foreach ($traces as $trace) {
-            foreach ($trace->getTests()->getTestsLocationsBySourceLine() as &$testsLocations) {
+            $tests = $trace->getTests();
+
+            if ($tests === null) {
+                continue;
+            }
+
+            foreach ($tests->getTestsLocationsBySourceLine() as &$testsLocations) {
                 foreach ($testsLocations as $line => $test) {
                     $testsLocations[$line] = $this->createCompleteTestLocation($test);
                 }

--- a/src/TestFramework/Coverage/ProxyTrace.php
+++ b/src/TestFramework/Coverage/ProxyTrace.php
@@ -90,16 +90,20 @@ class ProxyTrace implements Trace
 
     public function hasTests(): bool
     {
+        if ($this->lazyTestLocations === null) {
+            return false;
+        }
+
         return $this->getTestLocator()->hasTests();
     }
 
-    public function getTests(): TestLocations
+    public function getTests(): ?TestLocations
     {
         if ($this->lazyTestLocations !== null) {
             return $this->lazyTestLocations->get();
         }
 
-        return new TestLocations();
+        return null;
     }
 
     public function getAllTestsForMutation(NodeLineRangeData $lineRange, bool $isOnFunctionSignature): iterable
@@ -113,7 +117,11 @@ class ProxyTrace implements Trace
             return $this->tests;
         }
 
-        $this->tests = new TestLocator($this->getTests());
+        $testLocations = $this->getTests();
+
+        Assert::notNull($testLocations);
+
+        $this->tests = new TestLocator($testLocations);
 
         return $this->tests;
     }

--- a/src/TestFramework/Coverage/Trace.php
+++ b/src/TestFramework/Coverage/Trace.php
@@ -67,7 +67,7 @@ interface Trace
 
     public function hasTests(): bool;
 
-    public function getTests(): TestLocations;
+    public function getTests(): ?TestLocations;
 
     /**
      * @return iterable<TestLocation>

--- a/src/TestFramework/Coverage/UncoveredTraceProvider.php
+++ b/src/TestFramework/Coverage/UncoveredTraceProvider.php
@@ -35,8 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Coverage;
 
-use function Later\now;
-
 /**
  * Adds empty coverage report to uncovered files provided by BufferedSourceFileFilter.
  *
@@ -57,7 +55,7 @@ final class UncoveredTraceProvider implements TraceProvider
     public function provideTraces(): iterable
     {
         foreach ($this->bufferedFilter->getUnseenInCoverageReportFiles() as $splFileInfo) {
-            yield new ProxyTrace($splFileInfo, now(new TestLocations()));
+            yield new ProxyTrace($splFileInfo, null);
         }
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/ProxyTraceTest.php
+++ b/tests/phpunit/TestFramework/Coverage/ProxyTraceTest.php
@@ -97,6 +97,17 @@ final class ProxyTraceTest extends TestCase
         $this->assertFalse($trace->hasTests());
     }
 
+    public function test_it_returns_null_for_no_tests(): void
+    {
+        $fileInfoMock = $this->createMock(SplFileInfo::class);
+
+        $trace = new ProxyTrace($fileInfoMock, null);
+
+        $this->assertFalse($trace->hasTests());
+
+        $this->assertNull($trace->getTests());
+    }
+
     public function test_it_exposes_its_test_locations(): void
     {
         $fileInfoMock = $this->createMock(SplFileInfo::class);


### PR DESCRIPTION
This PR:

- [x] Refactors ProxyTrace/JUnitTestExecutionInfoAdder to skip uncovered traces; should save a few cycles
- [x] Covered by tests

PHP 8 build is failing on `master` too. And I can't reproduce it locally. Which means there's a change it'll go away with a next nightly build.