### PR TITLE
build: Disable the requirement checker

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -3,6 +3,7 @@
 
     "git-version": "package_version",
 
+    "check-requirements": false,
     "compression": "GZ",
     "compactors": [
         "KevinGH\\Box\\Compactor\\Json",


### PR DESCRIPTION
As per #1901, the requirement checker needs to be updated. I opened https://github.com/box-project/box/issues/1243 for this purpose. Meanwhile, to reduce the frictions in Infection, it is better to disable the requirement checker.
