### PR TITLE
Expect status 200 as well as 201 for Stryker Dashboard

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer update --no-interaction --prefer-dist --no-progress
+          composer install --no-interaction --prefer-dist --no-progress
 
       - name: Run tests
         run: |

--- a/src/Logger/Http/Response.php
+++ b/src/Logger/Http/Response.php
@@ -42,8 +42,8 @@ use Webmozart\Assert\Assert;
  */
 final class Response
 {
-    public const OK_RESPONSE_CODE = 200;
-    public const CREATED_RESPONSE_CODE = 201;
+    public const HTTP_OK = 200;
+    public const HTTP_CREATED = 201;
 
     private int $statusCode;
     private string $body;

--- a/src/Logger/Http/Response.php
+++ b/src/Logger/Http/Response.php
@@ -42,6 +42,7 @@ use Webmozart\Assert\Assert;
  */
 final class Response
 {
+    public const OK_RESPONSE_CODE = 200;
     public const CREATED_RESPONSE_CODE = 201;
 
     private int $statusCode;

--- a/src/Logger/Http/StrykerDashboardClient.php
+++ b/src/Logger/Http/StrykerDashboardClient.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Logger\Http;
 
+use function in_array;
 use Psr\Log\LoggerInterface;
 use function Safe\json_encode;
 use function Safe\sprintf;
@@ -68,7 +69,7 @@ class StrykerDashboardClient
 
         $statusCode = $response->getStatusCode();
 
-        if ($statusCode !== Response::CREATED_RESPONSE_CODE) {
+        if (!in_array($statusCode, [Response::OK_RESPONSE_CODE, Response::CREATED_RESPONSE_CODE], true)) {
             $this->logger->warning(sprintf(
                 'Stryker dashboard returned an unexpected response code: %s',
                 $statusCode)

--- a/src/Logger/Http/StrykerDashboardClient.php
+++ b/src/Logger/Http/StrykerDashboardClient.php
@@ -69,7 +69,7 @@ class StrykerDashboardClient
 
         $statusCode = $response->getStatusCode();
 
-        if (!in_array($statusCode, [Response::OK_RESPONSE_CODE, Response::CREATED_RESPONSE_CODE], true)) {
+        if (!in_array($statusCode, [Response::HTTP_OK, Response::HTTP_CREATED], true)) {
             $this->logger->warning(sprintf(
                 'Stryker dashboard returned an unexpected response code: %s',
                 $statusCode)

--- a/tests/phpunit/Logger/Http/StrykerDashboardClientTest.php
+++ b/tests/phpunit/Logger/Http/StrykerDashboardClientTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Logger\Http;
 
+use Generator;
 use Infection\Logger\Http\Response;
 use Infection\Logger\Http\StrykerCurlClient;
 use Infection\Logger\Http\StrykerDashboardClient;
@@ -76,7 +77,10 @@ final class StrykerDashboardClientTest extends TestCase
         );
     }
 
-    public function test_it_can_send_a_report(): void
+    /**
+     * @dataProvider provideResponseStatusCodes
+     */
+    public function test_it_can_send_a_report_with_expected_response_status_code(): void
     {
         $this->clientMock
             ->expects($this->once())
@@ -116,6 +120,13 @@ EOF
             ],
             $this->logger->getLogs()
         );
+    }
+
+    public function provideResponseStatusCodes(): Generator
+    {
+        yield '200 OK' => [Response::OK_RESPONSE_CODE];
+
+        yield '201 CREATED' => [Response::CREATED_RESPONSE_CODE];
     }
 
     public function test_it_issues_a_warning_when_the_report_could_not_be_sent(): void

--- a/tests/phpunit/Logger/Http/StrykerDashboardClientTest.php
+++ b/tests/phpunit/Logger/Http/StrykerDashboardClientTest.php
@@ -124,9 +124,9 @@ EOF
 
     public function provideResponseStatusCodes(): Generator
     {
-        yield '200 OK' => [Response::OK_RESPONSE_CODE];
+        yield '200 OK' => [Response::HTTP_OK];
 
-        yield '201 CREATED' => [Response::CREATED_RESPONSE_CODE];
+        yield '201 CREATED' => [Response::HTTP_CREATED];
     }
 
     public function test_it_issues_a_warning_when_the_report_could_not_be_sent(): void


### PR DESCRIPTION
Seems like Stryker Dashboard decided to return 200 status instead of previously returned 201.

Let's expect both in case they decide to change it again

Fixes https://github.com/infection/infection/issues/1475

- [ ] merge to master as well