### PR TITLE
Add PHP 8.4 mutator to replace `array_find_key()` with `null`

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -211,6 +211,7 @@
                 "ArrayAll": { "$ref": "#/definitions/default-mutator-config" },
                 "ArrayAny": { "$ref": "#/definitions/default-mutator-config" },
                 "ArrayFind": { "$ref": "#/definitions/default-mutator-config" },
+                "ArrayFindKey": { "$ref": "#/definitions/default-mutator-config" },
                 "ArrayItem": { "$ref": "#/definitions/default-mutator-config" },
                 "EqualIdentical": { "$ref": "#/definitions/default-mutator-config" },
                 "FalseValue": { "$ref": "#/definitions/default-mutator-config" },

--- a/src/Mutator/Nullify/ArrayFindKey.php
+++ b/src/Mutator/Nullify/ArrayFindKey.php
@@ -46,7 +46,7 @@ use PhpParser\Node;
  *
  * @implements Mutator<Node\Expr\FuncCall>
  */
-final class ArrayFind implements Mutator
+final class ArrayFindKey implements Mutator
 {
     use GetMutatorName;
 
@@ -54,16 +54,16 @@ final class ArrayFind implements Mutator
     {
         return new Definition(
             <<<'TXT'
-                Replaces a function call `array_find()` with boolean `null`.
+                Replaces a function call `array_find_key()` with boolean `null`.
                 TXT
             ,
             MutatorCategory::SEMANTIC_REDUCTION,
             <<<'TXT'
                 To kill this mutant, provide different values for the array so that your tests check
-                both cases: when `array_find()` returns `null` and founds value.
+                both cases: when `array_find_key()` returns `null` and founds value.
                 TXT,
             <<<'DIFF'
-                - $positiveNumber = array_find($numbers, fn ($number) => $number > 0);
+                - $positiveNumber = array_find_key($numbers, fn ($number) => $number > 0);
                 + $positiveNumber = null;
                 DIFF,
         );
@@ -85,6 +85,6 @@ final class ArrayFind implements Mutator
             return false;
         }
 
-        return $node->name->toLowerString() === 'array_find';
+        return $node->name->toLowerString() === 'array_find_key';
     }
 }

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -153,6 +153,7 @@ final class ProfileList
 
     public const NULLIFY_PROFILE = [
         Nullify\ArrayFind::class,
+        Nullify\ArrayFindKey::class,
     ];
 
     public const NUMBER_PROFILE = [
@@ -377,6 +378,7 @@ final class ProfileList
 
         // Nullify
         'ArrayFind' => Nullify\ArrayFind::class,
+        'ArrayFindKey' => Nullify\ArrayFindKey::class,
 
         // Number
         'DecrementInteger' => Number\DecrementInteger::class,

--- a/tests/phpunit/Mutator/Nullify/ArrayFindKeyTest.php
+++ b/tests/phpunit/Mutator/Nullify/ArrayFindKeyTest.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Mutator\Nullify;
+
+use Infection\Mutator\Nullify\ArrayFindKey;
+use Infection\Testing\BaseMutatorTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(ArrayFindKey::class)]
+final class ArrayFindKeyTest extends BaseMutatorTestCase
+{
+    /**
+     * @param string|string[] $expected
+     */
+    #[DataProvider('mutationsProvider')]
+    public function test_it_can_mutate(string $input, $expected = []): void
+    {
+        $this->assertMutatesInput($input, $expected);
+    }
+
+    public static function mutationsProvider(): iterable
+    {
+        yield 'It mutates correctly when provided with a variable' => [
+            <<<'PHP'
+                <?php
+
+                $positive = array_find_key($numbers, fn ($number) => $number > 0);
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $positive = null;
+                PHP
+            ,
+        ];
+
+        yield 'It mutates correctly when provided with an array' => [
+            <<<'PHP'
+                <?php
+
+                $positive = array_find_key(['A', 1, 'C'], fn ($number) => $number > 0);
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $positive = null;
+                PHP,
+        ];
+
+        yield 'It mutates correctly when provided with a constant' => [
+            <<<'PHP'
+                <?php
+
+                $positive = array_find_key(\Class_With_Const::Const, fn ($number) => $number > 0);
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $positive = null;
+                PHP,
+        ];
+
+        yield 'It mutates correctly when a backslash is in front of array_find_key' => [
+            <<<'PHP'
+                <?php
+
+                $positive = \array_find_key(['A', 1, 'C'], fn ($number) => $number > 0);
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $positive = null;
+                PHP,
+        ];
+
+        yield 'It does not mutate other array_ calls' => [
+            <<<'PHP'
+                <?php
+
+                $a = array_map('strtolower', ['A', 'B', 'C']);
+                PHP,
+        ];
+
+        yield 'It does not mutate functions named array_find_key' => [
+            <<<'PHP'
+                <?php
+
+                function array_find_key($text, $other)
+                {
+                }
+                PHP,
+        ];
+
+        yield 'It mutates correctly within if statements' => [
+            <<<'PHP'
+                <?php
+
+                if (array_find_key(['A', 1, 'C'], fn ($number) => $number > 0)) {
+                    return true;
+                }
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                if (null) {
+                    return true;
+                }
+                PHP,
+        ];
+
+        yield 'It mutates correctly when array_find_key is wrongly capitalized' => [
+            <<<'PHP'
+                <?php
+
+                $a = aRray_Find_kEy(['A', 1, 'C'], 'is_int');
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $a = null;
+                PHP,
+        ];
+
+        yield 'It mutates correctly when array_find_key uses another function as input' => [
+            <<<'PHP'
+                <?php
+
+                $a = array_find_key($foo->bar(), 'is_int');
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $a = null;
+                PHP,
+        ];
+
+        yield 'It mutates correctly when provided with a more complex situation' => [
+            <<<'PHP'
+                <?php
+
+                $a = array_find_key(array_filter(['A', 1, 'C'], function($char): bool {
+                    return !is_int($char);
+                }), 'is_int');
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $a = null;
+                PHP,
+        ];
+
+        yield 'It does not break when provided with a variable function name' => [
+            <<<'PHP'
+                <?php
+
+                $a = 'array_find';
+
+                $b = $a([1, 2, 3], 'is_int');
+                PHP
+            ,
+        ];
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Adds new mutator in addition to
  - https://github.com/infection/infection/pull/2009 
  - and https://github.com/infection/infection/pull/2010
  - https://github.com/infection/infection/pull/2049
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/269

Replaces a function call `array_find_key()` with boolean `null`.

```diff
- $positiveNumber = array_find_key($numbers, fn ($number) => $number > 0);
+ $positiveNumber = null;
```