### PR TITLE
Do not mark Mutant as Killed when no tests were executed

### DIFF
--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -136,7 +136,10 @@ class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements MemoryUsage
         // "Warnings!" - e.g. when deprecated functions are used, but tests pass
         $isWarning = preg_match('/warnings!/i', $output);
 
-        return $isOk || $isOkWithInfo || $isWarning;
+        // "No tests executed!" - e.g. when --filter option contains too large regular expression
+        $isNoTestsExecuted = preg_match('/No tests executed!/i', $output);
+
+        return $isOk || $isOkWithInfo || $isWarning | $isNoTestsExecuted;
     }
 
     public function getMemoryUsed(string $output): float

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -275,6 +275,8 @@ final class PhpUnitAdapterTest extends TestCase
         yield ['FAILURES!', false];
 
         yield ['ERRORS!', false];
+
+        yield ['No tests executed!', true];
     }
 
     public function memoryReportProvider(): iterable


### PR DESCRIPTION
See https://github.com/infection/infection/issues/1545

We should not mark a Mutant as killed when no tests were executed (regardless of the reason)