### PR TITLE
use $GLOBALS['_composer_autoload_path'] if possible

### DIFF
--- a/bin/infection
+++ b/bin/infection
@@ -49,6 +49,7 @@ if (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) === false) {
 // Infection autoloading
 (static function (): void {
     $autoload = $GLOBALS['_composer_autoload_path'] ?? '';
+
     if ($autoload && \file_exists($autoload)) {
         // Is installed via Composer
         include_once $autoload;

--- a/bin/infection
+++ b/bin/infection
@@ -48,6 +48,13 @@ if (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) === false) {
 
 // Infection autoloading
 (static function (): void {
+    if (\file_exists($autoload = ($GLOBALS['_composer_autoload_path'] ?? ''))) {
+        // Is installed via Composer
+        include_once $autoload;
+
+        return;
+    }
+
     if (\file_exists($autoload = __DIR__ . '/../../../autoload.php')) {
         // Is installed via Composer
         include_once $autoload;

--- a/bin/infection
+++ b/bin/infection
@@ -48,7 +48,8 @@ if (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) === false) {
 
 // Infection autoloading
 (static function (): void {
-    if (\file_exists($autoload = ($GLOBALS['_composer_autoload_path'] ?? ''))) {
+    $autoload = $GLOBALS['_composer_autoload_path'] ?? '';
+    if ($autoload && \file_exists($autoload)) {
         // Is installed via Composer
         include_once $autoload;
 

--- a/tests/e2e/Without_Git/run_tests.bash
+++ b/tests/e2e/Without_Git/run_tests.bash
@@ -2,6 +2,18 @@
 
 set -e
 
+# PRs from forked repositories are ignored cause we can't use such branches from another remote in composer.json below
+if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+  # Extract the repo full names from the event payload
+  pr_repo_full_name=$(jq -r .pull_request.head.repo.full_name "$GITHUB_EVENT_PATH")
+  base_repo_full_name=$(jq -r .repository.full_name "$GITHUB_EVENT_PATH")
+
+  if [[ "$pr_repo_full_name" != "$base_repo_full_name" ]]; then
+    echo "This pull request is from a forked repository."
+    exit 0
+  fi
+fi
+
 git_branch=$(echo "${GITHUB_HEAD_REF:-$(git rev-parse --abbrev-ref HEAD)}" | sed 's/\//\\\//g')
 
 echo "git_branch: ${git_branch}"

--- a/tests/e2e_tests
+++ b/tests/e2e_tests
@@ -51,6 +51,10 @@ exitOnError() {
     fi
 }
 
+echo "GITHUB_HEAD_REF=$GITHUB_HEAD_REF";
+echo "GITHUB_REPOSITORY=$GITHUB_REPOSITORY";
+echo "$(env)"
+
 e2e_tests_dirs=$(find . -maxdepth 1 -mindepth 1 -type d)
 
 # Export the function so xargs can use it

--- a/tests/e2e_tests
+++ b/tests/e2e_tests
@@ -51,28 +51,6 @@ exitOnError() {
     fi
 }
 
-echo "GITHUB_HEAD_REF=$GITHUB_HEAD_REF";
-echo "GITHUB_REPOSITORY=$GITHUB_REPOSITORY";
-cat "$GITHUB_EVENT_PATH"
-
-if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-  # Extract the repo full names from the event payload
-  pr_repo_full_name=$(jq -r .pull_request.head.repo.full_name "$GITHUB_EVENT_PATH")
-  base_repo_full_name=$(jq -r .repository.full_name "$GITHUB_EVENT_PATH")
-
-  echo $pr_repo_full_name
-  echo base_repo_full_name
-
-  # Compare the two repositories
-  if [[ "$pr_repo_full_name" != "$base_repo_full_name" ]]; then
-    echo "This pull request is from a forked repository."
-  else
-    echo "This pull request is from the same repository."
-  fi
-else
-  echo "This is not a pull request event."
-fi
-
 e2e_tests_dirs=$(find . -maxdepth 1 -mindepth 1 -type d)
 
 # Export the function so xargs can use it

--- a/tests/e2e_tests
+++ b/tests/e2e_tests
@@ -53,7 +53,25 @@ exitOnError() {
 
 echo "GITHUB_HEAD_REF=$GITHUB_HEAD_REF";
 echo "GITHUB_REPOSITORY=$GITHUB_REPOSITORY";
-echo "$(env)"
+cat "$GITHUB_EVENT_PATH"
+
+if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+  # Extract the repo full names from the event payload
+  pr_repo_full_name=$(jq -r .pull_request.head.repo.full_name "$GITHUB_EVENT_PATH")
+  base_repo_full_name=$(jq -r .repository.full_name "$GITHUB_EVENT_PATH")
+
+  echo $pr_repo_full_name
+  echo base_repo_full_name
+
+  # Compare the two repositories
+  if [[ "$pr_repo_full_name" != "$base_repo_full_name" ]]; then
+    echo "This pull request is from a forked repository."
+  else
+    echo "This pull request is from the same repository."
+  fi
+else
+  echo "This is not a pull request event."
+fi
 
 e2e_tests_dirs=$(find . -maxdepth 1 -mindepth 1 -type d)
 


### PR DESCRIPTION
I cloned infection into a local directory to install it via composer from there. 
So I can work on it in my normal project along side it. ( https://getcomposer.org/doc/05-repositories.md#path)

But than the autoloading is not found.
With the `$GLOBALS['_composer_autoload_path']` it is now possible to install it from anythere.
This is possible since composer 2.2:
https://getcomposer.org/doc/articles/vendor-binaries.md#finding-the-composer-autoloader-from-a-binary