### PR TITLE
Add new CatchBlockRemoval mutator

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -329,6 +329,7 @@
                         }
                     ]
                 },
+                "CatchBlockRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "FunctionCallRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "MethodCallRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "CloneRemoval": { "$ref": "#/definitions/default-mutator-config" },

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -175,6 +175,7 @@ final class ProfileList
 
     public const REMOVAL_PROFILE = [
         Mutator\Removal\ArrayItemRemoval::class,
+        Mutator\Removal\CatchBlockRemoval::class,
         Mutator\Removal\CloneRemoval::class,
         Mutator\Removal\ConcatOperandRemoval::class,
         Mutator\Removal\FunctionCallRemoval::class,
@@ -378,6 +379,7 @@ final class ProfileList
 
         // Removal
         'ArrayItemRemoval' => Mutator\Removal\ArrayItemRemoval::class,
+        'CatchBlockRemoval' => Mutator\Removal\CatchBlockRemoval::class,
         'CloneRemoval' => Mutator\Removal\CloneRemoval::class,
         'ConcatOperandRemoval' => Mutator\Removal\ConcatOperandRemoval::class,
         'FunctionCallRemoval' => Mutator\Removal\FunctionCallRemoval::class,

--- a/src/Mutator/Removal/CatchBlockRemoval.php
+++ b/src/Mutator/Removal/CatchBlockRemoval.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Removal;
+
+use function count;
+use Infection\Mutator\Definition;
+use Infection\Mutator\GetMutatorName;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\MutatorCategory;
+use PhpParser\Node;
+
+/**
+ * @internal
+ *
+ * @implements Mutator<Node\Stmt\TryCatch>
+ */
+final class CatchBlockRemoval implements Mutator
+{
+    use GetMutatorName;
+
+    public static function getDefinition(): ?Definition
+    {
+        return new Definition(
+            'Removes `catch` block when more than one defined in `try-catch`.',
+            MutatorCategory::SEMANTIC_REDUCTION,
+            null,
+            <<<'DIFF'
+try {
+    $callback();
+- } catch (\DomainException $ex) {
+-     $logger->log($ex);
+} catch (\LogicException $e) {
+    throw $e;
+}
+DIFF
+        );
+    }
+
+    public function canMutate(Node $node): bool
+    {
+        if (!$node instanceof Node\Stmt\TryCatch || count($node->catches) < 2) {
+            return false;
+        }
+
+        foreach ($node->catches as $catch) {
+            if ($catch->stmts !== []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return iterable<Node\Stmt\TryCatch>
+     */
+    public function mutate(Node $node): iterable
+    {
+        foreach ($node->catches as $i => $catch) {
+            if (!$this->hasAtLeastOneNonNopStatements(...$catch->stmts)) {
+                continue;
+            }
+
+            $catches = $node->catches;
+
+            unset($catches[$i]);
+
+            yield new Node\Stmt\TryCatch($node->stmts, $catches, $node->finally, $node->getAttributes());
+        }
+    }
+
+    private function hasAtLeastOneNonNopStatements(Node\Stmt ...$stmts): bool
+    {
+        foreach ($stmts as $stmt) {
+            if (!$stmt instanceof Node\Stmt\Nop) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/phpunit/Mutator/Removal/CatchBlockRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/CatchBlockRemovalTest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Removal;
+
+use Infection\Tests\Mutator\BaseMutatorTestCase;
+
+final class CatchBlockRemovalTest extends BaseMutatorTestCase
+{
+    /**
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
+     */
+    public function test_it_can_mutate(string $input, array|string $expected = []): void
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function mutationsProvider(): iterable
+    {
+        yield 'It removes catch block' => [
+            <<<'PHP'
+<?php
+
+try {
+    $callback();
+} catch (\DomainException $e) {
+    $logger->log($e);
+} catch (\LogicException $e) {
+    throw $e;
+} catch (\Throwable $e) {
+    throw new \RuntimeException();
+}
+PHP
+            ,
+            [
+                <<<'PHP'
+<?php
+
+try {
+    $callback();
+} catch (\LogicException $e) {
+    throw $e;
+} catch (\Throwable $e) {
+    throw new \RuntimeException();
+}
+PHP,
+                <<<'PHP'
+<?php
+
+try {
+    $callback();
+} catch (\DomainException $e) {
+    $logger->log($e);
+} catch (\Throwable $e) {
+    throw new \RuntimeException();
+}
+PHP,
+                <<<'PHP'
+<?php
+
+try {
+    $callback();
+} catch (\DomainException $e) {
+    $logger->log($e);
+} catch (\LogicException $e) {
+    throw $e;
+}
+PHP,
+            ],
+        ];
+
+        yield 'It does not mutate with one catch block' => [
+            <<<'PHP'
+<?php
+
+try {
+    $callback();
+} catch (\DomainException $e) {
+    $logger->log($e);
+}
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate if catch block does not contain statements' => [
+            <<<'PHP'
+<?php
+
+try {
+    $callback();
+} catch (\DomainException $e) {
+    // DO nothing
+} catch (\Throwable $e) {
+    throw new \RuntimeException();
+}
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+try {
+    $callback();
+} catch (\DomainException $e) {
+    // DO nothing
+}
+PHP
+        ];
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds new CatchBlockRemoval mutator
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/246

```diff
try {
    $callback();
- } catch (\DomainException $ex) {
-     $logger->log($ex);
} catch (\LogicException $e) {
    throw $e;
}
```

It won't remove catch block in case there is no statements
```diff
<?php

try {
    $callback();
} catch (\DomainException $e) {
    // DO nothing
- } catch (\Throwable $e) {
-     throw new \RuntimeException();
}
```