### PR TITLE
Mark Mutant as killed if Test Framework returns non-zero exit code

### DIFF
--- a/src/Mutant/MutantExecutionResultFactory.php
+++ b/src/Mutant/MutantExecutionResultFactory.php
@@ -106,7 +106,7 @@ class MutantExecutionResultFactory
 
         $output = $this->retrieveProcessOutput($process);
 
-        if ($this->testFrameworkAdapter->testsPass($output)) {
+        if ($process->getExitCode() === 0 && $this->testFrameworkAdapter->testsPass($output)) {
             return DetectionStatus::ESCAPED;
         }
 

--- a/tests/phpunit/Mutant/MutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/Mutant/MutantExecutionResultFactoryTest.php
@@ -316,7 +316,7 @@ DIFF,
             ->willReturn('Tests passed!')
         ;
         $processMock
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getExitCode')
             ->willReturn(0)
         ;
@@ -399,7 +399,7 @@ DIFF,
             ->willReturn('Tests failed!')
         ;
         $processMock
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getExitCode')
             ->willReturn(0)
         ;
@@ -456,6 +456,98 @@ DIFF,
             $this->resultFactory->createFromProcess($mutantProcess),
             $processCommandLine,
             'Tests failed!',
+            DetectionStatus::KILLED,
+            $mutantDiff,
+            $mutatorName,
+            $originalFilePath,
+            $originalStartingLine
+        );
+    }
+
+    /**
+     * PHPUnit can return "Tests passed! OK (10 tests, 32 assertions)" output, however
+     * return code will be non-zero.
+     *
+     * This happens when, for example, symfony/phpunit-bridge is used, and it detects
+     * outstanding deprecations which fails PHPUnit execution, while all the tests are passing
+     *
+     * See https://github.com/infection/infection/issues/1620#issuecomment-999073728
+     */
+    public function test_it_marks_mutant_as_killed_when_tests_pass_from_output_but_exit_code_is_non_zero(): void
+    {
+        $processMock = $this->createMock(Process::class);
+        $processMock
+            ->method('getCommandLine')
+            ->willReturn(
+                $processCommandLine = 'bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"'
+            )
+        ;
+        $processMock
+            ->method('isTerminated')
+            ->willReturn(true)
+        ;
+        $processMock
+            ->method('getOutput')
+            ->willReturn('Tests passed! OK (10 tests, 32 assertions)')
+        ;
+        $processMock
+            ->expects($this->exactly(2))
+            ->method('getExitCode')
+            ->willReturn(1) // PHPUnit says tests passed, but return code is non-zero
+        ;
+
+        $this->testFrameworkAdapterMock
+            ->expects($this->never())
+            ->method('testsPass')
+            ->with('Tests passed! OK (10 tests, 32 assertions)')
+            ->willReturn(true)
+        ;
+
+        $mutantProcess = new MutantProcess(
+            $processMock,
+            MutantBuilder::build(
+                '/path/to/mutant',
+                new Mutation(
+                    $originalFilePath = 'path/to/Foo.php',
+                    [],
+                    $mutatorName = MutatorName::getName(For_::class),
+                    [
+                        'startLine' => $originalStartingLine = 10,
+                        'endLine' => 15,
+                        'startTokenPos' => 0,
+                        'endTokenPos' => 8,
+                        'startFilePos' => 2,
+                        'endFilePos' => 4,
+                    ],
+                    'Unknown',
+                    MutatedNode::wrap(new Nop()),
+                    0,
+                    [
+                        new TestLocation(
+                            'FooTest::test_it_can_instantiate',
+                            '/path/to/acme/FooTest.php',
+                            0.01
+                        ),
+                    ]
+                ),
+                'killed#0',
+                $mutantDiff = <<<'DIFF'
+--- Original
++++ New
+@@ @@
+
+- echo 'original';
++ echo 'killed#0';
+
+DIFF,
+                '<?php $a = 1;'
+            )
+        );
+
+        $this->assertResultStateIs(
+            $this->resultFactory->createFromProcess($mutantProcess),
+            $processCommandLine,
+            'Tests passed! OK (10 tests, 32 assertions)',
             DetectionStatus::KILLED,
             $mutantDiff,
             $mutatorName,


### PR DESCRIPTION
PHPUnit can return `"Tests passed! OK (10 tests, 32 assertions)"` output, however return code will be non-zero.

This happens when, for example, `symfony/phpunit-bridge` is used with `SYMFONY_DEPRECATIONS_HELPER=max[self]=0`, and it detects outstanding deprecations which fails PHPUnit execution, while all the tests are passing

See https://github.com/infection/infection/issues/1620#issuecomment-999073728

Now, when Test Framework exit code is > 100, Mutant will be treated as `E`rrored (retained behavior).

When Test Framework exit code is non-zero, Mutant will be treated as Killed (new behavior), even if from output's point of view tests pass.

