### PR TITLE
Improve CPU core count detection: integrate FidryCpuCoreCounter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "composer-runtime-api": "^2.0",
         "colinodell/json5": "^2.2",
         "composer/xdebug-handler": "^2.0 || ^3.0",
-        "fidry/cpu-core-counter": "^0.2.0",
+        "fidry/cpu-core-counter": "^0.4.0",
         "infection/abstract-testframework-adapter": "^0.5.0",
         "infection/extension-installer": "^0.1.0",
         "infection/include-interceptor": "^0.2.5",

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "composer-runtime-api": "^2.0",
         "colinodell/json5": "^2.2",
         "composer/xdebug-handler": "^2.0 || ^3.0",
+        "fidry/cpu-core-counter": "^0.2.0",
         "infection/abstract-testframework-adapter": "^0.5.0",
         "infection/extension-installer": "^0.1.0",
         "infection/include-interceptor": "^0.2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e0cb233a07b9b27ad03b987783924ee",
+    "content-hash": "1b28a046e5a350ee1f6f022c00bb77d3",
     "packages": [
         {
             "name": "colinodell/json5",
@@ -236,20 +236,20 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.2.0",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "c528907a1284bde2850c267c058c1e151b72ffef"
+                "reference": "666cb04a02f2801f3b19955fc23c824f9018bf64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/c528907a1284bde2850c267c058c1e151b72ffef",
-                "reference": "c528907a1284bde2850c267c058c1e151b72ffef",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/666cb04a02f2801f3b19955fc23c824f9018bf64",
+                "reference": "666cb04a02f2801f3b19955fc23c824f9018bf64",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
                 "fidry/makefile": "^0.2.0",
@@ -258,14 +258,14 @@
                 "phpstan/phpstan-deprecation-rules": "^1.0.0",
                 "phpstan/phpstan-phpunit": "^1.2.2",
                 "phpstan/phpstan-strict-rules": "^1.4.4",
-                "phpunit/phpunit": "^9.5.26",
+                "phpunit/phpunit": "^9.5.26 || ^8.5.31",
                 "theofidry/php-cs-fixer-config": "^1.0",
                 "webmozarts/strict-phpunit": "^7.5"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Fidry\\CpuCounter\\": "src/"
+                    "Fidry\\CpuCoreCounter\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -285,7 +285,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.2.0"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.0"
             },
             "funding": [
                 {
@@ -293,7 +293,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-04T19:06:24+00:00"
+            "time": "2022-12-10T21:26:31+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8654ac18dfc89a9304280bddb2c8ac3",
+    "content-hash": "9e0cb233a07b9b27ad03b987783924ee",
     "packages": [
         {
             "name": "colinodell/json5",
@@ -233,6 +233,67 @@
                 }
             ],
             "time": "2021-12-23T21:03:16+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "c528907a1284bde2850c267c058c1e151b72ffef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/c528907a1284bde2850c267c058c1e151b72ffef",
+                "reference": "c528907a1284bde2850c267c058c1e151b72ffef",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^1.9.2",
+                "phpstan/phpstan-deprecation-rules": "^1.0.0",
+                "phpstan/phpstan-phpunit": "^1.2.2",
+                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpunit/phpunit": "^9.5.26",
+                "theofidry/php-cs-fixer-config": "^1.0",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-04T19:06:24+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",
@@ -4711,5 +4772,5 @@
     "platform-overrides": {
         "php": "8.0.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Resource/Processor/CpuCoresCountProvider.php
+++ b/src/Resource/Processor/CpuCoresCountProvider.php
@@ -35,9 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Resource\Processor;
 
+use function defined;
 use Fidry\CpuCounter\CpuCoreCounter;
 use Fidry\CpuCounter\NumberOfCpuCoreNotFound;
-use function defined;
 
 /**
  * @internal

--- a/src/Resource/Processor/CpuCoresCountProvider.php
+++ b/src/Resource/Processor/CpuCoresCountProvider.php
@@ -37,6 +37,7 @@ namespace Infection\Resource\Processor;
 
 use Fidry\CpuCounter\CpuCoreCounter;
 use Fidry\CpuCounter\NumberOfCpuCoreNotFound;
+use function defined;
 
 /**
  * @internal
@@ -48,6 +49,10 @@ final class CpuCoresCountProvider
      */
     public static function provide(): int
     {
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            return 1;
+        }
+
         try {
             return (new CpuCoreCounter())->getCount();
         } catch (NumberOfCpuCoreNotFound $exception) {

--- a/src/Resource/Processor/CpuCoresCountProvider.php
+++ b/src/Resource/Processor/CpuCoresCountProvider.php
@@ -35,18 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Resource\Processor;
 
-use function defined;
-use function extension_loaded;
-use const FILTER_VALIDATE_INT;
-use function filter_var;
-use function function_exists;
-use function is_int;
-use function is_readable;
-use Safe\Exceptions\ExecException;
-use function Safe\file_get_contents;
-use function Safe\shell_exec;
-use function substr_count;
-use function trim;
+use Fidry\CpuCounter\CpuCoreCounter;
+use Fidry\CpuCounter\NumberOfCpuCoreNotFound;
 
 /**
  * @internal
@@ -58,49 +48,10 @@ final class CpuCoresCountProvider
      */
     public static function provide(): int
     {
-        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+        try {
+            return (new CpuCoreCounter())->getCount();
+        } catch (NumberOfCpuCoreNotFound $exception) {
             return 1;
         }
-
-        if (!extension_loaded('pcntl') || !function_exists('shell_exec')) {
-            return 1;
-        }
-
-        try {
-            // for Linux
-            $hasNproc = trim(@shell_exec('command -v nproc'));
-
-            if ($hasNproc !== '') {
-                $nproc = trim(shell_exec('nproc'));
-                $cpuCount = filter_var($nproc, FILTER_VALIDATE_INT);
-
-                if (is_int($cpuCount)) {
-                    return $cpuCount;
-                }
-            }
-        } catch (ExecException) {
-        }
-
-        try {
-            // for MacOS
-            $ncpu = trim(shell_exec('sysctl -n hw.ncpu'));
-            $cpuCount = filter_var($ncpu, FILTER_VALIDATE_INT);
-
-            if (is_int($cpuCount)) {
-                return $cpuCount;
-            }
-        } catch (ExecException) {
-        }
-
-        if (is_readable('/proc/cpuinfo')) {
-            $cpuInfo = file_get_contents('/proc/cpuinfo');
-            $cpuCount = substr_count($cpuInfo, 'processor');
-
-            if ($cpuCount > 0) {
-                return $cpuCount;
-            }
-        }
-
-        return 1;
     }
 }

--- a/src/Resource/Processor/CpuCoresCountProvider.php
+++ b/src/Resource/Processor/CpuCoresCountProvider.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Resource\Processor;
 
 use function defined;
-use Fidry\CpuCounter\CpuCoreCounter;
-use Fidry\CpuCounter\NumberOfCpuCoreNotFound;
+use Fidry\CpuCoreCounter\CpuCoreCounter;
+use Fidry\CpuCoreCounter\NumberOfCpuCoreNotFound;
 
 /**
  * @internal


### PR DESCRIPTION
See https://github.com/theofidry/cpu-core-counter/issues/11 for the motivations.

The code should be sensibly the same, the notable differences are:

- fixed the deprecated usage of `hw.ncpu`
- add more ways to detect the CPU core counts
- better handling of failures

