### PR TITLE
Remove `@requires PHP >= 7.4` Annotations

### DIFF
--- a/tests/phpunit/Mutator/Operator/SpreadAssignmentTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadAssignmentTest.php
@@ -40,7 +40,6 @@ use Infection\Tests\Mutator\BaseMutatorTestCase;
 final class SpreadAssignmentTest extends BaseMutatorTestCase
 {
     /**
-     * @requires PHP >= 7.4
      * @dataProvider mutationsProvider
      *
      * @param string|string[] $expected

--- a/tests/phpunit/Mutator/Operator/SpreadOneItemTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadOneItemTest.php
@@ -40,7 +40,6 @@ use Infection\Tests\Mutator\BaseMutatorTestCase;
 final class SpreadOneItemTest extends BaseMutatorTestCase
 {
     /**
-     * @requires PHP >= 7.4
      * @dataProvider mutationsProvider
      *
      * @param string|string[] $expected

--- a/tests/phpunit/Mutator/Operator/SpreadRemovalTest.php
+++ b/tests/phpunit/Mutator/Operator/SpreadRemovalTest.php
@@ -40,7 +40,6 @@ use Infection\Tests\Mutator\BaseMutatorTestCase;
 final class SpreadRemovalTest extends BaseMutatorTestCase
 {
     /**
-     * @requires PHP >= 7.4
      * @dataProvider mutationsProvider
      *
      * @param string|string[] $expected


### PR DESCRIPTION
This PR removes annotations which are no longer needed because the project already requires PHP 7.4 or 8: https://github.com/infection/infection/blob/master/composer.json#L45

Addresses: https://github.com/infection/infection/pull/1529#discussion_r664563102