### PR TITLE
Remove symfony/console < 4.4 hack as minimum supported version is 5.4

### DIFF
--- a/src/Process/Factory/InitialTestsRunProcessFactory.php
+++ b/src/Process/Factory/InitialTestsRunProcessFactory.php
@@ -35,12 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Process\Factory;
 
-use Composer\InstalledVersions;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Process\OriginalPhpProcess;
-use function method_exists;
 use Symfony\Component\Process\Process;
-use function version_compare;
 
 /**
  * @internal
@@ -65,22 +62,13 @@ class InitialTestsRunProcessFactory
         // If we're expecting to receive a code coverage, test process must run in a vanilla environment
         $processClass = $skipCoverage ? Process::class : OriginalPhpProcess::class;
 
-        /** @var Process $process */
-        $process = new $processClass(
-            $this->testFrameworkAdapter->getInitialTestRunCommandLine(
+        return new $processClass(
+            command: $this->testFrameworkAdapter->getInitialTestRunCommandLine(
                 $testFrameworkExtraOptions,
                 $phpExtraOptions,
                 $skipCoverage
-            )
+            ),
+            timeout: null // Ignore the default timeout of 60 seconds
         );
-
-        $process->setTimeout(null); // Ignore the default timeout of 60 seconds
-
-        if (method_exists($process, 'inheritEnvironmentVariables') && version_compare((string) InstalledVersions::getPrettyVersion('symfony/console'), 'v4.4', '<')) {
-            // In version 4.4.0 this method is deprecated and removed in 5.0.0
-            $process->inheritEnvironmentVariables();
-        }
-
-        return $process;
     }
 }

--- a/src/Process/Factory/MutantProcessFactory.php
+++ b/src/Process/Factory/MutantProcessFactory.php
@@ -35,16 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Process\Factory;
 
-use Composer\InstalledVersions;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\MutantProcessWasFinished;
 use Infection\Mutant\Mutant;
 use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Process\MutantProcess;
-use function method_exists;
 use Symfony\Component\Process\Process;
-use function version_compare;
 
 /**
  * @internal
@@ -60,21 +57,15 @@ class MutantProcessFactory
     public function createProcessForMutant(Mutant $mutant, string $testFrameworkExtraOptions = ''): MutantProcess
     {
         $process = new Process(
-            $this->testFrameworkAdapter->getMutantCommandLine(
+            command: $this->testFrameworkAdapter->getMutantCommandLine(
                 $mutant->getTests(),
                 $mutant->getFilePath(),
                 $mutant->getMutation()->getHash(),
                 $mutant->getMutation()->getOriginalFilePath(),
                 $testFrameworkExtraOptions
-            )
+            ),
+            timeout: $this->timeout
         );
-
-        $process->setTimeout($this->timeout);
-
-        if (method_exists($process, 'inheritEnvironmentVariables') && version_compare((string) InstalledVersions::getPrettyVersion('symfony/console'), 'v4.4', '<')) {
-            // in version 4.4.0 this method is deprecated and removed in 5.0.0
-            $process->inheritEnvironmentVariables();
-        }
 
         $mutantProcess = new MutantProcess($process, $mutant);
 


### PR DESCRIPTION
This PR removes some hack which was applied when Infection supported symfony/console < 4.4 