### PR TITLE
Use php-cs-fixer from Makefile in order to keep same version

### DIFF
--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -12,9 +12,6 @@ jobs:
     name: Coding Standards
     runs-on: ubuntu-latest
 
-    env:
-      PHP_CS_FIXER_VERSION: v2.17.3
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -23,7 +20,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 7.4
-          tools: php-cs-fixer:${{ env.PHP_CS_FIXER_VERSION }}
 
       - name: Restore PHP-CS-Fixer cache
         uses: actions/cache@v2
@@ -32,6 +28,5 @@ jobs:
           key: "php-cs-fixer"
           restore-keys: "php-cs-fixer"
 
-      - name: Run PHP-CS-Fixer, version ${{ env.PHP_CS_FIXER_VERSION }}
-        run: |
-          php-cs-fixer fix --diff --diff-format=udiff --dry-run --verbose
+      - name: Run PHP-CS-Fixer
+        run: make cs-check

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BOX_URL="https://github.com/humbug/box/releases/download/3.10.0/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
 PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.18.2/php-cs-fixer.phar"
-PHP_CS_FIXER_CACHE=build/cache/.php_cs.cache
+PHP_CS_FIXER_CACHE=.php_cs.cache
 
 PHPSTAN=./vendor/bin/phpstan
 

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,15 @@ check_trailing_whitespaces:
 .PHONY: cs
 cs:	  	 	## Runs PHP-CS-Fixer
 cs: $(PHP_CS_FIXER)
-	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE)
+	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE) --diff --diff-format=udiff
 	LC_ALL=C sort -u .gitignore -o .gitignore
+	$(MAKE) check_trailing_whitespaces
+
+.PHONY: cs-check
+cs-check:		## Runs PHP-CS-Fixer in dry-run mode
+cs-check: $(PHP_CS_FIXER)
+	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE) --diff --diff-format=udiff --dry-run
+	LC_ALL=C sort -c -u .gitignore
 	$(MAKE) check_trailing_whitespaces
 
 .PHONY: phpstan
@@ -174,7 +181,7 @@ test-e2e-xdebug-80-docker: $(DOCKER_RUN_80_IMAGE) $(INFECTION)
 	$(DOCKER_RUN_80) ./tests/e2e_tests $(INFECTION)
 
 .PHONY: test-infection
-test-infection:	## Runs Infection against itself
+test-infection:		## Runs Infection against itself
 test-infection:
 	$(INFECTION) --threads=4
 

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -78,6 +78,7 @@ final class MakefileTest extends TestCase
 
 [33mcompile:[0m	 	 Bundles Infection into a PHAR
 [33mcs:[0m	  	 	 Runs PHP-CS-Fixer
+[33mcs-check:[0m		 Runs PHP-CS-Fixer in dry-run mode
 [33mprofile:[0m 	 	 Runs Blackfire
 [33mautoreview:[0m 	 	 Runs various checks (static analysis & AutoReview test suite)
 [33mtest:[0m		 	 Runs all the tests
@@ -87,7 +88,7 @@ final class MakefileTest extends TestCase
 [33mtest-e2e:[0m 	 	 Runs the end-to-end tests
 [33mtest-e2e-phpunit:[0m	 Runs PHPUnit-enabled subset of end-to-end tests
 [33mtest-e2e-docker:[0m 	 Runs the end-to-end tests on the different Docker platforms
-[33mtest-infection:[0m	 Runs Infection against itself
+[33mtest-infection:[0m		 Runs Infection against itself
 [33mtest-infection-docker:[0m	 Runs Infection against itself on the different Docker platforms
 
 EOF;

--- a/tests/phpunit/PhpParser/Visitor/IgnoreNode/ChangingIgnorerTest.php
+++ b/tests/phpunit/PhpParser/Visitor/IgnoreNode/ChangingIgnorerTest.php
@@ -42,7 +42,7 @@ final class ChangingIgnorerTest extends BaseNodeIgnorerTestCase
 {
     private const CODE_WITH_ONE_IGNORED_NODE = <<<'PHP'
 <?php
-        
+
 class Foo
 {
     public function bar()
@@ -55,7 +55,7 @@ PHP;
 
     private const CODE_WITH_ONE_COUNTED_NODE = <<<'PHP'
 <?php
-        
+
 class Foo
 {
     public function bar()


### PR DESCRIPTION
Our CI uses ab old version of PHP-CS-Fixer - 2.17.3 but Makefile downloads - 2.18.2.

This PR fixes this and now GA going to run `cs-check` from Makefile.

Initial discussion was in the https://github.com/infection/infection/pull/1487#pullrequestreview-595315127.