### PR TITLE
Do not add methods with 0% coverage to `TestsLocations` to prevent wasting of resources

### DIFF
--- a/src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php
+++ b/src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php
@@ -156,6 +156,10 @@ class XmlCoverageParser
         $methodsCoverage = [];
 
         foreach ($methodsCoverageNodes as $methodsCoverageNode) {
+            if ((int) $methodsCoverageNode->getAttribute('coverage') === 0) {
+                continue;
+            }
+
             $methodName = $methodsCoverageNode->getAttribute('name');
 
             $start = $methodsCoverageNode->getAttribute('start');

--- a/tests/phpunit/Fixtures/TestFramework/PhpUnit/Coverage/XmlCoverageFixtures.php
+++ b/tests/phpunit/Fixtures/TestFramework/PhpUnit/Coverage/XmlCoverageFixtures.php
@@ -104,10 +104,6 @@ final class XmlCoverageFixtures
                     ],
                 ],
                 'byMethod' => [
-                    'mutate' => [
-                        'startLine' => 19,
-                        'endLine' => 22,
-                    ],
                     'shouldMutate' => [
                         'startLine' => 24,
                         'endLine' => 35,
@@ -137,10 +133,6 @@ final class XmlCoverageFixtures
                     ],
                 ],
                 'byMethod' => [
-                    'mutate' => [
-                        'startLine' => 19,
-                        'endLine' => 22,
-                    ],
                     'shouldMutate' => [
                         'startLine' => 24,
                         'endLine' => 35,
@@ -170,10 +162,6 @@ final class XmlCoverageFixtures
                     ],
                 ],
                 'byMethod' => [
-                    'mutate' => [
-                        'startLine' => 19,
-                        'endLine' => 22,
-                    ],
                     'shouldMutate' => [
                         'startLine' => 24,
                         'endLine' => 35,


### PR DESCRIPTION
Consider the following XML coverage file https://github.com/infection/infection/blob/de7d826e770fbb0400c91272e5460e1ff880e65f/tests/phpunit/Fixtures/Files/phpunit/coverage/coverage-xml/FirstLevel/firstLevel.php.xml#L20 where `mutate()` method has 0% coverage.

There is no need to add this method to `TestsLocations` as later no tests will be found for its lines, so that the following code will just waste resources:

https://github.com/infection/infection/blob/de7d826e770fbb0400c91272e5460e1ff880e65f/src/TestFramework/Coverage/XmlReport/TestLocator.php#L117-L130

because since method is not covered - lines inside it also are not covered (check the XML coverage above)

For Infection itself, I see no benefits regarding time and memory used though, however it's clear that less operations are executed during Infection run.