### PR TITLE
Do not mutate coalesce operator in the Assignment mutator

### DIFF
--- a/src/Mutator/Arithmetic/Assignment.php
+++ b/src/Mutator/Arithmetic/Assignment.php
@@ -79,6 +79,6 @@ DIFF
 
     public function canMutate(Node $node): bool
     {
-        return $node instanceof Node\Expr\AssignOp;
+        return $node instanceof Node\Expr\AssignOp && !$node instanceof Node\Expr\AssignOp\Coalesce;
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/AssignmentTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/AssignmentTest.php
@@ -218,5 +218,14 @@ PHP
 $a = $b;
 PHP
         ];
+
+        yield 'It does not mutate Coalesce operator' => [
+            <<<'PHP'
+<?php
+
+$a ??= $b;
+PHP
+            ,
+        ];
     }
 }


### PR DESCRIPTION
This PR fixes https://github.com/infection/infection/issues/1738 and excludes coalesce operator mutation as part of the Assignment mutator. We have independent AssignCoalesce mutator.