### PR TITLE
Allows to run infection in a path that contain spaces

### DIFF
--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -35,10 +35,11 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpUnit\CommandLine;
 
-use function array_filter;
+use function array_map;
 use function array_merge;
 use function explode;
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
+use function ltrim;
 
 /**
  * @internal
@@ -47,14 +48,20 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
 {
     public function build(string $configPath, string $extraOptions): array
     {
-        $options = array_merge(
-            [
-                '--configuration',
-                $configPath,
-            ],
-            explode(' ', $extraOptions) // FIXME might break space-containing paths
-        );
+        $options = [
+            '--configuration',
+            $configPath,
+        ];
 
-        return array_filter($options);
+        if ($extraOptions !== '') {
+            $options = array_merge(
+                $options,
+                array_map(static function ($option): string {
+                    return '--' . $option;
+                }, explode(' --', ltrim($extraOptions, '-')))
+            );
+        }
+
+        return $options;
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -77,4 +77,18 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
             $this->builder->build($configPath, '--verbose --debug')
         );
     }
+
+    public function test_it_can_build_the_command_with_extra_options_that_contains_spaces(): void
+    {
+        $configPath = '/the config/path';
+
+        $this->assertSame(
+            [
+                '--configuration',
+                $configPath,
+                '--path=/a path/with spaces',
+            ],
+            $this->builder->build($configPath, '--path=/a path/with spaces')
+        );
+    }
 }


### PR DESCRIPTION
This PR:

- [x] Allows to run infection in a path that contain spaces
- [x] Covered by tests

#### Technical information

I wasn't able to run infection on a project located in a space-containing directory because `$extraOptions` was split by space, so I split the string by `" --"` instead.

Before:
```
'--coverage-xml=/a/spaced path/coverage-xml --log-junit=/a/spaced path/junit.xml'
=>
[
    '--coverage-xml=/a/spaced',
    'path/coverage-xml',
    '--log-junit=/a/spaced',
    'path/junit.xml',
]
```

After:
```
'--coverage-xml=/a/spaced path/coverage-xml --log-junit=/a/spaced path/junit.xml'
=>
[
    '--coverage-xml=/a/spaced path/coverage-xml',
    '--log-junit=/a/spaced path/junit.xml',
]
```

The downside of it is that it doesn't support parameters with single dash, but the only usage of this method is with double dash parameters so I don't know if I should handle this case that never happens.