### PR TITLE
Bump PHP version to 8.2

### DIFF
--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -26,7 +26,7 @@ jobs:
           # Should use the lowest supported version to ensure the CS-Fixer does
           # not get confused and apply a rule that would break on lower supported
           # versions.
-          php-version: 8.1
+          php-version: 8.2
 
       - name: Restore PHP-CS-Fixer cache
         uses: actions/cache@v4

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -21,18 +21,20 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '8.1' ]
+        php-version: [ '8.2' ]
         dependencies: [ locked ]
         composer: [ 'composer' ]
         coverage-driver: [ pcov, xdebug ]
         e2e-runner: [ 'bin/infection' ]
         include:
-          - { operating-system: 'windows-latest', php-version: '8.1', composer: 'composer', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.1', composer: 'composer', coverage-driver: 'pcov', e2e-runner: 'build/infection.phar' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.1', composer: 'composer', coverage-driver: 'xdebug', e2e-runner: 'build/infection.phar' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.2', composer: 'composer', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
+          - { operating-system: 'windows-latest', php-version: '8.2', composer: 'composer', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.2', composer: 'composer', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.2', composer: 'composer', coverage-driver: 'xdebug', e2e-runner: 'build/infection.phar' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.2', composer: 'composer', coverage-driver: 'pcov', e2e-runner: 'build/infection.phar' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.3', composer: 'composer', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
           - { operating-system: 'ubuntu-latest', php-version: '8.3', composer: 'composer', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
           - { operating-system: 'ubuntu-latest', php-version: '8.4', composer: 'composer', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.4', composer: 'composer', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
 
     name: E2E tests on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }} (${{ matrix.composer }}; ${{ matrix.dependencies }}), using ${{ matrix.coverage-driver }} with ${{ matrix.e2e-runner }}
 
@@ -119,7 +121,7 @@ jobs:
         run: make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=bin/infection
 
       - name: Run the whole set of E2E tests with prefixed PHAR
-        if: runner.os != 'Windows' && matrix.e2e-runner == 'build/infection.phar' && (matrix.php-version == '8.0' || matrix.php-version == '8.1')
+        if: runner.os != 'Windows' && matrix.e2e-runner == 'build/infection.phar' && matrix.php-version == '8.2'
         env:
           TERM: xterm-256color
         run: |

--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -16,7 +16,7 @@ jobs:
 
         strategy:
             matrix:
-                php-version: ['8.1']
+                php-version: ['8.2']
 
         name: Mutation Testing Code Review Annotations ${{ matrix.php-version }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           ini-values: memory_limit=512M, xdebug.mode=off
           tools: 'composer'
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,19 +22,17 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '8.1', '8.2', '8.3', '8.4' ]
+        php-version: [ '8.2', '8.3', '8.4' ]
         dependencies: [ locked, lowest, highest ]
         coverage-driver: [ pcov, xdebug ]
         symfony-version: [ '5.4.*', '6.*.*', '7.*.*' ]
         include:
           - operating-system: windows-latest
-            php-version: '8.1'
+            php-version: '8.2'
             dependencies: locked
             coverage-driver: xdebug
             symfony-version: '5.4.*'
         exclude:
-          - php-version: '8.1'
-            symfony-version: '7.*.*'
           - dependencies: 'locked'
             symfony-version: '6.*.*'
           - dependencies: 'locked'


### PR DESCRIPTION
Extracted from https://github.com/infection/infection/pull/2017

See

- https://github.com/infection/infection/blob/master/adr/0005-Bump-PHP-versions.md
- https://www.php.net/supported-versions.php

Next step, we will run Rector to upgrade to PHP 8.2 and to remove PHP 8.1 related code.