### PR TITLE
Trying to remove false positive on logical or.

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -15,6 +15,21 @@
         "global-ignoreSourceCodeByRegex": [
             "Assert::.*"
         ],
-        "@default": true
+        "@default": true,
+        "InstanceOf_": {
+            ignore: [
+                "Infection\\Mutator\\Boolean\\LogicalOr::canMutate"
+            ]
+        },
+        "LogicalAnd": {
+            ignore: [
+                "Infection\\Mutator\\Boolean\\LogicalOr::canMutate"
+            ]
+        },
+        "LogicalOr": {
+            ignore: [
+                "Infection\\Mutator\\Boolean\\LogicalOr::canMutate"
+            ]
+        }
     }
 }

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
+use function get_class;
+use function in_array;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
-use function get_class;
-use function in_array;
 
 /**
  * @internal

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -83,20 +83,6 @@ DIFF
             return false;
         }
 
-        $nodeLeftType = get_class($node->left);
-        $nodeRightType = get_class($node->right);
-
-        $mustCheckForVariableNamesNodeTypes = [
-            Node\Expr\BinaryOp\Identical::class,
-            Node\Expr\BinaryOp\NotIdentical::class,
-            Node\Expr\BinaryOp\Equal::class,
-            Node\Expr\BinaryOp\NotEqual::class,
-            Node\Expr\BinaryOp\Greater::class,
-            Node\Expr\BinaryOp\GreaterOrEqual::class,
-            Node\Expr\BinaryOp\Smaller::class,
-            Node\Expr\BinaryOp\SmallerOrEqual::class,
-        ];
-
         if (
             (
                 $node->left instanceof Node\Expr\BinaryOp\Identical

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
+use function array_intersect;
 use function get_class;
 use function in_array;
 use Infection\Mutator\Definition;
@@ -42,7 +43,6 @@ use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
-use function array_intersect;
 use function property_exists;
 
 /**
@@ -85,7 +85,7 @@ DIFF
             return false;
         }
 
-        $nodeLeft  = $node->left;
+        $nodeLeft = $node->left;
         $nodeRight = $node->right;
 
         if (
@@ -97,18 +97,18 @@ DIFF
             return true;
         }
 
-        $nodeLeftLeft  = $nodeLeft->left;
+        $nodeLeftLeft = $nodeLeft->left;
         $nodeLeftRight = $nodeLeft->right;
 
-        $nodeRightLeft  = $nodeRight->left;
+        $nodeRightLeft = $nodeRight->left;
         $nodeRightRight = $nodeRight->right;
 
-        $classNodeLeft  = get_class($nodeLeft);
+        $classNodeLeft = get_class($nodeLeft);
         $classNodeRight = get_class($nodeRight);
 
         if (
-            Node\Expr\BinaryOp\Identical::class === $classNodeLeft
-            && Node\Expr\BinaryOp\Identical::class === $classNodeRight
+            $classNodeLeft === Node\Expr\BinaryOp\Identical::class
+            && $classNodeRight === Node\Expr\BinaryOp\Identical::class
         ) {
             $varNameLeft = [];
 
@@ -153,7 +153,7 @@ DIFF
             )
         ) {
             $varNameLeft = null;
-            $valueLeft   = null;
+            $valueLeft = null;
 
             $numberScalar = [
                 Node\Scalar\LNumber::class,
@@ -168,16 +168,16 @@ DIFF
                 return true;
             }
 
-            if ($nodeLeftRight instanceof Node\Expr\Variable && null === $varNameLeft) {
+            if ($nodeLeftRight instanceof Node\Expr\Variable && $varNameLeft === null) {
                 $varNameLeft = $nodeLeftRight->name;
-            } elseif (in_array(get_class($nodeLeftRight), $numberScalar, true) && null === $valueLeft) {
+            } elseif (in_array(get_class($nodeLeftRight), $numberScalar, true) && $valueLeft === null) {
                 $valueLeft = $nodeLeftRight->value;
             } else {
                 return true;
             }
 
             $varNameRight = null;
-            $valueRight   = null;
+            $valueRight = null;
 
             if ($nodeRightLeft instanceof Node\Expr\Variable) {
                 $varNameRight = $nodeRightLeft->name;
@@ -187,9 +187,9 @@ DIFF
                 return true;
             }
 
-            if ($nodeRightRight instanceof Node\Expr\Variable && null === $varNameRight) {
+            if ($nodeRightRight instanceof Node\Expr\Variable && $varNameRight === null) {
                 $varNameRight = $nodeRightRight->name;
-            } elseif (in_array(get_class($nodeRightRight), $numberScalar, true) && null === $valueRight) {
+            } elseif (in_array(get_class($nodeRightRight), $numberScalar, true) && $valueRight === null) {
                 $valueRight = $nodeRightRight->value;
             } else {
                 return true;
@@ -200,14 +200,14 @@ DIFF
             }
 
             return (match ("{$nodeLeft->getOperatorSigil()}::{$nodeRight->getOperatorSigil()}") {
-                '<::>'   => static fn() => $valueRight < $valueLeft, // a<5 && a>7; 7<a<5; 7<5;
-                '<::>='  => static fn() => $valueRight < $valueLeft, // a<5 && a>=7; 7<=a<5; 7<5;
-                '<=::>=' => static fn() => $valueRight <= $valueLeft, // a<=5 && a>=7; 7<=a<=5; 7<=5;
-                '<=::>'  => static fn() => $valueRight < $valueLeft, // a<=5 && a>7; 7<a<=5; 7<5;
-                '>::<'   => static fn() => $valueRight > $valueLeft, // a>5 && a<7; 7>a>5; 7>5;
-                '>::<='  => static fn() => $valueRight > $valueLeft, // a>5 && a<=7; 7>=a>5; 7>5;
-                '>=::<=' => static fn() => $valueRight >= $valueLeft, // a>=5 && a<=7; 7>=a>=5; 7>=5;
-                '>=::<'  => static fn() => $valueRight > $valueLeft, // a>=5 && a<7; 7>a>=5; 7>5;
+                '<::>' => static fn () => $valueRight < $valueLeft, // a<5 && a>7; 7<a<5; 7<5;
+                '<::>=' => static fn () => $valueRight < $valueLeft, // a<5 && a>=7; 7<=a<5; 7<5;
+                '<=::>=' => static fn () => $valueRight <= $valueLeft, // a<=5 && a>=7; 7<=a<=5; 7<=5;
+                '<=::>' => static fn () => $valueRight < $valueLeft, // a<=5 && a>7; 7<a<=5; 7<5;
+                '>::<' => static fn () => $valueRight > $valueLeft, // a>5 && a<7; 7>a>5; 7>5;
+                '>::<=' => static fn () => $valueRight > $valueLeft, // a>5 && a<=7; 7>=a>5; 7>5;
+                '>=::<=' => static fn () => $valueRight >= $valueLeft, // a>=5 && a<=7; 7>=a>=5; 7>=5;
+                '>=::<' => static fn () => $valueRight > $valueLeft, // a>=5 && a<7; 7>a>=5; 7>5;
             })();
         }
 

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -88,9 +88,12 @@ DIFF
             Node\Expr\BinaryOp\Equal::class,
         ];
 
+        $classNodeLeft = get_class($node->left);
+        $classNodeRight = get_class($node->right);
+
         if (
-            in_array(get_class($node->left), $equalOp, true) === true
-            && in_array(get_class($node->right), $equalOp, true) === true
+            in_array($classNodeLeft, $equalOp, true)
+            && in_array($classNodeRight, $equalOp, true)
         ) {
             $varNameLeft = null;
 
@@ -123,11 +126,11 @@ DIFF
 
         if (
             (
-                in_array(get_class($node->left), $greaterOp, true) === true
-                && in_array(get_class($node->right), $smallerOp, true) === true
+                in_array($classNodeLeft, $greaterOp, true) === true
+                && in_array($classNodeRight, $smallerOp, true) === true
             ) || (
-                in_array(get_class($node->left), $smallerOp, true) === true
-                && in_array(get_class($node->right), $greaterOp, true) === true
+                in_array($classNodeLeft, $smallerOp, true) === true
+                && in_array($classNodeRight, $greaterOp, true) === true
             )
         ) {
             $varNameLeft = null;

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use function get_class;
-use function in_array;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
+use function get_class;
+use function in_array;
 
 /**
  * @internal
@@ -83,28 +83,32 @@ DIFF
             return false;
         }
 
+        $equalOp = [
+            Node\Expr\BinaryOp\Identical::class,
+            Node\Expr\BinaryOp\Equal::class,
+        ];
+
         if (
-            (
-                $node->left instanceof Node\Expr\BinaryOp\Identical
-                && $node->right instanceof Node\Expr\BinaryOp\Identical
-            ) || (
-                $node->left instanceof Node\Expr\BinaryOp\Equal
-                && $node->right instanceof Node\Expr\BinaryOp\Equal
-            )
+            in_array(get_class($node->left), $equalOp, true) === true
+            && in_array(get_class($node->right), $equalOp, true) === true
         ) {
-            $varName = '';
+            $varNameLeft = null;
 
             if ($node->left->left instanceof Node\Expr\Variable) {
-                $varName = $node->left->left->name;
+                $varNameLeft = $node->left->left->name;
             } elseif ($node->left->right instanceof Node\Expr\Variable) {
-                $varName = $node->left->right->name;
+                $varNameLeft = $node->left->right->name;
             }
 
+            $varNameRight = null;
+
             if ($node->right->left instanceof Node\Expr\Variable) {
-                return $varName !== $node->right->left->name;
+                $varNameRight = $node->right->left->name;
             } elseif ($node->right->right instanceof Node\Expr\Variable) {
-                return $varName !== $node->right->right->name;
+                $varNameRight = $node->right->right->name;
             }
+
+            return $varNameLeft !== $varNameRight;
         }
 
         $greaterOp = [

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -36,14 +36,11 @@ declare(strict_types=1);
 namespace Infection\Mutator\Boolean;
 
 use function array_intersect;
-use function get_class;
-use function in_array;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
 use PhpParser\Node;
-use function property_exists;
 
 /**
  * @internal

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
+use LogicException;
 use function array_intersect;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
@@ -226,6 +227,7 @@ DIFF
                 '>::<=' => static fn () => $valueRight > $valueLeft, // a>5 && a<=7; 7>=a>5; 7>5;
                 '>=::<=' => static fn () => $valueRight >= $valueLeft, // a>=5 && a<=7; 7>=a>=5; 7>=5;
                 '>=::<' => static fn () => $valueRight > $valueLeft, // a>=5 && a<7; 7>a>=5; 7>5;
+                default => throw new LogicException('This is an unreachable statement.')
             })();
         }
 

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -35,12 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Boolean;
 
-use LogicException;
 use function array_intersect;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
+use LogicException;
 use PhpParser\Node;
 
 /**

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -89,10 +89,8 @@ DIFF
         $nodeRight = $node->right;
 
         if (
-            !property_exists($nodeLeft, 'left')
-            || !property_exists($nodeLeft, 'right')
-            || !property_exists($nodeRight, 'left')
-            || !property_exists($nodeRight, 'right')
+            !$nodeLeft instanceof Node\Expr\BinaryOp
+            || !$nodeRight instanceof Node\Expr\BinaryOp
         ) {
             return true;
         }
@@ -103,12 +101,9 @@ DIFF
         $nodeRightLeft = $nodeRight->left;
         $nodeRightRight = $nodeRight->right;
 
-        $classNodeLeft = get_class($nodeLeft);
-        $classNodeRight = get_class($nodeRight);
-
         if (
-            $classNodeLeft === Node\Expr\BinaryOp\Identical::class
-            && $classNodeRight === Node\Expr\BinaryOp\Identical::class
+            $nodeLeft instanceof Node\Expr\BinaryOp\Identical
+            && $nodeRight instanceof Node\Expr\BinaryOp\Identical
         ) {
             $varNameLeft = [];
 
@@ -133,36 +128,49 @@ DIFF
             return array_intersect($varNameLeft, $varNameRight) === [];
         }
 
-        $greaterOp = [
-            Node\Expr\BinaryOp\Greater::class,
-            Node\Expr\BinaryOp\GreaterOrEqual::class,
-        ];
-
-        $smallerOp = [
-            Node\Expr\BinaryOp\Smaller::class,
-            Node\Expr\BinaryOp\SmallerOrEqual::class,
-        ];
-
         if (
             (
-                in_array($classNodeLeft, $greaterOp, true)
-                && in_array($classNodeRight, $smallerOp, true)
-            ) || (
-                in_array($classNodeLeft, $smallerOp, true)
-                && in_array($classNodeRight, $greaterOp, true)
+                $nodeLeft instanceof Node\Expr\BinaryOp\Greater
+                && $nodeRight instanceof Node\Expr\BinaryOp\Smaller
+            ) ||
+            (
+                $nodeLeft instanceof Node\Expr\BinaryOp\Greater
+                && $nodeRight instanceof Node\Expr\BinaryOp\SmallerOrEqual
+            ) ||
+            (
+                $nodeLeft instanceof Node\Expr\BinaryOp\GreaterOrEqual
+                && $nodeRight instanceof Node\Expr\BinaryOp\SmallerOrEqual
+            ) ||
+            (
+                $nodeLeft instanceof Node\Expr\BinaryOp\GreaterOrEqual
+                && $nodeRight instanceof Node\Expr\BinaryOp\Smaller
+            ) ||
+            (
+                $nodeLeft instanceof Node\Expr\BinaryOp\Smaller
+                && $nodeRight instanceof Node\Expr\BinaryOp\Greater
+            ) ||
+            (
+                $nodeLeft instanceof Node\Expr\BinaryOp\Smaller
+                && $nodeRight instanceof Node\Expr\BinaryOp\GreaterOrEqual
+            ) ||
+            (
+                $nodeLeft instanceof Node\Expr\BinaryOp\SmallerOrEqual
+                && $nodeRight instanceof Node\Expr\BinaryOp\GreaterOrEqual
+            ) ||
+            (
+                $nodeLeft instanceof Node\Expr\BinaryOp\SmallerOrEqual
+                && $nodeRight instanceof Node\Expr\BinaryOp\Greater
             )
         ) {
             $varNameLeft = null;
             $valueLeft = null;
 
-            $numberScalar = [
-                Node\Scalar\LNumber::class,
-                Node\Scalar\DNumber::class,
-            ];
-
             if ($nodeLeftLeft instanceof Node\Expr\Variable) {
                 $varNameLeft = $nodeLeftLeft->name;
-            } elseif (in_array(get_class($nodeLeftLeft), $numberScalar, true)) {
+            } elseif (
+                $nodeLeftLeft instanceof Node\Scalar\LNumber
+                || $nodeLeftLeft instanceof Node\Scalar\DNumber
+            ) {
                 $valueLeft = $nodeLeftLeft->value;
             } else {
                 return true;
@@ -170,7 +178,12 @@ DIFF
 
             if ($nodeLeftRight instanceof Node\Expr\Variable && $varNameLeft === null) {
                 $varNameLeft = $nodeLeftRight->name;
-            } elseif (in_array(get_class($nodeLeftRight), $numberScalar, true) && $valueLeft === null) {
+            } elseif (
+                (
+                    $nodeLeftRight instanceof Node\Scalar\LNumber
+                    || $nodeLeftRight instanceof Node\Scalar\DNumber
+                ) && $valueLeft === null
+            ) {
                 $valueLeft = $nodeLeftRight->value;
             } else {
                 return true;
@@ -181,7 +194,10 @@ DIFF
 
             if ($nodeRightLeft instanceof Node\Expr\Variable) {
                 $varNameRight = $nodeRightLeft->name;
-            } elseif (in_array(get_class($nodeRightLeft), $numberScalar, true)) {
+            } elseif (
+                $nodeRightLeft instanceof Node\Scalar\LNumber
+                || $nodeRightLeft instanceof Node\Scalar\DNumber
+            ) {
                 $valueRight = $nodeRightLeft->value;
             } else {
                 return true;
@@ -189,7 +205,12 @@ DIFF
 
             if ($nodeRightRight instanceof Node\Expr\Variable && $varNameRight === null) {
                 $varNameRight = $nodeRightRight->name;
-            } elseif (in_array(get_class($nodeRightRight), $numberScalar, true) && $valueRight === null) {
+            } elseif (
+                (
+                    $nodeRightRight instanceof Node\Scalar\LNumber
+                    || $nodeRightRight instanceof Node\Scalar\DNumber
+                ) && $valueRight === null
+            ) {
                 $valueRight = $nodeRightRight->value;
             } else {
                 return true;

--- a/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
@@ -99,11 +99,20 @@ PHP
             ,
         ];
 
-        yield 'It does not mutates logical or if same variable is tested against "Identical" (mirrored).' => [
+        yield 'It does not mutates logical or if same variable is tested against "Identical" (mirrored #1).' => [
             <<<'PHP'
 <?php
 
 $myVar === 'hello' || 'world' === $myVar;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutates logical or if same variable is tested against "Identical" (mirrored #2).' => [
+            <<<'PHP'
+<?php
+
+'world' === $myVar || $myVar === 'hello';
 PHP
             ,
         ];

--- a/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
@@ -66,11 +66,62 @@ PHP
             ,
         ];
 
+        yield 'It mutates logical or if variables names are different' => [
+            <<<'PHP'
+<?php
+
+$myVar === true || $myOtherVar === false;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar === true && $myOtherVar === false;
+PHP
+            ,
+        ];
+
         yield 'It does not mutate logical lower or' => [
             <<<'PHP'
 <?php
 
 true or false;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutates logical or if same variable is tested against "Identical".' => [
+            <<<'PHP'
+<?php
+
+$myVar === 'hello' || $myVar === 'world';
+PHP
+            ,
+        ];
+
+        yield 'It does not mutates logical or if same variable is tested against "Identical" (mirrored).' => [
+            <<<'PHP'
+<?php
+
+$myVar === 'hello' || 'world' === $myVar;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutates logical or if same variable is tested against "Greater" and "Smaller" #1.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 5 || $myVar > 10;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutates logical or if same variable is tested against "Greater" and "Smaller" #2.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 10 || $myVar > 5;
 PHP
             ,
         ];

--- a/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
@@ -66,21 +66,6 @@ PHP
             ,
         ];
 
-        yield 'It mutates logical or if variables names are different' => [
-            <<<'PHP'
-<?php
-
-$myVar === true || $myOtherVar === false;
-PHP
-            ,
-            <<<'PHP'
-<?php
-
-$myVar === true && $myOtherVar === false;
-PHP
-            ,
-        ];
-
         yield 'It does not mutate logical lower or' => [
             <<<'PHP'
 <?php
@@ -90,6 +75,14 @@ PHP
             ,
         ];
 
+        yield from $this->equalityMutationsProvider();
+        yield from $this->nonMutableSmallerAndGreaterMatrixMutationsProvider();
+        yield from $this->mutableSmallerAndGreaterMatrixMutationsProvider();
+        yield from $this->smallerAndGreaterMatrixWithSameValueMutationsProvider();
+    }
+
+    private function equalityMutationsProvider(): iterable
+    {
         yield 'It does not mutate logical or if same variable is tested against "Identical".' => [
             <<<'PHP'
 <?php
@@ -146,79 +139,156 @@ PHP
             ,
         ];
 
-        yield 'It does not mutate logical or if same variable is tested against "Greater" and "Smaller" #1.' => [
+        yield 'It mutates logical or if variables names are different' => [
+            <<<'PHP'
+<?php
+
+$myVar === true || $myOtherVar === false;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar === true && $myOtherVar === false;
+PHP
+            ,
+        ];
+    }
+
+    private function nonMutableSmallerAndGreaterMatrixMutationsProvider(): iterable
+    {
+        yield 'It does not mutate logical or if same variable is tested against "Smaller" and "Greater" #1.' => [
             <<<'PHP'
 <?php
 
 $myVar < 5 || $myVar > 10;
 PHP
-            ,
         ];
 
-        yield 'It does not mutate logical or if same variable is tested against "Greater" and "Smaller" #2.' => [
+        yield 'It does not mutate logical or if same variable is tested against "Smaller" and "Greater" #2.' => [
             <<<'PHP'
 <?php
 
 $myVar < 5 || $myVar > 10.1;
 PHP
-            ,
         ];
 
-        yield 'It does not mutate logical or if same variable is tested against "Greater" and "Smaller" #3.' => [
+        yield 'It does not mutate logical or if same variable is tested against "Smaller" and "Greater" #3.' => [
             <<<'PHP'
 <?php
 
 $myVar < 5.5 || $myVar > 10.1;
 PHP
-            ,
         ];
 
-        yield 'It does not mutate logical or if same variable is tested against "Greater" and "Smaller" #4.' => [
+        yield 'It does not mutate logical or if same variable is tested against "Smaller" and "Greater" #4.' => [
             <<<'PHP'
 <?php
 
 $myVar < 5.5 || $myVar > 10;
 PHP
-            ,
         ];
 
-        yield 'It does not mutate logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" #1.' => [
+        yield 'It does not mutate logical or if same variable is tested against "Smaller" and "GreaterOrEqual" #1.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 5 || $myVar >= 10;
+PHP
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "Smaller" and "GreaterOrEqual" #2.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 5 || $myVar >= 10.1;
+PHP
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "Smaller" and "GreaterOrEqual" #3.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 5.5 || $myVar >= 10.1;
+PHP
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "Smaller" and "GreaterOrEqual" #4.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 5.5 || $myVar >= 10;
+PHP
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "SmallerOrEqual" and "GreaterOrEqual" #1.' => [
             <<<'PHP'
 <?php
 
 $myVar <= 5 || $myVar >= 10;
 PHP
-            ,
         ];
 
-        yield 'It does not mutate logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" #2.' => [
+        yield 'It does not mutate logical or if same variable is tested against "SmallerOrEqual" and "GreaterOrEqual" #2.' => [
             <<<'PHP'
 <?php
 
 $myVar <= 5 || $myVar >= 10.1;
 PHP
-            ,
         ];
 
-        yield 'It does not mutate logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" #3.' => [
+        yield 'It does not mutate logical or if same variable is tested against "SmallerOrEqual" and "GreaterOrEqual" #3.' => [
             <<<'PHP'
 <?php
 
 $myVar <= 5.5 || $myVar >= 10.1;
 PHP
-            ,
         ];
 
-        yield 'It does not mutate logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" #4.' => [
+        yield 'It does not mutate logical or if same variable is tested against "SmallerOrEqual" and "GreaterOrEqual" #4.' => [
             <<<'PHP'
 <?php
 
 $myVar <= 5.5 || $myVar >= 10;
 PHP
-            ,
         ];
 
-        yield 'It mutates logical or if same variable is tested against "Greater" and "Smaller" and values permits it #1.' => [
+        yield 'It does not mutate logical or if same variable is tested against "SmallerOrEqual" and "Greater" #1.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 5 || $myVar > 10;
+PHP
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "SmallerOrEqual" and "Greater" #2.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 5 || $myVar > 10.1;
+PHP
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "SmallerOrEqual" and "Greater" #3.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 5.5 || $myVar > 10.1;
+PHP
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "SmallerOrEqual" and "Greater" #4.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 5.5 || $myVar > 10;
+PHP
+        ];
+    }
+
+    private function mutableSmallerAndGreaterMatrixMutationsProvider(): iterable
+    {
+        yield 'It mutates logical or if same variable is tested against "Smaller" and "Greater" and values permits it #1.' => [
             <<<'PHP'
 <?php
 
@@ -232,7 +302,7 @@ $myVar < 10 && $myVar > 5;
 PHP
         ];
 
-        yield 'It mutates logical or if same variable is tested against "Greater" and "Smaller" and values permits it #2.' => [
+        yield 'It mutates logical or if same variable is tested against "Smaller" and "Greater" and values permits it #2.' => [
             <<<'PHP'
 <?php
 
@@ -246,7 +316,7 @@ $myVar < 10 && $myVar > 5.5;
 PHP
         ];
 
-        yield 'It mutates logical or if same variable is tested against "Greater" and "Smaller" and values permits it #3.' => [
+        yield 'It mutates logical or if same variable is tested against "Smaller" and "Greater" and values permits it #3.' => [
             <<<'PHP'
 <?php
 
@@ -260,7 +330,7 @@ $myVar < 10.1 && $myVar > 5.5;
 PHP
         ];
 
-        yield 'It mutates logical or if same variable is tested against "Greater" and "Smaller" and values permits it #4.' => [
+        yield 'It mutates logical or if same variable is tested against "Smaller" and "Greater" and values permits it #4.' => [
             <<<'PHP'
 <?php
 
@@ -274,7 +344,63 @@ $myVar < 10.1 && $myVar > 5;
 PHP
         ];
 
-        yield 'It mutates logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" and values permits it #1.' => [
+        yield 'It mutates logical or if same variable is tested against "Smaller" and "GreaterOrEqual" and values permits it #1.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 10 || $myVar >= 5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar < 10 && $myVar >= 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "Smaller" and "GreaterOrEqual" and values permits it #2.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 10 || $myVar >= 5.5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar < 10 && $myVar >= 5.5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "Smaller" and "GreaterOrEqual" and values permits it #3.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 10.1 || $myVar >= 5.5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar < 10.1 && $myVar >= 5.5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "Smaller" and "GreaterOrEqual" and values permits it #4.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 10.1 || $myVar >= 5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar < 10.1 && $myVar >= 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "SmallerOrEqual" and "GreaterOrEqual" and values permits it #1.' => [
             <<<'PHP'
 <?php
 
@@ -288,7 +414,7 @@ $myVar <= 10 && $myVar >= 5;
 PHP
         ];
 
-        yield 'It mutates logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" and values permits it #2.' => [
+        yield 'It mutates logical or if same variable is tested against "SmallerOrEqual" and "GreaterOrEqual" and values permits it #2.' => [
             <<<'PHP'
 <?php
 
@@ -302,7 +428,7 @@ $myVar <= 10 && $myVar >= 5.5;
 PHP
         ];
 
-        yield 'It mutates logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" and values permits it #3.' => [
+        yield 'It mutates logical or if same variable is tested against "SmallerOrEqual" and "GreaterOrEqual" and values permits it #3.' => [
             <<<'PHP'
 <?php
 
@@ -316,7 +442,7 @@ $myVar <= 10.1 && $myVar >= 5.5;
 PHP
         ];
 
-        yield 'It mutates logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" and values permits it #4.' => [
+        yield 'It mutates logical or if same variable is tested against "SmallerOrEqual" and "GreaterOrEqual" and values permits it #4.' => [
             <<<'PHP'
 <?php
 
@@ -327,6 +453,141 @@ PHP
 <?php
 
 $myVar <= 10.1 && $myVar >= 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "SmallerOrEqual" and "Greater" and values permits it #1.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 10 || $myVar > 5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar <= 10 && $myVar > 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "SmallerOrEqual" and "Greater" and values permits it #2.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 10 || $myVar > 5.5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar <= 10 && $myVar > 5.5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "SmallerOrEqual" and "Greater" and values permits it #3.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 10.1 || $myVar > 5.5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar <= 10.1 && $myVar > 5.5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "SmallerOrEqual" and "Greater" and values permits it #4.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 10.1 || $myVar > 5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar <= 10.1 && $myVar > 5;
+PHP
+        ];
+    }
+
+    private function smallerAndGreaterMatrixWithSameValueMutationsProvider(): iterable
+    {
+        yield 'It mutates logical or if same variable is tested against "Smaller" and "Greater" and values are the same.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 5 || $myVar > 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "Greater" and "Smaller" and values are the same.' => [
+            <<<'PHP'
+<?php
+
+$myVar > 5 || $myVar < 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "Smaller" and "GreaterOrEqual" and values are the same.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 5 || $myVar >= 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "GreaterOrEqual" and "Smaller" and values are the same.' => [
+            <<<'PHP'
+<?php
+
+$myVar >= 5 || $myVar < 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "SmallerOrEqual" and "GreaterOrEqual" and values are the same.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 5 || $myVar >= 5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar <= 5 && $myVar >= 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" and values are the same.' => [
+            <<<'PHP'
+<?php
+
+$myVar >= 5 || $myVar <= 5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar >= 5 && $myVar <= 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "SmallerOrEqual" and "Greater" and values are the same.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 5 || $myVar > 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "Greater" and "SmallerOrEqual" and values are the same.' => [
+            <<<'PHP'
+<?php
+
+$myVar > 5 || $myVar <= 5;
 PHP
         ];
     }

--- a/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
@@ -114,6 +114,20 @@ $myVar == 'hello' && $myVar == 'world';
 PHP
         ];
 
+        yield 'It does mutate logical or if same variable is tested against "Equal" & "Identical".' => [
+            <<<'PHP'
+<?php
+
+$myVar === 'hello' || $myVar == 'world';
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar === 'hello' && $myVar == 'world';
+PHP
+        ];
+
         yield 'It does not mutate logical or if same variable is tested against "Identical" (mirrored #1).' => [
             <<<'PHP'
 <?php

--- a/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
@@ -90,7 +90,7 @@ PHP
             ,
         ];
 
-        yield 'It does not mutates logical or if same variable is tested against "Identical".' => [
+        yield 'It does not mutate logical or if same variable is tested against "Identical".' => [
             <<<'PHP'
 <?php
 
@@ -99,7 +99,22 @@ PHP
             ,
         ];
 
-        yield 'It does not mutates logical or if same variable is tested against "Identical" (mirrored #1).' => [
+        // TODO : improve this to mutate only if checking for falsy values on both sides.
+        yield 'It does mutate logical or if same variable is tested against "Equal".' => [
+            <<<'PHP'
+<?php
+
+$myVar == 'hello' || $myVar == 'world';
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar == 'hello' && $myVar == 'world';
+PHP
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "Identical" (mirrored #1).' => [
             <<<'PHP'
 <?php
 
@@ -108,7 +123,7 @@ PHP
             ,
         ];
 
-        yield 'It does not mutates logical or if same variable is tested against "Identical" (mirrored #2).' => [
+        yield 'It does not mutate logical or if same variable is tested against "Identical" (mirrored #2).' => [
             <<<'PHP'
 <?php
 
@@ -117,7 +132,7 @@ PHP
             ,
         ];
 
-        yield 'It does not mutates logical or if same variable is tested against "Greater" and "Smaller" #1.' => [
+        yield 'It does not mutate logical or if same variable is tested against "Greater" and "Smaller" #1.' => [
             <<<'PHP'
 <?php
 
@@ -126,13 +141,179 @@ PHP
             ,
         ];
 
-        yield 'It does not mutates logical or if same variable is tested against "Greater" and "Smaller" #2.' => [
+        yield 'It does not mutate logical or if same variable is tested against "Greater" and "Smaller" #2.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 5 || $myVar > 10.1;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "Greater" and "Smaller" #3.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 5.5 || $myVar > 10.1;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "Greater" and "Smaller" #4.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 5.5 || $myVar > 10;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" #1.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 5 || $myVar >= 10;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" #2.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 5 || $myVar >= 10.1;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" #3.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 5.5 || $myVar >= 10.1;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" #4.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 5.5 || $myVar >= 10;
+PHP
+            ,
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "Greater" and "Smaller" and values permits it #1.' => [
             <<<'PHP'
 <?php
 
 $myVar < 10 || $myVar > 5;
 PHP
             ,
+            <<<'PHP'
+<?php
+
+$myVar < 10 && $myVar > 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "Greater" and "Smaller" and values permits it #2.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 10 || $myVar > 5.5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar < 10 && $myVar > 5.5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "Greater" and "Smaller" and values permits it #3.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 10.1 || $myVar > 5.5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar < 10.1 && $myVar > 5.5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "Greater" and "Smaller" and values permits it #4.' => [
+            <<<'PHP'
+<?php
+
+$myVar < 10.1 || $myVar > 5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar < 10.1 && $myVar > 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" and values permits it #1.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 10 || $myVar >= 5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar <= 10 && $myVar >= 5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" and values permits it #2.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 10 || $myVar >= 5.5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar <= 10 && $myVar >= 5.5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" and values permits it #3.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 10.1 || $myVar >= 5.5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar <= 10.1 && $myVar >= 5.5;
+PHP
+        ];
+
+        yield 'It mutates logical or if same variable is tested against "GreaterOrEqual" and "SmallerOrEqual" and values permits it #4.' => [
+            <<<'PHP'
+<?php
+
+$myVar <= 10.1 || $myVar >= 5;
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$myVar <= 10.1 && $myVar >= 5;
+PHP
         ];
     }
 }


### PR DESCRIPTION
This PR:

- [x] Improve LogicalOr mutatability
- [x] Covered by tests

<!--
Remove if not relevant
-->

Fixes https://github.com/infection/infection/issues/1796

It improves the LogicalOr mutatability by detecting if we are trying to mutate to something that doesn't make sense.
For example :

```php
$myVar === 'hello' || $myVar === 'world';
```

cannot be mutated to 

```php
$myVar === 'hello' && $myVar === 'world';
```

I think there a lot more usecase that I don't cover such as

```php
$myVar < 5 || $myVar > 10;
```

can't be mutated but

```php
$myVar < 10 || $myVar > 5;
```

could. So not only should we check the variable name but also to what it compares. Although it would require to handle a lot of cases and Node class doesn't help much at the moment. Help appreciated to improve this further.

---
Edit : also handled some use cases regarding < & >