### PR TITLE
Allow to run one e2e test for debugging

### DIFF
--- a/tests/e2e_tests
+++ b/tests/e2e_tests
@@ -51,7 +51,7 @@ exitOnError() {
     fi
 }
 
-e2e_tests_dirs=$(find . -maxdepth 1 -mindepth 1 -type d | grep "${1:-}")
+e2e_tests_dirs=$(find . -maxdepth 1 -mindepth 1 -type d | grep "${2:-}")
 
 # Export the function so xargs can use it
 export -f run_infection_for_dir

--- a/tests/e2e_tests
+++ b/tests/e2e_tests
@@ -51,7 +51,7 @@ exitOnError() {
     fi
 }
 
-e2e_tests_dirs=$(find . -maxdepth 1 -mindepth 1 -type d)
+e2e_tests_dirs=$(find . -maxdepth 1 -mindepth 1 -type d | grep "${1:-}")
 
 # Export the function so xargs can use it
 export -f run_infection_for_dir


### PR DESCRIPTION
Allow to run one e2e test for debugging
  
This allows to run e.g.
    
```
tests/e2e_tests bin/infection SymfonyBridge
```
   
one folder for debugging purposes
