### PR TITLE
ci(refactor): Extract unit & integration tests from the CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,15 +66,6 @@ jobs:
         run: |
           composer install --no-interaction --prefer-dist --no-progress
 
-      - name: Run tests
-        shell: bash
-        run: |
-          if [[ "${{ matrix.php-version }}" == '8.2' ]]; then
-            export SYMFONY_DEPRECATIONS_HELPER=max[self]=0
-          fi
-
-          make test-unit
-
       - name: Cache E2E tests dependencies
         if: runner.os == 'Windows'
         uses: actions/cache@v2
@@ -129,12 +120,3 @@ jobs:
           # test PHAR works from subfolder
           cd build && ./infection.phar -V && cd ..
           make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=build/infection.phar BENCHMARK_SOURCES=
-
-      - name: Run integration tests
-        shell: bash
-        run: |
-          if [[ "${{ matrix.php-version }}" == '8.2' ]]; then
-            export SYMFONY_DEPRECATIONS_HELPER=max[self]=0
-          fi
-
-          make test-unit PHPUNIT_GROUP=integration

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           composer install --no-interaction --prefer-dist --no-progress
 
-      - name: Run tests
+      - name: Run unit tests
         shell: bash
         run: |
           if [[ "${{ matrix.php-version }}" == '8.2' ]]; then

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -70,6 +70,7 @@ jobs:
           make test-unit
 
       - name: Run integration tests
+        if: ${{ matrix.operating-system != 'windows-latest' }}
         shell: bash
         run: |
           if [[ "${{ matrix.php-version }}" == '8.2' ]]; then

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,15 +17,10 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '8.0' ]
+        php-version: [ '8.0', '8.1', '8.2' ]
         coverage-driver: [ pcov, xdebug ]
         include:
           - { operating-system: 'windows-latest', php-version: '8.0', coverage-driver: 'xdebug' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'pcov' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'xdebug' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.1', coverage-driver: 'pcov' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.1', coverage-driver: 'pcov' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.2', coverage-driver: 'xdebug' }
 
     name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }}
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,84 @@
+# yamllint disable rule:line-length
+# yamllint disable rule:braces
+
+name: Unit & Integration Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php-version: [ '8.0' ]
+        coverage-driver: [ pcov, xdebug ]
+        include:
+          - { operating-system: 'windows-latest', php-version: '8.0', coverage-driver: 'xdebug' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'pcov' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'xdebug' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.1', coverage-driver: 'pcov' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.1', coverage-driver: 'pcov' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.2', coverage-driver: 'xdebug' }
+
+    name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Configure for PHP >= 8.2
+        if: "matrix.php-version >= '8.2'"
+        run: |
+          composer config platform.php 8.1.99
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage-driver }}
+          ini-values: memory_limit=512M, xdebug.mode=off
+          tools: composer
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('composer.*') }}
+          restore-keys: |
+            composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('composer.*') }}-
+            composer-${{ runner.os }}-${{ matrix.php-version }}-
+            composer-${{ runner.os }}-
+            composer-
+
+      - name: Install dependencies
+        run: |
+          composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run tests
+        shell: bash
+        run: |
+          if [[ "${{ matrix.php-version }}" == '8.2' ]]; then
+            export SYMFONY_DEPRECATIONS_HELPER=max[self]=0
+          fi
+
+          make test-unit
+
+      - name: Run integration tests
+        shell: bash
+        run: |
+          if [[ "${{ matrix.php-version }}" == '8.2' ]]; then
+            export SYMFONY_DEPRECATIONS_HELPER=max[self]=0
+          fi
+
+          make test-unit PHPUNIT_GROUP=integration

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test-autoreview: $(PHPUNIT) vendor
 .PHONY: test-unit
 test-unit:	 	## Runs the unit tests
 test-unit: $(PHPUNIT) vendor
-	$(PHPUNIT) --group $(PHPUNIT_GROUP)
+	$(PHPUNIT) --group $(PHPUNIT_GROUP) --exclude-group e2e
 
 .PHONY: test-unit-parallel
 test-unit-parallel:	## Runs the unit tests in parallel


### PR DESCRIPTION
I think the end-to-end workflow is quite complex and hard to work with. There is several concerns brought by the nature of end-to-end tests and they also tend to be inherently slow. This makes it hard to further tweak the configuration and test a wider range of constraints.

I'm proposing to extract the unit & integration tests. This will allow to diversify the build to test:

- A wider range of operating systems
- More different PHP versions
- Highest/lowest or locked versions
- Specific Symfony versions

A PoC of that work can be seen in #1786.

⚠️ Requires to update the project settings afterwards as the build name changes