### PR TITLE
Do not remove array item when it is a part of attribute argument

### DIFF
--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -143,6 +143,10 @@ DIFF
             return false;
         }
 
+        if ($parent instanceof Node\Arg && ParentConnector::findParent($parent) instanceof Node\Attribute) {
+            return false;
+        }
+
         return true;
     }
 

--- a/tests/autoloaded/mutator-fixtures/ArrayItemRemoval/does-not-mutate-array-in-attribute.php
+++ b/tests/autoloaded/mutator-fixtures/ArrayItemRemoval/does-not-mutate-array-in-attribute.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ArrayItemRemoval_Array_In_Attribute;
+
+class Test
+{
+    #[Groups(['id'])]
+    public function method()
+    {
+    }
+}

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
@@ -36,7 +36,11 @@ declare(strict_types=1);
 namespace Infection\Tests\Mutator\Removal;
 
 use Infection\Tests\Mutator\BaseMutatorTestCase;
+use Infection\Tests\Mutator\MutatorFixturesProvider;
 
+/**
+ * @group integration
+ */
 final class ArrayItemRemovalTest extends BaseMutatorTestCase
 {
     /**
@@ -113,6 +117,10 @@ final class ArrayItemRemovalTest extends BaseMutatorTestCase
 
         yield 'It does not mutate lists with any number of elements' => [
             '<?php [$a, $b] = [];',
+        ];
+
+        yield 'It does not mutate arrays as an attribute argument' => [
+            MutatorFixturesProvider::getFixtureFileContent($this, 'does-not-mutate-array-in-attribute.php'),
         ];
     }
 }


### PR DESCRIPTION
This PR fixes https://github.com/infection/infection/issues/1797

ArrayItemRemoval mutator should be skipped when array is an attributes argument 