### PR TITLE
Make Mutator interface generic

### DIFF
--- a/devTools/phpstan-src-baseline.neon
+++ b/devTools/phpstan-src-baseline.neon
@@ -66,7 +66,7 @@ parameters:
 			path: ../src/Configuration/Configuration.php
 
 		-
-			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allIsInstanceOf\\(\\) with array\\<string, Infection\\\\Mutator\\\\Mutator\\> and 'Infection\\\\\\\\Mutator\\\\\\\\Mutator' will always evaluate to true\\.$#"
+			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allIsInstanceOf\\(\\) with array\\<string, Infection\\\\Mutator\\\\Mutator\\<PhpParser\\\\Node\\>\\> and 'Infection\\\\\\\\Mutator\\\\\\\\Mutator' will always evaluate to true\\.$#"
 			count: 1
 			path: ../src/Configuration/Configuration.php
 
@@ -181,7 +181,7 @@ parameters:
 			path: ../src/Metrics/MinMsiChecker.php
 
 		-
-			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allIsInstanceOf\\(\\) with array\\<Infection\\\\Mutator\\\\Mutator\\> and 'Infection\\\\\\\\Mutator\\\\\\\\Mutator' will always evaluate to true\\.$#"
+			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allIsInstanceOf\\(\\) with array\\<Infection\\\\Mutator\\\\Mutator\\<PhpParser\\\\Node\\>\\> and 'Infection\\\\\\\\Mutator\\\\\\\\Mutator' will always evaluate to true\\.$#"
 			count: 1
 			path: ../src/Mutation/FileMutationGenerator.php
 
@@ -191,7 +191,7 @@ parameters:
 			path: ../src/Mutation/FileMutationGenerator.php
 
 		-
-			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allIsInstanceOf\\(\\) with array\\<Infection\\\\Mutator\\\\Mutator\\> and 'Infection\\\\\\\\Mutator\\\\\\\\Mutator' will always evaluate to true\\.$#"
+			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allIsInstanceOf\\(\\) with array\\<Infection\\\\Mutator\\\\Mutator\\<PhpParser\\\\Node\\>\\> and 'Infection\\\\\\\\Mutator\\\\\\\\Mutator' will always evaluate to true\\.$#"
 			count: 1
 			path: ../src/Mutation/MutationGenerator.php
 
@@ -201,64 +201,9 @@ parameters:
 			path: ../src/Mutator/AllowedFunctionsConfig.php
 
 		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\AssignOp\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\Assignment\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/Assignment.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Equal\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\AssignmentEqual\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/AssignmentEqual.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\BooleanAnd\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\BitwiseAnd\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/BitwiseAnd.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BitwiseNot\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\BitwiseNot\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/BitwiseNot.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\BitwiseOr\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\BitwiseOr\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/BitwiseOr.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\BitwiseXor\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\BitwiseXor\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/BitwiseXor.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\PostDec\\|PhpParser\\\\Node\\\\Expr\\\\PreDec\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\Decrement\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/Decrement.php
-
-		-
 			message: "#^Instanceof between PhpParser\\\\Node\\\\Expr\\\\PostDec and PhpParser\\\\Node\\\\Expr\\\\PostDec will always evaluate to true\\.$#"
 			count: 1
 			path: ../src/Mutator/Arithmetic/Decrement.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Div\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\DivEqual\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/DivEqual.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Div\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\Division\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/Division.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Pow\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\Exponentiation\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/Exponentiation.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\PostInc\\|PhpParser\\\\Node\\\\Expr\\\\PreInc\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\Increment\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/Increment.php
 
 		-
 			message: "#^Instanceof between PhpParser\\\\Node\\\\Expr\\\\PostInc and PhpParser\\\\Node\\\\Expr\\\\PostInc will always evaluate to true\\.$#"
@@ -266,239 +211,9 @@ parameters:
 			path: ../src/Mutator/Arithmetic/Increment.php
 
 		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Minus\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\Minus\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/Minus.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Minus\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\MinusEqual\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/MinusEqual.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Mod\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\ModEqual\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/ModEqual.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Mod\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\Modulus\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/Modulus.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Mul\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\MulEqual\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/MulEqual.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Mul\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\Multiplication\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/Multiplication.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Plus\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\Plus\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/Plus.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Plus\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\PlusEqual\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/PlusEqual.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Pow\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\PowEqual\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/PowEqual.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\FuncCall\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\RoundingFamily\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/RoundingFamily.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\ShiftLeft\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\ShiftLeft\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/ShiftLeft.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\ShiftRight\\) of method Infection\\\\Mutator\\\\Arithmetic\\\\ShiftRight\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Arithmetic/ShiftRight.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\ArrayItem\\) of method Infection\\\\Mutator\\\\Boolean\\\\ArrayItem\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/ArrayItem.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Equal\\) of method Infection\\\\Mutator\\\\Boolean\\\\EqualIdentical\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/EqualIdentical.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\ConstFetch\\) of method Infection\\\\Mutator\\\\Boolean\\\\FalseValue\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/FalseValue.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Identical\\) of method Infection\\\\Mutator\\\\Boolean\\\\IdenticalEqual\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/IdenticalEqual.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\LogicalOr\\) of method Infection\\\\Mutator\\\\Boolean\\\\LogicalAnd\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/LogicalAnd.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\LogicalAnd\\) of method Infection\\\\Mutator\\\\Boolean\\\\LogicalLowerAnd\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/LogicalLowerAnd.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\LogicalOr\\) of method Infection\\\\Mutator\\\\Boolean\\\\LogicalLowerOr\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/LogicalLowerOr.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BooleanNot\\) of method Infection\\\\Mutator\\\\Boolean\\\\LogicalNot\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/LogicalNot.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\BooleanOr\\) of method Infection\\\\Mutator\\\\Boolean\\\\LogicalOr\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/LogicalOr.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\NotEqual\\) of method Infection\\\\Mutator\\\\Boolean\\\\NotEqualNotIdentical\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/NotEqualNotIdentical.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\NotIdentical\\) of method Infection\\\\Mutator\\\\Boolean\\\\NotIdenticalNotEqual\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/NotIdenticalNotEqual.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\ConstFetch\\) of method Infection\\\\Mutator\\\\Boolean\\\\TrueValue\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 2
-			path: ../src/Mutator/Boolean/TrueValue.php
-
-		-
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Assert\\:\\:boolean\\(\\) with bool and string will always evaluate to true\\.$#"
 			count: 1
 			path: ../src/Mutator/Boolean/TrueValueConfig.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\Yield_\\) of method Infection\\\\Mutator\\\\Boolean\\\\Yield_\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Boolean/Yield_.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\Cast\\) of method Infection\\\\Mutator\\\\Cast\\\\AbstractCastMutator\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Cast/AbstractCastMutator.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Greater\\) of method Infection\\\\Mutator\\\\ConditionalBoundary\\\\GreaterThan\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalBoundary/GreaterThan.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\GreaterOrEqual\\) of method Infection\\\\Mutator\\\\ConditionalBoundary\\\\GreaterThanOrEqualTo\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Smaller\\) of method Infection\\\\Mutator\\\\ConditionalBoundary\\\\LessThan\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalBoundary/LessThan.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\SmallerOrEqual\\) of method Infection\\\\Mutator\\\\ConditionalBoundary\\\\LessThanOrEqualTo\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Equal\\) of method Infection\\\\Mutator\\\\ConditionalNegotiation\\\\Equal\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalNegotiation/Equal.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Greater\\) of method Infection\\\\Mutator\\\\ConditionalNegotiation\\\\GreaterThanNegotiation\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\GreaterOrEqual\\) of method Infection\\\\Mutator\\\\ConditionalNegotiation\\\\GreaterThanOrEqualToNegotiation\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Identical\\) of method Infection\\\\Mutator\\\\ConditionalNegotiation\\\\Identical\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalNegotiation/Identical.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Smaller\\) of method Infection\\\\Mutator\\\\ConditionalNegotiation\\\\LessThanNegotiation\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\SmallerOrEqual\\) of method Infection\\\\Mutator\\\\ConditionalNegotiation\\\\LessThanOrEqualToNegotiation\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\NotEqual\\) of method Infection\\\\Mutator\\\\ConditionalNegotiation\\\\NotEqual\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalNegotiation/NotEqual.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\NotIdentical\\) of method Infection\\\\Mutator\\\\ConditionalNegotiation\\\\NotIdentical\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ConditionalNegotiation/NotIdentical.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\FuncCall\\) of method Infection\\\\Mutator\\\\Extensions\\\\BCMath\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 2
-			path: ../src/Mutator/Extensions/BCMath.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\FuncCall\\) of method Infection\\\\Mutator\\\\Extensions\\\\MBString\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 2
-			path: ../src/Mutator/Extensions/MBString.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\ClassMethod\\) of method Infection\\\\Mutator\\\\FunctionSignature\\\\ProtectedVisibility\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/FunctionSignature/ProtectedVisibility.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\ClassMethod\\) of method Infection\\\\Mutator\\\\FunctionSignature\\\\PublicVisibility\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/FunctionSignature/PublicVisibility.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Do_\\) of method Infection\\\\Mutator\\\\Loop\\\\DoWhile\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Loop/DoWhile.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\For_\\) of method Infection\\\\Mutator\\\\Loop\\\\For_\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Loop/For_.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Foreach_\\) of method Infection\\\\Mutator\\\\Loop\\\\Foreach_\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Loop/Foreach_.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\While_\\) of method Infection\\\\Mutator\\\\Loop\\\\While_\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Loop/While_.php
 
 		-
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Assert\\:\\:isArray\\(\\) with array and string will always evaluate to true\\.$#"
@@ -511,49 +226,9 @@ parameters:
 			path: ../src/Mutator/MutatorFactory.php
 
 		-
-			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allIsInstanceOf\\(\\) with array\\<Infection\\\\Mutator\\\\Mutator\\> and 'Infection\\\\\\\\Mutator\\\\\\\\Mutator' will always evaluate to true\\.$#"
+			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allIsInstanceOf\\(\\) with array\\<Infection\\\\Mutator\\\\Mutator\\<PhpParser\\\\Node\\>\\> and 'Infection\\\\\\\\Mutator\\\\\\\\Mutator' will always evaluate to true\\.$#"
 			count: 1
 			path: ../src/Mutator/NodeMutationGenerator.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Scalar\\\\LNumber\\) of method Infection\\\\Mutator\\\\Number\\\\DecrementInteger\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 2
-			path: ../src/Mutator/Number/DecrementInteger.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Scalar\\\\LNumber\\) of method Infection\\\\Mutator\\\\Number\\\\IncrementInteger\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 2
-			path: ../src/Mutator/Number/IncrementInteger.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Scalar\\\\DNumber\\) of method Infection\\\\Mutator\\\\Number\\\\OneZeroFloat\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 2
-			path: ../src/Mutator/Number/OneZeroFloat.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\AssignOp\\\\Coalesce\\) of method Infection\\\\Mutator\\\\Operator\\\\AssignCoalesce\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Operator/AssignCoalesce.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Break_\\) of method Infection\\\\Mutator\\\\Operator\\\\Break_\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Operator/Break_.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Coalesce\\) of method Infection\\\\Mutator\\\\Operator\\\\Coalesce\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Operator/Coalesce.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Continue_\\) of method Infection\\\\Mutator\\\\Operator\\\\Continue_\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Operator/Continue_.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Finally_\\) of method Infection\\\\Mutator\\\\Operator\\\\Finally_\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Operator/Finally_.php
 
 		-
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Assert\\:\\:isInstanceOf\\(\\) with PhpParser\\\\Node\\\\Stmt\\\\TryCatch and 'PhpParser\\\\\\\\Node\\\\\\\\Stmt\\\\\\\\TryCatch' will always evaluate to true\\.$#"
@@ -561,104 +236,9 @@ parameters:
 			path: ../src/Mutator/Operator/Finally_.php
 
 		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\ArrayItem\\) of method Infection\\\\Mutator\\\\Operator\\\\Spread\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Operator/Spread.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\Ternary\\) of method Infection\\\\Mutator\\\\Operator\\\\Ternary\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Operator/Ternary.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Throw_\\) of method Infection\\\\Mutator\\\\Operator\\\\Throw_\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Operator/Throw_.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\FuncCall\\) of method Infection\\\\Mutator\\\\Regex\\\\PregMatchMatches\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Regex/PregMatchMatches.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\FuncCall\\) of method Infection\\\\Mutator\\\\Regex\\\\PregQuote\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Regex/PregQuote.php
-
-		-
-			message: "#^Parameter \\#1 \\$arrayNode \\(PhpParser\\\\Node\\\\Expr\\\\Array_\\) of method Infection\\\\Mutator\\\\Removal\\\\ArrayItemRemoval\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 2
-			path: ../src/Mutator/Removal/ArrayItemRemoval.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\Clone_\\) of method Infection\\\\Mutator\\\\Removal\\\\CloneRemoval\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Removal/CloneRemoval.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Expression\\) of method Infection\\\\Mutator\\\\Removal\\\\FunctionCallRemoval\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Removal/FunctionCallRemoval.php
-
-		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
 			count: 1
 			path: ../src/Mutator/Removal/FunctionCallRemoval.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Expression\\) of method Infection\\\\Mutator\\\\Removal\\\\MethodCallRemoval\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Removal/MethodCallRemoval.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Switch_\\) of method Infection\\\\Mutator\\\\Removal\\\\SharedCaseRemoval\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Removal/SharedCaseRemoval.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Return_\\) of method Infection\\\\Mutator\\\\ReturnValue\\\\ArrayOneItem\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ReturnValue/ArrayOneItem.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Return_\\) of method Infection\\\\Mutator\\\\ReturnValue\\\\FloatNegation\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ReturnValue/FloatNegation.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Return_\\) of method Infection\\\\Mutator\\\\ReturnValue\\\\FunctionCall\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 2
-			path: ../src/Mutator/ReturnValue/FunctionCall.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Return_\\) of method Infection\\\\Mutator\\\\ReturnValue\\\\IntegerNegation\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ReturnValue/IntegerNegation.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Return_\\) of method Infection\\\\Mutator\\\\ReturnValue\\\\NewObject\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 2
-			path: ../src/Mutator/ReturnValue/NewObject.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\\\Return_\\) of method Infection\\\\Mutator\\\\ReturnValue\\\\This\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 2
-			path: ../src/Mutator/ReturnValue/This.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\Yield_\\) of method Infection\\\\Mutator\\\\ReturnValue\\\\YieldValue\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/ReturnValue/YieldValue.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\BinaryOp\\\\Spaceship\\) of method Infection\\\\Mutator\\\\Sort\\\\Spaceship\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Sort/Spaceship.php
-
-		-
-			message: "#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\FuncCall\\) of method Infection\\\\Mutator\\\\Unwrap\\\\AbstractUnwrapMutator\\:\\:mutate\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method Infection\\\\Mutator\\\\Mutator\\:\\:mutate\\(\\)$#"
-			count: 1
-			path: ../src/Mutator/Unwrap/AbstractUnwrapMutator.php
 
 		-
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allIsInstanceOf\\(\\) with array\\<PhpParser\\\\Node\\> and 'PhpParser\\\\\\\\Node' will always evaluate to true\\.$#"

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -66,7 +66,7 @@ class Configuration
     private string $logVerbosity;
     private string $tmpDir;
     private PhpUnit $phpUnit;
-    /** @var array<string, Mutator> */
+    /** @var array<string, Mutator<\PhpParser\Node>> */
     private array $mutators;
     private string $testFramework;
     private ?string $bootstrap = null;
@@ -92,7 +92,7 @@ class Configuration
      * @param string[] $sourceDirectories
      * @param string[] $sourceFilesExcludes
      * @param iterable<SplFileInfo> $sourceFiles
-     * @param array<string, Mutator> $mutators
+     * @param array<string, Mutator<\PhpParser\Node>> $mutators
      * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
      */
     public function __construct(
@@ -218,7 +218,7 @@ class Configuration
     }
 
     /**
-     * @return array<string, Mutator>
+     * @return array<string, Mutator<\PhpParser\Node>>
      */
     public function getMutators(): array
     {

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -174,7 +174,7 @@ class ConfigurationFactory
     /**
      * @param array<string, mixed> $schemaMutators
      *
-     * @return array<class-string<Mutator&ConfigurableMutator>, mixed[]>
+     * @return array<class-string<Mutator<\PhpParser\Node>&ConfigurableMutator<\PhpParser\Node>>, mixed[]>
      */
     private function resolveMutators(array $schemaMutators, string $mutatorsInput): array
     {

--- a/src/Mutation/FileMutationGenerator.php
+++ b/src/Mutation/FileMutationGenerator.php
@@ -67,7 +67,7 @@ class FileMutationGenerator
     }
 
     /**
-     * @param Mutator[] $mutators
+     * @param Mutator<\PhpParser\Node>[] $mutators
      * @param NodeIgnorer[] $nodeIgnorers
      *
      * @throws UnparsableFile

--- a/src/Mutation/MutationGenerator.php
+++ b/src/Mutation/MutationGenerator.php
@@ -54,14 +54,14 @@ use Webmozart\Assert\Assert;
 class MutationGenerator
 {
     private TraceProvider $traceProvider;
-    /** @var Mutator[] */
+    /** @var Mutator<\PhpParser\Node>[] */
     private array $mutators;
     private EventDispatcher $eventDispatcher;
     private FileMutationGenerator $fileMutationGenerator;
     private bool $runConcurrently;
 
     /**
-     * @param Mutator[] $mutators
+     * @param Mutator<\PhpParser\Node>[] $mutators
      */
     public function __construct(
         TraceProvider $traceProvider,

--- a/src/Mutator/Arithmetic/Assignment.php
+++ b/src/Mutator/Arithmetic/Assignment.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\AssignOp>
  */
 final class Assignment implements Mutator
 {
@@ -63,8 +65,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\AssignOp $node
      *
      * @return iterable<Node\Expr\Assign>
      */

--- a/src/Mutator/Arithmetic/AssignmentEqual.php
+++ b/src/Mutator/Arithmetic/AssignmentEqual.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Equal>
  */
 final class AssignmentEqual implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Equal $node
      *
      * @return iterable<Node\Expr\Assign>
      */

--- a/src/Mutator/Arithmetic/BitwiseAnd.php
+++ b/src/Mutator/Arithmetic/BitwiseAnd.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\BooleanAnd>
  */
 final class BitwiseAnd implements Mutator
 {
@@ -59,8 +61,6 @@ final class BitwiseAnd implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\BooleanAnd $node
      *
      * @return iterable<Node\Expr\BinaryOp\BitwiseOr>
      */

--- a/src/Mutator/Arithmetic/BitwiseNot.php
+++ b/src/Mutator/Arithmetic/BitwiseNot.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BitwiseNot>
  */
 final class BitwiseNot implements Mutator
 {
@@ -59,8 +61,6 @@ final class BitwiseNot implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BitwiseNot $node
      *
      * @return iterable<Node\Expr>
      */

--- a/src/Mutator/Arithmetic/BitwiseOr.php
+++ b/src/Mutator/Arithmetic/BitwiseOr.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\BitwiseOr>
  */
 final class BitwiseOr implements Mutator
 {
@@ -59,8 +61,6 @@ final class BitwiseOr implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\BitwiseOr $node
      *
      * @return iterable<Node\Expr\BinaryOp\BitwiseAnd>
      */

--- a/src/Mutator/Arithmetic/BitwiseXor.php
+++ b/src/Mutator/Arithmetic/BitwiseXor.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\BitwiseXor>
  */
 final class BitwiseXor implements Mutator
 {
@@ -59,8 +61,6 @@ final class BitwiseXor implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\BitwiseXor $node
      *
      * @return iterable<Node\Expr\BinaryOp\BitwiseAnd>
      */

--- a/src/Mutator/Arithmetic/Decrement.php
+++ b/src/Mutator/Arithmetic/Decrement.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\PreDec|Node\Expr\PostDec>
  */
 final class Decrement implements Mutator
 {
@@ -63,8 +65,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\PreDec|Node\Expr\PostDec $node
      *
      * @return iterable<Node\Expr\PreInc|Node\Expr\PostInc>
      */

--- a/src/Mutator/Arithmetic/DivEqual.php
+++ b/src/Mutator/Arithmetic/DivEqual.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\AssignOp\Div>
  */
 final class DivEqual implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\AssignOp\Div $node
      *
      * @return iterable<Node\Expr\AssignOp\Mul>
      */

--- a/src/Mutator/Arithmetic/Division.php
+++ b/src/Mutator/Arithmetic/Division.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Div>
  */
 final class Division implements Mutator
 {
@@ -59,8 +61,6 @@ final class Division implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Div $node
      *
      * @return iterable<Node\Expr\BinaryOp\Mul>
      */

--- a/src/Mutator/Arithmetic/Exponentiation.php
+++ b/src/Mutator/Arithmetic/Exponentiation.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Pow>
  */
 final class Exponentiation implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Pow $node
      *
      * @return iterable<Node\Expr\BinaryOp\Div>
      */

--- a/src/Mutator/Arithmetic/Increment.php
+++ b/src/Mutator/Arithmetic/Increment.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\PostInc|Node\Expr\PreInc>
  */
 final class Increment implements Mutator
 {
@@ -63,8 +65,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\PostInc|Node\Expr\PreInc $node
      *
      * @return iterable<Node\Expr\PreDec|Node\Expr\PostDec>
      */

--- a/src/Mutator/Arithmetic/Minus.php
+++ b/src/Mutator/Arithmetic/Minus.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Minus>
  */
 final class Minus implements Mutator
 {
@@ -59,8 +61,6 @@ final class Minus implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Minus $node
      *
      * @return iterable<Node\Expr\BinaryOp\Plus>
      */

--- a/src/Mutator/Arithmetic/MinusEqual.php
+++ b/src/Mutator/Arithmetic/MinusEqual.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\AssignOp\Minus>
  */
 final class MinusEqual implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\AssignOp\Minus $node
      *
      * @return iterable<Node\Expr\AssignOp\Plus>
      */

--- a/src/Mutator/Arithmetic/ModEqual.php
+++ b/src/Mutator/Arithmetic/ModEqual.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\AssignOp\Mod>
  */
 final class ModEqual implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\AssignOp\Mod $node
      *
      * @return iterable<Node\Expr\AssignOp\Mul>
      */

--- a/src/Mutator/Arithmetic/Modulus.php
+++ b/src/Mutator/Arithmetic/Modulus.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Mod>
  */
 final class Modulus implements Mutator
 {
@@ -59,8 +61,6 @@ final class Modulus implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Mod $node
      *
      * @return iterable<Node\Expr\BinaryOp\Mul>
      */

--- a/src/Mutator/Arithmetic/MulEqual.php
+++ b/src/Mutator/Arithmetic/MulEqual.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\AssignOp\Mul>
  */
 final class MulEqual implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\AssignOp\Mul $node
      *
      * @return iterable<Node\Expr\AssignOp\Div>
      */

--- a/src/Mutator/Arithmetic/Multiplication.php
+++ b/src/Mutator/Arithmetic/Multiplication.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Mul>
  */
 final class Multiplication implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Mul $node
      *
      * @return iterable<Node\Expr\BinaryOp\Div>
      */

--- a/src/Mutator/Arithmetic/Plus.php
+++ b/src/Mutator/Arithmetic/Plus.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Plus>
  */
 final class Plus implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Plus $node
      *
      * @return iterable<Node\Expr\BinaryOp\Minus>
      */

--- a/src/Mutator/Arithmetic/PlusEqual.php
+++ b/src/Mutator/Arithmetic/PlusEqual.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\AssignOp\Plus>
  */
 final class PlusEqual implements Mutator
 {
@@ -64,8 +66,6 @@ TXT
      * Replaces "+=" with "-="
      *
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\AssignOp\Plus $node
      *
      * @return iterable<Node\Expr\AssignOp\Minus>
      */

--- a/src/Mutator/Arithmetic/PowEqual.php
+++ b/src/Mutator/Arithmetic/PowEqual.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\AssignOp\Pow>
  */
 final class PowEqual implements Mutator
 {
@@ -64,8 +66,6 @@ TXT
      * Replaces "**=" with "/="
      *
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\AssignOp\Pow $node
      *
      * @return iterable<Node\Expr\AssignOp\Div>
      */

--- a/src/Mutator/Arithmetic/RoundingFamily.php
+++ b/src/Mutator/Arithmetic/RoundingFamily.php
@@ -44,6 +44,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\FuncCall>
  */
 final class RoundingFamily implements Mutator
 {
@@ -69,8 +71,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Expr\FuncCall>
      */

--- a/src/Mutator/Arithmetic/ShiftLeft.php
+++ b/src/Mutator/Arithmetic/ShiftLeft.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\ShiftLeft>
  */
 final class ShiftLeft implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\ShiftLeft $node
      *
      * @return iterable<Node\Expr\BinaryOp\ShiftRight>
      */

--- a/src/Mutator/Arithmetic/ShiftRight.php
+++ b/src/Mutator/Arithmetic/ShiftRight.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\ShiftRight>
  */
 final class ShiftRight implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\ShiftRight $node
      *
      * @return iterable<Node\Expr\BinaryOp\ShiftLeft>
      */

--- a/src/Mutator/Boolean/ArrayItem.php
+++ b/src/Mutator/Boolean/ArrayItem.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\ArrayItem>
  */
 final class ArrayItem implements Mutator
 {
@@ -68,8 +70,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\ArrayItem $node
      *
      * @return iterable<Node\Expr\BinaryOp\Greater>
      */

--- a/src/Mutator/Boolean/EqualIdentical.php
+++ b/src/Mutator/Boolean/EqualIdentical.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Equal>
  */
 final class EqualIdentical implements Mutator
 {
@@ -63,8 +65,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Equal $node
      *
      * @return iterable<Node\Expr\BinaryOp\Identical>
      */

--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\ConstFetch>
  */
 final class FalseValue implements Mutator
 {
@@ -59,8 +61,6 @@ final class FalseValue implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\ConstFetch $node
      *
      * @return iterable<Node\Expr\ConstFetch>
      */

--- a/src/Mutator/Boolean/IdenticalEqual.php
+++ b/src/Mutator/Boolean/IdenticalEqual.php
@@ -45,6 +45,8 @@ use PhpParser\Node;
  * @internal
  *
  * @deprecated This mutator is a semantic addition
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Identical>
  */
 final class IdenticalEqual implements Mutator
 {
@@ -65,8 +67,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Identical $node
      *
      * @return iterable<Node\Expr\BinaryOp\Equal>
      */

--- a/src/Mutator/Boolean/InstanceOf_.php
+++ b/src/Mutator/Boolean/InstanceOf_.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node>
  */
 final class InstanceOf_ implements Mutator
 {

--- a/src/Mutator/Boolean/LogicalAnd.php
+++ b/src/Mutator/Boolean/LogicalAnd.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\LogicalOr>
  */
 final class LogicalAnd implements Mutator
 {
@@ -59,8 +61,6 @@ final class LogicalAnd implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\LogicalOr $node
      *
      * @return iterable<Node\Expr\BinaryOp\BooleanOr>
      */

--- a/src/Mutator/Boolean/LogicalLowerAnd.php
+++ b/src/Mutator/Boolean/LogicalLowerAnd.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\LogicalAnd>
  */
 final class LogicalLowerAnd implements Mutator
 {
@@ -61,8 +63,6 @@ final class LogicalLowerAnd implements Mutator
      * @psalm-mutation-free
      *
      * Replaces "and" with "or"
-     *
-     * @param Node\Expr\BinaryOp\LogicalAnd $node
      *
      * @return iterable<Node\Expr\BinaryOp\LogicalOr>
      */

--- a/src/Mutator/Boolean/LogicalLowerOr.php
+++ b/src/Mutator/Boolean/LogicalLowerOr.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\LogicalOr>
  */
 final class LogicalLowerOr implements Mutator
 {
@@ -59,8 +61,6 @@ final class LogicalLowerOr implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\LogicalOr $node
      *
      * @return iterable<Node\Expr\BinaryOp\LogicalAnd>
      */

--- a/src/Mutator/Boolean/LogicalNot.php
+++ b/src/Mutator/Boolean/LogicalNot.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BooleanNot>
  */
 final class LogicalNot implements Mutator
 {
@@ -59,8 +61,6 @@ final class LogicalNot implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BooleanNot $node
      *
      * @return iterable<Node\Expr>
      */

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\BooleanOr>
  */
 final class LogicalOr implements Mutator
 {
@@ -61,8 +63,6 @@ final class LogicalOr implements Mutator
      * @psalm-mutation-free
      *
      * Replaces "||" with "&&"
-     *
-     * @param Node\Expr\BinaryOp\BooleanOr $node
      *
      * @return iterable<Node\Expr\BinaryOp\BooleanAnd>
      */

--- a/src/Mutator/Boolean/NotEqualNotIdentical.php
+++ b/src/Mutator/Boolean/NotEqualNotIdentical.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\NotEqual>
  */
 final class NotEqualNotIdentical implements Mutator
 {
@@ -63,8 +65,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\NotEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\NotIdentical>
      */

--- a/src/Mutator/Boolean/NotIdenticalNotEqual.php
+++ b/src/Mutator/Boolean/NotIdenticalNotEqual.php
@@ -45,6 +45,8 @@ use PhpParser\Node;
  * @internal
  *
  * @deprecated This mutator is a semantic addition
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\NotIdentical>
  */
 final class NotIdenticalNotEqual implements Mutator
 {
@@ -65,8 +67,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\NotIdentical $node
      *
      * @return iterable<Node\Expr\BinaryOp\NotEqual>
      */

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -47,6 +47,8 @@ use function Safe\array_flip;
 
 /**
  * @internal
+ *
+ * @implements ConfigurableMutator<Node\Expr\ConstFetch>
  */
 final class TrueValue implements ConfigurableMutator
 {
@@ -74,8 +76,6 @@ final class TrueValue implements ConfigurableMutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\ConstFetch $node
      *
      * @return iterable<Node\Expr\ConstFetch>
      */

--- a/src/Mutator/Boolean/Yield_.php
+++ b/src/Mutator/Boolean/Yield_.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\Yield_>
  */
 final class Yield_ implements Mutator
 {
@@ -68,8 +70,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\Yield_ $node
      *
      * @return iterable<Node\Expr\Yield_>
      */

--- a/src/Mutator/Cast/AbstractCastMutator.php
+++ b/src/Mutator/Cast/AbstractCastMutator.php
@@ -41,6 +41,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\Cast>
  */
 abstract class AbstractCastMutator implements Mutator
 {
@@ -48,8 +50,6 @@ abstract class AbstractCastMutator implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\Cast $node
      *
      * @return iterable<Node\Expr>
      */

--- a/src/Mutator/ConditionalBoundary/GreaterThan.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThan.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Greater>
  */
 final class GreaterThan implements Mutator
 {
@@ -64,8 +66,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Greater $node
      *
      * @return iterable<Node\Expr\BinaryOp\GreaterOrEqual>
      */

--- a/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/GreaterThanOrEqualTo.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\GreaterOrEqual>
  */
 final class GreaterThanOrEqualTo implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\GreaterOrEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\Greater>
      */

--- a/src/Mutator/ConditionalBoundary/LessThan.php
+++ b/src/Mutator/ConditionalBoundary/LessThan.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Smaller>
  */
 final class LessThan implements Mutator
 {
@@ -64,8 +66,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Smaller $node
      *
      * @return iterable<Node\Expr\BinaryOp\SmallerOrEqual>
      */

--- a/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
+++ b/src/Mutator/ConditionalBoundary/LessThanOrEqualTo.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\SmallerOrEqual>
  */
 final class LessThanOrEqualTo implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\SmallerOrEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\Smaller>
      */

--- a/src/Mutator/ConditionalNegotiation/Equal.php
+++ b/src/Mutator/ConditionalNegotiation/Equal.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Equal>
  */
 final class Equal implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Equal $node
      *
      * @return iterable<Node\Expr\BinaryOp\NotEqual>
      */

--- a/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Greater>
  */
 final class GreaterThanNegotiation implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Greater $node
      *
      * @return iterable<Node\Expr\BinaryOp\SmallerOrEqual>
      */

--- a/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\GreaterOrEqual>
  */
 final class GreaterThanOrEqualToNegotiation implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\GreaterOrEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\Smaller>
      */

--- a/src/Mutator/ConditionalNegotiation/Identical.php
+++ b/src/Mutator/ConditionalNegotiation/Identical.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Identical>
  */
 final class Identical implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Identical $node
      *
      * @return iterable<Node\Expr\BinaryOp\NotIdentical>
      */

--- a/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Smaller>
  */
 final class LessThanNegotiation implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Smaller $node
      *
      * @return iterable<Node\Expr\BinaryOp\GreaterOrEqual>
      */

--- a/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\SmallerOrEqual>
  */
 final class LessThanOrEqualToNegotiation implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\SmallerOrEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\Greater>
      */

--- a/src/Mutator/ConditionalNegotiation/NotEqual.php
+++ b/src/Mutator/ConditionalNegotiation/NotEqual.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\NotEqual>
  */
 final class NotEqual implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\NotEqual $node
      *
      * @return iterable<Node\Expr\BinaryOp\Equal>
      */

--- a/src/Mutator/ConditionalNegotiation/NotIdentical.php
+++ b/src/Mutator/ConditionalNegotiation/NotIdentical.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\NotIdentical>
  */
 final class NotIdentical implements Mutator
 {
@@ -64,8 +66,6 @@ TXT
      * Replaces "!==" with "==="
      *
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\NotIdentical $node
      *
      * @return iterable<Node\Expr\BinaryOp\Identical>
      */

--- a/src/Mutator/ConfigurableMutator.php
+++ b/src/Mutator/ConfigurableMutator.php
@@ -37,6 +37,9 @@ namespace Infection\Mutator;
 
 /**
  * @internal
+ *
+ * @template TNode of \PhpParser\Node
+ * @extends Mutator<TNode>
  */
 interface ConfigurableMutator extends Mutator
 {

--- a/src/Mutator/Extensions/BCMath.php
+++ b/src/Mutator/Extensions/BCMath.php
@@ -48,6 +48,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements ConfigurableMutator<Node\Expr\FuncCall>
  */
 final class BCMath implements ConfigurableMutator
 {
@@ -89,8 +91,6 @@ TXT
     /**
      * @psalm-mutation-free
      * @psalm-suppress ImpureMethodCall
-     *
-     * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Expr>
      */

--- a/src/Mutator/Extensions/MBString.php
+++ b/src/Mutator/Extensions/MBString.php
@@ -53,6 +53,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements ConfigurableMutator<Node\Expr\FuncCall>
  */
 final class MBString implements ConfigurableMutator
 {
@@ -95,8 +97,6 @@ TXT
     /**
      * @psalm-mutation-free
      * @psalm-suppress ImpureMethodCall
-     *
-     * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Expr\FuncCall>
      */

--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -46,6 +46,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\ClassMethod>
  */
 final class ProtectedVisibility implements Mutator
 {
@@ -62,8 +64,6 @@ final class ProtectedVisibility implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\ClassMethod $node
      *
      * @return iterable<Node\Stmt\ClassMethod>
      */

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -46,6 +46,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\ClassMethod>
  */
 final class PublicVisibility implements Mutator
 {
@@ -62,8 +64,6 @@ final class PublicVisibility implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\ClassMethod $node
      *
      * @return iterable<Node\Stmt\ClassMethod>
      */

--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -52,12 +52,19 @@ use function Safe\sprintf;
  * better performance optimization in our case.
  *
  * @internal
+ *
+ * @template TNode of Node
+ * @implements Mutator<TNode>
  */
 final class IgnoreMutator implements Mutator
 {
     private IgnoreConfig $config;
+    /** @var Mutator<TNode> */
     private Mutator $mutator;
 
+    /**
+     * @param Mutator<TNode> $mutator
+     */
     public function __construct(IgnoreConfig $config, Mutator $mutator)
     {
         $this->config = $config;

--- a/src/Mutator/Loop/DoWhile.php
+++ b/src/Mutator/Loop/DoWhile.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Do_>
  */
 final class DoWhile implements Mutator
 {
@@ -81,8 +83,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Do_ $node
      *
      * @return iterable<Node\Stmt\Do_>
      */

--- a/src/Mutator/Loop/For_.php
+++ b/src/Mutator/Loop/For_.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\For_>
  */
 final class For_ implements Mutator
 {
@@ -77,8 +79,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\For_ $node
      *
      * @return iterable<Node\Stmt\For_>
      */

--- a/src/Mutator/Loop/Foreach_.php
+++ b/src/Mutator/Loop/Foreach_.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Foreach_>
  */
 final class Foreach_ implements Mutator
 {
@@ -77,8 +79,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Foreach_ $node
      *
      * @return iterable<Node\Stmt\Foreach_>
      */

--- a/src/Mutator/Loop/While_.php
+++ b/src/Mutator/Loop/While_.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\While_>
  */
 final class While_ implements Mutator
 {
@@ -81,8 +83,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\While_ $node
      *
      * @return iterable<Node\Stmt\While_>
      */

--- a/src/Mutator/Mutator.php
+++ b/src/Mutator/Mutator.php
@@ -39,6 +39,7 @@ use PhpParser\Node;
 
 /**
  * @internal
+ * @template TNode of Node
  */
 interface Mutator
 {
@@ -50,6 +51,8 @@ interface Mutator
 
     /**
      * @psalm-mutation-free
+     *
+     * @param TNode $node
      *
      * @return iterable<Node|Node[]>
      */

--- a/src/Mutator/MutatorFactory.php
+++ b/src/Mutator/MutatorFactory.php
@@ -48,9 +48,9 @@ use Webmozart\Assert\Assert;
 final class MutatorFactory
 {
     /**
-     * @param array<class-string<Mutator&ConfigurableMutator>, mixed[]> $resolvedMutators
+     * @param array<class-string<Mutator<\PhpParser\Node>&ConfigurableMutator<\PhpParser\Node>>, mixed[]> $resolvedMutators
      *
-     * @return array<string, Mutator>
+     * @return array<string, Mutator<\PhpParser\Node>>
      */
     public function create(array $resolvedMutators): array
     {
@@ -105,8 +105,10 @@ final class MutatorFactory
     }
 
     /**
-     * @param class-string<ConfigurableMutator> $mutatorClassName
+     * @param class-string<ConfigurableMutator<\PhpParser\Node>> $mutatorClassName
      * @param mixed[] $settings
+     *
+     * @return ConfigurableMutator<\PhpParser\Node>
      */
     private static function getConfigurableMutator(string $mutatorClassName, array $settings): ConfigurableMutator
     {

--- a/src/Mutator/MutatorResolver.php
+++ b/src/Mutator/MutatorResolver.php
@@ -57,7 +57,7 @@ final class MutatorResolver
      *
      * @param array<string, bool|stdClass> $mutatorSettings
      *
-     * @return array<class-string<Mutator&ConfigurableMutator>, mixed[]>
+     * @return array<class-string<Mutator<\PhpParser\Node>&ConfigurableMutator<\PhpParser\Node>>, mixed[]>
      */
     public function resolve(array $mutatorSettings): array
     {

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -55,7 +55,7 @@ use Webmozart\Assert\Assert;
  */
 class NodeMutationGenerator
 {
-    /** @var Mutator[] */
+    /** @var Mutator<Node>[] */
     private array $mutators;
     private string $filePath;
     /** @var Node[] */
@@ -71,7 +71,7 @@ class NodeMutationGenerator
     private ?bool $isInsideFunctionMemoized = null;
 
     /**
-     * @param Mutator[] $mutators
+     * @param Mutator<Node>[] $mutators
      * @param Node[] $fileNodes
      */
     public function __construct(
@@ -114,6 +114,8 @@ class NodeMutationGenerator
     }
 
     /**
+     * @param Mutator<Node> $mutator
+     *
      * @return iterable<Mutation>
      */
     private function generateForMutator(Node $node, Mutator $mutator): iterable

--- a/src/Mutator/Number/AbstractNumberMutator.php
+++ b/src/Mutator/Number/AbstractNumberMutator.php
@@ -41,6 +41,9 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @template TNode of Node
+ * @implements Mutator<TNode>
  */
 abstract class AbstractNumberMutator implements Mutator
 {

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -44,6 +44,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @extends AbstractNumberMutator<Node\Scalar\LNumber>
  */
 final class DecrementInteger extends AbstractNumberMutator
 {
@@ -69,8 +71,6 @@ final class DecrementInteger extends AbstractNumberMutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Scalar\LNumber $node
      *
      * @return iterable<Node\Scalar\LNumber>
      */

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @extends AbstractNumberMutator<Node\Scalar\LNumber>
  */
 final class IncrementInteger extends AbstractNumberMutator
 {
@@ -59,8 +61,6 @@ final class IncrementInteger extends AbstractNumberMutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Scalar\LNumber $node
      *
      * @return iterable<Node\Scalar\LNumber>
      */

--- a/src/Mutator/Number/OneZeroFloat.php
+++ b/src/Mutator/Number/OneZeroFloat.php
@@ -42,6 +42,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @extends AbstractNumberMutator<Node\Scalar\DNumber>
  */
 final class OneZeroFloat extends AbstractNumberMutator
 {
@@ -61,8 +63,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Scalar\DNumber $node
      *
      * @return iterable<Node\Scalar\DNumber>
      */

--- a/src/Mutator/Operator/AssignCoalesce.php
+++ b/src/Mutator/Operator/AssignCoalesce.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\AssignOp\Coalesce>
  */
 final class AssignCoalesce implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\AssignOp\Coalesce $node
      *
      * @return iterable<Node\Expr\Assign>
      */

--- a/src/Mutator/Operator/Break_.php
+++ b/src/Mutator/Operator/Break_.php
@@ -44,6 +44,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Break_>
  */
 final class Break_ implements Mutator
 {
@@ -63,8 +65,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Break_ $node
      *
      * @return iterable<Node\Stmt\Continue_>
      */

--- a/src/Mutator/Operator/Coalesce.php
+++ b/src/Mutator/Operator/Coalesce.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Coalesce>
  */
 final class Coalesce implements Mutator
 {
@@ -63,8 +65,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Coalesce $node
      *
      * @return iterable<Node\Expr>
      */

--- a/src/Mutator/Operator/Continue_.php
+++ b/src/Mutator/Operator/Continue_.php
@@ -44,6 +44,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Continue_>
  */
 final class Continue_ implements Mutator
 {
@@ -63,8 +65,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Continue_ $node
      *
      * @return iterable<Node\Stmt\Break_>
      */

--- a/src/Mutator/Operator/Finally_.php
+++ b/src/Mutator/Operator/Finally_.php
@@ -46,6 +46,8 @@ use Webmozart\Assert\Assert;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Finally_>
  */
 final class Finally_ implements Mutator
 {
@@ -62,8 +64,6 @@ final class Finally_ implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Finally_ $node
      *
      * @return iterable<Node\Stmt\Nop>
      */

--- a/src/Mutator/Operator/Spread.php
+++ b/src/Mutator/Operator/Spread.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\ArrayItem>
  */
 final class Spread implements Mutator
 {
@@ -72,8 +74,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\ArrayItem $node
      *
      * @return iterable<Node\Expr\ArrayItem>
      */

--- a/src/Mutator/Operator/Ternary.php
+++ b/src/Mutator/Operator/Ternary.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\Ternary>
  */
 final class Ternary implements Mutator
 {
@@ -67,8 +69,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\Ternary $node
      *
      * @return iterable<Node\Expr>
      */

--- a/src/Mutator/Operator/Throw_.php
+++ b/src/Mutator/Operator/Throw_.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Throw_>
  */
 final class Throw_ implements Mutator
 {
@@ -75,8 +77,6 @@ TXT
      * @psalm-mutation-free
      *
      * Replaces "throw new Exception();" with "new Exception();"
-     *
-     * @param Node\Stmt\Throw_ $node
      *
      * @return iterable<Node\Stmt\Expression>
      */

--- a/src/Mutator/Regex/PregMatchMatches.php
+++ b/src/Mutator/Regex/PregMatchMatches.php
@@ -44,6 +44,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\FuncCall>
  */
 final class PregMatchMatches implements Mutator
 {
@@ -78,8 +80,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Expr\Cast\Int_>
      */

--- a/src/Mutator/Regex/PregQuote.php
+++ b/src/Mutator/Regex/PregQuote.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\FuncCall>
  */
 final class PregQuote implements Mutator
 {
@@ -73,8 +75,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Arg>
      */

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -50,6 +50,8 @@ use Webmozart\Assert\Assert;
 
 /**
  * @internal
+ *
+ * @implements ConfigurableMutator<Node\Expr\Array_>
  */
 final class ArrayItemRemoval implements ConfigurableMutator
 {
@@ -103,8 +105,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\Array_ $arrayNode
      *
      * @return iterable<Node\Expr\Array_>
      */

--- a/src/Mutator/Removal/CloneRemoval.php
+++ b/src/Mutator/Removal/CloneRemoval.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\Clone_>
  */
 final class CloneRemoval implements Mutator
 {
@@ -59,8 +61,6 @@ final class CloneRemoval implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\Clone_ $node
      *
      * @return iterable<Node\Expr>
      */

--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Expression>
  */
 final class FunctionCallRemoval implements Mutator
 {
@@ -74,8 +76,6 @@ final class FunctionCallRemoval implements Mutator
      * @psalm-mutation-free
      *
      * Replaces "doSmth()" with ""
-     *
-     * @param Node\Stmt\Expression $node
      *
      * @return iterable<Node\Stmt\Nop>
      */

--- a/src/Mutator/Removal/MethodCallRemoval.php
+++ b/src/Mutator/Removal/MethodCallRemoval.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Expression>
  */
 final class MethodCallRemoval implements Mutator
 {
@@ -59,8 +61,6 @@ final class MethodCallRemoval implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Expression $node
      *
      * @return iterable<Node\Stmt\Nop>
      */

--- a/src/Mutator/Removal/SharedCaseRemoval.php
+++ b/src/Mutator/Removal/SharedCaseRemoval.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Switch_>
  */
 final class SharedCaseRemoval implements Mutator
 {
@@ -74,8 +76,6 @@ final class SharedCaseRemoval implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Switch_ $node
      *
      * @return iterable<Node\Stmt\Switch_>
      */

--- a/src/Mutator/ReturnValue/ArrayOneItem.php
+++ b/src/Mutator/ReturnValue/ArrayOneItem.php
@@ -45,6 +45,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Return_>
  */
 final class ArrayOneItem implements Mutator
 {
@@ -78,8 +80,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Return_ $node
      *
      * @return iterable<Node\Stmt\Return_>
      */

--- a/src/Mutator/ReturnValue/FloatNegation.php
+++ b/src/Mutator/ReturnValue/FloatNegation.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Return_>
  */
 final class FloatNegation implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Return_ $node
      *
      * @return iterable<Node\Stmt\Return_>
      */

--- a/src/Mutator/ReturnValue/FunctionCall.php
+++ b/src/Mutator/ReturnValue/FunctionCall.php
@@ -42,6 +42,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @extends AbstractValueToNullReturnValue<Node\Stmt\Return_>
  */
 final class FunctionCall extends AbstractValueToNullReturnValue
 {
@@ -82,8 +84,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Return_ $node
      *
      * @return iterable<array<Node\Stmt\Expression|Node\Stmt\Return_>>
      */

--- a/src/Mutator/ReturnValue/IntegerNegation.php
+++ b/src/Mutator/ReturnValue/IntegerNegation.php
@@ -43,6 +43,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Stmt\Return_>
  */
 final class IntegerNegation implements Mutator
 {
@@ -62,8 +64,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Return_ $node
      *
      * @return iterable<Node\Stmt\Return_>
      */

--- a/src/Mutator/ReturnValue/NewObject.php
+++ b/src/Mutator/ReturnValue/NewObject.php
@@ -42,6 +42,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @extends AbstractValueToNullReturnValue<Node\Stmt\Return_>
  */
 final class NewObject extends AbstractValueToNullReturnValue
 {
@@ -82,8 +84,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Return_ $node
      *
      * @return iterable<array<Node\Stmt\Expression|Node\Stmt\Return_>>
      */

--- a/src/Mutator/ReturnValue/This.php
+++ b/src/Mutator/ReturnValue/This.php
@@ -42,6 +42,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @extends AbstractValueToNullReturnValue<Node\Stmt\Return_>
  */
 final class This extends AbstractValueToNullReturnValue
 {
@@ -58,8 +60,6 @@ final class This extends AbstractValueToNullReturnValue
      * Replaces "return $this;" with "return null;"
      *
      * @psalm-mutation-free
-     *
-     * @param Node\Stmt\Return_ $node
      *
      * @return iterable<Node\Stmt\Return_>
      */

--- a/src/Mutator/ReturnValue/YieldValue.php
+++ b/src/Mutator/ReturnValue/YieldValue.php
@@ -45,6 +45,8 @@ use PhpParser\Node;
  * @internal
  *
  * @see Yield_
+ *
+ * @implements Mutator<Node\Expr\Yield_>
  */
 final class YieldValue implements Mutator
 {
@@ -65,8 +67,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\Yield_ $node
      *
      * @return iterable<Node\Expr\Yield_>
      */

--- a/src/Mutator/Sort/Spaceship.php
+++ b/src/Mutator/Sort/Spaceship.php
@@ -44,6 +44,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\BinaryOp\Spaceship>
  */
 final class Spaceship implements Mutator
 {
@@ -63,8 +65,6 @@ TXT
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\BinaryOp\Spaceship $node
      *
      * @return iterable<Node\Expr\BinaryOp\Spaceship>
      */

--- a/src/Mutator/Unwrap/AbstractUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractUnwrapMutator.php
@@ -42,6 +42,8 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @implements Mutator<Node\Expr\FuncCall>
  */
 abstract class AbstractUnwrapMutator implements Mutator
 {
@@ -49,8 +51,6 @@ abstract class AbstractUnwrapMutator implements Mutator
 
     /**
      * @psalm-mutation-free
-     *
-     * @param Node\Expr\FuncCall $node
      *
      * @return iterable<Node\Arg>
      */

--- a/src/Mutator/Util/AbstractValueToNullReturnValue.php
+++ b/src/Mutator/Util/AbstractValueToNullReturnValue.php
@@ -43,6 +43,9 @@ use PhpParser\Node;
 
 /**
  * @internal
+ *
+ * @template TNode of Node
+ * @implements Mutator<TNode>
  */
 abstract class AbstractValueToNullReturnValue implements Mutator
 {

--- a/tests/phpunit/Fixtures/NullMutationVisitor.php
+++ b/tests/phpunit/Fixtures/NullMutationVisitor.php
@@ -11,10 +11,13 @@ use PhpParser\NodeVisitorAbstract;
 final class NullMutationVisitor extends NodeVisitorAbstract
 {
     /**
-     * @var Mutator[]
+     * @var Mutator<Node>
      */
     private $mutator;
 
+    /**
+     * @param Mutator<Node> $mutator
+     */
     public function __construct(Mutator $mutator)
     {
         $this->mutator = $mutator;

--- a/tests/phpunit/Fixtures/SimpleMutationsCollectorVisitor.php
+++ b/tests/phpunit/Fixtures/SimpleMutationsCollectorVisitor.php
@@ -15,7 +15,7 @@ use PhpParser\NodeVisitorAbstract;
 final class SimpleMutationsCollectorVisitor extends NodeVisitorAbstract
 {
     /**
-     * @var Mutator[]
+     * @var Mutator<\PhpParser\Node>
      */
     private $mutator;
 
@@ -29,6 +29,9 @@ final class SimpleMutationsCollectorVisitor extends NodeVisitorAbstract
      */
     private $fileAst;
 
+    /**
+     * @param Mutator<Node> $mutator
+     */
     public function __construct(Mutator $mutator, array $fileAst)
     {
         $this->mutator = $mutator;


### PR DESCRIPTION
This is a result of the discussion here: https://github.com/infection/infection/pull/1440#discussion_r530396555

Basically, this avoids having to either check the type of the given node in `mutate()` or suppressing warnings from static analyzers like PHPStan.