### PR TITLE
Don't print the number of processing files on CI

### DIFF
--- a/src/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriber.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Event\Subscriber;
 
 use Infection\Event\MutationGenerationWasStarted;
-use function Safe\sprintf;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -54,7 +53,7 @@ final class CiMutationGeneratingConsoleLoggerSubscriber implements EventSubscrib
             '',
             'Generate mutants...',
             '',
-            sprintf('Processing source code files: %s', $event->getMutableFilesCount()),
+            'Processing source code files...',
         ]);
     }
 }

--- a/tests/phpunit/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriberTest.php
@@ -64,12 +64,12 @@ final class CiMutationGeneratingConsoleLoggerSubscriberTest extends TestCase
                 '',
                 'Generate mutants...',
                 '',
-                'Processing source code files: 123',
+                'Processing source code files...',
             ]);
 
         $dispatcher = new SyncEventDispatcher();
         $dispatcher->addSubscriber(new CiMutationGeneratingConsoleLoggerSubscriber($this->output));
 
-        $dispatcher->dispatch(new MutationGenerationWasStarted(123));
+        $dispatcher->dispatch(new MutationGenerationWasStarted(0));
     }
 }


### PR DESCRIPTION
**TLDR: The printed amount of "processing source code files" is always 0 on CI. This MR removes the count from the output when it's ran on CI.**

By outputting 0 we thought we had some configuration issues on CI, but in fact we found out that it was properly configured, but just wrongly printed.

The reason is the files are being counted with the concurrent flag in the `MutationGenerator.php` so this causes it always to be 0.

```
vendor/bin/infection --no-progress [..]
Generate mutants...

Processing source code files 0...
```


*More in depth explanation:*

The `processing source code files` are being counted with the concurrent flag in the `MutationGenerator.php`.


```
$numberOfFiles = IterableCounter::bufferAndCountIfNeeded($traces, $this->runConcurrently);
```

Which makes the count always be 0 (see also `\Infection\Tests\Mutation\MutationGeneratorTest::test_it_does_not_count_files_in_concurrent_mode`)

Yet in the `CiMutationGeneratingConsoleLoggerSubscriber.php` the count is actually printed:

```
sprintf('Processing source code files: %s', $event->getMutableFilesCount()),
```

I see two options:
1) Remove the count, as it's always zero and confusing
2) 'Fix' the count, but that probably requires to not pass the `runConcurrently` to the counter, and make it `false`, but i'm not sure what the impact would be


With `--no-progress` (before fix)

```
Generate mutants...

Processing source code files 0...
```

With `--force-progress` (before fix)

```
Generate mutants...

Processing source code files: 24/24
```

With `--no-progress` (after fix)

```
Generate mutants...

Processing source code files...
```