### PR TITLE
For Mutant's phpunit.xml, set `executionOrder="default"` to prevent random ordering of the tests since we need them to be sorted (fastest - first)

### DIFF
--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -154,7 +154,8 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
             $tests,
             $mutantFilePath,
             $mutationHash,
-            $mutationOriginalFilePath
+            $mutationOriginalFilePath,
+            $this->getVersion()
         );
     }
 

--- a/src/TestFramework/Config/MutationConfigBuilder.php
+++ b/src/TestFramework/Config/MutationConfigBuilder.php
@@ -55,7 +55,8 @@ abstract class MutationConfigBuilder
         array $tests,
         string $mutantFilePath,
         string $mutationHash,
-        string $mutationOriginalFilePath
+        string $mutationOriginalFilePath,
+        string $version
     ): string;
 
     protected function getInterceptorFileContent(string $interceptorPath, string $originalFilePath, string $mutantFilePath): string

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -85,7 +85,8 @@ class MutationConfigBuilder extends ConfigBuilder
         array $tests,
         string $mutantFilePath,
         string $mutationHash,
-        string $mutationOriginalFilePath
+        string $mutationOriginalFilePath,
+        string $version
     ): string {
         $dom = $this->getDom();
         $xPath = new SafeDOMXPath($dom);
@@ -98,6 +99,9 @@ class MutationConfigBuilder extends ConfigBuilder
             $originalBootstrapFile = $this->originalBootstrapFile = $this->getOriginalBootstrapFilePath($xPath);
         }
 
+        // if original phpunit.xml has order by random, we should replace it to use `default` order and our sorting
+        // by <file> tags (e.g. the fastest tests first)
+        $this->configManipulator->setDefaultTestsOrderAttribute($version, $xPath);
         $this->configManipulator->setStopOnFailure($xPath);
         $this->configManipulator->deactivateColours($xPath);
         $this->configManipulator->deactivateResultCaching($xPath);

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -50,6 +50,7 @@ use function libxml_use_internal_errors;
 use LibXMLError;
 use LogicException;
 use function Safe\sprintf;
+use function version_compare;
 use Webmozart\Assert\Assert;
 
 /**
@@ -97,6 +98,15 @@ final class XmlConfigurationManipulator
     public function deactivateResultCaching(SafeDOMXPath $xPath): void
     {
         $this->setAttributeValue($xPath, 'cacheResult', 'false');
+    }
+
+    public function setDefaultTestsOrderAttribute(string $version, SafeDOMXPath $xPath): void
+    {
+        if (version_compare($version, '7.2', '<')) {
+            return;
+        }
+
+        $this->setAttributeValue($xPath, 'executionOrder', 'default');
     }
 
     public function deactivateStderrRedirection(SafeDOMXPath $xPath): void

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -93,7 +93,8 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
             [],
             self::MUTATED_FILE_PATH,
             self::HASH,
-            self::ORIGINAL_FILE_PATH
+            self::ORIGINAL_FILE_PATH,
+            '7.1'
         );
 
         $this->assertSame(
@@ -119,7 +120,8 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
             [],
             self::MUTATED_FILE_PATH,
             self::HASH,
-            self::ORIGINAL_FILE_PATH
+            self::ORIGINAL_FILE_PATH,
+            '7.1'
         );
 
         $tmp = $this->tmp;
@@ -200,7 +202,8 @@ XML
                     ],
                     self::MUTATED_FILE_PATH,
                     'hash1',
-                    self::ORIGINAL_FILE_PATH
+                    self::ORIGINAL_FILE_PATH,
+                    '7.1'
                 )
             )
         );
@@ -269,7 +272,8 @@ XML
                     ],
                     self::MUTATED_FILE_PATH,
                     'hash2',
-                    self::ORIGINAL_FILE_PATH
+                    self::ORIGINAL_FILE_PATH,
+                    '7.1'
                 )
             )
         );
@@ -308,7 +312,8 @@ PHP
                 [],
                 self::MUTATED_FILE_PATH,
                 self::HASH,
-                self::ORIGINAL_FILE_PATH
+                self::ORIGINAL_FILE_PATH,
+                '7.1'
             )
         );
     }
@@ -320,7 +325,8 @@ PHP
                 [],
                 self::MUTATED_FILE_PATH,
                 self::HASH,
-                self::ORIGINAL_FILE_PATH
+                self::ORIGINAL_FILE_PATH,
+                '7.1'
             )
         );
 
@@ -348,7 +354,8 @@ PHP
                 [],
                 self::MUTATED_FILE_PATH,
                 self::HASH,
-                self::ORIGINAL_FILE_PATH
+                self::ORIGINAL_FILE_PATH,
+                '7.1'
             )
         );
 
@@ -374,7 +381,8 @@ PHP
                 [],
                 self::MUTATED_FILE_PATH,
                 self::HASH,
-                self::ORIGINAL_FILE_PATH
+                self::ORIGINAL_FILE_PATH,
+                '7.1'
             )
         );
 
@@ -390,7 +398,8 @@ PHP
                 [],
                 self::MUTATED_FILE_PATH,
                 self::HASH,
-                self::ORIGINAL_FILE_PATH
+                self::ORIGINAL_FILE_PATH,
+                '7.1'
             )
         );
 
@@ -407,7 +416,8 @@ PHP
             [],
             self::MUTATED_FILE_PATH,
             self::HASH,
-            self::ORIGINAL_FILE_PATH
+            self::ORIGINAL_FILE_PATH,
+            '7.1'
         );
 
         $testSuite = $this->queryXpath(
@@ -426,7 +436,8 @@ PHP
                 [],
                 self::MUTATED_FILE_PATH,
                 self::HASH,
-                self::ORIGINAL_FILE_PATH
+                self::ORIGINAL_FILE_PATH,
+                '7.1'
             )
         );
 
@@ -443,7 +454,8 @@ PHP
                 [],
                 self::MUTATED_FILE_PATH,
                 self::HASH,
-                self::ORIGINAL_FILE_PATH
+                self::ORIGINAL_FILE_PATH,
+                '7.1'
             )
         );
 
@@ -451,6 +463,44 @@ PHP
 
         $this->assertInstanceOf(DOMNodeList::class, $printerClass);
         $this->assertSame(0, $printerClass->length);
+    }
+
+    public function test_it_sets_default_execution_order_when_attribute_is_absent(): void
+    {
+        $builder = $this->createConfigBuilder(self::FIXTURES . '/phpunit_without_coverage_whitelist.xml');
+
+        $xml = file_get_contents(
+            $builder->build(
+                [],
+                self::MUTATED_FILE_PATH,
+                self::HASH,
+                self::ORIGINAL_FILE_PATH,
+                '7.2'
+            )
+        );
+
+        $executionOrder = $this->queryXpath($xml, '/phpunit/@executionOrder')[0]->nodeValue;
+
+        $this->assertSame('default', $executionOrder);
+    }
+
+    public function test_it_sets_default_execution_order_when_attribute_is_present(): void
+    {
+        $builder = $this->createConfigBuilder(self::FIXTURES . '/phpunit_with_order_set.xml');
+
+        $xml = file_get_contents(
+            $builder->build(
+                [],
+                self::MUTATED_FILE_PATH,
+                self::HASH,
+                self::ORIGINAL_FILE_PATH,
+                '7.2'
+            )
+        );
+
+        $executionOrder = $this->queryXpath($xml, '/phpunit/@executionOrder')[0]->nodeValue;
+
+        $this->assertSame('default', $executionOrder);
     }
 
     /**
@@ -468,7 +518,8 @@ PHP
                 $tests,
                 self::MUTATED_FILE_PATH,
                 self::HASH,
-                self::ORIGINAL_FILE_PATH
+                self::ORIGINAL_FILE_PATH,
+                '7.1'
             )
         );
 
@@ -492,7 +543,8 @@ PHP
                 [],
                 self::MUTATED_FILE_PATH,
                 self::HASH,
-                self::ORIGINAL_FILE_PATH
+                self::ORIGINAL_FILE_PATH,
+                '7.1'
             )
         );
 
@@ -510,7 +562,8 @@ PHP
             [],
             self::MUTATED_FILE_PATH,
             self::HASH,
-            self::ORIGINAL_FILE_PATH
+            self::ORIGINAL_FILE_PATH,
+            '7.1'
         );
 
         $expectedCustomAutoloadFilePath = sprintf(

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -570,6 +570,53 @@ XML
         );
     }
 
+    public function test_it_sets_execution_order_to_default_for_phpunit_7_2(): void
+    {
+        $this->assertItChangesXML(<<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    syntaxCheck="false"
+>
+</phpunit>
+XML
+            ,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->setDefaultTestsOrderAttribute('7.2', $xPath);
+            },
+            <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    executionOrder="default"
+    syntaxCheck="false"
+>
+</phpunit>
+XML
+        );
+    }
+
+    public function test_it_does_not_set_execution_order_to_default_for_phpunit_7_1(): void
+    {
+        $this->assertItChangesXML(<<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    syntaxCheck="false"
+>
+</phpunit>
+XML
+            ,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->setDefaultTestsOrderAttribute('7.1', $xPath);
+            },
+            <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    syntaxCheck="false"
+>
+</phpunit>
+XML
+        );
+    }
+
     public function test_it_removes_existing_printers(): void
     {
         $this->assertItChangesXML(<<<'XML'


### PR DESCRIPTION
During the work on https://github.com/infection/infection/issues/1519, found that we have a critical bug. We always said we run the tests from fastest to slowest, hoping that the fastest tests fail first. It's true, unless the original `phpunit.xml` has an `executionOrder=random` attribute set (closest example - Infection's test suite itself).

---

When Infection builds Mutant's `phpunit.xml` file, we add `<file>` tags, sorted by tests execution time, so that the fastest tests runs first.

But when the original `phpunit.xml` contains `executionOrder="random"`, it was inherited to Mutant's `phpunit.xml` and broke the order, running the tests in a random order each time `infection` was executed.

This also explains why I got different execution time of Infection for the project with *slow functional* tests (there is the same issue for unit tests, but they are fast enough so this issue is not visible).

When Mutant is covered by 1000 functional tests, and tests are executed by random, it can be killed by the first test in run `#1` and can be killed by 1000-th test in run `#2`, if the killing test is executed the last.

With this update, all the tests will be executed in the same orders (fastest - first) in all the infection runs.

For more clarity, this is what happens in `master` right now with executing the same command 2 times:

```bash
'phpunit' '--configuration' 'infection/phpunitConfiguration.96749d7e4a15eec4f82a2413a56b5fba.infection.xml
```

`#1` run:

```bash
PHPUnit 9.5.7 by Sebastian Bergmann and contributors.

Random Seed:   1628355728

Testing 
.............................................................   61 / 1404 (  4%)
.............................................................  122 / 1404 (  8%)
.............................................................  183 / 1404 ( 13%)
.............................................................  244 / 1404 ( 17%)
.............................................................  305 / 1404 ( 21%)
.............................................................  366 / 1404 ( 26%)
.............................................................  427 / 1404 ( 30%)
.............................................................  488 / 1404 ( 34%)
E

Time: 01:05.354, Memory: 459.00 MB

There was 1 error:
```

`#2` run:

```bash
PHPUnit 9.5.7 by Sebastian Bergmann and contributors.

Random Seed:   1628355731

Testing 
.............................................................   61 / 1404 (  4%)
.............................................................  122 / 1404 (  8%)
.............................................................  183 / 1404 ( 13%)
.............................................................  244 / 1404 ( 17%)
..E

Time: 00:49.420, Memory: 349.00 MB

There was 1 error:
```

^ you can see that tests were executed in a random order, and the killing test was 499th in the `#1` run, and 245th in the `#2` run