### PR TITLE
Use different folders for PHPStan cache for src and tests folders

### DIFF
--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -3,6 +3,7 @@ includes:
     - phpstan-src-baseline.neon
 
 parameters:
+    tmpDir: ../build/cache/phpstan-src
     inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
         - '#.* value type specified in iterable type Symfony\\Component\\Process\\Process#'

--- a/devTools/phpstan-tests.neon
+++ b/devTools/phpstan-tests.neon
@@ -2,6 +2,7 @@ includes:
     - phpstan-tests-baseline.neon
 
 parameters:
+    tmpDir: ../build/cache/phpstan-tests
     parallel:
         processTimeout: 120.0
     checkGenericClassInNonGenericObjectType: false


### PR DESCRIPTION
without this patch, `make phpstan` overrides just written cache and always insects all files

with this patch, 2 different phpstan runs for src and tests folders use their own cache folders, so cache feature is used correctly
