### PR TITLE
Rename Makefile related variables

### DIFF
--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -237,8 +237,8 @@ EOF;
     {
         $testRules = array_filter(
             Parser::parse(file_get_contents(self::MAKEFILE_PATH)),
-            static function (array $targetSet): bool {
-                [$target, $prerequisites] = $targetSet;
+            static function (array $rule): bool {
+                [$target, $prerequisites] = $rule;
 
                 return strpos($target, 'test-') === 0
                     && substr($target, -7) === '-docker'


### PR DESCRIPTION
This PR is a pure renaming.

Working on the Makefiles a bit recently, I wanted to apply a few renamings in order to be more in line with the original Makefile terminoly. A TL:DR, this is a _rule_:

```
targets : pre-requisites
    recipe
```

We do use "target(s)" correctly (technically in Makefile, a rule may designate multiple targets, in our case though it does not matter). We use however "dependencies" instead of "pre-requisites" and "recipe" is unused (we do not consider the body of the rules).

So in this PR, I renamed:

- `targets` to `rules`: probably the most contentious one, it is slightly more correct although in our case the distinction not really existent
- `dependencies` to `pre-requisite`
- `targetSet` to `rule` (also makes the change of targets -> rules more natural)