### PR TITLE
Add `$schema` to generated `infection.json` config file for autocomple…

### DIFF
--- a/infection.json
+++ b/infection.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "./resources/schema.json",
     "timeout": 25,
     "source": {
         "directories": [

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -6,6 +6,9 @@
         "source"
     ],
     "properties": {
+        "$schema": {
+            "type": "string"
+        },
         "timeout": {
             "type": "number",
             "description": "The allowed timeout in seconds.",

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -37,7 +37,6 @@ namespace Infection\Command;
 
 use function count;
 use function file_exists;
-use function strpos;
 use const GLOB_ONLYDIR;
 use function implode;
 use Infection\Config\ConsoleHelper;
@@ -65,7 +64,7 @@ use function Safe\json_decode;
 use function Safe\json_encode;
 use function Safe\sprintf;
 use stdClass;
-use function str_starts_with;
+use function strpos;
 use function strstr;
 use Symfony\Component\Console\Input\InputOption;
 

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -37,6 +37,7 @@ namespace Infection\Command;
 
 use function count;
 use function file_exists;
+use function strpos;
 use const GLOB_ONLYDIR;
 use function implode;
 use Infection\Config\ConsoleHelper;
@@ -245,7 +246,7 @@ final class ConfigureCommand extends BaseCommand
         try {
             $version = strstr(Versions::getVersion(Application::PACKAGE_NAME), '@', true);
 
-            if ($version === false || str_starts_with($version, 'dev-')) {
+            if ($version === false || strpos($version, 'dev-') === 0) {
                 $version = 'master';
             }
         } catch (OutOfBoundsException $e) {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -55,9 +55,9 @@ use function trim;
  */
 final class Application extends BaseApplication
 {
-    private const NAME = 'Infection - PHP Mutation Testing Framework';
+    public const PACKAGE_NAME = 'infection/infection';
 
-    private const PACKAGE_NAME = 'infection/infection';
+    private const NAME = 'Infection - PHP Mutation Testing Framework';
 
     private const LOGO = '
     ____      ____          __  _

--- a/tests/e2e/Configure/infection.json.test
+++ b/tests/e2e/Configure/infection.json.test
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://raw.githubusercontent.com/infection/infection/master/resources/schema.json",
     "source": {
         "directories": [
             "src"


### PR DESCRIPTION
Now, generated `infection.json` file will include `$schema` key that IDEs will use for autocompletion.

Implements https://github.com/infection/infection/issues/1432