### PR TITLE
Create `MutationExecutionResult` instance with real path always, not mixed

### DIFF
--- a/src/Logger/Html/StrykerHtmlReportBuilder.php
+++ b/src/Logger/Html/StrykerHtmlReportBuilder.php
@@ -166,6 +166,9 @@ final class StrykerHtmlReportBuilder
 
         if ($this->metricsCalculator->getTotalMutantsCount() !== 0) {
             $resultsByPath = $this->retrieveResultsByPath();
+
+            Assert::minCount($resultsByPath, 1, 'There must be at least one result to build HTML report.');
+
             $basePath = Path::getLongestCommonBasePath(array_keys($resultsByPath));
 
             Assert::string($basePath, '$basePath must be a string');

--- a/src/Mutation/FileMutationGenerator.php
+++ b/src/Mutation/FileMutationGenerator.php
@@ -97,14 +97,12 @@ class FileMutationGenerator
             return;
         }
 
-        $fileInfo = $trace->getSourceFileInfo();
-
-        $initialStatements = $this->parser->parse($fileInfo);
+        $initialStatements = $this->parser->parse($trace->getSourceFileInfo());
 
         $mutationCollectorVisitor = new MutationCollectorVisitor(
             new NodeMutationGenerator(
                 $mutators,
-                $fileInfo->getPathname(),
+                $trace->getRealPath(),
                 $initialStatements,
                 $trace,
                 $onlyCovered,

--- a/tests/phpunit/Mutation/FileMutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/FileMutationGeneratorTest.php
@@ -114,6 +114,11 @@ final class FileMutationGeneratorTest extends TestCase
             ->method('getAllTestsForMutation')
             ->willReturn([])
         ;
+        $traceMock
+            ->expects($this->once())
+            ->method('getRealPath')
+            ->willReturn(self::FIXTURES_DIR . '/Mutation/OneFile/OneFile.php')
+        ;
 
         $mutationGenerator = SingletonContainer::getContainer()->getFileMutationGenerator();
 


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/1650

Previously, we could have a mix of real paths and relative paths in `MutationExecutionResult` instances. 

This broke HTML logger, which assumes that all paths are real (absolute), to find the base common path (`Path::getLongestCommonBasePath`).

