### PR TITLE
Use constants instead of hardcoded values for PHP_INT_(MAX|MIN) to run tests successfully on 32/64-bit systems

### DIFF
--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator\Number;
 
 use Infection\Tests\Mutator\BaseMutatorTestCase;
+use const PHP_INT_MIN;
 
 final class DecrementIntegerTest extends BaseMutatorTestCase
 {
@@ -507,11 +508,13 @@ preg_split('//', 'string', -2);
 PHP
         ];
 
+        $minInt = PHP_INT_MIN;
+
         yield 'It does not decrement min int' => [
-            <<<'PHP'
+            <<<"PHP"
 <?php
 
-if ($a === -9223372036854775808) {
+if (1 === {$minInt}) {
     echo 'bar';
 }
 PHP

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator\Number;
 
 use Infection\Tests\Mutator\BaseMutatorTestCase;
+use const PHP_INT_MAX;
 
 final class IncrementIntegerTest extends BaseMutatorTestCase
 {
@@ -242,17 +243,19 @@ preg_split('//', 'string', -1);
 PHP
         ];
 
+        $maxInt = PHP_INT_MAX;
+
         yield 'It does not increment max int' => [
-            <<<'PHP'
+            <<<"PHP"
 <?php
 
-random_int(10000000, 9223372036854775807);
+random_int(10000000, {$maxInt});
 PHP
             ,
-            <<<'PHP'
+            <<<"PHP"
 <?php
 
-random_int(10000001, 9223372036854775807);
+random_int(10000001, {$maxInt});
 PHP
         ];
     }


### PR DESCRIPTION
Fixes https://github.com/infection/infection/pull/1486#issuecomment-783583613