### PR TITLE
Draft: Re-enable installation of latest `phpunit/php-code-coverage:^9.2.21`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "webmozart/assert": "^1.3"
     },
     "conflict": {
-        "phpunit/php-code-coverage": ">9,<9.1.4 || >9.2.17",
+        "phpunit/php-code-coverage": ">9,<9.1.4 || >9.2.17,<9.2.21",
         "dg/bypass-finals": "<1.4.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d3011f80a3b7cb1d1d1c9238be44c28",
+    "content-hash": "34ed8f7c5230dcb2b81eda29681bbfd7",
     "packages": [
         {
             "name": "colinodell/json5",
@@ -3173,23 +3173,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.15",
+            "version": "9.2.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
+                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
-                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
+                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.13.0",
+                "nikic/php-parser": "^4.14",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -3238,7 +3238,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.21"
             },
             "funding": [
                 {
@@ -3246,7 +3246,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-07T09:28:20+00:00"
+            "time": "2022-12-14T13:26:54+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",


### PR DESCRIPTION
This change reverts some of #1773 by allowing the latest PHPUnit coverage tooling to be installed, for which @Slamdunk fixed coverage in regards of the `infection/infection` use-case.

Ref: https://github.com/sebastianbergmann/php-code-coverage/releases/tag/9.2.21
Ref: https://github.com/sebastianbergmann/php-code-coverage/pull/964
Ref: https://github.com/sebastianbergmann/php-code-coverage/commit/71525ea24e565834fda5efd67bc689b0d659abb9
