### PR TITLE
Add symfony polyfill bootstraps to Php-Scoper file whitelist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 # Variables
 #---------------------------------------------------------------------------
 BOX=./.tools/box
-BOX_URL="https://github.com/humbug/box/releases/download/3.9.1/box.phar"
+BOX_URL="https://github.com/humbug/box/releases/download/3.10.0/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
 PHP_CS_FIXER_URL="https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar"

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -33,6 +33,13 @@
 
 declare(strict_types=1);
 
+use Isolated\Symfony\Component\Finder\Finder;
+
+$polyfillsBootstrap = Finder::create()
+    ->files()
+    ->in(__DIR__ . '/vendor/symfony/polyfill-*')
+    ->name('bootstrap.php');
+
 return [
     'whitelist' => [
         \Composer\Autoload\ClassLoader::class,
@@ -45,6 +52,12 @@ return [
         'T_NULLSAFE_OBJECT_OPERATOR',
         'T_ATTRIBUTE',
     ],
+    'files-whitelist' => \array_map(
+        static function ($file) {
+            return $file->getPathName();
+        },
+        \iterator_to_array($polyfillsBootstrap)
+    ),
     'whitelist-global-constants' => false,
     'whitelist-global-classes' => false,
     'whitelist-global-functions' => false,


### PR DESCRIPTION
This PR adds Symfony polyfill bootstraps to Php-Scoper file whitelists to avoid issues like:
`Call to undefined function get_debug_type()` in symfony internals.

Reported Infection issue: https://github.com/infection/infection/issues/1470
Reported Php-Scoper issue with workaround: https://github.com/humbug/php-scoper/issues/440

and bumps up Box to 3.10.0 (have an issue with >= 3.11)