### PR TITLE
Use `InstalledVersions::getPrettyVersion()` to have `1.0.2` instead of `1.0.2.0` 

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -73,7 +73,7 @@ final class Application extends BaseApplication
     public function __construct(Container $container)
     {
         try {
-            $version = (string) InstalledVersions::getVersion(self::PACKAGE_NAME);
+            $version = (string) InstalledVersions::getPrettyVersion(self::PACKAGE_NAME);
             // @codeCoverageIgnoreStart
         } catch (OutOfBoundsException $e) {
             if (preg_match('#package .*' . preg_quote(self::PACKAGE_NAME, '#') . '.* not installed#i', $e->getMessage()) === 0) {

--- a/src/Process/Factory/InitialTestsRunProcessFactory.php
+++ b/src/Process/Factory/InitialTestsRunProcessFactory.php
@@ -79,7 +79,7 @@ class InitialTestsRunProcessFactory
 
         $process->setTimeout(null); // Ignore the default timeout of 60 seconds
 
-        if (method_exists($process, 'inheritEnvironmentVariables') && version_compare((string) InstalledVersions::getVersion('symfony/console'), 'v4.4', '<')) {
+        if (method_exists($process, 'inheritEnvironmentVariables') && version_compare((string) InstalledVersions::getPrettyVersion('symfony/console'), 'v4.4', '<')) {
             // In version 4.4.0 this method is deprecated and removed in 5.0.0
             $process->inheritEnvironmentVariables();
         }

--- a/src/Process/Factory/MutantProcessFactory.php
+++ b/src/Process/Factory/MutantProcessFactory.php
@@ -84,7 +84,7 @@ class MutantProcessFactory
 
         $process->setTimeout($this->timeout);
 
-        if (method_exists($process, 'inheritEnvironmentVariables') && version_compare((string) InstalledVersions::getVersion('symfony/console'), 'v4.4', '<')) {
+        if (method_exists($process, 'inheritEnvironmentVariables') && version_compare((string) InstalledVersions::getPrettyVersion('symfony/console'), 'v4.4', '<')) {
             // in version 4.4.0 this method is deprecated and removed in 5.0.0
             $process->inheritEnvironmentVariables();
         }


### PR DESCRIPTION
Use `InstalledVersions::getPrettyVersion()` to have `1.0.2` instead of `1.0.2.0`  with extra zero at the end

Fixes https://github.com/infection/infection/issues/1589