### PR TITLE
Prevent installation of `phpunit/php-code-coverage:>9.2.17`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "webmozart/assert": "^1.3"
     },
     "conflict": {
-        "phpunit/php-code-coverage": ">9 <9.1.4",
+        "phpunit/php-code-coverage": ">9,<9.1.4 || >9.2.17",
         "dg/bypass-finals": "<1.4.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c53b2c0b2c97deb9ebc865c4d2e05c39",
+    "content-hash": "8d3011f80a3b7cb1d1d1c9238be44c28",
     "packages": [
         {
             "name": "colinodell/json5",


### PR DESCRIPTION
Fixes #1773

Because of https://github.com/sebastianbergmann/php-code-coverage/issues/953, the current coverage reports used by `infection/infection` are unreliable, and we cannot use them for computing covered mutants in most codebases.

This patch introduces a temporary conflict, to be lifted after @Slamdunk's work on https://github.com/sebastianbergmann/php-code-coverage/pull/964 lands in upstream.

Quoting original issue:

 > As mentioned in the title, it would be useful to (temporarily) add `"conflict": {"phpunit/php-code-coverage": ">9.2.17"}` to the constraints of this package.
 >
 > The reason: coverage report became massively unreliable for the purposes of mutation testing starting with `phpunit/php-code-coverage:9.2.18`, as reported by @kukulich and acknowledged by @Slamdunk in https://github.com/sebastianbergmann/php-code-coverage/issues/953
 >
 > This is only a temporary measure: @Slamdunk has been talking with me about it, and he's hard at work on it in https://github.com/sebastianbergmann/php-code-coverage/pull/964, which should fix the problem, but which may take more time to land.
 >
 > At this moment, many mutation test suites keep going red due to invalid reduced coverage (some packages were even at 100%, and need constant adjustments when `composer.lock` gets changed).
 >
 > Therefore, it would be healthy to declare an incompatibility in a new minor release, for now.