### PR TITLE
Run MT workflows on PHP 8.1

### DIFF
--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                php-version: ['8.0']
+                php-version: ['8.0', '8.1']
 
         name: Mutation Testing Code Review Annotations ${{ matrix.php-version }}
 

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['8.0']
+        php-version: ['8.0', '8.1']
         coverage-driver: [pcov]
 
     name: Mutation testing on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }}


### PR DESCRIPTION
Extracted from #1765. This is an attempt to _partially_ fix the CI (since a part of it is still running on 8.0 it does not uncover yet the problem raised in #1765).