### PR TITLE
Set `failOnRisky`, `failOnWarning` to `true` if parameters are not already set for mutants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PHP_CS_FIXER_CACHE=.php_cs.cache
 PHPSTAN=./vendor/bin/phpstan
 
 PSALM=./.tools/psalm
-PSALM_URL="https://github.com/vimeo/psalm/releases/download/4.12.0/psalm.phar"
+PSALM_URL="https://github.com/vimeo/psalm/releases/download/v4.15.0/psalm.phar"
 
 PHPUNIT=vendor/phpunit/phpunit/phpunit
 PARATEST=vendor/bin/paratest --runner=WrapperRunner

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -101,7 +101,7 @@ class InitialConfigBuilder implements ConfigBuilder
 
         $this->addCoverageNodes($version, $xPath);
         $this->addRandomTestsOrderAttributesIfNotSet($version, $xPath);
-        $this->addFailOnAttributesIfNotSet($version, $xPath);
+        $this->configManipulator->addFailOnAttributesIfNotSet($version, $xPath);
         $this->configManipulator->replaceWithAbsolutePaths($xPath);
         $this->configManipulator->setStopOnFailure($xPath);
         $this->configManipulator->deactivateColours($xPath);
@@ -153,16 +153,6 @@ class InitialConfigBuilder implements ConfigBuilder
         if ($this->addAttributeIfNotSet('executionOrder', 'random', $xPath)) {
             $this->addAttributeIfNotSet('resolveDependencies', 'true', $xPath);
         }
-    }
-
-    private function addFailOnAttributesIfNotSet(string $version, SafeDOMXPath $xPath): void
-    {
-        if (version_compare($version, '5.2', '<')) {
-            return;
-        }
-
-        $this->addAttributeIfNotSet('failOnRisky', 'true', $xPath);
-        $this->addAttributeIfNotSet('failOnWarning', 'true', $xPath);
     }
 
     private function addAttributeIfNotSet(string $attribute, string $value, SafeDOMXPath $xPath): bool

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -101,6 +101,7 @@ class MutationConfigBuilder extends ConfigBuilder
 
         // activate PHPUnit's result cache and order tests by running defects first, then sorted by fastest first
         $this->configManipulator->handleResultCacheAndExecutionOrder($version, $xPath, $mutationHash);
+        $this->configManipulator->addFailOnAttributesIfNotSet($version, $xPath);
         $this->configManipulator->setStopOnFailure($xPath);
         $this->configManipulator->deactivateColours($xPath);
         $this->configManipulator->deactivateStderrRedirection($xPath);

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -200,6 +200,16 @@ final class XmlConfigurationManipulator
         );
     }
 
+    public function addFailOnAttributesIfNotSet(string $version, SafeDOMXPath $xPath): void
+    {
+        if (version_compare($version, '5.2', '<')) {
+            return;
+        }
+
+        $this->addAttributeIfNotSet('failOnRisky', 'true', $xPath);
+        $this->addAttributeIfNotSet('failOnWarning', 'true', $xPath);
+    }
+
     /**
      * @param string[] $srcDirs
      * @param list<string> $filteredSourceFilesToMutate
@@ -358,5 +368,19 @@ final class XmlConfigurationManipulator
         }
 
         return $this->createNode($dom, $nodeName);
+    }
+
+    private function addAttributeIfNotSet(string $attribute, string $value, SafeDOMXPath $xPath): bool
+    {
+        $nodeList = $xPath->query(sprintf('/phpunit/@%s', $attribute));
+
+        if ($nodeList->length === 0) {
+            $node = $xPath->query('/phpunit')[0];
+            $node->setAttribute($attribute, $value);
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/phpunit/Fixtures/Files/phpunit/phpunit_with_fail_on_risky_set.xml
+++ b/tests/phpunit/Fixtures/Files/phpunit/phpunit_with_fail_on_risky_set.xml
@@ -9,7 +9,7 @@
          processIsolation="false"
          syntaxCheck="false"
          executionOrder="reverse"
-         failOnRisky="true"
+         failOnRisky="false"
 >
     <testsuites>
         <testsuite name="Application Test Suite">

--- a/tests/phpunit/Fixtures/Files/phpunit/phpunit_with_fail_on_warning_set.xml
+++ b/tests/phpunit/Fixtures/Files/phpunit/phpunit_with_fail_on_warning_set.xml
@@ -9,7 +9,7 @@
          processIsolation="false"
          syntaxCheck="false"
          executionOrder="reverse"
-         failOnWarning="true"
+         failOnWarning="false"
 >
     <testsuites>
         <testsuite name="Application Test Suite">

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -407,7 +407,7 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
         $failOnRisky = $this->queryXpath($xml, sprintf('/phpunit/@%s', 'failOnRisky'));
 
         $this->assertInstanceOf(DOMNodeList::class, $failOnRisky);
-        $this->assertSame('true', $failOnRisky[0]->value);
+        $this->assertSame('false', $failOnRisky[0]->value);
     }
 
     public function test_it_does_not_update_fail_on_warning_attributes_if_it_is_already_set(): void
@@ -421,7 +421,7 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
         $failOnRisky = $this->queryXpath($xml, sprintf('/phpunit/@%s', 'failOnWarning'));
 
         $this->assertInstanceOf(DOMNodeList::class, $failOnRisky);
-        $this->assertSame('true', $failOnRisky[0]->value);
+        $this->assertSame('false', $failOnRisky[0]->value);
     }
 
     public function test_it_creates_a_configuration(): void


### PR DESCRIPTION
previously, we did the same for **initial** tests run generated `phpunit.xml`.

This update is for `phpunit.xml`, generated for each Mutant.

Related to https://github.com/infection/infection/pull/1280, https://github.com/infection/infection/issues/1620