### PR TITLE
add failing test for cacheResultFile

### DIFF
--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -90,7 +90,7 @@ class InitialConfigBuilder implements ConfigBuilder
         $this->addRandomTestsOrderAttributesIfNotSet($version, $xPath);
         $this->configManipulator->addFailOnAttributesIfNotSet($version, $xPath);
         $this->configManipulator->replaceWithAbsolutePaths($xPath);
-        $this->configManipulator->setStopOnFailure($xPath);
+        $this->configManipulator->setStopOnFailure($version, $xPath);
         $this->configManipulator->deactivateColours($xPath);
         $this->configManipulator->deactivateResultCaching($xPath);
         $this->configManipulator->deactivateStderrRedirection($xPath);

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -83,9 +83,9 @@ class MutationConfigBuilder extends ConfigBuilder
         }
 
         // activate PHPUnit's result cache and order tests by running defects first, then sorted by fastest first
-        $this->configManipulator->handleResultCacheAndExecutionOrder($version, $xPath, $mutationHash);
+        $this->configManipulator->handleResultCacheAndExecutionOrder($version, $xPath, $mutationHash, $this->tmpDir);
         $this->configManipulator->addFailOnAttributesIfNotSet($version, $xPath);
-        $this->configManipulator->setStopOnFailure($xPath);
+        $this->configManipulator->setStopOnFailure($version, $xPath);
         $this->configManipulator->deactivateColours($xPath);
         $this->configManipulator->deactivateStderrRedirection($xPath);
         $this->configManipulator->removeExistingLoggers($xPath);

--- a/tests/e2e/PHPUnit11/README.md
+++ b/tests/e2e/PHPUnit11/README.md
@@ -1,0 +1,9 @@
+# Title
+
+* Link to github ticket if relevant
+
+## Summary
+Short summary of the ticket
+
+## Full Ticket
+Full github ticket

--- a/tests/e2e/PHPUnit11/composer.json
+++ b/tests/e2e/PHPUnit11/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^11"
+    },
+    "autoload": {
+        "psr-4": {
+            "PHPUnit11\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PHPUnit11\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/e2e/PHPUnit11/expected-output.txt
+++ b/tests/e2e/PHPUnit11/expected-output.txt
@@ -1,0 +1,10 @@
+Total: 2
+
+Killed: 1
+Errored: 0
+Syntax Errors: 0
+Escaped: 1
+Timed Out: 0
+Skipped: 0
+Ignored: 0
+Not Covered: 0

--- a/tests/e2e/PHPUnit11/infection.json
+++ b/tests/e2e/PHPUnit11/infection.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../resources/schema.json",
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/PHPUnit11/phpunit.xml
+++ b/tests/e2e/PHPUnit11/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+
+         testdoxSummary="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/e2e/PHPUnit11/src/SourceClass.php
+++ b/tests/e2e/PHPUnit11/src/SourceClass.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PHPUnit11;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        $x = 1;
+        return 'hello';
+    }
+}

--- a/tests/e2e/PHPUnit11/tests/SourceClassTest.php
+++ b/tests/e2e/PHPUnit11/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PHPUnit11\Test;
+
+use PHPUnit11\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -332,7 +332,7 @@ final class XmlConfigurationManipulatorTest extends TestCase
     {
         $this->assertItChangesPrePHPUnit93Configuration(
             static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
-                $configManipulator->setStopOnFailure($xPath);
+                $configManipulator->setStopOnFailure('9.3', $xPath);
             },
             <<<'XML'
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -389,7 +389,7 @@ final class XmlConfigurationManipulatorTest extends TestCase
             XML
             ,
             static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
-                $configManipulator->setStopOnFailure($xPath);
+                $configManipulator->setStopOnFailure('9.3', $xPath);
             },
             <<<'XML'
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -404,6 +404,49 @@ final class XmlConfigurationManipulatorTest extends TestCase
                     printerClass="Fake\Printer\Class"
                     processIsolation="false"
                     stopOnFailure="true"
+                    syntaxCheck="false"
+                >
+                </phpunit>
+                XML,
+        );
+    }
+
+    public function test_it_sets_set_stop_on_defect_when_it_is_already_present_10_0(): void
+    {
+        $this->assertItChangesXML(<<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <phpunit
+                backupGlobals="false"
+                backupStaticAttributes="false"
+                bootstrap="app/autoload2.php"
+                colors="true"
+                convertErrorsToExceptions="true"
+                convertNoticesToExceptions="true"
+                convertWarningsToExceptions="true"
+                printerClass="Fake\Printer\Class"
+                processIsolation="false"
+                stopOnDefect="false"
+                syntaxCheck="false"
+            >
+            </phpunit>
+            XML
+            ,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->setStopOnFailure('10.0', $xPath);
+            },
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <phpunit
+                    backupGlobals="false"
+                    backupStaticAttributes="false"
+                    bootstrap="app/autoload2.php"
+                    colors="true"
+                    convertErrorsToExceptions="true"
+                    convertNoticesToExceptions="true"
+                    convertWarningsToExceptions="true"
+                    printerClass="Fake\Printer\Class"
+                    processIsolation="false"
+                    stopOnDefect="true"
                     syntaxCheck="false"
                 >
                 </phpunit>
@@ -627,6 +670,32 @@ final class XmlConfigurationManipulatorTest extends TestCase
         );
     }
 
+    public function test_it_activates_result_cache_and_execution_order_defects_for_phpunit_11_0(): void
+    {
+        $this->assertItChangesXML(<<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <phpunit
+                syntaxCheck="false"
+            >
+            </phpunit>
+            XML
+            ,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->handleResultCacheAndExecutionOrder('11.0', $xPath, 'a1b2c3', '/tmp');
+            },
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <phpunit
+                    executionOrder="defects"
+                    cacheResult="true"
+                    cacheDirectory="/tmp/.phpunit.result.cache.a1b2c3"
+                    syntaxCheck="false"
+                >
+                </phpunit>
+                XML,
+        );
+    }
+
     public function test_it_activates_result_cache_and_execution_order_defects_for_phpunit_7_3(): void
     {
         $this->assertItChangesXML(<<<'XML'
@@ -638,7 +707,7 @@ final class XmlConfigurationManipulatorTest extends TestCase
             XML
             ,
             static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
-                $configManipulator->handleResultCacheAndExecutionOrder('7.3', $xPath, 'a1b2c3');
+                $configManipulator->handleResultCacheAndExecutionOrder('7.3', $xPath, 'a1b2c3', '/tmp');
             },
             <<<'XML'
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -664,7 +733,7 @@ final class XmlConfigurationManipulatorTest extends TestCase
             XML
             ,
             static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
-                $configManipulator->handleResultCacheAndExecutionOrder('7.1', $xPath, 'a1b2c3');
+                $configManipulator->handleResultCacheAndExecutionOrder('7.1', $xPath, 'a1b2c3', '/tmp');
             },
             <<<'XML'
                 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This PR:

- [x] adds a new test for PHPUnit 11 and the testdoxSummary attribute
- [ ] find out how we can skip the `PHPUnit11` e2e folder in Github Actions using PHP <8.2
- [ ] fix the code so the failing test is gone

If I set the `testdoxSummary` in my `phpunit.xml` all mutations are magically killed.
It should show me that my `phpunit.xml` is not valid for infection or it should behave normally.

It has something to do with `handleResultCacheAndExecutionOrder` of the `XmlConfigurationManipulator`. because if I remove the lines:
````diff
        if (version_compare($version, '7.3', '>=')) {
-            $this->setAttributeValue($xPath, 'cacheResult', 'true');
-            $this->setAttributeValue($xPath, 'cacheResultFile', sprintf('.phpunit.result.cache.%s', $mutationHash));
-            $this->setAttributeValue($xPath, 'executionOrder', 'defects');

            return;
        }
````

it is working normally again :/

I could not find out why this really happens. Hope this Test helps