### PR TITLE
Use merge-base (three dot diff) instead of direct diff (#1653) (#1654)

### DIFF
--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -19,7 +19,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v2
-
+              with:
+                  fetch-depth: 0
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
@@ -47,5 +48,5 @@ jobs:
 
             - name: Run Infection for added files only
               run: |
-                  git fetch --depth=1 origin $GITHUB_BASE_REF
+                  git fetch origin $GITHUB_BASE_REF
                   php bin/infection -j2 --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --ignore-msi-with-no-mutations --only-covered

--- a/src/Logger/GitHub/GitDiffFileProvider.php
+++ b/src/Logger/GitHub/GitDiffFileProvider.php
@@ -92,7 +92,7 @@ class GitDiffFileProvider
                     escapeshellarg($gitDiffBase))
                 )
             );
-        } catch (ProcessFailedException) {
+        } catch (ProcessFailedException $_e) {
             /**
              * there is no common ancestor commit, or we are in a shallow checkout and do have a copy of it.
              * Fall back to direct diff

--- a/src/Logger/GitHub/GitDiffFileProvider.php
+++ b/src/Logger/GitHub/GitDiffFileProvider.php
@@ -38,6 +38,8 @@ namespace Infection\Logger\GitHub;
 use function escapeshellarg;
 use Infection\Process\ShellCommandLineExecutor;
 use function Safe\sprintf;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use function trim;
 
 /**
  * @final
@@ -57,9 +59,11 @@ class GitDiffFileProvider
 
     public function provide(string $gitDiffFilter, string $gitDiffBase): string
     {
+        $referenceCommit = $this->findReferenceCommit($gitDiffBase);
+
         $filter = $this->shellCommandLineExecutor->execute(sprintf(
             'git diff %s --diff-filter=%s --name-only | grep src/ | paste -s -d "," -',
-            escapeshellarg($gitDiffBase),
+            escapeshellarg($referenceCommit),
             escapeshellarg($gitDiffFilter)
         ));
 
@@ -72,9 +76,30 @@ class GitDiffFileProvider
 
     public function provideWithLines(string $gitDiffBase): string
     {
+        $referenceCommit = $this->findReferenceCommit($gitDiffBase);
+
         return $this->shellCommandLineExecutor->execute(sprintf(
             "git diff %s --unified=0 --diff-filter=AM | grep -v -e '^[+-]' -e '^index'",
-            escapeshellarg($gitDiffBase)
+            escapeshellarg($referenceCommit)
         ));
+    }
+
+    private function findReferenceCommit(string $gitDiffBase): string
+    {
+        try {
+            $comparisonCommit = trim($this->shellCommandLineExecutor->execute(sprintf(
+                    'git merge-base %s HEAD',
+                    escapeshellarg($gitDiffBase))
+                )
+            );
+        } catch (ProcessFailedException) {
+            /**
+             * there is no common ancestor commit, or we are in a shallow checkout and do have a copy of it.
+             * Fall back to direct diff
+             */
+            $comparisonCommit = $gitDiffBase;
+        }
+
+        return $comparisonCommit;
     }
 }

--- a/tests/phpunit/Logger/GitHub/GitDiffFileProviderTest.php
+++ b/tests/phpunit/Logger/GitHub/GitDiffFileProviderTest.php
@@ -90,6 +90,10 @@ final class GitDiffFileProviderTest extends TestCase
 
     public function test_it_falls_back_to_direct_diff_if_merge_base_is_not_availabe(): void
     {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped('Not testing this on Windows');
+        }
+
         $expectedMergeBaseCommandLine = 'git merge-base \'master\' HEAD';
         $shellCommandLineExecutor = $this->createMock(ShellCommandLineExecutor::class);
         $expectedDiffCommandLine = 'git diff \'master\' --diff-filter=\'AM\' --name-only | grep src/ | paste -s -d "," -';


### PR DESCRIPTION
Cherry picked from commit ae4435e0d9309 on master

* Use merge-base (three dot diff) instead of direct diff for git-diff-base (#1653)

* Add command line dumping for debugging

* Fetch full history to allow finding common ancestor, not just last commit

* Remove var_dumps

* Debug with git depth 1

* Fall back to direct diff if merge base commit is not avialable

* Restore deep git fetch

* Kill UnwrapTrim mutant
