### PR TITLE
Remove hacks for PHP 8.4

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -98,13 +98,8 @@ jobs:
       - name: Install Composer dependencies for E2E tests
         shell: bash
         run: |
-          if [[ "${{ matrix.php-version }}" == '8.4' ]]; then
-            ls tests/e2e/*/composer.json | xargs dirname | xargs -I{} -P 4 composer --working-dir={} config platform.php 8.3.99
-            ls tests/e2e/*/composer.json | xargs dirname | xargs -I{} -P 4 composer --working-dir={} install --no-interaction --prefer-dist --no-progress
-          else
-            ls tests/e2e/*/composer.json | xargs dirname |
-               xargs -I{} -P 4 composer --working-dir={} install --no-interaction --prefer-dist --no-progress || true
-          fi
+          ls tests/e2e/*/composer.json | xargs dirname |
+             xargs -I{} -P 4 composer --working-dir={} install --no-interaction --prefer-dist --no-progress || true
 
       - name: Run a subset of E2E tests
         if: runner.os == 'Windows'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,11 +58,6 @@ jobs:
         if: matrix.dependencies != 'locked'
         run: composer config --unset platform.php
 
-      - name: Configure for PHP >= 8.4
-        if: "matrix.php-version >= '8.4'"
-        run: |
-          composer config platform.php 8.3.99
-
       - name: Enforce the Symfony version used
         if: matrix.dependencies != 'locked'
         run: composer config extra.symfony.require ${{ matrix.symfony-version }}

--- a/composer.lock
+++ b/composer.lock
@@ -4031,25 +4031,26 @@
         },
         {
             "name": "sidz/phpstan-rules",
-            "version": "0.4.3",
+            "version": "0.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sidz/phpstan-rules.git",
-                "reference": "f3832cd58d6051ebb8b3f2a44aa8a9ade018d9f5"
+                "reference": "17bf97643b7b3d4557e0a0c1c2d958fcceade4fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sidz/phpstan-rules/zipball/f3832cd58d6051ebb8b3f2a44aa8a9ade018d9f5",
-                "reference": "f3832cd58d6051ebb8b3f2a44aa8a9ade018d9f5",
+                "url": "https://api.github.com/repos/sidz/phpstan-rules/zipball/17bf97643b7b3d4557e0a0c1c2d958fcceade4fd",
+                "reference": "17bf97643b7b3d4557e0a0c1c2d958fcceade4fd",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.14 || ^5.0",
-                "php": "^8.1, <8.4",
+                "php": "^8.1, <8.5",
                 "phpstan/phpstan": "^1.8"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.4",
+                "friendsofphp/php-cs-fixer": "^3.59",
+                "infection/infection": "^0.28.0",
+                "nikic/php-parser": "^4.14 || ^5.0",
                 "phpunit/phpunit": "^10.1"
             },
             "type": "phpstan-extension",
@@ -4087,7 +4088,7 @@
                 "issues": "https://github.com/sidz/phpstan-rules/issues",
                 "source": "https://github.com/sidz/phpstan-rules"
             },
-            "time": "2024-01-08T18:37:19+00:00"
+            "time": "2024-12-08T17:38:04+00:00"
         },
         {
             "name": "softcreatr/jsonpath",


### PR DESCRIPTION
Blockers:

- [x] `sidz/phpstan-rules` 0.4.0 requires php ^8.1, <8.3 https://github.com/infection/infection/actions/runs/12223158787/job/34094342209?pr=2014#step:10:17
- [x] `sidz/phpstan-rules[0.5.0, ..., 0.5.1] require phpstan/phpstan ^2.0`, so we need to upgrade to PHPStan 2 I guess