### PR TITLE
Fix coverage failure in case of an invalid file

### DIFF
--- a/src/PhpParser/Visitor/ReflectionVisitor.php
+++ b/src/PhpParser/Visitor/ReflectionVisitor.php
@@ -37,6 +37,7 @@ namespace Infection\PhpParser\Visitor;
 
 use function array_pop;
 use function count;
+use Error;
 use Infection\Reflection\AnonymousClassReflection;
 use Infection\Reflection\ClassReflection;
 use Infection\Reflection\CoreClassReflection;
@@ -184,7 +185,11 @@ final class ReflectionVisitor extends NodeVisitorAbstract
         $fqn = FullyQualifiedClassNameManipulator::getFqcn($node);
 
         if ($fqn !== null) {
-            return CoreClassReflection::fromClassName($fqn->toString());
+            try {
+                return CoreClassReflection::fromClassName($fqn->toString());
+            } catch (Error $e) {
+                return new NullReflection();
+            }
         }
 
         // TODO: check against interfaces


### PR DESCRIPTION
This PR:

- [ ] Adds new feature ...
- [ ] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

<!--
- Replace this comment by a detailed description of what your PR is solving.
- Use labels for different kinds of PR like `performance`, `feature`, etc.
- Use Milestone to show when this code is going to be released.

Deprecations? don't forget to update UPGRADE-*.md files
-->

My lib supports two incompatible versions of a dependency. Code for older version extends class that does not exist in newer one. Currently code coverage fails with `Uncaught Error: Class "Latte\Macros\MacroSet" not found` https://github.com/orisai/localization/actions/runs/3766779916/jobs/6403641877 (shown run uses only temporary commit, I also had to do the same fix in https://github.com/sebastianbergmann/php-code-coverage/pull/973)

After applying the fix, coverage no longer fails. And file is correctly reported as uncovered.
https://github.com/orisai/localization/commit/a0f7a0b766c738d0df99eed52f8f529aceabb4f3
https://github.com/orisai/localization/actions/runs/3766885353
