### PR TITLE
Display generated log file reports to console output

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -414,11 +414,14 @@ final class Container
             ),
             MutationTestingConsoleLoggerSubscriberFactory::class => static function (self $container): MutationTestingConsoleLoggerSubscriberFactory {
                 $config = $container->getConfiguration();
+                /** @var FederatedLogger $federatedMutationTestingResultsLogger */
+                $federatedMutationTestingResultsLogger = $container->getMutationTestingResultsLogger();
 
                 return new MutationTestingConsoleLoggerSubscriberFactory(
                     $container->getMetricsCalculator(),
                     $container->getResultsCollector(),
                     $container->getDiffColorizer(),
+                    $federatedMutationTestingResultsLogger,
                     $config->showMutations(),
                     $container->getOutputFormatter()
                 );

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -193,6 +193,13 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
                     $this->addIndentation(sprintf('- %s', $fileLogger->getFilePath()))
                 );
             }
+
+            return;
+        }
+
+        // for the case when no file loggers are configured and `--show-mutations` is not used
+        if (!$this->showMutations) {
+            $this->output->writeln(['', 'Note: to see escaped mutants run Infection with "--show-mutations" or configure file loggers.']);
         }
     }
 

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
@@ -37,6 +37,7 @@ namespace Infection\Event\Subscriber;
 
 use Infection\Console\OutputFormatter\OutputFormatter;
 use Infection\Differ\DiffColorizer;
+use Infection\Logger\FederatedLogger;
 use Infection\Metrics\MetricsCalculator;
 use Infection\Metrics\ResultsCollector;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -46,7 +47,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutationTestingConsoleLoggerSubscriberFactory implements SubscriberFactory
 {
-    public function __construct(private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector, private DiffColorizer $diffColorizer, private bool $showMutations, private OutputFormatter $formatter)
+    public function __construct(
+        private MetricsCalculator $metricsCalculator,
+        private ResultsCollector $resultsCollector,
+        private DiffColorizer $diffColorizer,
+        private FederatedLogger $mutationTestingResultsLogger,
+        private bool $showMutations,
+        private OutputFormatter $formatter)
     {
     }
 
@@ -58,6 +65,7 @@ final class MutationTestingConsoleLoggerSubscriberFactory implements SubscriberF
             $this->metricsCalculator,
             $this->resultsCollector,
             $this->diffColorizer,
+            $this->mutationTestingResultsLogger,
             $this->showMutations
         );
     }

--- a/src/Logger/FederatedLogger.php
+++ b/src/Logger/FederatedLogger.php
@@ -56,4 +56,12 @@ final class FederatedLogger implements MutationTestingResultsLogger
             $logger->log();
         }
     }
+
+    /**
+     * @return MutationTestingResultsLogger[]
+     */
+    public function getLoggers(): array
+    {
+        return $this->loggers;
+    }
 }

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -84,4 +84,9 @@ final class FileLogger implements MutationTestingResultsLogger
             ));
         }
     }
+
+    public function getFilePath(): string
+    {
+        return $this->filePath;
+    }
 }

--- a/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactoryTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Event\Subscriber;
 use Infection\Differ\DiffColorizer;
 use Infection\Event\Subscriber\MutationTestingConsoleLoggerSubscriber;
 use Infection\Event\Subscriber\MutationTestingConsoleLoggerSubscriberFactory;
+use Infection\Logger\FederatedLogger;
 use Infection\Metrics\MetricsCalculator;
 use Infection\Metrics\ResultsCollector;
 use Infection\Tests\Fixtures\Console\FakeOutputFormatter;
@@ -92,6 +93,7 @@ final class MutationTestingConsoleLoggerSubscriberFactoryTest extends TestCase
             $this->metricsCalculatorMock,
             $this->resultsCollectorMock,
             $this->diffColorizerMock,
+            new FederatedLogger(),
             $showMutations,
             new FakeOutputFormatter()
         );

--- a/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberTest.php
@@ -42,13 +42,28 @@ use Infection\Event\MutantProcessWasFinished;
 use Infection\Event\MutationTestingWasFinished;
 use Infection\Event\MutationTestingWasStarted;
 use Infection\Event\Subscriber\MutationTestingConsoleLoggerSubscriber;
+use Infection\Logger\FederatedLogger;
+use Infection\Logger\FileLogger;
 use Infection\Metrics\MetricsCalculator;
 use Infection\Metrics\ResultsCollector;
 use Infection\Mutant\MutantExecutionResult;
+use Infection\Tests\Fixtures\Logger\DummyLineMutationTestingResultsLogger;
+use Infection\Tests\Fixtures\Logger\FakeLogger;
+use Infection\Tests\Logger\FakeMutationTestingResultsLogger;
+use const PHP_EOL;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use function Safe\fopen;
+use function Safe\rewind;
+use function Safe\stream_get_contents;
+use function str_replace;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @group integration
+ */
 final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
 {
     /**
@@ -98,6 +113,7 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             $this->metricsCalculator,
             $this->resultsCollector,
             $this->diffColorizer,
+            new FederatedLogger(),
             false
         ));
 
@@ -121,6 +137,7 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             $this->metricsCalculator,
             $this->resultsCollector,
             $this->diffColorizer,
+            new FederatedLogger(),
             false
         ));
 
@@ -144,6 +161,7 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             $this->metricsCalculator,
             $this->resultsCollector,
             $this->diffColorizer,
+            new FederatedLogger(),
             false
         ));
 
@@ -196,6 +214,7 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             $this->metricsCalculator,
             $this->resultsCollector,
             $this->diffColorizer,
+            new FederatedLogger(),
             true
         ));
 
@@ -230,10 +249,55 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             $this->metricsCalculator,
             $this->resultsCollector,
             $this->diffColorizer,
+            new FederatedLogger(),
             true
         ));
 
         $dispatcher->dispatch(new MutationTestingWasFinished());
+    }
+
+    public function test_it_outputs_generated_file_log_paths_if_enabled(): void
+    {
+        $output = new StreamOutput(fopen('php://memory', 'w', false));
+
+        $dispatcher = new SyncEventDispatcher();
+        $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
+            $output,
+            $this->outputFormatter,
+            $this->metricsCalculator,
+            $this->resultsCollector,
+            $this->diffColorizer,
+            new FederatedLogger(
+                new FederatedLogger(
+                    new FileLogger(
+                        'relative/path.log',
+                        new Filesystem(),
+                        new DummyLineMutationTestingResultsLogger([]),
+                        new FakeLogger()
+                    ),
+                    new FileLogger(
+                        '/absolute/path.html',
+                        new Filesystem(),
+                        new DummyLineMutationTestingResultsLogger([]),
+                        new FakeLogger()
+                    ),
+                    new FakeMutationTestingResultsLogger(),
+                ),
+                new FakeMutationTestingResultsLogger(),
+            ),
+            false
+        ));
+
+        $dispatcher->dispatch(new MutationTestingWasFinished());
+
+        $this->assertStringContainsString(
+            <<<TEXT
+            Generated Reports:
+                     - relative/path.log
+                     - /absolute/path.html
+            TEXT
+            ,
+            $this->getDisplay($output));
     }
 
     public function test_it_reacts_on_mutation_testing_finished_and_show_mutations_on(): void
@@ -252,9 +316,19 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             $this->metricsCalculator,
             $this->resultsCollector,
             $this->diffColorizer,
+            new FederatedLogger(),
             true
         ));
 
         $dispatcher->dispatch(new MutationTestingWasFinished());
+    }
+
+    private function getDisplay(StreamOutput $output): string
+    {
+        rewind($output->getStream());
+
+        $display = stream_get_contents($output->getStream());
+
+        return str_replace(PHP_EOL, "\n", $display);
     }
 }


### PR DESCRIPTION
Implements #1675, related https://github.com/infection/infection/pull/1472#issuecomment-770921035

Now, when file loggers are configured, Infection will display this information to console for better DX, so developer understands where results are located.

![image](https://user-images.githubusercontent.com/3725595/181743829-7ab22231-dc4c-4182-8671-e10bec3957de.png)

When no file loggers are configured and `--show-mutations` option is not used, there will be a tip to use any of those (related to https://github.com/infection/infection/pull/1472#issuecomment-770921035):

![image](https://user-images.githubusercontent.com/3725595/181773169-dd7a1c1e-ecbe-4925-82a9-9afb6cfbe3a9.png)
