### PR TITLE
Add Mutator information to GitHub annotation logger

### DIFF
--- a/src/Logger/GitHubAnnotationsLogger.php
+++ b/src/Logger/GitHubAnnotationsLogger.php
@@ -63,7 +63,7 @@ final class GitHubAnnotationsLogger implements LineMutationTestingResultsLogger
             $error = [
                 'line' => $escapedExecutionResult->getOriginalStartingLine(),
                 'message' => <<<"TEXT"
-Escaped Mutant:
+Escaped Mutant for Mutator "{$escapedExecutionResult->getMutatorName()}":
 
 {$escapedExecutionResult->getMutantDiff()}
 TEXT

--- a/tests/phpunit/Logger/GitHubAnnotationsLoggerTest.php
+++ b/tests/phpunit/Logger/GitHubAnnotationsLoggerTest.php
@@ -68,8 +68,8 @@ final class GitHubAnnotationsLoggerTest extends TestCase
         yield 'all mutations' => [
             $this->createCompleteResultsCollector(),
             [
-                "::warning file=foo/bar,line=9::Escaped Mutant:%0A%0A--- Original%0A+++ New%0A@@ @@%0A%0A- echo 'original';%0A+ echo 'escaped#1';%0A\n",
-                "::warning file=foo/bar,line=10::Escaped Mutant:%0A%0A--- Original%0A+++ New%0A@@ @@%0A%0A- echo 'original';%0A+ echo 'escaped#0';%0A\n",
+                "::warning file=foo/bar,line=9::Escaped Mutant for Mutator \"PregQuote\":%0A%0A--- Original%0A+++ New%0A@@ @@%0A%0A- echo 'original';%0A+ echo 'escaped#1';%0A\n",
+                "::warning file=foo/bar,line=10::Escaped Mutant for Mutator \"For_\":%0A%0A--- Original%0A+++ New%0A@@ @@%0A%0A- echo 'original';%0A+ echo 'escaped#0';%0A\n",
             ],
         ];
     }


### PR DESCRIPTION
* It will give more information about what Mutator is used and will be in line with other loggers
* It will make it clear to understand why the diff can be empty, like in https://github.com/infection/infection/issues/1524

Fixes https://github.com/infection/infection/issues/1524