### PR TITLE
Add `INFECTION` and `TEST_TOKEN` environment variables for each Mutant process

### DIFF
--- a/src/Process/Runner/IndexedProcessBearer.php
+++ b/src/Process/Runner/IndexedProcessBearer.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Process\Runner;
+
+/**
+ * @internal
+ */
+final class IndexedProcessBearer
+{
+    public int $threadIndex;
+
+    public ProcessBearer $processBearer;
+
+    public function __construct(int $threadIndex, ProcessBearer $processBearer)
+    {
+        $this->threadIndex = $threadIndex;
+        $this->processBearer = $processBearer;
+    }
+}

--- a/src/Process/Runner/ParallelProcessRunner.php
+++ b/src/Process/Runner/ParallelProcessRunner.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Process\Runner;
 
-use Webmozart\Assert\Assert;
 use function array_shift;
 use function count;
 use Generator;
@@ -44,6 +43,7 @@ use function microtime;
 use function range;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use function usleep;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -66,6 +66,7 @@ use Infection\Mutant\DetectionStatus;
 use Infection\Mutation\MutationAttributeKeys;
 use Infection\Mutator\NodeMutationGenerator;
 use Infection\Process\OriginalPhpProcess;
+use Infection\Process\Runner\IndexedProcessBearer;
 use Infection\TestFramework\AdapterInstaller;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
 use Infection\TestFramework\Coverage\NodeLineRangeData;
@@ -227,10 +228,12 @@ final class ProjectCodeProvider
                     && !in_array(
                         $className,
                         [
+                            // having public properties on DTO is for performance reasons
                             TestLocations::class,
                             SourceMethodLineRange::class,
                             NodeLineRangeData::class,
                             TestFileTimeData::class,
+                            IndexedProcessBearer::class,
                         ],
                         true
                     )

--- a/tests/phpunit/Process/Runner/IndexedProcessBearerTest.php
+++ b/tests/phpunit/Process/Runner/IndexedProcessBearerTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Process\Runner;
+
+use Infection\Process\Runner\IndexedProcessBearer;
+use Infection\Process\Runner\ProcessBearer;
+use PHPUnit\Framework\TestCase;
+
+final class IndexedProcessBearerTest extends TestCase
+{
+    public function test_it_creates_object(): void
+    {
+        $processBearer = $this->createMock(ProcessBearer::class);
+
+        $indexedProcessBearer = new IndexedProcessBearer(
+            3,
+            $processBearer
+        );
+
+        $this->assertSame(3, $indexedProcessBearer->threadIndex);
+        $this->assertSame($processBearer, $indexedProcessBearer->processBearer);
+    }
+}

--- a/tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php
+++ b/tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php
@@ -113,6 +113,8 @@ final class ParallelProcessRunnerTest extends TestCase
         yield 'invalid thread' => [-1];
 
         yield 'nominal' => [4];
+
+        yield 'thread count more than processes' => [20];
     }
 
     private function runWithAllKindsOfProcesses(int $threadCount): void


### PR DESCRIPTION
Add `INFECTION` and `TEST_TOKEN` environment variables for each Mutant process to make it possible to run functional tests for different databases.

### Background:

We have a lot of functional tests that do real SQL queries to MySQL and decided to run tests in parallel. To achieve it, we integrated [Paratest](https://github.com/paratestphp/paratest) library.

Parallel processes can not write to the same database, because tests start to conflict with each other. To fix this issue, [Paratest provides](https://github.com/paratestphp/paratest#test-token) `TEST_TOKEN=<int>` environment variable for each process that can be used to set up different connections to the databases.

So if you have 3 parallel processes, these processes will use `db_1`, `db_2`, `db_3` correspondingly.

### Infection's issue with functional tests

The same goes for Infection. As soon as we start using more than 1 thread, our `ParallelProcessRunner` runs processes in parallel, and without `TEST_TOKEN` being passed, all those processes use the same database, which fails the test, making the majority of the Mutants killed.

This PR adds `TEST_TOKEN=<int>` env variable for each "mutant process".

Note: we can't use round-robin for thread indexes, because different processes take different amount of time. Consider the following example:

Imagine -we run Infection with 3 threads: `infection -j3`, and we have 4 mutations, so we need to run 4 processes when 3 of them can be in parallel

```
Process 1, TEST_TOKEN = 1
|--------------------------------------------------|
    Process 2, TEST_TOKEN = 2
    |------------|
         Process 3, TEST_TOKEN = 3
         |--|
             Process 4, TEST_TOKEN = 1
             |-----------------------------------------------------|
``` 

In this example, as soon as Process 3 finishes its work, we can run Process 4. It will mean that at the same time we will have exactly 3 parallel processes

* Process 1
* Process 2
* Process 4

But, since Process 1 takes too much time, round-robin algorithm gives `TEST_TOKEN` values of 1 for Process 4. And we have a situation where both processes Process 1 and Process 4 work with the same database at the same time.

To avoid such an issue, in this PR `TEST_TOKEN` gets the first available (free) index that is not used at this point of time by any other processes. For example above, as soon as Process 3 finishes its job, Process 4 will get `TEST_TOKEN=3`, because values 1 and 2 are still busy. 

```diff
Process 1, TEST_TOKEN = 1
|--------------------------------------------------|
    Process 2, TEST_TOKEN = 2
    |------------|
         Process 3, TEST_TOKEN = 3
         |--|
-           Process 4, TEST_TOKEN = 1
+           Process 4, TEST_TOKEN = 3
             |-----------------------------------------------------|
``` 

### `INFECTION` env variable

In our application, we have a custom `bootstrup` for PHPUnit, where we remove `var/cache` folder

```php
# tests/bootstrap.php

$filesystem = new Filesystem();

$filesystem->remove([__DIR__ . '/../var/cache/test']);
```

Since Infection runs PHPUnit in separate processes, this bootstrap file gets called for **each Mutant**, again breaking the whole process, because while Process 1 can work, Process 3 removes its cache.

So, we need to understand when PHPUnit process is executed from Infection, and skip such removing:

```php
$filesystem = new Filesystem();

if (!getenv('INFECTION')) {
    $filesystem->remove([__DIR__ . '/../var/cache/test']);
}
```


This PR:

- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/214

