### PR TITLE
Add GH Action to requrie tests in Pull Requests

### DIFF
--- a/.github/workflows/require-tests.yaml
+++ b/.github/workflows/require-tests.yaml
@@ -1,0 +1,13 @@
+name: 'Require tests if source code is changed'
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: infection/tests-checker-action@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Previously, we had a GitHub App - Tests Checker - https://github.com/infection/tests-checker to automatically request changes in opened PR if source code is changed without changing/adding tests.

However, GitHub App requires deploying application to 3rd-party server, which means more maintenance and work from my side.

I've rewrote this app as a GitHub action - https://github.com/infection/tests-checker-action - and will deprecate GitHub App.

So basically nothing new here, same functionality but with Action instead of App.

I will open a test PR after merging to check if it works and if we have enough permissions from github toketn