### PR TITLE
Add Paratest adapter to run tests in parallel for the initial tests run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test-unit: $(PHPUNIT)
 .PHONY: test-unit-parallel
 test-unit-parallel:	## Runs the unit tests in parallel
 test-unit-parallel:
-	$(PARATEST)
+	$(PARATEST) --group=default
 
 .PHONY: test-unit-docker
 test-unit-docker:	## Runs the unit tests on the different Docker platforms

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
     },
     "require-dev": {
         "ext-simplexml": "*",
-        "brianium/paratest": "^6.3",
+        "brianium/paratest": "^6.3.1",
         "helmich/phpunit-json-assert": "^3.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/extension-installer": "^1.0",
@@ -80,7 +80,7 @@
         "phpstan/phpstan-phpunit": "^0.12.6",
         "phpstan/phpstan-strict-rules": "^0.12.5",
         "phpstan/phpstan-webmozart-assert": "^0.12.2",
-        "phpunit/phpunit": "^9.3.11",
+        "phpunit/phpunit": "^9.5.8",
         "symfony/phpunit-bridge": "^4.4.18 || ^5.1.10",
         "symfony/yaml": "^5.0",
         "thecodingmachine/phpstan-safe-rule": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e386c963bbc78549523114db79bcb94c",
+    "content-hash": "1c0463c5316831ad4e56283e9c2496d0",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -2080,16 +2080,16 @@
     "packages-dev": [
         {
             "name": "brianium/paratest",
-            "version": "v6.3.0",
+            "version": "v6.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "268d5b2b4237c0abf76c4aa9633ad8580be01e1e"
+                "reference": "3d81e35876f6497467310b123583cca6bd4c38f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/268d5b2b4237c0abf76c4aa9633ad8580be01e1e",
-                "reference": "268d5b2b4237c0abf76c4aa9633ad8580be01e1e",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/3d81e35876f6497467310b123583cca6bd4c38f2",
+                "reference": "3d81e35876f6497467310b123583cca6bd4c38f2",
                 "shasum": ""
             },
             "require": {
@@ -2101,25 +2101,25 @@
                 "phpunit/php-code-coverage": "^9.2.6",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-timer": "^5.0.3",
-                "phpunit/phpunit": "^9.5.4",
+                "phpunit/phpunit": "^9.5.8",
                 "sebastian/environment": "^5.1.3",
-                "symfony/console": "^4.4.21 || ^5.2.6",
-                "symfony/process": "^4.4.21 || ^5.2.4"
+                "symfony/console": "^4.4.23 || ^5.3.6",
+                "symfony/process": "^4.4.22 || ^5.3.4"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9.0.0",
                 "ekino/phpstan-banned-code": "^0.4.0",
                 "ergebnis/phpstan-rules": "^0.15.3",
                 "ext-posix": "*",
-                "infection/infection": "^0.21.5",
-                "phpstan/phpstan": "^0.12.84",
+                "infection/infection": "^0.24",
+                "phpstan/phpstan": "^0.12.94",
                 "phpstan/phpstan-deprecation-rules": "^0.12.6",
-                "phpstan/phpstan-phpunit": "^0.12.18",
-                "phpstan/phpstan-strict-rules": "^0.12.9",
+                "phpstan/phpstan-phpunit": "^0.12.21",
+                "phpstan/phpstan-strict-rules": "^0.12.10",
                 "squizlabs/php_codesniffer": "^3.6.0",
-                "symfony/filesystem": "^5.2.6",
+                "symfony/filesystem": "^5.3.4",
                 "thecodingmachine/phpstan-strict-rules": "^0.12.1",
-                "vimeo/psalm": "^4.7.1"
+                "vimeo/psalm": "^4.9.2"
             },
             "bin": [
                 "bin/paratest"
@@ -2158,7 +2158,7 @@
             ],
             "support": {
                 "issues": "https://github.com/paratestphp/paratest/issues",
-                "source": "https://github.com/paratestphp/paratest/tree/v6.3.0"
+                "source": "https://github.com/paratestphp/paratest/tree/v6.3.1"
             },
             "funding": [
                 {
@@ -2170,7 +2170,7 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2021-04-27T09:24:27+00:00"
+            "time": "2021-08-10T07:38:58+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -2359,16 +2359,16 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -2413,22 +2413,22 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2020-06-27T14:33:11+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "3.0.4",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451"
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/e4782611070e50613683d2b9a57730e9a3ba5451",
-                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
                 "shasum": ""
             },
             "require": {
@@ -2464,9 +2464,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.0.4"
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
-            "time": "2020-12-13T23:18:30+00:00"
+            "time": "2021-02-23T14:00:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2628,16 +2628,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
                 "shasum": ""
             },
             "require": {
@@ -2689,9 +2689,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-03-17T13:42:18+00:00"
         },
         {
             "name": "phpspec/prophecy-phpunit",
@@ -3329,16 +3329,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.4",
+            "version": "9.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741"
+                "reference": "191768ccd5c85513b4068bdbe99bb6390c7d54fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c73c6737305e779771147af66c96ca6a7ed8a741",
-                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/191768ccd5c85513b4068bdbe99bb6390c7d54fb",
+                "reference": "191768ccd5c85513b4068bdbe99bb6390c7d54fb",
                 "shasum": ""
             },
             "require": {
@@ -3350,7 +3350,7 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
@@ -3368,7 +3368,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3",
+                "sebastian/type": "^2.3.4",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -3416,7 +3416,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.8"
             },
             "funding": [
                 {
@@ -3428,7 +3428,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-03-23T07:16:29+00:00"
+            "time": "2021-07-31T15:17:34+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3870,16 +3870,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
                 "shasum": ""
             },
             "require": {
@@ -3922,7 +3922,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
             },
             "funding": [
                 {
@@ -3930,7 +3930,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:55:19+00:00"
+            "time": "2021-06-11T13:31:12+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -4221,16 +4221,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.1",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
                 "shasum": ""
             },
             "require": {
@@ -4265,7 +4265,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
             },
             "funding": [
                 {
@@ -4273,7 +4273,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:18:59+00:00"
+            "time": "2021-06-15T12:49:02+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4678,5 +4678,5 @@
     "platform-overrides": {
         "php": "7.4.7"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -51,8 +51,8 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
     private CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder;
     private InitialConfigBuilder $initialConfigBuilder;
     private MutationConfigBuilder $mutationConfigBuilder;
-    private VersionParser $versionParser;
-    private CommandLineBuilder $commandLineBuilder;
+    protected VersionParser $versionParser;
+    protected CommandLineBuilder $commandLineBuilder;
     private ?string $version;
 
     public function __construct(
@@ -176,7 +176,7 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         );
     }
 
-    private function retrieveVersion(): string
+    protected function retrieveVersion(): string
     {
         $testFrameworkVersionExecutable = $this->commandLineBuilder->build(
             $this->testFrameworkExecutable,

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework;
 
+use Infection\TestFramework\PhpUnit\Adapter\ParatestAdapterFactory;
 use function array_filter;
 use function array_map;
 use function implode;
@@ -135,6 +136,30 @@ final class Factory
                 $skipCoverage,
                 $this->infectionConfig->getExecuteOnlyCoveringTestCases(),
                 $filteredSourceFilesToMutate
+            );
+        }
+
+        if ($adapterName === TestFrameworkTypes::PARATEST) {
+            $phpUnitConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPUNIT);
+
+            return ParatestAdapterFactory::create(
+                $this->testFrameworkFinder->find(
+                    TestFrameworkTypes::PARATEST,
+                    (string) $this->infectionConfig->getPhpUnit()->getCustomPath()
+                ),
+                $this->tmpDir,
+                $phpUnitConfigPath,
+                (string) $this->infectionConfig->getPhpUnit()->getConfigDir(),
+                $this->jUnitFilePath,
+                $this->projectDir,
+                $this->infectionConfig->getSourceDirectories(),
+                $skipCoverage,
+                $this->infectionConfig->getExecuteOnlyCoveringTestCases(),
+                $filteredSourceFilesToMutate,
+                $this->testFrameworkFinder->find(
+                    TestFrameworkTypes::PHPUNIT,
+                    (string) $this->infectionConfig->getPhpUnit()->getCustomPath()
+                )
             );
         }
 

--- a/src/TestFramework/PhpUnit/Adapter/ParatestAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/ParatestAdapter.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Infection\TestFramework\PhpUnit\Adapter;
+
+
+use Infection\AbstractTestFramework\MemoryUsageAware;
+use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\TestFramework\ProvidesInitialRunOnlyOptions;
+use Infection\TestFramework\TestFrameworkTypes;
+use Symfony\Component\Process\Process;
+use function Safe\preg_match;
+use function Safe\sprintf;
+
+/**
+ * @internal
+ */
+final class ParatestAdapter implements MemoryUsageAware, ProvidesInitialRunOnlyOptions, TestFrameworkAdapter
+{
+    private const NAME = 'Paratest';
+
+    private PhpUnitAdapter $phpUnitAdapter;
+
+    public function __construct(PhpUnitAdapter $phpUnitAdapter)
+    {
+        $this->phpUnitAdapter = $phpUnitAdapter;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    public function testsPass(string $output): bool
+    {
+        return $this->phpUnitAdapter->testsPass($output);
+    }
+
+    public function hasJUnitReport(): bool
+    {
+        return $this->phpUnitAdapter->hasJUnitReport();
+    }
+
+    public function getInitialTestRunCommandLine(string $extraOptions, array $phpExtraArgs, bool $skipCoverage): array
+    {
+        return $this->phpUnitAdapter->getInitialTestRunCommandLine($extraOptions, $phpExtraArgs, $skipCoverage);
+    }
+
+    public function getMutantCommandLine(array $coverageTests, string $mutatedFilePath, string $mutationHash, string $mutationOriginalFilePath, string $extraOptions): array
+    {
+        return $this->phpUnitAdapter->getMutantCommandLine(
+            $coverageTests,
+            $mutatedFilePath,
+            $mutationHash,
+            $mutationOriginalFilePath,
+            $extraOptions
+        );
+    }
+
+    public function getVersion(): string
+    {
+        return $this->phpUnitAdapter->getVersion();
+    }
+
+    public function getInitialTestsFailRecommendations(string $commandLine): string
+    {
+        return $this->phpUnitAdapter->getInitialTestsFailRecommendations($commandLine);
+    }
+
+    public function getMemoryUsed(string $output): float
+    {
+        return $this->phpUnitAdapter->getMemoryUsed($output);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getInitialRunOnlyOptions(): array
+    {
+        return $this->phpUnitAdapter->getInitialRunOnlyOptions();
+    }
+
+}
+

--- a/src/TestFramework/PhpUnit/Adapter/ParatestAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/ParatestAdapterFactory.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Infection\TestFramework\PhpUnit\Adapter;
+
+
+use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
+use Infection\Config\ValueProvider\PCOVDirectoryProvider;
+use Infection\TestFramework\CommandLineBuilder;
+use Infection\TestFramework\Coverage\JUnit\JUnitTestCaseSorter;
+use Infection\TestFramework\PhpUnit\CommandLine\ArgumentsAndOptionsBuilder;
+use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder;
+use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
+use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
+use Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator;
+use Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider;
+use Infection\TestFramework\VersionParser;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+use Webmozart\Assert\Assert;
+use function Safe\file_get_contents;
+
+/**
+ * @internal
+ */
+final class ParatestAdapterFactory implements TestFrameworkAdapterFactory
+{
+    /**
+     * @param list<string> $filteredSourceFilesToMutate
+     */
+    public static function create(
+        string $testFrameworkExecutable,
+        string $tmpDir,
+        string $testFrameworkConfigPath,
+        ?string $testFrameworkConfigDir,
+        string $jUnitFilePath,
+        string $projectDir,
+        array $sourceDirectories,
+        bool $skipCoverage,
+        bool $executeOnlyCoveringTestCases = false,
+        array $filteredSourceFilesToMutate = [],
+        ?string $phpUnitExecutable = null
+    ): TestFrameworkAdapter {
+        Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the Paratest adapter');
+        Assert::string($phpUnitExecutable, 'PHPUnit executable must be passed to Paratest adapter');
+
+        $testFrameworkConfigContent = file_get_contents($testFrameworkConfigPath);
+
+        $configManipulator = new XmlConfigurationManipulator(
+            new PathReplacer(
+                new Filesystem(),
+                $testFrameworkConfigDir
+            ),
+            $testFrameworkConfigDir
+        );
+
+        $versionParser = new VersionParser();
+        $commandLineBuilder = new CommandLineBuilder();
+
+        $phpUnitVersion = self::retrievePhpUnitVersion($versionParser, $commandLineBuilder, $phpUnitExecutable);
+
+        $phpUnitAdapter = new PhpUnitAdapter(
+            $testFrameworkExecutable,
+            $tmpDir,
+            $jUnitFilePath,
+            new PCOVDirectoryProvider(),
+            new InitialConfigBuilder(
+                $tmpDir,
+                $testFrameworkConfigContent,
+                $configManipulator,
+                new XmlConfigurationVersionProvider(),
+                $sourceDirectories,
+                $filteredSourceFilesToMutate
+            ),
+            new MutationConfigBuilder(
+                $tmpDir,
+                $testFrameworkConfigContent,
+                $configManipulator,
+                $projectDir,
+                new JUnitTestCaseSorter()
+            ),
+            new ArgumentsAndOptionsBuilder($executeOnlyCoveringTestCases),
+            $versionParser,
+            $commandLineBuilder,
+            $phpUnitVersion
+        );
+
+        return new ParatestAdapter($phpUnitAdapter);
+    }
+
+    private static function retrievePhpUnitVersion(VersionParser $versionParser, CommandLineBuilder $commandLineBuilder, string $phpUnitExecutable): string
+    {
+        $testFrameworkVersionExecutable = $commandLineBuilder->build(
+            $phpUnitExecutable,
+            [],
+            ['--version']
+        );
+
+        $process = new Process($testFrameworkVersionExecutable);
+        $process->mustRun();
+
+        return $versionParser->parse($process->getOutput());
+    }
+
+    public static function getAdapterName(): string
+    {
+        return 'paratest';
+    }
+
+    public static function getExecutableName(): string
+    {
+        return 'paratest';
+    }
+}
+

--- a/src/TestFramework/TestFrameworkTypes.php
+++ b/src/TestFramework/TestFrameworkTypes.php
@@ -40,15 +40,17 @@ namespace Infection\TestFramework;
  */
 final class TestFrameworkTypes
 {
-    public const PHPUNIT = 'phpunit';
+    public const CODECEPTION = 'codeception';
+    public const PARATEST = 'paratest';
     public const PEST = 'pest';
     public const PHPSPEC = 'phpspec';
-    public const CODECEPTION = 'codeception';
+    public const PHPUNIT = 'phpunit';
 
     public const TYPES = [
-        self::PEST,
-        self::PHPUNIT,
-        self::PHPSPEC,
         self::CODECEPTION,
+        self::PARATEST,
+        self::PEST,
+        self::PHPSPEC,
+        self::PHPUNIT,
     ];
 }


### PR DESCRIPTION
TL;DR I will decline this PR because Paratest works worse under Infection than PHPUnit (see below), but I opened it for future history, to have a diff and the explanation

---

As I continue experimenting with speeding up the Infection process, I noticed that generating coverage is a too slow operation (known issue), and one of the ideas is how to speed it up - run **initial tests run** in parallel, and [Paratest](https://github.com/paratestphp/paratest) is the lib that does exactly that (we use it as a default tests runner on my daily job, and I use it for Infection itself).

While it did improve performance for the **initial tests run** (7s instead of ~30s), it had a bad impact for the **mutant processes**.

![image](https://user-images.githubusercontent.com/3725595/128900831-b865350a-170f-4bb4-aaa1-f1f2f5ea1f21.png)

From this screenshot, we can see that it's faster to just run PHPUnit (1 process) for 4 tests rather than running Paratest with it's loader that creates additional subprocesses.

Negative difference is:

```diff
- Time: 00:00.020, Memory: 12.00 MB
+ Time: 00:00.105, Memory: 8.00 MB
```

it is 5x slower.

Another issue is when you run Infection with let's say 4 threads, and for each mutant Paratest tries to create another let's say 12 threads, we have 2 issues here:

1. CPU is overheated
2. functional tests start failing, because 2 parallel threads created 24 subthreads and they start to write to the same DB (note: parallelization works good for Infection with functional tests thanks to [`TEST_TOKEN`](https://infection.github.io/guide/usage.html#Exposed-environment-variables), but not when one of the subprocess produces another N subprocesses)

So, keeping in mind all the issues above, I understood that the best way to go is to split the whole process by 2 steps:

1. Generate code coverage using Paratest - very fast, collects the same coverage as PHPUnit
2. Provide this coverage to Infection and run with `--skip-initial-tests`

In commands it will be:

```
# Step 1
vendor/bin/paratest --processes 12 --runner=WrapperRunner --coverage-xml=reports/coverage/coverage-xml --log-junit=reports/coverage/junit.xml --stop-on-failure

# Step 2
vendor/bin/infection -j 12 --coverage=reports --skip-initial-tests --only-covering-test-cases
```