### PR TITLE
Use new PHP-CS-Fixer with parallelization

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 $header = \trim(\sprintf(
     'This code is licensed under the BSD 3-Clause License.%s',
@@ -72,6 +73,7 @@ $finder = Finder::create()
 ;
 
 return (new Config())
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PHP71Migration' => true,

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BOX=./.tools/box
 BOX_URL="https://github.com/humbug/box/releases/download/4.5.1/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
-PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.52.0/php-cs-fixer.phar"
+PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.57.1/php-cs-fixer.phar"
 PHP_CS_FIXER_CACHE=.php_cs.cache
 
 PHPSTAN=./vendor/bin/phpstan


### PR DESCRIPTION
See https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.57.0

```diff
- Fixed 0 of 915 files in 38.481 seconds, 27.008 MB memory use
+ Fixed 0 of 915 files in 8.115 seconds, 19.008 MB memory used
```