### PR TITLE
Fix file not found exception for Codeception Cest `bug`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,7 +21,8 @@ granular tests, you can run `make` to see the available commands.
 <br />
 <hr />
 
-« [Go back to the readme](README.md) »
+« [Go back to the readme][readme] »
 
 
 [docker]: https://www.docker.com/get-docker
+[readme]: /README.md

--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer update --no-interaction --prefer-dist --no-progress
+          composer install --no-interaction --prefer-dist --no-progress
 
       - name: Run tests
         run: |

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -12,9 +12,6 @@ jobs:
     name: Coding Standards
     runs-on: ubuntu-latest
 
-    env:
-      PHP_CS_FIXER_VERSION: v2.17.3
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -23,7 +20,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 7.4
-          tools: php-cs-fixer:${{ env.PHP_CS_FIXER_VERSION }}
 
       - name: Restore PHP-CS-Fixer cache
         uses: actions/cache@v2
@@ -32,6 +28,5 @@ jobs:
           key: "php-cs-fixer"
           restore-keys: "php-cs-fixer"
 
-      - name: Run PHP-CS-Fixer, version ${{ env.PHP_CS_FIXER_VERSION }}
-        run: |
-          php-cs-fixer fix --diff --diff-format=udiff --dry-run --verbose
+      - name: Run PHP-CS-Fixer
+        run: make cs-check

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -65,4 +65,4 @@ jobs:
         env:
           INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
         run: |
-          php bin/infection -j2 --skip-initial-tests --min-msi=$MIN_MSI --min-covered-msi=$MIN_COVERED_MSI --coverage=build/logs --log-verbosity=none --skip-initial-tests --no-interaction --no-progress
+          php bin/infection -j2 --skip-initial-tests --min-msi=$MIN_MSI --min-covered-msi=$MIN_COVERED_MSI --coverage=build/logs --log-verbosity=none --no-interaction --no-progress

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -62,5 +62,7 @@ jobs:
           php vendor/phpunit/phpunit/phpunit --stop-on-failure --coverage-xml=build/logs/coverage-xml --log-junit=build/logs/junit.xml
 
       - name: Run Infection
+        env:
+          INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
         run: |
           php bin/infection -j2 --skip-initial-tests --min-msi=$MIN_MSI --min-covered-msi=$MIN_COVERED_MSI --coverage=build/logs --log-verbosity=none --skip-initial-tests --no-interaction --no-progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Change Log
 
+## [0.20.1](https://github.com/infection/infection/tree/0.21.0) (2021-01-27)
+[Full Changelog](https://github.com/infection/infection/compare/0.20.2...0.21.0)
+
+**Added:**
+
+- Introduce `--noop` option to run Noop mutators that does not change the source code (AST) https://github.com/infection/infection/pull/1465
+- Add support for `@infection-ignore-all` annotation https://github.com/infection/infection/pull/1468
+- Introduce `--noop` option to run Noop mutators that do not change the source code (AST) https://github.com/infection/infection/pull/1465
+- Add a `describe` command https://github.com/infection/infection/pull/1442
+- [MUTATOR] Add `Concat` operator mutator https://github.com/infection/infection/pull/1440
+- [MUTATOR] Add `ConcatOperandRemoval` operator mutator https://github.com/infection/infection/pull/1440
+- [MUTATOR] Add `While` expression mutator https://github.com/infection/infection/pull/1405
+- [MUTATOR] Add `DoWhile` expression mutator https://github.com/infection/infection/pull/1411
+- [MUTATOR] Add `PregMatchRemoveFlags` mutator - remove flags one by one https://github.com/infection/infection/pull/1462
+- [MUTATOR] Add `PregMatchRemoveCaret` https://github.com/infection/infection/pull/1455
+- [MUTATOR] Add `PregMatchRemoveDollar` mutator https://github.com/infection/infection/pull/1455
+- [MUTATOR] Add `NullSafe` operator mutator https://github.com/infection/infection/pull/1457
+
+**Changed:**
+
+- [BC BREAK] Removed `OneZeroInteger` mutator in favor of `IncrementInteger`/`DecrementInteger` mutators
+- [BC BREAK] Rename `@zero_iteration` profile to the `@loop` #1407
+
+## [0.20.0](https://github.com/infection/infection/tree/0.20.0) (2020-11-01)
+[Full Changelog](https://github.com/infection/infection/compare/0.19.2...0.20.0)
+
+**Added:**
+
+- Add github logger to be able to use Annotations on GitHub Actions https://github.com/infection/infection/pull/1368
+- Add `--diff-git-filter` & `--git-diff-base` options https://github.com/infection/infection/pull/1368
+- [MUTATOR] Implement UnwrapSubstr mutator https://github.com/infection/infection/pull/1400
+- [MUTATOR] Implement UnwrapStrRev mutator https://github.com/infection/infection/pull/1399
+- [MUTATOR] Implement UnwrapRtrim mutator https://github.com/infection/infection/pull/1396
+- [MUTATOR] Implement UnwrapStrIreplace mutator https://github.com/infection/infection/pull/1397
+- [MUTATOR] Implement UnwrapStrShuffle mutator https://github.com/infection/infection/pull/1398
+- [MUTATOR] Implement UnwrapLtrim mutator https://github.com/infection/infection/pull/1395
+- [MUTATOR] Add Ternary operator mutator https://github.com/infection/infection/pull/1390
+- [MUTATOR] Add Flip Coalesce operator mutator  https://github.com/infection/infection/pull/1389
+
+**Changed:**
+
+- Remove redundant Coalesce Mutator and rename FlipCoalesce to Coalesce https://github.com/infection/infection/pull/1391
+
 ## [0.19.0](https://github.com/infection/infection/tree/0.19.0) (2020-10-28)
 [Full Changelog](https://github.com/infection/infection/compare/0.18.2...0.19.0)
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BOX_URL="https://github.com/humbug/box/releases/download/3.10.0/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
 PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.18.2/php-cs-fixer.phar"
-PHP_CS_FIXER_CACHE=build/cache/.php_cs.cache
+PHP_CS_FIXER_CACHE=.php_cs.cache
 
 PHPSTAN=./vendor/bin/phpstan
 

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,11 @@ PHPUNIT_GROUP=default
 compile:	 	## Bundles Infection into a PHAR
 compile: $(INFECTION)
 
+.PHONY: compile-docker
+compile-docker:	 	## Bundles Infection into a PHAR using docker
+compile-docker: $(DOCKER_RUN_74_IMAGE)
+	$(DOCKER_RUN_74) make compile
+
 .PHONY: check_trailing_whitespaces
 check_trailing_whitespaces:
 	./devTools/check_trailing_whitespaces.sh

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,15 @@ check_trailing_whitespaces:
 .PHONY: cs
 cs:	  	 	## Runs PHP-CS-Fixer
 cs: $(PHP_CS_FIXER)
-	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE)
+	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE) --diff --diff-format=udiff
 	LC_ALL=C sort -u .gitignore -o .gitignore
+	$(MAKE) check_trailing_whitespaces
+
+.PHONY: cs-check
+cs-check:		## Runs PHP-CS-Fixer in dry-run mode
+cs-check: $(PHP_CS_FIXER)
+	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE) --diff --diff-format=udiff --dry-run
+	LC_ALL=C sort -c -u .gitignore
 	$(MAKE) check_trailing_whitespaces
 
 .PHONY: phpstan
@@ -174,7 +181,7 @@ test-e2e-xdebug-80-docker: $(DOCKER_RUN_80_IMAGE) $(INFECTION)
 	$(DOCKER_RUN_80) ./tests/e2e_tests $(INFECTION)
 
 .PHONY: test-infection
-test-infection:	## Runs Infection against itself
+test-infection:		## Runs Infection against itself
 test-infection:
 	$(INFECTION) --threads=4
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BOX=./.tools/box
 BOX_URL="https://github.com/humbug/box/releases/download/3.10.0/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
-PHP_CS_FIXER_URL="https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar"
+PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.18.2/php-cs-fixer.phar"
 PHP_CS_FIXER_CACHE=build/cache/.php_cs.cache
 
 PHPSTAN=./vendor/bin/phpstan

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^7.4.7 || ^8.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",
@@ -52,7 +52,7 @@
         "infection/include-interceptor": "^0.2.4",
         "justinrainbow/json-schema": "^5.2",
         "nikic/php-parser": "^4.10.3",
-        "ocramius/package-versions": "^1.2 || ^2.0",
+        "ocramius/package-versions": "^1.11.0 || ^2.0",
         "ondram/ci-detector": "^3.3.0",
         "sanmai/later": "^0.1.1",
         "sanmai/pipeline": "^5.1",
@@ -86,7 +86,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.4.0"
+            "php": "7.4.7"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03ff3b54fd5c9a9d7c0140e52d2be174",
+    "content-hash": "2cf9f7ad9129eedccb617b0efc35bd51",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -344,29 +344,30 @@
         },
         {
             "name": "ocramius/package-versions",
-            "version": "1.9.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "94c9d42a466c57f91390cdd49c81313264f49d85"
+                "reference": "f51ff2b2b49baaa302d6bf71880e4d8b5acd7015"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/94c9d42a466c57f91390cdd49c81313264f49d85",
-                "reference": "94c9d42a466c57f91390cdd49c81313264f49d85",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/f51ff2b2b49baaa302d6bf71880e4d8b5acd7015",
+                "reference": "f51ff2b2b49baaa302d6bf71880e4d8b5acd7015",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1.0 || ^2.0",
-                "php": "^7.4.0"
+                "composer-plugin-api": "^2.0.0",
+                "composer-runtime-api": "^2.0.0",
+                "php": "^7.4.7"
             },
             "require-dev": {
-                "composer/composer": "^1.9.3 || ^2.0@dev",
-                "doctrine/coding-standard": "^7.0.2",
+                "composer/composer": "^2.0.0@dev",
+                "doctrine/coding-standard": "^8.1.0",
                 "ext-zip": "^1.15.0",
-                "infection/infection": "^0.15.3",
-                "phpunit/phpunit": "^9.1.1",
-                "vimeo/psalm": "^3.9.3"
+                "infection/infection": "^0.16.4",
+                "phpunit/phpunit": "^9.1.5",
+                "vimeo/psalm": "^3.12.2"
             },
             "type": "composer-plugin",
             "extra": {
@@ -393,7 +394,7 @@
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
             "support": {
                 "issues": "https://github.com/Ocramius/PackageVersions/issues",
-                "source": "https://github.com/Ocramius/PackageVersions/tree/1.9.0"
+                "source": "https://github.com/Ocramius/PackageVersions/tree/1.11.x"
             },
             "funding": [
                 {
@@ -405,7 +406,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-22T14:15:44+00:00"
+            "time": "2020-08-21T12:16:47+00:00"
         },
         {
             "name": "ondram/ci-detector",
@@ -1908,12 +1909,12 @@
             "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
@@ -1951,8 +1952,8 @@
                 "validate"
             ],
             "support": {
-                "issues": "https://github.com/webmozart/assert/issues",
-                "source": "https://github.com/webmozart/assert/tree/master"
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
             },
             "time": "2020-07-08T17:02:28+00:00"
         },
@@ -4570,7 +4571,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ^8.0",
+        "php": "^7.4.7 || ^8.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*"
@@ -4579,7 +4580,7 @@
         "ext-simplexml": "*"
     },
     "platform-overrides": {
-        "php": "7.4.0"
+        "php": "7.4.7"
     },
     "plugin-api-version": "2.0.0"
 }

--- a/devTools/Dockerfile-php74-xdebug
+++ b/devTools/Dockerfile-php74-xdebug
@@ -22,6 +22,7 @@ RUN apk add --no-cache \
         make \
         bash \
         expect \
+        git \
         zip
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/src/Config/ValueProvider/PCOVDirectoryProvider.php
+++ b/src/Config/ValueProvider/PCOVDirectoryProvider.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Config\ValueProvider;
+
+use Safe\Exceptions\InfoException;
+use function Safe\ini_get;
+
+/**
+ * Provides value for pcov.directory configuration option. Can be injected with a configuration object to provide a better, precise, value.
+ *
+ * @internal
+ * @final
+ */
+class PCOVDirectoryProvider
+{
+    private ?string $phpConfiguredPcovDirectory;
+
+    public function __construct(?string $iniValue = null)
+    {
+        try {
+            $this->phpConfiguredPcovDirectory = $iniValue ?? ini_get('pcov.directory');
+        } catch (InfoException $e) {
+            // Probably not using PCOV
+            $this->phpConfiguredPcovDirectory = null;
+        }
+    }
+
+    public function shallProvide(): bool
+    {
+        // That's the default value as per:
+        // https://github.com/krakjoe/pcov/blob/57e143363aa6ba3c4d1e1b0a2e68556e28f38950/pcov.c#L80-L83
+        return $this->phpConfiguredPcovDirectory === '';
+    }
+
+    public function getDirectory(): string
+    {
+        // Returning CWD simplicity's sake.
+        return '.';
+    }
+}

--- a/src/Logger/GitHub/GitDiffFileProvider.php
+++ b/src/Logger/GitHub/GitDiffFileProvider.php
@@ -52,7 +52,7 @@ class GitDiffFileProvider
     {
         return (string) shell_exec(
             sprintf(
-                'git diff %s --diff-filter=%s --name-only | grep src/ | paste -sd ","',
+                'git diff %s --diff-filter=%s --name-only | grep src/ | paste -s -d "," -',
                 escapeshellarg($gitDiffBase),
                 escapeshellarg($gitDiffFilter)
             )

--- a/src/Logger/Http/Response.php
+++ b/src/Logger/Http/Response.php
@@ -42,7 +42,8 @@ use Webmozart\Assert\Assert;
  */
 final class Response
 {
-    public const CREATED_RESPONSE_CODE = 201;
+    public const HTTP_OK = 200;
+    public const HTTP_CREATED = 201;
 
     private int $statusCode;
     private string $body;

--- a/src/Logger/Http/StrykerDashboardClient.php
+++ b/src/Logger/Http/StrykerDashboardClient.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Logger\Http;
 
+use function in_array;
 use Psr\Log\LoggerInterface;
 use function Safe\json_encode;
 use function Safe\sprintf;
@@ -68,7 +69,7 @@ class StrykerDashboardClient
 
         $statusCode = $response->getStatusCode();
 
-        if ($statusCode !== Response::CREATED_RESPONSE_CODE) {
+        if (!in_array($statusCode, [Response::HTTP_OK, Response::HTTP_CREATED], true)) {
             $this->logger->warning(sprintf(
                 'Stryker dashboard returned an unexpected response code: %s',
                 $statusCode)

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -40,6 +40,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\MutatorCategory;
 use Infection\PhpParser\Visitor\ParentConnector;
+use const PHP_INT_MIN;
 use PhpParser\Node;
 
 /**
@@ -94,6 +95,10 @@ DIFF
     public function canMutate(Node $node): bool
     {
         if (!$node instanceof Node\Scalar\LNumber) {
+            return false;
+        }
+
+        if ($node->value === PHP_INT_MIN) {
             return false;
         }
 

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -39,6 +39,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\MutatorCategory;
 use Infection\PhpParser\Visitor\ParentConnector;
+use const PHP_INT_MAX;
 use PhpParser\Node;
 
 /**
@@ -84,6 +85,10 @@ DIFF
     public function canMutate(Node $node): bool
     {
         if (!$node instanceof Node\Scalar\LNumber) {
+            return false;
+        }
+
+        if ($node->value === PHP_INT_MAX) {
             return false;
         }
 

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -105,6 +105,9 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
 
         // A format where the class name is inside `file` attribute of `testcase` tag
         yield '//testcase[contains(@file, "%s")][1]' => preg_replace('/^(.*):+.*$/', '$1.feature', $fullyQualifiedClassName);
+        
+        // A format where the class name parsed from feature and is inside `class` attribute of `testcase` tag
+        yield '//testcase[@class="%s"][1]' => preg_replace('/^(.*):+.*$/', '$1', $fullyQualifiedClassName);
     }
 
     private function getXPath(): SafeDOMXPath

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -105,7 +105,7 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
 
         // A format where the class name is inside `file` attribute of `testcase` tag
         yield '//testcase[contains(@file, "%s")][1]' => preg_replace('/^(.*):+.*$/', '$1.feature', $fullyQualifiedClassName);
-        
+
         // A format where the class name parsed from feature and is inside `class` attribute of `testcase` tag
         yield '//testcase[@class="%s"][1]' => preg_replace('/^(.*):+.*$/', '$1', $fullyQualifiedClassName);
     }

--- a/src/TestFramework/Coverage/ProxyTrace.php
+++ b/src/TestFramework/Coverage/ProxyTrace.php
@@ -108,6 +108,10 @@ class ProxyTrace implements Trace
 
     public function getAllTestsForMutation(NodeLineRangeData $lineRange, bool $isOnFunctionSignature): iterable
     {
+        if ($this->lazyTestLocations === null) {
+            return [];
+        }
+
         return $this->getTestLocator()->getAllTestsForMutation($lineRange, $isOnFunctionSignature);
     }
 

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -37,6 +37,7 @@ namespace Infection\TestFramework\PhpUnit\Adapter;
 
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
+use Infection\Config\ValueProvider\PCOVDirectoryProvider;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestCaseSorter;
 use Infection\TestFramework\PhpUnit\CommandLine\ArgumentsAndOptionsBuilder;
@@ -84,6 +85,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
             $testFrameworkExecutable,
             $tmpDir,
             $jUnitFilePath,
+            new PCOVDirectoryProvider(),
             new InitialConfigBuilder(
                 $tmpDir,
                 $testFrameworkConfigContent,

--- a/tests/e2e/PCOV_Directory/README.md
+++ b/tests/e2e/PCOV_Directory/README.md
@@ -1,0 +1,8 @@
+# Provide pcov.directory if none set
+
+Here we fool `pcov.directory` autodetection by adding empty directories PCOV will be happy to use by default. A quote:
+
+> When `pcov.directory` is left unset, PCOV will attempt to find `src`, `lib` or, `app` in the current working directory, in that order.
+
+https://github.com/infection/infection/issues/1497
+

--- a/tests/e2e/PCOV_Directory/composer.json
+++ b/tests/e2e/PCOV_Directory/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.3.11"
+    },
+    "autoload": {
+        "psr-4": {
+            "PCOV_Directory\\": "example/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PCOV_Directory\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/e2e/PCOV_Directory/example/SourceClass.php
+++ b/tests/e2e/PCOV_Directory/example/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PCOV_Directory;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/e2e/PCOV_Directory/expected-output.txt
+++ b/tests/e2e/PCOV_Directory/expected-output.txt
@@ -1,0 +1,8 @@
+Total: 1
+
+Killed: 1
+Errored: 0
+Escaped: 0
+Timed Out: 0
+Skipped: 0
+Not Covered: 0

--- a/tests/e2e/PCOV_Directory/infection.json
+++ b/tests/e2e/PCOV_Directory/infection.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "example"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/PCOV_Directory/phpunit.xml.dist
+++ b/tests/e2e/PCOV_Directory/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/schema/9.2.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./example/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/e2e/PCOV_Directory/src/Unused.php
+++ b/tests/e2e/PCOV_Directory/src/Unused.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PCOV_Directory;
+
+class Unused
+{
+
+}

--- a/tests/e2e/PCOV_Directory/tests/SourceClassTest.php
+++ b/tests/e2e/PCOV_Directory/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PCOV_Directory\Test;
+
+use PCOV_Directory\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -78,6 +78,7 @@ final class MakefileTest extends TestCase
 
 [33mcompile:[0m	 	 Bundles Infection into a PHAR
 [33mcs:[0m	  	 	 Runs PHP-CS-Fixer
+[33mcs-check:[0m		 Runs PHP-CS-Fixer in dry-run mode
 [33mprofile:[0m 	 	 Runs Blackfire
 [33mautoreview:[0m 	 	 Runs various checks (static analysis & AutoReview test suite)
 [33mtest:[0m		 	 Runs all the tests
@@ -87,7 +88,7 @@ final class MakefileTest extends TestCase
 [33mtest-e2e:[0m 	 	 Runs the end-to-end tests
 [33mtest-e2e-phpunit:[0m	 Runs PHPUnit-enabled subset of end-to-end tests
 [33mtest-e2e-docker:[0m 	 Runs the end-to-end tests on the different Docker platforms
-[33mtest-infection:[0m	 Runs Infection against itself
+[33mtest-infection:[0m		 Runs Infection against itself
 [33mtest-infection-docker:[0m	 Runs Infection against itself on the different Docker platforms
 
 EOF;

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -77,6 +77,7 @@ final class MakefileTest extends TestCase
 #---------------------------------------------------------------------------[0m
 
 [33mcompile:[0m	 	 Bundles Infection into a PHAR
+[33mcompile-docker:[0m	 	 Bundles Infection into a PHAR using docker
 [33mcs:[0m	  	 	 Runs PHP-CS-Fixer
 [33mcs-check:[0m		 Runs PHP-CS-Fixer in dry-run mode
 [33mprofile:[0m 	 	 Runs Blackfire

--- a/tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Config\ValueProvider;
+
+use function extension_loaded;
+use Infection\Config\ValueProvider\PCOVDirectoryProvider;
+use PHPUnit\Framework\TestCase;
+use Safe\Exceptions\InfoException;
+use function Safe\ini_get;
+
+final class PCOVDirectoryProviderTest extends TestCase
+{
+    public function test_it_shall_provide_directory_for_default_value(): void
+    {
+        $provider = new PCOVDirectoryProvider('');
+        $this->assertTrue($provider->shallProvide());
+        $this->assertSame('.', $provider->getDirectory());
+    }
+
+    public function test_it_shall_not_provide_directory_for_non_default_value(): void
+    {
+        $provider = new PCOVDirectoryProvider('example');
+        $this->assertFalse($provider->shallProvide());
+    }
+
+    public function test_it_loads_current_value_from_environment(): void
+    {
+        $provider = new PCOVDirectoryProvider();
+
+        try {
+            $this->assertSame(ini_get('pcov.directory') === '', $provider->shallProvide());
+        } catch (InfoException $e) {
+            if (extension_loaded('pcov')) {
+                throw $e;
+            }
+
+            $this->markTestSkipped('Skipped without PCOV');
+        }
+    }
+}

--- a/tests/phpunit/Fixtures/Files/phpunit/junit_codeception_cest.xml
+++ b/tests/phpunit/Fixtures/Files/phpunit/junit_codeception_cest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="acceptance" tests="3" assertions="10" errors="0" failures="0" skipped="0" time="0.000003">
+    <testcase file="/app/controllers/ExampleCest.php" name="FeatureA" class="app\controllers\ExampleCest" feature="featureA" assertions="2" time="0.000001"/>
+    <testcase file="/app/controllers/ExampleCest.php" name="FeatureB" class="app\controllers\ExampleCest" feature="featureB" assertions="1" time="0.000001"/>
+    <testcase file="/app/controllers/ExampleCest.php" name="FeatureC" class="app\controllers\ExampleCest" feature="featureC" assertions="7" time="0.000001"/>
+  </testsuite>
+</testsuites>

--- a/tests/phpunit/Logger/Http/StrykerDashboardClientTest.php
+++ b/tests/phpunit/Logger/Http/StrykerDashboardClientTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Logger\Http;
 
+use Generator;
 use Infection\Logger\Http\Response;
 use Infection\Logger\Http\StrykerCurlClient;
 use Infection\Logger\Http\StrykerDashboardClient;
@@ -76,7 +77,10 @@ final class StrykerDashboardClientTest extends TestCase
         );
     }
 
-    public function test_it_can_send_a_report(): void
+    /**
+     * @dataProvider provideResponseStatusCodes
+     */
+    public function test_it_can_send_a_report_with_expected_response_status_code(): void
     {
         $this->clientMock
             ->expects($this->once())
@@ -116,6 +120,13 @@ EOF
             ],
             $this->logger->getLogs()
         );
+    }
+
+    public function provideResponseStatusCodes(): Generator
+    {
+        yield '200 OK' => [Response::HTTP_OK];
+
+        yield '201 CREATED' => [Response::HTTP_CREATED];
     }
 
     public function test_it_issues_a_warning_when_the_report_could_not_be_sent(): void

--- a/tests/phpunit/Mutator/MutatorResolverTest.php
+++ b/tests/phpunit/Mutator/MutatorResolverTest.php
@@ -43,6 +43,7 @@ use Infection\Mutator\Arithmetic\Plus;
 use Infection\Mutator\Boolean\IdenticalEqual;
 use Infection\Mutator\Boolean\NotIdenticalNotEqual;
 use Infection\Mutator\Boolean\TrueValue;
+use Infection\Mutator\Extensions\MBString;
 use Infection\Mutator\Loop\For_;
 use Infection\Mutator\MutatorResolver;
 use Infection\Mutator\Number\DecrementInteger;
@@ -334,6 +335,9 @@ final class MutatorResolverTest extends TestCase
             'global-ignoreSourceCodeByRegex' => ['A::B', 'A::B', 'C::D'],
             MutatorName::getName(Plus::class) => true,
             MutatorName::getName(For_::class) => false,
+            MutatorName::getName(MBString::class) => [
+                'settings' => ['mb_substr' => false],
+            ],
             MutatorName::getName(IdenticalEqual::class) => [
                 'ignoreSourceCodeByRegex' => [],
             ],
@@ -342,6 +346,7 @@ final class MutatorResolverTest extends TestCase
         $this->assertSameMutatorsByClass(
             [
                 Plus::class,
+                MBString::class,
                 IdenticalEqual::class,
             ],
             $resolvedMutators
@@ -357,18 +362,29 @@ final class MutatorResolverTest extends TestCase
         $this->assertSame(
             [
                 'ignoreSourceCodeByRegex' => ['A::B', 'C::D'],
+                'settings' => ['mb_substr' => false],
+            ],
+            $resolvedMutators[MBString::class]
+        );
+
+        $this->assertSame(
+            [
+                'ignoreSourceCodeByRegex' => ['A::B', 'C::D'],
             ],
             $resolvedMutators[IdenticalEqual::class]
         );
     }
 
-    public function test_it_can_resolve_mutators_with_duplicate_global_and_and_per_mutator_settings(): void
+    public function test_it_can_resolve_mutators_with_duplicate_global_and_per_mutator_settings(): void
     {
         $resolvedMutators = $this->mutatorResolver->resolve([
             'global-ignore' => ['A::B'],
             'global-ignoreSourceCodeByRegex' => ['A::B', 'A::B', 'C::D'],
             MutatorName::getName(Plus::class) => true,
             MutatorName::getName(For_::class) => false,
+            MutatorName::getName(MBString::class) => [
+                'settings' => ['mb_substr' => false],
+            ],
             MutatorName::getName(IdenticalEqual::class) => [
                 'ignore' => ['B::C'],
                 'ignoreSourceCodeByRegex' => ['A::B', 'B::C'],
@@ -378,6 +394,7 @@ final class MutatorResolverTest extends TestCase
         $this->assertSameMutatorsByClass(
             [
                 Plus::class,
+                MBString::class,
                 IdenticalEqual::class,
             ],
             $resolvedMutators
@@ -389,6 +406,14 @@ final class MutatorResolverTest extends TestCase
                 'ignoreSourceCodeByRegex' => ['A::B', 'C::D'],
             ],
             $resolvedMutators[Plus::class]
+        );
+        $this->assertSame(
+            [
+                'ignore' => ['A::B'],
+                'ignoreSourceCodeByRegex' => ['A::B', 'C::D'],
+                'settings' => ['mb_substr' => false],
+            ],
+            $resolvedMutators[MBString::class]
         );
         $this->assertSame(
             [

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -506,5 +506,15 @@ PHP
 preg_split('//', 'string', -2);
 PHP
         ];
+
+        yield 'It does not decrement min int' => [
+            <<<'PHP'
+<?php
+
+if ($a === -9223372036854775808) {
+    echo 'bar';
+}
+PHP
+        ];
     }
 }

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator\Number;
 
 use Infection\Tests\Mutator\BaseMutatorTestCase;
+use const PHP_INT_MIN;
 
 final class DecrementIntegerTest extends BaseMutatorTestCase
 {
@@ -507,11 +508,13 @@ preg_split('//', 'string', -2);
 PHP
         ];
 
+        $minInt = PHP_INT_MIN;
+
         yield 'It does not decrement min int' => [
-            <<<'PHP'
+            <<<"PHP"
 <?php
 
-if ($a === -9223372036854775808) {
+if (1 === {$minInt}) {
     echo 'bar';
 }
 PHP

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -241,5 +241,19 @@ PHP
 preg_split('//', 'string', -1);
 PHP
         ];
+
+        yield 'It does not increment max int' => [
+            <<<'PHP'
+<?php
+
+random_int(10000000, 9223372036854775807);
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+random_int(10000001, 9223372036854775807);
+PHP
+        ];
     }
 }

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator\Number;
 
 use Infection\Tests\Mutator\BaseMutatorTestCase;
+use const PHP_INT_MAX;
 
 final class IncrementIntegerTest extends BaseMutatorTestCase
 {
@@ -242,17 +243,19 @@ preg_split('//', 'string', -1);
 PHP
         ];
 
+        $maxInt = PHP_INT_MAX;
+
         yield 'It does not increment max int' => [
-            <<<'PHP'
+            <<<"PHP"
 <?php
 
-random_int(10000000, 9223372036854775807);
+random_int(10000000, {$maxInt});
 PHP
             ,
-            <<<'PHP'
+            <<<"PHP"
 <?php
 
-random_int(10000001, 9223372036854775807);
+random_int(10000001, {$maxInt});
 PHP
         ];
     }

--- a/tests/phpunit/PhpParser/Visitor/IgnoreNode/ChangingIgnorerTest.php
+++ b/tests/phpunit/PhpParser/Visitor/IgnoreNode/ChangingIgnorerTest.php
@@ -42,7 +42,7 @@ final class ChangingIgnorerTest extends BaseNodeIgnorerTestCase
 {
     private const CODE_WITH_ONE_IGNORED_NODE = <<<'PHP'
 <?php
-        
+
 class Foo
 {
     public function bar()
@@ -55,7 +55,7 @@ PHP;
 
     private const CODE_WITH_ONE_COUNTED_NODE = <<<'PHP'
 <?php
-        
+
 class Foo
 {
     public function bar()

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProviderTest.php
@@ -52,6 +52,7 @@ final class JUnitTestFileDataProviderTest extends TestCase
     private const JUNIT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit.xml';
     private const JUNIT_DIFF_FORMAT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit2.xml';
     private const JUNIT_FEATURE_FORMAT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit_feature.xml';
+    private const JUNIT_CODECEPTION_CEST_FORMAT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit_codeception_cest.xml';
 
     /**
      * @var JUnitReportLocator|MockObject
@@ -143,6 +144,18 @@ final class JUnitTestFileDataProviderTest extends TestCase
         $testFileInfo = $this->provider->getTestFileInfo('FeatureA:Scenario A1');
 
         $this->assertSame('/codeception/tests/bdd/FeatureA.feature', $testFileInfo->path);
+    }
+
+    public function test_it_works_with_codeception_cest_format(): void
+    {
+        $this->jUnitLocatorMock
+            ->method('locate')
+            ->willReturn(self::JUNIT_CODECEPTION_CEST_FORMAT)
+        ;
+
+        $testFileInfo = $this->provider->getTestFileInfo('app\controllers\ExampleCest:FeatureA');
+
+        $this->assertSame('/app/controllers/ExampleCest.php', $testFileInfo->path);
     }
 
     /**

--- a/tests/phpunit/TestFramework/Coverage/ProxyTraceTest.php
+++ b/tests/phpunit/TestFramework/Coverage/ProxyTraceTest.php
@@ -109,6 +109,15 @@ final class ProxyTraceTest extends TestCase
         $this->assertNull($trace->getTests());
     }
 
+    public function test_it_returns_empty_iterable_for_no_tests(): void
+    {
+        $fileInfoMock = $this->createMock(SplFileInfo::class);
+
+        $trace = new ProxyTrace($fileInfoMock, null);
+
+        $this->assertCount(0, $trace->getAllTestsForMutation(new NodeLineRangeData(1, 2), false));
+    }
+
     public function test_it_exposes_its_test_locations(): void
     {
         $fileInfoMock = $this->createMock(SplFileInfo::class);

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -36,6 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpUnit\Adapter;
 
 use function array_map;
+use const DIRECTORY_SEPARATOR;
+use Infection\Config\ValueProvider\PCOVDirectoryProvider;
 use Infection\PhpParser\Visitor\IgnoreNode\PhpUnitCodeCoverageAnnotationIgnorer;
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 use Infection\TestFramework\CommandLineBuilder;
@@ -52,6 +54,7 @@ final class PhpUnitAdapterTest extends TestCase
      */
     private $adapter;
 
+    private $pcovDirectoryProvider;
     private $initialConfigBuilder;
     private $mutationConfigBuilder;
     private $cliArgumentsBuilder;
@@ -59,6 +62,7 @@ final class PhpUnitAdapterTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->pcovDirectoryProvider = $this->createMock(PCOVDirectoryProvider::class);
         $this->initialConfigBuilder = $this->createMock(InitialConfigBuilder::class);
         $this->mutationConfigBuilder = $this->createMock(MutationConfigBuilder::class);
         $this->cliArgumentsBuilder = $this->createMock(CommandLineArgumentsAndOptionsBuilder::class);
@@ -68,6 +72,7 @@ final class PhpUnitAdapterTest extends TestCase
             '/path/to/phpunit',
             '/tmp',
             '/tmp/infection/junit.xml',
+            $this->pcovDirectoryProvider,
             $this->initialConfigBuilder,
             $this->mutationConfigBuilder,
             $this->cliArgumentsBuilder,
@@ -147,6 +152,11 @@ final class PhpUnitAdapterTest extends TestCase
             ->willReturn(['/path/to/phpunit', '--dummy-argument'])
         ;
 
+        $this->pcovDirectoryProvider
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
         $initialTestRunCommandLine = $this->adapter->getInitialTestRunCommandLine('--group=default', ['-d', 'memory_limit=-1'], true);
 
         $this->assertSame(
@@ -184,6 +194,75 @@ final class PhpUnitAdapterTest extends TestCase
                 '--coverage-xml=/tmp/coverage-xml',
                 '--log-junit=/tmp/infection/junit.xml',
             ])
+        ;
+
+        $this->pcovDirectoryProvider
+            ->expects($this->once())
+            ->method('shallProvide')
+            ->willReturn(false)
+        ;
+
+        $this->pcovDirectoryProvider
+            ->expects($this->never())
+            ->method('getDirectory')
+        ;
+
+        $initialTestRunCommandLine = $this->adapter->getInitialTestRunCommandLine('--group=default', ['-d', 'memory_limit=-1'], false);
+
+        $this->assertSame(
+            [
+                '/path/to/phpunit',
+                '--group=default',
+                '--coverage-xml=/tmp/coverage-xml',
+                '--log-junit=/tmp/infection/junit.xml',
+            ],
+            $initialTestRunCommandLine
+        );
+    }
+
+    /**
+     * @group integration
+     */
+    public function test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested_and_pcov_is_in_use(): void
+    {
+        $this->cliArgumentsBuilder
+            ->expects($this->once())
+            ->method('build')
+            ->with('', '--group=default --coverage-xml=/tmp/coverage-xml --log-junit=/tmp/infection/junit.xml')
+            ->willReturn([
+                '--group=default', '--coverage-xml=/tmp/coverage-xml', '--log-junit=/tmp/infection/junit.xml',
+            ])
+        ;
+
+        $this->commandLineBuilder
+            ->expects($this->once())
+            ->method('build')
+            ->with('/path/to/phpunit', [
+                '-d',
+                'memory_limit=-1',
+                '-d',
+                '\\' === DIRECTORY_SEPARATOR ? 'pcov.directory="."' : "pcov.directory='.'",
+            ], [
+                '--group=default', '--coverage-xml=/tmp/coverage-xml', '--log-junit=/tmp/infection/junit.xml',
+            ])
+            ->willReturn([
+                '/path/to/phpunit',
+                '--group=default',
+                '--coverage-xml=/tmp/coverage-xml',
+                '--log-junit=/tmp/infection/junit.xml',
+            ])
+        ;
+
+        $this->pcovDirectoryProvider
+            ->expects($this->once())
+            ->method('shallProvide')
+            ->willReturn(true)
+        ;
+
+        $this->pcovDirectoryProvider
+            ->expects($this->once())
+            ->method('getDirectory')
+            ->willReturn('.')
         ;
 
         $initialTestRunCommandLine = $this->adapter->getInitialTestRunCommandLine('--group=default', ['-d', 'memory_limit=-1'], false);


### PR DESCRIPTION
For Codeception Cests there was TestFileNameNotFoundException because $fullyQualifiedClassName variable contains colon separated feature name but there is no .feature file in junit.xml report.

In  junit.xml  there is entries like so:

`<testcase file="/app/modules/site/controllers/ExampleErrorController_Cest.php" name="test400" class="app\modules\site\controllers\ExampleErrorController_Cest" feature="test400" assertions="3" time="0.010310"/>
`

And $fullyQualifiedClassName is like this `app\modules\site\controllers\ExampleErrorController_Cest:test400`

I think there is no need to open the issue for such a small bug and I've fixed it in my vendor directory and propose the change via pull request.