### PR TITLE
Relax version requirements for the pipeline library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "nikic/php-parser": "^4.13",
         "ondram/ci-detector": "^3.3.0",
         "sanmai/later": "^0.1.1",
-        "sanmai/pipeline": "^5.1",
+        "sanmai/pipeline": "^5.1 || ^6",
         "sebastian/diff": "^3.0.2 || ^4.0",
         "seld/jsonlint": "^1.7",
         "symfony/console": "^3.4.29 || ^4.1.19 || ^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08b6591cc93c6d5edab64eceaca91668",
+    "content-hash": "119f7c2f2bf8fba0f60d0c8b738e3594",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -593,16 +593,16 @@
         },
         {
             "name": "sanmai/pipeline",
-            "version": "v5.1.0",
+            "version": "v6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sanmai/pipeline.git",
-                "reference": "f935e10ddcb758c89829e7b69cfb1dc2b2638518"
+                "reference": "86c1df94c588ee075f977177aba1fe5d959045af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/f935e10ddcb758c89829e7b69cfb1dc2b2638518",
-                "reference": "f935e10ddcb758c89829e7b69cfb1dc2b2638518",
+                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/86c1df94c588ee075f977177aba1fe5d959045af",
+                "reference": "86c1df94c588ee075f977177aba1fe5d959045af",
                 "shasum": ""
             },
             "require": {
@@ -610,19 +610,19 @@
             },
             "require-dev": {
                 "ergebnis/composer-normalize": "^2.8",
-                "friendsofphp/php-cs-fixer": "^2.16",
+                "friendsofphp/php-cs-fixer": "^3",
                 "infection/infection": ">=0.10.5",
                 "league/pipeline": "^1.0 || ^0.3",
-                "phan/phan": "^1.1 || ^2.0 || ^3.0",
+                "phan/phan": ">=1.1",
                 "php-coveralls/php-coveralls": "^2.4.1",
                 "phpstan/phpstan": ">=0.10",
                 "phpunit/phpunit": "^7.4 || ^8.1 || ^9.4",
-                "vimeo/psalm": "^2.0 || ^3.0 || ^4.0"
+                "vimeo/psalm": ">=2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "v5.x-dev"
+                    "dev-main": "v6.x-dev"
                 }
             },
             "autoload": {
@@ -646,7 +646,7 @@
             "description": "General-purpose collections pipeline",
             "support": {
                 "issues": "https://github.com/sanmai/pipeline/issues",
-                "source": "https://github.com/sanmai/pipeline/tree/v5.1.0"
+                "source": "https://github.com/sanmai/pipeline/tree/v6.0"
             },
             "funding": [
                 {
@@ -654,7 +654,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-25T15:20:56+00:00"
+            "time": "2021-11-02T02:11:56+00:00"
         },
         {
             "name": "sebastian/diff",


### PR DESCRIPTION
This PR:

- [x] Relax version requirements for the pipeline library. The new version should be non BC breaking as far as Infection is concerned. It also comes with a bunch of new methods we hopefully could use later.
