### PR TITLE
fix: Inconsistent configuration file name

### DIFF
--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -163,7 +163,7 @@ final class ConfigureCommand extends BaseCommand
         $io->newLine();
         $io->writeln(sprintf(
             'Configuration file "<comment>%s</comment>" was created.',
-            SchemaConfigurationLoader::DEFAULT_DIST_CONFIG_FILE
+            SchemaConfigurationLoader::DEFAULT_CONFIG_FILE
         ));
         $io->newLine();
 


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/1678

This PR fixes #1678 by replacing the filename we say we created (`infection.json.dist`) with the one that actually gets created (`infection.json`).

The correct file name is inferred from the `saveConfig` method, where `SchemaConfigurationLoader::DEFAULT_CONFIG_FILE` is used.

https://github.com/infection/infection/blob/8110c0240caf4784de3ef370fbaa9cbbeb5a2de7/src/Command/ConfigureCommand.php#L225-L228