### PR TITLE
PHPStan fixes

### DIFF
--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -17,26 +17,6 @@ parameters:
             message: '#^Strict comparison using !== between array<int, Infection\\Mutant\\MutantExecutionResult> and array\(\) will always evaluate to true\.$#'
             count: 1
         -
-            path: '../src/Mutator/Number/DecrementInteger.php'
-            message: '#Casting to int .* already int#'
-            count: 1
-        -
-            path: '../src/PhpParser/FileParser.php'
-            message: '#Method Infection\\PhpParser\\FileParser::parse\(\) should return array<PhpParser\\Node> but returns array<PhpParser\\Node\\Stmt>\|null\.#'
-            count: 1
-        -
-            path: '../src/Reflection/AnonymousClassReflection.php'
-            message: '#Parameter \#1 \$argument of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object\, string given\.#'
-            count: 1
-        -
-            path: '../src/Reflection/CoreClassReflection.php'
-            message: '#Parameter \#1 \$argument of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object\, string given\.#'
-            count: 1
-        -
-            path: '../src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php'
-            message: '#Function realpath is unsafe to use\.#'
-            count: 1
-        -
             path: ../src/TestFramework/Factory.php
             message: '#^Parameter \#1 \$callback of function array_map expects callable\(Infection\\TestFramework\\Coverage\\Trace\|SplFileInfo\): mixed, Closure\(SplFileInfo\): string\|false given\.$#'
             count: 1
@@ -48,10 +28,11 @@ parameters:
             path: '../src/Container.php'
             message: '#^Method Infection\\Container::get.*\(\) should return .* but returns object\.$#'
             count: 1
-        -
-            path: '../src/FileSystem/DummyFileSystem.php'
-            message: '#Infection\\FileSystem\\DummyFileSystem#'
     level: max
     paths:
         - ../src
+    excludes_analyse:
+        - %currentWorkingDirectory%/src/FileSystem/DummyFileSystem.php
+    stubFiles:
+        - phpstan.stub
     treatPhpDocTypesAsCertain: false

--- a/devTools/phpstan.stub
+++ b/devTools/phpstan.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpParser\Node {
+    class Name {
+        /**
+         * @return class-string
+         */
+        public function toString() {}
+    }
+}

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -94,7 +94,7 @@ DIFF
             // PHP Parser reads negative number as a pair of minus sign and a positive int,
             // but positive part of PHP_INT_MIN leads to an overflow into float. To work
             // around this we have to cast the result value back to int after adding one.
-            $value = (int) ($node->value + 1);
+            $value = $node->value + 1;
         }
 
         yield new Node\Scalar\LNumber($value);

--- a/src/PhpParser/FileParser.php
+++ b/src/PhpParser/FileParser.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\PhpParser;
 
-use PhpParser\Node;
+use PhpParser\Node\Stmt;
 use PhpParser\Parser;
 use Symfony\Component\Finder\SplFileInfo;
 use Throwable;
@@ -56,12 +56,12 @@ class FileParser
     /**
      * @throws UnparsableFile
      *
-     * @return Node[]
+     * @return Stmt[]
      */
     public function parse(SplFileInfo $fileInfo): array
     {
         try {
-            return $this->parser->parse($fileInfo->getContents());
+            return $this->parser->parse($fileInfo->getContents()) ?? [];
         } catch (Throwable $throwable) {
             $filePath = $fileInfo->getRealPath() === false
                 ? $fileInfo->getPathname()

--- a/src/Reflection/AnonymousClassReflection.php
+++ b/src/Reflection/AnonymousClassReflection.php
@@ -49,6 +49,9 @@ final class AnonymousClassReflection implements ClassReflection
         $this->reflectionClass = $reflectionClass;
     }
 
+    /**
+     * @param class-string $className
+     */
     public static function fromClassName(string $className): self
     {
         return new self(new ReflectionClass($className));

--- a/src/Reflection/CoreClassReflection.php
+++ b/src/Reflection/CoreClassReflection.php
@@ -50,6 +50,9 @@ final class CoreClassReflection implements ClassReflection
         $this->reflectionClass = $reflectionClass;
     }
 
+    /**
+     * @param class-string $className
+     */
     public static function fromClassName(string $className): self
     {
         return new self(new ReflectionClass($className));

--- a/src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
@@ -40,8 +40,9 @@ use const DIRECTORY_SEPARATOR;
 use function file_exists;
 use function implode;
 use Infection\TestFramework\SafeDOMXPath;
-use function realpath as native_realpath;
+use Safe\Exceptions\FilesystemException;
 use function Safe\file_get_contents;
+use function Safe\realpath;
 use function Safe\sprintf;
 use function str_replace;
 use Symfony\Component\Finder\SplFileInfo;
@@ -130,9 +131,9 @@ class SourceFileInfoProvider
             ])
         );
 
-        $realPath = native_realpath($path);
-
-        if ($realPath === false) {
+        try {
+            $realPath = realpath($path);
+        } catch (FilesystemException $e) {
             $coverageFilePath = Path::canonicalize(
                 $this->coverageDir . DIRECTORY_SEPARATOR . $this->relativeCoverageFilePath
             );


### PR DESCRIPTION
Except straightforward fixes this PR introduces `phpstan.stub` (file extension according to [the suggesstion](https://phpstan.org/user-guide/stub-files)) - I wonder what's the opinion on the stub approach - is it something we want to have in Infection or do we prefer to not have it and live with more exceptions in `phpstan*.neon` files?