### PR TITLE
Fail Infection execution when at least 1 ignore source code regex wasn't matched

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -56,6 +56,7 @@ use Infection\Logger\ConsoleLogger;
 use Infection\Logger\GitHub\NoFilesInDiffToMutate;
 use Infection\Metrics\MinMsiCheckFailed;
 use Infection\Process\Runner\InitialTestsFailed;
+use Infection\Process\Runner\NotMatchedIgnoreSourceCodeRegexFound;
 use Infection\TestFramework\TestFrameworkTypes;
 use InvalidArgumentException;
 use const PHP_SAPI;
@@ -355,7 +356,7 @@ final class RunCommand extends BaseCommand
             $io->success($e->getMessage());
 
             return true;
-        } catch (InitialTestsFailed | MinMsiCheckFailed $exception) {
+        } catch (InitialTestsFailed | MinMsiCheckFailed | NotMatchedIgnoreSourceCodeRegexFound $exception) {
             // TODO: we can move that in a dedicated logger later and handle those cases in the
             // Engine instead
             $io->error($exception->getMessage());

--- a/src/Process/Runner/NotMatchedIgnoreSourceCodeRegexFound.php
+++ b/src/Process/Runner/NotMatchedIgnoreSourceCodeRegexFound.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Process\Runner;
+
+use Exception;
+use function implode;
+
+/**
+ * @internal
+ */
+final class NotMatchedIgnoreSourceCodeRegexFound extends Exception
+{
+    /**
+     * @param array<int, string> $notMatchedSourceCodeRegexes
+     */
+    public static function forRegexes(array $notMatchedSourceCodeRegexes): self
+    {
+        return new self('The following ignore source code regexes were not matched, consider removing them from `infection.json`: ' . implode(', ', $notMatchedSourceCodeRegexes));
+    }
+}

--- a/tests/e2e/Example_Test/infection.json
+++ b/tests/e2e/Example_Test/infection.json
@@ -9,5 +9,14 @@
     "logs": {
         "summary": "infection.log"
     },
-    "tmpDir": "."
+    "tmpDir": ".",
+    "mutators": {
+        "@default": false,
+        "ProtectedVisibility": true,
+        "Plus": true,
+        "global-ignoreSourceCodeByRegex": [
+            "public(.*)"
+        ],
+        "PublicVisibility": true
+    }
 }

--- a/tests/phpunit/Process/Runner/NotMatchedIgnoreSourceCodeRegexFoundTest.php
+++ b/tests/phpunit/Process/Runner/NotMatchedIgnoreSourceCodeRegexFoundTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Process\Runner;
+
+use Infection\Process\Runner\NotMatchedIgnoreSourceCodeRegexFound;
+use PHPUnit\Framework\TestCase;
+
+final class NotMatchedIgnoreSourceCodeRegexFoundTest extends TestCase
+{
+    public function test_it_is_being_created_with_a_message(): void
+    {
+        $exception = NotMatchedIgnoreSourceCodeRegexFound::forRegexes(['a', 'b']);
+
+        $this->assertInstanceOf(NotMatchedIgnoreSourceCodeRegexFound::class, $exception);
+        $this->assertSame(
+            'The following ignore source code regexes were not matched, consider removing them from `infection.json`: a, b',
+            $exception->getMessage()
+        );
+    }
+}


### PR DESCRIPTION
Implements https://github.com/infection/infection/issues/1604

Will be useful to remove stale/non-matching `ignoreSourceCodeByRegex` settings inside `infection.json` and will help debugging them.

