### PR TITLE
Use GitHub Annotations from Infection for all added/modified lines by using `--git-diff-lines`

### DIFF
--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -48,4 +48,4 @@ jobs:
             - name: Run Infection for added files only
               run: |
                   git fetch --depth=1 origin $GITHUB_BASE_REF
-                  php bin/infection -j2 --git-diff-filter=A --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --ignore-msi-with-no-mutations --only-covered
+                  php bin/infection -j2 --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --ignore-msi-with-no-mutations --only-covered


### PR DESCRIPTION
Instead of mutating only new files for GH annotations, we will mutate also modified files - only touched lines

based on https://github.com/infection/infection/pull/1632

