### PR TITLE
Include installed Test Frameworks in TestFrameworkTypes - Fixes 1863

### DIFF
--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -88,7 +88,7 @@ final class ConfigureCommand extends BaseCommand
                 InputOption::VALUE_REQUIRED,
                 sprintf(
                     'Name of the Test framework to use ("%s")',
-                    implode('", "', TestFrameworkTypes::TYPES)
+                    implode('", "', TestFrameworkTypes::getTypes())
                 ),
                 TestFrameworkTypes::PHPUNIT
             );

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -166,7 +166,7 @@ final class RunCommand extends BaseCommand
                 InputOption::VALUE_REQUIRED,
                 sprintf(
                     'Name of the Test framework to use ("%s")',
-                    implode('", "', TestFrameworkTypes::TYPES)
+                    implode('", "', TestFrameworkTypes::getTypes())
                 ),
                 Container::DEFAULT_TEST_FRAMEWORK
             )

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -108,7 +108,7 @@ class Configuration
         Assert::allString($sourceDirectories);
         Assert::allIsInstanceOf($mutators, Mutator::class);
         Assert::oneOf($logVerbosity, self::LOG_VERBOSITY);
-        Assert::nullOrOneOf($testFramework, TestFrameworkTypes::TYPES);
+        Assert::nullOrOneOf($testFramework, TestFrameworkTypes::getTypes());
         Assert::nullOrGreaterThanEq($minMsi, 0.);
         Assert::greaterThanEq($threadCount, 0);
 

--- a/src/Configuration/Schema/SchemaConfiguration.php
+++ b/src/Configuration/Schema/SchemaConfiguration.php
@@ -69,7 +69,7 @@ final class SchemaConfiguration
         private readonly ?string $testFrameworkExtraOptions
     ) {
         Assert::nullOrGreaterThanEq($timeout, 0);
-        Assert::nullOrOneOf($testFramework, TestFrameworkTypes::TYPES);
+        Assert::nullOrOneOf($testFramework, TestFrameworkTypes::getTypes());
         $this->timeout = $timeout;
         $this->testFramework = $testFramework;
     }

--- a/src/TestFramework/TestFrameworkTypes.php
+++ b/src/TestFramework/TestFrameworkTypes.php
@@ -35,8 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework;
 
-use Infection\ExtensionInstaller\GeneratedExtensionsConfig;
+use function count;
 use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
+use Infection\ExtensionInstaller\GeneratedExtensionsConfig;
+use function is_a;
 use Webmozart\Assert\Assert;
 
 /**

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -103,7 +103,6 @@ final class ProjectCodeProvider
         ComposerExecutableFinder::class,
         StrykerCurlClient::class,
         MutationGeneratingConsoleLoggerSubscriber::class,
-        TestFrameworkTypes::class,
         NodeMutationGenerator::class,
         NonExecutableFinder::class,
         AdapterInstaller::class,

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -75,7 +75,6 @@ use Infection\TestFramework\Coverage\SourceMethodLineRange;
 use Infection\TestFramework\Coverage\TestLocations;
 use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder as PhpUnitInitalConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder as PhpUnitMutationConfigBuilder;
-use Infection\TestFramework\TestFrameworkTypes;
 use Infection\Tests\AutoReview\ConcreteClassReflector;
 use function Infection\Tests\generator_to_phpunit_data_provider;
 use function iterator_to_array;

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -912,7 +912,7 @@ JSON
             ]),
         ];
 
-        foreach (TestFrameworkTypes::TYPES as $testFrameworkType) {
+        foreach (TestFrameworkTypes::getTypes() as $testFrameworkType) {
             yield '[testFramework] ' . $testFrameworkType => (static function () use (
                 $testFrameworkType
             ): array {

--- a/tests/phpunit/TestFramework/TestFrameworkTypesTest.php
+++ b/tests/phpunit/TestFramework/TestFrameworkTypesTest.php
@@ -45,7 +45,7 @@ final class TestFrameworkTypesTest extends TestCase
     {
         $types = TestFrameworkTypes::getTypes([]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 TestFrameworkTypes::PEST,
                 TestFrameworkTypes::PHPUNIT,
@@ -68,13 +68,13 @@ final class TestFrameworkTypesTest extends TestCase
             ]
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 TestFrameworkTypes::PEST,
                 TestFrameworkTypes::PHPUNIT,
                 TestFrameworkTypes::PHPSPEC,
                 TestFrameworkTypes::CODECEPTION,
-                "dummy",
+                'dummy',
             ],
             $types
         );

--- a/tests/phpunit/TestFramework/TestFrameworkTypesTest.php
+++ b/tests/phpunit/TestFramework/TestFrameworkTypesTest.php
@@ -33,56 +33,50 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework;
+namespace Infection\Tests\TestFramework;
 
-use Infection\ExtensionInstaller\GeneratedExtensionsConfig;
-use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
-use Webmozart\Assert\Assert;
+use Infection\TestFramework\TestFrameworkTypes;
+use Infection\Tests\Fixtures\TestFramework\DummyTestFrameworkFactory;
+use PHPUnit\Framework\TestCase;
 
-/**
- * @internal
- */
-final class TestFrameworkTypes
+final class TestFrameworkTypesTest extends TestCase
 {
-    public const PHPUNIT = 'phpunit';
-    public const PEST = 'pest';
-    public const PHPSPEC = 'phpspec';
-    public const CODECEPTION = 'codeception';
+    public function test_it_returns_default_types_when_no_test_framework_adapters_are_installed(): void
+    {
+        $types = TestFrameworkTypes::getTypes([]);
 
-    /**
-     * @var string[]
-     */
-    private static array $defaultTypes = [
-        self::PEST,
-        self::PHPUNIT,
-        self::PHPSPEC,
-        self::CODECEPTION,
-    ];
+        $this->assertEquals(
+            [
+                TestFrameworkTypes::PEST,
+                TestFrameworkTypes::PHPUNIT,
+                TestFrameworkTypes::PHPSPEC,
+                TestFrameworkTypes::CODECEPTION,
+            ],
+            $types
+        );
+    }
 
-    /**
-     * @param mixed[] $installedExtensions
-     *
-     * @return string[]
-     */
-    public static function getTypes(
-        array $installedExtensions = GeneratedExtensionsConfig::EXTENSIONS
-    ): array {
-        $types = self::$defaultTypes;
+    public function test_it_uses_installed_test_framework_adapters(): void
+    {
+        $types = TestFrameworkTypes::getTypes(
+            [
+                'infection/codeception-adapter' => [
+                        'install_path' => '/path/to/dummy/adapter/factory.php',
+                        'extra' => ['class' => DummyTestFrameworkFactory::class],
+                        'version' => '1.0.0',
+                    ],
+            ]
+        );
 
-        if (count($installedExtensions) > 0) {
-            foreach ($installedExtensions as $installedExtension) {
-                $factory = $installedExtension['extra']['class'];
-
-                Assert::classExists($factory);
-
-                if (!is_a($factory, TestFrameworkAdapterFactory::class, true)) {
-                    continue;
-                }
-
-                $types[] = $factory::getAdapterName();
-            }
-        }
-
-        return $types;
+        $this->assertEquals(
+            [
+                TestFrameworkTypes::PEST,
+                TestFrameworkTypes::PHPUNIT,
+                TestFrameworkTypes::PHPSPEC,
+                TestFrameworkTypes::CODECEPTION,
+                "dummy",
+            ],
+            $types
+        );
     }
 }


### PR DESCRIPTION
#### This PR:

Fixes https://github.com/infection/infection/issues/1863

#### Per the issue description:

My team has implemented a binary that wraps around PHPUnit and configures / executes tests for us when we simply point it at a particular directory. I want to implement an Infection Test Framework extension that we would only use internally that executes tests via our binary. Unfortunately, that's not possible because specifying a Test Framework whose type is not hardcoded in TestFrameworkTypes causes Infection to throw an error.

#### Changes mage:

I replaced all references to the constant array `TestFrameworkTypes::TYPES` with a static function `TestFrameworkTypes::getTypes()` that parses `GeneratedExtensionsConfig::EXTENSIONS` to include the names of all installed Adapters.