### PR TITLE
Add missing -c flag for touch commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,7 @@ $(PHP_CS_FIXER): Makefile
 	touch -c $@
 
 $(PHPSTAN): vendor
+	touch -c $@
 
 $(PSALM): Makefile
 	wget -q $(PSALM_URL) --output-document=$(PSALM)
@@ -246,6 +247,7 @@ $(PHPUNIT): vendor phpunit.xml.dist
 phpunit.xml.dist:
 	# Not updating phpunit.xml with:
 	# phpunit --migrate-configuration || true
+	touch -c $@
 
 $(DOCKER_FILE_IMAGE): devTools/Dockerfile
 	docker-compose build


### PR DESCRIPTION
This flag ensures the `touch` call does not create the file. This is perfect because the only purpose of the touch call here is to update the timestamp, not create a file.

This was already used in a few places, but a few calls were missing it and a few places did not have the touch call although could make use of it.