### PR TITLE
During all "unwrap" functions, return the real values instead of values wrapped with `Node\Arg()` class

### DIFF
--- a/src/Mutator/Unwrap/AbstractFunctionUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractFunctionUnwrapMutator.php
@@ -53,7 +53,7 @@ abstract class AbstractFunctionUnwrapMutator implements Mutator
     /**
      * @psalm-mutation-free
      *
-     * @return iterable<Node\Arg>
+     * @return iterable<Node\Expr>
      */
     final public function mutate(Node $node): iterable
     {

--- a/src/Mutator/Unwrap/AbstractFunctionUnwrapMutator.php
+++ b/src/Mutator/Unwrap/AbstractFunctionUnwrapMutator.php
@@ -66,7 +66,7 @@ abstract class AbstractFunctionUnwrapMutator implements Mutator
                 continue;
             }
 
-            yield $node->args[$index];
+            yield $node->args[$index]->value;
         }
     }
 

--- a/tests/phpunit/Mutator/Unwrap/UnwrapSubstrTest.php
+++ b/tests/phpunit/Mutator/Unwrap/UnwrapSubstrTest.php
@@ -187,5 +187,19 @@ $b = $a('Bar', 0, -1);
 PHP
             ,
         ];
+
+        yield 'It mutates correctly complex code with dynamic method name. Related to https://github.com/infection/infection/issues/1799' => [
+            <<<'PHP'
+<?php
+
+$object->{substr($key, 0, -2)}();
+PHP
+            ,
+            <<<'PHP'
+<?php
+
+$object->{$key}();
+PHP
+        ];
     }
 }


### PR DESCRIPTION
During all "unwrap" functions, return the real values instead of values wrapped with `Node\Arg()` class

Fixes https://github.com/infection/infection/issues/1799

Failing (before) code:

```php
$array->{substr($key, 0, -2)}()
```

---

Explanation: before this update, we incorrectly return all the values, wrapped with `Node\Arg()` class, since before mutating they were arguments of unwrapped function.

For example:

```diff
- $a = substr('test', 0, -2);
+ $a = 'test';
```

here, in pseudo-AST, we did the following:

```php
$a = Node\Arg('test');
```

which is not correct