### PR TITLE
Exclude Symfony polyfills so that Infection correctly works with PHAR

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4926,5 +4926,5 @@
     "platform-overrides": {
         "php": "8.0.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Exclude Symfony polyfills so that Infection correctly works with PHAR when no native extensions are present.

Related to https://github.com/infection/infection/pull/1608#discussion_r905602123

Unfortunately, our conversation with @theofidry was not completed, and I incorrectly removed Polyfills exclusion from scoper config.

Today, I had no `intl` and `mbstring` extensions and PHAR failed to work.

With this update, `make compile-docker` now generates correctly prefixed PHAR, which works even with no extensions, using Polyfills in the right way.