### PR TITLE
Treat log paths as relative to config directory

### DIFF
--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -289,21 +289,33 @@ final class ConfigurationFactoryTest extends TestCase
         ];
 
         yield 'null html file log path with existing path from config file' => self::createValueForHtmlLogFilePath(
-            'from-config.html',
+            '/from-config.html',
             null,
-            'from-config.html'
+            '/from-config.html'
+        );
+
+        yield 'absolute html file log path' => self::createValueForHtmlLogFilePath(
+            '/path/to/from-config.html',
+            null,
+            '/path/to/from-config.html',
+        );
+
+        yield 'relative html file log path' => self::createValueForHtmlLogFilePath(
+            'relative/path/to/from-config.html',
+            null,
+            '/path/to/relative/path/to/from-config.html'
         );
 
         yield 'override html file log path from CLI option with existing path from config file' => self::createValueForHtmlLogFilePath(
-            'from-config.html',
-            'from-cli.html',
-            'from-cli.html'
+            '/from-config.html',
+            '/from-cli.html',
+            '/from-cli.html'
         );
 
         yield 'set html file log path from CLI option when config file has no setting' => self::createValueForHtmlLogFilePath(
             null,
-            'from-cli.html',
-            'from-cli.html'
+            '/from-cli.html',
+            '/from-cli.html'
         );
 
         yield 'null html file log path in config and CLI' => self::createValueForHtmlLogFilePath(
@@ -799,15 +811,15 @@ final class ConfigurationFactoryTest extends TestCase
                 10,
                 new Source(['src/'], ['vendor/']),
                 new Logs(
-                    'text.log',
-                    'report.html',
-                    'summary.log',
-                    'json.log',
-                    'debug.log',
-                    'mutator.log',
+                    '/text.log',
+                    '/report.html',
+                    '/summary.log',
+                    '/json.log',
+                    '/debug.log',
+                    '/mutator.log',
                     true,
                     StrykerConfig::forFullReport('master'),
-                    'summary.json'
+                    '/summary.json'
                 ),
                 'config/tmp',
                 new PhpUnit(
@@ -856,15 +868,15 @@ final class ConfigurationFactoryTest extends TestCase
             'src/Foo.php, src/Bar.php',
             ['vendor/'],
             new Logs(
-                'text.log',
-                'report.html',
-                'summary.log',
-                'json.log',
-                'debug.log',
-                'mutator.log',
+                '/text.log',
+                '/report.html',
+                '/summary.log',
+                '/json.log',
+                '/debug.log',
+                '/mutator.log',
                 true,
                 StrykerConfig::forFullReport('master'),
-                'summary.json'
+                '/summary.json'
             ),
             'none',
             '/path/to/config/tmp/infection',


### PR DESCRIPTION
Partly fixes https://github.com/infection/infection/issues/857 (https://github.com/infection/infection/issues/857#issuecomment-558550587)

Log paths will be treated as relative to config directory with this change.

This is a breaking change for all users, that use relative paths in their config, right now. 

One one hand I'm not 100% sure, if this is worth it. On the other hand infection is still in `0.x`, so breaking changes should be accepted?