### PR TITLE
Make GitHub annotation work when Infection is run in subdirectory

### DIFF
--- a/src/Logger/GitHubAnnotationsLogger.php
+++ b/src/Logger/GitHubAnnotationsLogger.php
@@ -36,8 +36,9 @@ declare(strict_types=1);
 namespace Infection\Logger;
 
 use Infection\Metrics\ResultsCollector;
-use function Safe\getcwd;
+use function shell_exec;
 use function str_replace;
+use function trim;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -57,7 +58,7 @@ final class GitHubAnnotationsLogger implements LineMutationTestingResultsLogger
     public function getLogLines(): array
     {
         $lines = [];
-        $currentWorkingDirectory = getcwd();
+        $projectRootDirectory = trim((string) shell_exec('git rev-parse --show-toplevel'));
 
         foreach ($this->resultsCollector->getEscapedExecutionResults() as $escapedExecutionResult) {
             $error = [
@@ -71,7 +72,7 @@ TEXT
             ];
 
             $lines[] = $this->buildAnnotation(
-                Path::makeRelative($escapedExecutionResult->getOriginalFilePath(), $currentWorkingDirectory),
+                Path::makeRelative($escapedExecutionResult->getOriginalFilePath(), $projectRootDirectory),
                 $error,
             );
         }


### PR DESCRIPTION
When Infection is run in Git's repository root (with `./backend/vendor/bin/infection`) then logged warnings are fine:
> ::warning file=backend/src/Foo.php,line=42::Escaped Mutant for Mutator (...)

However, when Infection is run in subdirectory (`backend`, with command `./vendor/bin/infection`) then logged warnings are like this:
> ::warning file=src/Foo.php,line=42::Escaped Mutant for Mutator (...)

which makes Github annotation not working.

This change fixes that problem.