### PR TITLE
Get back `devTools/Dockerfile.json` to pin to it on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,8 @@ phpunit.xml.dist:
 	touch -c $@
 
 $(DOCKER_FILE_IMAGE): devTools/Dockerfile
-	docker-compose build
+	docker compose build php82
+	docker image inspect infection-php82 >> devTools/Dockerfile.json
 	touch -c $@
 
 tests/benchmark/MutationGenerator/sources: tests/benchmark/MutationGenerator/sources.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ phpunit.xml.dist:
 
 $(DOCKER_FILE_IMAGE): devTools/Dockerfile
 	docker compose build php82
-	docker image inspect infection-php82 >> devTools/Dockerfile.json
+	docker image inspect infection-php82 >> $(DOCKER_FILE_IMAGE)
 	touch -c $@
 
 tests/benchmark/MutationGenerator/sources: tests/benchmark/MutationGenerator/sources.tar.gz


### PR DESCRIPTION
# Problem

When I run `make compile-docker` 2 times in a row, docker builds the image 2 times while only the first run should trigger the build.

# Solution

If found that we used `devTools/Dockerfile***.json` files back in time to pin to them, here: https://github.com/infection/infection/pull/304/files

Now, it seems we depend on `devTools/Dockerfile.json` but it's never generated.

So this PR generates `devTools/Dockerfile.json` after image is built and now the second run doesn't trigger image build anymore.

----

@sanmai I would like your review here as my knowledge of Makefile is limited, and you were the author of this `Dockerfile.json` feature :)
