### PR TITLE
Allow phpstan and infection composer plugins to be executed (Composer 2.2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,11 @@
         "platform": {
             "php": "7.4.7"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true,
+            "infection/extension-installer": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -2269,9 +2269,6 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -4636,5 +4633,5 @@
     "platform-overrides": {
         "php": "7.4.7"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Let's see if it works with new Composer 2.2 requirements (https://getcomposer.org/doc/06-config.md#allow-plugins) and if it fixes https://github.com/infection/infection/pull/1623