### PR TITLE
Add a describe command

### DIFF
--- a/src/Command/DescribeCommand.php
+++ b/src/Command/DescribeCommand.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Command;
+
+use function array_key_exists;
+use function array_keys;
+use Infection\Console\IO;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\ProfileList;
+use function Safe\sprintf;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Question\Question;
+use Webmozart\Assert\Assert;
+
+/**
+ * @internal
+ */
+final class DescribeCommand extends BaseCommand
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('describe')
+            ->addArgument('Mutator name', InputArgument::OPTIONAL);
+    }
+
+    protected function executeCommand(IO $io): bool
+    {
+        $mutator = $io->getInput()->getArgument('Mutator name');
+
+        if ($mutator === null) {
+            $question = new Question('What mutator do you wish to describe?');
+            $question->setAutocompleterValues(array_keys(ProfileList::ALL_MUTATORS));
+            $mutator = $io->askQuestion(
+                $question
+            );
+        }
+
+        if (!array_key_exists($mutator, ProfileList::ALL_MUTATORS)) {
+            $io->error(sprintf(
+                '"The %s mutator does not exist"',
+                $mutator
+            ));
+
+            return false;
+        }
+
+        $mutatorClass = ProfileList::ALL_MUTATORS[$mutator];
+
+        Assert::subclassOf($mutatorClass, Mutator::class);
+
+        $definition = $mutatorClass::getDefinition();
+
+        if ($definition === null) {
+            $io->error(sprintf(
+                'Mutator "%s" does not have a defenition',
+                $mutator
+            ));
+
+            return false;
+        }
+
+        $io->writeln('Mutator Category: ' . $definition->getCategory());
+        $io->writeln(['', 'Description:']);
+        $io->writeln($definition->getDescription());
+        $remedy = $definition->getRemedies();
+
+        if ($remedy !== null) {
+            $io->writeln('');
+            $io->writeln($remedy);
+        }
+
+        return true;
+    }
+}

--- a/src/Command/DescribeCommand.php
+++ b/src/Command/DescribeCommand.php
@@ -54,6 +54,7 @@ final class DescribeCommand extends BaseCommand
     {
         $this
             ->setName('describe')
+            ->setDescription('Describes a mutator')
             ->addArgument('Mutator name', InputArgument::OPTIONAL);
     }
 

--- a/src/Command/DescribeCommand.php
+++ b/src/Command/DescribeCommand.php
@@ -96,6 +96,20 @@ final class DescribeCommand extends BaseCommand
         $io->writeln('Mutator Category: ' . $definition->getCategory());
         $io->writeln(['', 'Description:']);
         $io->writeln($definition->getDescription());
+
+        $diff = $definition->getDiff();
+
+        if ($diff !== null) {
+            $diffColorizer = $this->getApplication()->getContainer()->getDiffColorizer();
+            $io->writeln(
+                [
+                    '',
+                    'For example:',
+                    $diffColorizer->colorize($diff),
+                ]
+            );
+        }
+
         $remedy = $definition->getRemedies();
 
         if ($remedy !== null) {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -37,6 +37,7 @@ namespace Infection\Console;
 
 use function array_merge;
 use Infection\Command\ConfigureCommand;
+use Infection\Command\DescribeCommand;
 use Infection\Command\RunCommand;
 use Infection\Container;
 use OutOfBoundsException;
@@ -116,6 +117,7 @@ final class Application extends BaseApplication
             [
                 new ConfigureCommand(),
                 new RunCommand(),
+                new DescribeCommand(),
             ]
         );
 

--- a/src/Mutator/Arithmetic/Plus.php
+++ b/src/Mutator/Arithmetic/Plus.php
@@ -58,7 +58,11 @@ Replaces an addition operator (`+`) with a subtraction operator (`-`).
 TXT
             ,
             MutatorCategory::ORTHOGONAL_REPLACEMENT,
-            null
+            null,
+            <<<'DIFF'
+- $a = $b + $c;
++ $a = $b - $c;
+DIFF
         );
     }
 

--- a/src/Mutator/Definition.php
+++ b/src/Mutator/Definition.php
@@ -45,6 +45,7 @@ final class Definition
     private string $description;
     private string $category;
     private ?string $remedies;
+    private ?string $diff;
 
     /**
      * @param string $description Explanation on what the mutator is about
@@ -53,13 +54,15 @@ final class Definition
     public function __construct(
         string $description,
         string $category,
-        ?string $remedies
+        ?string $remedies,
+        ?string $diff = null
     ) {
         Assert::oneOf($category, MutatorCategory::ALL);
 
         $this->description = $description;
         $this->category = $category;
         $this->remedies = $remedies;
+        $this->diff = $diff;
     }
 
     public function getDescription(): string
@@ -75,5 +78,10 @@ final class Definition
     public function getRemedies(): ?string
     {
         return $this->remedies;
+    }
+
+    public function getDiff(): ?string
+    {
+        return $this->diff;
     }
 }

--- a/tests/phpunit/Command/DescribeCommandTest.php
+++ b/tests/phpunit/Command/DescribeCommandTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Command;
+
+use Infection\Console\Application;
+use Infection\Tests\SingletonContainer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class DescribeCommandTest extends TestCase
+{
+    public function test_it_describes(): void
+    {
+        $app = new Application(SingletonContainer::getContainer());
+
+        $tester = new CommandTester($app->find('describe'));
+
+        $result = $tester->execute([
+            'Mutator name' => 'Yield_',
+        ]);
+        $this->assertSame(0, $result);
+
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('Mutator Category: semanticReduction', $display);
+        $this->assertStringContainsString('Description:', $display);
+    }
+
+    public function test_it_described_the_remedy(): void
+    {
+        $app = new Application(SingletonContainer::getContainer());
+
+        $tester = new CommandTester($app->find('describe'));
+
+        $result = $tester->execute([
+            'Mutator name' => 'Yield_',
+        ]);
+        $this->assertSame(0, $result);
+
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('This mutation highlights the reliance of the side-effect', $display);
+    }
+
+    public function test_it_can_describe_a_mutator_when_asked_for_a_name(): void
+    {
+        $app = new Application(SingletonContainer::getContainer());
+
+        $tester = new CommandTester($app->find('describe'));
+
+        $tester->setInputs(['FalseValue']);
+        $result = $tester->execute([]);
+        $this->assertSame(0, $result);
+
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('Description:', $display);
+    }
+
+    public function test_it_errors_when_mutator_does_not_exist(): void
+    {
+        $app = new Application(SingletonContainer::getContainer());
+
+        $tester = new CommandTester($app->find('describe'));
+
+        $result = $tester->execute([
+            'Mutator name' => 'FooBar',
+        ]);
+        $this->assertSame(1, $result);
+
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('The FooBar mutator does not exist', $display);
+    }
+}

--- a/tests/phpunit/Mutator/DefinitionTest.php
+++ b/tests/phpunit/Mutator/DefinitionTest.php
@@ -47,13 +47,15 @@ final class DefinitionTest extends TestCase
     public function test_it_can_be_instantiated(
         string $description,
         string $category,
-        ?string $remedies
+        ?string $remedies,
+        ?string $diff
     ): void {
-        $definition = new Definition($description, $category, $remedies);
+        $definition = new Definition($description, $category, $remedies, $diff);
 
         $this->assertSame($description, $definition->getDescription());
         $this->assertSame($category, $definition->getCategory());
         $this->assertSame($remedies, $definition->getRemedies());
+        $this->assertSame($diff, $definition->getDiff());
     }
 
     public function valuesProvider(): iterable
@@ -62,12 +64,14 @@ final class DefinitionTest extends TestCase
             '',
             MutatorCategory::SEMANTIC_REDUCTION,
             null,
+            null,
         ];
 
         yield 'nominal' => [
             'This text is for explaining what the mutator is about.',
             MutatorCategory::SEMANTIC_REDUCTION,
             'This text is for providing guidelines on how to kill the mutant.',
+            'The diff',
         ];
     }
 }


### PR DESCRIPTION
This allows users to get a quick idea of a mutator,
without having to leave the cli.

This PR:

- [x] Adds a describe command, which describes mutators
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/204
