### PR TITLE
[Performance] Add files to coverage whitelist instead of the whole directories when `--filter` or `--git-diff-filter` are used

### DIFF
--- a/devTools/phpstan-src-baseline.neon
+++ b/devTools/phpstan-src-baseline.neon
@@ -306,6 +306,11 @@ parameters:
 			path: ../src/TestFramework/Coverage/XmlReport/XPathFactory.php
 
 		-
+			message: "#^Parameter \\#1 \\$it of function iterator_to_array expects Traversable, iterable\\<Infection\\\\TestFramework\\\\Coverage\\\\Trace\\|SplFileInfo\\> given\\.$#"
+			count: 1
+			path: ../src/TestFramework/Factory.php
+
+		-
 			message: "#^Method Infection\\\\TestFramework\\\\PhpUnit\\\\Adapter\\\\PestAdapterFactory\\:\\:create\\(\\) has parameter \\$sourceDirectories with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../src/TestFramework/PhpUnit/Adapter/PestAdapterFactory.php
@@ -358,11 +363,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
 			count: 1
-			path: ../src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
-			count: 2
 			path: ../src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
 
 		-

--- a/src/Container.php
+++ b/src/Container.php
@@ -290,6 +290,7 @@ final class Container
                     $container->getTestFrameworkFinder(),
                     $container->getDefaultJUnitFilePath(),
                     $config,
+                    $container->getSourceFileFilter(),
                     GeneratedExtensionsConfig::EXTENSIONS
                 );
             },

--- a/src/FileSystem/SourceFileCollector.php
+++ b/src/FileSystem/SourceFileCollector.php
@@ -56,7 +56,7 @@ class SourceFileCollector
         array $excludeDirectories
     ): iterable {
         if ($sourceDirectories === []) {
-            return;
+            return [];
         }
 
         $finder = Finder::create()
@@ -70,7 +70,6 @@ class SourceFileCollector
             $finder->notPath($excludeDirectory);
         }
 
-        // Generator here to make sure these files used only once
-        yield from $finder;
+        return $finder;
     }
 }

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -175,12 +175,12 @@ final class Factory
     /**
      * Get only those source files that will be mutated to use them in coverage whitelist
      *
-     * @return list<string>|null
+     * @return list<string>
      */
-    private function getFilteredSourceFilesToMutate(): ?array
+    private function getFilteredSourceFilesToMutate(): array
     {
         if ($this->sourceFileFilter->getFilters() === []) {
-            return null;
+            return [];
         }
 
         /** @var list<string> $filteredPaths */
@@ -190,10 +190,6 @@ final class Factory
             },
             iterator_to_array($this->sourceFileFilter->filter($this->infectionConfig->getSourceFiles()))
         ));
-
-        if ($filteredPaths === []) {
-            return null;
-        }
 
         return $filteredPaths;
     }

--- a/src/TestFramework/PhpUnit/Adapter/PestAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PestAdapterFactory.php
@@ -56,6 +56,9 @@ use Webmozart\Assert\Assert;
  */
 final class PestAdapterFactory implements TestFrameworkAdapterFactory
 {
+    /**
+     * @param list<string>|null $filteredSourceFilesToMutate
+     */
     public static function create(
         string $testFrameworkExecutable,
         string $tmpDir,
@@ -65,7 +68,8 @@ final class PestAdapterFactory implements TestFrameworkAdapterFactory
         string $projectDir,
         array $sourceDirectories,
         bool $skipCoverage,
-        bool $executeOnlyCoveringTestCases = false
+        bool $executeOnlyCoveringTestCases = false,
+        ?array $filteredSourceFilesToMutate = null
     ): TestFrameworkAdapter {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the Pest adapter');
 
@@ -89,7 +93,8 @@ final class PestAdapterFactory implements TestFrameworkAdapterFactory
                 $testFrameworkConfigContent,
                 $configManipulator,
                 new XmlConfigurationVersionProvider(),
-                $sourceDirectories
+                $sourceDirectories,
+                $filteredSourceFilesToMutate
             ),
             new MutationConfigBuilder(
                 $tmpDir,

--- a/src/TestFramework/PhpUnit/Adapter/PestAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PestAdapterFactory.php
@@ -57,7 +57,7 @@ use Webmozart\Assert\Assert;
 final class PestAdapterFactory implements TestFrameworkAdapterFactory
 {
     /**
-     * @param list<string>|null $filteredSourceFilesToMutate
+     * @param list<string> $filteredSourceFilesToMutate
      */
     public static function create(
         string $testFrameworkExecutable,
@@ -69,7 +69,7 @@ final class PestAdapterFactory implements TestFrameworkAdapterFactory
         array $sourceDirectories,
         bool $skipCoverage,
         bool $executeOnlyCoveringTestCases = false,
-        ?array $filteredSourceFilesToMutate = null
+        array $filteredSourceFilesToMutate = []
     ): TestFrameworkAdapter {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the Pest adapter');
 

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -58,6 +58,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
 {
     /**
      * @param string[] $sourceDirectories
+     * @param list<string>|null $filteredSourceFilesToMutate
      */
     public static function create(
         string $testFrameworkExecutable,
@@ -68,7 +69,8 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
         string $projectDir,
         array $sourceDirectories,
         bool $skipCoverage,
-        bool $executeOnlyCoveringTestCases = false
+        bool $executeOnlyCoveringTestCases = false,
+        ?array $filteredSourceFilesToMutate = null
     ): TestFrameworkAdapter {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the Pest adapter');
 
@@ -92,7 +94,8 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
                 $testFrameworkConfigContent,
                 $configManipulator,
                 new XmlConfigurationVersionProvider(),
-                $sourceDirectories
+                $sourceDirectories,
+                $filteredSourceFilesToMutate
             ),
             new MutationConfigBuilder(
                 $tmpDir,

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -58,7 +58,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
 {
     /**
      * @param string[] $sourceDirectories
-     * @param list<string>|null $filteredSourceFilesToMutate
+     * @param list<string> $filteredSourceFilesToMutate
      */
     public static function create(
         string $testFrameworkExecutable,
@@ -70,7 +70,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
         array $sourceDirectories,
         bool $skipCoverage,
         bool $executeOnlyCoveringTestCases = false,
-        ?array $filteredSourceFilesToMutate = null
+        array $filteredSourceFilesToMutate = []
     ): TestFrameworkAdapter {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the Pest adapter');
 

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -56,16 +56,20 @@ class InitialConfigBuilder implements ConfigBuilder
     private XmlConfigurationVersionProvider $versionProvider;
     /** @var string[] */
     private array $srcDirs;
+    /** @var list<string>|null */
+    private ?array $filteredSourceFilesToMutate;
 
     /**
      * @param string[] $srcDirs
+     * @param array<string>|null $filteredSourceFilesToMutate
      */
     public function __construct(
         string $tmpDir,
         string $originalXmlConfigContent,
         XmlConfigurationManipulator $configManipulator,
         XmlConfigurationVersionProvider $versionProvider,
-        array $srcDirs
+        array $srcDirs,
+        ?array $filteredSourceFilesToMutate
     ) {
         Assert::notEmpty(
             $originalXmlConfigContent,
@@ -77,6 +81,7 @@ class InitialConfigBuilder implements ConfigBuilder
         $this->configManipulator = $configManipulator;
         $this->versionProvider = $versionProvider;
         $this->srcDirs = $srcDirs;
+        $this->filteredSourceFilesToMutate = $filteredSourceFilesToMutate;
     }
 
     public function build(string $version): string
@@ -118,25 +123,25 @@ class InitialConfigBuilder implements ConfigBuilder
     private function addCoverageNodes(string $version, SafeDOMXPath $xPath): void
     {
         if (version_compare($version, '10', '>=')) {
-            $this->configManipulator->addCoverageIncludeNodesUnlessTheyExist($xPath, $this->srcDirs);
+            $this->configManipulator->addOrUpdateCoverageIncludeNodes($xPath, $this->srcDirs, $this->filteredSourceFilesToMutate);
 
             return;
         }
 
         if (version_compare($version, '9.3', '<')) {
-            $this->configManipulator->addLegacyCoverageWhitelistNodesUnlessTheyExist($xPath, $this->srcDirs);
+            $this->configManipulator->addOrUpdateLegacyCoverageWhitelistNodes($xPath, $this->srcDirs, $this->filteredSourceFilesToMutate);
 
             return;
         }
 
         // For versions between 9.3 and 10.0, fallback to version provider
         if (version_compare($this->versionProvider->provide($xPath), '9.3', '>=')) {
-            $this->configManipulator->addCoverageIncludeNodesUnlessTheyExist($xPath, $this->srcDirs);
+            $this->configManipulator->addOrUpdateCoverageIncludeNodes($xPath, $this->srcDirs, $this->filteredSourceFilesToMutate);
 
             return;
         }
 
-        $this->configManipulator->addLegacyCoverageWhitelistNodesUnlessTheyExist($xPath, $this->srcDirs);
+        $this->configManipulator->addOrUpdateLegacyCoverageWhitelistNodes($xPath, $this->srcDirs, $this->filteredSourceFilesToMutate);
     }
 
     private function addRandomTestsOrderAttributesIfNotSet(string $version, SafeDOMXPath $xPath): void

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -61,7 +61,7 @@ class InitialConfigBuilder implements ConfigBuilder
 
     /**
      * @param string[] $srcDirs
-     * @param array<string> $filteredSourceFilesToMutate
+     * @param list<string> $filteredSourceFilesToMutate
      */
     public function __construct(
         string $tmpDir,

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -56,12 +56,12 @@ class InitialConfigBuilder implements ConfigBuilder
     private XmlConfigurationVersionProvider $versionProvider;
     /** @var string[] */
     private array $srcDirs;
-    /** @var list<string>|null */
-    private ?array $filteredSourceFilesToMutate;
+    /** @var list<string> */
+    private array $filteredSourceFilesToMutate;
 
     /**
      * @param string[] $srcDirs
-     * @param array<string>|null $filteredSourceFilesToMutate
+     * @param array<string> $filteredSourceFilesToMutate
      */
     public function __construct(
         string $tmpDir,
@@ -69,7 +69,7 @@ class InitialConfigBuilder implements ConfigBuilder
         XmlConfigurationManipulator $configManipulator,
         XmlConfigurationVersionProvider $versionProvider,
         array $srcDirs,
-        ?array $filteredSourceFilesToMutate
+        array $filteredSourceFilesToMutate
     ) {
         Assert::notEmpty(
             $originalXmlConfigContent,

--- a/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
+++ b/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
@@ -48,7 +48,7 @@ use Symfony\Component\Filesystem\Filesystem;
 final class PathReplacer
 {
     private Filesystem $filesystem;
-    private ?string $phpUnitConfigDir = null;
+    private ?string $phpUnitConfigDir;
 
     public function __construct(Filesystem $filesystem, ?string $phpUnitConfigDir = null)
     {

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -132,18 +132,18 @@ final class XmlConfigurationManipulator
 
     /**
      * @param string[] $srcDirs
-     * @param list<string>|null $filteredSourceFilesToMutate
+     * @param list<string> $filteredSourceFilesToMutate
      */
-    public function addOrUpdateLegacyCoverageWhitelistNodes(SafeDOMXPath $xPath, array $srcDirs, ?array $filteredSourceFilesToMutate): void
+    public function addOrUpdateLegacyCoverageWhitelistNodes(SafeDOMXPath $xPath, array $srcDirs, array $filteredSourceFilesToMutate): void
     {
         $this->addOrUpdateCoverageNodes('filter', 'whitelist', $xPath, $srcDirs, $filteredSourceFilesToMutate);
     }
 
     /**
      * @param string[] $srcDirs
-     * @param list<string>|null $filteredSourceFilesToMutate
+     * @param list<string> $filteredSourceFilesToMutate
      */
-    public function addOrUpdateCoverageIncludeNodes(SafeDOMXPath $xPath, array $srcDirs, ?array $filteredSourceFilesToMutate): void
+    public function addOrUpdateCoverageIncludeNodes(SafeDOMXPath $xPath, array $srcDirs, array $filteredSourceFilesToMutate): void
     {
         $this->addOrUpdateCoverageNodes('coverage', 'include', $xPath, $srcDirs, $filteredSourceFilesToMutate);
     }
@@ -184,14 +184,14 @@ final class XmlConfigurationManipulator
 
     /**
      * @param string[] $srcDirs
-     * @param list<string>|null $filteredSourceFilesToMutate
+     * @param list<string> $filteredSourceFilesToMutate
      */
-    private function addOrUpdateCoverageNodes(string $parentName, string $listName, SafeDOMXPath $xPath, array $srcDirs, ?array $filteredSourceFilesToMutate): void
+    private function addOrUpdateCoverageNodes(string $parentName, string $listName, SafeDOMXPath $xPath, array $srcDirs, array $filteredSourceFilesToMutate): void
     {
         $coverageNodeExists = $this->nodeExists($xPath, "{$parentName}/{$listName}");
 
         if ($coverageNodeExists) {
-            if ($filteredSourceFilesToMutate === null) {
+            if ($filteredSourceFilesToMutate === []) {
                 // use original phpunit.xml's coverage setting since all files need to be mutated (no filter is set)
                 return;
             }
@@ -203,7 +203,7 @@ final class XmlConfigurationManipulator
 
         $listNode = $xPath->document->createElement($listName);
 
-        if ($filteredSourceFilesToMutate === null) {
+        if ($filteredSourceFilesToMutate === []) {
             foreach ($srcDirs as $srcDir) {
                 $directoryNode = $xPath->document->createElement(
                     'directory',

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -132,18 +132,20 @@ final class XmlConfigurationManipulator
 
     /**
      * @param string[] $srcDirs
+     * @param list<string>|null $filteredSourceFilesToMutate
      */
-    public function addLegacyCoverageWhitelistNodesUnlessTheyExist(SafeDOMXPath $xPath, array $srcDirs): void
+    public function addOrUpdateLegacyCoverageWhitelistNodes(SafeDOMXPath $xPath, array $srcDirs, ?array $filteredSourceFilesToMutate): void
     {
-        $this->addCoverageNodesUnlessTheyExist('filter', 'whitelist', $xPath, $srcDirs);
+        $this->addOrUpdateCoverageNodes('filter', 'whitelist', $xPath, $srcDirs, $filteredSourceFilesToMutate);
     }
 
     /**
      * @param string[] $srcDirs
+     * @param list<string>|null $filteredSourceFilesToMutate
      */
-    public function addCoverageIncludeNodesUnlessTheyExist(SafeDOMXPath $xPath, array $srcDirs): void
+    public function addOrUpdateCoverageIncludeNodes(SafeDOMXPath $xPath, array $srcDirs, ?array $filteredSourceFilesToMutate): void
     {
-        $this->addCoverageNodesUnlessTheyExist('coverage', 'include', $xPath, $srcDirs);
+        $this->addOrUpdateCoverageNodes('coverage', 'include', $xPath, $srcDirs, $filteredSourceFilesToMutate);
     }
 
     public function validate(string $configPath, SafeDOMXPath $xPath): bool
@@ -182,24 +184,43 @@ final class XmlConfigurationManipulator
 
     /**
      * @param string[] $srcDirs
+     * @param list<string>|null $filteredSourceFilesToMutate
      */
-    private function addCoverageNodesUnlessTheyExist(string $parentName, string $listName, SafeDOMXPath $xPath, array $srcDirs): void
+    private function addOrUpdateCoverageNodes(string $parentName, string $listName, SafeDOMXPath $xPath, array $srcDirs, ?array $filteredSourceFilesToMutate): void
     {
-        if ($this->nodeExists($xPath, "{$parentName}/{$listName}")) {
-            return;
+        $coverageNodeExists = $this->nodeExists($xPath, "{$parentName}/{$listName}");
+
+        if ($coverageNodeExists) {
+            if ($filteredSourceFilesToMutate === null) {
+                // use original phpunit.xml's coverage setting since all files need to be mutated (no filter is set)
+                return;
+            }
+
+            $this->removeCoverageChildNode($xPath, "{$parentName}/{$listName}");
         }
 
-        $filterNode = $this->createNode($xPath->document, $parentName);
+        $filterNode = $this->getOrCreateNode($xPath, $xPath->document, $parentName);
 
         $listNode = $xPath->document->createElement($listName);
 
-        foreach ($srcDirs as $srcDir) {
-            $directoryNode = $xPath->document->createElement(
-                'directory',
-                $srcDir
-            );
+        if ($filteredSourceFilesToMutate === null) {
+            foreach ($srcDirs as $srcDir) {
+                $directoryNode = $xPath->document->createElement(
+                    'directory',
+                    $srcDir
+                );
 
-            $listNode->appendChild($directoryNode);
+                $listNode->appendChild($directoryNode);
+            }
+        } else {
+            foreach ($filteredSourceFilesToMutate as $sourceFileRealPath) {
+                $directoryNode = $xPath->document->createElement(
+                    'file',
+                    $sourceFileRealPath
+                );
+
+                $listNode->appendChild($directoryNode);
+            }
         }
 
         $filterNode->appendChild($listNode);
@@ -264,7 +285,7 @@ final class XmlConfigurationManipulator
             $name
         ));
 
-        if ($nodeList->length) {
+        if ($nodeList->length > 0) {
             $document = $xPath->document->documentElement;
             Assert::isInstanceOf($document, DOMElement::class);
             $document->removeAttribute($name);
@@ -278,7 +299,7 @@ final class XmlConfigurationManipulator
             $name
         ));
 
-        if ($nodeList->length) {
+        if ($nodeList->length > 0) {
             $nodeList[0]->nodeValue = $value;
         } else {
             $node = $xPath->query('/phpunit')[0];
@@ -301,5 +322,23 @@ final class XmlConfigurationManipulator
         }
 
         throw new LogicException(sprintf('Unknown lib XML error level "%s"', $error->level));
+    }
+
+    private function removeCoverageChildNode(SafeDOMXPath $xPath, string $nodeQuery): void
+    {
+        foreach ($xPath->query($nodeQuery) as $node) {
+            $node->parentNode->removeChild($node);
+        }
+    }
+
+    private function getOrCreateNode(SafeDOMXPath $xPath, DOMDocument $dom, string $nodeName): DOMElement
+    {
+        $node = $xPath->query(sprintf('/phpunit/%s', $nodeName));
+
+        if ($node->length > 0) {
+            return $node[0];
+        }
+
+        return $this->createNode($dom, $nodeName);
     }
 }

--- a/tests/phpunit/Fixtures/Files/phpunit/phpunit_with_coverage_include_directories.xml
+++ b/tests/phpunit/Fixtures/Files/phpunit/phpunit_with_coverage_include_directories.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="app/autoload2.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>./*Bundle</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>src/</directory>
+            <directory>example/</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/tests/phpunit/TestFramework/FactoryTest.php
+++ b/tests/phpunit/TestFramework/FactoryTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\TestFramework;
 
 use Infection\Configuration\Configuration;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
+use Infection\FileSystem\SourceFileFilter;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\Factory;
 use Infection\Tests\Fixtures\TestFramework\DummyTestFrameworkAdapter;
@@ -58,7 +59,8 @@ final class FactoryTest extends TestCase
             $this->createMock(TestFrameworkFinder::class),
             '',
             $this->createMock(Configuration::class),
-            []
+            $this->createMock(SourceFileFilter::class),
+            [],
         );
 
         $this->expectException(InvalidArgumentException::class);
@@ -74,6 +76,7 @@ final class FactoryTest extends TestCase
             $this->createMock(TestFrameworkFinder::class),
             '',
             $this->createMock(Configuration::class),
+            $this->createMock(SourceFileFilter::class),
             [
                 'infection/codeception-adapter' => [
                         'install_path' => '/path/to/dummy/adapter/factory.php',

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -269,6 +269,19 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
         $this->assertSame(2, $whitelistedDirectories->length);
     }
 
+    public function test_it_replaces_coverage_filter_include_node_if_exists_but_filtered_source_files_provided(): void
+    {
+        $phpunitXmlPath = self::FIXTURES . '/phpunit_with_coverage_include_directories.xml';
+
+        $xml = file_get_contents($this->createConfigBuilder($phpunitXmlPath, ['src/File1.php'])->build('9.3'));
+
+        $coverageIncludeFiles = $this->queryXpath($xml, '/phpunit/coverage/include/file');
+
+        $this->assertInstanceOf(DOMNodeList::class, $coverageIncludeFiles);
+
+        $this->assertSame(1, $coverageIncludeFiles->length);
+    }
+
     public function test_it_creates_coverage_include_node_if_does_not_exist_for_future_version_of_phpunit(): void
     {
         $phpunitXmlPath = self::FIXTURES . '/phpunit_without_coverage_whitelist.xml';
@@ -539,14 +552,14 @@ XML
         return (new DOMXPath($dom))->query($query);
     }
 
-    private function createConfigBuilderForPHPUnit93(
-        ?string $originalPhpUnitXmlConfigPath = null
-    ): InitialConfigBuilder {
+    private function createConfigBuilderForPHPUnit93(): InitialConfigBuilder
+    {
         return $this->createConfigBuilder(self::FIXTURES . '/phpunit_93.xml');
     }
 
     private function createConfigBuilder(
-        ?string $originalPhpUnitXmlConfigPath = null
+        ?string $originalPhpUnitXmlConfigPath = null,
+        ?iterable $filteredSourceFilesToMutate = null
     ): InitialConfigBuilder {
         $phpunitXmlPath = $originalPhpUnitXmlConfigPath ?: self::FIXTURES . '/phpunit.xml';
 
@@ -559,7 +572,8 @@ XML
             file_get_contents($phpunitXmlPath),
             new XmlConfigurationManipulator($replacer, ''),
             new XmlConfigurationVersionProvider(),
-            $srcDirs
+            $srcDirs,
+            $filteredSourceFilesToMutate
         );
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -559,7 +559,7 @@ XML
 
     private function createConfigBuilder(
         ?string $originalPhpUnitXmlConfigPath = null,
-        ?iterable $filteredSourceFilesToMutate = null
+        array $filteredSourceFilesToMutate = []
     ): InitialConfigBuilder {
         $phpunitXmlPath = $originalPhpUnitXmlConfigPath ?: self::FIXTURES . '/phpunit.xml';
 

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -146,7 +146,7 @@ XML
         );
     }
 
-    public function test_it_adds_coverage_whitelist_to_pre_93_configuration(): void
+    public function test_it_adds_coverage_whitelist_directories_to_pre_93_configuration(): void
     {
         $this->assertItChangesXML(
             <<<'XML'
@@ -155,7 +155,7 @@ XML
 XML
             ,
             static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
-                $configManipulator->addLegacyCoverageWhitelistNodesUnlessTheyExist($xPath, ['src/', 'examples/']);
+                $configManipulator->addOrUpdateLegacyCoverageWhitelistNodes($xPath, ['src/', 'examples/'], null);
             },
             <<<'XML'
 <phpunit cacheTokens="true">
@@ -165,6 +165,85 @@ XML
       <directory>examples/</directory>
     </whitelist>
   </filter>
+</phpunit>
+XML
+            );
+    }
+
+    public function test_it_adds_coverage_whitelist_files_to_pre_93_configuration(): void
+    {
+        $this->assertItChangesXML(
+            <<<'XML'
+<phpunit cacheTokens="true">
+</phpunit>
+XML
+            ,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->addOrUpdateLegacyCoverageWhitelistNodes(
+                    $xPath,
+                    ['src/', 'examples/'],
+                    ['src/File1.php', 'example/File2.php']
+                );
+            },
+            <<<'XML'
+<phpunit cacheTokens="true">
+  <filter>
+    <whitelist>
+      <file>src/File1.php</file>
+      <file>example/File2.php</file>
+    </whitelist>
+  </filter>
+</phpunit>
+XML
+            );
+    }
+
+    public function test_it_adds_coverage_whitelist_directories_to_post_93_configuration(): void
+    {
+        $this->assertItChangesXML(
+            <<<'XML'
+<phpunit cacheTokens="true">
+</phpunit>
+XML
+            ,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->addOrUpdateCoverageIncludeNodes($xPath, ['src/', 'examples/'], null);
+            },
+            <<<'XML'
+<phpunit cacheTokens="true">
+  <coverage>
+    <include>
+      <directory>src/</directory>
+      <directory>examples/</directory>
+    </include>
+  </coverage>
+</phpunit>
+XML
+            );
+    }
+
+    public function test_it_adds_coverage_whitelist_files_to_post_93_configuration(): void
+    {
+        $this->assertItChangesXML(
+            <<<'XML'
+<phpunit cacheTokens="true">
+</phpunit>
+XML
+            ,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->addOrUpdateCoverageIncludeNodes($xPath,
+                    ['src/', 'examples/'],
+                    ['src/File1.php', 'example/File2.php']
+                );
+            },
+            <<<'XML'
+<phpunit cacheTokens="true">
+  <coverage>
+    <include>
+      <file>src/File1.php</file>
+      <file>example/File2.php</file>
+    </include>
+  </coverage>
 </phpunit>
 XML
             );

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -155,7 +155,7 @@ XML
 XML
             ,
             static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
-                $configManipulator->addOrUpdateLegacyCoverageWhitelistNodes($xPath, ['src/', 'examples/'], null);
+                $configManipulator->addOrUpdateLegacyCoverageWhitelistNodes($xPath, ['src/', 'examples/'], []);
             },
             <<<'XML'
 <phpunit cacheTokens="true">
@@ -207,7 +207,7 @@ XML
 XML
             ,
             static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
-                $configManipulator->addOrUpdateCoverageIncludeNodes($xPath, ['src/', 'examples/'], null);
+                $configManipulator->addOrUpdateCoverageIncludeNodes($xPath, ['src/', 'examples/'], []);
             },
             <<<'XML'
 <phpunit cacheTokens="true">


### PR DESCRIPTION
### Problem

Collecting coverage data is expensive operation.

Currently, when we build the initial tests `phpunit.xml` config, we add (if doesn't exist) the following coverage whitelist:

```xml
<phpunit>
    <coverage>
        <include>
            <directory>src/</directory>
            <directory>example/</directory>
        </include>
    </coverage>
</phpunit>
```

It means that **all** the files from directories `src/` and `example/` will be processed by coverage driver (be it `xdebug`, `pcov` or `phpdbg`
).

Collecting code coverage **costs a lot**, that's why this change tries to reduce the number of files added to coverage whitelist, replacing `<directory>` tag with N `<file>` tags if possible.

And one of such cases is when we use `--filter=src/path/to/File1.php,src/path/to/File2.php` option, or when we use `--git-diff-filter=AM` option, that results internally to `--filter=X,Y,Z`.

When the filter is used, we 100% know that we will mutate only particular files, so we need the code coverage only for them.

After this change, the following command

```
infection --filter=src/path/to/File1.php,src/path/to/File2.php
```

creates the following `phpunit.xml` for initial tests run that collects coverage:



```xml
<phpunit>
    <coverage>
        <include>
            <file>src/path/to/File1.php/</file>
            <file>src/path/to/File2.php/</file>
        </include>
    </coverage>
</phpunit>
```

This will dramatically decrease the time needed for collecting coverage data since we reduce the number of processed files.

### Some numbers

Tests (without Infection) with `src` **folder** in `coverage.include`:

```bash
............................................                  2423 / 2423 (100%)

Time: 03:11.112, Memory: 587.62 MB

OK (2423 tests, 9861 assertions)
Generating code coverage report ... done [00:12.564]
```


Tests (without Infection) with 5 **files** in `coverage.include`:

```bash
............................................                  2423 / 2423 (100%)

Time: 01:12.771, Memory: 34.00 MB

OK (2423 tests, 9861 assertions)
Generating code coverage report ... done [00:00.041]
```

Difference:

```diff
- Time: 03:11.112, Memory: 587.62 MB
+ Time: 01:12.771, Memory: 34.00 MB
```

So, it saves 2 from 3 minutes.

Another case is with Infection and `--filter` option used for the real project.

`master` vs this PR:

```diff
infection -j4 --only-covered --filter=src/Recorder/RecorderCapabilities.php --ignore-msi-with-no-mutations --show-mutations  --log-verbosity=all --only-covering-test-cases

- Time: 8s. Memory: 28.00MB
+ Time: 2s. Memory: 26.00MB
```

it is `4x` faster for the filtered file set.

---

Notes: 

This PR will benefit those developers, who use Infection with `--filter` or `--git-diff-filter` options, running MT for the changed/added files (which I personally highly recommend, as it allows using Infection for the project regardless of its size).

