### PR TITLE
Add `cacheDirectory` attribute for PHPUnit's coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,7 +23,7 @@
         </testsuite>
     </testsuites>
 
-    <coverage>
+    <coverage cacheDirectory="./reports/.coverage-cache">
         <include>
             <directory>src</directory>
         </include>


### PR DESCRIPTION
See https://phpunit.readthedocs.io/en/9.5/configuration.html?highlight=cachedirectory#the-coverage-element

> When code coverage data is collected and processed, static code analysis is performed to improve reasoning about the covered code. This is an expensive operation, whose result can be cached. When the `cacheDirectory` attribute is set, static analysis results will be cached in the specified directory.

From my tests, it doesn't add any visible benefit, but idk probably let's try to use it, otherwise why does it exist?