### PR TITLE
Add schema check to not allow duplicates in ignore and ignoreSourceCodeByRegex config options

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -122,6 +122,7 @@
             "properties": {
                 "global-ignore": {
                     "type": "array",
+                    "uniqueItems": true,
                     "items": {
                         "type": "string"
                     }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -128,6 +128,7 @@
                 },
                 "global-ignoreSourceCodeByRegex": {
                     "type": "array",
+                    "uniqueItems": true,
                     "items": {
                         "type": "string",
                         "format": "regex"

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -200,12 +200,14 @@
                             "properties": {
                                 "ignore": {
                                     "type": "array",
+                                    "uniqueItems": true,
                                     "items": {
                                         "type": "string"
                                     }
                                 },
                                 "ignoreSourceCodeByRegex": {
                                     "type": "array",
+                                    "uniqueItems": true,
                                     "items": {
                                         "type": "string",
                                         "format": "regex"
@@ -271,12 +273,14 @@
                             "properties": {
                                 "ignore": {
                                     "type": "array",
+                                    "uniqueItems": true,
                                     "items": {
                                         "type": "string"
                                     }
                                 },
                                 "ignoreSourceCodeByRegex": {
                                     "type": "array",
+                                    "uniqueItems": true,
                                     "items": {
                                         "type": "string",
                                         "format": "regex"
@@ -387,12 +391,14 @@
                             "properties": {
                                 "ignore": {
                                     "type": "array",
+                                    "uniqueItems": true,
                                     "items": {
                                         "type": "string"
                                     }
                                 },
                                 "ignoreSourceCodeByRegex": {
                                     "type": "array",
+                                    "uniqueItems": true,
                                     "items": {
                                         "type": "string",
                                         "format": "regex"
@@ -452,6 +458,7 @@
                                 },
                                 "ignoreSourceCodeByRegex": {
                                     "type": "array",
+                                    "uniqueItems": true,
                                     "items": {
                                         "type": "string",
                                         "format": "regex"
@@ -557,12 +564,14 @@
                     "properties": {
                         "ignore": {
                             "type": "array",
+                            "uniqueItems": true,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "ignoreSourceCodeByRegex": {
                             "type": "array",
+                            "uniqueItems": true,
                             "items": {
                                 "type": "string",
                                 "format": "regex"


### PR DESCRIPTION
Add schema check and do not allow to have duplicates in **ignore** and **ignoreSourceCodeByRegex** config options.

![image](https://user-images.githubusercontent.com/1302230/102005764-9efa6f00-3d2c-11eb-91a6-8ff0c29df26d.png)


cover https://github.com/infection/infection/issues/1459 request.

I'd say that we don't need to have https://github.com/infection/infection/pull/1460 with this fix. But in case to have a double check we may leave fix from https://github.com/infection/infection/pull/1460 as well.