### PR TITLE
Ignore `Assert::*` mutations

### DIFF
--- a/infection.json
+++ b/infection.json
@@ -12,6 +12,9 @@
         }
     },
     "mutators": {
+        "global-ignoreSourceCodeByRegex": [
+            "Assert::.*"
+        ],
         "@default": true
     }
 }


### PR DESCRIPTION
* Because most of them would be killed by psalm/phpstan static analysis tools (see https://github.com/Roave/infection-static-analysis-plugin, at some point will be supported natively by Infection)
* Because it doesn't make much sense to mutate some assertions, see below

https://github.com/infection/infection/blob/7e118c3c5762c44812f41c829d61bebf89fe4fa0/src/Command/BaseCommand.php#L56-L61

```diff
Assert::isInstanceOf(
            $application,
            Application::class,
            'Cannot access to the command application if the command has not been '
-            . 'registered to the application yet'
        );
```
^ there is no benefit in such mutations


MSI has been increased (which is expected):

```diff
Metrics:
-        Mutation Score Indicator (MSI): 69%
+        Mutation Score Indicator (MSI): 71%
         Mutation Code Coverage: 82%
-        Covered Code MSI: 84%
+        Covered Code MSI: 86%
```