### PR TITLE
Correctly build PHP 8.0 and 8.1 images and fix `compile-docker` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ INFECTION=./build/infection.phar
 
 DOCKER_RUN=docker-compose run
 DOCKER_RUN_80=$(DOCKER_RUN) php80 $(FLOCK) Makefile
+DOCKER_RUN_81=$(DOCKER_RUN) php81 $(FLOCK) Makefile
 DOCKER_FILE_IMAGE=devTools/Dockerfile.json
 
 FLOCK=./devTools/flock
@@ -56,7 +57,7 @@ compile: $(INFECTION)
 .PHONY: compile-docker
 compile-docker:	 	## Bundles Infection into a PHAR using docker
 compile-docker: $(DOCKER_FILE_IMAGE)
-	$(DOCKER_RUN_80) make compile
+	$(DOCKER_RUN_81) make compile
 
 .PHONY: check_trailing_whitespaces
 check_trailing_whitespaces:

--- a/devTools/Dockerfile
+++ b/devTools/Dockerfile
@@ -2,7 +2,7 @@ ARG PHP_VERSION
 
 FROM php:${PHP_VERSION}-cli-alpine
 
-ARG XDEBUG_VERSION=3.0.4
+ARG XDEBUG_VERSION
 
 RUN set -eux; \
     apk add --no-cache --virtual .build-deps \
@@ -29,7 +29,7 @@ RUN apk add --no-cache \
         git \
         zip
 
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.1 /usr/bin/composer /usr/bin/composer
 COPY memory-limit.ini xdebug.ini ${PHP_INI_DIR}/conf.d/
 
 RUN adduser -h /opt/infection -s /bin/bash -D infection

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,15 @@ services:
     build:
       context: devTools
       args:
-        PHP_VERSION: 8.0
+        PHP_VERSION: '8.0'
+        XDEBUG_VERSION: '3.0.4'
+    volumes:
+      - .:/opt/infection
+  php81:
+    build:
+      context: devTools
+      args:
+        PHP_VERSION: '8.1'
+        XDEBUG_VERSION: '3.1.5'
     volumes:
       - .:/opt/infection


### PR DESCRIPTION
```diff
- PHP_VERSION: 8.0
+ PHP_VERSION: '8.0'
```

funny but `8.0` (float) was treated as just `8` and resulted in the latest 8.* version, which is 8.1.9

Now we correctly build 8.0 image with older Xdebug and 8.1 version with newer Xdebug

Fixed https://github.com/infection/infection/issues/1713