### PR TITLE
Update name in mt-annotations.yaml

### DIFF
--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -1,7 +1,7 @@
 # yamllint disable rule:line-length
 # yamllint disable rule:braces
 
-name: Autoreview
+name: Annotations
 
 on:
     pull_request:


### PR DESCRIPTION
Currently at https://github.com/infection/infection/actions name `Autoreview` is duplicated:

![image](https://user-images.githubusercontent.com/9282069/132955587-1262b5a2-c41a-4250-af95-0411ee2243c1.png)
