### PR TITLE
Run Infection on PHP 8.1.

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.4']
+        php-version: ['8.0']
 
     name: Autoreview on PHP ${{ matrix.php-version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,15 +17,16 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['7.4']
+        php-version: ['8.0']
         dependencies: ['']
         coverage-driver: [pcov, xdebug]
         include:
           - { operating-system: 'windows-latest', php-version: '7.4', dependencies: '', coverage-driver: 'xdebug' }
           - { operating-system: 'ubuntu-latest', php-version: '7.4', dependencies: '--prefer-lowest', coverage-driver: 'pcov' }
           - { operating-system: 'ubuntu-latest', php-version: '8.0', dependencies: '--ignore-platform-req=php', coverage-driver: 'pcov' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.1', dependencies: '--ignore-platform-req=php', coverage-driver: 'pcov' }
 
-    continue-on-error: ${{ matrix.php-version == '8.0' }}
+    continue-on-error: ${{ matrix.php-version == '8.1' }}
     name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }} ${{ matrix.dependencies }}
 
     steps:
@@ -99,7 +100,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends expect
 
       - name: Run the whole set of E2E tests
-        continue-on-error: ${{ matrix.php-version == '8.0' }}
+        continue-on-error: ${{ matrix.php-version == '8.1' }}
         if: runner.os != 'Windows'
         env:
           TERM: xterm-256color

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.0
 
       - name: Restore PHP-CS-Fixer cache
         uses: actions/cache@v2

--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                php-version: ['7.4']
+                php-version: ['8.0']
 
         name: Mutation Testing Code Review Annotations ${{ matrix.php-version }}
 

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
-        php-version: ['7.4']
+        php-version: ['8.0']
         dependencies: ['']
         coverage-driver: [pcov]
 


### PR DESCRIPTION
This PR:
- [ ] Runs Infection on PHP 8.1.
- [ ] Makes PHP 8.0 main version which will be used for running Coding Standards, Mutation testing and so on
