### PR TITLE
ci: Use Composer after setting up PHP

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,11 +34,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Configure for PHP >= 8.2
-        if: "matrix.php-version >= '8.2'"
-        run: |
-          composer config platform.php 8.1.99
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -49,6 +44,11 @@ jobs:
         env:
           # This is necessary when installing a tool with a specific version
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure for PHP >= 8.2
+        if: "matrix.php-version >= '8.2'"
+        run: |
+            composer config platform.php 8.1.99
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,11 +28,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Configure for PHP >= 8.2
-        if: "matrix.php-version >= '8.2'"
-        run: |
-          composer config platform.php 8.1.99
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -40,6 +35,11 @@ jobs:
           coverage: ${{ matrix.coverage-driver }}
           ini-values: memory_limit=512M, xdebug.mode=off
           tools: composer
+
+      - name: Configure for PHP >= 8.2
+        if: "matrix.php-version >= '8.2'"
+        run: |
+            composer config platform.php 8.1.99
 
       - name: Get composer cache directory
         id: composer-cache


### PR DESCRIPTION
Indeed the Composer version used may not be the one expected otherwise.
