### PR TITLE
ci: Adapt the matrix to allow testing against different dependency ranges

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           - { operating-system: 'ubuntu-latest', php-version: '8.1', coverage-driver: 'pcov', e2e-runner: 'build/infection.phar' }
           - { operating-system: 'ubuntu-latest', php-version: '8.2', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
 
-    name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }} with ${{ matrix.e2e-runner }}
+    name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }} (${{ matrix.composer }}; ${{ matrix.dependency }}), using ${{ matrix.coverage-driver }} with ${{ matrix.e2e-runner }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,16 +19,16 @@ jobs:
         operating-system: [ ubuntu-latest ]
         php-version: [ '8.0' ]
         dependency: [ locked ]
-        composer: [ composer:v2.1 ]
+        composer: [ 'composer:v2.1' ]
         coverage-driver: [ pcov, xdebug ]
         e2e-runner: [ 'bin/infection' ]
         include:
-          - { operating-system: 'windows-latest', php-version: '8.0', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'pcov', e2e-runner: 'build/infection.phar' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.0', coverage-driver: 'xdebug', e2e-runner: 'build/infection.phar' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.1', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.1', coverage-driver: 'pcov', e2e-runner: 'build/infection.phar' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.2', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
+          - { operating-system: 'windows-latest', php-version: '8.0', composer: 'composer:v2.1', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.0', composer: 'composer:v2.1', coverage-driver: 'pcov', e2e-runner: 'build/infection.phar' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.0', composer: 'composer:v2.1', coverage-driver: 'xdebug', e2e-runner: 'build/infection.phar' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.1', composer: 'composer:v2.1', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.1', composer: 'composer:v2.1', coverage-driver: 'pcov', e2e-runner: 'build/infection.phar' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.2', composer: 'composer:v2.1', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
 
     name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }} (${{ matrix.composer }}; ${{ matrix.dependency }}), using ${{ matrix.coverage-driver }} with ${{ matrix.e2e-runner }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest ]
         php-version: [ '8.0' ]
+        dependency: [ locked ]
+        composer: [ composer:v2.1 ]
         coverage-driver: [ pcov, xdebug ]
         e2e-runner: [ 'bin/infection' ]
         include:
@@ -34,10 +36,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Configure for PHP >= 8.2
-        if: "matrix.php-version >= '8.2'"
-        run: |
-          composer config platform.php 8.1.99
+      - name: Remove the configured PHP platform
+        if: matrix.dependency != 'locked'
+        run: composer config --unset platform.php
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -45,7 +46,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           coverage: ${{ matrix.coverage-driver }}
           ini-values: memory_limit=512M, xdebug.mode=off
-          tools: composer:v2.1
+          tools: ${{ matrix.composer }}
         env:
           # This is necessary when installing a tool with a specific version
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,17 +58,25 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('composer.*') }}
-          restore-keys: |
-            composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('composer.*') }}-
-            composer-${{ runner.os }}-${{ matrix.php-version }}-
-            composer-${{ runner.os }}-
-            composer-
+            path: ${{ steps.composer-cache.outputs.dir }}
+            key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }} }}
+            restore-keys: |
+                composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }} }}-
+                composer-${{ runner.os }}-${{ matrix.php-version }}-
+                composer-${{ runner.os }}-
+                composer-
 
       - name: Install dependencies
-        run: |
-          composer install --no-interaction --prefer-dist --no-progress
+        if: ${{ matrix.dependencies == 'locked' }}
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Install highest dependencies
+        if: ${{ matrix.dependencies == 'highest' }}
+        run: composer update --no-interaction --prefer-dist --no-progress
+
+      - name: Install lowest dependencies
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: composer update --no-interaction --prefer-dist --no-progress --prefer-lowest
 
       - name: Cache E2E tests dependencies
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,13 +58,13 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-            path: ${{ steps.composer-cache.outputs.dir }}
-            key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }} }}
-            restore-keys: |
-                composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }} }}-
-                composer-${{ runner.os }}-${{ matrix.php-version }}-
-                composer-${{ runner.os }}-
-                composer-
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }} }}
+          restore-keys: |
+            composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }} }}-
+            composer-${{ runner.os }}-${{ matrix.php-version }}-
+            composer-${{ runner.os }}-
+            composer-
 
       - name: Install dependencies
         if: ${{ matrix.dependencies == 'locked' }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest ]
         php-version: [ '8.0' ]
-        dependency: [ locked ]
+        dependencies: [ locked ]
         composer: [ 'composer:v2.1' ]
         coverage-driver: [ pcov, xdebug ]
         e2e-runner: [ 'bin/infection' ]
@@ -30,7 +30,7 @@ jobs:
           - { operating-system: 'ubuntu-latest', php-version: '8.1', composer: 'composer:v2.1', coverage-driver: 'pcov', e2e-runner: 'build/infection.phar' }
           - { operating-system: 'ubuntu-latest', php-version: '8.2', composer: 'composer:v2.1', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
 
-    name: E2E tests on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }} (${{ matrix.composer }}; ${{ matrix.dependency }}), using ${{ matrix.coverage-driver }} with ${{ matrix.e2e-runner }}
+    name: E2E tests on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }} (${{ matrix.composer }}; ${{ matrix.dependencies }}), using ${{ matrix.coverage-driver }} with ${{ matrix.e2e-runner }}
 
     steps:
       - name: Checkout code
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove the configured PHP platform
-        if: matrix.dependency != 'locked'
+        if: matrix.dependencies != 'locked'
         run: composer config --unset platform.php
 
       - name: Get composer cache directory

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,15 +19,15 @@ jobs:
         operating-system: [ ubuntu-latest ]
         php-version: [ '8.0', '8.1', '8.2' ]
         # TODO: include highest & lowest
-        dependency: [ locked ]
+        dependencies: [ locked ]
         coverage-driver: [ pcov, xdebug ]
         include:
           - operating-system: windows-latest
             php-version: '8.0'
-            dependency: locked
+            dependencies: locked
             coverage-driver: xdebug
 
-    name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }} (${{ matrix.dependency }}), using ${{ matrix.coverage-driver }}
+    name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }} (${{ matrix.dependencies }}), using ${{ matrix.coverage-driver }}
 
     steps:
       - name: Checkout code
@@ -42,7 +42,7 @@ jobs:
           tools: composer
 
       - name: Remove the configured PHP platform
-        if: matrix.dependency != 'locked'
+        if: matrix.dependencies != 'locked'
         run: composer config --unset platform.php
 
       - name: Get composer cache directory

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,10 +28,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Configure for PHP >= 8.2
-        if: "matrix.php-version >= '8.2'"
-        run: |
-          composer config platform.php 8.1.99
+      - name: Remove the configured PHP platform
+        if: matrix.dependency != 'locked'
+        run: composer config --unset platform.php
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -49,16 +48,24 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('composer.*') }}
+          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }} }}
           restore-keys: |
-            composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('composer.*') }}-
+            composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }} }}-
             composer-${{ runner.os }}-${{ matrix.php-version }}-
             composer-${{ runner.os }}-
             composer-
 
       - name: Install dependencies
-        run: |
-          composer install --no-interaction --prefer-dist --no-progress
+        if: ${{ matrix.dependencies == 'locked' }}
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Install highest dependencies
+        if: ${{ matrix.dependencies == 'highest' }}
+        run: composer update --no-interaction --prefer-dist --no-progress
+
+      - name: Install lowest dependencies
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: composer update --no-interaction --prefer-dist --no-progress --prefer-lowest
 
       - name: Run unit tests
         shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,9 +18,15 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest ]
         php-version: [ '8.0', '8.1', '8.2' ]
+        # TODO: include highest & lowest
+        dependency: [ locked ]
+        # TODO: include phpdbg later
         coverage-driver: [ pcov, xdebug ]
         include:
-          - { operating-system: 'windows-latest', php-version: '8.0', coverage-driver: 'xdebug' }
+          - operating-system: windows-latest
+            php-version: '8.0'
+            dependency: locked
+            coverage-driver: xdebug
 
     name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }} (${{ matrix.dependency }}), using ${{ matrix.coverage-driver }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
         include:
           - { operating-system: 'windows-latest', php-version: '8.0', coverage-driver: 'xdebug' }
 
-    name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }}
+    name: CI on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }} (${{ matrix.dependency }}), using ${{ matrix.coverage-driver }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Rework the matrix to make it easier to test against`locked`, `highest` and `lowest` dependencies.
Also allow to update and test the Composer version used easily.

Extracted from #1775.