### PR TITLE
Avoid parser bugs for very large negative numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ cs:	  	 	## Runs PHP-CS-Fixer
 cs: $(PHP_CS_FIXER)
 	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE) --diff
 	LC_ALL=C sort -u .gitignore -o .gitignore
-	$(MAKE) check_trailing_whitespaces || true
+	$(MAKE) check_trailing_whitespaces
 
 .PHONY: cs-check
 cs-check:		## Runs PHP-CS-Fixer in dry-run mode

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ cs:	  	 	## Runs PHP-CS-Fixer
 cs: $(PHP_CS_FIXER)
 	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE) --diff
 	LC_ALL=C sort -u .gitignore -o .gitignore
-	$(MAKE) check_trailing_whitespaces
+	$(MAKE) check_trailing_whitespaces || true
 
 .PHONY: cs-check
 cs-check:		## Runs PHP-CS-Fixer in dry-run mode

--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -9,6 +9,10 @@ parameters:
         - '#.* value type specified in iterable type Symfony\\Component\\Process\\Process#'
         - '#generic class ReflectionClass (but )?does not specify its types#'
         -
+            path: '../src/Mutator/Number/DecrementInteger.php'
+            message: '#Casting to int .* already int#'
+            count: 1
+        -
             path: '../src/PhpParser/FileParser.php'
             message: '#Method Infection\\PhpParser\\FileParser::parse\(\) should return array<PhpParser\\Node> but returns array<PhpParser\\Node\\Stmt>\|null\.#'
             count: 1

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -86,7 +86,10 @@ DIFF
         $value = $node->value - 1;
 
         if ($parentNode instanceof Node\Expr\UnaryMinus) {
-            $value = $node->value + 1;
+            // PHP Parser reads negative number as a pair of minus sign and a positive int,
+            // but positive part of PHP_INT_MIN leads to an overflow into float. To work
+            // around this we have to cast the result value back to int.
+            $value = (int) ($node->value + 1);
         }
 
         yield new Node\Scalar\LNumber($value);

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -40,7 +40,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\MutatorCategory;
 use Infection\PhpParser\Visitor\ParentConnector;
-use const PHP_INT_MIN;
+use const PHP_INT_MAX;
 use PhpParser\Node;
 
 /**
@@ -106,13 +106,16 @@ DIFF
             return false;
         }
 
-        if ($node->value === PHP_INT_MIN) {
+        $parentNode = ParentConnector::getParent($node);
+
+        // We cannot increment PHP_INT_MAX as part of a negative number, leads to parser bugs.
+        if ($node->value === PHP_INT_MAX && $parentNode instanceof Node\Expr\UnaryMinus) {
             return false;
         }
 
         if (
             $node->value === 1
-            && ($this->isPartOfComparison($node) || ParentConnector::getParent($node) instanceof Node\Expr\Assign)
+            && ($this->isPartOfComparison($node) || $parentNode instanceof Node\Expr\Assign)
         ) {
             return false;
         }

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -85,10 +85,15 @@ DIFF
 
         $value = $node->value - 1;
 
+        /*
+         * Parser gives us only positive numbers we have to check if parent node
+         * isn't a minus sign. If so, then means we have a negated positive number so
+         * we have to add to it instead of substracting.
+         */
         if ($parentNode instanceof Node\Expr\UnaryMinus) {
             // PHP Parser reads negative number as a pair of minus sign and a positive int,
             // but positive part of PHP_INT_MIN leads to an overflow into float. To work
-            // around this we have to cast the result value back to int.
+            // around this we have to cast the result value back to int after adding one.
             $value = (int) ($node->value + 1);
         }
 

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -95,6 +95,7 @@ DIFF
 
         $parentNode = ParentConnector::getParent($node);
 
+        // We cannot increment largest positive integer, but we can do that for a negative integer
         if ($node->value === PHP_INT_MAX && !$parentNode instanceof Node\Expr\UnaryMinus) {
             return false;
         }

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -75,6 +75,11 @@ DIFF
 
         $value = $node->value + 1;
 
+        /*
+         * Parser gives us only positive numbers we have to check if parent node
+         * isn't a minus sign. If so, then means we have a negated positive number so
+         * we have to substract to it instead of adding.
+         */
         if ($parentNode instanceof Node\Expr\UnaryMinus) {
             $value = $node->value - 1;
         }

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -88,13 +88,15 @@ DIFF
             return false;
         }
 
-        if ($node->value === PHP_INT_MAX) {
+        $parentNode = ParentConnector::getParent($node);
+
+        if ($node->value === PHP_INT_MAX && !$parentNode instanceof Node\Expr\UnaryMinus) {
             return false;
         }
 
         if (
             $node->value === 0
-            && ($this->isPartOfComparison($node) || ParentConnector::getParent($node) instanceof Node\Expr\Assign)
+            && ($this->isPartOfComparison($node) || $parentNode instanceof Node\Expr\Assign)
         ) {
             return false;
         }

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -522,18 +522,11 @@ PHP
 
         $minIntPlus1 = PHP_INT_MIN + 1;
 
-        yield 'It will decrement min int plus one' => [
+        yield 'It does not decrement min int plus one to avoid parser bugs' => [
             <<<"PHP"
             <?php
 
             if (1 === {$minIntPlus1}) {
-                echo 'bar';
-            }
-            PHP,
-            <<<"PHP"
-            <?php
-
-            if (1 === -({$minIntPlus1}-1)) {
                 echo 'bar';
             }
             PHP,

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -520,13 +520,13 @@ if (1 === {$minInt}) {
 PHP
         ];
 
-        $minIntPlus1 = PHP_INT_MIN + 1;
+        $maxInt = PHP_INT_MAX;
 
-        yield 'It does not decrement min int plus one to avoid parser bugs' => [
+        yield 'It does not decrement max int negative to avoid parser bugs' => [
             <<<"PHP"
             <?php
 
-            if (1 === {$minIntPlus1}) {
+            if (1 === -{$maxInt}) {
                 echo 'bar';
             }
             PHP,

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -519,5 +519,24 @@ if (1 === {$minInt}) {
 }
 PHP
         ];
+
+        $minIntPlus1 = PHP_INT_MIN + 1;
+
+        yield 'It will decrement min int plus one' => [
+            <<<"PHP"
+            <?php
+            
+            if (1 === {$minIntPlus1}) {
+                echo 'bar';
+            }
+            PHP,
+            <<<"PHP"
+            <?php
+            
+            if (1 === -({$minIntPlus1}-1)) {
+                echo 'bar';
+            }
+            PHP,
+        ];
     }
 }

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator\Number;
 
 use Infection\Tests\Mutator\BaseMutatorTestCase;
+use const PHP_INT_MAX;
 use const PHP_INT_MIN;
 
 final class DecrementIntegerTest extends BaseMutatorTestCase

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -280,7 +280,7 @@ PHP
             ,
         ];
 
-        yield 'It increments a negative integer' => [
+        yield 'It decrements a negative integer' => [
             <<<'PHP'
 <?php
 

--- a/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/DecrementIntegerTest.php
@@ -525,14 +525,14 @@ PHP
         yield 'It will decrement min int plus one' => [
             <<<"PHP"
             <?php
-            
+
             if (1 === {$minIntPlus1}) {
                 echo 'bar';
             }
             PHP,
             <<<"PHP"
             <?php
-            
+
             if (1 === -({$minIntPlus1}-1)) {
                 echo 'bar';
             }

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -263,7 +263,7 @@ PHP
         $minIntPlus1 = PHP_INT_MIN + 1;
         $minIntPlus2 = $minIntPlus1 + 1;
 
-        yield 'It increments min int plus one, -PHP_INT_MAX' => [
+        yield 'It increments min int plus one, up to value of -PHP_INT_MAX' => [
             <<<"PHP"
             <?php
 
@@ -280,18 +280,6 @@ PHP
             }
             PHP
             ,
-        ];
-
-        $minInt = PHP_INT_MIN;
-
-        yield 'It does not increment min int because of a parser bug (we get DNumber instead of LNumber)' => [
-            <<<"PHP"
-            <?php
-
-            if (\$foo === {$minInt}) {
-                echo 'bar';
-            }
-            PHP,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -266,7 +266,7 @@ PHP
         yield 'It increments min int plus one, -PHP_INT_MAX' => [
             <<<"PHP"
             <?php
-                        
+
             if (\$foo === {$minIntPlus1}) {
                 echo 'bar';
             }
@@ -274,7 +274,7 @@ PHP
             ,
             <<<"PHP"
             <?php
-                        
+
             if (\$foo === {$minIntPlus2}) {
                 echo 'bar';
             }
@@ -287,7 +287,7 @@ PHP
         yield 'It does not increment min int because of a parser bug (we get DNumber)' => [
             <<<"PHP"
             <?php
-            
+ 
             if (\$foo === {$minInt}) {
                 echo 'bar';
             }

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\Mutator\Number;
 
 use Infection\Tests\Mutator\BaseMutatorTestCase;
 use const PHP_INT_MAX;
+use const PHP_INT_MIN;
 
 final class IncrementIntegerTest extends BaseMutatorTestCase
 {
@@ -257,6 +258,40 @@ PHP
 
 random_int(10000001, {$maxInt});
 PHP
+        ];
+
+        $minIntPlus1 = PHP_INT_MIN + 1;
+        $minIntPlus2 = $minIntPlus1 + 1;
+
+        yield 'It increments min int plus one, -PHP_INT_MAX' => [
+            <<<"PHP"
+            <?php
+                        
+            if (\$foo === {$minIntPlus1}) {
+                echo 'bar';
+            }
+            PHP
+            ,
+            <<<"PHP"
+            <?php
+                        
+            if (\$foo === {$minIntPlus2}) {
+                echo 'bar';
+            }
+            PHP
+            ,
+        ];
+
+        $minInt = PHP_INT_MIN;
+
+        yield 'It does not increment min int because of a parser bug (we get DNumber)' => [
+            <<<"PHP"
+            <?php
+            
+            if (\$foo === {$minInt}) {
+                echo 'bar';
+            }
+            PHP,
         ];
     }
 }

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -287,7 +287,7 @@ PHP
         yield 'It does not increment min int because of a parser bug (we get DNumber)' => [
             <<<"PHP"
             <?php
- 
+
             if (\$foo === {$minInt}) {
                 echo 'bar';
             }

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -284,7 +284,7 @@ PHP
 
         $minInt = PHP_INT_MIN;
 
-        yield 'It does not increment min int because of a parser bug (we get DNumber)' => [
+        yield 'It does not increment min int because of a parser bug (we get DNumber instead of LNumber)' => [
             <<<"PHP"
             <?php
 


### PR DESCRIPTION
This is another take on the problem #1574, born after discussion in #1579.

Here we completely dodge any parser issues by refusing to increment `-9223372036854775807` which is `-PHP_INT_MAX`.

If we try to increment `-PHP_INT_MAX` we'll get a very fully looking contraption from PHP Parser:

``` 
-(-9223372036854775807-1)
```

Fixes #1574

