### PR TITLE
Micro optimization to reduce array_merge calls

### DIFF
--- a/src/FileSystem/SourceFileCollector.php
+++ b/src/FileSystem/SourceFileCollector.php
@@ -59,17 +59,12 @@ class SourceFileCollector
             return [];
         }
 
-        $finder = Finder::create()
-            ->exclude($excludeDirectories)
+        return Finder::create()
             ->in($sourceDirectories)
+            ->exclude($excludeDirectories)
+            ->notPath($excludeDirectories)
             ->files()
             ->name('*.php')
         ;
-
-        foreach ($excludeDirectories as $excludeDirectory) {
-            $finder->notPath($excludeDirectory);
-        }
-
-        return $finder;
     }
 }

--- a/tests/phpunit/FileSystem/SourceFileCollectorTest.php
+++ b/tests/phpunit/FileSystem/SourceFileCollectorTest.php
@@ -151,6 +151,17 @@ final class SourceFileCollectorTest extends TestCase
                 'case1/sub-dir/b.php',
             ],
         ];
+
+        yield 'one directory, no filter, one common excludes and one file exclude' => [
+            [self::FIXTURES . '/case0'],
+            [
+                'sub-dir',
+                'a.php',
+            ],
+            [
+                'case0/outside-symlink.php',
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
Not a big win but this is a micro optimization will reduce amount of `array_merge` calls in case `excludes` option has more than one entry as Finder is doing array merge all the time `notPath` is called.

see https://github.com/symfony/finder/blob/5.4/Finder.php#L288