### PR TITLE
Calculate results and show metrics if Infection is interrupted with `SIGINT` (ctrl + c)

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.11.0@c9b192ab8400fdaf04b2b13d110575adc879aa90">
-  <file src="src/Event/Subscriber/StopInfectionOnSigintSignalSubscriber.php">
-    <UndefinedConstant>
-      <code>SIGINT</code>
-    </UndefinedConstant>
-  </file>
   <file src="src/Mutator/Extensions/BCMath.php">
     <ImpureFunctionCall>
       <code><![CDATA[$this->converters[$name->toLowerString()]($node)]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.11.0@c9b192ab8400fdaf04b2b13d110575adc879aa90">
+  <file src="src/Event/Subscriber/StopInfectionOnSigintSignalSubscriber.php">
+    <UndefinedConstant>
+      <code>SIGINT</code>
+    </UndefinedConstant>
+  </file>
   <file src="src/Mutator/Extensions/BCMath.php">
     <ImpureFunctionCall>
       <code><![CDATA[$this->converters[$name->toLowerString()]($node)]]></code>
@@ -9,11 +14,6 @@
     <ImpureFunctionCall>
       <code><![CDATA[$this->converters[$name->toLowerString()]($node)]]></code>
     </ImpureFunctionCall>
-  </file>
-  <file src="src/Event/Subscriber/StopInfectionOnSigintSignalSubscriber.php">
-    <UndefinedConstant occurrences="1">
-      <code>\SIGINT</code>
-    </UndefinedConstant>
   </file>
   <file src="src/Mutator/IgnoreMutator.php">
     <InvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10,6 +10,11 @@
       <code><![CDATA[$this->converters[$name->toLowerString()]($node)]]></code>
     </ImpureFunctionCall>
   </file>
+  <file src="src/Event/Subscriber/StopInfectionOnSigintSignalSubscriber.php">
+    <UndefinedConstant occurrences="1">
+      <code>\SIGINT</code>
+    </UndefinedConstant>
+  </file>
   <file src="src/Mutator/IgnoreMutator.php">
     <InvalidArgument>
       <code>$node</code>

--- a/src/Container.php
+++ b/src/Container.php
@@ -397,8 +397,8 @@ final class Container
                     $config->getTmpDir()
                 );
             },
-            StopInfectionOnSigintSignalSubscriberFactory::class => static fn(self $container): StopInfectionOnSigintSignalSubscriberFactory => new StopInfectionOnSigintSignalSubscriberFactory(),
-            DispatchPcntlSignalSubscriberFactory::class => static fn(self $container): DispatchPcntlSignalSubscriberFactory => new DispatchPcntlSignalSubscriberFactory(),
+            StopInfectionOnSigintSignalSubscriberFactory::class => static fn (self $container): StopInfectionOnSigintSignalSubscriberFactory => new StopInfectionOnSigintSignalSubscriberFactory(),
+            DispatchPcntlSignalSubscriberFactory::class => static fn (self $container): DispatchPcntlSignalSubscriberFactory => new DispatchPcntlSignalSubscriberFactory(),
             InitialTestsConsoleLoggerSubscriberFactory::class => static function (self $container): InitialTestsConsoleLoggerSubscriberFactory {
                 $config = $container->getConfiguration();
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -62,12 +62,14 @@ use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\EventDispatcher\SyncEventDispatcher;
 use Infection\Event\Subscriber\ChainSubscriberFactory;
 use Infection\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberFactory;
+use Infection\Event\Subscriber\DispatchPcntlSignalSubscriberFactory;
 use Infection\Event\Subscriber\InitialTestsConsoleLoggerSubscriberFactory;
 use Infection\Event\Subscriber\MutationGeneratingConsoleLoggerSubscriberFactory;
 use Infection\Event\Subscriber\MutationTestingConsoleLoggerSubscriberFactory;
 use Infection\Event\Subscriber\MutationTestingResultsCollectorSubscriberFactory;
 use Infection\Event\Subscriber\MutationTestingResultsLoggerSubscriberFactory;
 use Infection\Event\Subscriber\PerformanceLoggerSubscriberFactory;
+use Infection\Event\Subscriber\StopInfectionOnSigintSignalSubscriberFactory;
 use Infection\Event\Subscriber\SubscriberRegisterer;
 use Infection\ExtensionInstaller\GeneratedExtensionsConfig;
 use Infection\FileSystem\DummyFileSystem;
@@ -382,7 +384,9 @@ final class Container
                 $container->getMutationTestingConsoleLoggerSubscriberFactory(),
                 $container->getMutationTestingResultsLoggerSubscriberFactory(),
                 $container->getPerformanceLoggerSubscriberFactory(),
-                $container->getCleanUpAfterMutationTestingFinishedSubscriberFactory()
+                $container->getCleanUpAfterMutationTestingFinishedSubscriberFactory(),
+                $container->getStopInfectionOnSigintSignalSubscriberFactory(),
+                $container->getDispatchPcntlSignalSubscriberFactory(),
             ),
             CleanUpAfterMutationTestingFinishedSubscriberFactory::class => static function (self $container): CleanUpAfterMutationTestingFinishedSubscriberFactory {
                 $config = $container->getConfiguration();
@@ -392,6 +396,12 @@ final class Container
                     $container->getFileSystem(),
                     $config->getTmpDir()
                 );
+            },
+            StopInfectionOnSigintSignalSubscriberFactory::class => static function (self $container): StopInfectionOnSigintSignalSubscriberFactory {
+                return new StopInfectionOnSigintSignalSubscriberFactory();
+            },
+            DispatchPcntlSignalSubscriberFactory::class => static function (self $container): DispatchPcntlSignalSubscriberFactory {
+                return new DispatchPcntlSignalSubscriberFactory();
             },
             InitialTestsConsoleLoggerSubscriberFactory::class => static function (self $container): InitialTestsConsoleLoggerSubscriberFactory {
                 $config = $container->getConfiguration();
@@ -948,6 +958,16 @@ final class Container
     public function getCleanUpAfterMutationTestingFinishedSubscriberFactory(): CleanUpAfterMutationTestingFinishedSubscriberFactory
     {
         return $this->get(CleanUpAfterMutationTestingFinishedSubscriberFactory::class);
+    }
+
+    public function getStopInfectionOnSigintSignalSubscriberFactory(): StopInfectionOnSigintSignalSubscriberFactory
+    {
+        return $this->get(StopInfectionOnSigintSignalSubscriberFactory::class);
+    }
+
+    public function getDispatchPcntlSignalSubscriberFactory(): DispatchPcntlSignalSubscriberFactory
+    {
+        return $this->get(DispatchPcntlSignalSubscriberFactory::class);
     }
 
     public function getInitialTestsConsoleLoggerSubscriberFactory(): InitialTestsConsoleLoggerSubscriberFactory

--- a/src/Container.php
+++ b/src/Container.php
@@ -397,12 +397,8 @@ final class Container
                     $config->getTmpDir()
                 );
             },
-            StopInfectionOnSigintSignalSubscriberFactory::class => static function (self $container): StopInfectionOnSigintSignalSubscriberFactory {
-                return new StopInfectionOnSigintSignalSubscriberFactory();
-            },
-            DispatchPcntlSignalSubscriberFactory::class => static function (self $container): DispatchPcntlSignalSubscriberFactory {
-                return new DispatchPcntlSignalSubscriberFactory();
-            },
+            StopInfectionOnSigintSignalSubscriberFactory::class => static fn(self $container): StopInfectionOnSigintSignalSubscriberFactory => new StopInfectionOnSigintSignalSubscriberFactory(),
+            DispatchPcntlSignalSubscriberFactory::class => static fn(self $container): DispatchPcntlSignalSubscriberFactory => new DispatchPcntlSignalSubscriberFactory(),
             InitialTestsConsoleLoggerSubscriberFactory::class => static function (self $container): InitialTestsConsoleLoggerSubscriberFactory {
                 $config = $container->getConfiguration();
 

--- a/src/Event/MutationTestingWasStarted.php
+++ b/src/Event/MutationTestingWasStarted.php
@@ -42,7 +42,7 @@ use Infection\Process\Runner\ProcessRunner;
  */
 final class MutationTestingWasStarted
 {
-    public function __construct(private readonly int $mutationCount, private ProcessRunner $processRunner)
+    public function __construct(private readonly int $mutationCount, private readonly ProcessRunner $processRunner)
     {
     }
 

--- a/src/Event/MutationTestingWasStarted.php
+++ b/src/Event/MutationTestingWasStarted.php
@@ -35,17 +35,24 @@ declare(strict_types=1);
 
 namespace Infection\Event;
 
+use Infection\Process\Runner\ProcessRunner;
+
 /**
  * @internal
  */
 final class MutationTestingWasStarted
 {
-    public function __construct(private readonly int $mutationCount)
+    public function __construct(private readonly int $mutationCount, private ProcessRunner $processRunner)
     {
     }
 
     public function getMutationCount(): int
     {
         return $this->mutationCount;
+    }
+
+    public function getProcessRunner(): ProcessRunner
+    {
+        return $this->processRunner;
     }
 }

--- a/src/Event/Subscriber/DispatchPcntlSignalSubscriber.php
+++ b/src/Event/Subscriber/DispatchPcntlSignalSubscriber.php
@@ -33,17 +33,23 @@
 
 declare(strict_types=1);
 
-namespace Infection\Process\Runner;
+namespace Infection\Event\Subscriber;
+
+use function function_exists;
+use Infection\Event\MutantProcessWasFinished;
+use function Safe\pcntl_signal_dispatch;
 
 /**
  * @internal
  */
-interface ProcessRunner
+final class DispatchPcntlSignalSubscriber implements EventSubscriber
 {
-    /**
-     * @param iterable<ProcessBearer> $processes
-     */
-    public function run(iterable $processes): void;
+    public function onMutantProcessWasFinished(MutantProcessWasFinished $event): void
+    {
+        if (!function_exists('pcntl_signal_dispatch')) {
+            return;
+        }
 
-    public function stop(): void;
+        pcntl_signal_dispatch();
+    }
 }

--- a/src/Event/Subscriber/DispatchPcntlSignalSubscriberFactory.php
+++ b/src/Event/Subscriber/DispatchPcntlSignalSubscriberFactory.php
@@ -33,17 +33,17 @@
 
 declare(strict_types=1);
 
-namespace Infection\Process\Runner;
+namespace Infection\Event\Subscriber;
+
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @internal
  */
-interface ProcessRunner
+final class DispatchPcntlSignalSubscriberFactory implements SubscriberFactory
 {
-    /**
-     * @param iterable<ProcessBearer> $processes
-     */
-    public function run(iterable $processes): void;
-
-    public function stop(): void;
+    public function create(OutputInterface $output): EventSubscriber
+    {
+        return new DispatchPcntlSignalSubscriber();
+    }
 }

--- a/src/Event/Subscriber/StopInfectionOnSigintSignalSubscriber.php
+++ b/src/Event/Subscriber/StopInfectionOnSigintSignalSubscriber.php
@@ -38,6 +38,7 @@ namespace Infection\Event\Subscriber;
 use function function_exists;
 use Infection\Event\MutationTestingWasStarted;
 use function Safe\pcntl_signal;
+use const SIGINT;
 
 /**
  * @internal

--- a/src/Event/Subscriber/StopInfectionOnSigintSignalSubscriber.php
+++ b/src/Event/Subscriber/StopInfectionOnSigintSignalSubscriber.php
@@ -33,17 +33,25 @@
 
 declare(strict_types=1);
 
-namespace Infection\Process\Runner;
+namespace Infection\Event\Subscriber;
+
+use function function_exists;
+use Infection\Event\MutationTestingWasStarted;
+use function Safe\pcntl_signal;
 
 /**
  * @internal
  */
-interface ProcessRunner
+final class StopInfectionOnSigintSignalSubscriber implements EventSubscriber
 {
-    /**
-     * @param iterable<ProcessBearer> $processes
-     */
-    public function run(iterable $processes): void;
+    public function onMutationTestingWasStarted(MutationTestingWasStarted $event): void
+    {
+        if (!function_exists('pcntl_signal')) {
+            return;
+        }
 
-    public function stop(): void;
+        pcntl_signal(SIGINT, static function () use ($event): void {
+            $event->getProcessRunner()->stop();
+        });
+    }
 }

--- a/src/Event/Subscriber/StopInfectionOnSigintSignalSubscriberFactory.php
+++ b/src/Event/Subscriber/StopInfectionOnSigintSignalSubscriberFactory.php
@@ -33,17 +33,17 @@
 
 declare(strict_types=1);
 
-namespace Infection\Process\Runner;
+namespace Infection\Event\Subscriber;
+
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @internal
  */
-interface ProcessRunner
+final class StopInfectionOnSigintSignalSubscriberFactory implements SubscriberFactory
 {
-    /**
-     * @param iterable<ProcessBearer> $processes
-     */
-    public function run(iterable $processes): void;
-
-    public function stop(): void;
+    public function create(OutputInterface $output): EventSubscriber
+    {
+        return new StopInfectionOnSigintSignalSubscriber();
+    }
 }

--- a/src/Process/Runner/DryProcessRunner.php
+++ b/src/Process/Runner/DryProcessRunner.php
@@ -47,4 +47,9 @@ final class DryProcessRunner implements ProcessRunner
             // not even trigger the callback process
         }
     }
+
+    public function stop(): void
+    {
+        // not applicable for DryRunner
+    }
 }

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -68,7 +68,7 @@ class MutationTestingRunner
     public function run(iterable $mutations, string $testFrameworkExtraOptions): void
     {
         $numberOfMutants = IterableCounter::bufferAndCountIfNeeded($mutations, $this->runConcurrently);
-        $this->eventDispatcher->dispatch(new MutationTestingWasStarted($numberOfMutants));
+        $this->eventDispatcher->dispatch(new MutationTestingWasStarted($numberOfMutants, $this->processRunner));
 
         $processes = take($mutations)
             ->cast(fn (Mutation $mutation): Mutant => $this->mutantFactory->create($mutation))

--- a/src/Process/Runner/ParallelProcessRunner.php
+++ b/src/Process/Runner/ParallelProcessRunner.php
@@ -61,11 +61,18 @@ final class ParallelProcessRunner implements ProcessRunner
      */
     private array $availableThreadIndexes = [];
 
+    private bool $shouldStop = false;
+
     /**
      * @param int $poll Delay (in milliseconds) to wait in-between two polls
      */
     public function __construct(private readonly int $threadCount, private readonly int $poll = 1000)
     {
+    }
+
+    public function stop(): void
+    {
+        $this->shouldStop = true;
     }
 
     public function run(iterable $processes): void
@@ -92,6 +99,10 @@ final class ParallelProcessRunner implements ProcessRunner
 
         // start the initial batch of processes
         while ($process = array_shift($bucket)) {
+            if ($this->shouldStop) {
+                break;
+            }
+
             $threadIndex = array_shift($this->availableThreadIndexes);
 
             Assert::integer($threadIndex, 'Thread index can not be null.');

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -51,8 +51,10 @@ use Infection\Console\OutputFormatter\FormatterName;
 use Infection\Console\OutputFormatter\OutputFormatter;
 use Infection\Console\OutputFormatter\ProgressFormatter;
 use Infection\Console\XdebugHandler;
+use Infection\Event\Subscriber\DispatchPcntlSignalSubscriber;
 use Infection\Event\Subscriber\MutationGeneratingConsoleLoggerSubscriber;
 use Infection\Event\Subscriber\NullSubscriber;
+use Infection\Event\Subscriber\StopInfectionOnSigintSignalSubscriber;
 use Infection\FileSystem\DummyFileSystem;
 use Infection\FileSystem\Finder\ComposerExecutableFinder;
 use Infection\FileSystem\Finder\NonExecutableFinder;
@@ -113,6 +115,8 @@ final class ProjectCodeProvider
         FormatterName::class,
         ShellCommandLineExecutor::class,
         CpuCoresCountProvider::class,
+        DispatchPcntlSignalSubscriber::class,
+        StopInfectionOnSigintSignalSubscriber::class,
     ];
 
     /**

--- a/tests/phpunit/Event/MutationTestingWasStartedTest.php
+++ b/tests/phpunit/Event/MutationTestingWasStartedTest.php
@@ -36,15 +36,19 @@ declare(strict_types=1);
 namespace Infection\Tests\Event;
 
 use Infection\Event\MutationTestingWasStarted;
+use Infection\Process\Runner\ProcessRunner;
 use PHPUnit\Framework\TestCase;
 
 final class MutationTestingWasStartedTest extends TestCase
 {
-    public function test_it_exposes_its_mutation_count(): void
+    public function test_it_exposes_its_mutation_count_and_process_runner(): void
     {
         $count = 5;
-        $event = new MutationTestingWasStarted($count);
+        $processRunner = $this->createMock(ProcessRunner::class);
+
+        $event = new MutationTestingWasStarted($count, $processRunner);
 
         $this->assertSame($count, $event->getMutationCount());
+        $this->assertSame($processRunner, $event->getProcessRunner());
     }
 }

--- a/tests/phpunit/Event/Subscriber/DispatchPcntlSignalSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/DispatchPcntlSignalSubscriberFactoryTest.php
@@ -33,17 +33,23 @@
 
 declare(strict_types=1);
 
-namespace Infection\Process\Runner;
+namespace Infection\Tests\Event\Subscriber;
 
-/**
- * @internal
- */
-interface ProcessRunner
+use Infection\Event\Subscriber\DispatchPcntlSignalSubscriber;
+use Infection\Event\Subscriber\DispatchPcntlSignalSubscriberFactory;
+use Infection\Event\Subscriber\EventSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class DispatchPcntlSignalSubscriberFactoryTest extends TestCase
 {
-    /**
-     * @param iterable<ProcessBearer> $processes
-     */
-    public function run(iterable $processes): void;
+    public function test_it_creates_a_subscriber(): void
+    {
+        $outputMock = $this->createMock(OutputInterface::class);
 
-    public function stop(): void;
+        $subscriber = (new DispatchPcntlSignalSubscriberFactory())->create($outputMock);
+
+        $this->assertInstanceOf(DispatchPcntlSignalSubscriber::class, $subscriber);
+        $this->assertInstanceOf(EventSubscriber::class, $subscriber);
+    }
 }

--- a/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberTest.php
@@ -47,6 +47,7 @@ use Infection\Logger\FileLogger;
 use Infection\Metrics\MetricsCalculator;
 use Infection\Metrics\ResultsCollector;
 use Infection\Mutant\MutantExecutionResult;
+use Infection\Process\Runner\ProcessRunner;
 use Infection\Tests\Fixtures\Logger\DummyLineMutationTestingResultsLogger;
 use Infection\Tests\Fixtures\Logger\FakeLogger;
 use Infection\Tests\Logger\FakeMutationTestingResultsLogger;
@@ -117,7 +118,9 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             false
         ));
 
-        $dispatcher->dispatch(new MutationTestingWasStarted(1));
+        $processRunner = $this->createMock(ProcessRunner::class);
+
+        $dispatcher->dispatch(new MutationTestingWasStarted(1, $processRunner));
     }
 
     public function test_it_reacts_on_mutation_process_finished(): void

--- a/tests/phpunit/Event/Subscriber/StopInfectionOnSigintSignalSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/StopInfectionOnSigintSignalSubscriberFactoryTest.php
@@ -33,17 +33,23 @@
 
 declare(strict_types=1);
 
-namespace Infection\Process\Runner;
+namespace Infection\Tests\Event\Subscriber;
 
-/**
- * @internal
- */
-interface ProcessRunner
+use Infection\Event\Subscriber\EventSubscriber;
+use Infection\Event\Subscriber\StopInfectionOnSigintSignalSubscriber;
+use Infection\Event\Subscriber\StopInfectionOnSigintSignalSubscriberFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class StopInfectionOnSigintSignalSubscriberFactoryTest extends TestCase
 {
-    /**
-     * @param iterable<ProcessBearer> $processes
-     */
-    public function run(iterable $processes): void;
+    public function test_it_creates_a_subscriber(): void
+    {
+        $outputMock = $this->createMock(OutputInterface::class);
 
-    public function stop(): void;
+        $subscriber = (new StopInfectionOnSigintSignalSubscriberFactory())->create($outputMock);
+
+        $this->assertInstanceOf(StopInfectionOnSigintSignalSubscriber::class, $subscriber);
+        $this->assertInstanceOf(EventSubscriber::class, $subscriber);
+    }
 }

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -135,7 +135,7 @@ final class MutationTestingRunnerTest extends TestCase
 
         $this->assertAreSameEvents(
             [
-                new MutationTestingWasStarted(0),
+                new MutationTestingWasStarted(0, $this->processRunnerMock),
                 new MutationTestingWasFinished(),
             ],
             $this->eventDispatcher->getEvents()
@@ -214,7 +214,7 @@ final class MutationTestingRunnerTest extends TestCase
 
         $this->assertAreSameEvents(
             [
-                new MutationTestingWasStarted(3),
+                new MutationTestingWasStarted(3, $this->processRunnerMock),
                 $this->createMock(MutantProcessWasFinished::class),
                 new MutationTestingWasFinished(),
             ],
@@ -298,7 +298,7 @@ final class MutationTestingRunnerTest extends TestCase
 
         $this->assertAreSameEvents(
             [
-                new MutationTestingWasStarted(0),
+                new MutationTestingWasStarted(0, $this->processRunnerMock),
                 new MutationTestingWasFinished(),
             ],
             $this->eventDispatcher->getEvents()
@@ -363,7 +363,7 @@ final class MutationTestingRunnerTest extends TestCase
 
         $this->assertAreSameEvents(
             [
-                new MutationTestingWasStarted(0),
+                new MutationTestingWasStarted(0, $this->processRunnerMock),
                 new MutantProcessWasFinished(MutantExecutionResult::createFromNonCoveredMutant($mutant)),
                 new MutationTestingWasFinished(),
             ],
@@ -431,7 +431,7 @@ final class MutationTestingRunnerTest extends TestCase
 
         $this->assertAreSameEvents(
             [
-                new MutationTestingWasStarted(0),
+                new MutationTestingWasStarted(0, $this->processRunnerMock),
                 new MutationTestingWasFinished(),
             ],
             $this->eventDispatcher->getEvents()


### PR DESCRIPTION
Implements https://github.com/infection/infection/issues/1498

Before (in `master`), when Infection is interrupted, all the results were lost:

![infection-signal-1](https://github.com/infection/infection/assets/3725595/8031a982-a006-4174-a8e0-3fb753db35dd)

With this updated, all the accumulated results (before hitting `CTLR+C`) are used to prepare metrics. Also, file logs are created as well with accumulated results.

If `-s` is used, it additionally prints to console so developer can see mutants that were executed before `CTRL + C`:

![infection-signal-2](https://github.com/infection/infection/assets/3725595/405c9c5e-1b1e-4237-a597-596cd3a0cfe2)
