### PR TITLE
Fix node being undetected as part of function signature when too deeply nested.

### DIFF
--- a/src/PhpParser/Visitor/ReflectionVisitor.php
+++ b/src/PhpParser/Visitor/ReflectionVisitor.php
@@ -129,19 +129,25 @@ final class ReflectionVisitor extends NodeVisitorAbstract
         return null;
     }
 
+    /**
+     * Loop on all parents of the node until one is a Node\Param or a function-like, which means it is part of a
+     * signature.
+     */
     private function isPartOfFunctionSignature(Node $node): bool
     {
         if ($this->isFunctionLikeNode($node)) {
             return true;
         }
 
-        $parent = ParentConnector::findParent($node);
-
-        if ($parent === null) {
-            return false;
+        if ($node instanceof Node\Param) {
+            return true;
         }
 
-        return $parent instanceof Node\Param || $node instanceof Node\Param;
+        do {
+            $node = ParentConnector::findParent($node);
+        } while ($node !== null && ! $node instanceof Node\Param);
+
+        return $node !== null;
     }
 
     /**

--- a/src/PhpParser/Visitor/ReflectionVisitor.php
+++ b/src/PhpParser/Visitor/ReflectionVisitor.php
@@ -145,7 +145,7 @@ final class ReflectionVisitor extends NodeVisitorAbstract
 
         do {
             $node = ParentConnector::findParent($node);
-        } while ($node !== null && ! $node instanceof Node\Param);
+        } while ($node !== null && !$node instanceof Node\Param);
 
         return $node !== null;
     }

--- a/tests/autoloaded/mutator-fixtures/Reflection/rv-part-of-signature-flag-with-attributes.php
+++ b/tests/autoloaded/mutator-fixtures/Reflection/rv-part-of-signature-flag-with-attributes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace InfectionReflectionPartOfSignature;
+
+class Test
+{
+    public function foo(
+        int $param,
+        #[CustomAttribute(false)]
+        $test = 2.0
+    ): bool {
+        return count([]) === 1;
+    }
+}

--- a/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
@@ -86,6 +86,20 @@ final class ReflectionVisitorTest extends BaseVisitorTest
         $this->assertSame($expected, $spyVisitor->isPartOfSignature());
     }
 
+    /**
+     * @dataProvider isPartOfSignatureFlagWithAttributesProvider
+     */
+    public function test_it_marks_nodes_which_are_part_of_the_function_signature_with_attributes(string $nodeClass, bool $expected): void
+    {
+        $code = $this->getFileContent('Reflection/rv-part-of-signature-flag-with-attributes.php');
+
+        $spyVisitor = $this->getPartOfSignatureSpyVisitor($nodeClass);
+
+        $this->parseAndTraverse($code, $spyVisitor);
+
+        $this->assertSame($expected, $spyVisitor->isPartOfSignature());
+    }
+
     public function test_it_detects_if_it_is_traversing_inside_class_method(): void
     {
         $code = $this->getFileContent('Reflection/rv-inside-class-method.php');
@@ -198,6 +212,25 @@ final class ReflectionVisitorTest extends BaseVisitorTest
         yield [Node\Stmt\ClassMethod::class, true];
 
         yield [Node\Param::class, true];                    // $param
+
+        yield [Node\Scalar\DNumber::class, true];           // 2.0
+
+        yield [Node\Scalar\LNumber::class, false];          // 1
+
+        yield [Node\Expr\BinaryOp\Identical::class, false]; // ===
+
+        yield [Node\Arg::class, false];
+
+        yield [Node\Expr\Array_::class, false];             // []
+    }
+
+    public function isPartOfSignatureFlagWithAttributesProvider(): iterable
+    {
+        yield [Node\Stmt\ClassMethod::class, true];
+
+        yield [Node\Param::class, true];                    // $param
+
+        yield [Node\Expr\ConstFetch::class, true];          // false
 
         yield [Node\Scalar\DNumber::class, true];           // 2.0
 


### PR DESCRIPTION
This PR:

- [x] Covered by tests
- [x] Fixes https://github.com/infection/infection/issues/1846

To detect if a Node is part of a signature of a function/method, it used to be checked if that Node is a "function-like" Node or if its direct parent is a Node\Param. 
With the usage of PHP Attributes, Nodes to check can be more deeply nested, and looking at the direct parent is no longer sufficient.
This PR ensures that all ancestors are being parsed until a Node\Param is found, or no more parent exists.