### PR TITLE
Add support for latest ondram/ci-detector version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "infection/include-interceptor": "^0.2.5",
         "justinrainbow/json-schema": "^5.2.10",
         "nikic/php-parser": "^4.13",
-        "ondram/ci-detector": "^3.3.0",
+        "ondram/ci-detector": "^3.3.0 || ^4.0",
         "sanmai/later": "^0.1.1",
         "sanmai/pipeline": "^5.1 || ^6",
         "sebastian/diff": "^3.0.2 || ^4.0",


### PR DESCRIPTION
ondram/ci-detector now only supports ^3.3, when upgrading to the latest GrumPHP (https://packagist.org/packages/phpro/grumphp), ondram/ci-detector ^4.0 is required.

This PR:

- [x] Covered by tests (should be because of usage of supporting both lowest and highest dependencies)