### PR TITLE
Ignore switch(bool) statements in TrueValue and FalseValue mutators.

### DIFF
--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -39,6 +39,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
+use Infection\PhpParser\Visitor\ParentConnector;
 use PhpParser\Node;
 
 /**
@@ -75,7 +76,9 @@ final class FalseValue implements Mutator
 
     public function canMutate(Node $node): bool
     {
-        if (!$node instanceof Node\Expr\ConstFetch) {
+        $parentNode = ParentConnector::findParent($node);
+
+        if (!$node instanceof Node\Expr\ConstFetch || $parentNode instanceof Node\Stmt\Switch_) {
             return false;
         }
 

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -101,6 +101,10 @@ final class TrueValue implements ConfigurableMutator
         $parentNode = ParentConnector::findParent($node);
         $grandParentNode = $parentNode !== null ? ParentConnector::findParent($parentNode) : null;
 
+        if ($parentNode instanceof Node\Stmt\Switch_) {
+            return false;
+        }
+
         if (!$grandParentNode instanceof Node\Expr\FuncCall || !$grandParentNode->name instanceof Node\Name) {
             return true;
         }

--- a/tests/phpunit/Mutator/Boolean/FalseValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/FalseValueTest.php
@@ -80,6 +80,15 @@ final class FalseValueTest extends BaseMutatorTestCase
             ,
         ];
 
+        yield 'It does not mutate switch false to true' => [
+            <<<'PHP'
+                <?php
+
+                switch (false) {}
+                PHP
+            ,
+        ];
+
         yield 'It mutates all caps false to true' => [
             <<<'PHP'
                 <?php

--- a/tests/phpunit/Mutator/Boolean/TrueValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/TrueValueTest.php
@@ -106,6 +106,14 @@ final class TrueValueTest extends BaseMutatorTestCase
                 PHP,
         ];
 
+        yield 'It does not mutate switch true to false' => [
+            <<<'PHP'
+                <?php
+
+                switch (true) {}
+                PHP,
+        ];
+
         yield 'It mutates all caps true to false' => [
             <<<'PHP'
                 <?php


### PR DESCRIPTION
This PR:

- [x] Modifies TrueValue and FalseValue mutators to ignore switch(boolval) statements.
- [x] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

Fixes https://github.com/infection/infection/issues/819

This will stop false positives related to boolean values in switch conditions, where no code coverage has been detected.