### PR TITLE
Allow missing elements when destructuring arrays in foreach loops

### DIFF
--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -115,12 +115,6 @@ DIFF
      */
     public function mutate(Node $node): iterable
     {
-        $parent = $node->getAttribute('parent');
-        // Don't mutate destructured values in foreach loops
-        if ($parent instanceof Node\Stmt\Foreach_ && $parent->valueVar === $node) {
-            return;
-        }
-
         foreach ($this->getItemsIndexes($node->items) as $indexToRemove) {
             $newArrayNode = clone $node;
             unset($newArrayNode->items[$indexToRemove]);
@@ -147,6 +141,11 @@ DIFF
         }
 
         if ($parent instanceof Node\Arg && ParentConnector::findParent($parent) instanceof Node\Attribute) {
+            return false;
+        }
+
+        // Don't mutate destructured values in foreach loops
+        if ($parent instanceof Node\Stmt\Foreach_ && $parent->valueVar === $node) {
             return false;
         }
 

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -116,7 +116,11 @@ DIFF
      */
     public function mutate(Node $node): iterable
     {
-        Assert::allNotNull($node->items);
+        $parent = $node->getAttribute('parent');
+        // Don't mutate destructured values in foreach loops
+        if ($parent instanceof Node\Stmt\Foreach_ && $parent->valueVar === $node) {
+            return;
+        }
 
         foreach ($this->getItemsIndexes($node->items) as $indexToRemove) {
             $newArrayNode = clone $node;
@@ -153,7 +157,7 @@ DIFF
     /**
      * @psalm-mutation-free
      *
-     * @param ArrayItem[] $items
+     * @param array<array-key, ArrayItem|null> $items
      *
      * @return int[]
      */

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -46,7 +46,6 @@ use function min;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayItem;
 use function range;
-use Webmozart\Assert\Assert;
 
 /**
  * @internal

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
@@ -122,5 +122,9 @@ final class ArrayItemRemovalTest extends BaseMutatorTestCase
         yield 'It does not mutate arrays as an attribute argument' => [
             MutatorFixturesProvider::getFixtureFileContent($this, 'does-not-mutate-array-in-attribute.php'),
         ];
+
+        yield 'It does not mutate destructured array values in foreach loops' => [
+            '<?php foreach ($items as [, $value]) {}',
+        ];
     }
 }


### PR DESCRIPTION
This PR:

- [x] Covered by tests

This fixes a bug where Infection threw an exception when generating mutations for a codebase containing `<?php foreach ($items as [, $value]) {  }`.

The issue was an assertion that checked whether all elements in `Array_#$items` were non-null.

I'm not sure this is the ideal solution for this problem. Maybe we _do_ want to generate mutants in this position. But for now, it will at least no longer throw.

If I _just_ removed the assertion and widened the argument type on `getItemsIndexes`, then it would generate a mutant removing the empty first element, but I'm unsure whether that's an interesting mutation to have.