### PR TITLE
Correctly handle non UTF-8 characters in diff and process output for HTML logger

### DIFF
--- a/src/Logger/Html/StrykerHtmlReportBuilder.php
+++ b/src/Logger/Html/StrykerHtmlReportBuilder.php
@@ -58,6 +58,7 @@ use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\ProfileList;
 use Infection\Mutator\Removal\MethodCallRemoval;
+use Infection\Str;
 use function ltrim;
 use function md5;
 use const PHP_EOL;
@@ -249,14 +250,14 @@ final class StrykerHtmlReportBuilder
                 return [
                     'id' => $result->getMutantHash(),
                     'mutatorName' => $result->getMutatorName(),
-                    'replacement' => ltrim($replacement),
+                    'replacement' => Str::convertToUtf8(Str::trimLineReturns(ltrim($replacement))),
                     'description' => $this->getMutatorDescription($result->getMutatorName()),
                     'location' => [
                         'start' => ['line' => $result->getOriginalStartingLine(), 'column' => $startingColumn],
                         'end' => ['line' => $endingLine, 'column' => $endingColumn],
                     ],
                     'status' => self::DETECTION_STATUS_MAP[$result->getDetectionStatus()],
-                    'statusReason' => $result->getProcessOutput(),
+                    'statusReason' => Str::convertToUtf8(Str::trimLineReturns($result->getProcessOutput())),
                     'coveredBy' => array_unique(array_map(
                         fn (TestLocation $testLocation): string => $this->buildTestMethodId($testLocation->getMethod()),
                         $result->getTests()

--- a/src/Logger/JsonLogger.php
+++ b/src/Logger/JsonLogger.php
@@ -41,7 +41,6 @@ use Infection\Mutant\MutantExecutionResult;
 use Infection\Str;
 use function json_encode;
 use const JSON_THROW_ON_ERROR;
-use function mb_convert_encoding;
 
 /**
  * @internal
@@ -112,16 +111,11 @@ final class JsonLogger implements LineMutationTestingResultsLogger
                     'originalFilePath' => $mutantProcess->getOriginalFilePath(),
                     'originalStartLine' => $mutantProcess->getOriginalStartingLine(),
                 ],
-                'diff' => $this->convertToUtf8(Str::trimLineReturns($mutantProcess->getMutantDiff())),
-                'processOutput' => $this->convertToUtf8(Str::trimLineReturns($mutantProcess->getProcessOutput())),
+                'diff' => Str::convertToUtf8(Str::trimLineReturns($mutantProcess->getMutantDiff())),
+                'processOutput' => Str::convertToUtf8(Str::trimLineReturns($mutantProcess->getProcessOutput())),
             ];
         }
 
         return $mutatorRows;
-    }
-
-    private function convertToUtf8(string $string): string
-    {
-        return mb_convert_encoding($string, 'UTF-8', 'UTF-8');
     }
 }

--- a/src/Str.php
+++ b/src/Str.php
@@ -39,6 +39,7 @@ use function array_values;
 use function count;
 use function explode;
 use function implode;
+use function mb_convert_encoding;
 use const PHP_EOL;
 use function str_replace;
 use function trim;
@@ -88,5 +89,10 @@ final class Str
         }
 
         return implode(PHP_EOL, $lines);
+    }
+
+    public static function convertToUtf8(string $string): string
+    {
+        return mb_convert_encoding($string, 'UTF-8', 'UTF-8');
     }
 }

--- a/tests/phpunit/Logger/Html/StrykerHtmlReportBuilderTest.php
+++ b/tests/phpunit/Logger/Html/StrykerHtmlReportBuilderTest.php
@@ -53,6 +53,7 @@ use JsonSchema\Validator;
 use function Later\now;
 use const PHP_EOL;
 use PHPUnit\Framework\TestCase;
+use function Safe\base64_decode;
 use function Safe\file_get_contents;
 use function Safe\json_decode;
 use function Safe\json_encode;
@@ -182,6 +183,18 @@ final class StrykerHtmlReportBuilderTest extends TestCase
                                 'location' => ['start' => ['line' => 13, 'column' => 5], 'end' => ['line' => 13, 'column' => 6]],
                                 'status' => 'Killed',
                                 'statusReason' => 'Output without ability to detect the number of executed tests',
+                                'coveredBy' => ['06a6c58caae5aa33e9b787f064618f5e'],
+                                'killedBy' => [],
+                                'testsCompleted' => 0,
+                            ],
+                            [
+                                'id' => '22f68ca331c9262cc97322271d88d06d',
+                                'mutatorName' => 'PublicVisibility',
+                                'replacement' => 'protected function add(int $a, int $b) : int',
+                                'description' => 'Replaces the `public` method visibility keyword with `protected`.',
+                                'location' => ['start' => ['line' => 13, 'column' => 5], 'end' => ['line' => 13, 'column' => 6]],
+                                'status' => 'Killed',
+                                'statusReason' => 'Output without ability to detect the number of executed testsi?',
                                 'coveredBy' => ['06a6c58caae5aa33e9b787f064618f5e'],
                                 'killedBy' => [],
                                 'testsCompleted' => 0,
@@ -414,6 +427,34 @@ final class StrykerHtmlReportBuilderTest extends TestCase
                     new TestLocation('TestClass::test_method1', '/infection/path/to/TestClass.php', 0.123),
                 ],
                 'Output without ability to detect the number of executed tests'
+            ),
+            //
+            // with non UTF-8 character
+            $this->createMutantExecutionResult(
+                DetectionStatus::KILLED,
+                <<<'DIFF'
+                --- Original
+                +++ New
+                @@ @@
+                 use function array_fill_keys;
+                 final class ForHtmlReport2
+                 {
+                -    public function add(int $a, int $b) : int
+                +    protected function add(int $a, int $b) : int
+                     {
+                         return 0;
+                DIFF,
+                '22f68ca331c9262cc97322271d88d06d',
+                PublicVisibility::class,
+                realpath(__DIR__ . '/../../Fixtures/ForHtmlReport2.php'),
+                13,
+                35,
+                124,
+                547,
+                [
+                    new TestLocation('TestClass::test_method1', '/infection/path/to/TestClass.php', 0.123),
+                ],
+                'Output without ability to detect the number of executed tests' . base64_decode('abc', true) // produces non UTF-8 character
             ),
         );
     }


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/1643
