### PR TITLE
Use Null Coalescing Assignment Operator

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -718,7 +718,7 @@ final class Container
 
     public function getDefaultJUnitFilePath(): string
     {
-        return $this->defaultJUnitPath ?? $this->defaultJUnitPath = sprintf(
+        return $this->defaultJUnitPath ??= sprintf(
             '%s/%s',
             Path::canonicalize(
                 $this->getConfiguration()->getCoveragePath(),

--- a/src/Differ/FilesDiffChangedLines.php
+++ b/src/Differ/FilesDiffChangedLines.php
@@ -52,12 +52,11 @@ class FilesDiffChangedLines
 
     public function contains(string $fileRealPath, int $mutationStartLine, int $mutationEndLine, ?string $gitDiffBase): bool
     {
-        $map = $this->memoizedFilesChangedLinesMap
-            ?? $this->memoizedFilesChangedLinesMap = $this->diffChangedLinesParser->parse(
-                $this->diffFileProvider->provideWithLines($gitDiffBase ?? GitDiffFileProvider::DEFAULT_BASE),
-            );
+        $this->memoizedFilesChangedLinesMap ??= $this->diffChangedLinesParser->parse(
+            $this->diffFileProvider->provideWithLines($gitDiffBase ?? GitDiffFileProvider::DEFAULT_BASE),
+        );
 
-        foreach ($map[$fileRealPath] ?? [] as $changedLinesRange) {
+        foreach ($this->memoizedFilesChangedLinesMap[$fileRealPath] ?? [] as $changedLinesRange) {
             if ($mutationEndLine >= $changedLinesRange->getStartLine() && $mutationStartLine <= $changedLinesRange->getEndLine()) {
                 return true;
             }

--- a/src/Metrics/MetricsCalculator.php
+++ b/src/Metrics/MetricsCalculator.php
@@ -165,6 +165,6 @@ class MetricsCalculator implements Collector
 
     private function getCalculator(): Calculator
     {
-        return $this->calculator ?? $this->calculator = Calculator::fromMetrics($this);
+        return $this->calculator ??= Calculator::fromMetrics($this);
     }
 }

--- a/src/Mutant/MutantExecutionResult.php
+++ b/src/Mutant/MutantExecutionResult.php
@@ -39,7 +39,7 @@ use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\Mutator\MutatorResolver;
 use Later\Interfaces\Deferred;
 use RuntimeException;
-use function Safe\sprintf;
+use function sprintf;
 use function strlen;
 use function strrpos;
 use Webmozart\Assert\Assert;

--- a/src/Mutant/MutantFactory.php
+++ b/src/Mutant/MutantFactory.php
@@ -73,7 +73,7 @@ class MutantFactory
             $mutantFilePath,
             $mutation,
             $mutatedCode,
-            lazy($this->createMutantDiff($originalPrettyPrintedFile, $mutation, $mutatedCode)),
+            lazy($this->createMutantDiff($originalPrettyPrintedFile, $mutatedCode)),
             $originalPrettyPrintedFile,
         );
     }
@@ -90,7 +90,7 @@ class MutantFactory
      *
      * @return iterable<string>
      */
-    private function createMutantDiff(Deferred $originalPrettyPrintedFile, Mutation $mutation, Deferred $mutantCode): iterable
+    private function createMutantDiff(Deferred $originalPrettyPrintedFile, Deferred $mutantCode): iterable
     {
         yield $this->differ->diff($originalPrettyPrintedFile->get(), $mutantCode->get());
     }
@@ -103,7 +103,6 @@ class MutantFactory
     private function getOriginalPrettyPrintedFile(string $originalFilePath, array $originalStatements): iterable
     {
         // The same file may be mutated multiple times hence we can memoize that call
-        yield $this->printedFileCache[$originalFilePath]
-            ?? $this->printedFileCache[$originalFilePath] = $this->printer->prettyPrintFile($originalStatements);
+        yield $this->printedFileCache[$originalFilePath] ??= $this->printer->prettyPrintFile($originalStatements);
     }
 }

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -156,14 +156,12 @@ class NodeMutationGenerator
 
     private function isOnFunctionSignature(): bool
     {
-        return $this->isOnFunctionSignatureMemoized
-            ?? $this->isOnFunctionSignatureMemoized = $this->currentNode->getAttribute(ReflectionVisitor::IS_ON_FUNCTION_SIGNATURE, false);
+        return $this->isOnFunctionSignatureMemoized ??= $this->currentNode->getAttribute(ReflectionVisitor::IS_ON_FUNCTION_SIGNATURE, false);
     }
 
     private function isInsideFunction(): bool
     {
-        return $this->isInsideFunctionMemoized
-            ?? $this->isInsideFunctionMemoized = $this->currentNode->getAttribute(ReflectionVisitor::IS_INSIDE_FUNCTION_KEY, false);
+        return $this->isInsideFunctionMemoized ??= $this->currentNode->getAttribute(ReflectionVisitor::IS_INSIDE_FUNCTION_KEY, false);
     }
 
     /**

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -107,7 +107,7 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
 
     public function getVersion(): string
     {
-        return $this->version ?? $this->version = $this->retrieveVersion();
+        return $this->version ??= $this->retrieveVersion();
     }
 
     public function getInitialTestsFailRecommendations(string $commandLine): string

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -109,7 +109,7 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
 
     private function getXPath(): SafeDOMXPath
     {
-        return $this->xPath ?? $this->xPath = self::createXPath($this->jUnitLocator->locate());
+        return $this->xPath ??= self::createXPath($this->jUnitLocator->locate());
     }
 
     private static function createXPath(string $jUnitPath): SafeDOMXPath

--- a/tests/phpunit/BenchmarkTest.php
+++ b/tests/phpunit/BenchmarkTest.php
@@ -103,6 +103,6 @@ final class BenchmarkTest extends TestCase
 
     private function getPhpExecutable(): string
     {
-        return $this->phpExecutable ?? $this->phpExecutable = (new PhpExecutableFinder())->find();
+        return $this->phpExecutable ??= (new PhpExecutableFinder())->find();
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php
@@ -167,7 +167,7 @@ final class TestLocatorTest extends TestCase
 
     private function getTestsLocations(): array
     {
-        return self::$testsLocations ?? self::$testsLocations = [
+        return self::$testsLocations ??= [
             '/path/to/acme/Foo.php' => new TestLocations(
                 [
                     26 => [


### PR DESCRIPTION
This PR doesn't bring a big value it just replacing  `$variable ?? $variable = $this->dosmth()` with Null Coalescing Assignment Operator `$variable ??= $this->dosmth()`

Unfortunately there is no any rule nor in Rector or PHP-CS-Fixer which may cover such cases and fail builds in the future.

Existing in both projects doesn't take into account properties.
PHP-CS-Fixer: https://cs.symfony.com/doc/rules/operator/assign_null_coalescing_to_coalesce_equal.html
Rector: https://github.com/rectorphp/rector/blob/main/rules/Php74/Rector/Assign/NullCoalescingOperatorRector.php