### PR TITLE
Add return types to anonymous functions

### DIFF
--- a/devTools/phpstan-src-baseline.neon
+++ b/devTools/phpstan-src-baseline.neon
@@ -16,16 +16,6 @@ parameters:
 			path: ../src/Config/Guesser/SourceDirGuesser.php
 
 		-
-			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
-			count: 1
-			path: ../src/Config/ValueProvider/ExcludeDirsProvider.php
-
-		-
-			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
-			count: 1
-			path: ../src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
-
-		-
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allString\\(\\) with array\\<string\\> will always evaluate to true\\.$#"
 			count: 1
 			path: ../src/Configuration/Configuration.php
@@ -44,11 +34,6 @@ parameters:
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allString\\(\\) with array\\<string\\> will always evaluate to true\\.$#"
 			count: 1
 			path: ../src/Configuration/Schema/InvalidSchema.php
-
-		-
-			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
-			count: 1
-			path: ../src/Differ/DiffColorizer.php
 
 		-
 			message: "#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#"
@@ -186,24 +171,9 @@ parameters:
 			path: ../src/Process/OriginalPhpProcess.php
 
 		-
-			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
-			count: 3
-			path: ../src/Process/Runner/MutationTestingRunner.php
-
-		-
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: ../src/TestFramework/Config/TestFrameworkConfigLocator.php
-
-		-
-			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
-			count: 1
-			path: ../src/TestFramework/Coverage/BufferedSourceFileFilter.php
-
-		-
-			message: "#^Anonymous function should have native return typehint \"int\\<\\-1, 1\\>\"\\.$#"
-			count: 1
-			path: ../src/TestFramework/Coverage/JUnit/JUnitTestCaseSorter.php
 
 		-
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Assert\\:\\:notNull\\(\\) with DOMNodeList\\<DOMElement\\> will always evaluate to true\\.$#"

--- a/devTools/phpstan-tests-baseline.neon
+++ b/devTools/phpstan-tests-baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: ../tests/phpunit/AutoReview/Mutator/MutatorTest.php
 
 		-
-			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
-			count: 2
-			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
-
-		-
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Assert\\:\\:resource\\(\\) with resource will always evaluate to true\\.$#"
 			count: 1
 			path: ../tests/phpunit/Config/ValueProvider/BaseProviderTest.php
@@ -46,11 +41,6 @@ parameters:
 			path: ../tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
 
 		-
-			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
-			count: 1
-			path: ../tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
-
-		-
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: ../tests/phpunit/Console/E2ETest.php
@@ -59,11 +49,6 @@ parameters:
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsIterable\\(\\) with iterable\\<Infection\\\\TestFramework\\\\Coverage\\\\Trace\\> will always evaluate to true\\.$#"
 			count: 1
 			path: ../tests/phpunit/ContainerTest.php
-
-		-
-			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
-			count: 2
-			path: ../tests/phpunit/EngineTest.php
 
 		-
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Assert\\:\\:notNull\\(\\) with Infection\\\\Tests\\\\EnvVariableManipulation\\\\EnvBackup and 'Attempted to…' will always evaluate to true\\.$#"
@@ -126,11 +111,6 @@ parameters:
 			path: ../tests/phpunit/FileSystem/Finder/Exception/FinderExceptionTest.php
 
 		-
-			message: "#^Anonymous function should have native return typehint \"Generator\"\\.$#"
-			count: 1
-			path: ../tests/phpunit/IterableCounterTest.php
-
-		-
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Assert\\:\\:string\\(\\) with string will always evaluate to true\\.$#"
 			count: 1
 			path: ../tests/phpunit/Logger/DummyLogger.php
@@ -144,11 +124,6 @@ parameters:
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Assert\\:\\:string\\(\\) with string will always evaluate to true\\.$#"
 			count: 1
 			path: ../tests/phpunit/Mutator/BaseMutatorTestCase.php
-
-		-
-			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
-			count: 1
-			path: ../tests/phpunit/Mutator/Extensions/BCMathTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Infection\\\\\\\\Mutator\\\\\\\\Mutator' and Infection\\\\Mutator\\\\Mutator will always evaluate to true\\.$#"
@@ -171,11 +146,6 @@ parameters:
 			path: ../tests/phpunit/PhpParser/FileParserTest.php
 
 		-
-			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
-			count: 4
-			path: ../tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php
-
-		-
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
@@ -186,34 +156,14 @@ parameters:
 			path: ../tests/phpunit/Process/Factory/MutantProcessFactoryTest.php
 
 		-
-			message: "#^Anonymous function should have native return typehint \"Generator\"\\.$#"
-			count: 1
-			path: ../tests/phpunit/Process/Runner/DryProcessRunnerTest.php
-
-		-
 			message: "#^Instanceof between Infection\\\\Event\\\\MutationTestingWasFinished\\|Infection\\\\Event\\\\MutationTestingWasStarted and class\\-string will always evaluate to true\\.$#"
 			count: 1
 			path: ../tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
 
 		-
-			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
-			count: 2
-			path: ../tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
-
-		-
-			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
-			count: 1
-			path: ../tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php
-
-		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Infection\\\\\\\\TestFramework\\\\\\\\Coverage\\\\\\\\JUnit\\\\\\\\TestFileNameNotFoundException' and Infection\\\\TestFramework\\\\Coverage\\\\JUnit\\\\TestFileNameNotFoundException will always evaluate to true\\.$#"
 			count: 1
 			path: ../tests/phpunit/TestFramework/Coverage/JUnit/TestFileNameNotFoundExceptionTest.php
-
-		-
-			message: "#^Anonymous function should have native return typehint \"int\\<\\-1, 1\\>\"\\.$#"
-			count: 1
-			path: ../tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTest.php
 
 		-
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
@@ -224,11 +174,6 @@ parameters:
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: ../tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
-
-		-
-			message: "#^Anonymous function should have native return typehint \"Generator\"\\.$#"
-			count: 2
-			path: ../tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'DOMDocument' and DOMDocument will always evaluate to true\\.$#"

--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -108,7 +108,7 @@ final class ExcludeDirsProvider
             $globDirs = glob($sourceDirs[0] . '/*', GLOB_ONLYDIR);
 
             $autocompleteValues = array_map(
-                static function (string $dir) use ($sourceDirs) {
+                static function (string $dir) use ($sourceDirs): string {
                     return str_replace($sourceDirs[0] . '/', '', $dir);
                 },
                 $globDirs

--- a/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
+++ b/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
@@ -92,7 +92,7 @@ final class PhpUnitCustomExecutablePathProvider
 
     private function getValidator(): Closure
     {
-        return static function ($answerPath) {
+        return static function ($answerPath): string {
             $answerPath = $answerPath !== '' ? trim($answerPath) : $answerPath;
 
             if ($answerPath === '' || !file_exists($answerPath)) {

--- a/src/Differ/DiffColorizer.php
+++ b/src/Differ/DiffColorizer.php
@@ -50,7 +50,7 @@ class DiffColorizer
     public function colorize(string $diff): string
     {
         $lines = array_map(
-            static function (string $line) {
+            static function (string $line): string {
                 if (strpos($line, '-') === 0) {
                     return sprintf('<diff-del>%s</diff-del>', $line);
                 }

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -104,7 +104,7 @@ class MutationTestingRunner
             ->cast(function (Mutation $mutation): Mutant {
                 return $this->mutantFactory->create($mutation);
             })
-            ->filter(function (Mutant $mutant) {
+            ->filter(function (Mutant $mutant): bool {
                 $mutatorName = $mutant->getMutation()->getMutatorName();
 
                 if (!array_key_exists($mutatorName, $this->ignoreSourceCodeMutatorsMap)) {
@@ -119,7 +119,7 @@ class MutationTestingRunner
 
                 return true;
             })
-            ->filter(function (Mutant $mutant) {
+            ->filter(function (Mutant $mutant): bool {
                 // It's a proxy call to Mutation, can be done one stage up
                 if ($mutant->isCoveredByTest()) {
                     return true;
@@ -131,7 +131,7 @@ class MutationTestingRunner
 
                 return false;
             })
-            ->filter(function (Mutant $mutant) {
+            ->filter(function (Mutant $mutant): bool {
                 // TODO refactor this comparison into a dedicated comparer to make it possible to swap strategies
                 if ($mutant->getMutation()->getNominalTestExecutionTime() < $this->timeout) {
                     return true;

--- a/src/TestFramework/Coverage/BufferedSourceFileFilter.php
+++ b/src/TestFramework/Coverage/BufferedSourceFileFilter.php
@@ -85,7 +85,7 @@ class BufferedSourceFileFilter implements FileFilter
     public function filter(iterable $input): iterable
     {
         return take($this->filter->filter($input))
-            ->filter(function (Trace $trace) {
+            ->filter(function (Trace $trace): bool {
                 $traceRealPath = $trace->getSourceFileInfo()->getRealPath();
 
                 Assert::string($traceRealPath);

--- a/src/TestFramework/Coverage/JUnit/JUnitTestCaseSorter.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestCaseSorter.php
@@ -97,7 +97,7 @@ final class JUnitTestCaseSorter
         if ($numberOfTestLocation < self::USE_BUCKET_SORT_AFTER) {
             usort(
                 $uniqueTestLocations,
-                static function (TestLocation $a, TestLocation $b) {
+                static function (TestLocation $a, TestLocation $b): int {
                     return $a->getExecutionTime() <=> $b->getExecutionTime();
                 }
             );

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -171,7 +171,7 @@ final class ProjectCodeProvider
         ;
 
         $classes = array_map(
-            static function (SplFileInfo $file) {
+            static function (SplFileInfo $file): string {
                 return sprintf(
                     '%s\\%s%s%s',
                     'Infection',
@@ -274,7 +274,7 @@ final class ProjectCodeProvider
         ;
 
         $classes = array_map(
-            static function (SplFileInfo $file) {
+            static function (SplFileInfo $file): string {
                 $fqcnPart = ltrim(str_replace('phpunit', '', $file->getRelativePath()), DIRECTORY_SEPARATOR);
                 $fqcnPart = str_replace(DIRECTORY_SEPARATOR, '\\', $fqcnPart);
 

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
@@ -104,7 +104,7 @@ final class SchemaConfigurationFileLoaderTest extends TestCase
 
     private static function createRawConfigWithPathArgument(string $path): Constraint
     {
-        return new Callback(static function (SchemaConfigurationFile $config) use ($path) {
+        return new Callback(static function (SchemaConfigurationFile $config) use ($path): bool {
             self::assertSame($path, $config->getPath());
 
             return true;

--- a/tests/phpunit/EngineTest.php
+++ b/tests/phpunit/EngineTest.php
@@ -160,7 +160,7 @@ final class EngineTest extends TestCase
         $eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->with($this->callback(static function (ApplicationExecutionWasFinished $event) {
+            ->with($this->callback(static function (ApplicationExecutionWasFinished $event): bool {
                 return true;
             }));
 
@@ -208,7 +208,7 @@ final class EngineTest extends TestCase
         $mutationTestingRunner
             ->expects($this->once())
             ->method('run')
-            ->with($this->callback(static function (iterable $input) {
+            ->with($this->callback(static function (iterable $input): bool {
                 return true;
             }))
         ;

--- a/tests/phpunit/IterableCounterTest.php
+++ b/tests/phpunit/IterableCounterTest.php
@@ -63,7 +63,7 @@ final class IterableCounterTest extends TestCase
 
     public function test_it_counts_iterator(): void
     {
-        $generator = (static function () {
+        $generator = (static function (): iterable {
             yield from [1 => 1, 2, 3];
         })();
 

--- a/tests/phpunit/Mutator/Extensions/BCMathTest.php
+++ b/tests/phpunit/Mutator/Extensions/BCMathTest.php
@@ -205,7 +205,7 @@ final class BCMathTest extends BaseMutatorTestCase
 
     private function generateArgumentsExpression(int $numberOfArguments): string
     {
-        return implode(', ', array_map(static function (string $argument) {
+        return implode(', ', array_map(static function (string $argument): string {
             return "'$argument'";
         }, $numberOfArguments > 0 ? range(1, $numberOfArguments) : []));
     }

--- a/tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php
@@ -75,7 +75,7 @@ final class MutatorVisitorTest extends BaseVisitorTest
 
     public function providesMutationCases(): iterable
     {
-        yield 'it mutates the correct node' => (function () {
+        yield 'it mutates the correct node' => (function (): iterable {
             return [
                 $nodes = $this->parseCode(<<<'PHP'
 <?php
@@ -126,7 +126,7 @@ PHP
             ];
         })();
 
-        yield 'it can mutate the node with multiple-ones' => (function () {
+        yield 'it can mutate the node with multiple-ones' => (function (): iterable {
             return [
                 $nodes = $this->parseCode(<<<'PHP'
 <?php
@@ -178,7 +178,7 @@ PHP
             ];
         })();
 
-        yield 'it does not mutate if only one of start or end position is correctly set' => (function () {
+        yield 'it does not mutate if only one of start or end position is correctly set' => (function (): iterable {
             return [
                 $nodes = $this->parseCode(<<<'PHP'
 <?php
@@ -232,7 +232,7 @@ PHP
             ];
         })();
 
-        yield 'it does not mutate if the parser does not contain startTokenPos' => (static function () {
+        yield 'it does not mutate if the parser does not contain startTokenPos' => (static function (): iterable {
             $badLexer = new Lexer\Emulative([
                 'usedAttributes' => [
                     'comments',

--- a/tests/phpunit/Process/Runner/DryProcessRunnerTest.php
+++ b/tests/phpunit/Process/Runner/DryProcessRunnerTest.php
@@ -45,7 +45,7 @@ final class DryProcessRunnerTest extends TestCase
     {
         $called = false;
 
-        $processes = (static function () use (&$called) {
+        $processes = (static function () use (&$called): iterable {
             yield new FakeProcessBearer();
 
             $called = true;

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -553,7 +553,7 @@ final class MutationTestingRunnerTest extends TestCase
 
     private function emptyIterable(): Callback
     {
-        return $this->someIterable(static function (iterable $subject) {
+        return $this->someIterable(static function (iterable $subject): bool {
             foreach ($subject as $value) {
                 return false;
             }
@@ -564,7 +564,7 @@ final class MutationTestingRunnerTest extends TestCase
 
     private function iterableContaining(array $expected): Callback
     {
-        return $this->someIterable(static function (iterable $subject) use ($expected) {
+        return $this->someIterable(static function (iterable $subject) use ($expected): bool {
             $actual = [];
 
             foreach ($subject as $value) {

--- a/tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php
+++ b/tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php
@@ -64,7 +64,7 @@ final class PerformanceLoggerSubscriberTest extends TestCase
     {
         $this->output->expects($this->once())
             ->method('writeln')
-            ->with($this->callback(static function ($parameter) {
+            ->with($this->callback(static function ($parameter): bool {
                 return is_array($parameter) && $parameter[0] === '' && strpos($parameter[1], 'Time:') === 0;
             }));
 

--- a/tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTest.php
@@ -233,7 +233,7 @@ final class TestLocationBucketSorterTest extends TestCase
     {
         usort(
             $uniqueTestLocations,
-            static function (TestLocation $a, TestLocation $b) {
+            static function (TestLocation $a, TestLocation $b): int {
                 return $a->getExecutionTime() <=> $b->getExecutionTime();
             }
         );

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php
@@ -56,7 +56,7 @@ final class XmlConfigurationVersionProviderTest extends TestCase
     public function configurationsProvider()
     {
         yield from take($this->legacyConfigurationsProvider())
-            ->map(static function (string $xml) {
+            ->map(static function (string $xml): iterable {
                 yield $xml => [
                     SafeDOMXPath::fromString($xml),
                     false,
@@ -64,7 +64,7 @@ final class XmlConfigurationVersionProviderTest extends TestCase
             });
 
         yield from take($this->mainlineConfigurationsProvider())
-            ->map(static function (string $xml) {
+            ->map(static function (string $xml): iterable {
                 yield $xml => [
                     SafeDOMXPath::fromString($xml),
                     true,


### PR DESCRIPTION
This PR fixes issues "Anonymous function should have native return typehint" reported by PHPStan.