### PR TITLE
Upgrade ondram/ci-detector to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "infection/include-interceptor": "^0.2.5",
         "justinrainbow/json-schema": "^5.2.10",
         "nikic/php-parser": "^4.13.2",
-        "ondram/ci-detector": "^3.3.0",
+        "ondram/ci-detector": "^4.1.0",
         "sanmai/later": "^0.1.1",
         "sanmai/pipeline": "^5.1 || ^6",
         "sebastian/diff": "^3.0.2 || ^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e4d493069259751644dd2b02f784c71",
+    "content-hash": "ea6b31230335692cb8f51f8290838fee",
     "packages": [
         {
             "name": "composer/pcre",
@@ -438,16 +438,16 @@
         },
         {
             "name": "ondram/ci-detector",
-            "version": "3.5.1",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OndraM/ci-detector.git",
-                "reference": "594e61252843b68998bddd48078c5058fe9028bd"
+                "reference": "8a4b664e916df82ff26a44709942dfd593fa6f30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OndraM/ci-detector/zipball/594e61252843b68998bddd48078c5058fe9028bd",
-                "reference": "594e61252843b68998bddd48078c5058fe9028bd",
+                "url": "https://api.github.com/repos/OndraM/ci-detector/zipball/8a4b664e916df82ff26a44709942dfd593fa6f30",
+                "reference": "8a4b664e916df82ff26a44709942dfd593fa6f30",
                 "shasum": ""
             },
             "require": {
@@ -455,11 +455,11 @@
             },
             "require-dev": {
                 "ergebnis/composer-normalize": "^2.2",
-                "lmc/coding-standard": "^1.3 || ^2.0",
-                "php-parallel-lint/php-parallel-lint": "^1.1",
-                "phpstan/extension-installer": "^1.0.3",
-                "phpstan/phpstan": "^0.12.0",
-                "phpstan/phpstan-phpunit": "^0.12.1",
+                "lmc/coding-standard": "^1.3 || ^2.1",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0.5",
+                "phpstan/phpstan": "^0.12.58",
+                "phpstan/phpstan-phpunit": "^0.12.16",
                 "phpunit/phpunit": "^7.1 || ^8.0 || ^9.0"
             },
             "type": "library",
@@ -487,6 +487,9 @@
                 "appveyor",
                 "aws",
                 "aws codebuild",
+                "azure",
+                "azure devops",
+                "azure pipelines",
                 "bamboo",
                 "bitbucket",
                 "buddy",
@@ -494,19 +497,22 @@
                 "codebuild",
                 "continuous integration",
                 "continuousphp",
+                "devops",
                 "drone",
                 "github",
                 "gitlab",
                 "interface",
                 "jenkins",
+                "pipelines",
+                "sourcehut",
                 "teamcity",
                 "travis"
             ],
             "support": {
                 "issues": "https://github.com/OndraM/ci-detector/issues",
-                "source": "https://github.com/OndraM/ci-detector/tree/main"
+                "source": "https://github.com/OndraM/ci-detector/tree/4.1.0"
             },
-            "time": "2020-09-04T11:21:14+00:00"
+            "time": "2021-04-14T09:16:52+00:00"
         },
         {
             "name": "psr/container",
@@ -634,12 +640,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Later\\": "src/"
-                },
                 "files": [
                     "src/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Later\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1259,12 +1265,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1340,12 +1346,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -1424,12 +1430,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1501,12 +1507,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -1580,12 +1586,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -1889,13 +1895,6 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Safe\\": [
-                        "lib/",
-                        "deprecated/",
-                        "generated/"
-                    ]
-                },
                 "files": [
                     "deprecated/apc.php",
                     "deprecated/array.php",
@@ -1984,7 +1983,14 @@
                     "generated/yaz.php",
                     "generated/zip.php",
                     "generated/zlib.php"
-                ]
+                ],
+                "psr-4": {
+                    "Safe\\": [
+                        "lib/",
+                        "deprecated/",
+                        "generated/"
+                    ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2348,12 +2354,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3415,11 +3421,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -52,7 +52,7 @@ use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\MutatorParser;
 use Infection\Mutator\MutatorResolver;
 use Infection\TestFramework\TestFrameworkTypes;
-use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\CiDetectorInterface;
 use function Safe\sprintf;
 use function sys_get_temp_dir;
 use Webmozart\Assert\Assert;
@@ -74,7 +74,7 @@ class ConfigurationFactory
     private MutatorFactory $mutatorFactory;
     private MutatorParser $mutatorParser;
     private SourceFileCollector $sourceFileCollector;
-    private CiDetector $ciDetector;
+    private CiDetectorInterface $ciDetector;
     private GitDiffFileProvider $gitDiffFileProvider;
 
     public function __construct(
@@ -83,7 +83,7 @@ class ConfigurationFactory
         MutatorFactory $mutatorFactory,
         MutatorParser $mutatorParser,
         SourceFileCollector $sourceFileCollector,
-        CiDetector $ciDetector,
+        CiDetectorInterface $ciDetector,
         GitDiffFileProvider $gitDiffFileProvider
     ) {
         $this->tmpDirProvider = $tmpDirProvider;

--- a/src/Environment/BuildContextResolver.php
+++ b/src/Environment/BuildContextResolver.php
@@ -68,13 +68,13 @@ final class BuildContextResolver
             throw new CouldNotResolveBuildContext('The repository name could not be determined for the current process');
         }
 
-        if (trim($ci->getGitBranch()) === '') {
+        if (trim($ci->getBranch()) === '') {
             throw new CouldNotResolveBuildContext('The branch name could not be determined for the current process');
         }
 
         return new BuildContext(
             $ci->getRepositoryName(),
-            $ci->getGitBranch()
+            $ci->getBranch()
         );
     }
 }

--- a/tests/phpunit/Environment/BuildContextResolverTest.php
+++ b/tests/phpunit/Environment/BuildContextResolverTest.php
@@ -123,7 +123,7 @@ final class BuildContextResolverTest extends TestCase
             ->willReturn($repositoryName);
 
         $ci
-            ->method('getGitBranch')
+            ->method('getBranch')
             ->willReturn($gitBranch);
 
         $ciDetector = $this->createMock(CiDetector::class);
@@ -158,7 +158,7 @@ final class BuildContextResolverTest extends TestCase
             ->willReturn($repositoryName);
 
         $ci
-            ->method('getGitBranch')
+            ->method('getBranch')
             ->willReturn($gitBranch);
 
         $ciDetector = $this->createMock(CiDetector::class);
@@ -198,7 +198,7 @@ final class BuildContextResolverTest extends TestCase
             ->willReturn($repositoryName);
 
         $ci
-            ->method('getGitBranch')
+            ->method('getBranch')
             ->willReturn($gitBranch);
 
         $ciDetector = $this->createMock(CiDetector::class);

--- a/tests/phpunit/Fixtures/DummyCiDetector.php
+++ b/tests/phpunit/Fixtures/DummyCiDetector.php
@@ -7,11 +7,12 @@ namespace Infection\Tests\Fixtures;
 use Infection\Tests\UnsupportedMethod;
 use OndraM\CiDetector\Ci\CiInterface;
 use OndraM\CiDetector\CiDetector;
+use OndraM\CiDetector\CiDetectorInterface;
 use OndraM\CiDetector\Env;
 
-final class DummyCiDetector extends CiDetector
+final class DummyCiDetector implements CiDetectorInterface
 {
-    private $ciDetected;
+    private bool $ciDetected;
 
     public function __construct(bool $ciDetected)
     {


### PR DESCRIPTION
This PR:

- [x] Upgrades an existing project dependency `ondram/ci-detector` to its latest major version
- [x] Covered by existing tests

This PR aims to upgrade `ondram/ci-detector` to its latest major version, to ensure `infection` can be easily used together with tools like `composer-unused` requiring the new/latest major version of `ondram/ci-detector`.