### PR TITLE
Treat all function signature nodes as 1-line range to avoid duplicate TestLocations

### DIFF
--- a/src/TestFramework/Coverage/LineRangeCalculator.php
+++ b/src/TestFramework/Coverage/LineRangeCalculator.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\TestFramework\Coverage;
 
 use Infection\PhpParser\Visitor\ParentConnector;
+use Infection\PhpParser\Visitor\ReflectionVisitor;
 use PhpParser\Node;
 
 /**
@@ -47,7 +48,11 @@ final class LineRangeCalculator
     {
         $node = $this->getOuterMostArrayNode($node);
 
-        return new NodeLineRangeData($node->getStartLine(), $node->getEndLine());
+        $endLine = $node->getAttribute(ReflectionVisitor::IS_ON_FUNCTION_SIGNATURE, false) === true
+            ? $node->getStartLine() // function signature node should always be 1-line range: (start, start)
+            : $node->getEndLine();
+
+        return new NodeLineRangeData($node->getStartLine(), $endLine);
     }
 
     /**

--- a/src/TestFramework/Coverage/XmlReport/TestLocator.php
+++ b/src/TestFramework/Coverage/XmlReport/TestLocator.php
@@ -40,6 +40,7 @@ use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\TestFramework\Coverage\NodeLineRangeData;
 use Infection\TestFramework\Coverage\SourceMethodLineRange;
 use Infection\TestFramework\Coverage\TestLocations;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal
@@ -85,9 +86,9 @@ class TestLocator
      */
     private function getTestsForFunctionSignature(NodeLineRangeData $lineRange): iterable
     {
-        foreach ($lineRange->range as $line) {
-            yield from $this->getTestsForExecutedMethodOnLine($line);
-        }
+        Assert::count($lineRange->range, 1); // 1-line range
+
+        yield from $this->getTestsForExecutedMethodOnLine($lineRange->range[0]);
     }
 
     /**

--- a/tests/phpunit/TestFramework/Coverage/ProxyTraceTest.php
+++ b/tests/phpunit/TestFramework/Coverage/ProxyTraceTest.php
@@ -178,7 +178,7 @@ final class ProxyTraceTest extends TestCase
         $this->assertCount(
             1,
             iterator_to_array($trace->getAllTestsForMutation(
-                new NodeLineRangeData(19, 22),
+                new NodeLineRangeData(19, 19),
                 true
             ))
         );


### PR DESCRIPTION
Finally, caught a bug that leads to a massive `TestLocation[]` duplications. For the very simple example - our [e2e `Example_Test`](https://github.com/infection/infection/tree/master/tests/e2e/Example_Test) - we previously had 4 duplicate objects of `TestLocation` class because of this bug.

![infection-non-unique-bug](https://user-images.githubusercontent.com/3725595/146876278-94facaf1-1bf9-40d8-b1e6-2af35ff9102e.png)

The more lines a method has, the more duplicates of `TestLocation` objects mutant has.

how to reproduce:

Add a breakpoint here:

https://github.com/infection/infection/blob/af58050714ef00c4c624846a2c3e7a9fb6cea6f9/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php#L89

then

```bash
cd tests/e2e/ExampleTest

INFECTION_ALLOW_XDEBUG=1 XDEBUG_TRIGGER=yes ../../../bin/infection
```

and you will see 4 duplicated test locations for just 1 mutant.

---

### Explanation

Previously, `Node` of class `ClassMethod` (mutation `public -> protected`) returned a range of lines for the whole method. Consider the following code:

```php
class Test {
    public function findMe() // line 4
    {
        // ...
    } // line 7
}
```

for this code, `ClassMethod` node returned a [4, 7] range instead of [4, 4].

Because of this, later *for each line* (4, 5, 6, 7) we found all the test cases that cover these lines.

If we have 1 test case `TestClass::test_method_find_me` that covers `findMe()` method, then we returned 4 exactly the same duplicate test cases for `ClassMethod` mutation, one for each of (4, 5, 6, 7) lines.

For the real-world examples, if we have a method with 10 lines of code that are covered by 3 tests, we have `3 * 10 = 30` `TestLocation`s instead of just 3.

After this update, only 1 set of test cases returned for the function signature mutant

