### PR TITLE
Escape percent sign in `Assert::notSame` message

### DIFF
--- a/src/TestFramework/VersionParser.php
+++ b/src/TestFramework/VersionParser.php
@@ -37,6 +37,7 @@ namespace Infection\TestFramework;
 
 use function Safe\preg_match;
 use function Safe\sprintf;
+use function str_replace;
 use Webmozart\Assert\Assert;
 
 /**
@@ -54,7 +55,7 @@ final class VersionParser
         Assert::notSame(
             $matched,
             0,
-            sprintf('Expected "%s" to be contain a valid SemVer (sub)string value.', $content)
+            sprintf('Expected "%s" to be contain a valid SemVer (sub)string value.', str_replace('%', '%%', $content))
         );
 
         return $matches[0];

--- a/tests/phpunit/TestFramework/VersionParserTest.php
+++ b/tests/phpunit/TestFramework/VersionParserTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\TestFramework;
 use Infection\TestFramework\VersionParser;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use function Safe\sprintf;
 
 final class VersionParserTest extends TestCase
 {
@@ -61,15 +62,18 @@ final class VersionParserTest extends TestCase
         $this->assertSame($expectedVersion, $result);
     }
 
-    public function test_it_throws_exception_when_content_has_no_version_substring(): void
+    /**
+     * @dataProvider invalidVersionProvider
+     */
+    public function test_it_throws_exception_when_content_has_no_version_substring(string $content): void
     {
         try {
-            $this->versionParser->parse('abc');
+            $this->versionParser->parse($content);
 
             $this->fail();
         } catch (InvalidArgumentException $exception) {
             $this->assertSame(
-                'Expected "abc" to be contain a valid SemVer (sub)string value.',
+                sprintf('Expected "%s" to be contain a valid SemVer (sub)string value.', $content),
                 $exception->getMessage()
             );
         }
@@ -110,5 +114,12 @@ final class VersionParserTest extends TestCase
         yield 'phpspec RC' => ['phpspec version 5.0.0-rc1', '5.0.0-rc1'];
 
         yield 'PHPUnit' => ['PHPUnit 7.5.11 by Sebastian Bergmann and contributors.', '7.5.11'];
+    }
+
+    public function invalidVersionProvider(): iterable
+    {
+        yield 'ascii-only string' => ['abc'];
+
+        yield 'with percent sign' => ['%~'];
     }
 }


### PR DESCRIPTION
This PR fixes https://github.com/infection/infection/issues/1662

The 3rd argument of `Webmozart\Assert\Assert::notSame` is passed to `sprintf`:
```php
    public static function notSame($value, $expect, $message = '')
    {
        if ($expect === $value) {
            static::reportInvalidArgument(\sprintf(
                $message ?: 'Expected a value not identical to %s.',
                static::valueToString($expect)
            ));
        }
    }
```

See https://github.com/webmozarts/assert/blob/dc96b67/src/Assert.php#L831-L839

If we call it with a message containing `%~` then PHP thows `ValueError: Unknown format specifier "~"`.

This PR escapes the `%` sign to avoid this error.