### PR TITLE
Add box_dump to the list of ignored directories checked for trailing whitespaces

### DIFF
--- a/devTools/check_trailing_whitespaces.sh
+++ b/devTools/check_trailing_whitespaces.sh
@@ -29,6 +29,7 @@ files_with_trailing_whitespaces=$(
         -not -name "*.cache" \
         -not -name "*.log" \
         -not -path "./.composer/*" \
+        -not -path "./.box_dump/*" \
         -not -path "./build/*" \
         -not -path "./.git/*" \
         -not -path "./vendor/*" \


### PR DESCRIPTION
The directory `.box_dump` is created by box when running `compile` with the `--debug` option.