### PR TITLE
Code improvements for PHPStan v1

### DIFF
--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -34,10 +34,10 @@ parameters:
         -
             path: '../src/TestFramework/Coverage/CoverageChecker.php'
             message: '#Function ini_get is unsafe to use#'
-    level: max
+    level: 8
     paths:
         - ../src
-    excludes_analyse:
+    excludePaths:
         - %currentWorkingDirectory%/src/FileSystem/DummyFileSystem.php
     stubFiles:
         - phpstan.stub

--- a/devTools/phpstan-tests.neon
+++ b/devTools/phpstan-tests.neon
@@ -4,7 +4,7 @@ parameters:
         processTimeout: 120.0
     checkGenericClassInNonGenericObjectType: false
     checkMissingIterableValueType: false
-    excludes_analyse:
+    excludePaths:
         - %currentWorkingDirectory%/tests/e2e/*
         - %currentWorkingDirectory%/tests/phpunit/Fixtures/*
     inferPrivatePropertyTypeFromConstructor: true

--- a/tests/phpunit/Event/Subscriber/MutationTestingResultsCollectorSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingResultsCollectorSubscriberTest.php
@@ -35,46 +35,15 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Event\Subscriber;
 
-use Infection\Console\OutputFormatter\OutputFormatter;
-use Infection\Differ\DiffColorizer;
 use Infection\Event\EventDispatcher\SyncEventDispatcher;
 use Infection\Event\MutantProcessWasFinished;
 use Infection\Event\Subscriber\MutationTestingResultsCollectorSubscriber;
 use Infection\Metrics\Collector;
-use Infection\Metrics\MetricsCalculator;
-use Infection\Metrics\ResultsCollector;
 use Infection\Mutant\MutantExecutionResult;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Output\OutputInterface;
 
 final class MutationTestingResultsCollectorSubscriberTest extends TestCase
 {
-    /**
-     * @var OutputInterface|MockObject
-     */
-    private $output;
-
-    /**
-     * @var OutputFormatter|MockObject
-     */
-    private $outputFormatter;
-
-    /**
-     * @var MetricsCalculator|MockObject
-     */
-    private $metricsCalculator;
-
-    /**
-     * @var ResultsCollector|MockObject
-     */
-    private $resultsCollector;
-
-    /**
-     * @var DiffColorizer|MockObject
-     */
-    private $diffColorizer;
-
     public function test_it_reacts_on_mutation_process_finished(): void
     {
         $collectorA = $this->createMock(Collector::class);

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -67,11 +67,6 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
     private static $pathName;
 
     /**
-     * @var array
-     */
-    private static $names;
-
-    /**
      * @var Filesystem
      */
     private $fileSystem;
@@ -82,7 +77,6 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
     public static function setUpBeforeClass(): void
     {
         self::$pathName = getenv('PATH') ? 'PATH' : 'Path';
-        self::$names = [self::$pathName, 'PATHEXT'];
     }
 
     protected function setUp(): void

--- a/tests/phpunit/Logger/BadgeLoggerFactoryTest.php
+++ b/tests/phpunit/Logger/BadgeLoggerFactoryTest.php
@@ -39,56 +39,25 @@ use function array_map;
 use function get_class;
 use Infection\Configuration\Entry\Badge;
 use Infection\Configuration\Entry\Logs;
-use Infection\Console\LogVerbosity;
 use Infection\Logger\BadgeLogger;
 use Infection\Logger\BadgeLoggerFactory;
 use Infection\Logger\FederatedLogger;
 use Infection\Logger\FileLogger;
 use Infection\Logger\MutationTestingResultsLogger;
 use Infection\Metrics\MetricsCalculator;
-use Infection\Metrics\ResultsCollector;
 use Infection\Tests\Fixtures\FakeCiDetector;
 use Infection\Tests\Fixtures\Logger\FakeLogger;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @group integration
  */
 final class BadgeLoggerFactoryTest extends TestCase
 {
-    /**
-     * @var MetricsCalculator
-     */
-    private $metricsCalculator;
-
-    /**
-     * @var ResultsCollector
-     */
-    private $resultsCollector;
-
-    /**
-     * @var Filesystem|MockObject
-     */
-    private $fileSystemMock;
-
-    protected function setUp(): void
-    {
-        $this->metricsCalculator = new MetricsCalculator(2);
-        $this->resultsCollector = new ResultsCollector();
-
-        $this->fileSystemMock = $this->createMock(Filesystem::class);
-    }
-
     public function test_it_does_not_create_any_logger_for_no_verbosity_level_and_no_badge(): void
     {
-        $factory = $this->createLoggerFactory(
-            LogVerbosity::NONE,
-            true,
-            true
-        );
+        $factory = $this->createLoggerFactory();
 
         $logger = $factory->createFromLogEntries(
             new Logs(
@@ -107,11 +76,7 @@ final class BadgeLoggerFactoryTest extends TestCase
 
     public function test_it_creates_a_badge_logger_on_no_verbosity(): void
     {
-        $factory = $this->createLoggerFactory(
-            LogVerbosity::NONE,
-            true,
-            true
-        );
+        $factory = $this->createLoggerFactory();
 
         $logger = $factory->createFromLogEntries(
             new Logs(
@@ -135,11 +100,7 @@ final class BadgeLoggerFactoryTest extends TestCase
         Logs $logs,
         ?string $expectedLogger
     ): void {
-        $factory = $this->createLoggerFactory(
-            LogVerbosity::NORMAL,
-            true,
-            true
-        );
+        $factory = $this->createLoggerFactory();
 
         $logger = $factory->createFromLogEntries($logs);
 
@@ -186,13 +147,10 @@ final class BadgeLoggerFactoryTest extends TestCase
         ];
     }
 
-    private function createLoggerFactory(
-        string $logVerbosity,
-        bool $debugMode,
-        bool $onlyCoveredCode
-    ): BadgeLoggerFactory {
+    private function createLoggerFactory(): BadgeLoggerFactory
+    {
         return new BadgeLoggerFactory(
-            $this->metricsCalculator,
+            new MetricsCalculator(2),
             new FakeCiDetector(),
             new FakeLogger(),
         );

--- a/tests/phpunit/Mutator/BaseMutatorTestCase.php
+++ b/tests/phpunit/Mutator/BaseMutatorTestCase.php
@@ -67,8 +67,8 @@ abstract class BaseMutatorTestCase extends TestCase
     }
 
     /**
-     * @var string|string[]
-     * @var mixed[] $settings
+     * @param string|string[] $expectedCode
+     * @param mixed[] $settings
      */
     final public function doTest(string $inputCode, $expectedCode = [], array $settings = [], bool $allowInvalidCode = false): void
     {


### PR DESCRIPTION
This PR:

- replaces deprecated `excludes_analyse` with `excludePaths`
- changes PHPStan level from `max` to `8` - in PHPStan v1 the max level will be `9` with quite a few errors reported
- updates tests, mostly removing unused properties