### PR TITLE
fix(ci): Avoid getting rate limited when setting up PHP

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -29,6 +29,9 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer:v2.1
+          env:
+            # This is necessary when installing a tool with a specific version
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,9 @@ jobs:
           coverage: ${{ matrix.coverage-driver }}
           ini-values: memory_limit=512M, xdebug.mode=off
           tools: composer:v2.1
+          env:
+            # This is necessary when installing a tool with a specific version
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -27,6 +27,9 @@ jobs:
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2.1
                   coverage: pcov
+              env:
+                # This is necessary when installing a tool with a specific version
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Get composer cache directory
               id: composer-cache

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -36,6 +36,9 @@ jobs:
           php-version: ${{ matrix.php-version }}
           coverage: ${{ matrix.coverage-driver }}
           tools: composer:v2.1
+          env:
+            # This is necessary when installing a tool with a specific version
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
         id: composer-cache


### PR DESCRIPTION
Follow up of https://github.com/infection/infection/pull/1788#issuecomment-1361970838. I found it curious as to why this was happening and this is actually documented in [the doc](https://github.com/shivammathur/setup-php#wrench-tools-support):

>Except for major versions of composer, For other tools when you specify only the major version or the version in major.minor format for any tool you can get rate limited by GitHub's API. To avoid this, it is recommended to provide a [GitHub OAuth token](https://github.com/shivammathur/setup-php#composer-github-oauth). You can do that by setting GITHUB_TOKEN environment variable. The COMPOSER_TOKEN environment variable has been deprecated in favor of GITHUB_TOKEN and will be removed in the next major version.

I extracted this out of #1775 because I think it's doing a bit too much there at the moment and when reviewing a diff or checking the git history it will be harder to figure out why this change was there.

