### PR TITLE
Fix file not found exception for Codeception Cests (from branch 0.21)

### DIFF
--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -105,6 +105,9 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
 
         // A format where the class name is inside `file` attribute of `testcase` tag
         yield '//testcase[contains(@file, "%s")][1]' => preg_replace('/^(.*):+.*$/', '$1.feature', $fullyQualifiedClassName);
+
+        // A format where the class name parsed from feature and is inside `class` attribute of `testcase` tag
+        yield '//testcase[@class="%s"][1]' => preg_replace('/^(.*):+.*$/', '$1', $fullyQualifiedClassName);
     }
 
     private function getXPath(): SafeDOMXPath

--- a/tests/phpunit/Fixtures/Files/phpunit/junit_codeception_cest.xml
+++ b/tests/phpunit/Fixtures/Files/phpunit/junit_codeception_cest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="acceptance" tests="3" assertions="10" errors="0" failures="0" skipped="0" time="0.000003">
+    <testcase file="/app/controllers/ExampleCest.php" name="FeatureA" class="app\controllers\ExampleCest" feature="featureA" assertions="2" time="0.000001"/>
+    <testcase file="/app/controllers/ExampleCest.php" name="FeatureB" class="app\controllers\ExampleCest" feature="featureB" assertions="1" time="0.000001"/>
+    <testcase file="/app/controllers/ExampleCest.php" name="FeatureC" class="app\controllers\ExampleCest" feature="featureC" assertions="7" time="0.000001"/>
+  </testsuite>
+</testsuites>

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProviderTest.php
@@ -52,6 +52,7 @@ final class JUnitTestFileDataProviderTest extends TestCase
     private const JUNIT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit.xml';
     private const JUNIT_DIFF_FORMAT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit2.xml';
     private const JUNIT_FEATURE_FORMAT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit_feature.xml';
+    private const JUNIT_CODECEPTION_CEST_FORMAT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit_codeception_cest.xml';
 
     /**
      * @var JUnitReportLocator|MockObject
@@ -143,6 +144,18 @@ final class JUnitTestFileDataProviderTest extends TestCase
         $testFileInfo = $this->provider->getTestFileInfo('FeatureA:Scenario A1');
 
         $this->assertSame('/codeception/tests/bdd/FeatureA.feature', $testFileInfo->path);
+    }
+
+    public function test_it_works_with_codeception_cest_format(): void
+    {
+        $this->jUnitLocatorMock
+            ->method('locate')
+            ->willReturn(self::JUNIT_CODECEPTION_CEST_FORMAT)
+        ;
+
+        $testFileInfo = $this->provider->getTestFileInfo('app\controllers\ExampleCest:FeatureA');
+
+        $this->assertSame('/app/controllers/ExampleCest.php', $testFileInfo->path);
     }
 
     /**


### PR DESCRIPTION
For Codeception Cests there was TestFileNameNotFoundException because $fullyQualifiedClassName variable contains colon separated feature name but there is no .feature file in junit.xml report.

In  junit.xml  there is entries like so:

`<testcase file="/app/modules/site/controllers/ExampleErrorController_Cest.php" name="test400" class="app\modules\site\controllers\ExampleErrorController_Cest" feature="test400" assertions="3" time="0.010310"/>
`

And $fullyQualifiedClassName is like this `app\modules\site\controllers\ExampleErrorController_Cest:test400`

I think there is no need to open the issue for such a small bug and I've fixed it in my vendor directory and propose the change via pull request.