### PR TITLE
Add new MatchArmRemoval mutator

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -330,6 +330,7 @@
                     ]
                 },
                 "FunctionCallRemoval": { "$ref": "#/definitions/default-mutator-config" },
+                "MatchArmRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "MethodCallRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "CloneRemoval": { "$ref": "#/definitions/default-mutator-config" },
                 "ConcatOperandRemoval": { "$ref": "#/definitions/default-mutator-config" },

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -178,6 +178,7 @@ final class ProfileList
         Mutator\Removal\CloneRemoval::class,
         Mutator\Removal\ConcatOperandRemoval::class,
         Mutator\Removal\FunctionCallRemoval::class,
+        Mutator\Removal\MatchArmRemoval::class,
         Mutator\Removal\MethodCallRemoval::class,
         Mutator\Removal\SharedCaseRemoval::class,
     ];
@@ -381,6 +382,7 @@ final class ProfileList
         'CloneRemoval' => Mutator\Removal\CloneRemoval::class,
         'ConcatOperandRemoval' => Mutator\Removal\ConcatOperandRemoval::class,
         'FunctionCallRemoval' => Mutator\Removal\FunctionCallRemoval::class,
+        'MatchArmRemoval' => Mutator\Removal\MatchArmRemoval::class,
         'MethodCallRemoval' => Mutator\Removal\MethodCallRemoval::class,
         'SharedCaseRemoval' => Mutator\Removal\SharedCaseRemoval::class,
 

--- a/src/Mutator/Removal/MatchArmRemoval.php
+++ b/src/Mutator/Removal/MatchArmRemoval.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Removal;
+
+use function count;
+use Infection\Mutator\Definition;
+use Infection\Mutator\GetMutatorName;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\MutatorCategory;
+use PhpParser\Node;
+
+/**
+ * @internal
+ *
+ * @implements Mutator<Node\Expr\Match_>
+ */
+final class MatchArmRemoval implements Mutator
+{
+    use GetMutatorName;
+
+    public static function getDefinition(): ?Definition
+    {
+        return new Definition(
+            <<<'TXT'
+Removes `match arm`s from `match`.
+
+```php
+match ($x) {
+    'cond1', 'cond2' => true,
+    default => throw new \Exception(),
+};
+```
+
+Will be mutated to:
+
+```php
+match ($x) {
+    'cond1' => true,
+    default => throw new \Exception(),
+};
+```
+
+```php
+match ($x) {
+    'cond2' => true,
+    default => throw new \Exception(),
+};
+```
+
+And:
+```php
+match ($x) {
+    default => throw new \Exception(),
+};
+```
+TXT,
+            MutatorCategory::SEMANTIC_REDUCTION,
+            null,
+            <<<'DIFF'
+match ($x) {
+-   0 => false,
+    1 => true,
+    2 => null,
+    default => throw new \Exception(),
+};
+DIFF
+        );
+    }
+
+    public function canMutate(Node $node): bool
+    {
+        return $node instanceof Node\Expr\Match_
+            && count($node->arms) > 1;
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return iterable<Node\Expr\Match_>
+     */
+    public function mutate(Node $node): iterable
+    {
+        foreach ($node->arms as $i => $arm) {
+            $arms = $node->arms;
+
+            if ($arm->conds !== null && count($arm->conds) > 1) {
+                foreach ($arm->conds as $j => $cond) {
+                    $conds = $arm->conds;
+
+                    unset($conds[$j]);
+
+                    $arms[$i] = new Node\MatchArm($conds, $arm->body, $node->getAttributes());
+
+                    yield new Node\Expr\Match_($node->cond, $arms, $node->getAttributes());
+                }
+
+                continue;
+            }
+
+            unset($arms[$i]);
+
+            yield new Node\Expr\Match_($node->cond, $arms, $node->getAttributes());
+        }
+    }
+}

--- a/tests/phpunit/Mutator/Removal/MatchArmRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/MatchArmRemovalTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Removal;
+
+use Infection\Tests\Mutator\BaseMutatorTestCase;
+
+final class MatchArmRemovalTest extends BaseMutatorTestCase
+{
+    /**
+     * @dataProvider mutationsProvider
+     *
+     * @param string|string[] $expected
+     */
+    public function test_it_can_mutate(string $input, array|string $expected = []): void
+    {
+        $this->doTest($input, $expected);
+    }
+
+    public function mutationsProvider(): iterable
+    {
+        yield 'It removes match arm when more than one is defined' => [
+            <<<'PHP'
+<?php
+
+match ($x) {
+    0 => false,
+    1 => true,
+    2 => null,
+    default => throw new \Exception(),
+};
+PHP
+            ,
+            [
+                <<<'PHP'
+<?php
+
+match ($x) {
+    1 => true,
+    2 => null,
+    default => throw new \Exception(),
+};
+PHP,
+                <<<'PHP'
+<?php
+
+match ($x) {
+    0 => false,
+    2 => null,
+    default => throw new \Exception(),
+};
+PHP,
+                <<<'PHP'
+<?php
+
+match ($x) {
+    0 => false,
+    1 => true,
+    default => throw new \Exception(),
+};
+PHP,
+                <<<'PHP'
+<?php
+
+match ($x) {
+    0 => false,
+    1 => true,
+    2 => null,
+};
+PHP,
+            ],
+        ];
+
+        yield 'It does not remove one match arm' => [
+            <<<'PHP'
+<?php
+
+match ($x) {
+    0 => false,
+};
+PHP
+        ];
+
+        yield 'It removes match arm condition when more than one is defined' => [
+            <<<'PHP'
+<?php
+
+match ($x) {
+    'cond1', 'cond2', 'cond3' => false,
+    2 => null,
+    default => throw new \Exception(),
+};
+PHP
+            ,
+            [
+                <<<'PHP'
+<?php
+
+match ($x) {
+    'cond2', 'cond3' => false,
+    2 => null,
+    default => throw new \Exception(),
+};
+PHP,
+                <<<'PHP'
+<?php
+
+match ($x) {
+    'cond1', 'cond3' => false,
+    2 => null,
+    default => throw new \Exception(),
+};
+PHP,
+                <<<'PHP'
+<?php
+
+match ($x) {
+    'cond1', 'cond2' => false,
+    2 => null,
+    default => throw new \Exception(),
+};
+PHP,
+                <<<'PHP'
+<?php
+
+match ($x) {
+    'cond1', 'cond2', 'cond3' => false,
+    default => throw new \Exception(),
+};
+PHP,
+                <<<'PHP'
+<?php
+
+match ($x) {
+    'cond1', 'cond2', 'cond3' => false,
+    2 => null,
+};
+PHP
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds Add new MatchArmRemoval mutator
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/243

Mutates:

```diff
match ($x) {
-   'cond1', 'cond2' => false,
+  'cond2' => false,
    2 => null,
    default => throw new \Exception(),
};
```

```diff
match ($x) {
-   'cond1', 'cond2' => false,
+  'cond1' => false,
    2 => null,
    default => throw new \Exception(),
};
```

```diff
match ($x) {
-   'cond1', 'cond2' => false,
    2 => null,
    default => throw new \Exception(),
};
```

```diff
match ($x) {
   'cond1', 'cond2' => false,
-    2 => null,
    default => throw new \Exception(),
};
```

```diff
match ($x) {
   'cond1', 'cond2' => false,
    2 => null,
-    default => throw new \Exception(),
};
```