### PR TITLE
Temporarily use Composer 2.1.* instead of new 2.2 because of Box failures

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          tools: composer:v2
+          tools: composer:v2.1
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           coverage: ${{ matrix.coverage-driver }}
           ini-values: memory_limit=512M, xdebug.mode=off
-          tools: composer:v2
+          tools: composer:v2.1
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -24,7 +24,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-version }}
-                  tools: composer:v2
+                  tools: composer:v2.1
                   coverage: pcov
 
             - name: Get composer cache directory

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: ${{ matrix.coverage-driver }}
-          tools: composer:v2
+          tools: composer:v2.1
 
       - name: Get composer cache directory
         id: composer-cache


### PR DESCRIPTION
See https://github.com/infection/infection/runs/4611833764?check_suite_focus=true

```bash
? Dumping the Composer autoloader

In ComposerOrchestrator.php line 92:
                                  
  Could not dump the autoloader.  
                                  

In ComposerOrchestrator.php line 92:
                                                                               
  The command "'/usr/local/bin/composer' 'dump-autoload' '--classmap-authorit  
  ative' '--no-dev'" failed.                                                   
                                                                               
  Exit Code: 1(General error)                                                  
                                                                               
  Working directory: /tmp/box/Box46412                                         
                                                                               
  Output:                                                                      
  ================                                                             
Error: require(/tmp/box/Box46412/vendor/phpstan/phpstan/bootstrap.php):   
  Failed to open stream: No such file or directory                             
                                                                               
                                                                               
  Error Output:                                                                
  ================                                                             
  For additional security you should declare the allow-plugins config with a   
  list of packages names that are allowed to run code. See https://getcompose  
  r.org/allow-plugins                                                          
  You have until July 2022 to add the setting. Composer will then switch the   
  default behavior to disallow all plugins.                                    
                                                                               
                                                                               
                                                                               
    [ErrorException]                                                           
                                                                               
    require(/tmp/box/Box46412/vendor/phpstan/phpstan/bootstrap.php): Failed t  
  o open stream: No such file or directory                                     
                                                                               
                                                                               
                                                                               
  dump-autoload [-o|--optimize] [-a|--classmap-authoritative] [--apcu] [--apc  
  u-prefix APCU-PREFIX] [--dev] [--no-dev] [--ignore-platform-req IGNORE-PLAT  
  FORM-REQ] [--ignore-platform-reqs]                                           
                                                                               

compile [-c|--config CONFIG] [--debug] [--no-parallel] [--no-restart] [--dev] [--no-config] [--with-docker] [-d|--working-dir WORKING-DIR]

make: *** [Makefile:253: build/infection.phar] Error 1
```