### PR TITLE
Return unique tests for the range with more than 1 line

### DIFF
--- a/tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php
@@ -126,26 +126,6 @@ final class TestLocatorTest extends TestCase
                     'testFilePath' => '/path/to/acme/FooTest.php',
                     'testExecutionTime' => 0.456,
                 ],
-                [
-                    'testMethod' => 'Infection\Acme\FooTest::test_it_can_do_0',
-                    'testFilePath' => '/path/to/acme/FooTest.php',
-                    'testExecutionTime' => 0.123,
-                ],
-                [
-                    'testMethod' => 'Infection\Acme\FooTest::test_it_can_do_1',
-                    'testFilePath' => '/path/to/acme/FooTest.php',
-                    'testExecutionTime' => 0.456,
-                ],
-                [
-                    'testMethod' => 'Infection\Acme\FooTest::test_it_can_do_1',
-                    'testFilePath' => '/path/to/acme/FooTest.php',
-                    'testExecutionTime' => 0.456,
-                ],
-                [
-                    'testMethod' => 'Infection\Acme\FooTest::test_it_can_do_0',
-                    'testFilePath' => '/path/to/acme/FooTest.php',
-                    'testExecutionTime' => 0.123,
-                ],
             ],
         ];
 


### PR DESCRIPTION
Same test can cover more than 1 line. To avoid many duplicates, we need to return unique tests after accumulating them by each line from the `$lineRange`.

Consider the following example:

```php
public function foo(): string
{
    return $a // line 1, covered by test_case_1, test_case_2
       ? $b   // line 2, covered by test_case_1
       : $c;  // line 3, covered by test_case_2
}
```

on `master`, before https://github.com/infection/infection/pull/1619 (the first fix for non-unique `TestLocation`s) we had:

```bash
3 * 3 * 2 = 18 # (9 duplicates of test_case_1, 9 duplicates of test_case_2)
│   │   └─── number of test cases
│   └─────── number of source code lines
└─────────── number of outer iterations
```
after https://github.com/infection/infection/pull/1619 fix, we had

```bash
1 * 3 * 2 = 6 # (3 duplicates of test_case_1, 3 duplicates of test_case_2)
│   │   └─── number of test cases
│   └─────── number of source code lines
└─────────── number of outer iterations
```

because we removed outer iterations by making range [1-line](https://github.com/infection/infection/blob/30db7f9f3e2b6aa654408dd37587637479ad8b99/src/TestFramework/Coverage/LineRangeCalculator.php#L51-L54) for signature

and now, in this PR, we have

```bash
unique(tests from 3 lines) = 2 # (test_case_1, test_case_2), no duplicates
```

because after all tests for each line in the range are accumulated, we remove duplicates.

No time difference noticed. Memory improvements:

```diff
- Memory: 0.24GB
+ Memory: 0.23GB
```