### PR TITLE
Make the `--filter` option shorter for PHPUnit

### DIFF
--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -39,12 +39,14 @@ use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function count;
+use function end;
 use function explode;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 use function ltrim;
 use function preg_quote;
 use function rtrim;
+use function Safe\sprintf;
 
 /**
  * @internal
@@ -90,6 +92,13 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
 
             foreach ($tests as $testLocation) {
                 $testCaseString = $testLocation->getMethod();
+
+                $partsDelimitedByColons = explode('::', $testCaseString, 2);
+
+                if (count($partsDelimitedByColons) > 1) {
+                    $parts = explode('\\', $partsDelimitedByColons[0]);
+                    $testCaseString = sprintf('%s::%s', end($parts), $partsDelimitedByColons[1]);
+                }
 
                 if (array_key_exists($testCaseString, $usedTestCases)) {
                     continue;

--- a/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -142,7 +142,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
             [
                 'App\Test::test_case1',
             ],
-            '/App\\\\Test\:\:test_case1/',
+            '/Test\:\:test_case1/',
         ];
 
         yield '2 test cases' => [
@@ -151,25 +151,50 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 'App\Test::test_case1',
                 'App\Test::test_case2',
             ],
-            '/App\\\\Test\:\:test_case1|App\\\\Test\:\:test_case2/',
+            '/Test\:\:test_case1|Test\:\:test_case2/',
         ];
 
-        yield '2 simple test cases, 1 with data set and special character >' => [
+        yield '1 simple test case, 1 with data set and special character >' => [
             true,
             [
                 'App\Test::test_case1 with data set "With special character >"',
                 'App\Test::test_case2',
             ],
-            '/App\\\\Test\:\:test_case1 with data set "With special character \\>"|App\\\\Test\:\:test_case2/',
+            '/Test\:\:test_case1 with data set "With special character \\>"|Test\:\:test_case2/',
         ];
 
-        yield '2 simple test cases, 1 with data set and special character @' => [
+        yield '1 simple test case, 1 with data set and special character @' => [
             true,
             [
                 'App\Test::test_case1 with data set "With special character @"',
                 'App\Test::test_case2',
             ],
-            '/App\\\\Test\:\:test_case1 with data set "With special character @"|App\\\\Test\:\:test_case2/',
+            '/Test\:\:test_case1 with data set "With special character @"|Test\:\:test_case2/',
+        ];
+
+        yield '2 data sets from data provider for the same test case' => [
+            true,
+            [
+                'App\Test::test_case1 with data set "#1"',
+                'App\Test::test_case1 with data set "#2"',
+            ],
+            '/Test\:\:test_case1 with data set "\#1"|Test\:\:test_case1 with data set "\#2"/',
+        ];
+
+        yield '1 data set from data provider "With special char \\"' => [
+            true,
+            [
+                'App\Test::test_case1 with data set "With special char \\"',
+            ],
+            '/Test\:\:test_case1 with data set "With special char \\\\"/',
+        ];
+
+        yield '1 data set from data provider "With special chars ::"' => [
+            true,
+            [
+                'App\Test::test_case1 with data set "With special chars ::"',
+            ],
+            '/Test\:\:test_case1 with data set "With special chars \:\:"/',
         ];
     }
 }


### PR DESCRIPTION
This is just an attempt to make the `--filter` shorter. It doesn't fix https://github.com/infection/infection/issues/1545 though.

Explanation:

Difference between `master` and this PR with built `--filter`:

```diff
- /App\\Tests\\Functional\\Api\\Document\\DocumentTemplateTest\:\:test_it_can_update_document_template with data set "Returns error when at leas one of the business programs not in the document type'\''s list"
+ /DocumentTemplateTest\:\:test_it_can_update_document_template with data set "Returns error when at leas one of the business programs not in the document type'\''s list"
```

We can get rid of all the `App\\Tests\\Functional\\Api\\Document\\` and similar prefixes, leaving just `ClassTest::test_case_method` notation (or `ClassTest::test_case_method with data set "#1"` if data provider is used).

Why not just `test_case_method1|test_case_method2`? Because the less unique the filter, the more tests will be executed (which is worse from performance POV). If we have 1000 files with `test_case_method1`, then all the 1000 tests will be executed. Prefixing `test_case_method1` with `ClassTest::` make it hopefully unique.

On my real project test, this PR saves 13,000 characters from 50,000 and saves the performance (runs the same amount of tests, not more).