### PR TITLE
Ensure the make compile always compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,9 @@ PHPUNIT_GROUP=default
 
 .PHONY: compile
 compile:	 	## Bundles Infection into a PHAR
-compile: $(INFECTION)
+compile:
+	rm $(INFECTION) || true
+	make $(INFECTION)
 
 .PHONY: compile-docker
 compile-docker:	 	## Bundles Infection into a PHAR using docker


### PR DESCRIPTION
I think when one does `make compile`, that it does the compile, it currently may skip it though.

I admit in various project I was always a bit torn when in that situation:

- Sometimes I want it to be smart and not rebuild it if necessary, in which case the existing behaviour is fine
- With this change, if one wants to build it "smartly", then you need to do `make ./build/infection.phar` (i.e. know what `$(INFECTION)` is resolving to. I personally find that impractical.
- Without this change, if one wants to rebuild it, you need to do the same: find the resolved `$(INFECTION)`, remove that file and run `make compile` again
- Also note that `make compile -B` is likely not desired as it redo _everything_

Another alternative could be to add the command `_compile`:

```
_compile: $(INFECTION)
```

So that if you want to rebuild the PHAR but only because it's necessary, but don't want to resolve the variable, this command is available.