### PR TITLE
tests(makefile): moved cs-fixer download to GitHub releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BOX=./.tools/box
 BOX_URL="https://github.com/humbug/box/releases/download/3.10.0/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
-PHP_CS_FIXER_URL="https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar"
+PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.18.2/php-cs-fixer.phar"
 PHP_CS_FIXER_CACHE=build/cache/.php_cs.cache
 
 PHPSTAN=./vendor/bin/phpstan


### PR DESCRIPTION
This PR:

- [ ] Adds new feature ...
- [ ] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

When executing make cs cs-fixer was not properly downloaded. 
https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar seems to be offline.
I decided to move over to GitHub releases of cs-fixer.

Let me know if this is the way you want this to be fixed,