### PR TITLE
Remove `string` type declaration of parameter

### DIFF
--- a/src/FileSystem/Finder/Iterator/RealPathFilterIterator.php
+++ b/src/FileSystem/Finder/Iterator/RealPathFilterIterator.php
@@ -77,7 +77,7 @@ final class RealPathFilterIterator extends MultiplePcreFilterIterator
      *
      * @return string regexp corresponding to a given string or regexp
      */
-    protected function toRegex(string $str): string
+    protected function toRegex($str): string
     {
         return $this->isRegex($str) ? $str : '/' . preg_quote($str, '/') . '/';
     }


### PR DESCRIPTION
Fixes #1635

because:

* Covariance allows a child's method to return a more specific type than the return type of its parent's method.
* Contravariance allows a parameter type to be less specific in a child method, than that of its parent.

No test here, as I don't know how (and don't want) to mock parent class, but the proper test would be to test Infection with different supported Symfony versions, which is still not done 