### PR TITLE
Introduce `--noop` option to run Noop mutators that does not change the source code (AST)

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -255,7 +255,7 @@ final class RunCommand extends BaseCommand
                 self::OPTION_USE_NOOP_MUTATORS,
                 null,
                 InputOption::VALUE_NONE,
-                'Use noop mutators that do not change AST. For debugging purposes..',
+                'Use noop mutators that do not change AST. For debugging purposes.',
             )
             ->addOption(
                 self::OPTION_MIN_MSI,

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -114,6 +114,8 @@ final class RunCommand extends BaseCommand
     /** @var string */
     private const OPTION_LOGGER_GITHUB = 'logger-github';
 
+    private const OPTION_USE_NOOP_MUTATORS = 'noop';
+
     /** @var string */
     private const OPTION_MIN_MSI = 'min-msi';
 
@@ -248,6 +250,12 @@ final class RunCommand extends BaseCommand
                 null,
                 InputOption::VALUE_NONE,
                 'Log escaped Mutants as GitHub Annotations.',
+            )
+            ->addOption(
+                self::OPTION_USE_NOOP_MUTATORS,
+                null,
+                InputOption::VALUE_NONE,
+                'Use noop mutators that do not change AST. For debugging purposes..',
             )
             ->addOption(
                 self::OPTION_MIN_MSI,
@@ -435,7 +443,8 @@ final class RunCommand extends BaseCommand
             (bool) $input->getOption(self::OPTION_DRY_RUN),
             $gitDiffFilter,
             $gitDiffBase,
-            (bool) $input->getOption(self::OPTION_LOGGER_GITHUB)
+            (bool) $input->getOption(self::OPTION_LOGGER_GITHUB),
+            (bool) $input->getOption(self::OPTION_USE_NOOP_MUTATORS)
         );
     }
 

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -117,7 +117,8 @@ class ConfigurationFactory
         bool $dryRun,
         ?string $gitDiffFilter,
         ?string $gitDiffBase,
-        bool $useGitHubLogger
+        bool $useGitHubLogger,
+        bool $useNoopMutators
     ): Configuration {
         $configDir = dirname($schema->getFile());
 
@@ -135,7 +136,7 @@ class ConfigurationFactory
 
         $resolvedMutatorsArray = $this->resolveMutators($schema->getMutators(), $mutatorsInput);
 
-        $mutators = $this->mutatorFactory->create($resolvedMutatorsArray);
+        $mutators = $this->mutatorFactory->create($resolvedMutatorsArray, $useNoopMutators);
         $ignoreSourceCodeMutatorsMap = $this->retrieveIgnoreSourceCodeMutatorsMap($resolvedMutatorsArray);
 
         return new Configuration(

--- a/src/Container.php
+++ b/src/Container.php
@@ -165,6 +165,7 @@ final class Container
     public const DEFAULT_GIT_DIFF_FILTER = null;
     public const DEFAULT_GIT_DIFF_BASE = null;
     public const DEFAULT_USE_GITHUB_LOGGER = false;
+    public const DEFAULT_USE_NOOP_MUTATORS = false;
     public const DEFAULT_NO_PROGRESS = false;
     public const DEFAULT_FORCE_PROGRESS = false;
     public const DEFAULT_EXISTING_COVERAGE_PATH = null;
@@ -682,7 +683,8 @@ final class Container
             self::DEFAULT_DRY_RUN,
             self::DEFAULT_GIT_DIFF_FILTER,
             self::DEFAULT_GIT_DIFF_BASE,
-            self::DEFAULT_USE_GITHUB_LOGGER
+            self::DEFAULT_USE_GITHUB_LOGGER,
+            self::DEFAULT_USE_NOOP_MUTATORS
         );
     }
 
@@ -712,7 +714,8 @@ final class Container
         bool $dryRun,
         ?string $gitDiffFilter,
         ?string $gitDiffBase,
-        bool $useGitHubLogger
+        bool $useGitHubLogger,
+        bool $useNoopMutators
     ): self {
         $clone = clone $this;
 
@@ -786,7 +789,8 @@ final class Container
                 $dryRun,
                 $gitDiffFilter,
                 $gitDiffBase,
-                $useGitHubLogger
+                $useGitHubLogger,
+                $useNoopMutators
             ): Configuration {
                 return $container->getConfigurationFactory()->create(
                     $container->getSchemaConfiguration(),
@@ -810,7 +814,8 @@ final class Container
                     $dryRun,
                     $gitDiffFilter,
                     $gitDiffBase,
-                    $useGitHubLogger
+                    $useGitHubLogger,
+                    $useNoopMutators
                 );
             }
         );

--- a/src/Mutator/MutatorFactory.php
+++ b/src/Mutator/MutatorFactory.php
@@ -52,7 +52,7 @@ final class MutatorFactory
      *
      * @return array<string, Mutator<\PhpParser\Node>>
      */
-    public function create(array $resolvedMutators): array
+    public function create(array $resolvedMutators, bool $useNoopMutators): array
     {
         $mutators = [];
 
@@ -82,16 +82,15 @@ final class MutatorFactory
                     self::getConfigurableMutator($mutatorClassName, $settings) :
                     new $mutatorClassName();
 
-            if ($ignored === []) {
-                $mutators[$mutator->getName()] = $mutator;
-
-                continue;
+            if ($ignored !== []) {
+                $mutator = new IgnoreMutator(new IgnoreConfig($ignored), $mutator);
             }
 
-            $mutators[$mutator->getName()] = new IgnoreMutator(
-                new IgnoreConfig($ignored),
-                $mutator
-            );
+            if ($useNoopMutators) {
+                $mutator = new NoopMutator($mutator);
+            }
+
+            $mutators[$mutator->getName()] = $mutator;
         }
 
         return $mutators;

--- a/src/Mutator/NoopMutator.php
+++ b/src/Mutator/NoopMutator.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator;
+
+use DomainException;
+use PhpParser\Node;
+use function Safe\sprintf;
+
+/**
+ * @internal
+ *
+ * @template TNode of Node
+ * @implements Mutator<TNode>
+ */
+final class NoopMutator implements Mutator
+{
+    /** @var Mutator<TNode> */
+    private Mutator $mutator;
+
+    /**
+     * @param Mutator<TNode> $mutator
+     */
+    public function __construct(Mutator $mutator)
+    {
+        $this->mutator = $mutator;
+    }
+
+    public static function getDefinition(): ?Definition
+    {
+        throw new DomainException(sprintf(
+            'The class "%s" does not have a definition',
+            self::class
+        ));
+    }
+
+    public function canMutate(Node $node): bool
+    {
+        return $this->mutator->canMutate($node);
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return iterable<Node|Node[]>
+     */
+    public function mutate(Node $node): iterable
+    {
+        yield $node;
+    }
+
+    public function getName(): string
+    {
+        return $this->mutator->getName();
+    }
+}

--- a/tests/phpunit/ContainerTest.php
+++ b/tests/phpunit/ContainerTest.php
@@ -94,7 +94,8 @@ final class ContainerTest extends TestCase
             Container::DEFAULT_DRY_RUN,
             Container::DEFAULT_GIT_DIFF_FILTER,
             Container::DEFAULT_GIT_DIFF_BASE,
-            Container::DEFAULT_USE_GITHUB_LOGGER
+            Container::DEFAULT_USE_GITHUB_LOGGER,
+            Container::DEFAULT_USE_NOOP_MUTATORS
         );
 
         $traces = $newContainer->getUnionTraceProvider()->provideTraces();
@@ -142,7 +143,8 @@ final class ContainerTest extends TestCase
             Container::DEFAULT_DRY_RUN,
             Container::DEFAULT_GIT_DIFF_FILTER,
             Container::DEFAULT_GIT_DIFF_BASE,
-            Container::DEFAULT_USE_GITHUB_LOGGER
+            Container::DEFAULT_USE_GITHUB_LOGGER,
+            Container::DEFAULT_USE_NOOP_MUTATORS
         );
     }
 }

--- a/tests/phpunit/Mutator/BaseMutatorTestCase.php
+++ b/tests/phpunit/Mutator/BaseMutatorTestCase.php
@@ -119,7 +119,7 @@ abstract class BaseMutatorTestCase extends TestCase
             ->getMutatorFactory()
             ->create([
                 $mutatorClassName => ['settings' => $settings],
-            ])[MutatorName::getName($mutatorClassName)]
+            ], false)[MutatorName::getName($mutatorClassName)]
         ;
     }
 

--- a/tests/phpunit/Mutator/IgnoreMutatorTest.php
+++ b/tests/phpunit/Mutator/IgnoreMutatorTest.php
@@ -50,12 +50,12 @@ use PHPUnit\Framework\TestCase;
 final class IgnoreMutatorTest extends TestCase
 {
     /**
-     * @var MockObject|Mutator
+     * @var MockObject&Mutator
      */
     private $mutatorMock;
 
     /**
-     * @var MockObject|Node
+     * @var MockObject&Node
      */
     private $nodeMock;
 

--- a/tests/phpunit/Mutator/MutatorFactoryTest.php
+++ b/tests/phpunit/Mutator/MutatorFactoryTest.php
@@ -71,7 +71,7 @@ final class MutatorFactoryTest extends TestCase
 
     public function test_it_creates_no_mutator_if_no_profile_or_mutator_is_passed(): void
     {
-        $mutators = $this->mutatorFactory->create([]);
+        $mutators = $this->mutatorFactory->create([], false);
 
         $this->assertSame([], $mutators);
     }
@@ -81,7 +81,7 @@ final class MutatorFactoryTest extends TestCase
         $mutators = $this->mutatorFactory->create(array_fill_keys(
             ProfileList::ALL_MUTATORS,
             []
-        ));
+        ), false);
 
         $this->assertSameMutatorsByClass(
             array_values(ProfileList::ALL_MUTATORS),
@@ -95,7 +95,7 @@ final class MutatorFactoryTest extends TestCase
             TrueValue::class => [
                 'ignore' => ['A::B'],
             ],
-        ]);
+        ], false);
 
         $this->assertContainsOnlyInstancesOf(IgnoreMutator::class, $mutators);
         $this->assertSameMutatorsByClass([TrueValue::class], $mutators);
@@ -122,7 +122,7 @@ final class MutatorFactoryTest extends TestCase
     public function test_it_cannot_create_a_mutator_with_invalid_settings(): void
     {
         try {
-            $this->mutatorFactory->create([Plus::class => false]);
+            $this->mutatorFactory->create([Plus::class => false], false);
 
             $this->fail();
         } catch (InvalidArgumentException $exception) {
@@ -137,7 +137,7 @@ final class MutatorFactoryTest extends TestCase
     {
         $mutators = $this->mutatorFactory->create([
             Plus::class => ['unknown' => 'dunno'],
-        ]);
+        ], false);
 
         $this->assertSameMutatorsByClass([Plus::class], $mutators);
     }
@@ -149,7 +149,7 @@ final class MutatorFactoryTest extends TestCase
 
         $mutators = $this->mutatorFactory->create([
             TrueValue::class => ['settings' => $settings],
-        ]);
+        ], false);
 
         $this->assertSameMutatorsByClass([TrueValue::class], $mutators);
     }
@@ -157,7 +157,7 @@ final class MutatorFactoryTest extends TestCase
     public function test_it_cannot_create_an_unknown_mutator(): void
     {
         try {
-            $this->mutatorFactory->create(['Unknown\Mutator' => []]);
+            $this->mutatorFactory->create(['Unknown\Mutator' => []], false);
 
             $this->fail();
         } catch (InvalidArgumentException $exception) {

--- a/tests/phpunit/Mutator/MutatorRobustnessTest.php
+++ b/tests/phpunit/Mutator/MutatorRobustnessTest.php
@@ -92,7 +92,7 @@ final class MutatorRobustnessTest extends TestCase
                 yield $title => [
                     $fileName,
                     $fileContents,
-                    $mutatorFactory->create([$mutatorClassName => []])[MutatorName::getName($mutatorClassName)],
+                    $mutatorFactory->create([$mutatorClassName => []], false)[MutatorName::getName($mutatorClassName)],
                 ];
             }
         }

--- a/tests/phpunit/Mutator/NoopMutatorTest.php
+++ b/tests/phpunit/Mutator/NoopMutatorTest.php
@@ -47,12 +47,12 @@ use PHPUnit\Framework\TestCase;
 final class NoopMutatorTest extends TestCase
 {
     /**
-     * @var MockObject|Mutator
+     * @var MockObject&Mutator
      */
     private $mutatorMock;
 
     /**
-     * @var MockObject|Node
+     * @var MockObject&Node
      */
     private $nodeMock;
 

--- a/tests/phpunit/Mutator/NoopMutatorTest.php
+++ b/tests/phpunit/Mutator/NoopMutatorTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator;
+
+use DomainException;
+use Infection\Mutator\Arithmetic\Plus;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\NoopMutator;
+use function iterator_to_array;
+use PhpParser\Node;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class NoopMutatorTest extends TestCase
+{
+    /**
+     * @var MockObject|Mutator
+     */
+    private $mutatorMock;
+
+    /**
+     * @var MockObject|Node
+     */
+    private $nodeMock;
+
+    protected function setUp(): void
+    {
+        $this->mutatorMock = $this->createMock(Mutator::class);
+        $this->nodeMock = $this->createMock(Node::class);
+    }
+
+    public function test_it_cannot_give_a_definition(): void
+    {
+        try {
+            NoopMutator::getDefinition();
+
+            $this->fail();
+        } catch (DomainException $exception) {
+            $this->assertSame(
+                'The class "Infection\Mutator\NoopMutator" does not have a definition',
+                $exception->getMessage()
+            );
+        }
+    }
+
+    public function test_it_should_not_mutate_node_if_its_decorated_mutator_cannot(): void
+    {
+        $ignoreMutator = new NoopMutator($this->mutatorMock);
+
+        $this->mutatorMock
+            ->expects($this->once())
+            ->method('canMutate')
+            ->with($this->nodeMock)
+            ->willReturn(false)
+        ;
+
+        $mutate = $ignoreMutator->canMutate($this->nodeMock);
+
+        $this->assertFalse($mutate);
+    }
+
+    public function test_it_should_mutate_node_if_its_decorated_mutator_can(): void
+    {
+        $ignoreMutator = new NoopMutator($this->mutatorMock);
+
+        $this->mutatorMock
+            ->expects($this->once())
+            ->method('canMutate')
+            ->with($this->nodeMock)
+            ->willReturn(true)
+        ;
+
+        $mutate = $ignoreMutator->canMutate($this->nodeMock);
+
+        $this->assertTrue($mutate);
+    }
+
+    public function test_it_does_not_mutate_the_node(): void
+    {
+        $ignoreMutator = new NoopMutator($this->mutatorMock);
+
+        $mutatedNode = $ignoreMutator->mutate($this->nodeMock);
+
+        $this->assertSame([$this->nodeMock], iterator_to_array($mutatedNode));
+    }
+
+    public function test_it_exposes_its_decorated_mutator_name(): void
+    {
+        $ignoreMutator = new NoopMutator(new Plus());
+
+        $this->assertSame(
+            MutatorName::getName(Plus::class),
+            $ignoreMutator->getName()
+        );
+    }
+}

--- a/tests/phpunit/Mutator/ProfileListProvider.php
+++ b/tests/phpunit/Mutator/ProfileListProvider.php
@@ -38,9 +38,11 @@ namespace Infection\Tests\Mutator;
 use function array_filter;
 use const ARRAY_FILTER_USE_KEY;
 use function array_values;
+use function in_array;
 use Infection\CannotBeInstantiated;
 use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Mutator;
+use Infection\Mutator\NoopMutator;
 use Infection\Mutator\ProfileList;
 use ReflectionClass;
 use function Safe\ksort;
@@ -96,7 +98,7 @@ final class ProfileListProvider
             $shortClassName = substr($file->getFilename(), 0, -4);
             $className = self::getMutatorClassNameFromPath($file->getPathname());
 
-            if ($className === IgnoreMutator::class) {
+            if (in_array($className, [IgnoreMutator::class, NoopMutator::class], true)) {
                 continue;
             }
 


### PR DESCRIPTION
This is needed for debugging purposes, to understand how and why Infection kills mutant even if no change is made for the given source code line.

If, using `--noop` options, we see killed mutants, it means that Infection environment somehow breaks the tests

- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/206

Ideally, when you run 

```bash
bin/infection --noop 
```

you should see the following picture:

```bash
Processing source code files: 407/407
.: killed, M: escaped, U: uncovered, E: fatal error, T: timed out, S: skipped

UMMMMMMMMMM                                          (11 / 11)

11 mutations were generated:
       0 mutants were killed
       1 mutants were not covered by tests
      10 covered mutants were not detected
       0 errors were encountered
       0 time outs were encountered
       0 mutants required more time than configured

Metrics:
         Mutation Score Indicator (MSI): 0%
         Mutation Code Coverage: 90%
         Covered Code MSI: 0%
```

so, mutants are either not covered by tests **or escaped**. It means tests are green for each noop mutator that just don't change the code.

If we get killed mutants using `--noop` option, it indicates the issues with the test suite:

* probably tests suite can't work with random order
* probably `--threads=x` makes tests suite broken (tests can't run in parallel)
* something else

In order to further debug the issue, developer ca use `--log-verbosite=all` and `text` logger and analyze `infection.log` file to understand what was going wrong.

Interesting, running Infection for iself with 4 threads and `--noop` option uncovers issues with our tests suite as well:

```bash
bin/infection --noop --log-verbosity=all --threads=4
```

<details>
<summary>infection.log</summary>

```bash
60587   │ 76) /home/maksrafalko/apps/infection/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php:253    [M] Foreach_
60588   │ 
60589   │ --- Original
60590   │ +++ New
60591   │ 
60592   │ $ '/home/maksrafalko/apps/infection/vendor/phpunit/phpunit/phpunit' '--configuration' '/tmp/infection/phpunitConfiguration.aa6dcebeef88e4d0f2c093bac66eb6d1.infection.xml'
60593   │   PHPUnit 9.5.0 by Sebastian Bergmann and contributors.
60594   │   
60595   │   Runtime:       PHP 7.4.13
60596   │   Configuration: /tmp/infection/phpunitConfiguration.aa6dcebeef88e4d0f2c093bac66eb6d1.infection.xml
60597   │   Random Seed:   1610016633
60598   │   
60599   │   Testing 
60600   │   E
60601   │   
60602   │   Time: 00:00.004, Memory: 10.00 MB
60603   │   
60604   │   There was 1 error:
60605   │   
60606   │   1) Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_preserves_white_spaces_and_formatting
60607   │   fopen(/tmp/infection-test/FileSystemTestCase93939/interceptor.autoload.a1b2c3.infection.php): failed to open stream: No such file or directory
60608   │   
60609   │   /home/maksrafalko/apps/infection/vendor/infection/include-interceptor/src/IncludeInterceptor.php:111
60610   │   /home/maksrafalko/apps/infection/vendor/thecodingmachine/safe/generated/filesystem.php:339
60611   │   /home/maksrafalko/apps/infection/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php:91
60612   │   /home/maksrafalko/apps/infection/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php:122
60613   │   
60614   │   ERRORS!
60615   │   Tests: 1, Assertions: 0, Errors: 1.
60616   │ 
60617   │ 
60618   │ 77) /home/maksrafalko/apps/infection/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php:259    [M] MethodCallRemoval
60619   │ 
60620   │ --- Original
60621   │ +++ New
60622   │ 
60623   │ $ '/home/maksrafalko/apps/infection/vendor/phpunit/phpunit/phpunit' '--configuration' '/tmp/infection/phpunitConfiguration.651f3d9b82e0931c14af0ac02b8caf70.infection.xml'
60624   │   PHPUnit 9.5.0 by Sebastian Bergmann and contributors.
60625   │   
60626   │   Runtime:       PHP 7.4.13
60627   │   Configuration: /tmp/infection/phpunitConfiguration.651f3d9b82e0931c14af0ac02b8caf70.infection.xml
60628   │   Random Seed:   1610016633
60629   │   
60630   │   Testing 
60631   │   .......E
60632   │   
60633   │   Time: 00:00.008, Memory: 10.00 MB
60634   │   
60635   │   There was 1 error:
60636   │   
60637   │   1) Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_interceptor_is_included
60638   │   fopen(/tmp/infection-test/FileSystemTestCase68815/interceptor.autoload.a1b2c3.infection.php): failed to open stream: No such file or directory
60639   │   
60640   │   /home/maksrafalko/apps/infection/vendor/infection/include-interceptor/src/IncludeInterceptor.php:111
60641   │   /home/maksrafalko/apps/infection/vendor/thecodingmachine/safe/generated/filesystem.php:339
60642   │   /home/maksrafalko/apps/infection/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php:91
60643   │   /home/maksrafalko/apps/infection/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php:513
60644   │   
60645   │   ERRORS!
60646   │   Tests: 8, Assertions: 11, Errors: 1.

```
</details>

So, it looks like we have tests that can't work in parallel:

```
 fopen(/tmp/infection-test/FileSystemTestCase93939/interceptor.autoload.a1b2c3.infection.php): failed to open stream: No such file or directory
```