### PR TITLE
Upgrade xdebug-handler to v2 and handle that `coverage` option is set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",
-        "composer/xdebug-handler": "^1.3.3",
+        "composer/xdebug-handler": "^2.0",
         "infection/abstract-testframework-adapter": "^0.3.1",
         "infection/extension-installer": "^0.1.0",
         "infection/include-interceptor": "^0.2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2cf9f7ad9129eedccb617b0efc35bd51",
+    "content-hash": "e8ce59a79035c70a8366658b643e172a",
     "packages": [
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.5",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
+                "reference": "31d57697eb1971712a08031cfaff5a846d10bdf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/31d57697eb1971712a08031cfaff5a846d10bdf5",
+                "reference": "31d57697eb1971712a08031cfaff5a846d10bdf5",
                 "shasum": ""
             },
             "require": {
@@ -25,7 +25,8 @@
                 "psr/log": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
             "autoload": {
@@ -51,7 +52,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.0"
             },
             "funding": [
                 {
@@ -67,7 +68,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T08:04:11+00:00"
+            "time": "2021-04-09T19:40:06+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/src/Console/XdebugHandler.php
+++ b/src/Console/XdebugHandler.php
@@ -52,7 +52,7 @@ final class XdebugHandler
     {
         // We force the color option unconditionally since it is able to detect the --no-ansi option
         // to disable it if necessary
-        (new ComposerXdebugHandler(self::PREFIX, '--ansi'))
+        (new ComposerXdebugHandler(self::PREFIX))
             ->setLogger($logger)
             ->setPersistent()
             ->check()

--- a/src/Console/XdebugHandler.php
+++ b/src/Console/XdebugHandler.php
@@ -50,8 +50,6 @@ final class XdebugHandler
 
     public static function check(LoggerInterface $logger): void
     {
-        // We force the color option unconditionally since it is able to detect the --no-ansi option
-        // to disable it if necessary
         (new ComposerXdebugHandler(self::PREFIX))
             ->setLogger($logger)
             ->setPersistent()

--- a/src/TestFramework/Coverage/CoverageChecker.php
+++ b/src/TestFramework/Coverage/CoverageChecker.php
@@ -101,9 +101,9 @@ class CoverageChecker
         if (!$this->skipCoverage && !$this->hasCoverageGeneratorEnabled()) {
             throw new CoverageNotFound(<<<TXT
 Coverage needs to be generated but no code coverage generator (pcov, phpdbg or xdebug) has been detected. Please either:
-- Enable pcov and run infection again
+- Enable pcov and run Infection again
 - Use phpdbg, e.g. `phpdbg -qrr infection`
-- Enable Xdebug and run infection again
+- Enable Xdebug (in case of using Xdebug 3 check that `xdebug.mode` or environment variable XDEBUG_MODE set to `coverage`) and run Infection again
 - Use the "--coverage" option with path to the existing coverage report
 - Enable the code generator tool for the initial test run only, e.g. with `--initial-tests-php-options -d zend_extension=xdebug.so`
 TXT
@@ -172,7 +172,7 @@ TXT
     private function hasCoverageGeneratorEnabled(): bool
     {
         return PHP_SAPI === 'phpdbg'
-            || extension_loaded('xdebug')
+            || XdebugHandler::isXdebugActive()
             || extension_loaded('pcov')
             || XdebugHandler::getSkippedVersion()
             || $this->isXdebugIncludedInInitialTestPhpOptions()

--- a/tests/phpunit/TestFramework/Coverage/CoverageCheckerTest.php
+++ b/tests/phpunit/TestFramework/Coverage/CoverageCheckerTest.php
@@ -140,9 +140,9 @@ final class CoverageCheckerTest extends TestCase
         $this->expectException(CoverageNotFound::class);
         $this->expectExceptionMessage(<<<TXT
 Coverage needs to be generated but no code coverage generator (pcov, phpdbg or xdebug) has been detected. Please either:
-- Enable pcov and run infection again
+- Enable pcov and run Infection again
 - Use phpdbg, e.g. `phpdbg -qrr infection`
-- Enable Xdebug and run infection again
+- Enable Xdebug (in case of using Xdebug 3 check that `xdebug.mode` or environment variable XDEBUG_MODE set to `coverage`) and run Infection again
 - Use the "--coverage" option with path to the existing coverage report
 - Enable the code generator tool for the initial test run only, e.g. with `--initial-tests-php-options -d zend_extension=xdebug.so`
 TXT


### PR DESCRIPTION
Upgrade xdebug-handler to v2 and handle that `coverage` option is set in case of Xdebug 3

Feature Request: https://github.com/infection/infection/issues/1509
Issue: https://github.com/infection/infection/issues/1473