### PR TITLE
Add `cs-check` to `make autoreview`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ profile: vendor $(BENCHMARK_SOURCES)
 
 .PHONY: autoreview
 autoreview: 	 	## Runs various checks (static analysis & AutoReview test suite)
-autoreview: phpstan psalm validate test-autoreview rector-check
+autoreview: cs-check phpstan psalm validate test-autoreview rector-check
 
 .PHONY: test
 test:		 	## Runs all the tests

--- a/devTools/check_trailing_whitespaces.sh
+++ b/devTools/check_trailing_whitespaces.sh
@@ -31,6 +31,7 @@ files_with_trailing_whitespaces=$(
         -not -path "./.composer/*" \
         -not -path "./.cache/*" \
         -not -path "./.box_dump/*" \
+        -not -path "./.tools/*" \
         -not -path "./build/*" \
         -not -path "./.idea/*" \
         -not -path "./.git/*" \
@@ -42,6 +43,8 @@ files_with_trailing_whitespaces=$(
         -not -path "./tests/phpunit/Fixtures/Files/phpunit/format-whitespace/original-phpunit.xml" \
         -not -path "./tests/phpunit/StringNormalizerTest.php" \
         -not -path "./tests/phpunit/StrTest.php" \
+        -not -path "./tests/benchmark/Tracing/coverage.tar.gz" \
+        -not -path "./tests/benchmark/MutationGenerator/._sources" \
         -exec grep -EIHn "\\s$" {} \;
 )
 


### PR DESCRIPTION
I always run `make autoreview` before pushing to double check everything is good.

But for some reason, we didn't check code syles (by PHP-CS-Fixer) during `make autoreview`.

This PR adds it.

Also, ignore some folders from whitespaces check script as it's currently broken.
