### PR TITLE
Add ConcatOperandRemoval mutator (fixes #1439)

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -302,6 +302,7 @@
                 "FunctionCallRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "MethodCallRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "CloneRemoval": { "$ref": "#/definitions/default-mutator-config" },
+                "ConcatOperandRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "SharedCaseRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "ArrayOneItem": { "$ref": "#/definitions/default-mutator-config" },
                 "FloatNegation": { "$ref": "#/definitions/default-mutator-config" },

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -168,6 +168,7 @@ final class ProfileList
     public const REMOVAL_PROFILE = [
         Mutator\Removal\ArrayItemRemoval::class,
         Mutator\Removal\CloneRemoval::class,
+        Mutator\Removal\ConcatOperandRemoval::class,
         Mutator\Removal\FunctionCallRemoval::class,
         Mutator\Removal\MethodCallRemoval::class,
         Mutator\Removal\SharedCaseRemoval::class,
@@ -362,6 +363,7 @@ final class ProfileList
         // Removal
         'ArrayItemRemoval' => Mutator\Removal\ArrayItemRemoval::class,
         'CloneRemoval' => Mutator\Removal\CloneRemoval::class,
+        'ConcatOperandRemoval' => Mutator\Removal\ConcatOperandRemoval::class,
         'FunctionCallRemoval' => Mutator\Removal\FunctionCallRemoval::class,
         'MethodCallRemoval' => Mutator\Removal\MethodCallRemoval::class,
         'SharedCaseRemoval' => Mutator\Removal\SharedCaseRemoval::class,

--- a/src/Mutator/Removal/ConcatOperandRemoval.php
+++ b/src/Mutator/Removal/ConcatOperandRemoval.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Removal;
 
-use function assert;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
@@ -44,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Concat>
  */
 final class ConcatOperandRemoval implements Mutator
 {
@@ -84,8 +85,6 @@ TxT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Concat $node
      */
     public function mutate(Node $node): iterable
     {

--- a/src/Mutator/Removal/ConcatOperandRemoval.php
+++ b/src/Mutator/Removal/ConcatOperandRemoval.php
@@ -53,7 +53,7 @@ final class ConcatOperandRemoval implements Mutator
     public static function getDefinition(): ?Definition
     {
         return new Definition(
-            <<<'TXT'
+            <<<'TxT'
 Removes an operand from a string concatenation.
 
 ```php

--- a/src/Mutator/Removal/ConcatOperandRemoval.php
+++ b/src/Mutator/Removal/ConcatOperandRemoval.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Removal;
+
+use Infection\Mutator\Definition;
+use Infection\Mutator\GetMutatorName;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\MutatorCategory;
+use PhpParser\Node;
+
+use function assert;
+
+/**
+ * @internal
+ */
+final class ConcatOperandRemoval implements Mutator
+{
+    use GetMutatorName;
+
+    public static function getDefinition(): ?Definition
+    {
+        return new Definition(
+            <<<'TxT'
+Removes an operand from a string concatenation.
+
+```php
+$x = 'foo' . 'bar';
+```
+
+Will be mutated to:
+
+```php
+$x = 'foo';
+```
+
+And:
+
+```php
+$x = 'bar';
+
+TxT
+            ,
+            MutatorCategory::SEMANTIC_REDUCTION,
+            null
+        );
+    }
+
+    public function canMutate(Node $node): bool
+    {
+        return $node instanceof Node\Expr\BinaryOp\Concat;
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function mutate(Node $node): iterable
+    {
+        assert($node instanceof Node\Expr\BinaryOp\Concat);
+
+        yield $node->left;
+        yield $node->right;
+    }
+}

--- a/src/Mutator/Removal/ConcatOperandRemoval.php
+++ b/src/Mutator/Removal/ConcatOperandRemoval.php
@@ -89,8 +89,14 @@ TxT
     {
         assert($node instanceof Node\Expr\BinaryOp\Concat);
 
-        yield $node->left;
+        if ($node->left instanceof Node\Expr\BinaryOp\Concat) {
+            yield $node->left;
+
+            return;
+        }
 
         yield $node->right;
+
+        yield $node->left;
     }
 }

--- a/src/Mutator/Removal/ConcatOperandRemoval.php
+++ b/src/Mutator/Removal/ConcatOperandRemoval.php
@@ -53,7 +53,7 @@ final class ConcatOperandRemoval implements Mutator
     public static function getDefinition(): ?Definition
     {
         return new Definition(
-            <<<'TxT'
+            <<<'TXT'
 Removes an operand from a string concatenation.
 
 ```php
@@ -71,7 +71,7 @@ And:
 ```php
 $x = 'bar';
 
-TxT
+TXT
             ,
             MutatorCategory::SEMANTIC_REDUCTION,
             null

--- a/src/Mutator/Removal/ConcatOperandRemoval.php
+++ b/src/Mutator/Removal/ConcatOperandRemoval.php
@@ -53,7 +53,7 @@ final class ConcatOperandRemoval implements Mutator
     public static function getDefinition(): ?Definition
     {
         return new Definition(
-            <<<'TxT'
+            <<<'TXT'
 Removes an operand from a string concatenation.
 
 ```php

--- a/src/Mutator/Removal/ConcatOperandRemoval.php
+++ b/src/Mutator/Removal/ConcatOperandRemoval.php
@@ -84,11 +84,11 @@ TxT
 
     /**
      * @psalm-mutation-free
+     *
+     * @param Node\Expr\BinaryOp\Concat $node
      */
     public function mutate(Node $node): iterable
     {
-        assert($node instanceof Node\Expr\BinaryOp\Concat);
-
         if ($node->left instanceof Node\Expr\BinaryOp\Concat) {
             yield $node->left;
 

--- a/src/Mutator/Removal/ConcatOperandRemoval.php
+++ b/src/Mutator/Removal/ConcatOperandRemoval.php
@@ -35,13 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Removal;
 
+use function assert;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
-
-use function assert;
 
 /**
  * @internal
@@ -91,6 +90,7 @@ TxT
         assert($node instanceof Node\Expr\BinaryOp\Concat);
 
         yield $node->left;
+
         yield $node->right;
     }
 }

--- a/tests/phpunit/Mutator/Removal/ConcatOperandRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ConcatOperandRemovalTest.php
@@ -61,13 +61,109 @@ PHP
                 <<<'PHP'
 <?php
 
-'foo';
+'bar';
 PHP
                 ,
                 <<<'PHP'
 <?php
 
-'bar';
+'foo';
+PHP
+                ,
+            ],
+        ];
+
+        yield 'Removes each part of a 3-string concatenation' => [
+            <<<'PHP'
+<?php
+
+$a = 'a';
+$b = 'b';
+$a . $b . 'c';
+PHP
+            ,
+            [
+                <<<'PHP'
+<?php
+
+$a = 'a';
+$b = 'b';
+$b . 'c';
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$a = 'a';
+$b = 'b';
+$a . 'c';
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$a = 'a';
+$b = 'b';
+$a . $b;
+PHP
+                ,
+            ],
+        ];
+
+        yield 'Removes each part of multiple concatenations' => [
+            <<<'PHP'
+<?php
+
+$a = 'a';
+$b = 'b';
+$d = 'd';
+$a . $b . 'c' . $d . 'e';
+PHP
+            ,
+            [
+                <<<'PHP'
+<?php
+
+$a = 'a';
+$b = 'b';
+$d = 'd';
+$b . 'c' . $d . 'e';
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$a = 'a';
+$b = 'b';
+$d = 'd';
+$a . 'c' . $d . 'e';
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$a = 'a';
+$b = 'b';
+$d = 'd';
+$a . $b . $d . 'e';
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$a = 'a';
+$b = 'b';
+$d = 'd';
+$a . $b . 'c' . 'e';
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+$a = 'a';
+$b = 'b';
+$d = 'd';
+$a . $b . 'c' . $d;
 PHP
                 ,
             ],

--- a/tests/phpunit/Mutator/Removal/ConcatOperandRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ConcatOperandRemovalTest.php
@@ -1,4 +1,35 @@
 <?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 declare(strict_types=1);
 
@@ -38,7 +69,8 @@ PHP
 
 'bar';
 PHP
-            ]
+                ,
+            ],
         ];
     }
 }

--- a/tests/phpunit/Mutator/Removal/ConcatOperandRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ConcatOperandRemovalTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Removal;
+
+use Infection\Tests\Mutator\BaseMutatorTestCase;
+
+final class ConcatOperandRemovalTest extends BaseMutatorTestCase
+{
+    /**
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
+     */
+    public function test_it_can_mutate(string $input, $expected = []): void
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function mutationsProvider(): iterable
+    {
+        yield 'Removes both operands' => [
+            <<<'PHP'
+<?php
+'foo' . 'bar';
+PHP
+            ,
+            [
+                <<<'PHP'
+<?php
+
+'foo';
+PHP
+                ,
+                <<<'PHP'
+<?php
+
+'bar';
+PHP
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds a new `ConcatOperandRemoval` mutator that mutates `'foo' . 'bar'` to `'foo'` and `'bar'`.
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/199

fixes #1439