### PR TITLE
Fix issue_#1700 again

### DIFF
--- a/devTools/phpstan-src.neon
+++ b/devTools/phpstan-src.neon
@@ -32,9 +32,6 @@ parameters:
             message: '#^Method Infection\\Container::get.*\(\) should return .* but returns object\.$#'
             count: 1
         -
-            path: '../src/Process/OriginalPhpProcess.php'
-            message: '#Function ini_get is unsafe to use#'
-        -
             path: '../src/TestFramework/Coverage/CoverageChecker.php'
             message: '#Function ini_get is unsafe to use#'
         -

--- a/src/Process/OriginalPhpProcess.php
+++ b/src/Process/OriginalPhpProcess.php
@@ -39,7 +39,6 @@ use function array_merge;
 use Composer\XdebugHandler\PhpConfig;
 use Composer\XdebugHandler\XdebugHandler;
 use function extension_loaded;
-use function ini_get as ini_get_unsafe;
 use const PHP_SAPI;
 use Symfony\Component\Process\Process;
 
@@ -82,14 +81,8 @@ final class OriginalPhpProcess extends Process
             return false;
         }
 
-        // We also do not need to add XDEBUG_MODE for Xdebug <=3:
-        // it had coverage enabled at all times and it didn't have `xdebug.mode`.
-        if (ini_get_unsafe('xdebug.mode') === false) {
-            return false;
-        }
-
         // The last case: Xdebug 3+ running inactive.
-        return ini_get_unsafe('xdebug.mode') !== 'coverage';
+        return true;
 
         // Why going through all the trouble above? We don't want to enable
         // Xdebug when there are more compelling choices. In the end the user is


### PR DESCRIPTION
This PR:

Fixes https://github.com/infection/infection/issues/1700 again.

Since I use the latest version (0.26.12) and setup the same development environment, it still gets the same error that mention in above issue.

I try to collect the `ini_get_unsafe('xdebug.mode')` and `extension_loaded('xdebug')` values, and I found these values are `false`.

I also ensure that my `XDebug` extension is available and I try to `return true` directly. It's worked perfectly without presenting the above issue.

I suspect the internal `XDebug 3.x` enabling mechanism behavior is different from `XDebug 2.x` and that's the reason why these conditions are not worked well.

I also notice that the future Infection will not support old PHP 7.4 version. That is, it will not support `XDeBug 2.x` version in upcoming version.

I think it's time to remove these useless conditions and return `true` directly if the `pcov` and `phpdbg` are not loaded.