### PR TITLE
Display time and consumed memory even in case of insufficient MSI

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -110,14 +110,16 @@ final class Engine
         $this->runInitialTestSuite();
         $this->runMutationAnalysis();
 
-        $this->minMsiChecker->checkMetrics(
-            $this->metricsCalculator->getTestedMutantsCount(),
-            $this->metricsCalculator->getMutationScoreIndicator(),
-            $this->metricsCalculator->getCoveredCodeMutationScoreIndicator(),
-            $this->consoleOutput
-        );
-
-        $this->eventDispatcher->dispatch(new ApplicationExecutionWasFinished());
+        try {
+            $this->minMsiChecker->checkMetrics(
+                $this->metricsCalculator->getTestedMutantsCount(),
+                $this->metricsCalculator->getMutationScoreIndicator(),
+                $this->metricsCalculator->getCoveredCodeMutationScoreIndicator(),
+                $this->consoleOutput
+            );
+        } finally {
+            $this->eventDispatcher->dispatch(new ApplicationExecutionWasFinished());
+        }
     }
 
     private function runInitialTestSuite(): void


### PR DESCRIPTION
`Time: 3s. Memory: 15Mb` - this is printed on `ApplicationExecutionWasFinished` event, but if MSI check fails, exception is thrown and `ApplicationExecutionWasFinished` is not dispatched, so time and memory is not printed.

This change fixes the issue. Now, `ApplicationExecutionWasFinished` event is dispatched regardless of thrown exception

Before:

![image](https://user-images.githubusercontent.com/3725595/131247036-0aab72f5-5f66-4ca6-a41d-709d1cbbfe33.png)

After:

![image](https://user-images.githubusercontent.com/3725595/131247052-afc8493a-7f94-48b5-8085-117673c02186.png)
