### PR TITLE
Collect escaped mutants for GitLab json file logger

### DIFF
--- a/src/Metrics/TargetDetectionStatusesProvider.php
+++ b/src/Metrics/TargetDetectionStatusesProvider.php
@@ -119,6 +119,10 @@ class TargetDetectionStatusesProvider
             yield DetectionStatus::ESCAPED;
         }
 
+        if ($this->logConfig->getGitlabLogFilePath() !== null) {
+            yield DetectionStatus::ESCAPED;
+        }
+
         // Follows the logic in JsonLogger
         if ($this->logConfig->getJsonLogFilePath() !== null) {
             yield DetectionStatus::KILLED;

--- a/tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php
+++ b/tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php
@@ -164,6 +164,22 @@ final class TargetDetectionStatusesProviderTest extends TestCase
         ], $provider->get());
     }
 
+    public function test_it_provides_escaped_when_using_gitlab_logger(): void
+    {
+        $logs = $this->createMock(Logs::class);
+        $logs
+            ->expects($this->once())
+            ->method('getGitlabLogFilePath')
+            ->willReturn('gitlab.json')
+        ;
+
+        $provider = new TargetDetectionStatusesProvider($logs, LogVerbosity::NORMAL, true, false);
+
+        $this->assertProvides([
+            DetectionStatus::ESCAPED,
+        ], $provider->get());
+    }
+
     public function test_it_provides_certain_statuses_for_json_logger(): void
     {
         $logs = $this->createMock(Logs::class);


### PR DESCRIPTION
Fixes https://github.com/infection/infection/pull/1878#issuecomment-1763207756

Currently, if we run Infection only with `--logger-gitlab`, it doesn't collect escaped mutants wich leads to empty log -> no annotations are being shown on GitLab

