### PR TITLE
Add PHP 8.2 to docker-compose and remove PHP 8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ PARATEST=vendor/bin/paratest
 INFECTION=./build/infection.phar
 
 DOCKER_RUN=docker-compose run
-DOCKER_RUN_81=$(DOCKER_RUN) php81 $(FLOCK) Makefile
+DOCKER_RUN_82=$(DOCKER_RUN) php82 $(FLOCK) Makefile
 DOCKER_FILE_IMAGE=devTools/Dockerfile.json
 
 FLOCK=./devTools/flock
@@ -59,7 +59,7 @@ compile:
 .PHONY: compile-docker
 compile-docker:	 	## Bundles Infection into a PHAR using docker
 compile-docker: $(DOCKER_FILE_IMAGE)
-	$(DOCKER_RUN_81) make compile
+	$(DOCKER_RUN_82) make compile
 
 .PHONY: check_trailing_whitespaces
 check_trailing_whitespaces:
@@ -154,10 +154,10 @@ test-unit-parallel: $(PARATEST) vendor
 
 .PHONY: test-unit-docker
 test-unit-docker:	## Runs the unit tests on the different Docker platforms
-test-unit-docker: test-unit-81-docker
+test-unit-docker: test-unit-82-docker
 
-test-unit-81-docker: $(DOCKER_FILE_IMAGE) $(PHPUNIT)
-	$(DOCKER_RUN_81) $(PHPUNIT) --group $(PHPUNIT_GROUP)
+test-unit-82-docker: $(DOCKER_FILE_IMAGE) $(PHPUNIT)
+	$(DOCKER_RUN_82) $(PHPUNIT) --group $(PHPUNIT_GROUP)
 
 .PHONY: test-e2e
 test-e2e: 	 	## Runs the end-to-end tests
@@ -174,12 +174,12 @@ test-e2e-docker: 	## Runs the end-to-end tests on the different Docker platforms
 test-e2e-docker: test-e2e-xdebug-docker
 
 .PHONY: test-e2e-xdebug-docker
-test-e2e-xdebug-docker: test-e2e-xdebug-81-docker
+test-e2e-xdebug-docker: test-e2e-xdebug-82-docker
 
-.PHONY: test-e2e-xdebug-81-docker
-test-e2e-xdebug-81-docker: $(DOCKER_FILE_IMAGE) $(INFECTION)
-	$(DOCKER_RUN_81) $(PHPUNIT) --group $(E2E_PHPUNIT_GROUP)
-	$(DOCKER_RUN_81) ./tests/e2e_tests $(INFECTION)
+.PHONY: test-e2e-xdebug-82-docker
+test-e2e-xdebug-82-docker: $(DOCKER_FILE_IMAGE) $(INFECTION)
+	$(DOCKER_RUN_82) $(PHPUNIT) --group $(E2E_PHPUNIT_GROUP)
+	$(DOCKER_RUN_82) ./tests/e2e_tests $(INFECTION)
 
 .PHONY: test-infection
 test-infection:		## Runs Infection against itself
@@ -191,11 +191,11 @@ test-infection-docker:	## Runs Infection against itself on the different Docker 
 test-infection-docker: test-infection-xdebug-docker
 
 .PHONY: test-infection-xdebug-docker
-test-infection-xdebug-docker: test-infection-xdebug-81-docker
+test-infection-xdebug-docker: test-infection-xdebug-82-docker
 
-.PHONY: test-infection-xdebug-81-docker
-test-infection-xdebug-81-docker: $(DOCKER_FILE_IMAGE)
-	$(DOCKER_RUN_81) ./bin/infection --threads=max
+.PHONY: test-infection-xdebug-82-docker
+test-infection-xdebug-82-docker: $(DOCKER_FILE_IMAGE)
+	$(DOCKER_RUN_82) ./bin/infection --threads=max
 
 #
 # Rules from files (non-phony targets)

--- a/devTools/Dockerfile
+++ b/devTools/Dockerfile
@@ -4,6 +4,10 @@ FROM php:${PHP_VERSION}-cli-alpine
 
 ARG XDEBUG_VERSION
 
+RUN apk add --update --no-cache \
+		linux-headers \
+	;
+
 RUN set -eux; \
     apk add --no-cache --virtual .build-deps \
         ${PHPIZE_DEPS} \
@@ -24,7 +28,7 @@ RUN set -eux; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
-    apk add --no-cache --virtual .phpexts-rundeps ${runDeps}; \
+    apk add --no-cache --virtual .app-phpexts-rundeps ${runDeps}; \
     apk del .build-deps
 
 RUN apk add --no-cache \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
       context: devTools
       args:
         PHP_VERSION: '8.2'
-        XDEBUG_VERSION: '3.4.0'
+        XDEBUG_VERSION: '3.4.1'
     volumes:
       - .:/opt/infection

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
-version: '3'
 services:
-  php81:
+  php82:
     build:
       context: devTools
       args:
-        PHP_VERSION: '8.1'
-        XDEBUG_VERSION: '3.1.5'
+        PHP_VERSION: '8.2'
+        XDEBUG_VERSION: '3.4.0'
     volumes:
       - .:/opt/infection


### PR DESCRIPTION
- PHP 8.1 has been dropped
- it's convenient to have 8.2 docker image to be built and used to run particular commands when you are on 8.3/8.4 locally