### PR TITLE
Add support for PHPUnit 10.1 and use `<source />` tag for coverage instead of `<coverage />`

### DIFF
--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -109,6 +109,12 @@ class InitialConfigBuilder implements ConfigBuilder
 
     private function addCoverageNodes(string $version, SafeDOMXPath $xPath): void
     {
+        if (version_compare($version, '10.1', '>=')) {
+            $this->configManipulator->addOrUpdateSourceIncludeNodes($xPath, $this->srcDirs, $this->filteredSourceFilesToMutate);
+
+            return;
+        }
+
         if (version_compare($version, '10', '>=')) {
             $this->configManipulator->addOrUpdateCoverageIncludeNodes($xPath, $this->srcDirs, $this->filteredSourceFilesToMutate);
 

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -161,6 +161,15 @@ final class XmlConfigurationManipulator
         $this->addOrUpdateCoverageNodes('coverage', 'include', $xPath, $srcDirs, $filteredSourceFilesToMutate);
     }
 
+    /**
+     * @param string[] $srcDirs
+     * @param list<string> $filteredSourceFilesToMutate
+     */
+    public function addOrUpdateSourceIncludeNodes(SafeDOMXPath $xPath, array $srcDirs, array $filteredSourceFilesToMutate): void
+    {
+        $this->addOrUpdateCoverageNodes('source', 'include', $xPath, $srcDirs, $filteredSourceFilesToMutate);
+    }
+
     public function validate(string $configPath, SafeDOMXPath $xPath): bool
     {
         if ($xPath->query('/phpunit')->length === 0) {

--- a/tests/e2e/PHPUnit101/README.md
+++ b/tests/e2e/PHPUnit101/README.md
@@ -1,0 +1,3 @@
+# Ensure PHPUnit 10.1 compatibility
+
+See: https://github.com/infection/infection/issues/1840

--- a/tests/e2e/PHPUnit101/composer.json
+++ b/tests/e2e/PHPUnit101/composer.json
@@ -1,15 +1,15 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^9.3.11"
+        "phpunit/phpunit": "^10.1"
     },
     "autoload": {
         "psr-4": {
-            "PHPUnit93\\": "src/"
+            "PHPUnit101\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "PHPUnit93\\Test\\": "tests/"
+            "PHPUnit101\\Test\\": "tests/"
         }
     }
 }

--- a/tests/e2e/PHPUnit101/expected-output.txt
+++ b/tests/e2e/PHPUnit101/expected-output.txt
@@ -1,0 +1,10 @@
+Total: 1
+
+Killed: 1
+Errored: 0
+Syntax Errors: 0
+Escaped: 0
+Timed Out: 0
+Skipped: 0
+Ignored: 0
+Not Covered: 0

--- a/tests/e2e/PHPUnit101/infection.json
+++ b/tests/e2e/PHPUnit101/infection.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../resources/schema.json",
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/PHPUnit101/phpunit.xml
+++ b/tests/e2e/PHPUnit101/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/e2e/PHPUnit101/src/SourceClass.php
+++ b/tests/e2e/PHPUnit101/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PHPUnit101;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/e2e/PHPUnit101/tests/SourceClassTest.php
+++ b/tests/e2e/PHPUnit101/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PHPUnit101\Test;
+
+use PHPUnit101\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -282,7 +282,7 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
         $this->assertSame(1, $coverageIncludeFiles->length);
     }
 
-    public function test_it_creates_coverage_include_node_if_does_not_exist_for_future_version_of_phpunit(): void
+    public function test_it_creates_coverage_include_node_if_does_not_exist_for_10_0_version_of_phpunit(): void
     {
         $phpunitXmlPath = self::FIXTURES . '/phpunit_without_coverage_whitelist.xml';
 
@@ -295,7 +295,7 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
         $this->assertSame(2, $includedDirectories->length);
     }
 
-    public function test_it_does_not_create_legacy_coverage_filter_whitelist_node_for_future_version_of_phpunit(): void
+    public function test_it_does_not_create_legacy_coverage_filter_whitelist_node_for_10_0_version_of_phpunit(): void
     {
         $phpunitXmlPath = self::FIXTURES . '/phpunit_without_coverage_whitelist.xml';
 
@@ -306,6 +306,19 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
         $this->assertInstanceOf(DOMNodeList::class, $whitelistedDirectories);
 
         $this->assertSame(0, $whitelistedDirectories->length);
+    }
+
+    public function test_it_creates_source_include_node_if_does_not_exist_for_10_1_version_of_phpunit(): void
+    {
+        $phpunitXmlPath = self::FIXTURES . '/phpunit_without_coverage_whitelist.xml';
+
+        $xml = file_get_contents($this->createConfigBuilder($phpunitXmlPath)->build('10.1'));
+
+        $includedDirectories = $this->queryXpath($xml, '/phpunit/source/include/directory');
+
+        $this->assertInstanceOf(DOMNodeList::class, $includedDirectories);
+
+        $this->assertSame(2, $includedDirectories->length);
     }
 
     public function test_it_does_not_create_coverage_filter_whitelist_node_if_already_exist(): void

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -279,6 +279,30 @@ XML
         );
     }
 
+    public function test_it_adds_source_include_directories_to_post_10_1_configuration(): void
+    {
+        $this->assertItChangesXML(
+            <<<'XML'
+<phpunit cacheTokens="true">
+</phpunit>
+XML
+            ,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->addOrUpdateSourceIncludeNodes($xPath, ['src/', 'examples/'], []);
+            },
+            <<<'XML'
+<phpunit cacheTokens="true">
+  <source>
+    <include>
+      <directory>src/</directory>
+      <directory>examples/</directory>
+    </include>
+  </source>
+</phpunit>
+XML
+        );
+    }
+
     public function test_it_removes_existing_loggers_from_post_93_configuration(): void
     {
         $this->assertItChangesPostPHPUnit93Configuration(


### PR DESCRIPTION
- Fixes https://github.com/infection/infection/issues/1840 
- Related to https://github.com/sebastianbergmann/phpunit/issues/5294

