### PR TITLE
Provide new logger "summaryJson".

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -95,6 +95,10 @@
                 "github": {
                     "type": "boolean",
                     "description": "GitHub Annotations for escaped Mutants in the added/modifies files"
+                },
+                "summaryJson": {
+                    "type": "string",
+                    "definition": "Summary JSON log file, which contains only the statistics from the complete JSON file."
                 }
             }
         },

--- a/src/Configuration/Entry/Logs.php
+++ b/src/Configuration/Entry/Logs.php
@@ -49,6 +49,7 @@ class Logs
     private ?string $perMutatorFilePath;
     private bool $useGitHubAnnotationsLogger;
     private ?StrykerConfig $strykerConfig;
+    private ?string $summaryJsonLogFilePath;
 
     public function __construct(
         ?string $textLogFilePath,
@@ -58,7 +59,8 @@ class Logs
         ?string $debugLogFilePath,
         ?string $perMutatorFilePath,
         bool $useGitHubAnnotationsLogger,
-        ?StrykerConfig $strykerConfig
+        ?StrykerConfig $strykerConfig,
+        ?string $summaryJsonLogFilePath
     ) {
         $this->textLogFilePath = $textLogFilePath;
         $this->htmlLogFilePath = $htmlLogFilePath;
@@ -68,6 +70,7 @@ class Logs
         $this->perMutatorFilePath = $perMutatorFilePath;
         $this->useGitHubAnnotationsLogger = $useGitHubAnnotationsLogger;
         $this->strykerConfig = $strykerConfig;
+        $this->summaryJsonLogFilePath = $summaryJsonLogFilePath;
     }
 
     public static function createEmpty(): self
@@ -80,6 +83,7 @@ class Logs
             null,
             null,
             false,
+            null,
             null
         );
     }
@@ -132,5 +136,10 @@ class Logs
     public function getStrykerConfig(): ?StrykerConfig
     {
         return $this->strykerConfig;
+    }
+
+    public function getSummaryJsonLogFilePath(): ?string
+    {
+        return $this->summaryJsonLogFilePath;
     }
 }

--- a/src/Configuration/Schema/SchemaConfigurationFactory.php
+++ b/src/Configuration/Schema/SchemaConfigurationFactory.php
@@ -88,7 +88,8 @@ class SchemaConfigurationFactory
             self::normalizeString($logs->debug ?? null),
             self::normalizeString($logs->perMutator ?? null),
             $logs->github ?? false,
-            self::createStrykerConfig($logs->stryker ?? null)
+            self::createStrykerConfig($logs->stryker ?? null),
+            self::normalizeString($logs->summaryJson ?? null),
         );
     }
 

--- a/src/Logger/FileLoggerFactory.php
+++ b/src/Logger/FileLoggerFactory.php
@@ -90,6 +90,8 @@ class FileLoggerFactory
 
         yield $logConfig->getPerMutatorFilePath() => $this->createPerMutatorLogger();
 
+        yield $logConfig->getSummaryJsonLogFilePath() => $this->createSummaryJsonLogger();
+
         if ($logConfig->getUseGitHubAnnotationsLogger()) {
             yield GitHubAnnotationsLogger::DEFAULT_OUTPUT => $this->createGitHubAnnotationsLogger();
         }
@@ -156,5 +158,10 @@ class FileLoggerFactory
             $this->metricsCalculator,
             $this->resultsCollector
         );
+    }
+
+    private function createSummaryJsonLogger(): LineMutationTestingResultsLogger
+    {
+        return new SummaryJsonLogger($this->metricsCalculator);
     }
 }

--- a/tests/phpunit/Configuration/ConfigurationAssertions.php
+++ b/tests/phpunit/Configuration/ConfigurationAssertions.php
@@ -105,7 +105,8 @@ trait ConfigurationAssertions
             $expectedLogs->getDebugLogFilePath(),
             $expectedLogs->getPerMutatorFilePath(),
             $expectedLogs->getUseGitHubAnnotationsLogger(),
-            $expectedLogs->getStrykerConfig()
+            $expectedLogs->getStrykerConfig(),
+            $expectedLogs->getSummaryJsonLogFilePath()
         );
         $this->assertSame($expectedLogVerbosity, $configuration->getLogVerbosity());
         $this->assertSame($expectedTmpDir, $configuration->getTmpDir());

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -806,7 +806,8 @@ final class ConfigurationFactoryTest extends TestCase
                     'debug.log',
                     'mutator.log',
                     true,
-                    StrykerConfig::forFullReport('master')
+                    StrykerConfig::forFullReport('master'),
+                    'summary.json'
                 ),
                 'config/tmp',
                 new PhpUnit(
@@ -862,7 +863,8 @@ final class ConfigurationFactoryTest extends TestCase
                 'debug.log',
                 'mutator.log',
                 true,
-                StrykerConfig::forFullReport('master')
+                StrykerConfig::forFullReport('master'),
+                'summary.json'
             ),
             'none',
             '/path/to/config/tmp/infection',
@@ -1289,6 +1291,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             null,
             $useGitHubAnnotationsLogger,
+            null,
             null,
         );
 
@@ -2079,6 +2082,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             true,
             null,
+            null,
         );
 
         return [
@@ -2096,6 +2100,7 @@ final class ConfigurationFactoryTest extends TestCase
                     null,
                     null,
                     false,
+                    null,
                     null,
                 ),
                 '',

--- a/tests/phpunit/Configuration/ConfigurationTest.php
+++ b/tests/phpunit/Configuration/ConfigurationTest.php
@@ -215,7 +215,8 @@ final class ConfigurationTest extends TestCase
                 'debug.log',
                 'mutator.log',
                 true,
-                StrykerConfig::forBadge('master')
+                StrykerConfig::forBadge('master'),
+                'summary.json'
             ),
             'default',
             'custom-dir',

--- a/tests/phpunit/Configuration/Entry/LogsTest.php
+++ b/tests/phpunit/Configuration/Entry/LogsTest.php
@@ -54,7 +54,8 @@ final class LogsTest extends TestCase
         ?string $debugLogFilePath,
         ?string $perMutatorFilePath,
         bool $useGitHubAnnotationsLogger,
-        ?StrykerConfig $strykerConfig
+        ?StrykerConfig $strykerConfig,
+        ?string $summaryJsonLogFilePath
     ): void {
         $logs = new Logs(
             $textLogFilePath,
@@ -64,7 +65,8 @@ final class LogsTest extends TestCase
             $debugLogFilePath,
             $perMutatorFilePath,
             $useGitHubAnnotationsLogger,
-            $strykerConfig
+            $strykerConfig,
+            $summaryJsonLogFilePath
         );
 
         $this->assertLogsStateIs(
@@ -76,7 +78,8 @@ final class LogsTest extends TestCase
             $debugLogFilePath,
             $perMutatorFilePath,
             $useGitHubAnnotationsLogger,
-            $strykerConfig
+            $strykerConfig,
+            $summaryJsonLogFilePath
         );
     }
 
@@ -93,6 +96,7 @@ final class LogsTest extends TestCase
             null,
             null,
             false,
+            null,
             null
         );
     }
@@ -108,6 +112,7 @@ final class LogsTest extends TestCase
             null,
             false,
             null,
+            null,
         ];
 
         yield 'complete' => [
@@ -119,6 +124,7 @@ final class LogsTest extends TestCase
             'perMutator.log',
             true,
             StrykerConfig::forBadge('master'),
+            'summary.json',
         ];
     }
 }

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -232,6 +232,7 @@ JSON
                     null,
                     null,
                     false,
+                    null,
                     null
                 ),
             ]),
@@ -259,6 +260,7 @@ JSON
                     null,
                     null,
                     false,
+                    null,
                     null
                 ),
             ]),
@@ -286,6 +288,7 @@ JSON
                     null,
                     null,
                     false,
+                    null,
                     null
                 ),
             ]),
@@ -313,6 +316,7 @@ JSON
                     null,
                     null,
                     false,
+                    null,
                     null
                 ),
             ]),
@@ -340,6 +344,7 @@ JSON
                     'debug.log',
                     null,
                     false,
+                    null,
                     null
                 ),
             ]),
@@ -367,6 +372,7 @@ JSON
                     null,
                     'perMutator.log',
                     false,
+                    null,
                     null
                 ),
             ]),
@@ -396,7 +402,8 @@ JSON
                     null,
                     null,
                     false,
-                    StrykerConfig::forBadge('master')
+                    StrykerConfig::forBadge('master'),
+                    null
                 ),
             ]),
         ];
@@ -425,7 +432,8 @@ JSON
                     null,
                     null,
                     false,
-                    StrykerConfig::forFullReport('master')
+                    StrykerConfig::forFullReport('master'),
+                    null
                 ),
             ]),
         ];
@@ -454,7 +462,8 @@ JSON
                     null,
                     null,
                     false,
-                    StrykerConfig::forBadge('/^foo$/')
+                    StrykerConfig::forBadge('/^foo$/'),
+                    null
                 ),
             ]),
         ];
@@ -483,7 +492,36 @@ JSON
                     null,
                     null,
                     false,
-                    StrykerConfig::forFullReport('/^foo$/')
+                    StrykerConfig::forFullReport('/^foo$/'),
+                    null
+                ),
+            ]),
+        ];
+
+        yield '[logs][summaryJson] nominal' => [
+            <<<'JSON'
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "logs": {
+        "summaryJson": "summary.json"
+    }
+}
+JSON
+            ,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'logs' => new Logs(
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false,
+                    null,
+                    'summary.json'
                 ),
             ]),
         ];
@@ -504,7 +542,8 @@ JSON
         "github": true,
         "stryker": {
             "badge": "master"
-        }
+        },
+        "summaryJson": "summary.json"
     }
 }
 JSON
@@ -519,7 +558,8 @@ JSON
                     'debug.log',
                     'perMutator.log',
                     true,
-                    StrykerConfig::forBadge('master')
+                    StrykerConfig::forBadge('master'),
+                    'summary.json'
                 ),
             ]),
         ];
@@ -588,7 +628,8 @@ JSON
         "github": true ,
         "stryker": {
             "badge": " master "
-        }
+        },
+        "summaryJson": " summary.json "
     }
 }
 JSON
@@ -603,7 +644,8 @@ JSON
                     'debug.log',
                     'perMutator.log',
                     true,
-                    StrykerConfig::forBadge('master')
+                    StrykerConfig::forBadge('master'),
+                    'summary.json'
                 ),
             ]),
         ];
@@ -2238,7 +2280,8 @@ JSON
         "github": true,
         "stryker": {
             "badge": "master"
-        }
+        },
+        "summaryJson": "summary.json"
     },
     "tmpDir": "custom-tmp",
     "phpUnit": {
@@ -2475,7 +2518,8 @@ JSON
                     'debug.log',
                     'perMutator.log',
                     true,
-                    StrykerConfig::forBadge('master')
+                    StrykerConfig::forBadge('master'),
+                    'summary.json'
                 ),
                 'tmpDir' => 'custom-tmp',
                 'phpunit' => new PhpUnit(

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationTest.php
@@ -127,7 +127,8 @@ final class SchemaConfigurationTest extends TestCase
                 'debug.log',
                 'mutator.log',
                 true,
-                StrykerConfig::forFullReport('master')
+                StrykerConfig::forFullReport('master'),
+                'summary.json'
             ),
             'path/to/tmp',
             new PhpUnit('dist/phpunit', 'bin/phpunit'),

--- a/tests/phpunit/Logger/FileLoggerFactoryTest.php
+++ b/tests/phpunit/Logger/FileLoggerFactoryTest.php
@@ -51,6 +51,7 @@ use Infection\Logger\JsonLogger;
 use Infection\Logger\MutationTestingResultsLogger;
 use Infection\Logger\PerMutatorLogger;
 use Infection\Logger\SummaryFileLogger;
+use Infection\Logger\SummaryJsonLogger;
 use Infection\Logger\TextFileLogger;
 use Infection\Metrics\MetricsCalculator;
 use Infection\Metrics\ResultsCollector;
@@ -105,7 +106,8 @@ final class FileLoggerFactoryTest extends TestCase
                 '/a/file',
                 '/a/file',
                 true,
-                null
+                null,
+                '/a/file',
             )
         );
 
@@ -146,6 +148,7 @@ final class FileLoggerFactoryTest extends TestCase
                 null,
                 null,
                 false,
+                null,
                 null
             ),
             [TextFileLogger::class],
@@ -160,6 +163,7 @@ final class FileLoggerFactoryTest extends TestCase
                 null,
                 null,
                 false,
+                null,
                 null
             ),
             [HtmlFileLogger::class],
@@ -174,6 +178,7 @@ final class FileLoggerFactoryTest extends TestCase
                 null,
                 null,
                 false,
+                null,
                 null
             ),
             [SummaryFileLogger::class],
@@ -188,6 +193,7 @@ final class FileLoggerFactoryTest extends TestCase
                 'debug_file',
                 null,
                 false,
+                null,
                 null
             ),
             [DebugFileLogger::class],
@@ -202,6 +208,7 @@ final class FileLoggerFactoryTest extends TestCase
                 null,
                 null,
                 false,
+                null,
                 null
             ),
             [JsonLogger::class],
@@ -216,6 +223,7 @@ final class FileLoggerFactoryTest extends TestCase
                 null,
                 'per_muator',
                 false,
+                null,
                 null
             ),
             [PerMutatorLogger::class],
@@ -230,9 +238,25 @@ final class FileLoggerFactoryTest extends TestCase
                 null,
                 null,
                 true,
+                null,
                 null
             ),
             [GitHubAnnotationsLogger::class],
+        ];
+
+        yield 'summary-json logger' => [
+            new Logs(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                null,
+                'summary-json'
+            ),
+            [SummaryJsonLogger::class],
         ];
 
         yield 'all loggers' => [
@@ -244,7 +268,8 @@ final class FileLoggerFactoryTest extends TestCase
                 'debug',
                 'per_mutator',
                 true,
-                StrykerConfig::forBadge('branch')
+                StrykerConfig::forBadge('branch'),
+                'summary-json'
             ),
             [
                 TextFileLogger::class,
@@ -254,6 +279,7 @@ final class FileLoggerFactoryTest extends TestCase
                 DebugFileLogger::class,
                 PerMutatorLogger::class,
                 GitHubAnnotationsLogger::class,
+                SummaryJsonLogger::class,
             ],
         ];
     }

--- a/tests/phpunit/Logger/FileLoggerFactoryTest.php
+++ b/tests/phpunit/Logger/FileLoggerFactoryTest.php
@@ -278,8 +278,8 @@ final class FileLoggerFactoryTest extends TestCase
                 JsonLogger::class,
                 DebugFileLogger::class,
                 PerMutatorLogger::class,
-                GitHubAnnotationsLogger::class,
                 SummaryJsonLogger::class,
+                GitHubAnnotationsLogger::class,
             ],
         ];
     }

--- a/tests/phpunit/Logger/StrykerLoggerFactoryTest.php
+++ b/tests/phpunit/Logger/StrykerLoggerFactoryTest.php
@@ -70,7 +70,8 @@ final class StrykerLoggerFactoryTest extends TestCase
                 '/a/file',
                 '/a/file',
                 true,
-                null
+                null,
+                '/a/file',
             )
         );
 
@@ -90,7 +91,8 @@ final class StrykerLoggerFactoryTest extends TestCase
                 null,
                 null,
                 false,
-                StrykerConfig::forBadge('master')
+                StrykerConfig::forBadge('master'),
+                null
             )
         );
 
@@ -133,7 +135,8 @@ final class StrykerLoggerFactoryTest extends TestCase
                 null,
                 null,
                 false,
-                StrykerConfig::forBadge('foo')
+                StrykerConfig::forBadge('foo'),
+                null
             ),
             StrykerLogger::class,
         ];
@@ -147,7 +150,8 @@ final class StrykerLoggerFactoryTest extends TestCase
                 null,
                 null,
                 false,
-                StrykerConfig::forFullReport('foo')
+                StrykerConfig::forFullReport('foo'),
+                null
             ),
             StrykerLogger::class,
         ];
@@ -161,7 +165,8 @@ final class StrykerLoggerFactoryTest extends TestCase
                 'debug',
                 'per_mutator',
                 true,
-                StrykerConfig::forBadge('branch')
+                StrykerConfig::forBadge('branch'),
+                'summary_json'
             ),
             StrykerLogger::class,
         ];

--- a/tests/phpunit/Logger/SummaryJsonLoggerTest.php
+++ b/tests/phpunit/Logger/SummaryJsonLoggerTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Logger;
+
+use Infection\Logger\SummaryJsonLogger;
+use Infection\Metrics\Collector;
+use Infection\Metrics\MetricsCalculator;
+use Infection\Mutant\DetectionStatus;
+use Infection\Mutator\Loop\For_;
+use const JSON_THROW_ON_ERROR;
+use PHPUnit\Framework\TestCase;
+use function Safe\json_decode;
+
+/**
+ * @group integration
+ */
+final class SummaryJsonLoggerTest extends TestCase
+{
+    use CreateMetricsCalculator;
+
+    /**
+     * @dataProvider metricsProvider
+     */
+    public function test_it_logs_correctly_with_mutations(
+        MetricsCalculator $metricsCalculator,
+        array $expectedContents
+    ): void {
+        $logger = new SummaryJsonLogger($metricsCalculator);
+
+        $this->assertLoggedContentIs($expectedContents, $logger);
+    }
+
+    public function metricsProvider(): iterable
+    {
+        yield 'no mutations; only covered' => [
+            new MetricsCalculator(2),
+            [
+                'stats' => [
+                    'totalMutantsCount' => 0,
+                    'killedCount' => 0,
+                    'notCoveredCount' => 0,
+                    'escapedCount' => 0,
+                    'errorCount' => 0,
+                    'syntaxErrorCount' => 0,
+                    'skippedCount' => 0,
+                    'ignoredCount' => 0,
+                    'timeOutCount' => 0,
+                    'msi' => 0,
+                    'mutationCodeCoverage' => 0,
+                    'coveredCodeMsi' => 0,
+                ],
+            ],
+        ];
+
+        yield 'all mutations; only covered' => [
+            $this->createCompleteMetricsCalculator(),
+            [
+                'stats' => [
+                    'totalMutantsCount' => 16,
+                    'killedCount' => 2,
+                    'notCoveredCount' => 2,
+                    'escapedCount' => 2,
+                    'errorCount' => 2,
+                    'syntaxErrorCount' => 2,
+                    'skippedCount' => 2,
+                    'ignoredCount' => 2,
+                    'timeOutCount' => 2,
+                    'msi' => 66.67,
+                    'mutationCodeCoverage' => 83.33,
+                    'coveredCodeMsi' => 80,
+                ],
+            ],
+        ];
+
+        yield 'uncovered mutations' => [
+            $this->createUncoveredMetricsCalculator(),
+            [
+                'stats' => [
+                    'totalMutantsCount' => 1,
+                    'killedCount' => 0,
+                    'notCoveredCount' => 1,
+                    'escapedCount' => 0,
+                    'errorCount' => 0,
+                    'syntaxErrorCount' => 0,
+                    'skippedCount' => 0,
+                    'ignoredCount' => 0,
+                    'timeOutCount' => 0,
+                    'msi' => 0,
+                    'mutationCodeCoverage' => 0,
+                    'coveredCodeMsi' => 0,
+                ],
+            ],
+        ];
+
+        yield 'Ignored mutations' => [
+            $this->createIgnoredMetricsCalculator(),
+            [
+                'stats' => [
+                    'totalMutantsCount' => 1,
+                    'killedCount' => 0,
+                    'notCoveredCount' => 0,
+                    'escapedCount' => 0,
+                    'errorCount' => 0,
+                    'syntaxErrorCount' => 0,
+                    'skippedCount' => 0,
+                    'ignoredCount' => 1,
+                    'timeOutCount' => 0,
+                    'msi' => 0,
+                    'mutationCodeCoverage' => 0,
+                    'coveredCodeMsi' => 0,
+                ],
+            ],
+        ];
+    }
+
+    private function assertLoggedContentIs(array $expectedJson, SummaryJsonLogger $logger): void
+    {
+        $this->assertSame($expectedJson, json_decode($logger->getLogLines()[0], true, JSON_THROW_ON_ERROR));
+    }
+
+    private function createUncoveredMetricsCalculator(): MetricsCalculator
+    {
+        $collector = new MetricsCalculator(2);
+
+        $this->initUncoveredCollector($collector);
+
+        return $collector;
+    }
+
+    private function initUncoveredCollector(Collector $collector): void
+    {
+        $collector->collect(
+            $this->createMutantExecutionResult(
+                0,
+                For_::class,
+                DetectionStatus::NOT_COVERED,
+                'uncovered#0'
+            ),
+        );
+    }
+
+    private function createIgnoredMetricsCalculator(): MetricsCalculator
+    {
+        $collector = new MetricsCalculator(2);
+
+        $this->initIgnoredCollector($collector);
+
+        return $collector;
+    }
+
+    private function initIgnoredCollector(Collector $collector): void
+    {
+        $collector->collect(
+            $this->createMutantExecutionResult(
+                0,
+                For_::class,
+                DetectionStatus::IGNORED,
+                'ignored#0'
+            ),
+        );
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/251
- Fixes https://github.com/infection/infection/issues/1807

This PR provides a new logger that give only a summary of mutation tests on JSON format in order to easily programmatically parse such results for CI or programmed processes, and without using the original JSON logger that might be too heavy (more than 750Mb on some of my projects, for instance).

I was able to unit-test and check the PHPCS and PHPStan. For an unknown reason, I wasn't able to validate Psalm as `CURL*` const are not recognized on my php version (even after I installed `php8.0-curl` :shrug: ).
I wasn't able to run PHP Infection on itself as it crashed my computer, probably for RAM reasons.

Thanks a lot!