### PR TITLE
When IgnoreMutator decorator class is used, work with underlying class of mutator to get its definition

### DIFF
--- a/src/Logger/Html/StrykerHtmlReportBuilder.php
+++ b/src/Logger/Html/StrykerHtmlReportBuilder.php
@@ -319,7 +319,7 @@ final class StrykerHtmlReportBuilder
     {
         Assert::true(MutatorResolver::isValidMutator($mutatorClass), sprintf('Unknown mutator "%s"', $mutatorClass));
 
-        /** @var Mutator<NodeAbstract> $mutatorClass */
+        /** @var class-string<Mutator<NodeAbstract>> $mutatorClass */
         $mutatorClass = ProfileList::ALL_MUTATORS[$mutatorName] ?? $mutatorClass;
 
         $definition = $mutatorClass::getDefinition();

--- a/src/Logger/Html/StrykerHtmlReportBuilder.php
+++ b/src/Logger/Html/StrykerHtmlReportBuilder.php
@@ -54,13 +54,16 @@ use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutator\FunctionSignature\ProtectedVisibility;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
+use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\MutatorResolver;
+use Infection\Mutator\ProfileList;
 use Infection\Mutator\Removal\MethodCallRemoval;
 use Infection\Str;
 use function ltrim;
 use function md5;
 use const PHP_EOL;
+use PhpParser\NodeAbstract;
 use function Safe\file_get_contents;
 use function Safe\preg_match;
 use function Safe\preg_split;
@@ -246,7 +249,7 @@ final class StrykerHtmlReportBuilder
                     'id' => $result->getMutantHash(),
                     'mutatorName' => $result->getMutatorName(),
                     'replacement' => Str::convertToUtf8(Str::trimLineReturns(ltrim($replacement))),
-                    'description' => $this->getMutatorDescription($result->getMutatorClass()),
+                    'description' => $this->getMutatorDescription($result->getMutatorName(), $result->getMutatorClass()),
                     'location' => [
                         'start' => ['line' => $result->getOriginalStartingLine(), 'column' => $startingColumn],
                         'end' => ['line' => $endingLine, 'column' => $endingColumn],
@@ -312,9 +315,12 @@ final class StrykerHtmlReportBuilder
         return 0;
     }
 
-    private function getMutatorDescription(string $mutatorClass): string
+    private function getMutatorDescription(string $mutatorName, string $mutatorClass): string
     {
         Assert::true(MutatorResolver::isValidMutator($mutatorClass), sprintf('Unknown mutator "%s"', $mutatorClass));
+
+        /** @var Mutator<NodeAbstract> $mutatorClass */
+        $mutatorClass = ProfileList::ALL_MUTATORS[$mutatorName] ?? $mutatorClass;
 
         $definition = $mutatorClass::getDefinition();
 

--- a/tests/phpunit/Logger/Html/StrykerHtmlReportBuilderTest.php
+++ b/tests/phpunit/Logger/Html/StrykerHtmlReportBuilderTest.php
@@ -45,6 +45,7 @@ use Infection\Metrics\ResultsCollector;
 use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutator\FunctionSignature\PublicVisibility;
+use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Removal\ArrayItemRemoval;
 use Infection\Mutator\Removal\MethodCallRemoval;
 use Infection\Tests\Mutator\MutatorName;
@@ -301,7 +302,7 @@ final class StrykerHtmlReportBuilderTest extends TestCase
                              $this->inner('3');
                     DIFF,
                 '32f68ca331c9262cc97322271d88d06d',
-                PublicVisibility::class,
+                IgnoreMutator::class,
                 realpath(__DIR__ . '/../../Fixtures/ForHtmlReport.php'),
                 13,
                 35,
@@ -312,6 +313,8 @@ final class StrykerHtmlReportBuilderTest extends TestCase
                     // check that duplicate values are moved in the report
                     new TestLocation('TestClass::test_method1', '/infection/path/to/TestClass.php', 0.123),
                 ],
+                'PHPUnit output. Tests: 1, Assertions: 3',
+                'PublicVisibility',
             ),
             // this tests diff on the one-line method call removal
             self::createMutantExecutionResult(
@@ -472,6 +475,7 @@ final class StrykerHtmlReportBuilderTest extends TestCase
         int $originalEndFilePosition,
         array $testLocations,
         ?string $processOutput = 'PHPUnit output. Tests: 1, Assertions: 3',
+        ?string $mutatorName = null,
     ): MutantExecutionResult {
         return new MutantExecutionResult(
             'bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"',
@@ -480,7 +484,7 @@ final class StrykerHtmlReportBuilderTest extends TestCase
             now(normalize_trailing_spaces($diff)),
             $mutantHash,
             $mutatorClassName,
-            MutatorName::getName($mutatorClassName),
+            $mutatorName ?? MutatorName::getName($mutatorClassName),
             $originalFileRealPath,
             $originalStartingLine,
             $originalEndingLine,


### PR DESCRIPTION
Fixes:

```
DomainException: The class "Infection\Mutator\IgnoreMutator" does not have a definition
```

on StrykerHtmlReportBuilder.php

Bug has been introduced in https://github.com/infection/infection/pull/1686/files#diff-01143bfb1cd8c30fa7f368e58fa5b9bebf3f35de2a4bc509123ed81358b59ff8R249

---

fixes master builds
