### PR TITLE
build: Remove Symfony PHPUnitBridge

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -78,10 +78,6 @@ jobs:
         if: ${{ matrix.dependencies == 'lowest' }}
         run: composer update --no-interaction --prefer-dist --no-progress --prefer-lowest
 
-      - name: Configure the Symfony deprecations helper
-        if: ${{ matrix.php-version }} == '8.2'
-        run: echo "{SYMFONY_DEPRECATIONS_HELPER}={max[self]=0}" >> $GITHUB_ENV
-
       - name: Cache E2E tests dependencies
         if: runner.os == 'Windows'
         uses: actions/cache@v3

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Collect coverage report
         run: |
-          SYMFONY_DEPRECATIONS_HELPER=disabled php vendor/phpunit/phpunit/phpunit --stop-on-failure \
+          php vendor/phpunit/phpunit/phpunit --stop-on-failure \
             --coverage-xml=build/logs/coverage-xml \
             --log-junit=build/logs/junit.xml
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,10 +66,6 @@ jobs:
         if: matrix.dependencies != 'locked'
         run: composer config extra.symfony.require ${{ matrix.symfony-version }}
 
-      - name: Disable deprecations for non-locked dependencies
-        if: matrix.dependencies != 'locked'
-        run: echo "SYMFONY_DEPRECATIONS_HELPER=max[self]=0" >> $GITHUB_ENV
-
       # See https://symfony.com/doc/current/bundles/best_practices.html#require-a-specific-symfony-version
       - name: Install Flex
         if: matrix.dependencies != 'locked'
@@ -104,10 +100,6 @@ jobs:
       - name: Install lowest dependencies
         if: ${{ matrix.dependencies == 'lowest' }}
         run: composer update --no-interaction --prefer-dist --no-progress --prefer-lowest
-
-      - name: Configure the Symfony deprecations helper
-        if: ${{ matrix.php-version }} == '8.2'
-        run: echo "{SYMFONY_DEPRECATIONS_HELPER}={max[self]=0}" >> $GITHUB_ENV
 
       - name: Run unit tests
         shell: bash

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,6 @@
         "phpunit/phpunit": "^9.6",
         "rector/rector": "^0.16.0",
         "sidz/phpstan-rules": "^0.4.0",
-        "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
         "thecodingmachine/phpstan-safe-rule": "^1.2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3fe1922e709c4ab91ad45b147f4d6d31",
+    "content-hash": "ad51c11197f0eafc547b5124204c7a9b",
     "packages": [
         {
             "name": "colinodell/json5",
@@ -4733,89 +4733,6 @@
                 }
             ],
             "time": "2020-10-27T11:37:08+00:00"
-        },
-        {
-            "name": "symfony/phpunit-bridge",
-            "version": "v5.4.26",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "d04639b395e25efa4260fc5b12a9fa1eafb38a64"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/d04639b395e25efa4260fc5b12a9fa1eafb38a64",
-                "reference": "d04639b395e25efa4260fc5b12a9fa1eafb38a64",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1.3",
-                "symfony/deprecation-contracts": "^2.1|^3"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<7.5|9.1.2"
-            },
-            "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0|^6.0"
-            },
-            "suggest": {
-                "symfony/error-handler": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
-            },
-            "bin": [
-                "bin/simple-phpunit"
-            ],
-            "type": "symfony-bridge",
-            "extra": {
-                "thanks": {
-                    "name": "phpunit/phpunit",
-                    "url": "https://github.com/sebastianbergmann/phpunit"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Bridge\\PhpUnit\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/phpunit-bridge/tree/v5.4.26"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-07-12T15:44:31+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af34aee57083f6d4f1af82b8eb435654",
+    "content-hash": "8cdf52939b7918f58fceacc31011569e",
     "packages": [
         {
             "name": "colinodell/json5",
@@ -4738,89 +4738,6 @@
                 }
             ],
             "time": "2020-10-27T11:37:08+00:00"
-        },
-        {
-            "name": "symfony/phpunit-bridge",
-            "version": "v5.4.26",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "d04639b395e25efa4260fc5b12a9fa1eafb38a64"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/d04639b395e25efa4260fc5b12a9fa1eafb38a64",
-                "reference": "d04639b395e25efa4260fc5b12a9fa1eafb38a64",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1.3",
-                "symfony/deprecation-contracts": "^2.1|^3"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<7.5|9.1.2"
-            },
-            "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0|^6.0"
-            },
-            "suggest": {
-                "symfony/error-handler": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
-            },
-            "bin": [
-                "bin/simple-phpunit"
-            ],
-            "type": "symfony-bridge",
-            "extra": {
-                "thanks": {
-                    "name": "phpunit/phpunit",
-                    "url": "https://github.com/sebastianbergmann/phpunit"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Bridge\\PhpUnit\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/phpunit-bridge/tree/v5.4.26"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-07-12T15:44:31+00:00"
         },
         {
             "name": "symfony/polyfill-php81",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
 >
 
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
         <env name="COLUMNS" value="100" force="true" />
     </php>
 
@@ -34,10 +33,5 @@
             <group>e2e</group>
         </exclude>
     </groups>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-        <listener class="Symfony\Bridge\PhpUnit\CoverageListener" />
-    </listeners>
 
 </phpunit>

--- a/phpunit_autoreview.xml
+++ b/phpunit_autoreview.xml
@@ -10,10 +10,6 @@
          verbose="true"
 >
 
-    <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
-    </php>
-
     <testsuites>
         <testsuite name="Auto-Review Test Suite">
             <directory>tests/phpunit/AutoReview</directory>
@@ -25,10 +21,5 @@
             <directory>tests/phpunit/AutoReview</directory>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-        <listener class="Symfony\Bridge\PhpUnit\CoverageListener" />
-    </listeners>
 
 </phpunit>


### PR DESCRIPTION
As per #1921, we want to upgrade to PHPUnit 10/11 and the bridge is not compatible yet (and is unlikely to be for some time still).