### PR TITLE
Improving Dockerfiles

### DIFF
--- a/devTools/Dockerfile-php74-xdebug
+++ b/devTools/Dockerfile-php74-xdebug
@@ -1,11 +1,13 @@
 FROM php:7.4-cli-alpine
 
+ARG XDEBUG_VERSION=3.0.4
+
 RUN set -eux; \
     apk add --no-cache --virtual .build-deps \
         ${PHPIZE_DEPS} \
         build-base \
     ; \
-    pecl install xdebug; \
+    pecl install xdebug-${XDEBUG_VERSION}; \
     pecl clear-cache; \
     docker-php-ext-enable xdebug ;\
     runDeps="$( \
@@ -25,7 +27,7 @@ RUN apk add --no-cache \
         git \
         zip
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 COPY devTools/memory-limit.ini devTools/xdebug-coverage.ini ${PHP_INI_DIR}/conf.d/
 
 RUN adduser -h /opt/infection -s /bin/bash -D infection

--- a/devTools/Dockerfile-php80-xdebug
+++ b/devTools/Dockerfile-php80-xdebug
@@ -1,14 +1,14 @@
 FROM php:8.0-cli-alpine
 
-ARG XDEBUG_VERSION=3.0.1
+ARG XDEBUG_VERSION=3.0.4
 
 RUN set -eux; \
     apk add --no-cache --virtual .build-deps \
         ${PHPIZE_DEPS} \
         build-base \
     ; \
-    mkdir -p /usr/src/php/ext/xdebug && curl -fsSL https://pecl.php.net/get/xdebug-${XDEBUG_VERSION} | tar -xvz -C "/usr/src/php/ext/xdebug" --strip 1; \
-    docker-php-ext-install -j$(nproc) xdebug; \
+    pecl install xdebug-${XDEBUG_VERSION}; \
+    pecl clear-cache; \
     docker-php-ext-enable xdebug ;\
     runDeps="$( \
         scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
@@ -16,7 +16,6 @@ RUN set -eux; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
-    rm -rf /usr/src/php; \
     apk add --no-cache --virtual .phpexts-rundeps ${runDeps}; \
     apk del .build-deps
 
@@ -27,7 +26,7 @@ RUN apk add --no-cache \
         expect \
         zip
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 COPY devTools/memory-limit.ini devTools/xdebug-coverage.ini ${PHP_INI_DIR}/conf.d/
 
 RUN adduser -h /opt/infection -s /bin/bash -D infection


### PR DESCRIPTION
- Use PECL in PHP 8.0 Dockerfile
- Define specific Xdebug version PHP 7.4 Dockerfile
- Use Composer `v2` instead of `latest` in both Dockerfiles