### PR TITLE
Fallback to the simple diff colorizer (previous implementation) for multiline diffs

### DIFF
--- a/tests/phpunit/Differ/DiffColorizerTest.php
+++ b/tests/phpunit/Differ/DiffColorizerTest.php
@@ -136,6 +136,27 @@ final class DiffColorizerTest extends TestCase
                          }</code>
                     CODE,
             ],
+            'bug-1999' => [
+                <<<'CODE'
+                         protected function name()
+                         {
+                    -        return strtolower(get_class($this));
+                    +        strtolower(get_class($this));
+                    +        return null;
+                         }
+                     }
+                    CODE,
+                <<<'CODE'
+                    <code>
+                         protected function name()
+                         {
+                    <diff-del>-        return strtolower(get_class($this));</diff-del>
+                    <diff-add>+        strtolower(get_class($this));</diff-add>
+                    <diff-add>+        return null;</diff-add>
+                         }
+                     }</code>
+                    CODE,
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/1999

We introduced inline highlighter for diffs in https://github.com/infection/infection/pull/1974 (thanks to @Slamdunk). However, there was an incorrect assumption that we only have one-line diffs. This is not true.

The case which is currently fails is the following:

```diff
@@ @@
      */
     protected function name()
     {
-        return strtolower(get_class($this));
+        strtolower(get_class($this));
+        return null;
     }
 }
```

I checked how `diff-so-fancy` works with multiline diffs, and it turned out that it just skips inline diffs, using simple algorithm, see images below.

`diff-so-fancy` for multiline case (now we have the same result after this MR):

<img width="415" alt="image" src="https://github.com/user-attachments/assets/5a2e223e-f3b6-4836-a0fd-d76969eee3c3">

`diff-so-fancy` for one-line case (we have the same result):

<img width="408" alt="image" src="https://github.com/user-attachments/assets/49f4ef7b-61d0-4ad5-9c2f-cc3256117eaa">

So, for the cases when we have multiline diffs, I just added fallback - our old algorithm of colorizing diffs.

----

I've tested this patch with @sanmai's reproducer, it works fine:

```
vendor/bin/infection --min-msi=80 --min-covered-msi=80 --show-mutations -jmax -vvv --mutators=FunctionCall --filter=AbstractTag
```

<img width="434" alt="image" src="https://github.com/user-attachments/assets/e596a271-ecea-44c9-a169-64188004334a">
