### PR TITLE
Refactor MakefileTest

### DIFF
--- a/devTools/phpstan-tests.neon
+++ b/devTools/phpstan-tests.neon
@@ -29,6 +29,9 @@ parameters:
         -
             message: '#Function ini_get is unsafe to use#'
             path: ../tests/phpunit/Process/OriginalPhpProcessTest.php
+        -
+            message: '#Function shell_exec is unsafe to use#'
+            path: ../tests/phpunit/AutoReview/Makefile/MakefileTest.php
     level: 4
     paths:
         - ../tests/phpunit

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -237,8 +237,8 @@ EOF;
     {
         $testRules = array_filter(
             Parser::parse(file_get_contents(self::MAKEFILE_PATH)),
-            static function (array $targetSet): bool {
-                [$target, $prerequisites] = $targetSet;
+            static function (array $rule): bool {
+                [$target, $prerequisites] = $rule;
 
                 return strpos($target, 'test-') === 0
                     && substr($target, -7) === '-docker'


### PR DESCRIPTION
This is built upon #1754 so if you want to check a cleaner diff do skip the first two commits.

This PR is also pure refactoring: there is no new elements being tested, but it is more than simple renaming. The goal here is to prepare for further upcoming changes but I think those changes themselves should be good enough on their own.