### PR TITLE
Always use strict parameters

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -63,9 +63,11 @@ $finder = Finder::create()
     ])
     ->ignoreDotFiles(false)
     ->name('*php')
-    ->name('.php_cs.dist')
-    ->name('infection')
-    ->name('infection-debug')
+    ->append([
+        __DIR__ . '/bin/infection',
+        __DIR__ . '/bin/infection-debug',
+        __FILE__,
+    ])
 ;
 
 return (new Config())
@@ -155,6 +157,7 @@ return (new Config())
         'single_line_throw' => false,
         'static_lambda' => true,
         'strict_comparison' => true,
+        'strict_param' => true,
         'yoda_style' => [
             'equal' => false,
             'identical' => false,

--- a/devTools/phpstan-src-baseline.neon
+++ b/devTools/phpstan-src-baseline.neon
@@ -151,11 +151,6 @@ parameters:
 			path: ../src/Mutator/Operator/Finally_.php
 
 		-
-			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 1
-			path: ../src/Mutator/Removal/FunctionCallRemoval.php
-
-		-
 			message: "#^Call to static method Webmozart\\\\Assert\\\\Mixin\\:\\:allIsInstanceOf\\(\\) with array\\<PhpParser\\\\Node\\> and 'PhpParser\\\\\\\\Node' will always evaluate to true\\.$#"
 			count: 1
 			path: ../src/PhpParser/MutatedNode.php

--- a/src/Mutator/Removal/FunctionCallRemoval.php
+++ b/src/Mutator/Removal/FunctionCallRemoval.php
@@ -104,6 +104,6 @@ DIFF
             return true;
         }
 
-        return !in_array($name->toLowerString(), $this->doNotRemoveFunctions);
+        return !in_array($name->toLowerString(), $this->doNotRemoveFunctions, true);
     }
 }

--- a/tests/phpunit/Logger/JsonLoggerTest.php
+++ b/tests/phpunit/Logger/JsonLoggerTest.php
@@ -363,7 +363,7 @@ final class JsonLoggerTest extends TestCase
                 0,
                 For_::class,
                 DetectionStatus::NOT_COVERED,
-                base64_decode('abc') // produces non UTF-8 character
+                base64_decode('abc', true) // produces non UTF-8 character
             ),
         );
 


### PR DESCRIPTION
In many other places strict parameters are already used, with the `strict_param` fixer all will be fir sure.

(the root of this PR is PHPStan error in baseline file)