### PR TITLE
Draft: fix: Detect invalid PHP-Parser versions

### DIFF
--- a/tests/e2e/IncompatiblePhpParser/.gitignore
+++ b/tests/e2e/IncompatiblePhpParser/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/*.cache

--- a/tests/e2e/IncompatiblePhpParser/composer.json
+++ b/tests/e2e/IncompatiblePhpParser/composer.json
@@ -1,0 +1,18 @@
+{
+    "require": {
+        "nikic/php-parser": "^4.19.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10"
+    },
+    "autoload": {
+        "psr-4": {
+            "e2ePhpParserVersion\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "e2ePhpParserVersion\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/e2e/IncompatiblePhpParser/expected-output.txt
+++ b/tests/e2e/IncompatiblePhpParser/expected-output.txt
@@ -1,0 +1,10 @@
+Total: 1
+
+Killed: 1
+Errored: 0
+Syntax Errors: 0
+Escaped: 0
+Timed Out: 0
+Skipped: 0
+Ignored: 0
+Not Covered: 0

--- a/tests/e2e/IncompatiblePhpParser/infection.json
+++ b/tests/e2e/IncompatiblePhpParser/infection.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/IncompatiblePhpParser/phpunit.xml.dist
+++ b/tests/e2e/IncompatiblePhpParser/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/schema/10.4.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/tests/e2e/IncompatiblePhpParser/src/AstSampleProvider.php
+++ b/tests/e2e/IncompatiblePhpParser/src/AstSampleProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace e2ePhpParserVersion;
+
+use PhpParser\ParserFactory;
+
+class AstSampleProvider
+{
+    public static function provideSample(): array
+    {
+        $code = <<<'CODE'
+        <?php
+
+        function test($foo)
+        {
+            var_dump($foo);
+        }
+        CODE;
+
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+
+        return $parser->parse($code);
+    }
+}

--- a/tests/e2e/IncompatiblePhpParser/tests/AstSampleProviderTest.php
+++ b/tests/e2e/IncompatiblePhpParser/tests/AstSampleProviderTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace e2ePhpParserVersion\Test;
+
+use e2ePhpParserVersion\AstSampleProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AstSampleProvider::class)]
+class AstSampleProviderTest extends TestCase
+{
+    public function test_it_can_provide_a_sample(): void
+    {
+        $sample = AstSampleProvider::provideSample();
+
+        self::assertNotEmpty($sample);
+    }
+}

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -168,7 +168,6 @@ final class E2ETest extends TestCase
     }
 
     #[DataProvider('e2eTestSuiteDataProvider')]
-    #[RunInSeparateProcess]
     public function test_it_runs_an_e2e_test_with_success(string $fullPath): void
     {
         $this->runOnE2EFixture($fullPath);
@@ -182,6 +181,10 @@ final class E2ETest extends TestCase
             ->directories();
 
         foreach ($directories as $dirName) {
+            if (basename((string) $dirName) !== 'IncompatiblePhpParser') {
+                continue;
+            }
+
             if (file_exists($dirName . '/run_tests.bash')) {
                 // skipping non-standard tests
                 // specifically Memory_Limit - it is very slow to fail


### PR DESCRIPTION
Related to #1984.

The goal of the PR is to bail out more gracefully when an incompatible version of PHP-Parser is used.