### PR TITLE
Remove Symfony6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,10 +60,10 @@
         "sanmai/later": "^0.1.1",
         "sanmai/pipeline": "^5.1 || ^6",
         "sebastian/diff": "^3.0.2 || ^4.0",
-        "symfony/console": "^5.4 || ^6.0",
-        "symfony/filesystem": "^5.4 || ^6.0",
-        "symfony/finder": "^5.4 || ^6.0",
-        "symfony/process": "^5.4 || ^6.0",
+        "symfony/console": "^5.4",
+        "symfony/filesystem": "^5.4",
+        "symfony/finder": "^5.4",
+        "symfony/process": "^5.4",
         "thecodingmachine/safe": "^2.1.2",
         "webmozart/assert": "^1.3"
     },
@@ -83,8 +83,8 @@
         "phpstan/phpstan-strict-rules": "^1.1.0",
         "phpstan/phpstan-webmozart-assert": "^1.0.2",
         "phpunit/phpunit": "^9.5.5",
-        "symfony/phpunit-bridge": "^5.4 || ^6.0",
-        "symfony/yaml": "^5.4 || ^6.0",
+        "symfony/phpunit-bridge": "^5.4",
+        "symfony/yaml": "^5.4",
         "thecodingmachine/phpstan-safe-rule": "^1.2.0"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c53b2c0b2c97deb9ebc865c4d2e05c39",
+    "content-hash": "941bc5d9a93f522449a851928c62a2f6",
     "packages": [
         {
             "name": "colinodell/json5",


### PR DESCRIPTION
I'm having too much of a hard time in #1765. The root of the issue is:

- Symfony6 was introduced in #1606 but without tests
- Symfony6 was actually never executed ever in the Infection CI, so any issue raised was missed
- There is signature incompatibilities between Symfony5 and Symfony6, which is a problem for code such as `DummyFileSystem` (fatal error kind of problem – so any autoloading of the file is breaking things hard)

I think we'll have to either review a few usages, assuming we can make it work, or drop Symfony5 support in the next version.

Meanwhile however I think it's best to (temporarily) disallow Symfony6 to allow to bump the minimum required PHP version to 8.1.