### PR TITLE
Remove container after usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ PARATEST=vendor/bin/paratest
 
 INFECTION=./build/infection.phar
 
-DOCKER_RUN=docker-compose run
+DOCKER_RUN=docker-compose run --rm
 DOCKER_RUN_82=$(DOCKER_RUN) php82 $(FLOCK) Makefile
 DOCKER_FILE_IMAGE=devTools/Dockerfile.json
 


### PR DESCRIPTION
Because later, on subsequent run, `docker compose` complains about orphan docker containers

```
WARN[0000] Found orphan containers ([infection-php82-run-455e142090f0]) for this project.

If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
```