### PR TITLE
Install `pcntl` in docker image as `make autoreview` fails with absent `SIGINT` const

### DIFF
--- a/devTools/Dockerfile
+++ b/devTools/Dockerfile
@@ -8,6 +8,12 @@ RUN set -eux; \
     apk add --no-cache --virtual .build-deps \
         ${PHPIZE_DEPS} \
         build-base \
+        libzip-dev \
+        zlib-dev \
+    ; \
+    docker-php-ext-configure zip; \
+    docker-php-ext-install -j$(nproc) \
+        pcntl \
     ; \
     pecl install xdebug-${XDEBUG_VERSION}; \
     pecl clear-cache; \


### PR DESCRIPTION
```bash
docker compose run php81 make autoreview
```

didn't work before, because Psalm was failing, complaining `\SIGINT` doesn't exist.

Now it works.
