### PR TITLE
Use unique values in `ignoreSourceCodeByRegex` to not waste resources

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -37,6 +37,8 @@ namespace Infection\Configuration;
 
 use function array_fill_keys;
 use function array_key_exists;
+use function array_unique;
+use function array_values;
 use function dirname;
 use Infection\Configuration\Entry\Logs;
 use Infection\Configuration\Entry\PhpUnit;
@@ -285,7 +287,7 @@ class ConfigurationFactory
 
                 Assert::isArray($config['ignoreSourceCodeByRegex']);
 
-                $map[$mutatorName] = $config['ignoreSourceCodeByRegex'];
+                $map[$mutatorName] = array_values(array_unique($config['ignoreSourceCodeByRegex']));
             }
         }
 

--- a/src/Mutator/MutatorResolver.php
+++ b/src/Mutator/MutatorResolver.php
@@ -36,7 +36,10 @@ declare(strict_types=1);
 namespace Infection\Mutator;
 
 use function array_key_exists;
+use function array_map;
 use function array_merge_recursive;
+use function array_unique;
+use function array_values;
 use function class_exists;
 use InvalidArgumentException;
 use function Safe\sprintf;
@@ -78,7 +81,7 @@ final class MutatorResolver
                 /** @var string[] $globalSetting */
                 $globalSetting = $setting;
 
-                $globalSettings['ignoreSourceCodeByRegex'] = $globalSetting;
+                $globalSettings['ignoreSourceCodeByRegex'] = array_values(array_unique($globalSetting));
                 unset($mutatorSettings[self::GLOBAL_IGNORE_SOURCE_CODE_BY_REGEX_SETTING]);
             }
         }
@@ -135,7 +138,10 @@ final class MutatorResolver
             return (array) $settings;
         }
 
-        return array_merge_recursive($globalSettings, (array) $settings);
+        return array_map(
+            static fn (array $values): array => array_values(array_unique($values)),
+            array_merge_recursive($globalSettings, (array) $settings)
+        );
     }
 
     /**

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -588,6 +588,21 @@ final class ConfigurationFactoryTest extends TestCase
             ['MethodCallRemoval' => ['Assert::.*']]
         );
 
+        yield 'ignore source code by regex with duplicates' => self::createValueForIgnoreSourceCodeByRegex(
+            [
+                '@default' => false,
+                'MethodCallRemoval' => (object) [
+                    'ignoreSourceCodeByRegex' => [
+                        'Assert::.*',
+                        'Assert::.*',
+                        'Test::.*',
+                        'Test::.*',
+                    ],
+                ],
+            ],
+            ['MethodCallRemoval' => ['Assert::.*', 'Test::.*']]
+        );
+
         yield 'mutators from config & input' => self::createValueForMutators(
             [
                 '@default' => true,


### PR DESCRIPTION
Fixes #1459

