### PR TITLE
refactor(ci): Execute Auto-Review tests on PHP 8.2

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.0']
+        php-version: ['8.1']
 
     name: Autoreview on PHP ${{ matrix.php-version }}
 
@@ -28,7 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          tools: composer:v2.1
+          tools: composer
 
       - name: Get composer cache directory
         id: composer-cache
@@ -48,7 +48,6 @@ jobs:
         run: |
           composer install --no-interaction --prefer-dist --no-progress
 
-      - name: Run tests
-        run: |
-          make autoreview -k
+      - name: Run auto-review tests
+        run: make autoreview --keep-going
 

--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -16,7 +16,8 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.1']
+        # Should use the latest supported PHP version
+        php-version: ['8.2']
 
     name: Autoreview on PHP ${{ matrix.php-version }}
 
@@ -49,5 +50,6 @@ jobs:
           composer install --no-interaction --prefer-dist --no-progress
 
       - name: Run auto-review tests
+        # Ensures we see all the errors
         run: make autoreview --keep-going
 


### PR DESCRIPTION
- Execute the Auto-Review tests on PHP 8.2 instead of 8.0: I think it should be executed on the latest supported version and will help to incrementally go towards #1765.
- Remove the locked Composer version: At the very least for an auto-review test I do not think the Composer version should matter.
- Use the extended option of `-k` for better readabilty

⚠️  Requires to update the project settings afterwards as the build name changes
⚠️  Not a big deal, but if merged before/after #1789 to mind the `env` setting for the php setup step which is no longer necessary (see this change https://github.com/infection/infection/pull/1789/files#diff-87ab0e37e52f2d5a98de1c719e9222197e1f875c57ed290a6b10f0c640e5b001R32)