### PR TITLE
Use the latest composer 2 to prevent issue with incompatibility for Box and composer 2.1

### DIFF
--- a/devTools/Dockerfile
+++ b/devTools/Dockerfile
@@ -35,7 +35,7 @@ RUN apk add --no-cache \
         git \
         zip
 
-COPY --from=composer:2.1 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 COPY memory-limit.ini xdebug.ini ${PHP_INI_DIR}/conf.d/
 
 RUN adduser -h /opt/infection -s /bin/bash -D infection


### PR DESCRIPTION
`make compile-docker` is currently doesn't work.

This PR fixes the issue.

Extracted from https://github.com/infection/infection/pull/1686