### PR TITLE
Bump up PHP-Parser to 4.10.3 and fix ternary mutator tests

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -288,16 +288,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.2",
+            "version": "v4.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "658f1be311a230e0907f5dfe0213742aff0596de"
+                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/658f1be311a230e0907f5dfe0213742aff0596de",
-                "reference": "658f1be311a230e0907f5dfe0213742aff0596de",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
+                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
                 "shasum": ""
             },
             "require": {
@@ -338,9 +338,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.3"
             },
-            "time": "2020-09-26T10:30:38+00:00"
+            "time": "2020-12-03T17:45:45+00:00"
         },
         {
             "name": "ocramius/package-versions",

--- a/tests/phpunit/Mutator/Operator/TernaryTest.php
+++ b/tests/phpunit/Mutator/Operator/TernaryTest.php
@@ -94,13 +94,13 @@ PHP
                     <<<'PHP'
 <?php
 
-true ? false : 'true' ? 't' : 'f';
+(true ? false : 'true') ? 't' : 'f';
 PHP
                     ,
                     <<<'PHP'
 <?php
 
-true ? 'true' : false ? 'f' : 't';
+(true ? 'true' : false) ? 'f' : 't';
 PHP
                 ],
             ];
@@ -116,13 +116,13 @@ PHP
                     <<<'PHP'
 <?php
 
-true ? false : true ?: 'f';
+(true ? false : true) ?: 'f';
 PHP
                     ,
                     <<<'PHP'
 <?php
 
-true ?: false ? 'f' : (true ?: false);
+(true ?: false) ? 'f' : (true ?: false);
 PHP
                 ],
             ];
@@ -138,13 +138,13 @@ PHP
                     <<<'PHP'
 <?php
 
-true ? false : 'true' ? 't' : 'f';
+(true ? false : 'true') ? 't' : 'f';
 PHP
                     ,
                     <<<'PHP'
 <?php
 
-true ? 'true' : false ? 'f' : 't';
+(true ? 'true' : false) ? 'f' : 't';
 PHP
                 ],
             ];
@@ -160,13 +160,13 @@ PHP
                     <<<'PHP'
 <?php
 
-true ? false : true ? 't' : 'f';
+(true ? false : true) ? 't' : 'f';
 PHP
                     ,
                     <<<'PHP'
 <?php
 
-true ?: false ? 'f' : 't';
+(true ?: false) ? 'f' : 't';
 PHP
                 ],
             ];


### PR DESCRIPTION
This PR: Bumps up PHP-Parser to 4.10.3 and fix Ternary mutator tests.