### PR TITLE
Ignore 1 in Div assignment operator (DivEqual).

### DIFF
--- a/src/Mutator/Arithmetic/DivEqual.php
+++ b/src/Mutator/Arithmetic/DivEqual.php
@@ -78,6 +78,27 @@ DIFF
 
     public function canMutate(Node $node): bool
     {
-        return $node instanceof Node\Expr\AssignOp\Div;
+        if (!$node instanceof Node\Expr\AssignOp\Div) {
+            return false;
+        }
+
+        if ($this->isNumericOne($node->expr)) {
+            return false;
+        }
+
+        if ($node->expr instanceof Node\Expr\UnaryMinus && $this->isNumericOne($node->expr->expr)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isNumericOne(Node $node): bool
+    {
+        if ($node instanceof Node\Scalar\LNumber && $node->value === 1) {
+            return true;
+        }
+
+        return $node instanceof Node\Scalar\DNumber && $node->value === 1.0;
     }
 }

--- a/tests/phpunit/Mutator/Arithmetic/DivEqualTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/DivEqualTest.php
@@ -76,5 +76,45 @@ $a = 10 / 2;
 PHP
             ,
         ];
+
+        yield 'It does not mutate division by 1 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = 1;
+$a /= 1;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate division by -1 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = 1;
+$a /= -1;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate division by 1.0 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = 1;
+$a /= 1.0;
+PHP
+            ,
+        ];
+
+        yield 'It does not mutate division by -1.0 to avoid an equivalent mutation' => [
+            <<<'PHP'
+<?php
+
+$a = 1;
+$a /= -1.0;
+PHP
+            ,
+        ];
     }
 }


### PR DESCRIPTION
This PR:

- [ ] Adds new feature ...
- [x] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

Follow up to #1884 - Implement the same rules for division operator, ignoring `1` and `-1`.