### PR TITLE
Fix for fallback to the simple diff colorizer for multiline removed lines

### DIFF
--- a/devTools/phpstan-src-baseline.neon
+++ b/devTools/phpstan-src-baseline.neon
@@ -19,18 +19,6 @@ parameters:
 			path: ../src/Config/Guesser/SourceDirGuesser.php
 
 		-
-			message: '#^Call to function is_array\(\) with array\{list\<string\>\} will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: ../src/Differ/DiffColorizer.php
-
-		-
-			message: '#^Offset 0 on array\{list\<string\>\} on left side of \?\? always exists and is not nullable\.$#'
-			identifier: nullCoalesce.offset
-			count: 1
-			path: ../src/Differ/DiffColorizer.php
-
-		-
 			message: '#^Offset 1 might not exist on array\{0\?\: string, 1\?\: non\-empty\-string\}\.$#'
 			identifier: offsetAccess.notFound
 			count: 1

--- a/src/Differ/DiffColorizer.php
+++ b/src/Differ/DiffColorizer.php
@@ -35,11 +35,11 @@ declare(strict_types=1);
 
 namespace Infection\Differ;
 
+use function array_filter;
 use function array_map;
 use function count;
 use function explode;
 use function implode;
-use function is_array;
 use function mb_strlen;
 use function mb_strpos;
 use function mb_strrpos;
@@ -138,8 +138,9 @@ class DiffColorizer
 
     private function isMultiLineDiff(string $diff): bool
     {
-        preg_match_all('/^\+.*$/m', $diff, $matches);
+        preg_match_all('/(^\+.*$)|(^-.*$)/m', $diff, $matches);
 
-        return is_array($matches) && count($matches[0] ?? []) > 1;
+        return count(array_filter($matches[1])) > 1
+            || count(array_filter($matches[2])) > 1;
     }
 }

--- a/tests/phpunit/Differ/DiffColorizerTest.php
+++ b/tests/phpunit/Differ/DiffColorizerTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Differ;
 
-use Generator;
 use Infection\Differ\DiffColorizer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -57,9 +56,9 @@ final class DiffColorizerTest extends TestCase
     }
 
     /**
-     * @return Generator<non-empty-string, list<non-empty-string>>
+     * @return iterable<non-empty-string, list<non-empty-string>>
      */
-    public static function provideDiffs(): Generator
+    public static function provideDiffs(): iterable
     {
         yield 'full-deletion' => [
             <<<'CODE'
@@ -141,6 +140,7 @@ final class DiffColorizerTest extends TestCase
                 CODE,
         ];
 
+        // https://github.com/infection/infection/issues/1999
         yield 'bug-1999' => [
             <<<'CODE'
                      protected function name()

--- a/tests/phpunit/Differ/DiffColorizerTest.php
+++ b/tests/phpunit/Differ/DiffColorizerTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Differ;
 
+use Generator;
 use Infection\Differ\DiffColorizer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -56,107 +57,136 @@ final class DiffColorizerTest extends TestCase
     }
 
     /**
-     * @return array<non-empty-string, list<non-empty-string>>
+     * @return Generator<non-empty-string, list<non-empty-string>>
      */
-    public static function provideDiffs(): array
+    public static function provideDiffs(): Generator
     {
-        return [
-            'full-deletion' => [
-                <<<'CODE'
-                         function ($a) {
-                    -        exit();
-                    +
-                         }
-                    CODE,
-                <<<'CODE'
-                    <code>
-                         function ($a) {
-                    <diff-del>-<diff-del-inline>        exit();</diff-del-inline></diff-del>
-                    <diff-add>+</diff-add>
-                         }</code>
-                    CODE,
-            ],
-            'full-addition' => [
-                <<<'CODE'
-                         function ($a) {
-                    -
-                    +        exit();
-                         }
-                    CODE,
-                <<<'CODE'
-                    <code>
-                         function ($a) {
-                    <diff-del>-</diff-del>
-                    <diff-add>+<diff-add-inline>        exit();</diff-add-inline></diff-add>
-                         }</code>
-                    CODE,
-            ],
-            'partial-deletion' => [
-                <<<'CODE'
-                         function ($a) {
-                    -        return 'foo' . 'bar';
-                    +        return 'foo';
-                         }
-                    CODE,
-                <<<'CODE'
-                    <code>
-                         function ($a) {
-                    <diff-del>-        return 'foo'<diff-del-inline> . 'bar'</diff-del-inline>;</diff-del>
-                    <diff-add>+        return 'foo';</diff-add>
-                         }</code>
-                    CODE,
-            ],
-            'partial-addition' => [
-                <<<'CODE'
-                         function ($a) {
-                    -        return 'foo';
-                    +        return 'foo' . 'bar';
-                         }
-                    CODE,
-                <<<'CODE'
-                    <code>
-                         function ($a) {
-                    <diff-del>-        return 'foo';</diff-del>
-                    <diff-add>+        return 'foo'<diff-add-inline> . 'bar'</diff-add-inline>;</diff-add>
-                         }</code>
-                    CODE,
-            ],
-            'deletion-and-addition' => [
-                <<<'CODE'
-                         function ($a, $b) {
-                    -        return $a && $b;
-                    +        return $a || $b;
-                         }
-                    CODE,
-                <<<'CODE'
-                    <code>
-                         function ($a, $b) {
-                    <diff-del>-        return $a <diff-del-inline>&&</diff-del-inline> $b;</diff-del>
-                    <diff-add>+        return $a <diff-add-inline>||</diff-add-inline> $b;</diff-add>
-                         }</code>
-                    CODE,
-            ],
-            'bug-1999' => [
-                <<<'CODE'
-                         protected function name()
-                         {
-                    -        return strtolower(get_class($this));
-                    +        strtolower(get_class($this));
-                    +        return null;
-                         }
+        yield 'full-deletion' => [
+            <<<'CODE'
+                     function ($a) {
+                -        exit();
+                +
                      }
-                    CODE,
-                <<<'CODE'
-                    <code>
-                         protected function name()
-                         {
-                    <diff-del>-        return strtolower(get_class($this));</diff-del>
-                    <diff-add>+        strtolower(get_class($this));</diff-add>
-                    <diff-add>+        return null;</diff-add>
-                         }
+                CODE,
+            <<<'CODE'
+                <code>
+                     function ($a) {
+                <diff-del>-<diff-del-inline>        exit();</diff-del-inline></diff-del>
+                <diff-add>+</diff-add>
                      }</code>
-                    CODE,
-            ],
+                CODE,
+        ];
+
+        yield 'full-addition' => [
+            <<<'CODE'
+                     function ($a) {
+                -
+                +        exit();
+                     }
+                CODE,
+            <<<'CODE'
+                <code>
+                     function ($a) {
+                <diff-del>-</diff-del>
+                <diff-add>+<diff-add-inline>        exit();</diff-add-inline></diff-add>
+                     }</code>
+                CODE,
+        ];
+
+        yield 'partial-deletion' => [
+            <<<'CODE'
+                     function ($a) {
+                -        return 'foo' . 'bar';
+                +        return 'foo';
+                     }
+                CODE,
+            <<<'CODE'
+                <code>
+                     function ($a) {
+                <diff-del>-        return 'foo'<diff-del-inline> . 'bar'</diff-del-inline>;</diff-del>
+                <diff-add>+        return 'foo';</diff-add>
+                     }</code>
+                CODE,
+        ];
+
+        yield 'partial-addition' => [
+            <<<'CODE'
+                     function ($a) {
+                -        return 'foo';
+                +        return 'foo' . 'bar';
+                     }
+                CODE,
+            <<<'CODE'
+                <code>
+                     function ($a) {
+                <diff-del>-        return 'foo';</diff-del>
+                <diff-add>+        return 'foo'<diff-add-inline> . 'bar'</diff-add-inline>;</diff-add>
+                     }</code>
+                CODE,
+        ];
+
+        yield 'deletion-and-addition' => [
+            <<<'CODE'
+                     function ($a, $b) {
+                -        return $a && $b;
+                +        return $a || $b;
+                     }
+                CODE,
+            <<<'CODE'
+                <code>
+                     function ($a, $b) {
+                <diff-del>-        return $a <diff-del-inline>&&</diff-del-inline> $b;</diff-del>
+                <diff-add>+        return $a <diff-add-inline>||</diff-add-inline> $b;</diff-add>
+                     }</code>
+                CODE,
+        ];
+
+        yield 'bug-1999' => [
+            <<<'CODE'
+                     protected function name()
+                     {
+                -        return strtolower(get_class($this));
+                +        strtolower(get_class($this));
+                +        return null;
+                     }
+                 }
+                CODE,
+            <<<'CODE'
+                <code>
+                     protected function name()
+                     {
+                <diff-del>-        return strtolower(get_class($this));</diff-del>
+                <diff-add>+        strtolower(get_class($this));</diff-add>
+                <diff-add>+        return null;</diff-add>
+                     }
+                 }</code>
+                CODE,
+        ];
+
+        yield 'multiple-removed-lines' => [
+            <<<'CODE'
+                         try {
+                             $response = new Response();
+                         } catch (RateLimitExceededException) {
+                             throw new TooManyRequestsHttpException();
+                -        } finally {
+                -            $limiter->reset();
+                         }
+                +        $limiter->reset();
+                         return $response;
+                CODE,
+            <<<'CODE'
+                <code>
+                         try {
+                             $response = new Response();
+                         } catch (RateLimitExceededException) {
+                             throw new TooManyRequestsHttpException();
+                <diff-del>-        } finally {</diff-del>
+                <diff-del>-            $limiter->reset();</diff-del>
+                         }
+                <diff-add>+        $limiter->reset();</diff-add>
+                         return $response;</code>
+                CODE,
         ];
     }
 }


### PR DESCRIPTION
This PR fixes fatal error thrown in the DiffColorizer when multiple _removed_ lines occurs in the diff. For example UnwrapFinally mutator may return multiple lines.
I faced with this issue on one of my current projects.

Solution for now is to do the same what we did in the https://github.com/infection/infection/pull/2000.

Affected versions: > 0.29.1