### PR TITLE
Do not remove attributes from class methods when visibility is mutated

### DIFF
--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -82,6 +82,7 @@ DIFF
                 'params' => $node->getParams(),
                 'returnType' => $node->getReturnType(),
                 'stmts' => $node->getStmts(),
+                'attrGroups' => $node->getAttrGroups(),
             ],
             $node->getAttributes()
         );

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -81,6 +81,7 @@ DIFF
                 'params' => $node->getParams(),
                 'returnType' => $node->getReturnType(),
                 'stmts' => $node->getStmts(),
+                'attrGroups' => $node->getAttrGroups(),
             ],
             $node->getAttributes()
         );

--- a/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -227,5 +227,41 @@ function something()
 }
 PHP
         ];
+
+        yield 'It does not remove attributes' => [
+            <<<'PHP'
+<?php
+
+namespace PublicVisibilityOneClass;
+
+class Test
+{
+    #[SomeAttribute1]
+    #[SomeAttribute2]
+    protected function &foo(int $param, $test = 1) : bool
+    {
+        echo 1;
+        return false;
+    }
+}
+PHP,
+            <<<'PHP'
+<?php
+
+namespace PublicVisibilityOneClass;
+
+class Test
+{
+    #[SomeAttribute1]
+    #[SomeAttribute2]
+    private function &foo(int $param, $test = 1) : bool
+    {
+        echo 1;
+        return false;
+    }
+}
+PHP
+            ,
+        ];
     }
 }

--- a/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
@@ -343,5 +343,41 @@ PHP
             }];
             PHP,
         ];
+
+        yield 'It does not remove attributes' => [
+            <<<'PHP'
+<?php
+
+namespace PublicVisibilityOneClass;
+
+class Test
+{
+    #[SomeAttribute1]
+    #[SomeAttribute2]
+    public function &foo(int $param, $test = 1) : bool
+    {
+        echo 1;
+        return false;
+    }
+}
+PHP,
+            <<<'PHP'
+<?php
+
+namespace PublicVisibilityOneClass;
+
+class Test
+{
+    #[SomeAttribute1]
+    #[SomeAttribute2]
+    protected function &foo(int $param, $test = 1) : bool
+    {
+        echo 1;
+        return false;
+    }
+}
+PHP
+            ,
+        ];
     }
 }


### PR DESCRIPTION
Previously, attributes were removed when e.g. `public` was mutated to `protected`.

Now, attributes are retained.

Bug is reproduced here: https://infection-php.dev/r/zokd

Fixes #1895 