### PR TITLE
Do not mutate Coalesce operator when `null` is used on the right

### DIFF
--- a/src/Mutator/Operator/Coalesce.php
+++ b/src/Mutator/Operator/Coalesce.php
@@ -92,6 +92,7 @@ DIFF
     {
         return $node instanceof Node\Expr\BinaryOp\Coalesce
             && !$node->left instanceof Node\Expr\ConstFetch
-            && !$node->left instanceof Node\Expr\ClassConstFetch;
+            && !$node->left instanceof Node\Expr\ClassConstFetch
+            && !($node->right instanceof Node\Expr\ConstFetch && $node->right->name->toLowerString() === 'null');
     }
 }

--- a/tests/phpunit/Mutator/Operator/CoalesceTest.php
+++ b/tests/phpunit/Mutator/Operator/CoalesceTest.php
@@ -163,5 +163,33 @@ new class {
 };
 PHP
         ];
+
+        yield 'It does not mutate when null is used with one coalesce' => [
+            <<<'PHP'
+<?php
+
+$foo = 'foo';
+$foo ?? null;
+PHP
+            ,
+        ];
+
+        yield 'It does not move null from the last position with 2 coalesce' => [
+            <<<'PHP'
+<?php
+
+$foo = 'foo';
+$bar = 'bar';
+$foo ?? $bar ?? null;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$foo = 'foo';
+$bar = 'bar';
+$bar ?? $foo ?? null;
+PHP
+        ];
     }
 }


### PR DESCRIPTION
Because it's impossible to kill such Mutant

Fixes https://github.com/infection/infection/issues/1725

