### PR TITLE
Log thread count as part of performance

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -433,7 +433,8 @@ final class Container
             PerformanceLoggerSubscriberFactory::class => static fn (self $container): PerformanceLoggerSubscriberFactory => new PerformanceLoggerSubscriberFactory(
                 $container->getStopwatch(),
                 $container->getTimeFormatter(),
-                $container->getMemoryFormatter()
+                $container->getMemoryFormatter(),
+                $container->getConfiguration()->getThreadCount()
             ),
             CommandLineBuilder::class => static fn (): CommandLineBuilder => new CommandLineBuilder(),
             SourceFileCollector::class => static fn (): SourceFileCollector => new SourceFileCollector(),

--- a/src/Event/Subscriber/PerformanceLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/PerformanceLoggerSubscriberFactory.php
@@ -46,8 +46,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class PerformanceLoggerSubscriberFactory implements SubscriberFactory
 {
-    public function __construct(private Stopwatch $stopwatch, private TimeFormatter $timeFormatter, private MemoryFormatter $memoryFormatter)
-    {
+    public function __construct(
+        private Stopwatch $stopwatch,
+        private TimeFormatter $timeFormatter,
+        private MemoryFormatter $memoryFormatter,
+        private int $threadCount,
+    ) {
     }
 
     public function create(OutputInterface $output): EventSubscriber
@@ -56,6 +60,7 @@ final class PerformanceLoggerSubscriberFactory implements SubscriberFactory
             $this->stopwatch,
             $this->timeFormatter,
             $this->memoryFormatter,
+            $this->threadCount,
             $output
         );
     }

--- a/src/Resource/Listener/PerformanceLoggerSubscriber.php
+++ b/src/Resource/Listener/PerformanceLoggerSubscriber.php
@@ -42,7 +42,7 @@ use Infection\Resource\Memory\MemoryFormatter;
 use Infection\Resource\Time\Stopwatch;
 use Infection\Resource\Time\TimeFormatter;
 use function memory_get_peak_usage;
-use function Safe\sprintf;
+use function sprintf;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -50,7 +50,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class PerformanceLoggerSubscriber implements EventSubscriber
 {
-    public function __construct(private Stopwatch $stopwatch, private TimeFormatter $timeFormatter, private MemoryFormatter $memoryFormatter, private OutputInterface $output)
+    public function __construct(
+        private Stopwatch $stopwatch,
+        private TimeFormatter $timeFormatter,
+        private MemoryFormatter $memoryFormatter,
+        private int $threadCount,
+        private OutputInterface $output)
     {
     }
 
@@ -66,9 +71,10 @@ final class PerformanceLoggerSubscriber implements EventSubscriber
         $this->output->writeln([
             '',
             sprintf(
-                'Time: %s. Memory: %s',
+                'Time: %s. Memory: %s. Threads: %s',
                 $this->timeFormatter->toHumanReadableString($time),
-                $this->memoryFormatter->toHumanReadableString(memory_get_peak_usage(true))
+                $this->memoryFormatter->toHumanReadableString(memory_get_peak_usage(true)),
+                $this->threadCount
             ),
         ]);
     }

--- a/src/Resource/Memory/MemoryFormatter.php
+++ b/src/Resource/Memory/MemoryFormatter.php
@@ -43,8 +43,9 @@ use Webmozart\Assert\Assert;
 
 /**
  * @internal
+ * @final
  */
-final class MemoryFormatter
+class MemoryFormatter
 {
     private const UNITS = [
         'B',

--- a/src/Resource/Time/TimeFormatter.php
+++ b/src/Resource/Time/TimeFormatter.php
@@ -39,8 +39,9 @@ use function trim;
 
 /**
  * @internal
+ * @final
  */
-final class TimeFormatter
+class TimeFormatter
 {
     private const TIME_HORIZONS = [
         'h' => 3600,

--- a/tests/phpunit/Event/Subscriber/PerformanceLoggerSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/PerformanceLoggerSubscriberFactoryTest.php
@@ -50,7 +50,8 @@ final class PerformanceLoggerSubscriberFactoryTest extends TestCase
         $factory = new PerformanceLoggerSubscriberFactory(
             new Stopwatch(),
             new TimeFormatter(),
-            new MemoryFormatter()
+            new MemoryFormatter(),
+            1
         );
 
         $subscriber = $factory->create(new FakeOutput());

--- a/tests/phpunit/Fixtures/Resource/Memory/FakeMemoryFormatter.php
+++ b/tests/phpunit/Fixtures/Resource/Memory/FakeMemoryFormatter.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Infection\Tests\Fixtures\Resource\Memory;
+
+use Infection\Resource\Memory\MemoryFormatter;
+
+final class FakeMemoryFormatter extends MemoryFormatter
+{
+    public function __construct(private float $bytes)
+    {
+    }
+
+    public function toHumanReadableString(float $bytes): string
+    {
+        return parent::toHumanReadableString($this->bytes);
+    }
+}

--- a/tests/phpunit/Fixtures/Resource/Time/FakeTimeFormatter.php
+++ b/tests/phpunit/Fixtures/Resource/Time/FakeTimeFormatter.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Infection\Tests\Fixtures\Resource\Time;
+
+use Infection\Resource\Time\TimeFormatter;
+
+final class FakeTimeFormatter extends TimeFormatter
+{
+    public function __construct(private float $seconds)
+    {
+    }
+
+    public function toHumanReadableString(float $seconds): string
+    {
+        return parent::toHumanReadableString($this->seconds);
+    }
+}

--- a/tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php
+++ b/tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php
@@ -39,13 +39,12 @@ use Infection\Event\ApplicationExecutionWasFinished;
 use Infection\Event\ApplicationExecutionWasStarted;
 use Infection\Event\EventDispatcher\SyncEventDispatcher;
 use Infection\Resource\Listener\PerformanceLoggerSubscriber;
-use Infection\Resource\Memory\MemoryFormatter;
 use Infection\Resource\Time\Stopwatch;
-use Infection\Resource\Time\TimeFormatter;
+use Infection\Tests\Fixtures\Resource\Memory\FakeMemoryFormatter;
+use Infection\Tests\Fixtures\Resource\Time\FakeTimeFormatter;
 use function is_array;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use function strpos;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class PerformanceLoggerSubscriberTest extends TestCase
@@ -65,14 +64,17 @@ final class PerformanceLoggerSubscriberTest extends TestCase
         $this->output->expects($this->once())
             ->method('writeln')
             ->with($this->callback(static function ($parameter): bool {
-                return is_array($parameter) && $parameter[0] === '' && strpos($parameter[1], 'Time:') === 0;
+                $expectedOutput = 'Time: 5s. Memory: 2.00KB. Threads: 1';
+
+                return is_array($parameter) && $parameter[0] === '' && $parameter[1] === $expectedOutput;
             }));
 
         $dispatcher = new SyncEventDispatcher();
         $dispatcher->addSubscriber(new PerformanceLoggerSubscriber(
-            new Stopwatch(),
-            new TimeFormatter(),
-            new MemoryFormatter(),
+            new StopWatch(),
+            new FakeTimeFormatter(5),
+            new FakeMemoryFormatter(2048),
+            1,
             $this->output
         ));
 


### PR DESCRIPTION
When using `--threads=max` it's hard to figure out how many threads were actually used. This will help figure out are more details about the performance of the infection run.

This is just a suggestion for now. If you think it's useful, I can add coverage for tests.

This PR:

- [x] Adds new feature ...
- [x] Covered by tests