### PR TITLE
Do not run Infection for itself on windows

### DIFF
--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest]
+        operating-system: [ubuntu-latest]
         php-version: ['7.4']
         coverage-driver: [pcov]
 


### PR DESCRIPTION
* It takes too much time (26m vs 6-7m on Ubuntu)
* We already test Infection on Windows in `ci.yaml` in e2e tests

As a result, the whole build will take 6-7 minutes instead of 26 minutes
