### PR TITLE
refactor(ci): Review the mutation testing workflow

### DIFF
--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Collect coverage report
         run: |
-            SYMFONY_DEPRECATIONS_HELPER=disabled php vendor/phpunit/phpunit/phpunit --stop-on-failure \
+          SYMFONY_DEPRECATIONS_HELPER=disabled php vendor/phpunit/phpunit/phpunit --stop-on-failure \
             --coverage-xml=build/logs/coverage-xml \
             --log-junit=build/logs/junit.xml
 

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Collect coverage report
         run: |
-          php -dxdebug.mode=coverage vendor/phpunit/phpunit/phpunit --stop-on-failure \
+            XDEBUG_MODE=coverage php vendor/phpunit/phpunit/phpunit --stop-on-failure \
             --coverage-xml=build/logs/coverage-xml \
             --log-junit=build/logs/junit.xml
 

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -38,8 +38,7 @@ jobs:
         with:
           # Any supported PHP version is fine
           php-version: '8.2'
-          coverage: xdebug
-          ini-values: xdebug.mode=off
+          coverage: pcov
           tools: composer
 
       - name: Get composer cache directory
@@ -63,7 +62,7 @@ jobs:
 
       - name: Collect coverage report
         run: |
-            XDEBUG_MODE=coverage SYMFONY_DEPRECATIONS_HELPER=disabled php vendor/phpunit/phpunit/phpunit --stop-on-failure \
+            SYMFONY_DEPRECATIONS_HELPER=disabled php vendor/phpunit/phpunit/phpunit --stop-on-failure \
             --coverage-xml=build/logs/coverage-xml \
             --log-junit=build/logs/junit.xml
 

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -1,6 +1,15 @@
 # yamllint disable rule:line-length
 # yamllint disable rule:braces
 
+# This build is to test the whole execute the PHPUnit tests & collect the coverage
+# report and run infection.
+# We are not interested in:
+# - Running it on different systems (e.g. Windows, which was disabled because too slow)
+# - Min/maxing the PHP version used: it can be any supported version
+# - Using different dependencies than the locked ones
+# - Using different code coverages
+# All of those variants may be interesting but are better tested in more scoped
+# tests like in ci.yaml.
 name: Mutation Testing
 
 on:
@@ -16,15 +25,9 @@ env:
 
 jobs:
   tests:
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        operating-system: [ubuntu-latest]
-        php-version: ['8.0']
-        coverage-driver: [pcov]
-
-    name: Mutation testing on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }}
+    name: Infection results on itself
 
     steps:
       - name: Checkout code
@@ -33,9 +36,11 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
-          coverage: ${{ matrix.coverage-driver }}
-          tools: composer:v2.1
+          # Any supported PHP version is fine
+          php-version: '8.2'
+          coverage: xdebug
+          ini-values: xdebug.mode=off
+          tools: composer
 
       - name: Get composer cache directory
         id: composer-cache
@@ -52,12 +57,13 @@ jobs:
             composer-
 
       - name: Install dependencies
-        run: |
-          composer update --no-interaction --prefer-dist --no-progress
+        # Run the locked dependencies: we are not interested in testing different
+        # variations here so having a stable set is better.
+        run: composer install --no-interaction --prefer-dist --no-progress
 
       - name: Collect coverage report
         run: |
-          php vendor/phpunit/phpunit/phpunit --stop-on-failure \
+          php -dxdebug.mode=coverage vendor/phpunit/phpunit/phpunit --stop-on-failure \
             --coverage-xml=build/logs/coverage-xml \
             --log-junit=build/logs/junit.xml
 

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -10,7 +10,7 @@
 # - Using different code coverages
 # All of those variants may be interesting but are better tested in more scoped
 # tests like in ci.yaml.
-name: Infection on Infection
+name: Mutation Testing
 
 on:
   pull_request:

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -10,7 +10,7 @@
 # - Using different code coverages
 # All of those variants may be interesting but are better tested in more scoped
 # tests like in ci.yaml.
-name: Mutation Testing
+name: Infection on Infection
 
 on:
   pull_request:
@@ -27,7 +27,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
 
-    name: Infection results on itself
+    name: Infection complete run on Infection
 
     steps:
       - name: Checkout code

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Collect coverage report
         run: |
-            XDEBUG_MODE=coverage php vendor/phpunit/phpunit/phpunit --stop-on-failure \
+            XDEBUG_MODE=coverage SYMFONY_DEPRECATIONS_HELPER=disabled php vendor/phpunit/phpunit/phpunit --stop-on-failure \
             --coverage-xml=build/logs/coverage-xml \
             --log-junit=build/logs/junit.xml
 


### PR DESCRIPTION
My understanding of that build was, from what I understand in #1365, to have a dedicated pipeline mimicking what a typical user pipeline may look like and testing our mutation badge feature. Over time this was slightly tweaked:

- The test for windows was removed because overly slow (#1611)
- Remove testing against different dependencies (#1535) – Likely due to instability in the build

I think the build is still useful, but we now have a more comprehensive and diversified test suite to test the different OS, dependencies, code coverage reports and co in `ci.yaml`. Hence this build can be more scoped and from that simplified.

- Document the above in the build
- Bump the PHP version to 8.2
- Use the locked version of the dependencies
- Use the latest Composer version available

Tried to switch to Xdebug. I was curious if there is a big time difference but in general I also know Xdebug is more accurate than pcov, so we may prefer this to enforce a specific MSI score.

Comparing with [this build](https://github.com/infection/infection/actions/runs/3734647686/jobs/6336945755), we had:

|  | pcov | Xdebug | delta |
|--|--|--| --|
| time taken (unit tests) | 1m7 | 1m34|+40%|
| time taken (infection) | 8m7 | 13m41 | +70%|
| MSI |73%| | 75% | +2% |

At least from those results it doesn't look worth it.

⚠️ Requires to update the project settings afterwards as the build name changes