### PR TITLE
Correclty prefix PHAR to avoid `Composer\*` namespaces conflicts with the application code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 # Variables
 #---------------------------------------------------------------------------
 BOX=./.tools/box
-BOX_URL="https://github.com/humbug/box/releases/download/3.16.0/box.phar"
+BOX_URL="https://github.com/humbug/box/releases/download/4.0.2/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
 PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.9.5/php-cs-fixer.phar"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 # Variables
 #---------------------------------------------------------------------------
 BOX=./.tools/box
-BOX_URL="https://github.com/humbug/box/releases/download/4.0.2/box.phar"
+BOX_URL="https://github.com/humbug/box/releases/download/3.16.0/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
 PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.9.5/php-cs-fixer.phar"

--- a/box.json.dist
+++ b/box.json.dist
@@ -10,7 +10,6 @@
         "KevinGH\\Box\\Compactor\\PhpScoper"
     ],
     "files": [
-        "resources/schema.json",
-        "vendor/composer/installed.php"
+        "resources/schema.json"
     ]
 }

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -50,4 +50,5 @@ return [
     ],
     'prefix' => 'Infected',
     'exclude-classes' => [\Composer\InstalledVersions::class],
+    'exclude-files' => ['vendor/composer/InstalledVersions.php'],
 ];

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 return [
     'whitelist' => [
-        'Composer\*',
         // PHP 8.0
         'T_NAME_QUALIFIED',
         'T_NAME_FULLY_QUALIFIED',
@@ -49,4 +48,6 @@ return [
         'T_ENUM',
         'T_READONLY',
     ],
+    'prefix' => 'Infected',
+    'exclude-classes' => [\Composer\InstalledVersions::class],
 ];

--- a/tests/e2e/Composer_Xdebug_Handler_Version_1/README.md
+++ b/tests/e2e/Composer_Xdebug_Handler_Version_1/README.md
@@ -1,0 +1,7 @@
+# Summary
+
+* Related to https://github.com/infection/infection/issues/1677
+
+Previously, Infection didn't prefixed `Composer\*` namespaces and we had a bug where not prefixed `Composer\XdebugHandler` inside the PHAR of version 2.* could conflict with app's `Composer\XdebugHandler` of verions 1.*.
+
+This test ensures Infection PHAR with prefixed `Composer\XdebugHandler` can work with the app's old `Composer\XdebugHandler`

--- a/tests/e2e/Composer_Xdebug_Handler_Version_1/composer.json
+++ b/tests/e2e/Composer_Xdebug_Handler_Version_1/composer.json
@@ -1,0 +1,18 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.5.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Composer_Xdebug_Handler_Version_1\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Composer_Xdebug_Handler_Version_1\\Test\\": "tests/"
+        }
+    },
+    "require": {
+        "composer/xdebug-handler": "^1"
+    }
+}

--- a/tests/e2e/Composer_Xdebug_Handler_Version_1/expected-output.txt
+++ b/tests/e2e/Composer_Xdebug_Handler_Version_1/expected-output.txt
@@ -1,0 +1,10 @@
+Total: 1
+
+Killed: 1
+Errored: 0
+Syntax Errors: 0
+Escaped: 0
+Timed Out: 0
+Skipped: 0
+Ignored: 0
+Not Covered: 0

--- a/tests/e2e/Composer_Xdebug_Handler_Version_1/infection.json
+++ b/tests/e2e/Composer_Xdebug_Handler_Version_1/infection.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../resources/schema.json",
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/Composer_Xdebug_Handler_Version_1/phpunit.xml
+++ b/tests/e2e/Composer_Xdebug_Handler_Version_1/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/schema/9.2.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/e2e/Composer_Xdebug_Handler_Version_1/run_tests.bash
+++ b/tests/e2e/Composer_Xdebug_Handler_Version_1/run_tests.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if [ "${1}" = "bin/infection" ]
+then
+    # skipping for non-PHAR as it will 100% has a conflict with dependencies
+    exit 0
+fi
+
+readonly INFECTION=../../../${1}
+
+set -e pipefail
+
+if [ "$DRIVER" = "phpdbg" ]
+then
+    phpdbg -qrr $INFECTION
+else
+    php $INFECTION
+fi
+
+diff -w expected-output.txt infection.log

--- a/tests/e2e/Composer_Xdebug_Handler_Version_1/src/SourceClass.php
+++ b/tests/e2e/Composer_Xdebug_Handler_Version_1/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Composer_Xdebug_Handler_Version_1;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/e2e/Composer_Xdebug_Handler_Version_1/tests/SourceClassTest.php
+++ b/tests/e2e/Composer_Xdebug_Handler_Version_1/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Composer_Xdebug_Handler_Version_1\Test;
+
+use Composer_Xdebug_Handler_Version_1\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/e2e_tests
+++ b/tests/e2e_tests
@@ -23,7 +23,7 @@ do
 
     if [ -f "run_tests.bash" ]
     then
-        output="$(INFECTION_E2E_TESTS_ENV=1 bash run_tests.bash)"
+        output="$(INFECTION_E2E_TESTS_ENV=1 bash run_tests.bash ${1:-bin/infection})"
     else
         output="$(INFECTION_E2E_TESTS_ENV=1 bash ../standard_script.bash ${1:-bin/infection})"
     fi


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/1677

Previously, we excluded the whole `Composer\*` namespace from prefixing, leaving it as is. And since Infection uses `composer/xdebug-handler` v2, it failed for all the projects that use v1 because of incompatible API.

This PR prefixes all the classes in `Composer\*`, except one.

I believe there is still a bug in Box/PHP-Scoper which I reported and had to workaround it https://github.com/humbug/php-scoper/issues/678

With this workaround it works and the new e2e test that fails for `master` now works in this branch