### PR TITLE
Enable Rector's `AddCoversClassAttributeRector` rule

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3517,16 +3517,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "1.0.3",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "c59507a9090b465d65e1aceed91e5b81986e375b"
+                "reference": "73eb63e4f9011dba6b7c66c3262543014e352f34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/c59507a9090b465d65e1aceed91e5b81986e375b",
-                "reference": "c59507a9090b465d65e1aceed91e5b81986e375b",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/73eb63e4f9011dba6b7c66c3262543014e352f34",
+                "reference": "73eb63e4f9011dba6b7c66c3262543014e352f34",
                 "shasum": ""
             },
             "require": {
@@ -3538,6 +3538,9 @@
                 "rector/rector-downgrade-php": "*",
                 "rector/rector-phpunit": "*",
                 "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
             },
             "bin": [
                 "bin/rector"
@@ -3561,7 +3564,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/1.0.3"
+                "source": "https://github.com/rectorphp/rector/tree/1.0.5"
             },
             "funding": [
                 {
@@ -3569,7 +3572,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-14T15:04:18+00:00"
+            "time": "2024-05-10T05:31:15+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/rector.php
+++ b/rector.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\AddCoversClassAttributeRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -42,6 +43,9 @@ return RectorConfig::configure()
         __DIR__ . '/tests/phpunit',
     ])
     ->withPhpSets(php81: true)
+    ->withRules([
+        AddCoversClassAttributeRector::class,
+    ])
     ->withSkip([
         ReadOnlyPropertyRector::class => [
             // property can't be readonly as it's returned by reference and may be updated

--- a/src/TestFramework/Coverage/BufferedSourceFileFilter.php
+++ b/src/TestFramework/Coverage/BufferedSourceFileFilter.php
@@ -37,7 +37,6 @@ namespace Infection\TestFramework\Coverage;
 
 use function array_key_exists;
 use Infection\FileSystem\FileFilter;
-use Infection\FileSystem\SourceFileFilter;
 use function Pipeline\take;
 use Symfony\Component\Finder\SplFileInfo;
 use Webmozart\Assert\Assert;
@@ -64,7 +63,6 @@ class BufferedSourceFileFilter implements FileFilter
     private array $sourceFiles = [];
 
     /**
-     * @param SourceFileFilter|FileFilter $filter
      * @param iterable<SplFileInfo> $sourceFiles
      */
     public function __construct(

--- a/src/TestFramework/Coverage/CoveredTraceProvider.php
+++ b/src/TestFramework/Coverage/CoveredTraceProvider.php
@@ -37,7 +37,6 @@ namespace Infection\TestFramework\Coverage;
 
 use Infection\FileSystem\FileFilter;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder;
-use Infection\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProvider;
 
 /**
  * Filters traces and augments them with timing data from JUnit report.
@@ -46,10 +45,6 @@ use Infection\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProvider;
  */
 final class CoveredTraceProvider implements TraceProvider
 {
-    /**
-     * @param PhpUnitXmlCoverageTraceProvider|TraceProvider $primaryTraceProvider
-     * @param BufferedSourceFileFilter|FileFilter $bufferedFilter
-     */
     public function __construct(private readonly TraceProvider $primaryTraceProvider, private readonly JUnitTestExecutionInfoAdder $testFileDataAdder, private readonly FileFilter $bufferedFilter)
     {
     }

--- a/src/TestFramework/Coverage/UnionTraceProvider.php
+++ b/src/TestFramework/Coverage/UnionTraceProvider.php
@@ -43,10 +43,6 @@ namespace Infection\TestFramework\Coverage;
  */
 final class UnionTraceProvider implements TraceProvider
 {
-    /**
-     * @param CoveredTraceProvider|TraceProvider $coveredTraceProvider
-     * @param UncoveredTraceProvider|TraceProvider $uncoveredTraceProvider
-     */
     public function __construct(private readonly TraceProvider $coveredTraceProvider, private readonly TraceProvider $uncoveredTraceProvider, private readonly bool $onlyCovered)
     {
     }


### PR DESCRIPTION
- Rule: https://github.com/rectorphp/rector-phpunit/blob/main/docs/rector_rules_overview.md#addcoversclassattributerector
- see my explanation why it's needed https://github.com/rectorphp/rector-phpunit/pull/319#issue-2204576592

Actually, I have already applied this rule previously for Infection's codebase when created it locally. Now it's enabled and will fix all future tests after new Rector 1.0.5 is released, so we can use it from the Rector's core.