### PR TITLE
Use merge-base (three dot diff) instead of direct diff for git-diff-ase (#1653)

### DIFF
--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -20,7 +20,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v2
               with:
-                  fetch-depth: 1
+                  fetch-depth: 0
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:

--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -19,7 +19,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v2
-
+              with:
+                  fetch-depth: 0
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
@@ -47,5 +48,5 @@ jobs:
 
             - name: Run Infection for added files only
               run: |
-                  git fetch --depth=1 origin $GITHUB_BASE_REF
+                  git fetch origin $GITHUB_BASE_REF
                   php bin/infection -j2 --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --ignore-msi-with-no-mutations --only-covered

--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -20,7 +20,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v2
               with:
-                  fetch-depth: 0
+                  fetch-depth: 1
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:

--- a/src/Logger/GitHub/GitDiffFileProvider.php
+++ b/src/Logger/GitHub/GitDiffFileProvider.php
@@ -56,7 +56,7 @@ class GitDiffFileProvider
     {
         $filter = $this->shellCommandLineExecutor->execute(sprintf(
             'git diff %s --diff-filter=%s --name-only | grep src/ | paste -s -d "," -',
-            escapeshellarg($gitDiffBase),
+            escapeshellarg($gitDiffBase . '...HEAD'),
             escapeshellarg($gitDiffFilter)
         ));
 
@@ -71,7 +71,7 @@ class GitDiffFileProvider
     {
         return $this->shellCommandLineExecutor->execute(sprintf(
             "git diff %s --unified=0 --diff-filter=AM | grep -v -e '^[+-]' -e '^index'",
-            escapeshellarg($gitDiffBase)
+            escapeshellarg($gitDiffBase . '...HEAD')
         ));
     }
 }

--- a/src/Logger/GitHub/GitDiffFileProvider.php
+++ b/src/Logger/GitHub/GitDiffFileProvider.php
@@ -54,15 +54,11 @@ class GitDiffFileProvider
 
     public function provide(string $gitDiffFilter, string $gitDiffBase): string
     {
-        $commandLine = sprintf(
+        $filter = $this->shellCommandLineExecutor->execute(sprintf(
             'git diff %s --diff-filter=%s --name-only | grep src/ | paste -s -d "," -',
             escapeshellarg($gitDiffBase . '...HEAD'),
             escapeshellarg($gitDiffFilter)
-        );
-
-        var_dump(compact('commandLine'));
-
-        $filter = $this->shellCommandLineExecutor->execute($commandLine);
+        ));
 
         if ($filter === '') {
             throw NoFilesInDiffToMutate::create();
@@ -73,13 +69,9 @@ class GitDiffFileProvider
 
     public function provideWithLines(string $gitDiffBase): string
     {
-        $commandLine = sprintf(
+        return $this->shellCommandLineExecutor->execute(sprintf(
             "git diff %s --unified=0 --diff-filter=AM | grep -v -e '^[+-]' -e '^index'",
             escapeshellarg($gitDiffBase . '...HEAD')
-        );
-
-        var_dump(compact('commandLine'));
-
-        return $this->shellCommandLineExecutor->execute($commandLine);
+        ));
     }
 }

--- a/src/Logger/GitHub/GitDiffFileProvider.php
+++ b/src/Logger/GitHub/GitDiffFileProvider.php
@@ -60,6 +60,8 @@ class GitDiffFileProvider
             escapeshellarg($gitDiffFilter)
         ));
 
+        var_dump(compact('filter'));
+
         if ($filter === '') {
             throw NoFilesInDiffToMutate::create();
         }

--- a/src/Logger/GitHub/GitDiffFileProvider.php
+++ b/src/Logger/GitHub/GitDiffFileProvider.php
@@ -54,11 +54,15 @@ class GitDiffFileProvider
 
     public function provide(string $gitDiffFilter, string $gitDiffBase): string
     {
-        $filter = $this->shellCommandLineExecutor->execute(sprintf(
+        $commandLine = sprintf(
             'git diff %s --diff-filter=%s --name-only | grep src/ | paste -s -d "," -',
             escapeshellarg($gitDiffBase . '...HEAD'),
             escapeshellarg($gitDiffFilter)
-        ));
+        );
+
+        var_dump(compact('commandLine'));
+
+        $filter = $this->shellCommandLineExecutor->execute($commandLine);
 
         if ($filter === '') {
             throw NoFilesInDiffToMutate::create();
@@ -69,9 +73,13 @@ class GitDiffFileProvider
 
     public function provideWithLines(string $gitDiffBase): string
     {
-        return $this->shellCommandLineExecutor->execute(sprintf(
+        $commandLine = sprintf(
             "git diff %s --unified=0 --diff-filter=AM | grep -v -e '^[+-]' -e '^index'",
             escapeshellarg($gitDiffBase . '...HEAD')
-        ));
+        );
+
+        var_dump(compact('commandLine'));
+
+        return $this->shellCommandLineExecutor->execute($commandLine);
     }
 }

--- a/tests/phpunit/Logger/GitHub/GitDiffFileProviderTest.php
+++ b/tests/phpunit/Logger/GitHub/GitDiffFileProviderTest.php
@@ -73,7 +73,7 @@ final class GitDiffFileProviderTest extends TestCase
             ->willReturnCallback(function (string $command) use ($expectedDiffCommandLine, $expectedMergeBaseCommandLine): string {
                 switch ($command) {
                     case $expectedMergeBaseCommandLine:
-                        return '0ABCMERGE_BASE_342';
+                        return "0ABCMERGE_BASE_342\n";
                     case $expectedDiffCommandLine:
                         return 'src/A.php,src/B.php';
                     default:


### PR DESCRIPTION
This PR:

- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/233

Fixes https://github.com/infection/infection/issues/1653


Currently when using --git-diff-base=master infection generates mutants for any lines that appear in a direct diff between HEAD and master. This PR changes that to use diff between HEAD and the merge-base of HEAD and master - i.e. the diff you see on a github pull request.

We use the three dot diff syntax for git to get the comparison between the merge base and HEAD. This diff shows work done on the HEAD branch, and should ignore any changes made in the parallel on the base branch. This seems more useful for evaluating the head branch, and fits the description:

https://github.com/infection/infection/blob/d96aa59f8e8604a172899ac5be1585a0ed0c5f8a/src/Command/RunCommand.php#L253

