### PR TITLE
Upgrade Infection to minimum PHP 8.0 using Rector

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.4']
+        php-version: ['8.0']
 
     name: Autoreview on PHP ${{ matrix.php-version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,6 @@ jobs:
         e2e-runner: ['bin/infection']
         include:
           - { operating-system: 'windows-latest', php-version: '8.0', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
           - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'pcov', e2e-runner: 'build/infection.phar' }
           - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'xdebug', e2e-runner: 'build/infection.phar' }
           - { operating-system: 'ubuntu-latest', php-version: '8.1', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['7.4']
+        php-version: ['8.0']
         coverage-driver: [pcov, xdebug]
         e2e-runner: ['bin/infection']
         include:
-          - { operating-system: 'windows-latest', php-version: '7.4', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
-          - { operating-system: 'ubuntu-latest', php-version: '7.4', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
+          - { operating-system: 'windows-latest', php-version: '8.0', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
           - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'pcov', e2e-runner: 'build/infection.phar' }
           - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'xdebug', e2e-runner: 'build/infection.phar' }
           - { operating-system: 'ubuntu-latest', php-version: '8.1', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.0
 
       - name: Restore PHP-CS-Fixer cache
         uses: actions/cache@v2

--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                php-version: ['7.4']
+                php-version: ['8.0']
 
         name: Mutation Testing Code Review Annotations ${{ matrix.php-version }}
 

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['7.4']
+        php-version: ['8.0']
         coverage-driver: [pcov]
 
     name: Mutation testing on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }}

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ PARATEST=vendor/bin/paratest --runner=WrapperRunner
 INFECTION=./build/infection.phar
 
 DOCKER_RUN=docker-compose run
-DOCKER_RUN_74=$(DOCKER_RUN) php74 $(FLOCK) Makefile
 DOCKER_RUN_80=$(DOCKER_RUN) php80 $(FLOCK) Makefile
 DOCKER_FILE_IMAGE=devTools/Dockerfile.json
 
@@ -57,7 +56,7 @@ compile: $(INFECTION)
 .PHONY: compile-docker
 compile-docker:	 	## Bundles Infection into a PHAR using docker
 compile-docker: $(DOCKER_FILE_IMAGE)
-	$(DOCKER_RUN_74) make compile
+	$(DOCKER_RUN_80) make compile
 
 .PHONY: check_trailing_whitespaces
 check_trailing_whitespaces:
@@ -144,11 +143,7 @@ test-unit-parallel:
 
 .PHONY: test-unit-docker
 test-unit-docker:	## Runs the unit tests on the different Docker platforms
-test-unit-docker: test-unit-74-docker test-unit-80-docker
-
-.PHONY: test-unit-74-docker
-test-unit-74-docker: $(DOCKER_FILE_IMAGE) $(PHPUNIT)
-	$(DOCKER_RUN_74) $(PHPUNIT) --group $(PHPUNIT_GROUP)
+test-unit-docker: test-unit-80-docker
 
 .PHONY: test-unit-80-docker
 test-unit-80-docker: $(DOCKER_FILE_IMAGE) $(PHPUNIT)
@@ -169,12 +164,7 @@ test-e2e-docker: 	## Runs the end-to-end tests on the different Docker platforms
 test-e2e-docker: test-e2e-phpdbg-docker test-e2e-xdebug-docker
 
 .PHONY: test-e2e-phpdbg-docker
-test-e2e-phpdbg-docker: test-e2e-phpdbg-74-docker test-e2e-phpdbg-80-docker
-
-.PHONY: test-e2e-phpdbg-74-docker
-test-e2e-phpdbg-74-docker: $(DOCKER_FILE_IMAGE) $(INFECTION)
-	$(DOCKER_RUN_74) $(PHPUNIT) --group $(E2E_PHPUNIT_GROUP)
-	$(DOCKER_RUN_74) env PHPDBG=1 ./tests/e2e_tests $(INFECTION)
+test-e2e-phpdbg-docker: test-e2e-phpdbg-80-docker
 
 .PHONY: test-e2e-phpdbg-80-docker
 test-e2e-phpdbg-80-docker: $(DOCKER_FILE_IMAGE) $(INFECTION)
@@ -182,12 +172,7 @@ test-e2e-phpdbg-80-docker: $(DOCKER_FILE_IMAGE) $(INFECTION)
 	$(DOCKER_RUN_80) env PHPDBG=1 ./tests/e2e_tests $(INFECTION)
 
 .PHONY: test-e2e-xdebug-docker
-test-e2e-xdebug-docker: test-e2e-xdebug-74-docker test-e2e-xdebug-80-docker
-
-.PHONY: test-e2e-xdebug-74-docker
-test-e2e-xdebug-74-docker: $(DOCKER_FILE_IMAGE) $(INFECTION)
-	$(DOCKER_RUN_74) $(PHPUNIT) --group $(E2E_PHPUNIT_GROUP)
-	$(DOCKER_RUN_74) ./tests/e2e_tests $(INFECTION)
+test-e2e-xdebug-docker: test-e2e-xdebug-80-docker
 
 .PHONY: test-e2e-xdebug-80-docker
 test-e2e-xdebug-80-docker: $(DOCKER_FILE_IMAGE) $(INFECTION)
@@ -204,22 +189,14 @@ test-infection-docker:	## Runs Infection against itself on the different Docker 
 test-infection-docker: test-infection-phpdbg-docker test-infection-xdebug-docker
 
 .PHONY: test-infection-phpdbg-docker
-test-infection-phpdbg-docker: test-infection-phpdbg-74-docker test-infection-phpdbg-80-docker
-
-.PHONY: test-infection-phpdbg-74-docker
-test-infection-phpdbg-74-docker: $(DOCKER_FILE_IMAGE)
-	$(DOCKER_RUN_74) phpdbg -qrr bin/infection --threads=4
+test-infection-phpdbg-docker: test-infection-phpdbg-80-docker
 
 .PHONY: test-infection-phpdbg-80-docker
 test-infection-phpdbg-80-docker: $(DOCKER_FILE_IMAGE)
 	$(DOCKER_RUN_80) phpdbg -qrr bin/infection --threads=4
 
 .PHONY: test-infection-xdebug-docker
-test-infection-xdebug-docker: test-infection-xdebug-74-docker test-infection-xdebug-80-docker
-
-.PHONY: test-infection-xdebug-74-docker
-test-infection-xdebug-74-docker: $(DOCKER_FILE_IMAGE)
-	$(DOCKER_RUN_74) ./bin/infection --threads=4
+test-infection-xdebug-docker: test-infection-xdebug-80-docker
 
 .PHONY: test-infection-xdebug-80-docker
 test-infection-xdebug-80-docker: $(DOCKER_FILE_IMAGE)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Minimum PHP version: 7.4.0](https://img.shields.io/badge/php-7.4.0%2B-blue.svg)](https://packagist.org/packages/infection/infection)
+[![Minimum PHP version: 8.0.0](https://img.shields.io/badge/php-8.0.0%2B-blue.svg)](https://packagist.org/packages/infection/infection)
 [![Latest Stable Version](https://poser.pugx.org/infection/infection/v/stable)](https://packagist.org/packages/infection/infection)
 [![Continuous Integration](https://github.com/infection/infection/workflows/Continuous%20Integration/badge.svg)](https://github.com/infection/infection/actions)
 [![Build Status](https://travis-ci.org/infection/infection.svg?branch=master)](https://travis-ci.org/infection/infection)

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         }
     ],
     "require": {
-        "php": "^7.4.7 || ^8.0",
+        "php": "^8.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",
@@ -87,7 +87,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.4.7"
+            "php": "8.0.0"
         },
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1cfb8421d5b969ceac14216afd743417",
+    "content-hash": "9109a1b8329f37ca995add047b10f181",
     "packages": [
         {
             "name": "composer/pcre",
@@ -4694,7 +4694,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4.7 || ^8.0",
+        "php": "^8.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",
@@ -4704,7 +4704,7 @@
         "ext-simplexml": "*"
     },
     "platform-overrides": {
-        "php": "7.4.7"
+        "php": "8.0.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -14,7 +14,11 @@ parameters:
         - '#^Variable (method|property) (access|call) #'
         -
             path: '../src/Metrics/MetricsCalculator.php'
-            message: '#^Strict comparison using !== between array<int, Infection\\Mutant\\MutantExecutionResult> and array{} will always evaluate to true\.$#'
+            message: '#^Strict comparison using !== between array<int|string, Infection\\Mutant\\MutantExecutionResult> and array{} will always evaluate to true\.$#'
+            count: 1
+        -
+            path: '../src/Mutator/MutatorResolver.php'
+            message: '#^Method Infection\\Mutator\\MutatorResolver::resolveSettings\(\) has parameter \$settings with no value type specified in iterable type array\.$#'
             count: 1
         -
             path: ../src/TestFramework/Factory.php

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,5 @@
 version: '3'
 services:
-  php74:
-    build:
-      context: devTools
-      args:
-        PHP_VERSION: 7.4
-    volumes:
-      - .:/opt/infection
   php80:
     build:
       context: devTools

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -49,11 +49,8 @@ class ConsoleOutput
     private const RUNNING_WITH_DEBUGGER_NOTE = 'You are running Infection with %s enabled.';
     private const MIN_MSI_CAN_GET_INCREASED_NOTICE = 'The %s is %s%% percentage points over the required %s. Consider increasing the required %s percentage the next time you run Infection.';
 
-    private ConsoleLogger $logger;
-
-    public function __construct(ConsoleLogger $logger)
+    public function __construct(private ConsoleLogger $logger)
     {
-        $this->logger = $logger;
     }
 
     public function logVerbosityDeprecationNotice(string $valueToUse): void

--- a/src/Console/OutputFormatter/DotFormatter.php
+++ b/src/Console/OutputFormatter/DotFormatter.php
@@ -49,11 +49,8 @@ final class DotFormatter extends AbstractOutputFormatter
 {
     private const DOTS_PER_ROW = 50;
 
-    private OutputInterface $output;
-
-    public function __construct(OutputInterface $output)
+    public function __construct(private OutputInterface $output)
     {
-        $this->output = $output;
     }
 
     public function start(int $mutationCount): void

--- a/src/Console/OutputFormatter/FormatterFactory.php
+++ b/src/Console/OutputFormatter/FormatterFactory.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Console\OutputFormatter;
 
 use function implode;
-use LogicException;
 use function Safe\sprintf;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -47,11 +46,8 @@ use Webmozart\Assert\Assert;
  */
 final class FormatterFactory
 {
-    private OutputInterface $output;
-
-    public function __construct(OutputInterface $output)
+    public function __construct(private OutputInterface $output)
     {
-        $this->output = $output;
     }
 
     public function create(string $formatterName): OutputFormatter
@@ -65,14 +61,9 @@ final class FormatterFactory
             )
         );
 
-        switch ($formatterName) {
-            case FormatterName::PROGRESS:
-                return new ProgressFormatter(new ProgressBar($this->output));
-
-            case FormatterName::DOT:
-                return new DotFormatter($this->output);
-        }
-
-        throw new LogicException('Unreachable statement');
+        return match ($formatterName) {
+            FormatterName::PROGRESS => new ProgressFormatter(new ProgressBar($this->output)),
+            FormatterName::DOT => new DotFormatter($this->output),
+        };
     }
 }

--- a/src/Console/OutputFormatter/ProgressFormatter.php
+++ b/src/Console/OutputFormatter/ProgressFormatter.php
@@ -43,11 +43,8 @@ use Symfony\Component\Console\Helper\ProgressBar;
  */
 final class ProgressFormatter extends AbstractOutputFormatter
 {
-    private ProgressBar $progressBar;
-
-    public function __construct(ProgressBar $progressBar)
+    public function __construct(private ProgressBar $progressBar)
     {
-        $this->progressBar = $progressBar;
     }
 
     public function start(int $mutationCount): void

--- a/src/Container.php
+++ b/src/Container.php
@@ -218,74 +218,47 @@ final class Container
     public static function create(): self
     {
         $container = new self([
-            Filesystem::class => static function (): Filesystem {
-                return new Filesystem();
-            },
-            TmpDirProvider::class => static function (): TmpDirProvider {
-                return new TmpDirProvider();
-            },
-            IndexXmlCoverageParser::class => static function (): IndexXmlCoverageParser {
-                return new IndexXmlCoverageParser();
-            },
-            XmlCoverageParser::class => static function (): XmlCoverageParser {
-                // TODO XmlCoverageParser might want to notify ProcessRunner if it can't parse another file due to lack of RAM
-                return new XmlCoverageParser();
-            },
-            CoveredTraceProvider::class => static function (self $container): CoveredTraceProvider {
-                return new CoveredTraceProvider(
-                    $container->getPhpUnitXmlCoverageTraceProvider(),
-                    $container->getJUnitTestExecutionInfoAdder(),
-                    $container->getBufferedSourceFileFilter(),
-                );
-            },
-            UnionTraceProvider::class => static function (self $container): UnionTraceProvider {
-                return new UnionTraceProvider(
-                    $container->getCoveredTraceProvider(),
-                    $container->getUncoveredTraceProvider(),
-                    $container->getConfiguration()->mutateOnlyCoveredCode()
-                );
-            },
-            BufferedSourceFileFilter::class => static function (self $container): BufferedSourceFileFilter {
-                return new BufferedSourceFileFilter(
-                    $container->getSourceFileFilter(),
-                    $container->getConfiguration()->getSourceFiles(),
-                );
-            },
-            UncoveredTraceProvider::class => static function (self $container): UncoveredTraceProvider {
-                return new UncoveredTraceProvider(
-                    $container->getBufferedSourceFileFilter()
-                );
-            },
-            SourceFileFilter::class => static function (self $container): SourceFileFilter {
-                return new SourceFileFilter(
-                    $container->getConfiguration()->getSourceFilesFilter(),
-                    $container->getConfiguration()->getSourceFilesExcludes()
-                );
-            },
-            JUnitTestExecutionInfoAdder::class => static function (self $container): JUnitTestExecutionInfoAdder {
-                return new JUnitTestExecutionInfoAdder(
-                    $container->getTestFrameworkAdapter(),
-                    $container->getMemoizedTestFileDataProvider()
-                );
-            },
-            PhpUnitXmlCoverageTraceProvider::class => static function (self $container): PhpUnitXmlCoverageTraceProvider {
-                return new PhpUnitXmlCoverageTraceProvider(
-                    $container->getIndexXmlCoverageLocator(),
-                    $container->getIndexXmlCoverageParser(),
-                    $container->getXmlCoverageParser()
-                );
-            },
-            IndexXmlCoverageLocator::class => static function (self $container): IndexXmlCoverageLocator {
-                return new IndexXmlCoverageLocator(
-                    $container->getConfiguration()->getCoveragePath()
-                );
-            },
-            RootsFileOrDirectoryLocator::class => static function (self $container): RootsFileOrDirectoryLocator {
-                return new RootsFileOrDirectoryLocator(
-                    [$container->getProjectDir()],
-                    $container->getFileSystem()
-                );
-            },
+            Filesystem::class => static fn (): Filesystem => new Filesystem(),
+            TmpDirProvider::class => static fn (): TmpDirProvider => new TmpDirProvider(),
+            IndexXmlCoverageParser::class => static fn (): IndexXmlCoverageParser => new IndexXmlCoverageParser(),
+            XmlCoverageParser::class => static fn (): XmlCoverageParser => new XmlCoverageParser(),
+            CoveredTraceProvider::class => static fn (self $container): CoveredTraceProvider => new CoveredTraceProvider(
+                $container->getPhpUnitXmlCoverageTraceProvider(),
+                $container->getJUnitTestExecutionInfoAdder(),
+                $container->getBufferedSourceFileFilter(),
+            ),
+            UnionTraceProvider::class => static fn (self $container): UnionTraceProvider => new UnionTraceProvider(
+                $container->getCoveredTraceProvider(),
+                $container->getUncoveredTraceProvider(),
+                $container->getConfiguration()->mutateOnlyCoveredCode()
+            ),
+            BufferedSourceFileFilter::class => static fn (self $container): BufferedSourceFileFilter => new BufferedSourceFileFilter(
+                $container->getSourceFileFilter(),
+                $container->getConfiguration()->getSourceFiles(),
+            ),
+            UncoveredTraceProvider::class => static fn (self $container): UncoveredTraceProvider => new UncoveredTraceProvider(
+                $container->getBufferedSourceFileFilter()
+            ),
+            SourceFileFilter::class => static fn (self $container): SourceFileFilter => new SourceFileFilter(
+                $container->getConfiguration()->getSourceFilesFilter(),
+                $container->getConfiguration()->getSourceFilesExcludes()
+            ),
+            JUnitTestExecutionInfoAdder::class => static fn (self $container): JUnitTestExecutionInfoAdder => new JUnitTestExecutionInfoAdder(
+                $container->getTestFrameworkAdapter(),
+                $container->getMemoizedTestFileDataProvider()
+            ),
+            PhpUnitXmlCoverageTraceProvider::class => static fn (self $container): PhpUnitXmlCoverageTraceProvider => new PhpUnitXmlCoverageTraceProvider(
+                $container->getIndexXmlCoverageLocator(),
+                $container->getIndexXmlCoverageParser(),
+                $container->getXmlCoverageParser()
+            ),
+            IndexXmlCoverageLocator::class => static fn (self $container): IndexXmlCoverageLocator => new IndexXmlCoverageLocator(
+                $container->getConfiguration()->getCoveragePath()
+            ),
+            RootsFileOrDirectoryLocator::class => static fn (self $container): RootsFileOrDirectoryLocator => new RootsFileOrDirectoryLocator(
+                [$container->getProjectDir()],
+                $container->getFileSystem()
+            ),
             Factory::class => static function (self $container): Factory {
                 $config = $container->getConfiguration();
 
@@ -300,42 +273,24 @@ final class Container
                     GeneratedExtensionsConfig::EXTENSIONS
                 );
             },
-            MutantCodeFactory::class => static function (self $container): MutantCodeFactory {
-                return new MutantCodeFactory($container->getPrinter());
-            },
-            MutantFactory::class => static function (self $container): MutantFactory {
-                return new MutantFactory(
-                    $container->getConfiguration()->getTmpDir(),
-                    $container->getDiffer(),
-                    $container->getPrinter(),
-                    $container->getMutantCodeFactory()
-                );
-            },
-            Differ::class => static function (): Differ {
-                return new Differ(new BaseDiffer());
-            },
-            SyncEventDispatcher::class => static function (): SyncEventDispatcher {
-                return new SyncEventDispatcher();
-            },
-            ParallelProcessRunner::class => static function (self $container): ParallelProcessRunner {
-                return new ParallelProcessRunner($container->getConfiguration()->getThreadCount());
-            },
-            DryProcessRunner::class => static function (): DryProcessRunner {
-                return new DryProcessRunner();
-            },
-            TestFrameworkConfigLocator::class => static function (self $container): TestFrameworkConfigLocator {
-                return new TestFrameworkConfigLocator(
-                    (string) $container->getConfiguration()->getPhpUnit()->getConfigDir()
-                );
-            },
-            DiffColorizer::class => static function (): DiffColorizer {
-                return new DiffColorizer();
-            },
-            MemoizedTestFileDataProvider::class => static function (self $container): TestFileDataProvider {
-                return new MemoizedTestFileDataProvider(
-                    new JUnitTestFileDataProvider($container->getJUnitReportLocator())
-                );
-            },
+            MutantCodeFactory::class => static fn (self $container): MutantCodeFactory => new MutantCodeFactory($container->getPrinter()),
+            MutantFactory::class => static fn (self $container): MutantFactory => new MutantFactory(
+                $container->getConfiguration()->getTmpDir(),
+                $container->getDiffer(),
+                $container->getPrinter(),
+                $container->getMutantCodeFactory()
+            ),
+            Differ::class => static fn (): Differ => new Differ(new BaseDiffer()),
+            SyncEventDispatcher::class => static fn (): SyncEventDispatcher => new SyncEventDispatcher(),
+            ParallelProcessRunner::class => static fn (self $container): ParallelProcessRunner => new ParallelProcessRunner($container->getConfiguration()->getThreadCount()),
+            DryProcessRunner::class => static fn (): DryProcessRunner => new DryProcessRunner(),
+            TestFrameworkConfigLocator::class => static fn (self $container): TestFrameworkConfigLocator => new TestFrameworkConfigLocator(
+                (string) $container->getConfiguration()->getPhpUnit()->getConfigDir()
+            ),
+            DiffColorizer::class => static fn (): DiffColorizer => new DiffColorizer(),
+            MemoizedTestFileDataProvider::class => static fn (self $container): TestFileDataProvider => new MemoizedTestFileDataProvider(
+                new JUnitTestFileDataProvider($container->getJUnitReportLocator())
+            ),
             Lexer::class => static function (): Lexer {
                 $attributes = MutationAttributeKeys::ALL;
                 $attributes[] = 'comments';
@@ -347,78 +302,44 @@ final class Container
 
                 return (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);
             },
-            FileParser::class => static function (self $container): FileParser {
-                return new FileParser($container->getParser());
-            },
-            PrettyPrinterAbstract::class => static function (): Standard {
-                return new Standard();
-            },
-            MetricsCalculator::class => static function (self $container): MetricsCalculator {
-                return new MetricsCalculator($container->getConfiguration()->getMsiPrecision());
-            },
-            ResultsCollector::class => static function (self $container): ResultsCollector {
-                return new ResultsCollector();
-            },
-            Stopwatch::class => static function (): Stopwatch {
-                return new Stopwatch();
-            },
-            TimeFormatter::class => static function (): TimeFormatter {
-                return new TimeFormatter();
-            },
-            MemoryFormatter::class => static function (): MemoryFormatter {
-                return new MemoryFormatter();
-            },
-            MemoryLimiter::class => static function (self $container): MemoryLimiter {
-                return new MemoryLimiter(
-                    $container->getFileSystem(),
-                    (string) php_ini_loaded_file(),
-                    new MemoryLimiterEnvironment()
-                );
-            },
-            SchemaConfigurationLoader::class => static function (self $container): SchemaConfigurationLoader {
-                return new SchemaConfigurationLoader(
-                    $container->getRootsFileLocator(),
-                    $container->getSchemaConfigurationFileLoader()
-                );
-            },
-            RootsFileLocator::class => static function (self $container): RootsFileLocator {
-                return new RootsFileLocator(
-                    [$container->getProjectDir()],
-                    $container->getFileSystem()
-                );
-            },
-            SchemaConfigurationFileLoader::class => static function (self $container): SchemaConfigurationFileLoader {
-                return new SchemaConfigurationFileLoader(
-                    $container->getSchemaValidator(),
-                    $container->getSchemaConfigurationFactory()
-                );
-            },
-            SchemaValidator::class => static function (): SchemaValidator {
-                return new SchemaValidator();
-            },
-            SchemaConfigurationFactory::class => static function (): SchemaConfigurationFactory {
-                return new SchemaConfigurationFactory();
-            },
-            ConfigurationFactory::class => static function (self $container): ConfigurationFactory {
-                return new ConfigurationFactory(
-                    $container->getTmpDirProvider(),
-                    $container->getMutatorResolver(),
-                    $container->getMutatorFactory(),
-                    $container->getMutatorParser(),
-                    $container->getSourceFileCollector(),
-                    $container->getCiDetector(),
-                    $container->getGitDiffFileProvider()
-                );
-            },
-            MutatorResolver::class => static function (): MutatorResolver {
-                return new MutatorResolver();
-            },
-            MutatorFactory::class => static function (): MutatorFactory {
-                return new MutatorFactory();
-            },
-            MutatorParser::class => static function (): MutatorParser {
-                return new MutatorParser();
-            },
+            FileParser::class => static fn (self $container): FileParser => new FileParser($container->getParser()),
+            PrettyPrinterAbstract::class => static fn (): Standard => new Standard(),
+            MetricsCalculator::class => static fn (self $container): MetricsCalculator => new MetricsCalculator($container->getConfiguration()->getMsiPrecision()),
+            ResultsCollector::class => static fn (self $container): ResultsCollector => new ResultsCollector(),
+            Stopwatch::class => static fn (): Stopwatch => new Stopwatch(),
+            TimeFormatter::class => static fn (): TimeFormatter => new TimeFormatter(),
+            MemoryFormatter::class => static fn (): MemoryFormatter => new MemoryFormatter(),
+            MemoryLimiter::class => static fn (self $container): MemoryLimiter => new MemoryLimiter(
+                $container->getFileSystem(),
+                (string) php_ini_loaded_file(),
+                new MemoryLimiterEnvironment()
+            ),
+            SchemaConfigurationLoader::class => static fn (self $container): SchemaConfigurationLoader => new SchemaConfigurationLoader(
+                $container->getRootsFileLocator(),
+                $container->getSchemaConfigurationFileLoader()
+            ),
+            RootsFileLocator::class => static fn (self $container): RootsFileLocator => new RootsFileLocator(
+                [$container->getProjectDir()],
+                $container->getFileSystem()
+            ),
+            SchemaConfigurationFileLoader::class => static fn (self $container): SchemaConfigurationFileLoader => new SchemaConfigurationFileLoader(
+                $container->getSchemaValidator(),
+                $container->getSchemaConfigurationFactory()
+            ),
+            SchemaValidator::class => static fn (): SchemaValidator => new SchemaValidator(),
+            SchemaConfigurationFactory::class => static fn (): SchemaConfigurationFactory => new SchemaConfigurationFactory(),
+            ConfigurationFactory::class => static fn (self $container): ConfigurationFactory => new ConfigurationFactory(
+                $container->getTmpDirProvider(),
+                $container->getMutatorResolver(),
+                $container->getMutatorFactory(),
+                $container->getMutatorParser(),
+                $container->getSourceFileCollector(),
+                $container->getCiDetector(),
+                $container->getGitDiffFileProvider()
+            ),
+            MutatorResolver::class => static fn (): MutatorResolver => new MutatorResolver(),
+            MutatorFactory::class => static fn (): MutatorFactory => new MutatorFactory(),
+            MutatorParser::class => static fn (): MutatorParser => new MutatorParser(),
             CoverageChecker::class => static function (self $container): CoverageChecker {
                 $config = $container->getConfiguration();
                 $testFrameworkAdapter = $container->getTestFrameworkAdapter();
@@ -434,12 +355,10 @@ final class Container
                     $container->getIndexXmlCoverageLocator()
                 );
             },
-            JUnitReportLocator::class => static function (self $container): JUnitReportLocator {
-                return new JUnitReportLocator(
-                    $container->getConfiguration()->getCoveragePath(),
-                    $container->getDefaultJUnitFilePath()
-                );
-            },
+            JUnitReportLocator::class => static fn (self $container): JUnitReportLocator => new JUnitReportLocator(
+                $container->getConfiguration()->getCoveragePath(),
+                $container->getDefaultJUnitFilePath()
+            ),
             MinMsiChecker::class => static function (self $container): MinMsiChecker {
                 $config = $container->getConfiguration();
 
@@ -449,23 +368,19 @@ final class Container
                     (float) $config->getMinCoveredMsi()
                 );
             },
-            SubscriberRegisterer::class => static function (self $container): SubscriberRegisterer {
-                return new SubscriberRegisterer(
-                    $container->getEventDispatcher(),
-                    $container->getSubscriberFactoryRegistry()
-                );
-            },
-            ChainSubscriberFactory::class => static function (self $container): ChainSubscriberFactory {
-                return new ChainSubscriberFactory(
-                    $container->getInitialTestsConsoleLoggerSubscriberFactory(),
-                    $container->getMutationGeneratingConsoleLoggerSubscriberFactory(),
-                    $container->getMutationTestingResultsCollectorSubscriberFactory(),
-                    $container->getMutationTestingConsoleLoggerSubscriberFactory(),
-                    $container->getMutationTestingResultsLoggerSubscriberFactory(),
-                    $container->getPerformanceLoggerSubscriberFactory(),
-                    $container->getCleanUpAfterMutationTestingFinishedSubscriberFactory()
-                );
-            },
+            SubscriberRegisterer::class => static fn (self $container): SubscriberRegisterer => new SubscriberRegisterer(
+                $container->getEventDispatcher(),
+                $container->getSubscriberFactoryRegistry()
+            ),
+            ChainSubscriberFactory::class => static fn (self $container): ChainSubscriberFactory => new ChainSubscriberFactory(
+                $container->getInitialTestsConsoleLoggerSubscriberFactory(),
+                $container->getMutationGeneratingConsoleLoggerSubscriberFactory(),
+                $container->getMutationTestingResultsCollectorSubscriberFactory(),
+                $container->getMutationTestingConsoleLoggerSubscriberFactory(),
+                $container->getMutationTestingResultsLoggerSubscriberFactory(),
+                $container->getPerformanceLoggerSubscriberFactory(),
+                $container->getCleanUpAfterMutationTestingFinishedSubscriberFactory()
+            ),
             CleanUpAfterMutationTestingFinishedSubscriberFactory::class => static function (self $container): CleanUpAfterMutationTestingFinishedSubscriberFactory {
                 $config = $container->getConfiguration();
 
@@ -484,21 +399,17 @@ final class Container
                     $config->isDebugEnabled()
                 );
             },
-            MutationGeneratingConsoleLoggerSubscriberFactory::class => static function (self $container): MutationGeneratingConsoleLoggerSubscriberFactory {
-                return new MutationGeneratingConsoleLoggerSubscriberFactory(
-                    $container->getConfiguration()->noProgress()
-                );
-            },
-            MutationTestingResultsCollectorSubscriberFactory::class => static function (self $container): MutationTestingResultsCollectorSubscriberFactory {
-                return new MutationTestingResultsCollectorSubscriberFactory(
-                   ...array_filter([
-                       $container->getMetricsCalculator(),
-                       $container->getFilteringResultsCollectorFactory()->create(
-                           $container->getResultsCollector()
-                       ),
-                   ])
-                );
-            },
+            MutationGeneratingConsoleLoggerSubscriberFactory::class => static fn (self $container): MutationGeneratingConsoleLoggerSubscriberFactory => new MutationGeneratingConsoleLoggerSubscriberFactory(
+                $container->getConfiguration()->noProgress()
+            ),
+            MutationTestingResultsCollectorSubscriberFactory::class => static fn (self $container): MutationTestingResultsCollectorSubscriberFactory => new MutationTestingResultsCollectorSubscriberFactory(
+               ...array_filter([
+                   $container->getMetricsCalculator(),
+                   $container->getFilteringResultsCollectorFactory()->create(
+                       $container->getResultsCollector()
+                   ),
+               ])
+            ),
             MutationTestingConsoleLoggerSubscriberFactory::class => static function (self $container): MutationTestingConsoleLoggerSubscriberFactory {
                 $config = $container->getConfiguration();
 
@@ -510,27 +421,17 @@ final class Container
                     $container->getOutputFormatter()
                 );
             },
-            MutationTestingResultsLoggerSubscriberFactory::class => static function (self $container): MutationTestingResultsLoggerSubscriberFactory {
-                return new MutationTestingResultsLoggerSubscriberFactory(
-                    $container->getMutationTestingResultsLogger()
-                );
-            },
-            PerformanceLoggerSubscriberFactory::class => static function (self $container): PerformanceLoggerSubscriberFactory {
-                return new PerformanceLoggerSubscriberFactory(
-                    $container->getStopwatch(),
-                    $container->getTimeFormatter(),
-                    $container->getMemoryFormatter()
-                );
-            },
-            CommandLineBuilder::class => static function (): CommandLineBuilder {
-                return new CommandLineBuilder();
-            },
-            SourceFileCollector::class => static function (): SourceFileCollector {
-                return new SourceFileCollector();
-            },
-            NodeTraverserFactory::class => static function (): NodeTraverserFactory {
-                return new NodeTraverserFactory();
-            },
+            MutationTestingResultsLoggerSubscriberFactory::class => static fn (self $container): MutationTestingResultsLoggerSubscriberFactory => new MutationTestingResultsLoggerSubscriberFactory(
+                $container->getMutationTestingResultsLogger()
+            ),
+            PerformanceLoggerSubscriberFactory::class => static fn (self $container): PerformanceLoggerSubscriberFactory => new PerformanceLoggerSubscriberFactory(
+                $container->getStopwatch(),
+                $container->getTimeFormatter(),
+                $container->getMemoryFormatter()
+            ),
+            CommandLineBuilder::class => static fn (): CommandLineBuilder => new CommandLineBuilder(),
+            SourceFileCollector::class => static fn (): SourceFileCollector => new SourceFileCollector(),
+            NodeTraverserFactory::class => static fn (): NodeTraverserFactory => new NodeTraverserFactory(),
             FileMutationGenerator::class => static function (self $container): FileMutationGenerator {
                 $configuration = $container->getConfiguration();
 
@@ -543,20 +444,14 @@ final class Container
                     $configuration->getGitDiffBase()
                 );
             },
-            DiffChangedLinesParser::class => static function (self $container): DiffChangedLinesParser {
-                return new DiffChangedLinesParser();
-            },
-            FilesDiffChangedLines::class => static function (self $container): FilesDiffChangedLines {
-                return new FilesDiffChangedLines($container->getDiffChangedLinesParser(), $container->getGitDiffFileProvider());
-            },
-            StrykerLoggerFactory::class => static function (self $container): StrykerLoggerFactory {
-                return new StrykerLoggerFactory(
-                    $container->getMetricsCalculator(),
-                    $container->getStrykerHtmlReportBuilder(),
-                    $container->getCiDetector(),
-                    $container->getLogger()
-                );
-            },
+            DiffChangedLinesParser::class => static fn (self $container): DiffChangedLinesParser => new DiffChangedLinesParser(),
+            FilesDiffChangedLines::class => static fn (self $container): FilesDiffChangedLines => new FilesDiffChangedLines($container->getDiffChangedLinesParser(), $container->getGitDiffFileProvider()),
+            StrykerLoggerFactory::class => static fn (self $container): StrykerLoggerFactory => new StrykerLoggerFactory(
+                $container->getMetricsCalculator(),
+                $container->getStrykerHtmlReportBuilder(),
+                $container->getCiDetector(),
+                $container->getLogger()
+            ),
             FileLoggerFactory::class => static function (self $container): FileLoggerFactory {
                 $config = $container->getConfiguration();
 
@@ -571,19 +466,15 @@ final class Container
                     $container->getStrykerHtmlReportBuilder()
                 );
             },
-            MutationTestingResultsLogger::class => static function (self $container): MutationTestingResultsLogger {
-                return new FederatedLogger(...array_filter([
-                    $container->getFileLoggerFactory()->createFromLogEntries(
-                        $container->getConfiguration()->getLogs()
-                    ),
-                    $container->getStrykerLoggerFactory()->createFromLogEntries(
-                        $container->getConfiguration()->getLogs()
-                    ),
-                ]));
-            },
-            StrykerHtmlReportBuilder::class => static function (self $container): StrykerHtmlReportBuilder {
-                return new StrykerHtmlReportBuilder($container->getMetricsCalculator(), $container->getResultsCollector());
-            },
+            MutationTestingResultsLogger::class => static fn (self $container): MutationTestingResultsLogger => new FederatedLogger(...array_filter([
+                $container->getFileLoggerFactory()->createFromLogEntries(
+                    $container->getConfiguration()->getLogs()
+                ),
+                $container->getStrykerLoggerFactory()->createFromLogEntries(
+                    $container->getConfiguration()->getLogs()
+                ),
+            ])),
+            StrykerHtmlReportBuilder::class => static fn (self $container): StrykerHtmlReportBuilder => new StrykerHtmlReportBuilder($container->getMetricsCalculator(), $container->getResultsCollector()),
             TargetDetectionStatusesProvider::class => static function (self $container): TargetDetectionStatusesProvider {
                 $config = $container->getConfiguration();
 
@@ -594,9 +485,7 @@ final class Container
                     $config->showMutations()
                 );
             },
-            FilteringResultsCollectorFactory::class => static function (self $container): FilteringResultsCollectorFactory {
-                return new FilteringResultsCollectorFactory($container->getTargetDetectionStatusesProvider());
-            },
+            FilteringResultsCollectorFactory::class => static fn (self $container): FilteringResultsCollectorFactory => new FilteringResultsCollectorFactory($container->getTargetDetectionStatusesProvider()),
             TestFrameworkAdapter::class => static function (self $container): TestFrameworkAdapter {
                 $config = $container->getConfiguration();
 
@@ -605,25 +494,19 @@ final class Container
                     $config->shouldSkipCoverage()
                 );
             },
-            InitialTestsRunProcessFactory::class => static function (self $container): InitialTestsRunProcessFactory {
-                return new InitialTestsRunProcessFactory(
-                    $container->getTestFrameworkAdapter()
-                );
-            },
-            InitialTestsRunner::class => static function (self $container): InitialTestsRunner {
-                return new InitialTestsRunner(
-                    $container->getInitialTestRunProcessFactory(),
-                    $container->getEventDispatcher()
-                );
-            },
-            MutantProcessFactory::class => static function (self $container): MutantProcessFactory {
-                return new MutantProcessFactory(
-                    $container->getTestFrameworkAdapter(),
-                    $container->getConfiguration()->getProcessTimeout(),
-                    $container->getEventDispatcher(),
-                    $container->getMutantExecutionResultFactory()
-                );
-            },
+            InitialTestsRunProcessFactory::class => static fn (self $container): InitialTestsRunProcessFactory => new InitialTestsRunProcessFactory(
+                $container->getTestFrameworkAdapter()
+            ),
+            InitialTestsRunner::class => static fn (self $container): InitialTestsRunner => new InitialTestsRunner(
+                $container->getInitialTestRunProcessFactory(),
+                $container->getEventDispatcher()
+            ),
+            MutantProcessFactory::class => static fn (self $container): MutantProcessFactory => new MutantProcessFactory(
+                $container->getTestFrameworkAdapter(),
+                $container->getConfiguration()->getProcessTimeout(),
+                $container->getEventDispatcher(),
+                $container->getMutantExecutionResultFactory()
+            ),
             MutationGenerator::class => static function (self $container): MutationGenerator {
                 $config = $container->getConfiguration();
 
@@ -652,36 +535,16 @@ final class Container
                     $configuration->getIgnoreSourceCodeMutatorsMap()
                 );
             },
-            LineRangeCalculator::class => static function (): LineRangeCalculator {
-                return new LineRangeCalculator();
-            },
-            TestFrameworkFinder::class => static function (): TestFrameworkFinder {
-                return new TestFrameworkFinder();
-            },
-            TestFrameworkExtraOptionsFilter::class => static function (): TestFrameworkExtraOptionsFilter {
-                return new TestFrameworkExtraOptionsFilter();
-            },
-            AdapterInstallationDecider::class => static function (): AdapterInstallationDecider {
-                return new AdapterInstallationDecider(new QuestionHelper());
-            },
-            AdapterInstaller::class => static function (): AdapterInstaller {
-                return new AdapterInstaller(new ComposerExecutableFinder());
-            },
-            MutantExecutionResultFactory::class => static function (self $container): MutantExecutionResultFactory {
-                return new MutantExecutionResultFactory($container->getTestFrameworkAdapter());
-            },
-            FormatterFactory::class => static function (self $container): FormatterFactory {
-                return new FormatterFactory($container->getOutput());
-            },
-            DiffSourceCodeMatcher::class => static function (): DiffSourceCodeMatcher {
-                return new DiffSourceCodeMatcher();
-            },
-            ShellCommandLineExecutor::class => static function (): ShellCommandLineExecutor {
-                return new ShellCommandLineExecutor();
-            },
-            GitDiffFileProvider::class => static function (self $container): GitDiffFileProvider {
-                return new GitDiffFileProvider($container->getShellCommandLineExecutor());
-            },
+            LineRangeCalculator::class => static fn (): LineRangeCalculator => new LineRangeCalculator(),
+            TestFrameworkFinder::class => static fn (): TestFrameworkFinder => new TestFrameworkFinder(),
+            TestFrameworkExtraOptionsFilter::class => static fn (): TestFrameworkExtraOptionsFilter => new TestFrameworkExtraOptionsFilter(),
+            AdapterInstallationDecider::class => static fn (): AdapterInstallationDecider => new AdapterInstallationDecider(new QuestionHelper()),
+            AdapterInstaller::class => static fn (): AdapterInstaller => new AdapterInstaller(new ComposerExecutableFinder()),
+            MutantExecutionResultFactory::class => static fn (self $container): MutantExecutionResultFactory => new MutantExecutionResultFactory($container->getTestFrameworkAdapter()),
+            FormatterFactory::class => static fn (self $container): FormatterFactory => new FormatterFactory($container->getOutput()),
+            DiffSourceCodeMatcher::class => static fn (): DiffSourceCodeMatcher => new DiffSourceCodeMatcher(),
+            ShellCommandLineExecutor::class => static fn (): ShellCommandLineExecutor => new ShellCommandLineExecutor(),
+            GitDiffFileProvider::class => static fn (self $container): GitDiffFileProvider => new GitDiffFileProvider($container->getShellCommandLineExecutor()),
         ]);
 
         return $container->withValues(
@@ -758,50 +621,41 @@ final class Container
 
         $clone->offsetSet(
             CiDetector::class,
-            static function () use ($forceProgress): CiDetector {
-                return $forceProgress ? new NullCiDetector() : new MemoizedCiDetector();
-            }
+            static fn (): CiDetector => $forceProgress ? new NullCiDetector() : new MemoizedCiDetector()
         );
 
         $clone->offsetSet(
             LoggerInterface::class,
-            static function () use ($logger): LoggerInterface {
-                return $logger;
-            }
+            static fn (): LoggerInterface => $logger
         );
 
         $clone->offsetSet(
             SchemaConfiguration::class,
-            static function (self $container) use ($configFile): SchemaConfiguration {
-                return $container->getSchemaConfigurationLoader()->loadConfiguration(
-                    array_filter(
-                        [
-                            $configFile,
-                            SchemaConfigurationLoader::DEFAULT_CONFIG_FILE,
-                            SchemaConfigurationLoader::DEFAULT_DIST_CONFIG_FILE,
-                        ]
-                    )
-                );
-            }
+            static fn (self $container): SchemaConfiguration => $container->getSchemaConfigurationLoader()->loadConfiguration(
+                array_filter(
+                    [
+                        $configFile,
+                        SchemaConfigurationLoader::DEFAULT_CONFIG_FILE,
+                        SchemaConfigurationLoader::DEFAULT_DIST_CONFIG_FILE,
+                    ]
+                )
+            )
         );
 
         $clone->offsetSet(
             OutputInterface::class,
-            static function () use ($output): OutputInterface {
-                return $output;
-            }
+            static fn (): OutputInterface => $output
         );
 
         $clone->offsetSet(
             OutputFormatter::class,
-            static function (self $container) use ($formatterName): OutputFormatter {
-                return $container->getFormatterFactory()->create($formatterName);
-            }
+            static fn (self $container): OutputFormatter => $container->getFormatterFactory()->create($formatterName)
         );
 
         $clone->offsetSet(
             Configuration::class,
-            static function (self $container) use (
+            static fn (self $container): Configuration => $container->getConfigurationFactory()->create(
+                $container->getSchemaConfiguration(),
                 $existingCoveragePath,
                 $initialTestsPhpOptions,
                 $skipInitialTests,
@@ -827,36 +681,7 @@ final class Container
                 $htmlLogFilePath,
                 $useNoopMutators,
                 $executeOnlyCoveringTestCases
-            ): Configuration {
-                return $container->getConfigurationFactory()->create(
-                    $container->getSchemaConfiguration(),
-                    $existingCoveragePath,
-                    $initialTestsPhpOptions,
-                    $skipInitialTests,
-                    $logVerbosity,
-                    $debug,
-                    $onlyCovered,
-                    $noProgress,
-                    $ignoreMsiWithNoMutations,
-                    $minMsi,
-                    $showMutations,
-                    $minCoveredMsi,
-                    $msiPrecision,
-                    $mutatorsInput,
-                    $testFramework,
-                    $testFrameworkExtraOptions,
-                    $filter,
-                    $threadCount,
-                    $dryRun,
-                    $gitDiffFilter,
-                    $isForGitDiffLines,
-                    $gitDiffBase,
-                    $useGitHubLogger,
-                    $htmlLogFilePath,
-                    $useNoopMutators,
-                    $executeOnlyCoveringTestCases
-                );
-            }
+            )
         );
 
         return $clone;

--- a/src/Differ/ChangedLinesRange.php
+++ b/src/Differ/ChangedLinesRange.php
@@ -40,13 +40,8 @@ namespace Infection\Differ;
  */
 final class ChangedLinesRange
 {
-    private int $startLine;
-    private int $endLine;
-
-    public function __construct(int $startLine, int $endLine)
+    public function __construct(private int $startLine, private int $endLine)
     {
-        $this->startLine = $startLine;
-        $this->endLine = $endLine;
     }
 
     public function getStartLine(): int

--- a/src/Differ/DiffChangedLinesParser.php
+++ b/src/Differ/DiffChangedLinesParser.php
@@ -42,7 +42,7 @@ use function Safe\preg_match;
 use function Safe\preg_split;
 use function Safe\realpath;
 use function Safe\sprintf;
-use function strpos;
+use function str_starts_with;
 use Webmozart\Assert\Assert;
 
 /**
@@ -73,7 +73,7 @@ class DiffChangedLinesParser
         $resultMap = [];
 
         foreach ($lines as $line) {
-            if (strpos($line, 'diff ') === 0) {
+            if (str_starts_with($line, 'diff ')) {
                 preg_match('/diff.*a\/.*\sb\/(.*)/', $line, $matches);
 
                 Assert::keyExists(
@@ -83,7 +83,7 @@ class DiffChangedLinesParser
                 );
 
                 $filePath = realpath($matches[self::MATCH_INDEX]);
-            } elseif (strpos($line, '@@ ') === 0) {
+            } elseif (str_starts_with($line, '@@ ')) {
                 Assert::string($filePath, sprintf('Real path for file from diff can not be calculated. Diff: %s', $unifiedGreppedDiff));
 
                 preg_match('/\s\+(.*)\s@/', $line, $matches);

--- a/src/Differ/DiffColorizer.php
+++ b/src/Differ/DiffColorizer.php
@@ -39,7 +39,7 @@ use function array_map;
 use function explode;
 use function implode;
 use function Safe\sprintf;
-use function strpos;
+use function str_starts_with;
 
 /**
  * @internal
@@ -51,11 +51,11 @@ class DiffColorizer
     {
         $lines = array_map(
             static function (string $line): string {
-                if (strpos($line, '-') === 0) {
+                if (str_starts_with($line, '-')) {
                     return sprintf('<diff-del>%s</diff-del>', $line);
                 }
 
-                if (strpos($line, '+') === 0) {
+                if (str_starts_with($line, '+')) {
                     return sprintf('<diff-add>%s</diff-add>', $line);
                 }
 

--- a/src/Differ/DiffSourceCodeMatcher.php
+++ b/src/Differ/DiffSourceCodeMatcher.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Differ;
 
 use function Safe\preg_match;
-use function strpos;
+use function str_contains;
 
 /**
  * @internal
@@ -60,7 +60,7 @@ final class DiffSourceCodeMatcher
     private function findDelimiter(string $sourceCodeRegex): string
     {
         foreach (self::POSSIBLE_DELIMITERS as $possibleDelimiter) {
-            if (strpos($sourceCodeRegex, $possibleDelimiter) === false) {
+            if (!str_contains($sourceCodeRegex, $possibleDelimiter)) {
                 return $possibleDelimiter;
             }
         }

--- a/src/Differ/Differ.php
+++ b/src/Differ/Differ.php
@@ -47,11 +47,8 @@ use SebastianBergmann\Diff\Differ as BaseDiffer;
  */
 class Differ
 {
-    private BaseDiffer $differ;
-
-    public function __construct(BaseDiffer $differ)
+    public function __construct(private BaseDiffer $differ)
     {
-        $this->differ = $differ;
     }
 
     /**

--- a/src/Differ/FilesDiffChangedLines.php
+++ b/src/Differ/FilesDiffChangedLines.php
@@ -43,15 +43,11 @@ use Infection\Logger\GitHub\GitDiffFileProvider;
  */
 class FilesDiffChangedLines
 {
-    private DiffChangedLinesParser $diffChangedLinesParser;
-    private GitDiffFileProvider $diffFileProvider;
     /** @var array<string, ChangedLinesRange[]> */
-    private ?array $memoizedFilesChangedLinesMap;
+    private ?array $memoizedFilesChangedLinesMap = null;
 
-    public function __construct(DiffChangedLinesParser $diffChangedLinesParser, GitDiffFileProvider $diffFileProvider)
+    public function __construct(private DiffChangedLinesParser $diffChangedLinesParser, private GitDiffFileProvider $diffFileProvider)
     {
-        $this->diffChangedLinesParser = $diffChangedLinesParser;
-        $this->diffFileProvider = $diffFileProvider;
     }
 
     public function contains(string $fileRealPath, int $mutationStartLine, int $mutationEndLine, ?string $gitDiffBase): bool

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -60,45 +60,8 @@ use Infection\TestFramework\TestFrameworkExtraOptionsFilter;
  */
 final class Engine
 {
-    private Configuration $config;
-    private TestFrameworkAdapter $adapter;
-    private CoverageChecker $coverageChecker;
-    private EventDispatcher $eventDispatcher;
-    private InitialTestsRunner $initialTestsRunner;
-    private MemoryLimiter $memoryLimiter;
-    private MutationGenerator $mutationGenerator;
-    private MutationTestingRunner $mutationTestingRunner;
-    private MinMsiChecker $minMsiChecker;
-    private ConsoleOutput $consoleOutput;
-    private MetricsCalculator $metricsCalculator;
-    private TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter;
-
-    public function __construct(
-        Configuration $config,
-        TestFrameworkAdapter $adapter,
-        CoverageChecker $coverageChecker,
-        EventDispatcher $eventDispatcher,
-        InitialTestsRunner $initialTestsRunner,
-        MemoryLimiter $memoryLimiter,
-        MutationGenerator $mutationGenerator,
-        MutationTestingRunner $mutationTestingRunner,
-        MinMsiChecker $minMsiChecker,
-        ConsoleOutput $consoleOutput,
-        MetricsCalculator $metricsCalculator,
-        TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter
-    ) {
-        $this->config = $config;
-        $this->adapter = $adapter;
-        $this->coverageChecker = $coverageChecker;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->initialTestsRunner = $initialTestsRunner;
-        $this->memoryLimiter = $memoryLimiter;
-        $this->mutationGenerator = $mutationGenerator;
-        $this->mutationTestingRunner = $mutationTestingRunner;
-        $this->minMsiChecker = $minMsiChecker;
-        $this->consoleOutput = $consoleOutput;
-        $this->metricsCalculator = $metricsCalculator;
-        $this->testFrameworkExtraOptionsFilter = $testFrameworkExtraOptionsFilter;
+    public function __construct(private Configuration $config, private TestFrameworkAdapter $adapter, private CoverageChecker $coverageChecker, private EventDispatcher $eventDispatcher, private InitialTestsRunner $initialTestsRunner, private MemoryLimiter $memoryLimiter, private MutationGenerator $mutationGenerator, private MutationTestingRunner $mutationTestingRunner, private MinMsiChecker $minMsiChecker, private ConsoleOutput $consoleOutput, private MetricsCalculator $metricsCalculator, private TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter)
+    {
     }
 
     /**

--- a/src/Environment/BuildContext.php
+++ b/src/Environment/BuildContext.php
@@ -40,13 +40,8 @@ namespace Infection\Environment;
  */
 final class BuildContext
 {
-    private string $repositorySlug;
-    private string $branch;
-
-    public function __construct(string $repositorySlug, string $branch)
+    public function __construct(private string $repositorySlug, private string $branch)
     {
-        $this->repositorySlug = $repositorySlug;
-        $this->branch = $branch;
     }
 
     public function repositorySlug(): string

--- a/src/Environment/BuildContextResolver.php
+++ b/src/Environment/BuildContextResolver.php
@@ -44,18 +44,15 @@ use function trim;
  */
 final class BuildContextResolver
 {
-    private CiDetector $ciDetector;
-
-    public function __construct(CiDetector $ciDetector)
+    public function __construct(private CiDetector $ciDetector)
     {
-        $this->ciDetector = $ciDetector;
     }
 
     public function resolve(): BuildContext
     {
         try {
             $ci = $this->ciDetector->detect();
-        } catch (CiNotDetectedException $exception) {
+        } catch (CiNotDetectedException) {
             throw new CouldNotResolveBuildContext('The current process is not executed in a CI build');
         }
 

--- a/src/Event/EventDispatcher/SyncEventDispatcher.php
+++ b/src/Event/EventDispatcher/SyncEventDispatcher.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Event\EventDispatcher;
 
-use function get_class;
 use Infection\Event\Subscriber\EventSubscriber;
 use ReflectionClass;
 use ReflectionMethod;
@@ -54,7 +53,7 @@ final class SyncEventDispatcher implements EventDispatcher
 
     public function dispatch(object $event): void
     {
-        $name = get_class($event);
+        $name = $event::class;
 
         foreach ($this->getListeners($name) as $listener) {
             $listener($event);

--- a/src/Event/InitialTestSuiteWasFinished.php
+++ b/src/Event/InitialTestSuiteWasFinished.php
@@ -40,11 +40,8 @@ namespace Infection\Event;
  */
 final class InitialTestSuiteWasFinished
 {
-    private string $outputText;
-
-    public function __construct(string $outputText)
+    public function __construct(private string $outputText)
     {
-        $this->outputText = $outputText;
     }
 
     public function getOutputText(): string

--- a/src/Event/MutantProcessWasFinished.php
+++ b/src/Event/MutantProcessWasFinished.php
@@ -43,11 +43,8 @@ use Infection\Mutant\MutantExecutionResult;
  */
 class MutantProcessWasFinished
 {
-    private MutantExecutionResult $executionResult;
-
-    public function __construct(MutantExecutionResult $executionResult)
+    public function __construct(private MutantExecutionResult $executionResult)
     {
-        $this->executionResult = $executionResult;
     }
 
     public function getExecutionResult(): MutantExecutionResult

--- a/src/Event/MutationGenerationWasStarted.php
+++ b/src/Event/MutationGenerationWasStarted.php
@@ -40,11 +40,8 @@ namespace Infection\Event;
  */
 final class MutationGenerationWasStarted
 {
-    private int $mutableFilesCount;
-
-    public function __construct(int $mutableFilesCount)
+    public function __construct(private int $mutableFilesCount)
     {
-        $this->mutableFilesCount = $mutableFilesCount;
     }
 
     public function getMutableFilesCount(): int

--- a/src/Event/MutationTestingWasStarted.php
+++ b/src/Event/MutationTestingWasStarted.php
@@ -40,11 +40,8 @@ namespace Infection\Event;
  */
 final class MutationTestingWasStarted
 {
-    private int $mutationCount;
-
-    public function __construct(int $mutationCount)
+    public function __construct(private int $mutationCount)
     {
-        $this->mutationCount = $mutationCount;
     }
 
     public function getMutationCount(): int

--- a/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
@@ -46,20 +46,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class CiInitialTestsConsoleLoggerSubscriber implements EventSubscriber
 {
-    private OutputInterface $output;
-    private TestFrameworkAdapter $testFrameworkAdapter;
-
-    public function __construct(OutputInterface $output, TestFrameworkAdapter $testFrameworkAdapter)
+    public function __construct(private OutputInterface $output, private TestFrameworkAdapter $testFrameworkAdapter)
     {
-        $this->output = $output;
-        $this->testFrameworkAdapter = $testFrameworkAdapter;
     }
 
     public function onInitialTestSuiteWasStarted(InitialTestSuiteWasStarted $event): void
     {
         try {
             $version = $this->testFrameworkAdapter->getVersion();
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             $version = 'unknown';
         }
 

--- a/src/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriber.php
@@ -44,11 +44,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class CiMutationGeneratingConsoleLoggerSubscriber implements EventSubscriber
 {
-    private OutputInterface $output;
-
-    public function __construct(OutputInterface $output)
+    public function __construct(private OutputInterface $output)
     {
-        $this->output = $output;
     }
 
     public function onMutationGenerationWasStarted(MutationGenerationWasStarted $event): void

--- a/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php
+++ b/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php
@@ -44,13 +44,8 @@ use Symfony\Component\Finder\Finder;
  */
 final class CleanUpAfterMutationTestingFinishedSubscriber implements EventSubscriber
 {
-    private Filesystem $filesystem;
-    private string $tmpDir;
-
-    public function __construct(Filesystem $filesystem, string $tmpDir)
+    public function __construct(private Filesystem $filesystem, private string $tmpDir)
     {
-        $this->filesystem = $filesystem;
-        $this->tmpDir = $tmpDir;
     }
 
     public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void

--- a/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactory.php
+++ b/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactory.php
@@ -43,15 +43,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class CleanUpAfterMutationTestingFinishedSubscriberFactory implements SubscriberFactory
 {
-    private bool $debug;
-    private Filesystem $fileSystem;
-    private string $tmpDir;
-
-    public function __construct(bool $debug, Filesystem $fileSystem, string $tmpDir)
+    public function __construct(private bool $debug, private Filesystem $fileSystem, private string $tmpDir)
     {
-        $this->debug = $debug;
-        $this->fileSystem = $fileSystem;
-        $this->tmpDir = $tmpDir;
     }
 
     public function create(OutputInterface $output): EventSubscriber

--- a/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriber.php
@@ -50,17 +50,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class InitialTestsConsoleLoggerSubscriber implements EventSubscriber
 {
-    private OutputInterface $output;
     private ProgressBar $progressBar;
-    private TestFrameworkAdapter $testFrameworkAdapter;
-    private bool $debug;
 
-    public function __construct(OutputInterface $output, TestFrameworkAdapter $testFrameworkAdapter, bool $debug)
+    public function __construct(private OutputInterface $output, private TestFrameworkAdapter $testFrameworkAdapter, private bool $debug)
     {
-        $this->output = $output;
-        $this->testFrameworkAdapter = $testFrameworkAdapter;
-        $this->debug = $debug;
-
         $this->progressBar = new ProgressBar($this->output);
         $this->progressBar->setFormat('verbose');
     }
@@ -69,7 +62,7 @@ final class InitialTestsConsoleLoggerSubscriber implements EventSubscriber
     {
         try {
             $version = $this->testFrameworkAdapter->getVersion();
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             $version = 'unknown';
         }
 

--- a/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriberFactory.php
@@ -43,18 +43,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class InitialTestsConsoleLoggerSubscriberFactory implements SubscriberFactory
 {
-    private bool $skipProgressBar;
-    private TestFrameworkAdapter $testFrameworkAdapter;
-    private bool $debug;
-
-    public function __construct(
-        bool $skipProgressBar,
-        TestFrameworkAdapter $testFrameworkAdapter,
-        bool $debug
-    ) {
-        $this->skipProgressBar = $skipProgressBar;
-        $this->testFrameworkAdapter = $testFrameworkAdapter;
-        $this->debug = $debug;
+    public function __construct(private bool $skipProgressBar, private TestFrameworkAdapter $testFrameworkAdapter, private bool $debug)
+    {
     }
 
     public function create(OutputInterface $output): EventSubscriber

--- a/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriber.php
@@ -46,13 +46,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutationGeneratingConsoleLoggerSubscriber implements EventSubscriber
 {
-    private OutputInterface $output;
     private ProgressBar $progressBar;
 
-    public function __construct(OutputInterface $output)
+    public function __construct(private OutputInterface $output)
     {
-        $this->output = $output;
-
         $this->progressBar = new ProgressBar($this->output);
         $this->progressBar->setFormat('Processing source code files: %current%/%max%');
     }

--- a/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriberFactory.php
@@ -42,11 +42,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutationGeneratingConsoleLoggerSubscriberFactory implements SubscriberFactory
 {
-    private bool $skipProgressBar;
-
-    public function __construct(bool $skipProgressBar)
+    public function __construct(private bool $skipProgressBar)
     {
-        $this->skipProgressBar = $skipProgressBar;
     }
 
     public function create(OutputInterface $output): EventSubscriber

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -58,29 +58,10 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
 {
     private const PAD_LENGTH = 8;
 
-    private OutputInterface $output;
-    private OutputFormatter $outputFormatter;
-    private MetricsCalculator $metricsCalculator;
-    private ResultsCollector $resultsCollector;
-    private bool $showMutations;
-    private DiffColorizer $diffColorizer;
-
     private int $mutationCount = 0;
 
-    public function __construct(
-        OutputInterface $output,
-        OutputFormatter $outputFormatter,
-        MetricsCalculator $metricsCalculator,
-        ResultsCollector $resultsCollector,
-        DiffColorizer $diffColorizer,
-        bool $showMutations
-    ) {
-        $this->output = $output;
-        $this->outputFormatter = $outputFormatter;
-        $this->metricsCalculator = $metricsCalculator;
-        $this->resultsCollector = $resultsCollector;
-        $this->showMutations = $showMutations;
-        $this->diffColorizer = $diffColorizer;
+    public function __construct(private OutputInterface $output, private OutputFormatter $outputFormatter, private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector, private DiffColorizer $diffColorizer, private bool $showMutations)
+    {
     }
 
     public function onMutationTestingWasStarted(MutationTestingWasStarted $event): void
@@ -181,10 +162,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
         $this->output->writeln(['', 'Please note that some mutants will inevitably be harmless (i.e. false positives).']);
     }
 
-    /**
-     * @param int|string $subject
-     */
-    private function getPadded($subject, int $padLength = self::PAD_LENGTH): string
+    private function getPadded(int | string $subject, int $padLength = self::PAD_LENGTH): string
     {
         return str_pad((string) $subject, $padLength, ' ', STR_PAD_LEFT);
     }

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
@@ -46,24 +46,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutationTestingConsoleLoggerSubscriberFactory implements SubscriberFactory
 {
-    private MetricsCalculator $metricsCalculator;
-    private ResultsCollector $resultsCollector;
-    private DiffColorizer $diffColorizer;
-    private bool $showMutations;
-    private OutputFormatter $formatter;
-
-    public function __construct(
-        MetricsCalculator $metricsCalculator,
-        ResultsCollector $resultsCollector,
-        DiffColorizer $diffColorizer,
-        bool $showMutations,
-        OutputFormatter $formatter
-    ) {
-        $this->metricsCalculator = $metricsCalculator;
-        $this->resultsCollector = $resultsCollector;
-        $this->diffColorizer = $diffColorizer;
-        $this->showMutations = $showMutations;
-        $this->formatter = $formatter;
+    public function __construct(private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector, private DiffColorizer $diffColorizer, private bool $showMutations, private OutputFormatter $formatter)
+    {
     }
 
     public function create(OutputInterface $output): EventSubscriber

--- a/src/Event/Subscriber/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingResultsLoggerSubscriber.php
@@ -43,11 +43,8 @@ use Infection\Logger\MutationTestingResultsLogger;
  */
 final class MutationTestingResultsLoggerSubscriber implements EventSubscriber
 {
-    private MutationTestingResultsLogger $logger;
-
-    public function __construct(MutationTestingResultsLogger $logger)
+    public function __construct(private MutationTestingResultsLogger $logger)
     {
-        $this->logger = $logger;
     }
 
     public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void

--- a/src/Event/Subscriber/MutationTestingResultsLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingResultsLoggerSubscriberFactory.php
@@ -43,11 +43,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutationTestingResultsLoggerSubscriberFactory implements SubscriberFactory
 {
-    private MutationTestingResultsLogger $logger;
-
-    public function __construct(MutationTestingResultsLogger $logger)
+    public function __construct(private MutationTestingResultsLogger $logger)
     {
-        $this->logger = $logger;
     }
 
     public function create(OutputInterface $output): EventSubscriber

--- a/src/Event/Subscriber/PerformanceLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/PerformanceLoggerSubscriberFactory.php
@@ -46,18 +46,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class PerformanceLoggerSubscriberFactory implements SubscriberFactory
 {
-    private Stopwatch $stopwatch;
-    private TimeFormatter $timeFormatter;
-    private MemoryFormatter $memoryFormatter;
-
-    public function __construct(
-        Stopwatch $stopwatch,
-        TimeFormatter $timeFormatter,
-        MemoryFormatter $memoryFormatter
-    ) {
-        $this->stopwatch = $stopwatch;
-        $this->timeFormatter = $timeFormatter;
-        $this->memoryFormatter = $memoryFormatter;
+    public function __construct(private Stopwatch $stopwatch, private TimeFormatter $timeFormatter, private MemoryFormatter $memoryFormatter)
+    {
     }
 
     public function create(OutputInterface $output): EventSubscriber

--- a/src/Event/Subscriber/SubscriberRegisterer.php
+++ b/src/Event/Subscriber/SubscriberRegisterer.php
@@ -43,15 +43,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class SubscriberRegisterer
 {
-    private EventDispatcher $eventDispatcher;
-    private ChainSubscriberFactory $subscriberRegistry;
-
-    public function __construct(
-        EventDispatcher $eventDispatcher,
-        ChainSubscriberFactory $subscriberRegistry
-    ) {
-        $this->eventDispatcher = $eventDispatcher;
-        $this->subscriberRegistry = $subscriberRegistry;
+    public function __construct(private EventDispatcher $eventDispatcher, private ChainSubscriberFactory $subscriberRegistry)
+    {
     }
 
     public function registerSubscribers(OutputInterface $output): void

--- a/src/FileSystem/Finder/ComposerExecutableFinder.php
+++ b/src/FileSystem/Finder/ComposerExecutableFinder.php
@@ -39,7 +39,7 @@ use Infection\FileSystem\Finder\Exception\FinderException;
 use function Safe\getcwd;
 use function Safe\realpath;
 use function Safe\sprintf;
-use function strpos;
+use function str_contains;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
 
@@ -58,7 +58,7 @@ final class ComposerExecutableFinder
             $path = $finder->find($name, null, $immediatePaths);
 
             if ($path !== null) {
-                if (strpos($path, '.phar') === false) {
+                if (!str_contains($path, '.phar')) {
                     return $path;
                 }
 

--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -111,7 +111,7 @@ class TestFrameworkFinder
 
             $process->mustRun();
             $vendorPath = trim($process->getOutput());
-        } catch (RuntimeException $e) {
+        } catch (RuntimeException) {
             $candidate = getcwd() . '/vendor/bin';
 
             if (file_exists($candidate)) {

--- a/src/FileSystem/Locator/RootsFileLocator.php
+++ b/src/FileSystem/Locator/RootsFileLocator.php
@@ -51,17 +51,15 @@ final class RootsFileLocator implements Locator
 {
     /** @var string[] */
     private array $roots;
-    private \Symfony\Component\Filesystem\Filesystem $filesystem;
 
     /**
      * @param string[] $roots
      */
-    public function __construct(array $roots, Filesystem $filesystem)
+    public function __construct(array $roots, private Filesystem $filesystem)
     {
         Assert::allString($roots);
 
         $this->roots = $roots;
-        $this->filesystem = $filesystem;
     }
 
     public function locate(string $fileName): string
@@ -111,7 +109,7 @@ final class RootsFileLocator implements Locator
 
         try {
             return $this->locate(current($fileNames));
-        } catch (FileNotFound $exception) {
+        } catch (FileNotFound) {
             array_shift($fileNames);
 
             return $this->innerLocateOneOf($fileNames);

--- a/src/FileSystem/Locator/RootsFileOrDirectoryLocator.php
+++ b/src/FileSystem/Locator/RootsFileOrDirectoryLocator.php
@@ -50,17 +50,15 @@ final class RootsFileOrDirectoryLocator implements Locator
 {
     /** @var string[] */
     private array $roots;
-    private Filesystem $filesystem;
 
     /**
      * @param string[] $roots
      */
-    public function __construct(array $roots, Filesystem $filesystem)
+    public function __construct(array $roots, private Filesystem $filesystem)
     {
         Assert::allString($roots);
 
         $this->roots = $roots;
-        $this->filesystem = $filesystem;
     }
 
     public function locate(string $fileName): string
@@ -108,7 +106,7 @@ final class RootsFileOrDirectoryLocator implements Locator
 
         try {
             return $this->locate(current($fileNames));
-        } catch (FileOrDirectoryNotFound $exception) {
+        } catch (FileOrDirectoryNotFound) {
             array_shift($fileNames);
 
             return $this->innerLocateOneOf($fileNames);

--- a/src/FileSystem/SourceFileFilter.php
+++ b/src/FileSystem/SourceFileFilter.php
@@ -56,21 +56,14 @@ class SourceFileFilter implements FileFilter
     private array $filters;
 
     /**
-     * @var string[]
-     */
-    private array $excludeDirectories;
-
-    /**
      * @param string[] $excludeDirectories
      */
-    public function __construct(string $filter, array $excludeDirectories)
+    public function __construct(string $filter, private array $excludeDirectories)
     {
         $this->filters = array_filter(array_map(
             'trim',
             explode(',', $filter)
         ));
-
-        $this->excludeDirectories = $excludeDirectories;
     }
 
     /**

--- a/src/Logger/ConsoleLogger.php
+++ b/src/Logger/ConsoleLogger.php
@@ -37,7 +37,6 @@ namespace Infection\Logger;
 
 use DateTime;
 use DateTimeInterface;
-use function get_class;
 use function gettype;
 use Infection\Console\IO;
 use function is_object;
@@ -46,7 +45,7 @@ use function method_exists;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;
 use function Safe\sprintf;
-use function strpos;
+use function str_contains;
 use function strtr;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webmozart\Assert\Assert;
@@ -87,11 +86,8 @@ final class ConsoleLogger extends AbstractLogger
         LogLevel::NOTICE => 'note',
     ];
 
-    private IO $io;
-
-    public function __construct(IO $io)
+    public function __construct(private IO $io)
     {
-        $this->io = $io;
     }
 
     /**
@@ -150,7 +146,7 @@ final class ConsoleLogger extends AbstractLogger
      */
     private function interpolate(string $message, array $context): string
     {
-        if (strpos($message, '{') === false) {
+        if (!str_contains($message, '{')) {
             return $message;
         }
 
@@ -165,7 +161,7 @@ final class ConsoleLogger extends AbstractLogger
             } elseif ($val instanceof DateTimeInterface) {
                 $replacements["{{$key}}"] = $val->format(DateTime::RFC3339);
             } elseif (is_object($val)) {
-                $replacements["{{$key}}"] = '[object ' . get_class($val) . ']';
+                $replacements["{{$key}}"] = '[object ' . $val::class . ']';
             } else {
                 $replacements["{{$key}}"] = '[' . gettype($val) . ']';
             }

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -52,18 +52,8 @@ use function strlen;
  */
 final class DebugFileLogger implements LineMutationTestingResultsLogger
 {
-    private MetricsCalculator $metricsCalculator;
-    private ResultsCollector $resultsCollector;
-    private bool $onlyCoveredMode;
-
-    public function __construct(
-        MetricsCalculator $metricsCalculator,
-        ResultsCollector $resultsCollector,
-        bool $onlyCoveredMode
-    ) {
-        $this->metricsCalculator = $metricsCalculator;
-        $this->resultsCollector = $resultsCollector;
-        $this->onlyCoveredMode = $onlyCoveredMode;
+    public function __construct(private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector, private bool $onlyCoveredMode)
+    {
     }
 
     public function getLogLines(): array

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -41,7 +41,7 @@ use const PHP_EOL;
 use Psr\Log\LoggerInterface;
 use function Safe\file_put_contents;
 use function Safe\sprintf;
-use function strpos;
+use function str_starts_with;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -50,21 +50,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class FileLogger implements MutationTestingResultsLogger
 {
-    private string $filePath;
-    private Filesystem $fileSystem;
-    private LineMutationTestingResultsLogger $lineLogger;
-    private LoggerInterface $logger;
-
-    public function __construct(
-        string $filePath,
-        Filesystem $fileSystem,
-        LineMutationTestingResultsLogger $lineLogger,
-        LoggerInterface $logger
-    ) {
-        $this->filePath = $filePath;
-        $this->fileSystem = $fileSystem;
-        $this->lineLogger = $lineLogger;
-        $this->logger = $logger;
+    public function __construct(private string $filePath, private Filesystem $fileSystem, private LineMutationTestingResultsLogger $lineLogger, private LoggerInterface $logger)
+    {
     }
 
     public function log(): void
@@ -72,7 +59,7 @@ final class FileLogger implements MutationTestingResultsLogger
         $content = implode(PHP_EOL, $this->lineLogger->getLogLines());
 
         // If the output should be written to a stream then just write it directly
-        if (strpos($this->filePath, 'php://') === 0) {
+        if (str_starts_with($this->filePath, 'php://')) {
             if (in_array($this->filePath, ['php://stdout', 'php://stderr'], true)) {
                 file_put_contents($this->filePath, $content);
             } else {

--- a/src/Logger/FileLoggerFactory.php
+++ b/src/Logger/FileLoggerFactory.php
@@ -50,34 +50,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class FileLoggerFactory
 {
-    private MetricsCalculator $metricsCalculator;
-    private ResultsCollector $resultsCollector;
-
-    private Filesystem $filesystem;
-    private string $logVerbosity;
-    private bool $debugMode;
-    private bool $onlyCoveredCode;
-    private LoggerInterface $logger;
-    private StrykerHtmlReportBuilder $strykerHtmlReportBuilder;
-
-    public function __construct(
-        MetricsCalculator $metricsCalculator,
-        ResultsCollector $resultsCollector,
-        Filesystem $filesystem,
-        string $logVerbosity,
-        bool $debugMode,
-        bool $onlyCoveredCode,
-        LoggerInterface $logger,
-        StrykerHtmlReportBuilder $strykerHtmlReportBuilder
-    ) {
-        $this->metricsCalculator = $metricsCalculator;
-        $this->resultsCollector = $resultsCollector;
-        $this->filesystem = $filesystem;
-        $this->logVerbosity = $logVerbosity;
-        $this->debugMode = $debugMode;
-        $this->onlyCoveredCode = $onlyCoveredCode;
-        $this->logger = $logger;
-        $this->strykerHtmlReportBuilder = $strykerHtmlReportBuilder;
+    public function __construct(private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector, private Filesystem $filesystem, private string $logVerbosity, private bool $debugMode, private bool $onlyCoveredCode, private LoggerInterface $logger, private StrykerHtmlReportBuilder $strykerHtmlReportBuilder)
+    {
     }
 
     public function createFromLogEntries(Logs $logConfig): MutationTestingResultsLogger

--- a/src/Logger/GitHub/GitDiffFileProvider.php
+++ b/src/Logger/GitHub/GitDiffFileProvider.php
@@ -48,11 +48,8 @@ class GitDiffFileProvider
 {
     public const DEFAULT_BASE = 'origin/master';
 
-    private ShellCommandLineExecutor $shellCommandLineExecutor;
-
-    public function __construct(ShellCommandLineExecutor $shellCommandLineExecutor)
+    public function __construct(private ShellCommandLineExecutor $shellCommandLineExecutor)
     {
-        $this->shellCommandLineExecutor = $shellCommandLineExecutor;
     }
 
     public function provide(string $gitDiffFilter, string $gitDiffBase): string

--- a/src/Logger/GitHubAnnotationsLogger.php
+++ b/src/Logger/GitHubAnnotationsLogger.php
@@ -48,11 +48,8 @@ final class GitHubAnnotationsLogger implements LineMutationTestingResultsLogger
 {
     public const DEFAULT_OUTPUT = 'php://stdout';
 
-    private ResultsCollector $resultsCollector;
-
-    public function __construct(ResultsCollector $resultsCollector)
+    public function __construct(private ResultsCollector $resultsCollector)
     {
-        $this->resultsCollector = $resultsCollector;
     }
 
     public function getLogLines(): array

--- a/src/Logger/Html/HtmlFileLogger.php
+++ b/src/Logger/Html/HtmlFileLogger.php
@@ -43,12 +43,8 @@ use function Safe\json_encode;
  */
 final class HtmlFileLogger implements LineMutationTestingResultsLogger
 {
-    private StrykerHtmlReportBuilder $strykerHtmlReportBuilder;
-
-    public function __construct(
-        StrykerHtmlReportBuilder $strykerHtmlReportBuilder
-    ) {
-        $this->strykerHtmlReportBuilder = $strykerHtmlReportBuilder;
+    public function __construct(private StrykerHtmlReportBuilder $strykerHtmlReportBuilder)
+    {
     }
 
     public function getLogLines(): array

--- a/src/Logger/Html/StrykerHtmlReportBuilder.php
+++ b/src/Logger/Html/StrykerHtmlReportBuilder.php
@@ -66,8 +66,8 @@ use function Safe\file_get_contents;
 use function Safe\preg_match;
 use function Safe\preg_split;
 use function Safe\substr;
+use function str_starts_with;
 use function strlen;
-use function strpos;
 use Webmozart\Assert\Assert;
 use Webmozart\PathUtil\Path;
 
@@ -90,15 +90,8 @@ final class StrykerHtmlReportBuilder
     private const PLUS_LENGTH = 1;
     private const DIFF_HEADERS_LINES_COUNT = 3;
 
-    private MetricsCalculator $metricsCalculator;
-    private ResultsCollector $resultsCollector;
-
-    public function __construct(
-        MetricsCalculator $metricsCalculator,
-        ResultsCollector $resultsCollector
-    ) {
-        $this->metricsCalculator = $metricsCalculator;
-        $this->resultsCollector = $resultsCollector;
+    public function __construct(private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector)
+    {
     }
 
     public function build(): array
@@ -274,9 +267,7 @@ final class StrykerHtmlReportBuilder
         $lines = preg_split('/\n|\r\n?/', $diff);
 
         $lines = array_map(
-            static function (string $line): string {
-                return isset($line[0]) ? substr($line, self::PLUS_LENGTH) : $line;
-            },
+            static fn (string $line): string => isset($line[0]) ? substr($line, self::PLUS_LENGTH) : $line,
             array_filter(
             /*
             --- Original
@@ -284,9 +275,7 @@ final class StrykerHtmlReportBuilder
             @@ @@
              */
                 array_slice($lines, self::DIFF_HEADERS_LINES_COUNT),
-                static function (string $line): bool {
-                    return strpos($line, '+') === 0;
-                }
+                static fn (string $line): bool => str_starts_with($line, '+')
             )
         );
 

--- a/src/Logger/Http/Response.php
+++ b/src/Logger/Http/Response.php
@@ -46,9 +46,8 @@ final class Response
     public const HTTP_CREATED = 201;
 
     private int $statusCode;
-    private string $body;
 
-    public function __construct(int $statusCode, string $body)
+    public function __construct(int $statusCode, private string $body)
     {
         Assert::range(
             $statusCode,
@@ -58,7 +57,6 @@ final class Response
         );
 
         $this->statusCode = $statusCode;
-        $this->body = $body;
     }
 
     public function getStatusCode(): int

--- a/src/Logger/Http/StrykerCurlClient.php
+++ b/src/Logger/Http/StrykerCurlClient.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Logger\Http;
 
-use function curl_close;
 use const CURLINFO_HTTP_CODE;
 use const CURLOPT_CUSTOMREQUEST;
 use const CURLOPT_HEADER;
@@ -83,19 +82,15 @@ class StrykerCurlClient
 
         $handle = curl_init();
 
-        try {
-            curl_setopt($handle, CURLOPT_URL, $url);
-            curl_setopt($handle, CURLOPT_CUSTOMREQUEST, 'PUT');
-            curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($handle, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($handle, CURLOPT_POSTFIELDS, $reportJson);
-            curl_setopt($handle, CURLOPT_HEADER, true);
+        curl_setopt($handle, CURLOPT_URL, $url);
+        curl_setopt($handle, CURLOPT_CUSTOMREQUEST, 'PUT');
+        curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($handle, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($handle, CURLOPT_POSTFIELDS, $reportJson);
+        curl_setopt($handle, CURLOPT_HEADER, true);
 
-            $body = (string) curl_exec($handle);
-            $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-        } finally {
-            curl_close($handle);
-        }
+        $body = (string) curl_exec($handle);
+        $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
 
         return new Response($statusCode, $body);
     }

--- a/src/Logger/Http/StrykerDashboardClient.php
+++ b/src/Logger/Http/StrykerDashboardClient.php
@@ -44,13 +44,8 @@ use function Safe\sprintf;
  */
 class StrykerDashboardClient
 {
-    private StrykerCurlClient $client;
-    private LoggerInterface $logger;
-
-    public function __construct(StrykerCurlClient $client, LoggerInterface $logger)
+    public function __construct(private StrykerCurlClient $client, private LoggerInterface $logger)
     {
-        $this->client = $client;
-        $this->logger = $logger;
     }
 
     public function sendReport(

--- a/src/Logger/JsonLogger.php
+++ b/src/Logger/JsonLogger.php
@@ -48,18 +48,8 @@ use function mb_convert_encoding;
  */
 final class JsonLogger implements LineMutationTestingResultsLogger
 {
-    private MetricsCalculator $metricsCalculator;
-    private ResultsCollector $resultsCollector;
-    private bool $onlyCoveredMode;
-
-    public function __construct(
-        MetricsCalculator $metricsCalculator,
-        ResultsCollector $resultsCollector,
-        bool $onlyCoveredMode
-    ) {
-        $this->metricsCalculator = $metricsCalculator;
-        $this->resultsCollector = $resultsCollector;
-        $this->onlyCoveredMode = $onlyCoveredMode;
+    public function __construct(private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector, private bool $onlyCoveredMode)
+    {
     }
 
     /**

--- a/src/Logger/PerMutatorLogger.php
+++ b/src/Logger/PerMutatorLogger.php
@@ -57,15 +57,8 @@ use function strlen;
  */
 final class PerMutatorLogger implements LineMutationTestingResultsLogger
 {
-    private MetricsCalculator $metricsCalculator;
-    private ResultsCollector $resultsCollector;
-
-    public function __construct(
-        MetricsCalculator $metricsCalculator,
-        ResultsCollector $resultsCollector
-    ) {
-        $this->metricsCalculator = $metricsCalculator;
-        $this->resultsCollector = $resultsCollector;
+    public function __construct(private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector)
+    {
     }
 
     public function getLogLines(): array

--- a/src/Logger/StrykerLogger.php
+++ b/src/Logger/StrykerLogger.php
@@ -53,30 +53,8 @@ use function Safe\sprintf;
  */
 final class StrykerLogger implements MutationTestingResultsLogger
 {
-    private BuildContextResolver $buildContextResolver;
-    private StrykerApiKeyResolver $strykerApiKeyResolver;
-    private StrykerDashboardClient $strykerDashboardClient;
-    private MetricsCalculator $metricsCalculator;
-    private StrykerConfig $strykerConfig;
-    private LoggerInterface $logger;
-    private StrykerHtmlReportBuilder $strykerHtmlReportBuilder;
-
-    public function __construct(
-        BuildContextResolver $buildContextResolver,
-        StrykerApiKeyResolver $strykerApiKeyResolver,
-        StrykerDashboardClient $strykerDashboardClient,
-        MetricsCalculator $metricsCalculator,
-        StrykerHtmlReportBuilder $strykerHtmlReportBuilder,
-        StrykerConfig $strykerConfig,
-        LoggerInterface $logger
-    ) {
-        $this->buildContextResolver = $buildContextResolver;
-        $this->strykerApiKeyResolver = $strykerApiKeyResolver;
-        $this->strykerDashboardClient = $strykerDashboardClient;
-        $this->metricsCalculator = $metricsCalculator;
-        $this->strykerHtmlReportBuilder = $strykerHtmlReportBuilder;
-        $this->strykerConfig = $strykerConfig;
-        $this->logger = $logger;
+    public function __construct(private BuildContextResolver $buildContextResolver, private StrykerApiKeyResolver $strykerApiKeyResolver, private StrykerDashboardClient $strykerDashboardClient, private MetricsCalculator $metricsCalculator, private StrykerHtmlReportBuilder $strykerHtmlReportBuilder, private StrykerConfig $strykerConfig, private LoggerInterface $logger)
+    {
     }
 
     public function log(): void

--- a/src/Logger/StrykerLoggerFactory.php
+++ b/src/Logger/StrykerLoggerFactory.php
@@ -51,21 +51,8 @@ use Psr\Log\LoggerInterface;
  */
 class StrykerLoggerFactory
 {
-    private MetricsCalculator $metricsCalculator;
-    private StrykerHtmlReportBuilder $strykerHtmlReportBuilder;
-    private CiDetector $ciDetector;
-    private LoggerInterface $logger;
-
-    public function __construct(
-        MetricsCalculator $metricsCalculator,
-        StrykerHtmlReportBuilder $strykerHtmlReportBuilder,
-        CiDetector $ciDetector,
-        LoggerInterface $logger
-    ) {
-        $this->metricsCalculator = $metricsCalculator;
-        $this->ciDetector = $ciDetector;
-        $this->logger = $logger;
-        $this->strykerHtmlReportBuilder = $strykerHtmlReportBuilder;
+    public function __construct(private MetricsCalculator $metricsCalculator, private StrykerHtmlReportBuilder $strykerHtmlReportBuilder, private CiDetector $ciDetector, private LoggerInterface $logger)
+    {
     }
 
     public function createFromLogEntries(Logs $logConfig): ?MutationTestingResultsLogger

--- a/src/Logger/SummaryFileLogger.php
+++ b/src/Logger/SummaryFileLogger.php
@@ -45,11 +45,8 @@ use Infection\Metrics\MetricsCalculator;
  */
 final class SummaryFileLogger implements LineMutationTestingResultsLogger
 {
-    private MetricsCalculator $metricsCalculator;
-
-    public function __construct(MetricsCalculator $metricsCalculator)
+    public function __construct(private MetricsCalculator $metricsCalculator)
     {
-        $this->metricsCalculator = $metricsCalculator;
     }
 
     public function getLogLines(): array

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -51,21 +51,8 @@ use function strlen;
  */
 final class TextFileLogger implements LineMutationTestingResultsLogger
 {
-    private ResultsCollector $resultsCollector;
-    private bool $debugVerbosity;
-    private bool $onlyCoveredMode;
-    private bool $debugMode;
-
-    public function __construct(
-        ResultsCollector $resultsCollector,
-        bool $debugVerbosity,
-        bool $onlyCoveredMode,
-        bool $debugMode
-    ) {
-        $this->resultsCollector = $resultsCollector;
-        $this->debugVerbosity = $debugVerbosity;
-        $this->onlyCoveredMode = $onlyCoveredMode;
-        $this->debugMode = $debugMode;
+    public function __construct(private ResultsCollector $resultsCollector, private bool $debugVerbosity, private bool $onlyCoveredMode, private bool $debugMode)
+    {
     }
 
     public function getLogLines(): array
@@ -205,9 +192,7 @@ final class TextFileLogger implements LineMutationTestingResultsLogger
         return implode(
             PHP_EOL,
             array_map(
-                static function (string $line): string {
-                    return '  ' . $line;
-                },
+                static fn (string $line): string => '  ' . $line,
                 explode(PHP_EOL, Str::trimLineReturns($value))
             )
         );

--- a/src/Metrics/Calculator.php
+++ b/src/Metrics/Calculator.php
@@ -43,33 +43,14 @@ use function round;
  */
 final class Calculator
 {
-    private int $roundingPrecision;
-    private int $killedCount;
-    private int $errorCount;
-    private int $timedOutCount;
-    private int $notTestedCount;
-    private int $totalCount;
-
     private ?float $mutationScoreIndicator = null;
 
     private ?float $coverageRate = null;
 
     private ?float $coveredMutationScoreIndicator = null;
 
-    public function __construct(
-        int $roundingPrecision,
-        int $killedCount,
-        int $errorCount,
-        int $timedOutCount,
-        int $notTestedCount,
-        int $totalCount
-    ) {
-        $this->roundingPrecision = $roundingPrecision;
-        $this->killedCount = $killedCount;
-        $this->errorCount = $errorCount;
-        $this->timedOutCount = $timedOutCount;
-        $this->notTestedCount = $notTestedCount;
-        $this->totalCount = $totalCount;
+    public function __construct(private int $roundingPrecision, private int $killedCount, private int $errorCount, private int $timedOutCount, private int $notTestedCount, private int $totalCount)
+    {
     }
 
     public static function fromMetrics(MetricsCalculator $calculator): self

--- a/src/Metrics/FilteringResultsCollector.php
+++ b/src/Metrics/FilteringResultsCollector.php
@@ -45,26 +45,18 @@ use Infection\Mutant\MutantExecutionResult;
  */
 class FilteringResultsCollector implements Collector
 {
-    private Collector $targetCollector;
-    /** @var array<string, mixed> */
-    private array $targetDetectionStatuses;
-
     /**
      * @param array<string, mixed> $targetDetectionStatuses
      */
-    public function __construct(Collector $targetCollector, array $targetDetectionStatuses)
+    public function __construct(private Collector $targetCollector, private array $targetDetectionStatuses)
     {
-        $this->targetCollector = $targetCollector;
-        $this->targetDetectionStatuses = $targetDetectionStatuses;
     }
 
     public function collect(MutantExecutionResult ...$executionResults): void
     {
         $executionResults = array_filter(
             $executionResults,
-            function (MutantExecutionResult $executionResults): bool {
-                return array_key_exists($executionResults->getDetectionStatus(), $this->targetDetectionStatuses);
-            }
+            fn (MutantExecutionResult $executionResults): bool => array_key_exists($executionResults->getDetectionStatus(), $this->targetDetectionStatuses)
         );
 
         if ($executionResults !== []) {

--- a/src/Metrics/FilteringResultsCollectorFactory.php
+++ b/src/Metrics/FilteringResultsCollectorFactory.php
@@ -43,11 +43,8 @@ use Infection\Mutant\DetectionStatus;
  */
 final class FilteringResultsCollectorFactory
 {
-    private TargetDetectionStatusesProvider $statusesProvider;
-
-    public function __construct(TargetDetectionStatusesProvider $statusesProvider)
+    public function __construct(private TargetDetectionStatusesProvider $statusesProvider)
     {
-        $this->statusesProvider = $statusesProvider;
     }
 
     public function create(Collector $targetCollector): ?Collector

--- a/src/Metrics/MetricsCalculator.php
+++ b/src/Metrics/MetricsCalculator.php
@@ -46,8 +46,6 @@ use function Safe\sprintf;
  */
 class MetricsCalculator implements Collector
 {
-    private int $roundingPrecision;
-
     /**
      * @var array<string, int>
      */
@@ -57,10 +55,8 @@ class MetricsCalculator implements Collector
 
     private ?Calculator $calculator = null;
 
-    public function __construct(int $roundingPrecision)
+    public function __construct(private int $roundingPrecision)
     {
-        $this->roundingPrecision = $roundingPrecision;
-
         foreach (DetectionStatus::ALL as $status) {
             $this->countByStatus[$status] = 0;
         }

--- a/src/Metrics/MinMsiChecker.php
+++ b/src/Metrics/MinMsiChecker.php
@@ -45,18 +45,8 @@ class MinMsiChecker
 {
     private const VALUE_OVER_REQUIRED_TOLERANCE = 2;
 
-    private bool $ignoreMsiWithNoMutations;
-    private float $minMsi;
-    private float $minCoveredCodeMsi;
-
-    public function __construct(
-        bool $ignoreMsiWithNoMutations,
-        float $minMsi,
-        float $minCoveredMsi
-    ) {
-        $this->ignoreMsiWithNoMutations = $ignoreMsiWithNoMutations;
-        $this->minMsi = $minMsi;
-        $this->minCoveredCodeMsi = $minCoveredMsi;
+    public function __construct(private bool $ignoreMsiWithNoMutations, private float $minMsi, private float $minCoveredCodeMsi)
+    {
     }
 
     /**

--- a/src/Metrics/TargetDetectionStatusesProvider.php
+++ b/src/Metrics/TargetDetectionStatusesProvider.php
@@ -49,21 +49,8 @@ use function Safe\array_flip;
  */
 class TargetDetectionStatusesProvider
 {
-    private Logs $logConfig;
-    private string $logVerbosity;
-    private bool $onlyCoveredMode;
-    private bool $showMutations;
-
-    public function __construct(
-        Logs $logConfig,
-        string $logVerbosity,
-        bool $onlyCoveredMode,
-        bool $showMutations
-    ) {
-        $this->logConfig = $logConfig;
-        $this->logVerbosity = $logVerbosity;
-        $this->onlyCoveredMode = $onlyCoveredMode;
-        $this->showMutations = $showMutations;
+    public function __construct(private Logs $logConfig, private string $logVerbosity, private bool $onlyCoveredMode, private bool $showMutations)
+    {
     }
 
     /**

--- a/src/Mutant/Mutant.php
+++ b/src/Mutant/Mutant.php
@@ -45,32 +45,13 @@ use Later\Interfaces\Deferred;
  */
 class Mutant
 {
-    private string $mutantFilePath;
-    private Mutation $mutation;
-    /** @var Deferred<string> */
-    private Deferred $mutatedCode;
-    /** @var Deferred<string> */
-    private Deferred $diff;
-    /** @var Deferred<string> */
-    private Deferred $prettyPrintedOriginalCode;
-
     /**
      * @param Deferred<string> $mutatedCode
      * @param Deferred<string> $diff
      * @param Deferred<string> $prettyPrintedOriginalCode
      */
-    public function __construct(
-        string $mutantFilePath,
-        Mutation $mutation,
-        Deferred $mutatedCode,
-        Deferred $diff,
-        Deferred $prettyPrintedOriginalCode
-    ) {
-        $this->mutantFilePath = $mutantFilePath;
-        $this->mutation = $mutation;
-        $this->mutatedCode = $mutatedCode;
-        $this->diff = $diff;
-        $this->prettyPrintedOriginalCode = $prettyPrintedOriginalCode;
+    public function __construct(private string $mutantFilePath, private Mutation $mutation, private Deferred $mutatedCode, private Deferred $diff, private Deferred $prettyPrintedOriginalCode)
+    {
     }
 
     public function getFilePath(): string

--- a/src/Mutant/MutantCodeFactory.php
+++ b/src/Mutant/MutantCodeFactory.php
@@ -47,11 +47,8 @@ use PhpParser\PrettyPrinterAbstract;
  */
 class MutantCodeFactory
 {
-    private PrettyPrinterAbstract $printer;
-
-    public function __construct(PrettyPrinterAbstract $prettyPrinter)
+    public function __construct(private PrettyPrinterAbstract $printer)
     {
-        $this->printer = $prettyPrinter;
     }
 
     public function createCode(Mutation $mutation): string

--- a/src/Mutant/MutantExecutionResult.php
+++ b/src/Mutant/MutantExecutionResult.php
@@ -50,36 +50,8 @@ use Webmozart\Assert\Assert;
  */
 class MutantExecutionResult
 {
-    private string $processCommandLine;
-    private string $processOutput;
     private string $detectionStatus;
-
-    /**
-     * @var Deferred<string>
-     */
-    private Deferred $mutantDiff;
-    private string $mutantHash;
     private string $mutatorName;
-    private string $originalFilePath;
-    private int $originalStartingLine;
-    private int $originalEndingLine;
-    private int $originalStartFilePosition;
-    private int $originalEndFilePosition;
-
-    /**
-     * @var Deferred<string>
-     */
-    private Deferred $originalCode;
-
-    /**
-     * @var Deferred<string>
-     */
-    private Deferred $mutatedCode;
-
-    /**
-     * @var TestLocation[]
-     */
-    private array $tests;
 
     /**
      * @param Deferred<string> $mutantDiff
@@ -88,38 +60,25 @@ class MutantExecutionResult
      * @param TestLocation[] $tests
      */
     public function __construct(
-        string $processCommandLine,
-        string $processOutput,
+        private string $processCommandLine,
+        private string $processOutput,
         string $detectionStatus,
-        Deferred $mutantDiff,
-        string $mutantHash,
+        private Deferred $mutantDiff,
+        private string $mutantHash,
         string $mutatorName,
-        string $originalFilePath,
-        int $originalStartingLine,
-        int $originalEndingLine,
-        int $originalStartFilePosition,
-        int $originalEndFilePosition,
-        Deferred $originalCode,
-        Deferred $mutatedCode,
-        array $tests
+        private string $originalFilePath,
+        private int $originalStartingLine,
+        private int $originalEndingLine,
+        private int $originalStartFilePosition,
+        private int $originalEndFilePosition,
+        private Deferred $originalCode,
+        private Deferred $mutatedCode,
+        private array $tests
     ) {
         Assert::oneOf($detectionStatus, DetectionStatus::ALL);
         Assert::oneOf($mutatorName, array_keys(ProfileList::ALL_MUTATORS));
-
-        $this->processCommandLine = $processCommandLine;
-        $this->processOutput = $processOutput;
         $this->detectionStatus = $detectionStatus;
-        $this->mutantDiff = $mutantDiff;
-        $this->mutantHash = $mutantHash;
         $this->mutatorName = $mutatorName;
-        $this->originalFilePath = $originalFilePath;
-        $this->originalStartingLine = $originalStartingLine;
-        $this->originalEndingLine = $originalEndingLine;
-        $this->originalCode = $originalCode;
-        $this->mutatedCode = $mutatedCode;
-        $this->tests = $tests;
-        $this->originalStartFilePosition = $originalStartFilePosition;
-        $this->originalEndFilePosition = $originalEndFilePosition;
     }
 
     public static function createFromNonCoveredMutant(Mutant $mutant): self

--- a/src/Mutant/MutantExecutionResultFactory.php
+++ b/src/Mutant/MutantExecutionResultFactory.php
@@ -48,11 +48,8 @@ use Webmozart\Assert\Assert;
  */
 class MutantExecutionResultFactory
 {
-    private TestFrameworkAdapter $testFrameworkAdapter;
-
-    public function __construct(TestFrameworkAdapter $testFrameworkAdapter)
+    public function __construct(private TestFrameworkAdapter $testFrameworkAdapter)
     {
-        $this->testFrameworkAdapter = $testFrameworkAdapter;
     }
 
     public function createFromProcess(MutantProcess $mutantProcess): MutantExecutionResult

--- a/src/Mutant/MutantFactory.php
+++ b/src/Mutant/MutantFactory.php
@@ -49,26 +49,13 @@ use function Safe\sprintf;
  */
 class MutantFactory
 {
-    private string $tmpDir;
-    private Differ $differ;
-    private PrettyPrinterAbstract $printer;
-
     /**
      * @var string[]
      */
     private array $printedFileCache = [];
-    private MutantCodeFactory $mutantCodeFactory;
 
-    public function __construct(
-        string $tmpDir,
-        Differ $differ,
-        PrettyPrinterAbstract $printer,
-        MutantCodeFactory $mutantCodeFactory
-    ) {
-        $this->tmpDir = $tmpDir;
-        $this->differ = $differ;
-        $this->printer = $printer;
-        $this->mutantCodeFactory = $mutantCodeFactory;
+    public function __construct(private string $tmpDir, private Differ $differ, private PrettyPrinterAbstract $printer, private MutantCodeFactory $mutantCodeFactory)
+    {
     }
 
     public function create(Mutation $mutation): Mutant

--- a/src/Mutation/FileMutationGenerator.php
+++ b/src/Mutation/FileMutationGenerator.php
@@ -53,27 +53,8 @@ use Webmozart\Assert\Assert;
  */
 class FileMutationGenerator
 {
-    private FileParser $parser;
-    private NodeTraverserFactory $traverserFactory;
-    private LineRangeCalculator $lineRangeCalculator;
-    private FilesDiffChangedLines $filesDiffChangedLines;
-    private bool $isForGitDiffLines;
-    private ?string $gitDiffBase;
-
-    public function __construct(
-        FileParser $parser,
-        NodeTraverserFactory $traverserFactory,
-        LineRangeCalculator $lineRangeCalculator,
-        FilesDiffChangedLines $filesDiffChangedLines,
-        bool $isForGitDiffLines,
-        ?string $gitDiffBase
-    ) {
-        $this->parser = $parser;
-        $this->traverserFactory = $traverserFactory;
-        $this->lineRangeCalculator = $lineRangeCalculator;
-        $this->filesDiffChangedLines = $filesDiffChangedLines;
-        $this->isForGitDiffLines = $isForGitDiffLines;
-        $this->gitDiffBase = $gitDiffBase;
+    public function __construct(private FileParser $parser, private NodeTraverserFactory $traverserFactory, private LineRangeCalculator $lineRangeCalculator, private FilesDiffChangedLines $filesDiffChangedLines, private bool $isForGitDiffLines, private ?string $gitDiffBase)
+    {
     }
 
     /**

--- a/src/Mutation/Mutation.php
+++ b/src/Mutation/Mutation.php
@@ -53,17 +53,9 @@ use Webmozart\Assert\Assert;
  */
 class Mutation
 {
-    private string $originalFilePath;
     private string $mutatorName;
-    private string $mutatedNodeClass;
-    private MutatedNode $mutatedNode;
-    private int $mutationByMutatorIndex;
     /** @var array<string|int|float> */
     private array $attributes;
-    /** @var Node[] */
-    private array $originalFileAst;
-    /** @var TestLocation[] */
-    private array $tests;
     private bool $coveredByTests;
     private ?float $nominalTimeToTest = null;
 
@@ -75,29 +67,22 @@ class Mutation
      * @param TestLocation[] $tests
      */
     public function __construct(
-        string $originalFilePath,
-        array $originalFileAst,
+        private string $originalFilePath,
+        private array $originalFileAst,
         string $mutatorName,
         array $attributes,
-        string $mutatedNodeClass,
-        MutatedNode $mutatedNode,
-        int $mutationByMutatorIndex,
-        array $tests
+        private string $mutatedNodeClass,
+        private MutatedNode $mutatedNode,
+        private int $mutationByMutatorIndex,
+        private array $tests
     ) {
         Assert::oneOf($mutatorName, array_keys(ProfileList::ALL_MUTATORS));
 
         foreach (MutationAttributeKeys::ALL as $key) {
             Assert::keyExists($attributes, $key);
         }
-
-        $this->originalFilePath = $originalFilePath;
-        $this->originalFileAst = $originalFileAst;
         $this->mutatorName = $mutatorName;
         $this->attributes = array_intersect_key($attributes, array_flip(MutationAttributeKeys::ALL));
-        $this->mutatedNodeClass = $mutatedNodeClass;
-        $this->mutatedNode = $mutatedNode;
-        $this->mutationByMutatorIndex = $mutationByMutatorIndex;
-        $this->tests = $tests;
         $this->coveredByTests = $tests !== [];
     }
 

--- a/src/Mutation/MutationGenerator.php
+++ b/src/Mutation/MutationGenerator.php
@@ -53,30 +53,21 @@ use Webmozart\Assert\Assert;
  */
 class MutationGenerator
 {
-    private TraceProvider $traceProvider;
     /** @var Mutator<\PhpParser\Node>[] */
     private array $mutators;
-    private EventDispatcher $eventDispatcher;
-    private FileMutationGenerator $fileMutationGenerator;
-    private bool $runConcurrently;
 
     /**
      * @param Mutator<\PhpParser\Node>[] $mutators
      */
     public function __construct(
-        TraceProvider $traceProvider,
+        private TraceProvider $traceProvider,
         array $mutators,
-        EventDispatcher $eventDispatcher,
-        FileMutationGenerator $fileMutationGenerator,
-        bool $runConcurrently
+        private EventDispatcher $eventDispatcher,
+        private FileMutationGenerator $fileMutationGenerator,
+        private bool $runConcurrently
     ) {
         Assert::allIsInstanceOf($mutators, Mutator::class);
-
-        $this->traceProvider = $traceProvider;
         $this->mutators = $mutators;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->fileMutationGenerator = $fileMutationGenerator;
-        $this->runConcurrently = $runConcurrently;
     }
 
     /**

--- a/src/Mutator/Definition.php
+++ b/src/Mutator/Definition.php
@@ -42,27 +42,20 @@ use Webmozart\Assert\Assert;
  */
 final class Definition
 {
-    private string $description;
     private string $category;
-    private ?string $remedies;
-    private string $diff;
 
     /**
      * @param string $description Explanation on what the mutator is about
      * @param string|null $remedies Guidelines or recommendations on how to kill the generated mutations
      */
     public function __construct(
-        string $description,
+        private string $description,
         string $category,
-        ?string $remedies,
-        string $diff
+        private ?string $remedies,
+        private string $diff
     ) {
         Assert::oneOf($category, MutatorCategory::ALL);
-
-        $this->description = $description;
         $this->category = $category;
-        $this->remedies = $remedies;
-        $this->diff = $diff;
     }
 
     public function getDescription(): string

--- a/src/Mutator/IgnoreConfig.php
+++ b/src/Mutator/IgnoreConfig.php
@@ -46,20 +46,16 @@ use function Safe\array_flip;
  */
 class IgnoreConfig
 {
-    /** @var string[] */
-    private array $patterns;
     /** @var array<string, int> */
     private array $hashtable = [];
 
     /**
-     * @param string[] $ignored
+     * @param string[] $patterns
      */
-    public function __construct(array $ignored)
+    public function __construct(private array $patterns)
     {
-        $this->patterns = $ignored;
-
-        if ($ignored !== []) {
-            $this->hashtable = array_flip($ignored);
+        if ($patterns !== []) {
+            $this->hashtable = array_flip($patterns);
         }
     }
 

--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -58,17 +58,11 @@ use function Safe\sprintf;
  */
 final class IgnoreMutator implements Mutator
 {
-    private IgnoreConfig $config;
-    /** @var Mutator<TNode> */
-    private Mutator $mutator;
-
     /**
      * @param Mutator<TNode> $mutator
      */
-    public function __construct(IgnoreConfig $config, Mutator $mutator)
+    public function __construct(private IgnoreConfig $config, private Mutator $mutator)
     {
-        $this->config = $config;
-        $this->mutator = $mutator;
     }
 
     public static function getDefinition(): ?Definition

--- a/src/Mutator/MutatorResolver.php
+++ b/src/Mutator/MutatorResolver.php
@@ -122,12 +122,11 @@ final class MutatorResolver
     }
 
     /**
-     * @param stdClass|bool $settings
      * @param array<string, string[]> $globalSettings
      *
      * @return array<string, mixed[]>|bool
      */
-    private static function resolveSettings($settings, array $globalSettings)
+    private static function resolveSettings(bool | stdClass | array $settings, array $globalSettings): array | bool
     {
         if ($settings === false) {
             return false;
@@ -159,7 +158,7 @@ final class MutatorResolver
      */
     private static function registerFromProfile(
         string $profile,
-        $settings,
+        array | bool $settings,
         array &$mutators
     ): void {
         foreach (ProfileList::ALL_PROFILES[$profile] as $mutatorOrProfile) {
@@ -199,7 +198,7 @@ final class MutatorResolver
      */
     private static function registerFromName(
         string $mutator,
-        $settings,
+        array | bool $settings,
         array &$mutators
     ): void {
         if (!array_key_exists($mutator, ProfileList::ALL_MUTATORS)) {
@@ -222,7 +221,7 @@ final class MutatorResolver
      */
     private static function registerFromClass(
         string $mutatorClassName,
-        $settings,
+        array | bool $settings,
         array &$mutators
     ): void {
         if ($settings === false) {
@@ -232,7 +231,7 @@ final class MutatorResolver
         }
 
         if ($settings === true || $settings === []) {
-            $mutators[$mutatorClassName] = $mutators[$mutatorClassName] ?? [];
+            $mutators[$mutatorClassName] ??= [];
 
             return;
         }

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Mutator;
 
 use function count;
-use function get_class;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\Differ\FilesDiffChangedLines;
 use Infection\Logger\GitHub\GitDiffFileProvider;
@@ -59,21 +58,12 @@ class NodeMutationGenerator
 {
     /** @var Mutator<Node>[] */
     private array $mutators;
-    private string $filePath;
-    /** @var Node[] */
-    private array $fileNodes;
-    private Trace $trace;
-    private bool $onlyCovered;
-    private LineRangeCalculator $lineRangeCalculator;
 
     private Node $currentNode;
     /** @var TestLocation[]|null */
     private ?array $testsMemoized = null;
     private ?bool $isOnFunctionSignatureMemoized = null;
     private ?bool $isInsideFunctionMemoized = null;
-    private FilesDiffChangedLines $filesDiffChangedLines;
-    private bool $isForGitDiffLines;
-    private ?string $gitDiffBase;
 
     /**
      * @param Mutator<Node>[] $mutators
@@ -81,26 +71,18 @@ class NodeMutationGenerator
      */
     public function __construct(
         array $mutators,
-        string $filePath,
-        array $fileNodes,
-        Trace $trace,
-        bool $onlyCovered,
-        bool $isForGitDiffLines,
-        ?string $gitDiffBase,
-        LineRangeCalculator $lineRangeCalculator,
-        FilesDiffChangedLines $filesDiffChangedLines
+        private string $filePath,
+        private array $fileNodes,
+        private Trace $trace,
+        private bool $onlyCovered,
+        private bool $isForGitDiffLines,
+        private ?string $gitDiffBase,
+        private LineRangeCalculator $lineRangeCalculator,
+        private FilesDiffChangedLines $filesDiffChangedLines
     ) {
         Assert::allIsInstanceOf($mutators, Mutator::class);
 
         $this->mutators = $mutators;
-        $this->filePath = $filePath;
-        $this->fileNodes = $fileNodes;
-        $this->trace = $trace;
-        $this->onlyCovered = $onlyCovered;
-        $this->isForGitDiffLines = $isForGitDiffLines;
-        $this->gitDiffBase = $gitDiffBase;
-        $this->lineRangeCalculator = $lineRangeCalculator;
-        $this->filesDiffChangedLines = $filesDiffChangedLines;
     }
 
     /**
@@ -161,7 +143,7 @@ class NodeMutationGenerator
                 $this->fileNodes,
                 $mutator->getName(),
                 $node->getAttributes(),
-                get_class($node),
+                $node::class,
                 MutatedNode::wrap($mutatedNode),
                 $mutationByMutatorIndex,
                 $tests

--- a/src/Mutator/NoopMutator.php
+++ b/src/Mutator/NoopMutator.php
@@ -47,15 +47,11 @@ use function Safe\sprintf;
  */
 final class NoopMutator implements Mutator
 {
-    /** @var Mutator<TNode> */
-    private Mutator $mutator;
-
     /**
      * @param Mutator<TNode> $mutator
      */
-    public function __construct(Mutator $mutator)
+    public function __construct(private Mutator $mutator)
     {
-        $this->mutator = $mutator;
     }
 
     public static function getDefinition(): ?Definition

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -58,11 +58,8 @@ final class ArrayItemRemoval implements ConfigurableMutator
     use GetConfigClassName;
     use GetMutatorName;
 
-    private ArrayItemRemovalConfig $config;
-
-    public function __construct(ArrayItemRemovalConfig $config)
+    public function __construct(private ArrayItemRemovalConfig $config)
     {
-        $this->config = $config;
     }
 
     public static function getDefinition(): ?Definition
@@ -158,19 +155,14 @@ DIFF
      */
     private function getItemsIndexes(array $items): array
     {
-        switch ($this->config->getRemove()) {
-            case 'first':
-                return [0];
-
-            case 'last':
-                return [count($items) - 1];
-
-            default:
-                return range(
-                    0,
-                    min(count($items),
-                        $this->config->getLimit()) - 1
-                );
-        }
+        return match ($this->config->getRemove()) {
+            'first' => [0],
+            'last' => [count($items) - 1],
+            default => range(
+                0,
+                min(count($items),
+                    $this->config->getLimit()) - 1
+            ),
+        };
     }
 }

--- a/src/PhpParser/FileParser.php
+++ b/src/PhpParser/FileParser.php
@@ -46,11 +46,8 @@ use Throwable;
  */
 class FileParser
 {
-    private Parser $parser;
-
-    public function __construct(Parser $parser)
+    public function __construct(private Parser $parser)
     {
-        $this->parser = $parser;
     }
 
     /**

--- a/src/PhpParser/MutatedNode.php
+++ b/src/PhpParser/MutatedNode.php
@@ -63,7 +63,7 @@ final class MutatedNode
     /**
      * @param Node|Node[] $value
      */
-    public static function wrap($value): self
+    public static function wrap(array | \PhpParser\Node $value): self
     {
         return new self($value);
     }
@@ -71,7 +71,7 @@ final class MutatedNode
     /**
      * @return Node|Node[]
      */
-    public function unwrap()
+    public function unwrap(): array | \PhpParser\Node
     {
         return $this->value;
     }

--- a/src/PhpParser/MutatedNode.php
+++ b/src/PhpParser/MutatedNode.php
@@ -63,7 +63,7 @@ final class MutatedNode
     /**
      * @param Node|Node[] $value
      */
-    public static function wrap(array | \PhpParser\Node $value): self
+    public static function wrap($value): self
     {
         return new self($value);
     }
@@ -71,7 +71,7 @@ final class MutatedNode
     /**
      * @return Node|Node[]
      */
-    public function unwrap(): array | \PhpParser\Node
+    public function unwrap()
     {
         return $this->value;
     }

--- a/src/PhpParser/Visitor/IgnoreAllMutationsAnnotationReaderVisitor.php
+++ b/src/PhpParser/Visitor/IgnoreAllMutationsAnnotationReaderVisitor.php
@@ -39,7 +39,7 @@ use Infection\PhpParser\Visitor\IgnoreNode\ChangingIgnorer;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 use SplObjectStorage;
-use function strpos;
+use function str_contains;
 
 /**
  * @internal
@@ -48,26 +48,17 @@ final class IgnoreAllMutationsAnnotationReaderVisitor extends NodeVisitorAbstrac
 {
     private const IGNORE_ALL_MUTATIONS_ANNOTATION = '@infection-ignore-all';
 
-    private ChangingIgnorer $changingIgnorer;
-
-    /**
-     * @var SplObjectStorage<object, mixed>
-     */
-    private SplObjectStorage $ignoredNodes;
-
     /**
      * @param SplObjectStorage<object, mixed> $ignoredNodes
      */
-    public function __construct(ChangingIgnorer $changingIgnorer, SplObjectStorage $ignoredNodes)
+    public function __construct(private ChangingIgnorer $changingIgnorer, private SplObjectStorage $ignoredNodes)
     {
-        $this->changingIgnorer = $changingIgnorer;
-        $this->ignoredNodes = $ignoredNodes;
     }
 
     public function enterNode(Node $node): ?Node
     {
         foreach ($node->getComments() as $comment) {
-            if (strpos($comment->getText(), self::IGNORE_ALL_MUTATIONS_ANNOTATION) !== false) {
+            if (str_contains($comment->getText(), self::IGNORE_ALL_MUTATIONS_ANNOTATION)) {
                 $this->changingIgnorer->startIgnoring();
                 $this->ignoredNodes->attach($node);
             }

--- a/src/PhpParser/Visitor/MutationCollectorVisitor.php
+++ b/src/PhpParser/Visitor/MutationCollectorVisitor.php
@@ -50,11 +50,8 @@ final class MutationCollectorVisitor extends NodeVisitorAbstract
      */
     private array $mutationChunks = [];
 
-    private NodeMutationGenerator $mutationGenerator;
-
-    public function __construct(NodeMutationGenerator $mutationGenerator)
+    public function __construct(private NodeMutationGenerator $mutationGenerator)
     {
-        $this->mutationGenerator = $mutationGenerator;
     }
 
     public function beforeTraverse(array $nodes): ?array

--- a/src/PhpParser/Visitor/MutatorVisitor.php
+++ b/src/PhpParser/Visitor/MutatorVisitor.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\PhpParser\Visitor;
 
 use function array_key_exists;
-use function get_class;
 use Infection\Mutation\Mutation;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
@@ -46,11 +45,8 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class MutatorVisitor extends NodeVisitorAbstract
 {
-    private Mutation $mutation;
-
-    public function __construct(Mutation $mutation)
+    public function __construct(private Mutation $mutation)
     {
-        $this->mutation = $mutation;
     }
 
     public function leaveNode(Node $node)
@@ -66,7 +62,7 @@ final class MutatorVisitor extends NodeVisitorAbstract
         $samePosition = $attributes['startTokenPos'] === $mutatedAttributes['startTokenPos']
             && $attributes['endTokenPos'] === $mutatedAttributes['endTokenPos'];
 
-        if ($samePosition && $this->mutation->getMutatedNodeClass() === get_class($node)) {
+        if ($samePosition && $this->mutation->getMutatedNodeClass() === $node::class) {
             return $this->mutation->getMutatedNode()->unwrap();
             // TODO STOP TRAVERSING
             // TODO check all built-in visitors, in particular FirstFindingVisitor

--- a/src/PhpParser/Visitor/NonMutableNodesIgnorerVisitor.php
+++ b/src/PhpParser/Visitor/NonMutableNodesIgnorerVisitor.php
@@ -46,16 +46,10 @@ use PhpParser\NodeVisitorAbstract;
 final class NonMutableNodesIgnorerVisitor extends NodeVisitorAbstract
 {
     /**
-     * @var NodeIgnorer[]
-     */
-    private array $nodeIgnorers;
-
-    /**
      * @param NodeIgnorer[] $nodeIgnorers
      */
-    public function __construct(array $nodeIgnorers)
+    public function __construct(private array $nodeIgnorers)
     {
-        $this->nodeIgnorers = $nodeIgnorers;
     }
 
     public function enterNode(Node $node)

--- a/src/Process/Factory/InitialTestsRunProcessFactory.php
+++ b/src/Process/Factory/InitialTestsRunProcessFactory.php
@@ -48,11 +48,8 @@ use function version_compare;
  */
 class InitialTestsRunProcessFactory
 {
-    private TestFrameworkAdapter $testFrameworkAdapter;
-
-    public function __construct(TestFrameworkAdapter $testFrameworkAdapter)
+    public function __construct(private TestFrameworkAdapter $testFrameworkAdapter)
     {
-        $this->testFrameworkAdapter = $testFrameworkAdapter;
     }
 
     /**

--- a/src/Process/Factory/MutantProcessFactory.php
+++ b/src/Process/Factory/MutantProcessFactory.php
@@ -52,22 +52,9 @@ use function version_compare;
  */
 class MutantProcessFactory
 {
-    private TestFrameworkAdapter $testFrameworkAdapter;
-    private float $timeout;
-    private EventDispatcher $eventDispatcher;
-    private MutantExecutionResultFactory $resultFactory;
-
     // TODO: is it necessary for the timeout to be an int?
-    public function __construct(
-        TestFrameworkAdapter $testFrameworkAdapter,
-        float $timeout,
-        EventDispatcher $eventDispatcher,
-        MutantExecutionResultFactory $resultFactory
-    ) {
-        $this->testFrameworkAdapter = $testFrameworkAdapter;
-        $this->timeout = $timeout;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->resultFactory = $resultFactory;
+    public function __construct(private TestFrameworkAdapter $testFrameworkAdapter, private float $timeout, private EventDispatcher $eventDispatcher, private MutantExecutionResultFactory $resultFactory)
+    {
     }
 
     public function createProcessForMutant(Mutant $mutant, string $testFrameworkExtraOptions = ''): MutantProcess

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -46,16 +46,12 @@ use Symfony\Component\Process\Process;
  */
 class MutantProcess implements ProcessBearer
 {
-    private Process $process;
-    private Mutant $mutant;
     private Closure $callback;
 
     private bool $timedOut = false;
 
-    public function __construct(Process $process, Mutant $mutant)
+    public function __construct(private Process $process, private Mutant $mutant)
     {
-        $this->process = $process;
-        $this->mutant = $mutant;
         $this->callback = static function (): void {};
     }
 

--- a/src/Process/Runner/IndexedProcessBearer.php
+++ b/src/Process/Runner/IndexedProcessBearer.php
@@ -40,13 +40,7 @@ namespace Infection\Process\Runner;
  */
 final class IndexedProcessBearer
 {
-    public int $threadIndex;
-
-    public ProcessBearer $processBearer;
-
-    public function __construct(int $threadIndex, ProcessBearer $processBearer)
+    public function __construct(public int $threadIndex, public ProcessBearer $processBearer)
     {
-        $this->threadIndex = $threadIndex;
-        $this->processBearer = $processBearer;
     }
 }

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -48,15 +48,8 @@ use Symfony\Component\Process\Process;
  */
 class InitialTestsRunner
 {
-    private InitialTestsRunProcessFactory $processBuilder;
-    private EventDispatcher $eventDispatcher;
-
-    public function __construct(
-        InitialTestsRunProcessFactory $processFactory,
-        EventDispatcher $eventDispatcher
-    ) {
-        $this->processBuilder = $processFactory;
-        $this->eventDispatcher = $eventDispatcher;
+    public function __construct(private InitialTestsRunProcessFactory $processBuilder, private EventDispatcher $eventDispatcher)
+    {
     }
 
     /**

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -55,40 +55,11 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class MutationTestingRunner
 {
-    private MutantProcessFactory $processFactory;
-    private MutantFactory $mutantFactory;
-    private ProcessRunner $processRunner;
-    private EventDispatcher $eventDispatcher;
-    private Filesystem $fileSystem;
-    private DiffSourceCodeMatcher $diffSourceCodeMatcher;
-    private bool $runConcurrently;
-    private float $timeout;
-    /** @var array<string, array<int, string>> */
-    private array $ignoreSourceCodeMutatorsMap;
-
     /**
      * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
      */
-    public function __construct(
-        MutantProcessFactory $processFactory,
-        MutantFactory $mutantFactory,
-        ProcessRunner $processRunner,
-        EventDispatcher $eventDispatcher,
-        Filesystem $fileSystem,
-        DiffSourceCodeMatcher $diffSourceCodeMatcher,
-        bool $runConcurrently,
-        float $timeout,
-        array $ignoreSourceCodeMutatorsMap
-    ) {
-        $this->processFactory = $processFactory;
-        $this->mutantFactory = $mutantFactory;
-        $this->processRunner = $processRunner;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->fileSystem = $fileSystem;
-        $this->diffSourceCodeMatcher = $diffSourceCodeMatcher;
-        $this->runConcurrently = $runConcurrently;
-        $this->timeout = $timeout;
-        $this->ignoreSourceCodeMutatorsMap = $ignoreSourceCodeMutatorsMap;
+    public function __construct(private MutantProcessFactory $processFactory, private MutantFactory $mutantFactory, private ProcessRunner $processRunner, private EventDispatcher $eventDispatcher, private Filesystem $fileSystem, private DiffSourceCodeMatcher $diffSourceCodeMatcher, private bool $runConcurrently, private float $timeout, private array $ignoreSourceCodeMutatorsMap)
+    {
     }
 
     /**
@@ -100,9 +71,7 @@ class MutationTestingRunner
         $this->eventDispatcher->dispatch(new MutationTestingWasStarted($numberOfMutants));
 
         $processes = take($mutations)
-            ->cast(function (Mutation $mutation): Mutant {
-                return $this->mutantFactory->create($mutation);
-            })
+            ->cast(fn (Mutation $mutation): Mutant => $this->mutantFactory->create($mutation))
             ->filter(function (Mutant $mutant): bool {
                 $mutatorName = $mutant->getMutation()->getMutatorName();
 

--- a/src/Process/Runner/ParallelProcessRunner.php
+++ b/src/Process/Runner/ParallelProcessRunner.php
@@ -61,16 +61,11 @@ final class ParallelProcessRunner implements ProcessRunner
      */
     private array $availableThreadIndexes = [];
 
-    private int $threadCount;
-    private int $poll;
-
     /**
      * @param int $poll Delay (in milliseconds) to wait in-between two polls
      */
-    public function __construct(int $threadCount, int $poll = 1000)
+    public function __construct(private int $threadCount, private int $poll = 1000)
     {
-        $this->threadCount = $threadCount;
-        $this->poll = $poll;
     }
 
     public function run(iterable $processes): void
@@ -131,7 +126,7 @@ final class ParallelProcessRunner implements ProcessRunner
 
             try {
                 $process->checkTimeout();
-            } catch (ProcessTimedOutException $exception) {
+            } catch (ProcessTimedOutException) {
                 $processBearer->markAsTimedOut();
             }
 
@@ -175,7 +170,7 @@ final class ParallelProcessRunner implements ProcessRunner
         $bucket[] = $input->current();
         $input->next();
 
-        return (int) (microtime(true) - $start) * 1000000; // ns to ms
+        return (int) (microtime(true) - $start) * 1_000_000; // ns to ms
     }
 
     /**

--- a/src/Reflection/AnonymousClassReflection.php
+++ b/src/Reflection/AnonymousClassReflection.php
@@ -42,11 +42,8 @@ use ReflectionClass;
  */
 final class AnonymousClassReflection implements ClassReflection
 {
-    private ReflectionClass $reflectionClass;
-
-    private function __construct(ReflectionClass $reflectionClass)
+    private function __construct(private ReflectionClass $reflectionClass)
     {
-        $this->reflectionClass = $reflectionClass;
     }
 
     /**

--- a/src/Reflection/CoreClassReflection.php
+++ b/src/Reflection/CoreClassReflection.php
@@ -43,11 +43,8 @@ use ReflectionException;
  */
 final class CoreClassReflection implements ClassReflection
 {
-    private ReflectionClass $reflectionClass;
-
-    private function __construct(ReflectionClass $reflectionClass)
+    private function __construct(private ReflectionClass $reflectionClass)
     {
-        $this->reflectionClass = $reflectionClass;
     }
 
     /**
@@ -62,7 +59,7 @@ final class CoreClassReflection implements ClassReflection
     {
         try {
             $method = $this->reflectionClass->getMethod($methodName)->getPrototype();
-        } catch (ReflectionException $e) {
+        } catch (ReflectionException) {
             return false;
         }
 

--- a/src/Reflection/Visibility.php
+++ b/src/Reflection/Visibility.php
@@ -43,11 +43,8 @@ final class Visibility
     public const PUBLIC = 'public';
     public const PROTECTED = 'protected';
 
-    private string $variant;
-
-    private function __construct(string $variant)
+    private function __construct(private string $variant)
     {
-        $this->variant = $variant;
     }
 
     public static function asPublic(): self

--- a/src/Resource/Listener/PerformanceLoggerSubscriber.php
+++ b/src/Resource/Listener/PerformanceLoggerSubscriber.php
@@ -50,21 +50,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class PerformanceLoggerSubscriber implements EventSubscriber
 {
-    private Stopwatch $stopwatch;
-    private OutputInterface $output;
-    private TimeFormatter $timeFormatter;
-    private MemoryFormatter $memoryFormatter;
-
-    public function __construct(
-        Stopwatch $stopwatch,
-        TimeFormatter $timeFormatter,
-        MemoryFormatter $memoryFormatter,
-        OutputInterface $output
-    ) {
-        $this->stopwatch = $stopwatch;
-        $this->timeFormatter = $timeFormatter;
-        $this->output = $output;
-        $this->memoryFormatter = $memoryFormatter;
+    public function __construct(private Stopwatch $stopwatch, private TimeFormatter $timeFormatter, private MemoryFormatter $memoryFormatter, private OutputInterface $output)
+    {
     }
 
     public function onApplicationExecutionWasStarted(ApplicationExecutionWasStarted $event): void

--- a/src/Resource/Memory/MemoryLimiter.php
+++ b/src/Resource/Memory/MemoryLimiter.php
@@ -48,18 +48,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class MemoryLimiter
 {
-    private Filesystem $fileSystem;
-    private string $phpIniPath;
-    private MemoryLimiterEnvironment $environment;
-
-    public function __construct(
-        Filesystem $fileSystem,
-        string $phpIniPath,
-        MemoryLimiterEnvironment $environment
-    ) {
-        $this->fileSystem = $fileSystem;
-        $this->phpIniPath = $phpIniPath;
-        $this->environment = $environment;
+    public function __construct(private Filesystem $fileSystem, private string $phpIniPath, private MemoryLimiterEnvironment $environment)
+    {
     }
 
     public function limitMemory(string $processOutput, TestFrameworkAdapter $adapter): void
@@ -106,7 +96,7 @@ class MemoryLimiter
                 $tmpConfigPath,
                 PHP_EOL . sprintf('memory_limit = %dM', $memoryLimit)
             );
-        } catch (IOException $exception) {
+        } catch (IOException) {
             // Cannot add a memory limit: file is not writable
         }
     }

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -47,30 +47,8 @@ use Symfony\Component\Process\Process;
  */
 abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
 {
-    private string $testFrameworkExecutable;
-    private CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder;
-    private InitialConfigBuilder $initialConfigBuilder;
-    private MutationConfigBuilder $mutationConfigBuilder;
-    private VersionParser $versionParser;
-    private CommandLineBuilder $commandLineBuilder;
-    private ?string $version;
-
-    public function __construct(
-        string $testFrameworkExecutable,
-        InitialConfigBuilder $initialConfigBuilder,
-        MutationConfigBuilder $mutationConfigBuilder,
-        CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder,
-        VersionParser $versionParser,
-        CommandLineBuilder $commandLineBuilder,
-        ?string $version = null
-    ) {
-        $this->testFrameworkExecutable = $testFrameworkExecutable;
-        $this->initialConfigBuilder = $initialConfigBuilder;
-        $this->mutationConfigBuilder = $mutationConfigBuilder;
-        $this->argumentsAndOptionsBuilder = $argumentsAndOptionsBuilder;
-        $this->versionParser = $versionParser;
-        $this->commandLineBuilder = $commandLineBuilder;
-        $this->version = $version;
+    public function __construct(private string $testFrameworkExecutable, private InitialConfigBuilder $initialConfigBuilder, private MutationConfigBuilder $mutationConfigBuilder, private CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder, private VersionParser $versionParser, private CommandLineBuilder $commandLineBuilder, private ?string $version = null)
+    {
     }
 
     abstract public function testsPass(string $output): bool;

--- a/src/TestFramework/AdapterInstallationDecider.php
+++ b/src/TestFramework/AdapterInstallationDecider.php
@@ -52,11 +52,8 @@ final class AdapterInstallationDecider
         TestFrameworkTypes::PHPSPEC => 'Infection\TestFramework\PhpSpec\PhpSpecAdapter',
     ];
 
-    private QuestionHelper $questionHelper;
-
-    public function __construct(QuestionHelper $questionHelper)
+    public function __construct(private QuestionHelper $questionHelper)
     {
-        $this->questionHelper = $questionHelper;
     }
 
     public function shouldBeInstalled(string $adapterName, IO $io): bool

--- a/src/TestFramework/AdapterInstaller.php
+++ b/src/TestFramework/AdapterInstaller.php
@@ -50,6 +50,7 @@ final class AdapterInstaller
         TestFrameworkTypes::PHPSPEC => 'infection/phpspec-adapter',
     ];
 
+    // 2 minutes
     private const TIMEOUT = 120.0;
 
     public function __construct(private ComposerExecutableFinder $composerExecutableFinder)

--- a/src/TestFramework/AdapterInstaller.php
+++ b/src/TestFramework/AdapterInstaller.php
@@ -50,13 +50,10 @@ final class AdapterInstaller
         TestFrameworkTypes::PHPSPEC => 'infection/phpspec-adapter',
     ];
 
-    private const TIMEOUT = 120.0; // 2 minutes
+    private const TIMEOUT = 120.0;
 
-    private ComposerExecutableFinder $composerExecutableFinder;
-
-    public function __construct(ComposerExecutableFinder $composerExecutableFinder)
+    public function __construct(private ComposerExecutableFinder $composerExecutableFinder)
     {
-        $this->composerExecutableFinder = $composerExecutableFinder;
     }
 
     public function install(string $adapterName): void

--- a/src/TestFramework/Config/MutationConfigBuilder.php
+++ b/src/TestFramework/Config/MutationConfigBuilder.php
@@ -39,7 +39,7 @@ use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Phar;
 use function Safe\sprintf;
 use function str_replace;
-use function strpos;
+use function str_starts_with;
 use function strstr;
 use Webmozart\Assert\Assert;
 
@@ -63,7 +63,7 @@ abstract class MutationConfigBuilder
     {
         $infectionPhar = '';
 
-        if (strpos(__FILE__, 'phar:') === 0) {
+        if (str_starts_with(__FILE__, 'phar:')) {
             $infectionPhar = sprintf(
                 '\Phar::loadPhar("%s", "%s");',
                 str_replace('phar://', '', Phar::running(true)),

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -54,11 +54,8 @@ final class TestFrameworkConfigLocator implements TestFrameworkConfigLocatorInte
         'dist.yml',
     ];
 
-    private string $configDir;
-
-    public function __construct(string $configDir)
+    public function __construct(private string $configDir)
     {
-        $this->configDir = $configDir;
     }
 
     public function locate(string $testFrameworkName, ?string $customDir = null): string

--- a/src/TestFramework/Coverage/BufferedSourceFileFilter.php
+++ b/src/TestFramework/Coverage/BufferedSourceFileFilter.php
@@ -56,8 +56,6 @@ use Webmozart\Assert\Assert;
  */
 class BufferedSourceFileFilter implements FileFilter
 {
-    private FileFilter $filter;
-
     /**
      * An associative array mapping real paths to SplFileInfo objects.
      *
@@ -70,11 +68,9 @@ class BufferedSourceFileFilter implements FileFilter
      * @param iterable<SplFileInfo> $sourceFiles
      */
     public function __construct(
-        FileFilter $filter,
+        private FileFilter $filter,
         iterable $sourceFiles
     ) {
-        $this->filter = $filter;
-
         // Make a map of source files so we can check covered files against it.
         // We don't filter here on the assumption that hash table lookups are faster.
         foreach ($sourceFiles as $sourceFile) {

--- a/src/TestFramework/Coverage/CoverageChecker.php
+++ b/src/TestFramework/Coverage/CoverageChecker.php
@@ -57,34 +57,19 @@ class CoverageChecker
 {
     private const PHPUNIT = 'phpunit';
     private const CODECEPTION = 'codeception';
-
-    private bool $skipCoverage;
-    private bool $skipInitialTests;
-    private string $initialTestPhpOptions;
-    private string $coveragePath;
-    private bool $jUnitReport;
-    private JUnitReportLocator $jUnitReportLocator;
     private string $frameworkAdapterName;
-    private IndexXmlCoverageLocator $indexXmlCoverageLocator;
 
     public function __construct(
-        bool $skipCoverage,
-        bool $skipInitialTests,
-        string $initialTestPhpOptions,
-        string $coveragePath,
-        bool $junitReport,
-        JUnitReportLocator $jUnitReportLocator,
+        private bool $skipCoverage,
+        private bool $skipInitialTests,
+        private string $initialTestPhpOptions,
+        private string $coveragePath,
+        private bool $jUnitReport,
+        private JUnitReportLocator $jUnitReportLocator,
         string $testFrameworkAdapterName,
-        IndexXmlCoverageLocator $indexXmlCoverageLocator
+        private IndexXmlCoverageLocator $indexXmlCoverageLocator
     ) {
-        $this->skipCoverage = $skipCoverage;
-        $this->skipInitialTests = $skipInitialTests;
-        $this->initialTestPhpOptions = $initialTestPhpOptions;
-        $this->coveragePath = $coveragePath;
-        $this->jUnitReport = $junitReport;
-        $this->jUnitReportLocator = $jUnitReportLocator;
         $this->frameworkAdapterName = strtolower($testFrameworkAdapterName);
-        $this->indexXmlCoverageLocator = $indexXmlCoverageLocator;
     }
 
     public function checkCoverageRequirements(): void

--- a/src/TestFramework/Coverage/CoveredTraceProvider.php
+++ b/src/TestFramework/Coverage/CoveredTraceProvider.php
@@ -46,24 +46,12 @@ use Infection\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProvider;
  */
 final class CoveredTraceProvider implements TraceProvider
 {
-    private TraceProvider $primaryTraceProvider;
-
-    private JUnitTestExecutionInfoAdder $testFileDataAdder;
-
-    private FileFilter $bufferedFilter;
-
     /**
      * @param PhpUnitXmlCoverageTraceProvider|TraceProvider $primaryTraceProvider
      * @param BufferedSourceFileFilter|FileFilter $bufferedFilter
      */
-    public function __construct(
-        TraceProvider $primaryTraceProvider,
-        JUnitTestExecutionInfoAdder $testFileDataAdder,
-        FileFilter $bufferedFilter
-    ) {
-        $this->primaryTraceProvider = $primaryTraceProvider;
-        $this->testFileDataAdder = $testFileDataAdder;
-        $this->bufferedFilter = $bufferedFilter;
+    public function __construct(private TraceProvider $primaryTraceProvider, private JUnitTestExecutionInfoAdder $testFileDataAdder, private FileFilter $bufferedFilter)
+    {
     }
 
     /**

--- a/src/TestFramework/Coverage/JUnit/JUnitReportLocator.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitReportLocator.php
@@ -53,14 +53,12 @@ use Webmozart\PathUtil\Path;
  */
 class JUnitReportLocator
 {
-    private string $coveragePath;
     private string $defaultJUnitPath;
 
     private ?string $jUnitPath = null;
 
-    public function __construct(string $coveragePath, string $defaultJUnitPath)
+    public function __construct(private string $coveragePath, string $defaultJUnitPath)
     {
-        $this->coveragePath = $coveragePath;
         $this->defaultJUnitPath = Path::canonicalize($defaultJUnitPath);
     }
 
@@ -103,9 +101,7 @@ class JUnitReportLocator
                 implode(
                     '", "',
                     array_map(
-                        static function (SplFileInfo $fileInfo): string {
-                            return Path::canonicalize($fileInfo->getPathname());
-                        },
+                        static fn (SplFileInfo $fileInfo): string => Path::canonicalize($fileInfo->getPathname()),
                         $files
                     )
                 )

--- a/src/TestFramework/Coverage/JUnit/JUnitTestCaseSorter.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestCaseSorter.php
@@ -97,9 +97,7 @@ final class JUnitTestCaseSorter
         if ($numberOfTestLocation < self::USE_BUCKET_SORT_AFTER) {
             usort(
                 $uniqueTestLocations,
-                static function (TestLocation $a, TestLocation $b): int {
-                    return $a->getExecutionTime() <=> $b->getExecutionTime();
-                }
+                static fn (TestLocation $a, TestLocation $b): int => $a->getExecutionTime() <=> $b->getExecutionTime()
             );
 
             return self::sortedLocationsGenerator($uniqueTestLocations);

--- a/src/TestFramework/Coverage/JUnit/JUnitTestCaseTimeAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestCaseTimeAdder.php
@@ -47,16 +47,10 @@ use function strpos;
 final class JUnitTestCaseTimeAdder
 {
     /**
-     * @var TestLocation[]
-     */
-    private array $tests;
-
-    /**
      * @param TestLocation[] $tests
      */
-    public function __construct(array $tests)
+    public function __construct(private array $tests)
     {
-        $this->tests = $tests;
     }
 
     public function getTotalTestTime(): float

--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -48,17 +48,8 @@ use Infection\TestFramework\Coverage\Trace;
  */
 class JUnitTestExecutionInfoAdder
 {
-    private TestFileDataProvider $testFileDataProvider;
-
-    private TestFrameworkAdapter $adapter;
-
-    public function __construct(
-        TestFrameworkAdapter $adapter,
-        TestFileDataProvider $testFileDataProvider
-    ) {
-        $this->adapter = $adapter;
-
-        $this->testFileDataProvider = $testFileDataProvider;
+    public function __construct(private TestFrameworkAdapter $adapter, private TestFileDataProvider $testFileDataProvider)
+    {
     }
 
     /**

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -48,13 +48,10 @@ use Webmozart\Assert\Assert;
  */
 final class JUnitTestFileDataProvider implements TestFileDataProvider
 {
-    private JUnitReportLocator $jUnitLocator;
-
     private ?SafeDOMXPath $xPath = null;
 
-    public function __construct(JUnitReportLocator $jUnitLocator)
+    public function __construct(private JUnitReportLocator $jUnitLocator)
     {
-        $this->jUnitLocator = $jUnitLocator;
     }
 
     /**

--- a/src/TestFramework/Coverage/JUnit/MemoizedTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/MemoizedTestFileDataProvider.php
@@ -42,16 +42,13 @@ use function array_key_exists;
  */
 final class MemoizedTestFileDataProvider implements TestFileDataProvider
 {
-    private TestFileDataProvider $provider;
-
     /**
      * @var array<string, TestFileTimeData>
      */
     private array $cache = [];
 
-    public function __construct(TestFileDataProvider $decoratedProvider)
+    public function __construct(private TestFileDataProvider $provider)
     {
-        $this->provider = $decoratedProvider;
     }
 
     public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData

--- a/src/TestFramework/Coverage/JUnit/TestFileTimeData.php
+++ b/src/TestFramework/Coverage/JUnit/TestFileTimeData.php
@@ -40,13 +40,7 @@ namespace Infection\TestFramework\Coverage\JUnit;
  */
 final class TestFileTimeData
 {
-    public string $path;
-
-    public float $time;
-
-    public function __construct(string $path, float $time)
+    public function __construct(public string $path, public float $time)
     {
-        $this->path = $path;
-        $this->time = $time;
     }
 }

--- a/src/TestFramework/Coverage/ProxyTrace.php
+++ b/src/TestFramework/Coverage/ProxyTrace.php
@@ -49,24 +49,13 @@ use Webmozart\Assert\Assert;
  */
 class ProxyTrace implements Trace
 {
-    private SplFileInfo $sourceFile;
-
-    /**
-     * @var ?Deferred<TestLocations>
-     */
-    private ?Deferred $lazyTestLocations;
-
     private ?TestLocator $tests = null;
 
     /**
      * @param Deferred<TestLocations> $lazyTestLocations
      */
-    public function __construct(SplFileInfo $sourceFile, ?Deferred $lazyTestLocations = null)
+    public function __construct(private SplFileInfo $sourceFile, private ?Deferred $lazyTestLocations = null)
     {
-        $this->sourceFile = $sourceFile;
-
-        // There's no point to have it parsed right away as we may not need it, e.g. because of a filter
-        $this->lazyTestLocations = $lazyTestLocations;
     }
 
     public function getSourceFileInfo(): SplFileInfo

--- a/src/TestFramework/Coverage/SourceMethodLineRange.php
+++ b/src/TestFramework/Coverage/SourceMethodLineRange.php
@@ -40,13 +40,8 @@ namespace Infection\TestFramework\Coverage;
  */
 final class SourceMethodLineRange
 {
-    private int $startLine;
-    private int $endLine;
-
-    public function __construct(int $startLine, int $endLine)
+    public function __construct(private int $startLine, private int $endLine)
     {
-        $this->startLine = $startLine;
-        $this->endLine = $endLine;
     }
 
     public function getStartLine(): int

--- a/src/TestFramework/Coverage/TestLocations.php
+++ b/src/TestFramework/Coverage/TestLocations.php
@@ -42,21 +42,12 @@ use Infection\AbstractTestFramework\Coverage\TestLocation;
  */
 final class TestLocations
 {
-    /** @var array<int, array<int, TestLocation>> */
-    private array $byLine;
-    /** @var array<string, SourceMethodLineRange> */
-    private array $byMethod;
-
     /**
-     * @param array<int, array<int, TestLocation>> $testLocationsBySourceLine
-     * @param array<string, SourceMethodLineRange> $sourceMethodLineRangeByMethod
+     * @param array<int, array<int, TestLocation>> $byLine
+     * @param array<string, SourceMethodLineRange> $byMethod
      */
-    public function __construct(
-        array $testLocationsBySourceLine = [],
-        array $sourceMethodLineRangeByMethod = []
-    ) {
-        $this->byLine = $testLocationsBySourceLine;
-        $this->byMethod = $sourceMethodLineRangeByMethod;
+    public function __construct(private array $byLine = [], private array $byMethod = [])
+    {
     }
 
     /**

--- a/src/TestFramework/Coverage/UncoveredTraceProvider.php
+++ b/src/TestFramework/Coverage/UncoveredTraceProvider.php
@@ -42,11 +42,8 @@ namespace Infection\TestFramework\Coverage;
  */
 final class UncoveredTraceProvider implements TraceProvider
 {
-    private BufferedSourceFileFilter $bufferedFilter;
-
-    public function __construct(BufferedSourceFileFilter $bufferedFilter)
+    public function __construct(private BufferedSourceFileFilter $bufferedFilter)
     {
-        $this->bufferedFilter = $bufferedFilter;
     }
 
     /**

--- a/src/TestFramework/Coverage/UnionTraceProvider.php
+++ b/src/TestFramework/Coverage/UnionTraceProvider.php
@@ -43,24 +43,12 @@ namespace Infection\TestFramework\Coverage;
  */
 final class UnionTraceProvider implements TraceProvider
 {
-    private TraceProvider $coveredTraceProvider;
-
-    private TraceProvider $uncoveredTraceProvider;
-
-    private bool $onlyCovered;
-
     /**
      * @param CoveredTraceProvider|TraceProvider $coveredTraceProvider
      * @param UncoveredTraceProvider|TraceProvider $uncoveredTraceProvider
      */
-    public function __construct(
-        TraceProvider $coveredTraceProvider,
-        TraceProvider $uncoveredTraceProvider,
-        bool $onlyCovered
-    ) {
-        $this->coveredTraceProvider = $coveredTraceProvider;
-        $this->uncoveredTraceProvider = $uncoveredTraceProvider;
-        $this->onlyCovered = $onlyCovered;
+    public function __construct(private TraceProvider $coveredTraceProvider, private TraceProvider $uncoveredTraceProvider, private bool $onlyCovered)
+    {
     }
 
     /**

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php
@@ -53,14 +53,12 @@ use Webmozart\PathUtil\Path;
  */
 class IndexXmlCoverageLocator
 {
-    private string $coveragePath;
     private string $defaultIndexPath;
 
     private ?string $indexPath = null;
 
-    public function __construct(string $coveragePath)
+    public function __construct(private string $coveragePath)
     {
-        $this->coveragePath = $coveragePath;
         $this->defaultIndexPath = Path::canonicalize($coveragePath . '/coverage-xml/index.xml');
     }
 
@@ -103,9 +101,7 @@ class IndexXmlCoverageLocator
                 implode(
                     '", "',
                     array_map(
-                        static function (SplFileInfo $fileInfo): string {
-                            return Path::canonicalize($fileInfo->getPathname());
-                        },
+                        static fn (SplFileInfo $fileInfo): string => Path::canonicalize($fileInfo->getPathname()),
                         $files
                     )
                 )

--- a/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProvider.php
@@ -48,18 +48,8 @@ use function Safe\file_get_contents;
  */
 class PhpUnitXmlCoverageTraceProvider implements TraceProvider
 {
-    private IndexXmlCoverageLocator $indexLocator;
-    private IndexXmlCoverageParser $indexParser;
-    private XmlCoverageParser $parser;
-
-    public function __construct(
-        IndexXmlCoverageLocator $indexCoverageLocator,
-        IndexXmlCoverageParser $indexCoverageXmlParser,
-        XmlCoverageParser $coverageXmlParser
-    ) {
-        $this->indexLocator = $indexCoverageLocator;
-        $this->indexParser = $indexCoverageXmlParser;
-        $this->parser = $coverageXmlParser;
+    public function __construct(private IndexXmlCoverageLocator $indexLocator, private IndexXmlCoverageParser $indexParser, private XmlCoverageParser $parser)
+    {
     }
 
     /**

--- a/src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
@@ -56,23 +56,10 @@ use Webmozart\PathUtil\Path;
  */
 class SourceFileInfoProvider
 {
-    private string $coverageIndexPath;
-    private string $coverageDir;
-    private string $relativeCoverageFilePath;
-    private string $projectSource;
-
     private ?SafeDOMXPath $xPath = null;
 
-    public function __construct(
-        string $coverageIndexPath,
-        string $coverageDir,
-        string $relativeCoverageFilePath,
-        string $projectSource
-    ) {
-        $this->coverageIndexPath = $coverageIndexPath;
-        $this->coverageDir = $coverageDir;
-        $this->relativeCoverageFilePath = $relativeCoverageFilePath;
-        $this->projectSource = $projectSource;
+    public function __construct(private string $coverageIndexPath, private string $coverageDir, private string $relativeCoverageFilePath, private string $projectSource)
+    {
     }
 
     /**
@@ -133,7 +120,7 @@ class SourceFileInfoProvider
 
         try {
             $realPath = realpath($path);
-        } catch (FilesystemException $e) {
+        } catch (FilesystemException) {
             $coverageFilePath = Path::canonicalize(
                 $this->coverageDir . DIRECTORY_SEPARATOR . $this->relativeCoverageFilePath
             );

--- a/src/TestFramework/Coverage/XmlReport/TestLocator.php
+++ b/src/TestFramework/Coverage/XmlReport/TestLocator.php
@@ -48,11 +48,8 @@ use Webmozart\Assert\Assert;
  */
 class TestLocator
 {
-    private TestLocations $testLocations;
-
-    public function __construct(TestLocations $testLocations)
+    public function __construct(private TestLocations $testLocations)
     {
-        $this->testLocations = $testLocations;
     }
 
     public function hasTests(): bool

--- a/src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php
+++ b/src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php
@@ -111,8 +111,7 @@ class XmlCoverageParser
     }
 
     /**
-     * @param DOMNodeList|DOMElement[] $coveredLineNodes
-     * @phpstan-param DOMNodeList<DOMElement> $coveredLineNodes
+     * @param DOMNodeList<DOMElement> $coveredLineNodes
      *
      * @return array<int, array<int, TestLocation>>
      */
@@ -145,9 +144,7 @@ class XmlCoverageParser
     }
 
     /**
-     * @param DOMNodeList|DOMElement[] $methodsCoverageNodes
-     *
-     * @phpstan-param DOMNodeList<DOMElement> $methodsCoverageNodes
+     * @param DOMNodeList<DOMElement> $methodsCoverageNodes
      *
      * @return SourceMethodLineRange[]
      */

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -58,40 +58,11 @@ use Webmozart\Assert\Assert;
  */
 final class Factory
 {
-    private string $tmpDir;
-    private string $projectDir;
-    private TestFrameworkConfigLocatorInterface $configLocator;
-    private TestFrameworkFinder $testFrameworkFinder;
-    private string $jUnitFilePath;
-    private Configuration $infectionConfig;
-    private SourceFileFilter $sourceFileFilter;
-
-    /**
-     * @var array<string, array<string, mixed>>
-     */
-    private array $installedExtensions;
-
     /**
      * @param array<string, array<string, mixed>> $installedExtensions
      */
-    public function __construct(
-        string $tmpDir,
-        string $projectDir,
-        TestFrameworkConfigLocatorInterface $configLocator,
-        TestFrameworkFinder $testFrameworkFinder,
-        string $jUnitFilePath,
-        Configuration $infectionConfig,
-        SourceFileFilter $sourceFileFilter,
-        array $installedExtensions
-    ) {
-        $this->tmpDir = $tmpDir;
-        $this->configLocator = $configLocator;
-        $this->projectDir = $projectDir;
-        $this->jUnitFilePath = $jUnitFilePath;
-        $this->infectionConfig = $infectionConfig;
-        $this->testFrameworkFinder = $testFrameworkFinder;
-        $this->sourceFileFilter = $sourceFileFilter;
-        $this->installedExtensions = $installedExtensions;
+    public function __construct(private string $tmpDir, private string $projectDir, private TestFrameworkConfigLocatorInterface $configLocator, private TestFrameworkFinder $testFrameworkFinder, private string $jUnitFilePath, private Configuration $infectionConfig, private SourceFileFilter $sourceFileFilter, private array $installedExtensions)
+    {
     }
 
     public function create(string $adapterName, bool $skipCoverage): TestFrameworkAdapter
@@ -185,9 +156,7 @@ final class Factory
 
         /** @var list<string> $filteredPaths */
         $filteredPaths = array_filter(array_map(
-            static function (SplFileInfo $file) {
-                return $file->getRealPath();
-            },
+            static fn (SplFileInfo $file) => $file->getRealPath(),
             iterator_to_array($this->sourceFileFilter->filter($this->infectionConfig->getSourceFiles()))
         ));
 

--- a/src/TestFramework/PhpUnit/Adapter/PestAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PestAdapter.php
@@ -49,11 +49,8 @@ final class PestAdapter implements MemoryUsageAware, ProvidesInitialRunOnlyOptio
 {
     private const NAME = 'Pest';
 
-    private PhpUnitAdapter $phpUnitAdapter;
-
-    public function __construct(PhpUnitAdapter $phpUnitAdapter)
+    public function __construct(private PhpUnitAdapter $phpUnitAdapter)
     {
-        $this->phpUnitAdapter = $phpUnitAdapter;
     }
 
     public function getName(): string

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -59,17 +59,11 @@ class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements MemoryUsage
 {
     public const COVERAGE_DIR = 'coverage-xml';
 
-    private string $tmpDir;
-
-    private string $jUnitFilePath;
-
-    private PCOVDirectoryProvider $pcovDirectoryProvider;
-
     public function __construct(
         string $testFrameworkExecutable,
-        string $tmpDir,
-        string $jUnitFilePath,
-        PCOVDirectoryProvider $pcovDirectoryProvider,
+        private string $tmpDir,
+        private string $jUnitFilePath,
+        private PCOVDirectoryProvider $pcovDirectoryProvider,
         InitialConfigBuilder $initialConfigBuilder,
         MutationConfigBuilder $mutationConfigBuilder,
         CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder,
@@ -78,10 +72,6 @@ class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements MemoryUsage
         ?string $version = null
     ) {
         parent::__construct($testFrameworkExecutable, $initialConfigBuilder, $mutationConfigBuilder, $argumentsAndOptionsBuilder, $versionParser, $commandLineBuilder, $version);
-
-        $this->tmpDir = $tmpDir;
-        $this->jUnitFilePath = $jUnitFilePath;
-        $this->pcovDirectoryProvider = $pcovDirectoryProvider;
     }
 
     public function hasJUnitReport(): bool

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -53,11 +53,8 @@ use function Safe\sprintf;
  */
 final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilder
 {
-    private bool $executeOnlyCoveringTestCases;
-
-    public function __construct(bool $executeOnlyCoveringTestCases)
+    public function __construct(private bool $executeOnlyCoveringTestCases)
     {
-        $this->executeOnlyCoveringTestCases = $executeOnlyCoveringTestCases;
     }
 
     public function buildForInitialTestsRun(string $configPath, string $extraOptions): array
@@ -70,9 +67,7 @@ final class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptions
         if ($extraOptions !== '') {
             $options = array_merge(
                 $options,
-                array_map(static function ($option): string {
-                    return '--' . $option;
-                }, explode(' --', ltrim($extraOptions, '-')))
+                array_map(static fn ($option): string => '--' . $option, explode(' --', ltrim($extraOptions, '-')))
             );
         }
 

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -50,38 +50,25 @@ use Webmozart\Assert\Assert;
  */
 class InitialConfigBuilder implements ConfigBuilder
 {
-    private string $tmpDir;
     private string $originalXmlConfigContent;
-    private XmlConfigurationManipulator $configManipulator;
-    private XmlConfigurationVersionProvider $versionProvider;
-    /** @var string[] */
-    private array $srcDirs;
-    /** @var list<string> */
-    private array $filteredSourceFilesToMutate;
 
     /**
      * @param string[] $srcDirs
      * @param list<string> $filteredSourceFilesToMutate
      */
     public function __construct(
-        string $tmpDir,
+        private string $tmpDir,
         string $originalXmlConfigContent,
-        XmlConfigurationManipulator $configManipulator,
-        XmlConfigurationVersionProvider $versionProvider,
-        array $srcDirs,
-        array $filteredSourceFilesToMutate
+        private XmlConfigurationManipulator $configManipulator,
+        private XmlConfigurationVersionProvider $versionProvider,
+        private array $srcDirs,
+        private array $filteredSourceFilesToMutate
     ) {
         Assert::notEmpty(
             $originalXmlConfigContent,
             'The original XML config content cannot be an empty string'
         );
-
-        $this->tmpDir = $tmpDir;
         $this->originalXmlConfigContent = $originalXmlConfigContent;
-        $this->configManipulator = $configManipulator;
-        $this->versionProvider = $versionProvider;
-        $this->srcDirs = $srcDirs;
-        $this->filteredSourceFilesToMutate = $filteredSourceFilesToMutate;
     }
 
     public function build(string $version): string

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -53,29 +53,12 @@ use Webmozart\Assert\Assert;
  */
 class MutationConfigBuilder extends ConfigBuilder
 {
-    private string $tmpDir;
-    private string $projectDir;
-    private string $originalXmlConfigContent;
-    private XmlConfigurationManipulator $configManipulator;
-    private JUnitTestCaseSorter $jUnitTestCaseSorter;
-
     private ?string $originalBootstrapFile = null;
 
     private ?DOMDocument $dom = null;
 
-    public function __construct(
-        string $tmpDir,
-        string $originalXmlConfigContent,
-        XmlConfigurationManipulator $configManipulator,
-        string $projectDir,
-        JUnitTestCaseSorter $jUnitTestCaseSorter
-    ) {
-        $this->tmpDir = $tmpDir;
-        $this->projectDir = $projectDir;
-
-        $this->originalXmlConfigContent = $originalXmlConfigContent;
-        $this->configManipulator = $configManipulator;
-        $this->jUnitTestCaseSorter = $jUnitTestCaseSorter;
+    public function __construct(private string $tmpDir, private string $originalXmlConfigContent, private XmlConfigurationManipulator $configManipulator, private string $projectDir, private JUnitTestCaseSorter $jUnitTestCaseSorter)
+    {
     }
 
     /**

--- a/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
+++ b/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
@@ -48,19 +48,14 @@ use function trim;
  */
 final class PathReplacer
 {
-    private Filesystem $filesystem;
-    private ?string $phpUnitConfigDir;
-
-    public function __construct(Filesystem $filesystem, ?string $phpUnitConfigDir = null)
+    public function __construct(private Filesystem $filesystem, private ?string $phpUnitConfigDir = null)
     {
-        $this->filesystem = $filesystem;
-        $this->phpUnitConfigDir = $phpUnitConfigDir;
     }
 
     /**
      * @param DOMNode|DOMElement $domElement
      */
-    public function replaceInNode(DOMNode $domElement): void
+    public function replaceInNode(DOMElement | DOMNode $domElement): void
     {
         $path = trim($domElement->nodeValue);
 

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -58,13 +58,8 @@ use Webmozart\Assert\Assert;
  */
 final class XmlConfigurationManipulator
 {
-    private PathReplacer $pathReplacer;
-    private string $phpUnitConfigDir;
-
-    public function __construct(PathReplacer $pathReplacer, string $phpUnitConfigDir)
+    public function __construct(private PathReplacer $pathReplacer, private string $phpUnitConfigDir)
     {
-        $this->pathReplacer = $pathReplacer;
-        $this->phpUnitConfigDir = $phpUnitConfigDir;
     }
 
     public function replaceWithAbsolutePaths(SafeDOMXPath $xPath): void

--- a/src/TestFramework/SafeDOMXPath.php
+++ b/src/TestFramework/SafeDOMXPath.php
@@ -48,13 +48,10 @@ use Webmozart\Assert\Assert;
  */
 final class SafeDOMXPath
 {
-    private DOMDocument $document;
-
     private DOMXPath $xPath;
 
-    public function __construct(DOMDocument $document)
+    public function __construct(private DOMDocument $document)
     {
-        $this->document = $document;
         $this->xPath = new DOMXPath($document);
     }
 


### PR DESCRIPTION
Closes https://github.com/infection/infection/issues/1573

PHP 7.4 is no longer maintained. 

Used versions of Infection:

![image](https://user-images.githubusercontent.com/3725595/148830717-3731f7ae-f122-4a7a-a4a4-a6c7c1cd5370.png)

PHP 8 is used by the same number of users (approximately).

We released 0.26.0 with PHP 7.4 support and continue fix bugs for 0.26 branch. New releases will be for PHP 8.0 only.

Also, most of the boilerplate code, related to properties initialization, has been removed

![image](https://user-images.githubusercontent.com/3725595/148833019-0d4aa275-c3fa-44cc-9336-a3a903ec2582.png)
