### PR TITLE
Add PHP 8.4 mutator to replace `array_find()` with `null`

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -210,6 +210,7 @@
                 "RoundingFamily": { "$ref": "#/definitions/default-mutator-config" },
                 "ArrayAll": { "$ref": "#/definitions/default-mutator-config" },
                 "ArrayAny": { "$ref": "#/definitions/default-mutator-config" },
+                "ArrayFind": { "$ref": "#/definitions/default-mutator-config" },
                 "ArrayItem": { "$ref": "#/definitions/default-mutator-config" },
                 "EqualIdentical": { "$ref": "#/definitions/default-mutator-config" },
                 "FalseValue": { "$ref": "#/definitions/default-mutator-config" },

--- a/src/Mutator/Nullify/ArrayFind.php
+++ b/src/Mutator/Nullify/ArrayFind.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutator\Nullify;
+
+use Infection\Mutator\Definition;
+use Infection\Mutator\GetMutatorName;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\MutatorCategory;
+use PhpParser\Node;
+
+/**
+ * @internal
+ *
+ * @implements Mutator<Node\Expr\FuncCall>
+ */
+final class ArrayFind implements Mutator
+{
+    use GetMutatorName;
+
+    public static function getDefinition(): Definition
+    {
+        return new Definition(
+            <<<'TXT'
+                Replaces a function call `array_find()` with boolean `null`.
+                TXT
+            ,
+            MutatorCategory::SEMANTIC_REDUCTION,
+            <<<'TXT'
+                To kill this mutant, provide different values for the array so that your tests check
+                both cases: when `array_find()` returns `null` and found value.
+                TXT,
+            <<<'DIFF'
+                - $positiveNumber = array_find($numbers, fn ($number) => $number > 0);
+                + $positiveNumber = null;
+                DIFF,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     *
+     * @return iterable<Node\Expr\ConstFetch>
+     */
+    public function mutate(Node $node): iterable
+    {
+        yield new Node\Expr\ConstFetch(new Node\Name('null'));
+    }
+
+    public function canMutate(Node $node): bool
+    {
+        if (!$node instanceof Node\Expr\FuncCall || !$node->name instanceof Node\Name) {
+            return false;
+        }
+
+        return $node->name->toLowerString() === 'array_find';
+    }
+}

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -57,6 +57,7 @@ final class ProfileList
         '@function_signature' => self::FUNCTION_SIGNATURE_PROFILE,
         '@identical' => self::IDENTICAL_PROFILE,
         '@loop' => self::LOOP_PROFILE,
+        '@nullify' => self::NULLIFY_PROFILE,
         '@number' => self::NUMBER_PROFILE,
         '@operator' => self::OPERATOR_PROFILE,
         '@regex' => self::REGEX_PROFILE,
@@ -148,6 +149,10 @@ final class ProfileList
     public const IDENTICAL_PROFILE = [
         Boolean\EqualIdentical::class,
         Boolean\NotEqualNotIdentical::class,
+    ];
+
+    public const NULLIFY_PROFILE = [
+        Nullify\ArrayFind::class,
     ];
 
     public const NUMBER_PROFILE = [
@@ -369,6 +374,9 @@ final class ProfileList
         // Function Signature
         'ProtectedVisibility' => FunctionSignature\ProtectedVisibility::class,
         'PublicVisibility' => FunctionSignature\PublicVisibility::class,
+
+        // Nullify
+        'ArrayFind' => Nullify\ArrayFind::class,
 
         // Number
         'DecrementInteger' => Number\DecrementInteger::class,

--- a/tests/phpunit/Mutator/Nullify/ArrayFindTest.php
+++ b/tests/phpunit/Mutator/Nullify/ArrayFindTest.php
@@ -33,16 +33,15 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Mutator\Boolean;
+namespace Infection\Tests\Mutator\Nullify;
 
-use Infection\Mutator\Boolean\ArrayAny;
+use Infection\Mutator\Nullify\ArrayFind;
 use Infection\Testing\BaseMutatorTestCase;
-use const PHP_VERSION_ID;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-#[CoversClass(ArrayAny::class)]
-final class ArrayAnyTest extends BaseMutatorTestCase
+#[CoversClass(ArrayFind::class)]
+final class ArrayFindTest extends BaseMutatorTestCase
 {
     /**
      * @param string|string[] $expected
@@ -59,13 +58,13 @@ final class ArrayAnyTest extends BaseMutatorTestCase
             <<<'PHP'
                 <?php
 
-                $anyPositive = array_any($numbers, fn ($number) => $number > 0);
+                $positive = array_find($numbers, fn ($number) => $number > 0);
                 PHP
             ,
             <<<'PHP'
                 <?php
 
-                $anyPositive = true;
+                $positive = null;
                 PHP
             ,
         ];
@@ -74,13 +73,13 @@ final class ArrayAnyTest extends BaseMutatorTestCase
             <<<'PHP'
                 <?php
 
-                $anyPositive = array_any(['A', 1, 'C'], fn ($number) => $number > 0);
+                $positive = array_find(['A', 1, 'C'], fn ($number) => $number > 0);
                 PHP
             ,
             <<<'PHP'
                 <?php
 
-                $anyPositive = true;
+                $positive = null;
                 PHP,
         ];
 
@@ -88,27 +87,27 @@ final class ArrayAnyTest extends BaseMutatorTestCase
             <<<'PHP'
                 <?php
 
-                $anyPositive = array_any(\Class_With_Const::Const, fn ($number) => $number > 0);
+                $positive = array_find(\Class_With_Const::Const, fn ($number) => $number > 0);
                 PHP
             ,
             <<<'PHP'
                 <?php
 
-                $anyPositive = true;
+                $positive = null;
                 PHP,
         ];
 
-        yield 'It mutates correctly when a backslash is in front of array_any' => [
+        yield 'It mutates correctly when a backslash is in front of array_find' => [
             <<<'PHP'
                 <?php
 
-                $anyPositive = \array_any(['A', 1, 'C'], fn ($number) => $number > 0);
+                $positive = \array_find(['A', 1, 'C'], fn ($number) => $number > 0);
                 PHP
             ,
             <<<'PHP'
                 <?php
 
-                $anyPositive = true;
+                $positive = null;
                 PHP,
         ];
 
@@ -120,11 +119,11 @@ final class ArrayAnyTest extends BaseMutatorTestCase
                 PHP,
         ];
 
-        yield 'It does not mutate functions named array_any' => [
+        yield 'It does not mutate functions named array_find' => [
             <<<'PHP'
                 <?php
 
-                function array_any($text, $other)
+                function array_find($text, $other)
                 {
                 }
                 PHP,
@@ -134,7 +133,7 @@ final class ArrayAnyTest extends BaseMutatorTestCase
             <<<'PHP'
                 <?php
 
-                if (array_any(['A', 1, 'C'], fn ($number) => $number > 0)) {
+                if (array_find(['A', 1, 'C'], fn ($number) => $number > 0)) {
                     return true;
                 }
                 PHP
@@ -142,37 +141,37 @@ final class ArrayAnyTest extends BaseMutatorTestCase
             <<<'PHP'
                 <?php
 
-                if (true) {
+                if (null) {
                     return true;
                 }
                 PHP,
         ];
 
-        yield 'It mutates correctly when array_any is wrongly capitalized' => [
+        yield 'It mutates correctly when array_find is wrongly capitalized' => [
             <<<'PHP'
                 <?php
 
-                $a = arRay_aNy(['A', 1, 'C'], 'is_int');
+                $a = aRray_Find(['A', 1, 'C'], 'is_int');
                 PHP
             ,
             <<<'PHP'
                 <?php
 
-                $a = true;
+                $a = null;
                 PHP,
         ];
 
-        yield 'It mutates correctly when array_any uses another function as input' => [
+        yield 'It mutates correctly when array_find uses another function as input' => [
             <<<'PHP'
                 <?php
 
-                $a = array_any($foo->bar(), 'is_int');
+                $a = array_find($foo->bar(), 'is_int');
                 PHP
             ,
             <<<'PHP'
                 <?php
 
-                $a = true;
+                $a = null;
                 PHP,
         ];
 
@@ -180,7 +179,7 @@ final class ArrayAnyTest extends BaseMutatorTestCase
             <<<'PHP'
                 <?php
 
-                $a = array_any(array_filter(['A', 1, 'C'], function($char): bool {
+                $a = array_find(array_filter(['A', 1, 'C'], function($char): bool {
                     return !is_int($char);
                 }), 'is_int');
                 PHP
@@ -188,7 +187,7 @@ final class ArrayAnyTest extends BaseMutatorTestCase
             <<<'PHP'
                 <?php
 
-                $a = true;
+                $a = null;
                 PHP,
         ];
 
@@ -196,46 +195,11 @@ final class ArrayAnyTest extends BaseMutatorTestCase
             <<<'PHP'
                 <?php
 
-                $a = 'array_any';
+                $a = 'array_find';
 
                 $b = $a([1, 2, 3], 'is_int');
                 PHP
             ,
         ];
-
-        if (PHP_VERSION_ID >= 80400) {
-            yield 'It mutates correctly when provided inside getter PHP 8.4 syntax' => [
-                <<<'PHP'
-                    <?php
-
-                    new class
-                    {
-                        private array $numbers = [];
-                        public function __construct(array $numbers)
-                        {
-                            $this->numbers = $numbers;
-                        }
-
-                        public bool $anyPositive { get => array_any(fn (int $number) => $number > 0); }
-                    };
-                    PHP
-                ,
-                <<<'PHP'
-                    <?php
-
-                    new class
-                    {
-                        private array $numbers = [];
-                        public function __construct(array $numbers)
-                        {
-                            $this->numbers = $numbers;
-                        }
-                        public bool $anyPositive {
-                            get => true;
-                        }
-                    };
-                    PHP,
-            ];
-        }
     }
 }


### PR DESCRIPTION
This PR:

- [x] Adds new mutator in addition to
  - https://github.com/infection/infection/pull/2009 
  - and https://github.com/infection/infection/pull/2010
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/268

Replaces a function call `array_find()` with boolean `null`.

```diff
- $positiveNumber = array_find($numbers, fn ($number) => $number > 0);
+ $positiveNumber = null;
```