### PR TITLE
Use explicit `e2e-runner` and test PHAR on PHP 8.0 with Xdebug

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,10 +21,11 @@ jobs:
         coverage-driver: [pcov, xdebug]
         e2e-runner: ['bin/infection']
         include:
-          - { operating-system: 'windows-latest', php-version: '7.4', coverage-driver: 'xdebug' }
-          - { operating-system: 'ubuntu-latest', php-version: '7.4', coverage-driver: 'pcov' }
+          - { operating-system: 'windows-latest', php-version: '7.4', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
+          - { operating-system: 'ubuntu-latest', php-version: '7.4', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
           - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'pcov', e2e-runner: 'build/infection.phar' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.1', coverage-driver: 'pcov' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'xdebug', e2e-runner: 'build/infection.phar' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.1', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
 
     name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }} with ${{ matrix.e2e-runner }}
 
@@ -104,10 +105,13 @@ jobs:
         env:
           TERM: xterm-256color
         run: |
+          if [[ "${{ matrix.php-version }}" == '8.1' ]]; then
+            export SYMFONY_DEPRECATIONS_HELPER=max[direct]=1
+          fi
           make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=bin/infection
 
       - name: Run the whole set of E2E tests with prefixed PHAR
-        if: runner.os != 'Windows' && matrix.e2e-runner != 'bin/infection' && matrix.php-version == '8.0'
+        if: runner.os != 'Windows' && matrix.e2e-runner == 'build/infection.phar' && (matrix.php-version == '8.0' || matrix.php-version == '8.1')
         env:
           TERM: xterm-256color
         run: |


### PR DESCRIPTION
```diff
- Tests / CI on ubuntu-latest with PHP 8.1, using pcov with 
+ Tests / CI on ubuntu-latest with PHP 8.1, using pcov with `bin/infection`
+ Tests / CI on ubuntu-latest with PHP 8.1, using pcov with `build/infection.phar`
```

* Now all jobs will have correct displayed names
* Conditions are now positive `== 'build/infection.phar` instead of negative `!= 'bin/infection`. Because empty string inside `e2e-runner` was resulted to `true` with negative condition
* New step: test PHAR on PHP 8.0 with `Xdebug` (in addition to `pcov`)