### PR TITLE
Update GitDiffFileProvider.php

### DIFF
--- a/src/Logger/GitHub/GitDiffFileProvider.php
+++ b/src/Logger/GitHub/GitDiffFileProvider.php
@@ -52,7 +52,7 @@ class GitDiffFileProvider
     {
         return (string) shell_exec(
             sprintf(
-                'git diff %s --diff-filter=%s --name-only | grep src/ | paste -sd ","',
+                'git diff %s --diff-filter=%s --name-only | grep src/ | paste -s -d "," -',
                 escapeshellarg($gitDiffBase),
                 escapeshellarg($gitDiffFilter)
             )


### PR DESCRIPTION
Fixes #1492

@wolfgangschaefer if you can verify this command produces expected output on macOS:

```
(echo a; echo b; echo c) | paste -s -d "," -
```

Should be `a,b,c`