### PR TITLE
Add PHP 8.4 mutator to replace `array_all()` with `true`

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -208,6 +208,7 @@
                 "ShiftLeft": { "$ref": "#/definitions/default-mutator-config" },
                 "ShiftRight": { "$ref": "#/definitions/default-mutator-config" },
                 "RoundingFamily": { "$ref": "#/definitions/default-mutator-config" },
+                "ArrayAll": { "$ref": "#/definitions/default-mutator-config" },
                 "ArrayItem": { "$ref": "#/definitions/default-mutator-config" },
                 "EqualIdentical": { "$ref": "#/definitions/default-mutator-config" },
                 "FalseValue": { "$ref": "#/definitions/default-mutator-config" },

--- a/src/Mutator/Boolean/ArrayAll.php
+++ b/src/Mutator/Boolean/ArrayAll.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Boolean;
+
+use Infection\Mutator\Definition;
+use Infection\Mutator\GetMutatorName;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\MutatorCategory;
+use PhpParser\Node;
+
+/**
+ * @internal
+ *
+ * @implements Mutator<Node\Expr\FuncCall>
+ */
+final class ArrayAll implements Mutator
+{
+    use GetMutatorName;
+
+    public static function getDefinition(): Definition
+    {
+        return new Definition(
+            <<<'TXT'
+                Replaces a function call `array_all()` with boolean `true`.
+                TXT
+            ,
+            MutatorCategory::SEMANTIC_REDUCTION,
+            <<<'TXT'
+                To kill this mutant, provide different values for the array so that your tests check
+                both cases: when `array_all()` returns `false` and `true`.
+                TXT,
+            <<<'DIFF'
+                - $allPositive = array_all($numbers, fn ($number) => $number > 0);
+                + $allPositive = true;
+                DIFF,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return iterable<Node\Expr\ConstFetch>
+     */
+    public function mutate(Node $node): iterable
+    {
+        yield new Node\Expr\ConstFetch(new Node\Name('true'));
+    }
+
+    public function canMutate(Node $node): bool
+    {
+        if (!$node instanceof Node\Expr\FuncCall || !$node->name instanceof Node\Name) {
+            return false;
+        }
+
+        return $node->name->toLowerString() === 'array_all';
+    }
+}

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -93,6 +93,7 @@ final class ProfileList
     ];
 
     public const BOOLEAN_PROFILE = [
+        Boolean\ArrayAll::class,
         Boolean\ArrayItem::class,
         // EqualIdentical disabled from the default boolean profile
         Boolean\FalseValue::class,
@@ -325,6 +326,7 @@ final class ProfileList
         'ShiftRight' => Arithmetic\ShiftRight::class,
 
         // Boolean
+        'ArrayAll' => Boolean\ArrayAll::class,
         'ArrayItem' => Boolean\ArrayItem::class,
         'EqualIdentical' => Boolean\EqualIdentical::class,
         'FalseValue' => Boolean\FalseValue::class,

--- a/tests/phpunit/Mutator/Boolean/ArrayAllTest.php
+++ b/tests/phpunit/Mutator/Boolean/ArrayAllTest.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Boolean;
+
+use Infection\Mutator\Boolean\ArrayAll;
+use Infection\Testing\BaseMutatorTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(ArrayAll::class)]
+final class ArrayAllTest extends BaseMutatorTestCase
+{
+    /**
+     * @param string|string[] $expected
+     */
+    #[DataProvider('mutationsProvider')]
+    public function test_it_can_mutate(string $input, $expected = []): void
+    {
+        $this->assertMutatesInput($input, $expected);
+    }
+
+    public static function mutationsProvider(): iterable
+    {
+        yield 'It mutates correctly when provided with a variable' => [
+            <<<'PHP'
+                <?php
+
+                $allPositive = array_all($numbers, fn ($number) => $number > 0);
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $allPositive = true;
+                PHP
+            ,
+        ];
+
+        yield 'It mutates correctly when provided with an array' => [
+            <<<'PHP'
+                <?php
+
+                $allPositive = array_all(['A', 1, 'C'], fn ($number) => $number > 0);
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $allPositive = true;
+                PHP,
+        ];
+
+        yield 'It mutates correctly when provided with a constant' => [
+            <<<'PHP'
+                <?php
+
+                $allPositive = array_all(\Class_With_Const::Const, fn ($number) => $number > 0);
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $allPositive = true;
+                PHP,
+        ];
+
+        yield 'It mutates correctly when a backslash is in front of array_all' => [
+            <<<'PHP'
+                <?php
+
+                $allPositive = \array_all(['A', 1, 'C'], fn ($number) => $number > 0);
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $allPositive = true;
+                PHP,
+        ];
+
+        yield 'It does not mutate other array_ calls' => [
+            <<<'PHP'
+                <?php
+
+                $a = array_map('strtolower', ['A', 'B', 'C']);
+                PHP,
+        ];
+
+        yield 'It does not mutate functions named array_all' => [
+            <<<'PHP'
+                <?php
+
+                function array_all($text, $other)
+                {
+                }
+                PHP,
+        ];
+
+        yield 'It mutates correctly within if statements' => [
+            <<<'PHP'
+                <?php
+
+                if (array_all(['A', 1, 'C'], fn ($number) => $number > 0)) {
+                    return true;
+                }
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                if (true) {
+                    return true;
+                }
+                PHP,
+        ];
+
+        yield 'It mutates correctly when array_all is wrongly capitalized' => [
+            <<<'PHP'
+                <?php
+
+                $a = aRrAy_AlL(['A', 1, 'C'], 'is_int');
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $a = true;
+                PHP,
+        ];
+
+        yield 'It mutates correctly when array_all uses another function as input' => [
+            <<<'PHP'
+                <?php
+
+                $a = array_all($foo->bar(), 'is_int');
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $a = true;
+                PHP,
+        ];
+
+        yield 'It mutates correctly when provided with a more complex situation' => [
+            <<<'PHP'
+                <?php
+
+                $a = array_all(array_filter(['A', 1, 'C'], function($char): bool {
+                    return !is_int($char);
+                }), 'is_int');
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $a = true;
+                PHP,
+        ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+                <?php
+
+                $a = 'array_all';
+
+                $b = $a([1, 2, 3], 'is_int');
+                PHP
+            ,
+        ];
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds new mutator
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/265

Replaces a function call `array_all()` with boolean `true`.

```diff
- $allPositive = array_all($numbers, fn ($number) => $number > 0);
+ $allPositive = true;
```