### PR TITLE
Build PHAR distribution using docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,11 @@ PHPUNIT_GROUP=default
 compile:	 	## Bundles Infection into a PHAR
 compile: $(INFECTION)
 
+.PHONY: compile-docker
+compile-docker:	 	## Bundles Infection into a PHAR using docker
+compile-docker: $(DOCKER_RUN_74_IMAGE)
+	$(DOCKER_RUN_74) make compile
+
 .PHONY: check_trailing_whitespaces
 check_trailing_whitespaces:
 	./devTools/check_trailing_whitespaces.sh

--- a/devTools/Dockerfile-php74-xdebug
+++ b/devTools/Dockerfile-php74-xdebug
@@ -22,6 +22,7 @@ RUN apk add --no-cache \
         make \
         bash \
         expect \
+        git \
         zip
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -77,6 +77,7 @@ final class MakefileTest extends TestCase
 #---------------------------------------------------------------------------[0m
 
 [33mcompile:[0m	 	 Bundles Infection into a PHAR
+[33mcompile-docker:[0m	 	 Bundles Infection into a PHAR using docker
 [33mcs:[0m	  	 	 Runs PHP-CS-Fixer
 [33mcs-check:[0m		 Runs PHP-CS-Fixer in dry-run mode
 [33mprofile:[0m 	 	 Runs Blackfire


### PR DESCRIPTION
I have PHP 8.0.2 installed locally, and `make compile` does not work there.

I'm not 100% sure we need it, but it was very handy to build Infection PHAR using docker locally, rather than reinstalling PHP and/or looking why it does not work (still useful).

So, since we have other commands executed in docker container, I would like to propose having such new command for docker as well.