### PR TITLE
Use stable versions of xdebug and php 8 images

### DIFF
--- a/devTools/Dockerfile-php74-xdebug
+++ b/devTools/Dockerfile-php74-xdebug
@@ -25,7 +25,7 @@ RUN apk add --no-cache \
         zip
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
-COPY devTools/memory-limit.ini ${PHP_INI_DIR}/conf.d/
+COPY devTools/memory-limit.ini devTools/xdebug-coverage.ini ${PHP_INI_DIR}/conf.d/
 
 RUN adduser -h /opt/infection -s /bin/bash -D infection
 

--- a/devTools/Dockerfile-php80-xdebug
+++ b/devTools/Dockerfile-php80-xdebug
@@ -1,6 +1,6 @@
-FROM php:8.0-rc-cli-alpine
+FROM php:8.0-cli-alpine
 
-ARG XDEBUG_VERSION=3.0.0beta1
+ARG XDEBUG_VERSION=3.0.0
 
 RUN set -eux; \
     apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
Use stable versions of xdebug and php 8 in the docker containers

p.s. waiting stable php 8 images.