### PR TITLE
Remove `thecodingmachine/safe` from whitelist of Scoper config and prefix it for PHAR

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -43,7 +43,6 @@ $polyfillsBootstrap = Finder::create()
 return [
     'whitelist' => [
         'Composer\*',
-        'Safe\*',
         // PHP 8.0
         'T_NAME_QUALIFIED',
         'T_NAME_FULLY_QUALIFIED',


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/1683

Originally was added in https://github.com/infection/infection/pull/1072 as it wasn't working with the old Box version