### PR TITLE
[Logs] Highlight inline differences in CLI

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.11.0@c9b192ab8400fdaf04b2b13d110575adc879aa90">
+  <file src="src/Differ/DiffColorizer.php">
+    <InvalidArrayOffset>
+      <code>$lines[$prevIndex]</code>
+    </InvalidArrayOffset>
+  </file>
   <file src="src/Mutator/Extensions/BCMath.php">
     <ImpureFunctionCall>
       <code><![CDATA[$this->converters[$name->toLowerString()]($node)]]></code>

--- a/src/Console/OutputFormatterStyleConfigurator.php
+++ b/src/Console/OutputFormatterStyleConfigurator.php
@@ -72,9 +72,9 @@ final class OutputFormatterStyleConfigurator
     private static function configureDiffStyle(OutputFormatterInterface $formatter): void
     {
         $formatter->setStyle('diff-add', new OutputFormatterStyle('green', null, ['bold']));
-        $formatter->setStyle('diff-add-inline', new OutputFormatterStyle( 'green', null, ['bold', 'reverse']));
+        $formatter->setStyle('diff-add-inline', new OutputFormatterStyle('green', null, ['bold', 'reverse']));
         $formatter->setStyle('diff-del', new OutputFormatterStyle('red', null, ['bold']));
-        $formatter->setStyle('diff-del-inline', new OutputFormatterStyle( 'red', null, ['bold', 'reverse']));
+        $formatter->setStyle('diff-del-inline', new OutputFormatterStyle('red', null, ['bold', 'reverse']));
     }
 
     private static function configureMutationScoreStyle(OutputFormatterInterface $formatter): void

--- a/src/Console/OutputFormatterStyleConfigurator.php
+++ b/src/Console/OutputFormatterStyleConfigurator.php
@@ -71,8 +71,10 @@ final class OutputFormatterStyleConfigurator
 
     private static function configureDiffStyle(OutputFormatterInterface $formatter): void
     {
-        $formatter->setStyle('diff-add', new OutputFormatterStyle('green'));
-        $formatter->setStyle('diff-del', new OutputFormatterStyle('red'));
+        $formatter->setStyle('diff-add', new OutputFormatterStyle('green', null, ['bold']));
+        $formatter->setStyle('diff-add-inline', new OutputFormatterStyle( 'green', null, ['bold', 'reverse']));
+        $formatter->setStyle('diff-del', new OutputFormatterStyle('red', null, ['bold']));
+        $formatter->setStyle('diff-del-inline', new OutputFormatterStyle( 'red', null, ['bold', 'reverse']));
     }
 
     private static function configureMutationScoreStyle(OutputFormatterInterface $formatter): void

--- a/src/Container.php
+++ b/src/Container.php
@@ -285,7 +285,7 @@ final class Container
                 $container->getPrinter(),
                 $container->getMutantCodeFactory(),
             ),
-            Differ::class => static fn (): Differ => new Differ(new BaseDiffer(new UnifiedDiffOutputBuilder())),
+            Differ::class => static fn (): Differ => new Differ(new BaseDiffer(new UnifiedDiffOutputBuilder(''))),
             SyncEventDispatcher::class => static fn (): SyncEventDispatcher => new SyncEventDispatcher(),
             ParallelProcessRunner::class => static fn (self $container): ParallelProcessRunner => new ParallelProcessRunner($container->getConfiguration()->getThreadCount()),
             DryProcessRunner::class => static fn (): DryProcessRunner => new DryProcessRunner(),

--- a/src/Differ/DiffColorizer.php
+++ b/src/Differ/DiffColorizer.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Differ;
 
-use function array_map;
+use Webmozart\Assert\Assert;
 use function explode;
 use function implode;
 use function sprintf;
@@ -49,21 +49,49 @@ class DiffColorizer
 {
     public function colorize(string $diff): string
     {
-        $lines = array_map(
-            static function (string $line): string {
-                if (str_starts_with($line, '-')) {
-                    return sprintf('<diff-del>%s</diff-del>', $line);
-                }
+        $lines = explode("\n", $diff);
+        foreach ($lines as $index => $line) {
+            if (! str_starts_with($line, '+')) {
+                continue;
+            }
 
-                if (str_starts_with($line, '+')) {
-                    return sprintf('<diff-add>%s</diff-add>', $line);
-                }
+            $prevIndex = $index - 1;
+            $prevLine = $lines[$prevIndex];
 
-                return $line;
-            },
-            explode("\n", $diff),
-        );
+            Assert::same($prevLine[0], '-');
+
+            $lines[$prevIndex] = sprintf('<diff-del>-%s</diff-del>',
+                $this->inlineDiff(substr($prevLine, 1), substr($line, 1), '<diff-del-inline>', '</diff-del-inline>')
+            );
+            $lines[$index] = sprintf('<diff-add>+%s</diff-add>',
+                $this->inlineDiff(substr($line, 1), substr($prevLine, 1), '<diff-add-inline>', '</diff-add-inline>')
+            );
+        }
 
         return sprintf('<code>%s%s</code>', "\n", implode("\n", $lines));
+    }
+
+    private function inlineDiff(string $previousLine, string $nextLine, string $leftAddition, string $rightAddition): string
+    {
+        $previousLineLength = mb_strlen($previousLine);
+        $nextLineLength = mb_strlen($nextLine);
+
+        $start = $previousLineLength;
+        while ($start && 0 !== mb_strpos($nextLine, mb_substr($previousLine, 0, $start))) {
+            --$start;
+        }
+
+        $end = $start;
+        while ($end < $previousLineLength && mb_strrpos($nextLine, ($t = mb_substr($previousLine, $end)), $start) !== ($nextLineLength - mb_strlen($t))) {
+            ++$end;
+        }
+
+        $return = $previousLine;
+        if ($start < $end) {
+            $return = substr_replace($return, $rightAddition, $end, 0);
+            $return = substr_replace($return, $leftAddition, $start, 0);
+        }
+
+        return $return;
     }
 }

--- a/src/Logger/Html/StrykerHtmlReportBuilder.php
+++ b/src/Logger/Html/StrykerHtmlReportBuilder.php
@@ -91,7 +91,7 @@ final class StrykerHtmlReportBuilder
     ];
 
     private const PLUS_LENGTH = 1;
-    private const DIFF_HEADERS_LINES_COUNT = 3;
+    private const DIFF_HEADERS_LINES_COUNT = 1;
 
     public function __construct(private readonly MetricsCalculator $metricsCalculator, private readonly ResultsCollector $resultsCollector)
     {
@@ -276,8 +276,6 @@ final class StrykerHtmlReportBuilder
             static fn (string $line): string => isset($line[0]) ? substr($line, self::PLUS_LENGTH) : $line,
             array_filter(
                 /*
-                --- Original
-                +++ New
                 @@ @@
                  */
                 array_slice($lines, self::DIFF_HEADERS_LINES_COUNT),

--- a/tests/phpunit/Console/OutputFormatterStyleConfiguratorTest.php
+++ b/tests/phpunit/Console/OutputFormatterStyleConfiguratorTest.php
@@ -48,7 +48,7 @@ final class OutputFormatterStyleConfiguratorTest extends TestCase
     {
         $formatter = $this->createMock(OutputFormatterInterface::class);
         $formatter
-            ->expects($this->exactly(14))
+            ->expects($this->exactly(16))
             ->method('setStyle')
         ;
 

--- a/tests/phpunit/Differ/DiffColorizerTest.php
+++ b/tests/phpunit/Differ/DiffColorizerTest.php
@@ -37,36 +37,105 @@ namespace Infection\Tests\Differ;
 
 use Infection\Differ\DiffColorizer;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(DiffColorizer::class)]
 final class DiffColorizerTest extends TestCase
 {
-    public function test_id_adds_colours_to_a_given_diff(): void
+    /**
+     * @param non-empty-string $originalDiff
+     * @param non-empty-string $expected
+     */
+    #[DataProvider('provideDiffs')]
+    public function test_id_adds_colours_to_a_given_diff(string $originalDiff, string $expected): void
     {
-        $originalDiff = <<<'CODE'
-            --- Original
-            +++ New
-            @@ @@
-                 function ($a) {
-            -        return $a < 0;
-            +        return $a <= 0;
-                 }
-            CODE;
-
-        $expected = <<<'CODE'
-            <code>
-            <diff-del>--- Original</diff-del>
-            <diff-add>+++ New</diff-add>
-            @@ @@
-                 function ($a) {
-            <diff-del>-        return $a < 0;</diff-del>
-            <diff-add>+        return $a <= 0;</diff-add>
-                 }</code>
-            CODE;
-
         $actual = (new DiffColorizer())->colorize($originalDiff);
 
         $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @return list<list<non-empty-string>>
+     */
+    public static function provideDiffs(): array
+    {
+        return [
+            'full-deletion' => [
+                <<<'CODE'
+                     function ($a) {
+                -        exit();
+                +
+                     }
+                CODE,
+                <<<'CODE'
+                <code>
+                     function ($a) {
+                <diff-del>-<diff-del-inline>        exit();</diff-del-inline></diff-del>
+                <diff-add>+</diff-add>
+                     }</code>
+                CODE,
+            ],
+            'full-addition' => [
+                <<<'CODE'
+                     function ($a) {
+                -
+                +        exit();
+                     }
+                CODE,
+                <<<'CODE'
+                <code>
+                     function ($a) {
+                <diff-del>-</diff-del>
+                <diff-add>+<diff-add-inline>        exit();</diff-add-inline></diff-add>
+                     }</code>
+                CODE,
+            ],
+            'partial-deletion' => [
+                <<<'CODE'
+                     function ($a) {
+                -        return 'foo' . 'bar';
+                +        return 'foo';
+                     }
+                CODE,
+                <<<'CODE'
+                <code>
+                     function ($a) {
+                <diff-del>-        return 'foo'<diff-del-inline> . 'bar'</diff-del-inline>;</diff-del>
+                <diff-add>+        return 'foo';</diff-add>
+                     }</code>
+                CODE,
+            ],
+            'partial-addition' => [
+                <<<'CODE'
+                     function ($a) {
+                -        return 'foo';
+                +        return 'foo' . 'bar';
+                     }
+                CODE,
+                <<<'CODE'
+                <code>
+                     function ($a) {
+                <diff-del>-        return 'foo';</diff-del>
+                <diff-add>+        return 'foo'<diff-add-inline> . 'bar'</diff-add-inline>;</diff-add>
+                     }</code>
+                CODE,
+            ],
+            'deletion-and-addition' => [
+                <<<'CODE'
+                     function ($a, $b) {
+                -        return $a && $b;
+                +        return $a || $b;
+                     }
+                CODE,
+                <<<'CODE'
+                <code>
+                     function ($a, $b) {
+                <diff-del>-        return $a <diff-del-inline>&&</diff-del-inline> $b;</diff-del>
+                <diff-add>+        return $a <diff-add-inline>||</diff-add-inline> $b;</diff-add>
+                     }</code>
+                CODE,
+            ],
+        ];
     }
 }

--- a/tests/phpunit/Differ/DiffColorizerTest.php
+++ b/tests/phpunit/Differ/DiffColorizerTest.php
@@ -56,85 +56,85 @@ final class DiffColorizerTest extends TestCase
     }
 
     /**
-     * @return list<list<non-empty-string>>
+     * @return array<non-empty-string, list<non-empty-string>>
      */
     public static function provideDiffs(): array
     {
         return [
             'full-deletion' => [
                 <<<'CODE'
-                     function ($a) {
-                -        exit();
-                +
-                     }
-                CODE,
+                         function ($a) {
+                    -        exit();
+                    +
+                         }
+                    CODE,
                 <<<'CODE'
-                <code>
-                     function ($a) {
-                <diff-del>-<diff-del-inline>        exit();</diff-del-inline></diff-del>
-                <diff-add>+</diff-add>
-                     }</code>
-                CODE,
+                    <code>
+                         function ($a) {
+                    <diff-del>-<diff-del-inline>        exit();</diff-del-inline></diff-del>
+                    <diff-add>+</diff-add>
+                         }</code>
+                    CODE,
             ],
             'full-addition' => [
                 <<<'CODE'
-                     function ($a) {
-                -
-                +        exit();
-                     }
-                CODE,
+                         function ($a) {
+                    -
+                    +        exit();
+                         }
+                    CODE,
                 <<<'CODE'
-                <code>
-                     function ($a) {
-                <diff-del>-</diff-del>
-                <diff-add>+<diff-add-inline>        exit();</diff-add-inline></diff-add>
-                     }</code>
-                CODE,
+                    <code>
+                         function ($a) {
+                    <diff-del>-</diff-del>
+                    <diff-add>+<diff-add-inline>        exit();</diff-add-inline></diff-add>
+                         }</code>
+                    CODE,
             ],
             'partial-deletion' => [
                 <<<'CODE'
-                     function ($a) {
-                -        return 'foo' . 'bar';
-                +        return 'foo';
-                     }
-                CODE,
+                         function ($a) {
+                    -        return 'foo' . 'bar';
+                    +        return 'foo';
+                         }
+                    CODE,
                 <<<'CODE'
-                <code>
-                     function ($a) {
-                <diff-del>-        return 'foo'<diff-del-inline> . 'bar'</diff-del-inline>;</diff-del>
-                <diff-add>+        return 'foo';</diff-add>
-                     }</code>
-                CODE,
+                    <code>
+                         function ($a) {
+                    <diff-del>-        return 'foo'<diff-del-inline> . 'bar'</diff-del-inline>;</diff-del>
+                    <diff-add>+        return 'foo';</diff-add>
+                         }</code>
+                    CODE,
             ],
             'partial-addition' => [
                 <<<'CODE'
-                     function ($a) {
-                -        return 'foo';
-                +        return 'foo' . 'bar';
-                     }
-                CODE,
+                         function ($a) {
+                    -        return 'foo';
+                    +        return 'foo' . 'bar';
+                         }
+                    CODE,
                 <<<'CODE'
-                <code>
-                     function ($a) {
-                <diff-del>-        return 'foo';</diff-del>
-                <diff-add>+        return 'foo'<diff-add-inline> . 'bar'</diff-add-inline>;</diff-add>
-                     }</code>
-                CODE,
+                    <code>
+                         function ($a) {
+                    <diff-del>-        return 'foo';</diff-del>
+                    <diff-add>+        return 'foo'<diff-add-inline> . 'bar'</diff-add-inline>;</diff-add>
+                         }</code>
+                    CODE,
             ],
             'deletion-and-addition' => [
                 <<<'CODE'
-                     function ($a, $b) {
-                -        return $a && $b;
-                +        return $a || $b;
-                     }
-                CODE,
+                         function ($a, $b) {
+                    -        return $a && $b;
+                    +        return $a || $b;
+                         }
+                    CODE,
                 <<<'CODE'
-                <code>
-                     function ($a, $b) {
-                <diff-del>-        return $a <diff-del-inline>&&</diff-del-inline> $b;</diff-del>
-                <diff-add>+        return $a <diff-add-inline>||</diff-add-inline> $b;</diff-add>
-                     }</code>
-                CODE,
+                    <code>
+                         function ($a, $b) {
+                    <diff-del>-        return $a <diff-del-inline>&&</diff-del-inline> $b;</diff-del>
+                    <diff-add>+        return $a <diff-add-inline>||</diff-add-inline> $b;</diff-add>
+                         }</code>
+                    CODE,
             ],
         ];
     }

--- a/tests/phpunit/Logger/Html/StrykerHtmlReportBuilderTest.php
+++ b/tests/phpunit/Logger/Html/StrykerHtmlReportBuilderTest.php
@@ -289,8 +289,6 @@ final class StrykerHtmlReportBuilderTest extends TestCase
             self::createMutantExecutionResult(
                 DetectionStatus::KILLED,
                 <<<'DIFF'
-                    --- Original
-                    +++ New
                     @@ @@
                      use function array_fill_keys;
                      final class ForHtmlReport
@@ -320,8 +318,6 @@ final class StrykerHtmlReportBuilderTest extends TestCase
             self::createMutantExecutionResult(
                 DetectionStatus::ESCAPED,
                 <<<'DIFF'
-                    --- Original
-                    +++ New
                     @@ @@
                      {
                          public function add(int $a, int $b) : int
@@ -348,8 +344,6 @@ final class StrykerHtmlReportBuilderTest extends TestCase
             self::createMutantExecutionResult(
                 DetectionStatus::ESCAPED,
                 <<<'DIFF'
-                    --- Original
-                    +++ New
                     @@ @@
                          public function add(int $a, int $b) : int
                          {
@@ -376,8 +370,6 @@ final class StrykerHtmlReportBuilderTest extends TestCase
             self::createMutantExecutionResult(
                 DetectionStatus::ESCAPED,
                 <<<'DIFF'
-                    --- Original
-                    +++ New
                     @@ @@
                                  default:
                                      break;
@@ -406,8 +398,6 @@ final class StrykerHtmlReportBuilderTest extends TestCase
             self::createMutantExecutionResult(
                 DetectionStatus::KILLED,
                 <<<'DIFF'
-                    --- Original
-                    +++ New
                     @@ @@
                      use function array_fill_keys;
                      final class ForHtmlReport2
@@ -434,8 +424,6 @@ final class StrykerHtmlReportBuilderTest extends TestCase
             self::createMutantExecutionResult(
                 DetectionStatus::KILLED,
                 <<<'DIFF'
-                    --- Original
-                    +++ New
                     @@ @@
                      use function array_fill_keys;
                      final class ForHtmlReport2


### PR DESCRIPTION
Fix https://github.com/infection/infection/issues/1810

> Why not to use [`jfcherng/php-diff`](https://github.com/jfcherng/php-diff) or [`diff-so-fancy`](https://github.com/so-fancy/diff-so-fancy)?

Infection's use case is much more limited: diffs are one-line only, and within the same line only one difference can happen.
Yes the algorithm in this PR needs some time to get understood, but less than tracking and maintaining another dependency.