### PR TITLE
Correctly handle exception code mutants

### DIFF
--- a/tests/e2e/Exception_Code/README.md
+++ b/tests/e2e/Exception_Code/README.md
@@ -1,0 +1,4 @@
+# Exception code mutants are killed
+
+Tests that `DecrementInteger` and `IncrementInteger` mutants on exception code
+are killed.

--- a/tests/e2e/Exception_Code/composer.json
+++ b/tests/e2e/Exception_Code/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.5.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "ExceptionCode\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "ExceptionCode\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/e2e/Exception_Code/expected-output.txt
+++ b/tests/e2e/Exception_Code/expected-output.txt
@@ -1,0 +1,10 @@
+Total: 5
+
+Killed: 5
+Errored: 0
+Syntax Errors: 0
+Escaped: 0
+Timed Out: 0
+Skipped: 0
+Ignored: 0
+Not Covered: 0

--- a/tests/e2e/Exception_Code/infection.json
+++ b/tests/e2e/Exception_Code/infection.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../resources/schema.json",
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/Exception_Code/phpunit.xml
+++ b/tests/e2e/Exception_Code/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/tests/e2e/Exception_Code/src/ClassThatThrowsException.php
+++ b/tests/e2e/Exception_Code/src/ClassThatThrowsException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ExceptionCode;
+
+final class ClassThatThrowsException
+{
+    public static function someMethod(): void
+    {
+        throw new SomeException();
+    }
+}

--- a/tests/e2e/Exception_Code/src/SomeException.php
+++ b/tests/e2e/Exception_Code/src/SomeException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ExceptionCode;
+
+use Exception;
+
+final class SomeException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'some message',
+            1337
+        );
+    }
+}

--- a/tests/e2e/Exception_Code/tests/ClassThatThrowsExceptionTest.php
+++ b/tests/e2e/Exception_Code/tests/ClassThatThrowsExceptionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ExceptionCode\Test;
+
+use ExceptionCode\ClassThatThrowsException;
+use PHPUnit\Framework\TestCase;
+
+class ClassThatThrowsExceptionTest extends TestCase
+{
+    public function test_exception_code_is_correct()
+    {
+        $this->expectExceptionMessage('some message');
+        $this->expectExceptionCode(1337);
+
+        ClassThatThrowsException::someMethod();
+    }
+}


### PR DESCRIPTION
I've been having this issue but don't really know where to start in order to fix this, so I thought the best way would be to provide a failing test.

When Infection creates the `DecrementInteger` and `IncrementInteger` mutants on an exception code, even if this code is part of a test, the report will mark those two mutants as uncovered. Changing the code manually leads to a failing test.

Any hint on how we could fix this behavior?