### PR TITLE
ci: Add meta jobs to ease editing the protection rules

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -56,3 +56,18 @@ jobs:
         # Ensures we see all the errors
         run: make autoreview --keep-going
 
+  # This is a meta job to avoid to have to constantly change the protection rules
+  # whenever we touch the matrix.
+  tests-status:
+    name: Autoreview Status
+    runs-on: ubuntu-latest
+    needs: tests
+    if: always()
+    steps:
+      - name: Successful run
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+
+      - name: Failing run
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,3 +123,19 @@ jobs:
           # test PHAR works from subfolder
           cd build && ./infection.phar -V && cd ..
           make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=build/infection.phar BENCHMARK_SOURCES=
+
+  # This is a meta job to avoid to have to constantly change the protection rules
+  # whenever we touch the matrix.
+  tests-status:
+      name: CI Status
+      runs-on: ubuntu-latest
+      needs: tests
+      if: always()
+      steps:
+          - name: Successful run
+            if: ${{ !(contains(needs.*.result, 'failure')) }}
+            run: exit 0
+
+          - name: Failing run
+            if: ${{ contains(needs.*.result, 'failure') }}
+            run: exit 1

--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -53,3 +53,19 @@ jobs:
               run: |
                   git fetch origin $GITHUB_BASE_REF
                   php bin/infection --threads=max --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --only-covered
+
+    # This is a meta job to avoid to have to constantly change the protection rules
+    # whenever we touch the matrix.
+    tests-status:
+        name: Annotations Status
+        runs-on: ubuntu-latest
+        needs: tests
+        if: always()
+        steps:
+            - name: Successful run
+              if: ${{ !(contains(needs.*.result, 'failure')) }}
+              run: exit 0
+
+            - name: Failing run
+              if: ${{ contains(needs.*.result, 'failure') }}
+              run: exit 1

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -81,3 +81,19 @@ jobs:
             --log-verbosity=none \
             --no-interaction \
             --no-progress
+
+  # This is a meta job to avoid to have to constantly change the protection rules
+  # whenever we touch the matrix.
+  tests-status:
+      name: Mutation Testing Status
+      runs-on: ubuntu-latest
+      needs: tests
+      if: always()
+      steps:
+          - name: Successful run
+            if: ${{ !(contains(needs.*.result, 'failure')) }}
+            run: exit 0
+
+          - name: Failing run
+            if: ${{ contains(needs.*.result, 'failure') }}
+            run: exit 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,3 +78,19 @@ jobs:
           fi
 
           make test-unit PHPUNIT_GROUP=integration
+
+  # This is a meta job to avoid to have to constantly change the protection rules
+  # whenever we touch the matrix.
+  tests-status:
+    name: Unit & Integration Tests Status
+    runs-on: ubuntu-latest
+    needs: tests
+    if: always()
+    steps:
+      - name: Successful run
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+
+      - name: Failing run
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
With this the protection rules can depend on static names. Of course they may still change over time as we adapt the CI, but this provides a lot more flexibility as we can now freely edit the matrix without having to constantly edit the project projection rules.

Closes #1800.
