### PR TITLE
Add `allow-plugins` config for for `pestphp/pest-plugin` to avoid failing builds

### DIFF
--- a/tests/e2e/SymfonyFlex/composer.json
+++ b/tests/e2e/SymfonyFlex/composer.json
@@ -13,5 +13,10 @@
         "psr-4": {
             "SymfonyFlex\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     }
 }

--- a/tests/e2e/Syntax_Error_Pest/composer.json
+++ b/tests/e2e/Syntax_Error_Pest/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Syntax_Error_Pest\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     }
 }


### PR DESCRIPTION
Should fix build failures like this https://github.com/infection/infection/actions/runs/3734696981/jobs/6337055910#step:10:2511

Same has already been added to another e2e test:

https://github.com/infection/infection/blob/b6ae298e9a2000d3af2eadd7343c5776db6a1c24/tests/e2e/PestTestFramework/composer.json#L15-L19

Should fix https://github.com/infection/infection/pull/1782

### Why it fails randomly?

Seems like the reason why it fails randomly is when `setup php` action fails to setup composer **2.1**, and (I assume) composer **2.2** is installed by default, resulting in failures because of absense of `allowed-plugins`

See https://github.com/infection/infection/actions/runs/3734759922/jobs/6337196890#step:4:18 (fails) and https://github.com/infection/infection/actions/runs/3751882494/jobs/6373403435#step:4:15 (passes)