### PR TITLE
[Performance] Improve Infection performance executed against slow test suites

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -116,6 +116,8 @@ final class RunCommand extends BaseCommand
 
     private const OPTION_USE_NOOP_MUTATORS = 'noop';
 
+    private const OPTION_EXECUTE_ONLY_COVERING_TEST_CASES = 'only-covering-test-cases';
+
     /** @var string */
     private const OPTION_MIN_MSI = 'min-msi';
 
@@ -256,6 +258,12 @@ final class RunCommand extends BaseCommand
                 null,
                 InputOption::VALUE_NONE,
                 'Use noop mutators that do not change AST. For debugging purposes.',
+            )
+            ->addOption(
+                self::OPTION_EXECUTE_ONLY_COVERING_TEST_CASES,
+                null,
+                InputOption::VALUE_NONE,
+                'Execute only those test cases that cover mutated line, not the whole file with covering test cases. Can dramatically speed up Mutation Testing for slow test suites. For PHPUnit / Pest it uses `--filter` option',
             )
             ->addOption(
                 self::OPTION_MIN_MSI,
@@ -444,7 +452,8 @@ final class RunCommand extends BaseCommand
             $gitDiffFilter,
             $gitDiffBase,
             (bool) $input->getOption(self::OPTION_LOGGER_GITHUB),
-            (bool) $input->getOption(self::OPTION_USE_NOOP_MUTATORS)
+            (bool) $input->getOption(self::OPTION_USE_NOOP_MUTATORS),
+            (bool) $input->getOption(self::OPTION_EXECUTE_ONLY_COVERING_TEST_CASES)
         );
     }
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -87,6 +87,7 @@ class Configuration
     private bool $dryRun;
     /** @var array<string, array<int, string>> */
     private array $ignoreSourceCodeMutatorsMap;
+    private bool $executeOnlyCoveringTestCases;
 
     /**
      * @param string[] $sourceDirectories
@@ -123,7 +124,8 @@ class Configuration
         int $msiPrecision,
         int $threadCount,
         bool $dryRun,
-        array $ignoreSourceCodeMutatorsMap
+        array $ignoreSourceCodeMutatorsMap,
+        bool $executeOnlyCoveringTestCases
     ) {
         Assert::nullOrGreaterThanEq($timeout, 0);
         Assert::allString($sourceDirectories);
@@ -161,6 +163,7 @@ class Configuration
         $this->threadCount = $threadCount;
         $this->dryRun = $dryRun;
         $this->ignoreSourceCodeMutatorsMap = $ignoreSourceCodeMutatorsMap;
+        $this->executeOnlyCoveringTestCases = $executeOnlyCoveringTestCases;
     }
 
     public function getProcessTimeout(): float
@@ -316,5 +319,10 @@ class Configuration
     public function getIgnoreSourceCodeMutatorsMap(): array
     {
         return $this->ignoreSourceCodeMutatorsMap;
+    }
+
+    public function getExecuteOnlyCoveringTestCases(): bool
+    {
+        return $this->executeOnlyCoveringTestCases;
     }
 }

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -118,7 +118,8 @@ class ConfigurationFactory
         ?string $gitDiffFilter,
         ?string $gitDiffBase,
         bool $useGitHubLogger,
-        bool $useNoopMutators
+        bool $useNoopMutators,
+        bool $executeOnlyCoveringTestCases
     ): Configuration {
         $configDir = dirname($schema->getFile());
 
@@ -170,7 +171,8 @@ class ConfigurationFactory
             $msiPrecision,
             $threadCount,
             $dryRun,
-            $ignoreSourceCodeMutatorsMap
+            $ignoreSourceCodeMutatorsMap,
+            $executeOnlyCoveringTestCases
         );
     }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -166,6 +166,7 @@ final class Container
     public const DEFAULT_GIT_DIFF_BASE = null;
     public const DEFAULT_USE_GITHUB_LOGGER = false;
     public const DEFAULT_USE_NOOP_MUTATORS = false;
+    public const DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES = false;
     public const DEFAULT_NO_PROGRESS = false;
     public const DEFAULT_FORCE_PROGRESS = false;
     public const DEFAULT_EXISTING_COVERAGE_PATH = null;
@@ -684,7 +685,8 @@ final class Container
             self::DEFAULT_GIT_DIFF_FILTER,
             self::DEFAULT_GIT_DIFF_BASE,
             self::DEFAULT_USE_GITHUB_LOGGER,
-            self::DEFAULT_USE_NOOP_MUTATORS
+            self::DEFAULT_USE_NOOP_MUTATORS,
+            self::DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES
         );
     }
 
@@ -715,7 +717,8 @@ final class Container
         ?string $gitDiffFilter,
         ?string $gitDiffBase,
         bool $useGitHubLogger,
-        bool $useNoopMutators
+        bool $useNoopMutators,
+        bool $executeOnlyCoveringTestCases
     ): self {
         $clone = clone $this;
 
@@ -790,7 +793,8 @@ final class Container
                 $gitDiffFilter,
                 $gitDiffBase,
                 $useGitHubLogger,
-                $useNoopMutators
+                $useNoopMutators,
+                $executeOnlyCoveringTestCases
             ): Configuration {
                 return $container->getConfigurationFactory()->create(
                     $container->getSchemaConfiguration(),
@@ -815,7 +819,8 @@ final class Container
                     $gitDiffFilter,
                     $gitDiffBase,
                     $useGitHubLogger,
-                    $useNoopMutators
+                    $useNoopMutators,
+                    $executeOnlyCoveringTestCases
                 );
             }
         );

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -91,7 +91,7 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         array $phpExtraArgs,
         bool $skipCoverage
     ): array {
-        return $this->getCommandLine($this->buildInitialConfigFile(), $extraOptions, $phpExtraArgs);
+        return $this->getCommandLine($this->buildInitialConfigFile(), $extraOptions, $phpExtraArgs, []);
     }
 
     /**
@@ -116,7 +116,8 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
                 $mutationOriginalFilePath
             ),
             $extraOptions,
-            []
+            [],
+            $tests,
         );
     }
 
@@ -154,15 +155,17 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
 
     /**
      * @param string[] $phpExtraArgs
+     * @param TestLocation[] $tests
      *
      * @return string[]
      */
     private function getCommandLine(
         string $configPath,
         string $extraOptions,
-        array $phpExtraArgs
+        array $phpExtraArgs,
+        array $tests
     ): array {
-        $frameworkArgs = $this->argumentsAndOptionsBuilder->build($configPath, $extraOptions);
+        $frameworkArgs = $this->argumentsAndOptionsBuilder->build($configPath, $extraOptions, $tests);
 
         return $this->commandLineBuilder->build(
             $this->testFrameworkExecutable,

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -91,7 +91,10 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         array $phpExtraArgs,
         bool $skipCoverage
     ): array {
-        return $this->getCommandLine($this->buildInitialConfigFile(), $extraOptions, $phpExtraArgs, []);
+        return $this->getCommandLine(
+            $phpExtraArgs,
+            $this->argumentsAndOptionsBuilder->buildForInitialTestsRun($this->buildInitialConfigFile(), $extraOptions)
+        );
     }
 
     /**
@@ -109,15 +112,17 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         string $extraOptions
     ): array {
         return $this->getCommandLine(
-            $this->buildMutationConfigFile(
-                $tests,
-                $mutantFilePath,
-                $mutationHash,
-                $mutationOriginalFilePath
-            ),
-            $extraOptions,
             [],
-            $tests,
+            $this->argumentsAndOptionsBuilder->buildForMutant(
+                $this->buildMutationConfigFile(
+                    $tests,
+                    $mutantFilePath,
+                    $mutationHash,
+                    $mutationOriginalFilePath
+                ),
+                $extraOptions,
+                $tests
+            )
         );
     }
 
@@ -155,22 +160,18 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
 
     /**
      * @param string[] $phpExtraArgs
-     * @param TestLocation[] $tests
+     * @param string[] $testFrameworkArgs
      *
      * @return string[]
      */
     private function getCommandLine(
-        string $configPath,
-        string $extraOptions,
         array $phpExtraArgs,
-        array $tests
+        array $testFrameworkArgs
     ): array {
-        $frameworkArgs = $this->argumentsAndOptionsBuilder->build($configPath, $extraOptions, $tests);
-
         return $this->commandLineBuilder->build(
             $this->testFrameworkExecutable,
             $phpExtraArgs,
-            $frameworkArgs
+            $testFrameworkArgs
         );
     }
 

--- a/src/TestFramework/CommandLineArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/CommandLineArgumentsAndOptionsBuilder.php
@@ -43,9 +43,14 @@ use Infection\AbstractTestFramework\Coverage\TestLocation;
 interface CommandLineArgumentsAndOptionsBuilder
 {
     /**
+     * @return string[]
+     */
+    public function buildForInitialTestsRun(string $configPath, string $extraOptions): array;
+
+    /**
      * @param TestLocation[] $tests
      *
      * @return string[]
      */
-    public function build(string $configPath, string $extraOptions, array $tests): array;
+    public function buildForMutant(string $configPath, string $extraOptions, array $tests): array;
 }

--- a/src/TestFramework/CommandLineArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/CommandLineArgumentsAndOptionsBuilder.php
@@ -35,13 +35,17 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework;
 
+use Infection\AbstractTestFramework\Coverage\TestLocation;
+
 /**
  * @internal
  */
 interface CommandLineArgumentsAndOptionsBuilder
 {
     /**
+     * @param TestLocation[] $tests
+     *
      * @return string[]
      */
-    public function build(string $configPath, string $extraOptions): array;
+    public function build(string $configPath, string $extraOptions, array $tests): array;
 }

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -102,7 +102,8 @@ final class Factory
                 $this->jUnitFilePath,
                 $this->projectDir,
                 $this->infectionConfig->getSourceDirectories(),
-                $skipCoverage
+                $skipCoverage,
+                $this->infectionConfig->getExecuteOnlyCoveringTestCases()
             );
         }
 
@@ -120,7 +121,8 @@ final class Factory
                 $this->jUnitFilePath,
                 $this->projectDir,
                 $this->infectionConfig->getSourceDirectories(),
-                $skipCoverage
+                $skipCoverage,
+                $this->infectionConfig->getExecuteOnlyCoveringTestCases()
             );
         }
 

--- a/src/TestFramework/PhpUnit/Adapter/PestAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PestAdapterFactory.php
@@ -64,7 +64,8 @@ final class PestAdapterFactory implements TestFrameworkAdapterFactory
         string $jUnitFilePath,
         string $projectDir,
         array $sourceDirectories,
-        bool $skipCoverage
+        bool $skipCoverage,
+        bool $executeOnlyCoveringTestCases = false
     ): TestFrameworkAdapter {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the Pest adapter');
 
@@ -97,7 +98,7 @@ final class PestAdapterFactory implements TestFrameworkAdapterFactory
                 $projectDir,
                 new JUnitTestCaseSorter()
             ),
-            new ArgumentsAndOptionsBuilder(),
+            new ArgumentsAndOptionsBuilder($executeOnlyCoveringTestCases),
             new VersionParser(),
             new CommandLineBuilder()
         );

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -67,7 +67,8 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
         string $jUnitFilePath,
         string $projectDir,
         array $sourceDirectories,
-        bool $skipCoverage
+        bool $skipCoverage,
+        bool $executeOnlyCoveringTestCases = false
     ): TestFrameworkAdapter {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the Pest adapter');
 
@@ -100,7 +101,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
                 $projectDir,
                 new JUnitTestCaseSorter()
             ),
-            new ArgumentsAndOptionsBuilder(),
+            new ArgumentsAndOptionsBuilder($executeOnlyCoveringTestCases),
             new VersionParser(),
             new CommandLineBuilder()
         );

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -39,11 +39,13 @@ use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function count;
+use function escapeshellarg;
 use function escapeshellcmd;
 use function explode;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 use function ltrim;
+use function preg_quote;
 use function rtrim;
 
 /**
@@ -97,7 +99,7 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
 
                 $usedTestCases[$testCaseString] = true;
 
-                $filterString .= escapeshellcmd($testCaseString) . '|';
+                $filterString .= preg_quote($testCaseString, '/') . '|';
             }
 
             $filterString = rtrim($filterString, '|') . '/';

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -45,6 +45,7 @@ use function implode;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 use function ltrim;
+use function Safe\sprintf;
 
 /**
  * @internal
@@ -74,8 +75,6 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
     {
         $options = $this->buildForInitialTestsRun($configPath, $extraOptions);
 
-//                preg_replace('/\swith data set (.*)/', '', $test->getMethod())
-
         if (count($tests) > 0) {
             $escapedTests = array_map(
                 static fn (TestLocation $testLocation): string => escapeshellcmd($testLocation->getMethod()),
@@ -83,7 +82,7 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
             );
 
             $options[] = '--filter';
-            $options[] = implode('|', array_unique($escapedTests));
+            $options[] = sprintf('/%s/', implode('|', array_unique($escapedTests)));
         }
 
         return $options;

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -39,8 +39,6 @@ use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function count;
-use function escapeshellarg;
-use function escapeshellcmd;
 use function explode;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -37,7 +37,12 @@ namespace Infection\TestFramework\PhpUnit\CommandLine;
 
 use function array_map;
 use function array_merge;
+use function array_unique;
+use function count;
+use function escapeshellcmd;
 use function explode;
+use function implode;
+use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 use function ltrim;
 
@@ -46,7 +51,8 @@ use function ltrim;
  */
 final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilder
 {
-    public function build(string $configPath, string $extraOptions): array
+    // todo build & buildForMutant
+    public function build(string $configPath, string $extraOptions, array $tests): array
     {
         $options = [
             '--configuration',
@@ -60,6 +66,18 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
                     return '--' . $option;
                 }, explode(' --', ltrim($extraOptions, '-')))
             );
+        }
+
+//                preg_replace('/\swith data set (.*)/', '', $test->getMethod())
+
+        if (count($tests) > 0) {
+            $escapedTests = array_map(
+                static fn (TestLocation $testLocation): string => escapeshellcmd($testLocation->getMethod()),
+                $tests
+            );
+
+            $options[] = '--filter';
+            $options[] = implode('|', array_unique($escapedTests));
         }
 
         return $options;

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -51,8 +51,7 @@ use function ltrim;
  */
 final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilder
 {
-    // todo build & buildForMutant
-    public function build(string $configPath, string $extraOptions, array $tests): array
+    public function buildForInitialTestsRun(string $configPath, string $extraOptions): array
     {
         $options = [
             '--configuration',
@@ -67,6 +66,13 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
                 }, explode(' --', ltrim($extraOptions, '-')))
             );
         }
+
+        return $options;
+    }
+
+    public function buildForMutant(string $configPath, string $extraOptions, array $tests): array
+    {
+        $options = $this->buildForInitialTestsRun($configPath, $extraOptions);
 
 //                preg_replace('/\swith data set (.*)/', '', $test->getMethod())
 

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -51,6 +51,13 @@ use function rtrim;
  */
 final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilder
 {
+    private bool $executeOnlyCoveringTestCases;
+
+    public function __construct(bool $executeOnlyCoveringTestCases)
+    {
+        $this->executeOnlyCoveringTestCases = $executeOnlyCoveringTestCases;
+    }
+
     public function buildForInitialTestsRun(string $configPath, string $extraOptions): array
     {
         $options = [
@@ -77,7 +84,7 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
     {
         $options = $this->buildForInitialTestsRun($configPath, $extraOptions);
 
-        if (count($tests) > 0) {
+        if ($this->executeOnlyCoveringTestCases && count($tests) > 0) {
             $filterString = '/';
             $usedTestCases = [];
 

--- a/tests/e2e/PestTestFramework/tests/ForPestWithDataProviderTest.php
+++ b/tests/e2e/PestTestFramework/tests/ForPestWithDataProviderTest.php
@@ -10,7 +10,7 @@ test('tests division with inline dataset', function (float $a, float $b, float $
     [2.0, 4.0, 0.5]
 ]);
 
-test('tests division with shared dataset', function (float $a, float $b, float $expectedResult) {
+test('tests division with shared dataset, with special | char', function (float $a, float $b, float $expectedResult) {
     $sourceClass = new ForPestWithDataProvider();
 
     expect($sourceClass->div($a, $b))->toBe($expectedResult);

--- a/tests/phpunit/Configuration/ConfigurationAssertions.php
+++ b/tests/phpunit/Configuration/ConfigurationAssertions.php
@@ -83,7 +83,8 @@ trait ConfigurationAssertions
         int $expectedMsiPrecision,
         int $expectedThreadCount,
         bool $expectedDryRyn,
-        array $expectedIgnoreSourceCodeMutatorsMap
+        array $expectedIgnoreSourceCodeMutatorsMap,
+        bool $expectedExecuteOnlyCoveringTestCases
     ): void {
         $this->assertSame($expectedTimeout, $configuration->getProcessTimeout());
         $this->assertSame($expectedSourceDirectories, $configuration->getSourceDirectories());
@@ -132,6 +133,7 @@ trait ConfigurationAssertions
         $this->assertSame($expectedThreadCount, $configuration->getThreadCount());
         $this->assertSame($expectedDryRyn, $configuration->isDryRun());
         $this->assertSame($expectedIgnoreSourceCodeMutatorsMap, $configuration->getIgnoreSourceCodeMutatorsMap());
+        $this->assertSame($expectedExecuteOnlyCoveringTestCases, $configuration->getExecuteOnlyCoveringTestCases());
     }
 
     /**

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -138,7 +138,8 @@ final class ConfigurationFactoryTest extends TestCase
         ?float $expectedMinMsi,
         bool $expectedShowMutations,
         ?float $expectedMinCoveredMsi,
-        array $expectedIgnoreSourceCodeMutatorsMap
+        array $expectedIgnoreSourceCodeMutatorsMap,
+        bool $inputExecuteOnlyCoveringTestCases
     ): void {
         $config = $this
             ->createConfigurationFactory($ciDetected)
@@ -165,7 +166,8 @@ final class ConfigurationFactoryTest extends TestCase
                 $inputGitDiffFilter,
                 $inputGitDiffBase,
                 $inputUseGitHubAnnotationsLogger,
-                $inputUseNoopMutators
+                $inputUseNoopMutators,
+                $inputExecuteOnlyCoveringTestCases
             )
         ;
 
@@ -198,7 +200,8 @@ final class ConfigurationFactoryTest extends TestCase
             $inputMsiPrecision,
             $inputThreadsCount,
             $inputDryRun,
-            $expectedIgnoreSourceCodeMutatorsMap
+            $expectedIgnoreSourceCodeMutatorsMap,
+            $inputExecuteOnlyCoveringTestCases
         );
     }
 
@@ -272,6 +275,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            true,
         ];
 
         yield 'null timeout' => self::createValueForTimeout(
@@ -717,6 +721,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
 
         yield 'complete' => [
@@ -813,6 +818,7 @@ final class ConfigurationFactoryTest extends TestCase
             true,
             81.5,
             [],
+            false,
         ];
     }
 
@@ -885,6 +891,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -957,6 +964,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -1030,6 +1038,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -1102,6 +1111,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -1175,6 +1185,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -1248,6 +1259,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -1321,6 +1333,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -1394,6 +1407,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             $expectedMinCoveredMsi,
             [],
+            false,
         ];
     }
 
@@ -1468,6 +1482,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -1541,6 +1556,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -1615,6 +1631,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -1688,6 +1705,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -1765,6 +1783,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             [],
+            false,
         ];
     }
 
@@ -1843,6 +1862,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null,
             $expectedIgnoreSourceCodeMutatorsMap,
+            false,
         ];
     }
 

--- a/tests/phpunit/Configuration/ConfigurationTest.php
+++ b/tests/phpunit/Configuration/ConfigurationTest.php
@@ -87,7 +87,8 @@ final class ConfigurationTest extends TestCase
         int $msiPrecision,
         int $threadsCount,
         bool $dryRun,
-        array $ignoreSourceCodeMutatorsMap
+        array $ignoreSourceCodeMutatorsMap,
+        bool $executeOnlyCoveringTestCases
     ): void {
         $config = new Configuration(
             $timeout,
@@ -117,7 +118,8 @@ final class ConfigurationTest extends TestCase
             $msiPrecision,
             $threadsCount,
             $dryRun,
-            $ignoreSourceCodeMutatorsMap
+            $ignoreSourceCodeMutatorsMap,
+            $executeOnlyCoveringTestCases
         );
 
         $this->assertConfigurationStateIs(
@@ -149,7 +151,8 @@ final class ConfigurationTest extends TestCase
             $msiPrecision,
             $threadsCount,
             $dryRun,
-            $ignoreSourceCodeMutatorsMap
+            $ignoreSourceCodeMutatorsMap,
+            $executeOnlyCoveringTestCases
         );
     }
 
@@ -184,6 +187,7 @@ final class ConfigurationTest extends TestCase
             0,
             false,
             [],
+            false,
         ];
 
         yield 'nominal' => [
@@ -230,6 +234,7 @@ final class ConfigurationTest extends TestCase
             [
                 'For_' => ['.*someMethod.*'],
             ],
+            true,
         ];
     }
 }

--- a/tests/phpunit/ContainerTest.php
+++ b/tests/phpunit/ContainerTest.php
@@ -95,7 +95,8 @@ final class ContainerTest extends TestCase
             Container::DEFAULT_GIT_DIFF_FILTER,
             Container::DEFAULT_GIT_DIFF_BASE,
             Container::DEFAULT_USE_GITHUB_LOGGER,
-            Container::DEFAULT_USE_NOOP_MUTATORS
+            Container::DEFAULT_USE_NOOP_MUTATORS,
+            Container::DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES
         );
 
         $traces = $newContainer->getUnionTraceProvider()->provideTraces();
@@ -144,7 +145,8 @@ final class ContainerTest extends TestCase
             Container::DEFAULT_GIT_DIFF_FILTER,
             Container::DEFAULT_GIT_DIFF_BASE,
             Container::DEFAULT_USE_GITHUB_LOGGER,
-            Container::DEFAULT_USE_NOOP_MUTATORS
+            Container::DEFAULT_USE_NOOP_MUTATORS,
+            Container::DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES,
         );
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PestAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PestAdapterTest.php
@@ -129,7 +129,7 @@ final class PestAdapterTest extends TestCase
     {
         $this->cliArgumentsBuilder
             ->expects($this->once())
-            ->method('build')
+            ->method('buildForInitialTestsRun')
             ->with('', '--group=default')
         ;
 
@@ -163,7 +163,7 @@ final class PestAdapterTest extends TestCase
     {
         $this->cliArgumentsBuilder
             ->expects($this->once())
-            ->method('build')
+            ->method('buildForInitialTestsRun')
             ->with('', '--group=default --coverage-xml=/tmp/coverage-xml --log-junit=/tmp/infection/junit.xml')
             ->willReturn([
                 '--group=default', '--coverage-xml=/tmp/coverage-xml', '--log-junit=/tmp/infection/junit.xml',
@@ -215,7 +215,7 @@ final class PestAdapterTest extends TestCase
     {
         $this->cliArgumentsBuilder
             ->expects($this->once())
-            ->method('build')
+            ->method('buildForInitialTestsRun')
             ->with('', '--group=default --coverage-xml=/tmp/coverage-xml --log-junit=/tmp/infection/junit.xml')
             ->willReturn([
                 '--group=default', '--coverage-xml=/tmp/coverage-xml', '--log-junit=/tmp/infection/junit.xml',

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -129,7 +129,7 @@ final class PhpUnitAdapterTest extends TestCase
     {
         $this->cliArgumentsBuilder
             ->expects($this->once())
-            ->method('build')
+            ->method('buildForInitialTestsRun')
             ->with('', '--group=default')
         ;
 
@@ -163,7 +163,7 @@ final class PhpUnitAdapterTest extends TestCase
     {
         $this->cliArgumentsBuilder
             ->expects($this->once())
-            ->method('build')
+            ->method('buildForInitialTestsRun')
             ->with('', '--group=default --coverage-xml=/tmp/coverage-xml --log-junit=/tmp/infection/junit.xml')
             ->willReturn([
                 '--group=default', '--coverage-xml=/tmp/coverage-xml', '--log-junit=/tmp/infection/junit.xml',
@@ -215,7 +215,7 @@ final class PhpUnitAdapterTest extends TestCase
     {
         $this->cliArgumentsBuilder
             ->expects($this->once())
-            ->method('build')
+            ->method('buildForInitialTestsRun')
             ->with('', '--group=default --coverage-xml=/tmp/coverage-xml --log-junit=/tmp/infection/junit.xml')
             ->willReturn([
                 '--group=default', '--coverage-xml=/tmp/coverage-xml', '--log-junit=/tmp/infection/junit.xml',

--- a/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -142,7 +142,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
             [
                 'App\Test::test_case1',
             ],
-            '/App\\\\Test::test_case1/',
+            '/App\\\\Test\:\:test_case1/',
         ];
 
         yield '2 test cases' => [
@@ -151,7 +151,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 'App\Test::test_case1',
                 'App\Test::test_case2',
             ],
-            '/App\\\\Test::test_case1|App\\\\Test::test_case2/',
+            '/App\\\\Test\:\:test_case1|App\\\\Test\:\:test_case2/',
         ];
 
         yield '2 simple test cases, 1 with data set and special character >' => [
@@ -160,7 +160,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 'App\Test::test_case1 with data set "With special character >"',
                 'App\Test::test_case2',
             ],
-            '/App\\\\Test::test_case1 with data set "With special character \\>"|App\\\\Test::test_case2/',
+            '/App\\\\Test\:\:test_case1 with data set "With special character \\>"|App\\\\Test\:\:test_case2/',
         ];
 
         yield '2 simple test cases, 1 with data set and special character @' => [
@@ -169,7 +169,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 'App\Test::test_case1 with data set "With special character @"',
                 'App\Test::test_case2',
             ],
-            '/App\\\\Test::test_case1 with data set "With special character @"|App\\\\Test::test_case2/',
+            '/App\\\\Test\:\:test_case1 with data set "With special character @"|App\\\\Test\:\:test_case2/',
         ];
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpUnit\CommandLine;
 
+use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\TestFramework\PhpUnit\CommandLine\ArgumentsAndOptionsBuilder;
 use PHPUnit\Framework\TestCase;
 
@@ -59,7 +60,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 '--configuration',
                 $configPath,
             ],
-            $this->builder->build($configPath, '')
+            $this->builder->build($configPath, '', [])
         );
     }
 
@@ -74,7 +75,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 '--verbose',
                 '--debug',
             ],
-            $this->builder->build($configPath, '--verbose --debug')
+            $this->builder->build($configPath, '--verbose --debug', [])
         );
     }
 
@@ -87,8 +88,17 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 '--configuration',
                 $configPath,
                 '--path=/a path/with spaces',
+                '--filter',
+                'App\\\\Test::test_case1|App\\\\Test::test_case2',
             ],
-            $this->builder->build($configPath, '--path=/a path/with spaces')
+            $this->builder->build(
+                $configPath,
+                '--path=/a path/with spaces',
+                [
+                    TestLocation::forTestMethod('App\Test::test_case1'),
+                    TestLocation::forTestMethod('App\Test::test_case2'),
+                ]
+            )
         );
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -60,7 +60,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 '--configuration',
                 $configPath,
             ],
-            $this->builder->build($configPath, '', [])
+            $this->builder->buildForInitialTestsRun($configPath, '')
         );
     }
 
@@ -75,7 +75,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 '--verbose',
                 '--debug',
             ],
-            $this->builder->build($configPath, '--verbose --debug', [])
+            $this->builder->buildForInitialTestsRun($configPath, '--verbose --debug')
         );
     }
 
@@ -88,10 +88,24 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 '--configuration',
                 $configPath,
                 '--path=/a path/with spaces',
+            ],
+            $this->builder->buildForInitialTestsRun($configPath, '--path=/a path/with spaces')
+        );
+    }
+
+    public function test_it_can_build_the_command_with_filter_option_for_covering_tests_for_mutant(): void
+    {
+        $configPath = '/the config/path';
+
+        $this->assertSame(
+            [
+                '--configuration',
+                $configPath,
+                '--path=/a path/with spaces',
                 '--filter',
                 'App\\\\Test::test_case1|App\\\\Test::test_case2',
             ],
-            $this->builder->build(
+            $this->builder->buildForMutant(
                 $configPath,
                 '--path=/a path/with spaces',
                 [


### PR DESCRIPTION
This PR dramatically improves performance for Infection executed against functional (read - slow) tests.

```diff
- Time: 4m 18s. Memory: 0.05GB
+ Time: 1m 19s. Memory: 0.06GB
```

for one of the PR in my daily job's project.

## Problem

As you know, we always said that Infection runs only those tests that cover mutated line, not the all tests from an application.

It is partially true, but not exactly. PHPUnit's XML file allows us to only [filter original set of tests by `<directory>` or `<file>` ](https://phpunit.readthedocs.io/en/9.5/configuration.html#the-testsuite-element).

And this is what we do starting from 2017. 

<details>
<summary>Example of a `phpunit.xml` file generated by Infection for one of the Mutant (click me)</summary>


```xml
<?xml version="1.0" encoding="UTF-8"?>
<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/schema/9.2.xsd" bootstrap="/infection/tests/e2e/PestTestFramework/./infection/interceptor.autoload.740af9ed4589f3494f0c14ed544eec29.infection.php" colors="false" stopOnFailure="true" cacheResult="false" stderr="false">
  <testsuites>
    <testsuite name="Infection testsuite with filtered tests">
      <file>/infection/tests/e2e/PestTestFramework/tests/CalculatorPhpUnitTest.php</file>
    </testsuite>
  </testsuites>
  <filter>
    <whitelist>
      <directory>/infection/tests/e2e/PestTestFramework/src/</directory>
    </whitelist>
  </filter>
</phpunit>

```

</details>

Notice in the example above, that we tell PHPUnit to run tests only from `CalculatorPhpUnitTest.php`. But this file can contain 1 test that covers mutated line, **and hundreds of other tests** that still will be executed for Mutant. 

It wasn't always noticeable because we (ok, at least I am) used Infection for **unit** tests, which are fast enough.

However, since I'm currently working on a project with 2000+ *functional* tests and run Infection against this huge functional test suite, this became a bottleneck.

Imagine there is a file `ProductApiTest.php` that covers all the API endpoints with functional tests (Symfony WebTestCase).

* In this file, there is only 1 test case that covers mutated line. This test case takes **1s**
* In this file, there are additionally other 100 test cases that together take **15s**

So, with Infection 0.23.0 (current `master`), instead of running 1 test case for 1s, we run all the tests from `ProductApiTest.php` for 1+15=16s.

## Solution

With this PR, for the example explained above, we run only 1 test case for 1s, *saving 15 from 16 seconds*.

### Technical details

Since PHPUnit doesn't allow us to provide test cases on `phpunit.xml` file level, we can only do it on a command line level, using `--filter` option

* Command line on `master`: `'phpunit' '--configuration' '/path-to/phpunitConfiguration.d3b360aa95bfe11dadbe87dbd49b70c4.infection.xml'`
* Command line on this PR: `'phpunit' '--configuration' '/path-to/phpunitConfiguration.d3b360aa95bfe11dadbe87dbd49b70c4.infection.xml' '--filter' '/App\\Test::test_case1|App\\Test::test_case2/'` 

Instead of 1000 words, here is an example of the logs for the escaped mutant:

`master`:

```bash
3) /srv/api/src/DataPersister/TableViewDataPersister.php:32    [M] InstanceOf_

--- Original
+++ New
@@ @@
     }
     public function persist($data, array $context = [])
     {
-        if ($data instanceof TableView && ($context['collection_operation_name'] ?? null) === 'post' && $this->security->getUser() instanceof Employee) {
+        if ($data instanceof TableView && ($context['collection_operation_name'] ?? null) === 'post' && true) {
             /** @var Employee $employee */
             $employee = $this->security->getUser();
             $data->setCreatedBy($employee);

$ '/srv/api/vendor/phpunit/phpunit/phpunit' '--configuration' '/tmp/infection/phpunitConfiguration.1aadd4bc46a4b6ae51fb8e3a0d295e89.infection.xml'
  Test cache cleared
  PHPUnit 9.5.6 by Sebastian Bergmann and contributors.
  
  Random Seed:   1625689971
  
  Testing 
  .............................................................   61 / 1166 (  5%)
  .............................................................  122 / 1166 ( 10%)
  .............................................................  183 / 1166 ( 15%)
  .............................................................  244 / 1166 ( 20%)
  .............................................................  305 / 1166 ( 26%)
  .............................................................  366 / 1166 ( 31%)
  .............................................................  427 / 1166 ( 36%)
  .............................................................  488 / 1166 ( 41%)
  .............................................................  549 / 1166 ( 47%)
  .............................................................  610 / 1166 ( 52%)
  .............................................................  671 / 1166 ( 57%)
  ..............................
```

and this PR:

```bash
3) /srv/api/src/DataPersister/TableViewDataPersister.php:32    [M] InstanceOf_

--- Original
+++ New
@@ @@
     }
     public function persist($data, array $context = [])
     {
-        if ($data instanceof TableView && ($context['collection_operation_name'] ?? null) === 'post' && $this->security->getUser() instanceof Employee) {
+        if ($data instanceof TableView && ($context['collection_operation_name'] ?? null) === 'post' && true) {
             /** @var Employee $employee */
             $employee = $this->security->getUser();
             $data->setCreatedBy($employee);

$ '/srv/api/vendor/phpunit/phpunit/phpunit' '--configuration' '/tmp/infection/phpunitConfiguration.5b66e9f56127cb2a42531283cf8dc120.infection.xml' '--filter' '/App\\Tests\\[...very long filter]/'
  Test cache cleared
  PHPUnit 9.5.6 by Sebastian Bergmann and contributors.
  
  Random Seed:   1625689648
  
  Testing 
  ...............................................................  63 / 192 ( 32%)
  ............................................................... 126 / 192 ( 65%)
  ............................................................... 189 / 192 ( 98%)
  ...                                                             192 / 192 (100%)
```

So it is 192 executed tests (in this branch) instead of 1166 (in `master`). 

## How it impacts unit (fast) test suites

I tried to understand the impact for fast tests, running `master` branch and this PR against Infection itsetlf:

```bash
make test-infection-xdebug-80-docker
```

From my tests, running Infection against Infection becomes *slower* with this PR.

```
master:
  2m 52s. Memory: 0.17GB
  2m 47s. Memory: 0.17GB
  2m 46s. Memory: 0.17GB

PR:
  3m 8s. Memory: 0.19GB
  3m 6s. Memory: 0.19GB
  3m 9s. Memory: 0.19GB
```

* Why was memory usage increased (I don't think it's a problem though)? Because now we need to store all those `--filter '/the long list of test cases/' options
* Why was the execution time increased? From my tests, there are 2 reasons
  * Using `--filter` in PHPUnit itself adds some penalty as I understand, because this option is matched using `preg_match()` inside PHPUnit. But this adds only 5 extra seconds with the "Infection for Infection" example. 
  * Preparing a unique set of test cases and build `--filter '/the long list of test cases/' option takes the most extra time

Keeping that in mind, probably it's better to enable this feature by some option? If so, what the name of this new option you can recommend?

* `--only-covering-test-cases`
* `--slow-tests` (probably it will be some common option to enable not just this feature)
* ...

I don't know.

### Conclusion

The slower the tests, the more benefit / performance boost this PR will give.

---

- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/221