### PR TITLE
Disable Box Requirements Checker as it conflicts with symfony/service-contracts package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ $(INFECTION): vendor $(shell find bin/ src/ -type f) $(BOX) box.json.dist .git/H
 	composer install --no-dev
 	$(BOX) --version
 	$(BOX) validate
-	$(BOX) compile
+	BOX_REQUIREMENT_CHECKER=0 $(BOX) compile
 	composer remove infection/codeception-adapter infection/phpspec-adapter
 	composer install
 	touch -c $@


### PR DESCRIPTION
This PR disables (discussed in https://github.com/infection/infection/issues/1901) Box Requirements checker as it conflicts with symfony/service-contracts and fail builds