### PR TITLE
fix: adjust signature of inherited method

### DIFF
--- a/src/FileSystem/Finder/Iterator/RealPathFilterIterator.php
+++ b/src/FileSystem/Finder/Iterator/RealPathFilterIterator.php
@@ -77,7 +77,7 @@ final class RealPathFilterIterator extends MultiplePcreFilterIterator
      *
      * @return string regexp corresponding to a given string or regexp
      */
-    protected function toRegex($str)
+    protected function toRegex(string $str): string
     {
         return $this->isRegex($str) ? $str : '/' . preg_quote($str, '/') . '/';
     }


### PR DESCRIPTION
Infection currently requires:
`symfony/finder:^3.4.29 || ^4.1.19 || ^5.0 || ^6.0`

In version ^5.0, the signature of the following parameter changed:
`MultiplePcreFilterIterator::toRegex(string $str)`

In version ^6.0, the return type of the method changed as well.

To ensure inheritance compatibility, the signature of the method
`RealPathFilterIterator::toRegex` is changed.