### PR TITLE
Trim "\n" and "\t" characters when replacing relative paths with absolute ones during XML config creation

### DIFF
--- a/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
+++ b/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
@@ -41,6 +41,7 @@ use function ltrim;
 use function Safe\sprintf;
 use function str_replace;
 use Symfony\Component\Filesystem\Filesystem;
+use function trim;
 
 /**
  * @internal
@@ -61,11 +62,13 @@ final class PathReplacer
      */
     public function replaceInNode(DOMNode $domElement): void
     {
-        if (!$this->filesystem->isAbsolutePath($domElement->nodeValue)) {
+        $path = trim($domElement->nodeValue);
+
+        if (!$this->filesystem->isAbsolutePath($path)) {
             $newPath = sprintf(
                 '%s/%s',
                 $this->phpUnitConfigDir,
-                ltrim($domElement->nodeValue, '\/')
+                ltrim($path, '\/')
             );
 
             // remove all occurrences of "/./". realpath can't be used because of glob patterns

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -110,6 +110,36 @@ XML
         );
     }
 
+    public function test_it_replaces_with_absolute_paths_xml_file_with_tabs(): void
+    {
+        $this->assertItChangesXML(
+            <<<'XML'
+<phpunit cacheTokens="true">
+    <testsuites>
+		<testsuite name="All Tests">
+			<directory suffix="UnitTest.php">
+				./Tests
+			</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>
+XML
+            ,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->replaceWithAbsolutePaths($xPath);
+            },
+            <<<'XML'
+<phpunit cacheTokens="true">
+  <testsuites>
+    <testsuite name="All Tests">
+      <directory suffix="UnitTest.php">/Tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>
+XML
+        );
+    }
+
     public function test_it_removes_existing_loggers_from_pre_93_configuration(): void
     {
         $this->assertItChangesPrePHPUnit93Configuration(


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/1542

When XML config contains "\n" or "\t" characters in the tag with paths, it breaks the path when Infection replaces relative paths with absolute ones.

Solution: just trim it.

Example of the problematic `phpunit.xml`:

https://github.com/alexdodonov/mezon-router/blob/dea1e597aba3dbd86148b9e9fc129048530c3280/phpunit.xml#L13-L15

Reason of the bug in debugger:

![tabs-bug](https://user-images.githubusercontent.com/3725595/128753845-825fb928-a6cf-4779-baa4-cf0ee25020e0.png)
