### PR TITLE
Declare conflict with uncompatible versions of antecedent/patchwork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
     },
     "conflict": {
         "phpunit/php-code-coverage": ">9,<9.1.4 || >9.2.17,<9.2.21",
+        "antecedent/patchwork": "<2.1.25",
         "dg/bypass-finals": "<1.4.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f94feb0a5c9510948f9bfa8f238cd2af",
+    "content-hash": "42a2ee6dd0b1912a5e0bd1e37b159ae6",
     "packages": [
         {
             "name": "colinodell/json5",


### PR DESCRIPTION
Let's fix #1827 for good.

There's a chance somebody installs Infection with an incompatible version of the package, and we will have to spend time responding, investigating, and so forth. If we declare a conflict, all we will have to do is to ask to update to the latest version of Infection, and the issue will be gone.
