### PR TITLE
Do not auto-detect project root directory inside RunCommand, do it only if GitHub/GitLab loggers are used

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -65,7 +65,6 @@ use function is_numeric;
 use function max;
 use const PHP_SAPI;
 use Psr\Log\LoggerInterface;
-use function Safe\shell_exec;
 use function sprintf;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -434,18 +433,6 @@ final class RunCommand extends BaseCommand
         $gitlabFileLogPath = trim((string) $input->getOption(self::OPTION_LOGGER_GITLAB));
         $htmlFileLogPath = trim((string) $input->getOption(self::OPTION_LOGGER_HTML));
         $loggerProjectRootDirectory = $input->getOption(self::OPTION_LOGGER_PROJECT_ROOT_DIRECTORY);
-
-        // auto-detect project-root-directory on GitHub and GitLab if not manually set
-        // default retrieve it using git rev-parse
-        if ($loggerProjectRootDirectory === null) {
-            if (($githubWorkspace = getenv('GITHUB_WORKSPACE')) !== false) {
-                $loggerProjectRootDirectory = $githubWorkspace;
-            } elseif (($gitlabCiProjectDir = getenv('CI_PROJECT_DIR')) !== false) {
-                $loggerProjectRootDirectory = $gitlabCiProjectDir;
-            } else {
-                $loggerProjectRootDirectory = trim(shell_exec('git rev-parse --show-toplevel'));
-            }
-        }
 
         /** @var string|null $minMsi */
         $minMsi = $input->getOption(self::OPTION_MIN_MSI);

--- a/src/Logger/FileLoggerFactory.php
+++ b/src/Logger/FileLoggerFactory.php
@@ -59,10 +59,6 @@ class FileLoggerFactory
         $loggers = [];
 
         foreach ($this->createLineLoggers($logConfig) as $filePath => $lineLogger) {
-            if ($filePath === null) {
-                continue;
-            }
-
             $loggers[] = $this->wrapWithFileLogger($filePath, $lineLogger);
         }
 
@@ -70,7 +66,7 @@ class FileLoggerFactory
     }
 
     /**
-     * @return iterable<?string, LineMutationTestingResultsLogger>
+     * @return iterable<string, LineMutationTestingResultsLogger>
      */
     private function createLineLoggers(Logs $logConfig): iterable
     {
@@ -78,21 +74,37 @@ class FileLoggerFactory
             return;
         }
 
-        yield $logConfig->getTextLogFilePath() => $this->createTextLogger();
+        if ($logConfig->getTextLogFilePath() !== null) {
+            yield $logConfig->getTextLogFilePath() => $this->createTextLogger();
+        }
 
-        yield $logConfig->getHtmlLogFilePath() => $this->createHtmlLogger();
+        if ($logConfig->getHtmlLogFilePath() !== null) {
+            yield $logConfig->getHtmlLogFilePath() => $this->createHtmlLogger();
+        }
 
-        yield $logConfig->getSummaryLogFilePath() => $this->createSummaryLogger();
+        if ($logConfig->getSummaryLogFilePath() !== null) {
+            yield $logConfig->getSummaryLogFilePath() => $this->createSummaryLogger();
+        }
 
-        yield $logConfig->getJsonLogFilePath() => $this->createJsonLogger();
+        if ($logConfig->getJsonLogFilePath() !== null) {
+            yield $logConfig->getJsonLogFilePath() => $this->createJsonLogger();
+        }
 
-        yield $logConfig->getGitlabLogFilePath() => $this->createGitlabLogger();
+        if ($logConfig->getGitlabLogFilePath() !== null) {
+            yield $logConfig->getGitlabLogFilePath() => $this->createGitlabLogger();
+        }
 
-        yield $logConfig->getDebugLogFilePath() => $this->createDebugLogger();
+        if ($logConfig->getDebugLogFilePath() !== null) {
+            yield $logConfig->getDebugLogFilePath() => $this->createDebugLogger();
+        }
 
-        yield $logConfig->getPerMutatorFilePath() => $this->createPerMutatorLogger();
+        if ($logConfig->getPerMutatorFilePath() !== null) {
+            yield $logConfig->getPerMutatorFilePath() => $this->createPerMutatorLogger();
+        }
 
-        yield $logConfig->getSummaryJsonLogFilePath() => $this->createSummaryJsonLogger();
+        if ($logConfig->getSummaryJsonLogFilePath() !== null) {
+            yield $logConfig->getSummaryJsonLogFilePath() => $this->createSummaryJsonLogger();
+        }
 
         if ($logConfig->getUseGitHubAnnotationsLogger()) {
             yield GitHubAnnotationsLogger::DEFAULT_OUTPUT => $this->createGitHubAnnotationsLogger();

--- a/tests/benchmark/Tracing/provide-traces-closure.php
+++ b/tests/benchmark/Tracing/provide-traces-closure.php
@@ -76,6 +76,7 @@ $container = Container::create()->withValues(
     true,
     Container::DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES,
     Container::DEFAULT_MAP_SOURCE_CLASS_TO_TEST_STRATEGY,
+    Container::DEFAULT_LOGGER_PROJECT_ROOT_DIRECTORY,
 );
 
 $generateTraces = static function (?int $maxCount) use ($container): iterable {


### PR DESCRIPTION
Do not auto-detect project root directory inside RunCommand, do it only if GitHub/GitLab loggers are used.

Also, do not create file loggers if they are not configured, only create/instantiate objects if explicitly asked by configuration file, otherwise constructor fails with `git rev-parse` as well.

Fixes https://github.com/infection/infection/issues/1980 and https://github.com/infection/infection/issues/1981

Test will be as a separate PR as it's not that easy to cover it, re-creating the env without git. I'm going to use a docker container and e2e test, but let's not block here and release a fix version.