### PR TITLE
Apply multiline promoted properties fixer to improve code readability

### DIFF
--- a/src/Config/ConsoleHelper.php
+++ b/src/Config/ConsoleHelper.php
@@ -44,8 +44,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ConsoleHelper
 {
-    public function __construct(private readonly FormatterHelper $formatterHelper)
-    {
+    public function __construct(
+        private readonly FormatterHelper $formatterHelper,
+    ) {
     }
 
     public function writeSection(OutputInterface $output, string $text, string $style = 'bg=blue;fg=white'): void

--- a/src/Config/Guesser/PhpUnitPathGuesser.php
+++ b/src/Config/Guesser/PhpUnitPathGuesser.php
@@ -46,8 +46,9 @@ final readonly class PhpUnitPathGuesser
 {
     private const CURRENT_DIR_PATH = '.';
 
-    public function __construct(private stdClass $composerJsonContent)
-    {
+    public function __construct(
+        private stdClass $composerJsonContent,
+    ) {
     }
 
     public function guess(): string

--- a/src/Config/Guesser/SourceDirGuesser.php
+++ b/src/Config/Guesser/SourceDirGuesser.php
@@ -49,8 +49,9 @@ use function trim;
  */
 class SourceDirGuesser
 {
-    public function __construct(private readonly stdClass $composerJsonContent)
-    {
+    public function __construct(
+        private readonly stdClass $composerJsonContent,
+    ) {
     }
 
     /**

--- a/src/Config/ValueProvider/SourceDirsProvider.php
+++ b/src/Config/ValueProvider/SourceDirsProvider.php
@@ -53,8 +53,11 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
  */
 final readonly class SourceDirsProvider
 {
-    public function __construct(private ConsoleHelper $consoleHelper, private QuestionHelper $questionHelper, private SourceDirGuesser $sourceDirGuesser)
-    {
+    public function __construct(
+        private ConsoleHelper $consoleHelper,
+        private QuestionHelper $questionHelper,
+        private SourceDirGuesser $sourceDirGuesser,
+    ) {
     }
 
     /**

--- a/src/Config/ValueProvider/TextLogFileProvider.php
+++ b/src/Config/ValueProvider/TextLogFileProvider.php
@@ -45,8 +45,10 @@ use Symfony\Component\Console\Question\Question;
  */
 final readonly class TextLogFileProvider
 {
-    public function __construct(private ConsoleHelper $consoleHelper, private QuestionHelper $questionHelper)
-    {
+    public function __construct(
+        private ConsoleHelper $consoleHelper,
+        private QuestionHelper $questionHelper,
+    ) {
     }
 
     /**

--- a/src/Configuration/Entry/PhpUnit.php
+++ b/src/Configuration/Entry/PhpUnit.php
@@ -40,8 +40,10 @@ namespace Infection\Configuration\Entry;
  */
 final class PhpUnit
 {
-    public function __construct(private ?string $configDir, private readonly ?string $customPath)
-    {
+    public function __construct(
+        private ?string $configDir,
+        private readonly ?string $customPath,
+    ) {
     }
 
     public function setConfigDir(string $dir): void

--- a/src/Configuration/Entry/StrykerConfig.php
+++ b/src/Configuration/Entry/StrykerConfig.php
@@ -55,8 +55,10 @@ final class StrykerConfig
      *
      * @throws InvalidArgumentException when the provided $branch looks like a regular expression, but is not a valid one
      */
-    private function __construct(string $branch, private readonly bool $isForFullReport)
-    {
+    private function __construct(
+        string $branch,
+        private readonly bool $isForFullReport,
+    ) {
         if (preg_match('#^/.+/$#', $branch) === 0) {
             $this->branchMatch = '/^' . preg_quote($branch, '/') . '$/';
 

--- a/src/Configuration/Schema/SchemaConfigurationFile.php
+++ b/src/Configuration/Schema/SchemaConfigurationFile.php
@@ -49,8 +49,9 @@ final class SchemaConfigurationFile
 {
     private ?stdClass $decodedContents = null;
 
-    public function __construct(private readonly string $path)
-    {
+    public function __construct(
+        private readonly string $path,
+    ) {
     }
 
     public function getPath(): string

--- a/src/Configuration/Schema/SchemaConfigurationFileLoader.php
+++ b/src/Configuration/Schema/SchemaConfigurationFileLoader.php
@@ -40,8 +40,10 @@ namespace Infection\Configuration\Schema;
  */
 class SchemaConfigurationFileLoader
 {
-    public function __construct(private readonly SchemaValidator $schemaValidator, private readonly SchemaConfigurationFactory $factory)
-    {
+    public function __construct(
+        private readonly SchemaValidator $schemaValidator,
+        private readonly SchemaConfigurationFactory $factory,
+    ) {
     }
 
     public function loadFile(string $file): SchemaConfiguration

--- a/src/Configuration/Schema/SchemaConfigurationLoader.php
+++ b/src/Configuration/Schema/SchemaConfigurationLoader.php
@@ -54,8 +54,10 @@ final readonly class SchemaConfigurationLoader
     private const DEFAULT_DIST_JSON_CONFIG_FILE = 'infection.json.dist';
     private const DEFAULT_JSON_CONFIG_FILE = 'infection.json';
 
-    public function __construct(private Locator $locator, private SchemaConfigurationFileLoader $fileLoader)
-    {
+    public function __construct(
+        private Locator $locator,
+        private SchemaConfigurationFileLoader $fileLoader,
+    ) {
     }
 
     /**

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -72,8 +72,9 @@ final class Application extends BaseApplication
 
 ';
 
-    public function __construct(private readonly Container $container)
-    {
+    public function __construct(
+        private readonly Container $container,
+    ) {
         parent::__construct(self::NAME, self::getPrettyVersion());
         $this->setDefaultCommand('run');
     }

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -49,8 +49,9 @@ class ConsoleOutput
     private const RUNNING_WITH_DEBUGGER_NOTE = 'You are running Infection with %s enabled.';
     private const MIN_MSI_CAN_GET_INCREASED_NOTICE = 'The %s is %s%% percentage points over the required %s. Consider increasing the required %s percentage the next time you run Infection.';
 
-    public function __construct(private readonly ConsoleLogger $logger)
-    {
+    public function __construct(
+        private readonly ConsoleLogger $logger,
+    ) {
     }
 
     public function logVerbosityDeprecationNotice(string $valueToUse): void

--- a/src/Console/OutputFormatter/DotFormatter.php
+++ b/src/Console/OutputFormatter/DotFormatter.php
@@ -49,8 +49,9 @@ final class DotFormatter extends AbstractOutputFormatter
 {
     private const DOTS_PER_ROW = 50;
 
-    public function __construct(private readonly OutputInterface $output)
-    {
+    public function __construct(
+        private readonly OutputInterface $output,
+    ) {
     }
 
     public function start(int $mutationCount): void

--- a/src/Console/OutputFormatter/FormatterFactory.php
+++ b/src/Console/OutputFormatter/FormatterFactory.php
@@ -46,8 +46,9 @@ use Webmozart\Assert\Assert;
  */
 final readonly class FormatterFactory
 {
-    public function __construct(private OutputInterface $output)
-    {
+    public function __construct(
+        private OutputInterface $output,
+    ) {
     }
 
     public function create(string $formatterName): OutputFormatter

--- a/src/Console/OutputFormatter/ProgressFormatter.php
+++ b/src/Console/OutputFormatter/ProgressFormatter.php
@@ -43,8 +43,9 @@ use Symfony\Component\Console\Helper\ProgressBar;
  */
 final class ProgressFormatter extends AbstractOutputFormatter
 {
-    public function __construct(private readonly ProgressBar $progressBar)
-    {
+    public function __construct(
+        private readonly ProgressBar $progressBar,
+    ) {
     }
 
     public function start(int $mutationCount): void

--- a/src/Differ/ChangedLinesRange.php
+++ b/src/Differ/ChangedLinesRange.php
@@ -40,8 +40,10 @@ namespace Infection\Differ;
  */
 final readonly class ChangedLinesRange
 {
-    public function __construct(private int $startLine, private int $endLine)
-    {
+    public function __construct(
+        private int $startLine,
+        private int $endLine,
+    ) {
     }
 
     public function getStartLine(): int

--- a/src/Differ/Differ.php
+++ b/src/Differ/Differ.php
@@ -47,8 +47,9 @@ use SebastianBergmann\Diff\Differ as BaseDiffer;
  */
 class Differ
 {
-    public function __construct(private readonly BaseDiffer $differ)
-    {
+    public function __construct(
+        private readonly BaseDiffer $differ,
+    ) {
     }
 
     /**

--- a/src/Differ/FilesDiffChangedLines.php
+++ b/src/Differ/FilesDiffChangedLines.php
@@ -46,8 +46,10 @@ class FilesDiffChangedLines
     /** @var array<string, ChangedLinesRange[]> */
     private ?array $memoizedFilesChangedLinesMap = null;
 
-    public function __construct(private readonly DiffChangedLinesParser $diffChangedLinesParser, private readonly GitDiffFileProvider $diffFileProvider)
-    {
+    public function __construct(
+        private readonly DiffChangedLinesParser $diffChangedLinesParser,
+        private readonly GitDiffFileProvider $diffFileProvider,
+    ) {
     }
 
     public function contains(string $fileRealPath, int $mutationStartLine, int $mutationEndLine, ?string $gitDiffBase): bool

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -60,8 +60,20 @@ use Infection\TestFramework\TestFrameworkExtraOptionsFilter;
  */
 final readonly class Engine
 {
-    public function __construct(private Configuration $config, private TestFrameworkAdapter $adapter, private CoverageChecker $coverageChecker, private EventDispatcher $eventDispatcher, private InitialTestsRunner $initialTestsRunner, private MemoryLimiter $memoryLimiter, private MutationGenerator $mutationGenerator, private MutationTestingRunner $mutationTestingRunner, private MinMsiChecker $minMsiChecker, private ConsoleOutput $consoleOutput, private MetricsCalculator $metricsCalculator, private TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter)
-    {
+    public function __construct(
+        private Configuration $config,
+        private TestFrameworkAdapter $adapter,
+        private CoverageChecker $coverageChecker,
+        private EventDispatcher $eventDispatcher,
+        private InitialTestsRunner $initialTestsRunner,
+        private MemoryLimiter $memoryLimiter,
+        private MutationGenerator $mutationGenerator,
+        private MutationTestingRunner $mutationTestingRunner,
+        private MinMsiChecker $minMsiChecker,
+        private ConsoleOutput $consoleOutput,
+        private MetricsCalculator $metricsCalculator,
+        private TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter,
+    ) {
     }
 
     /**

--- a/src/Environment/BuildContext.php
+++ b/src/Environment/BuildContext.php
@@ -40,8 +40,10 @@ namespace Infection\Environment;
  */
 final readonly class BuildContext
 {
-    public function __construct(private string $repositorySlug, private string $branch)
-    {
+    public function __construct(
+        private string $repositorySlug,
+        private string $branch,
+    ) {
     }
 
     public function repositorySlug(): string

--- a/src/Environment/BuildContextResolver.php
+++ b/src/Environment/BuildContextResolver.php
@@ -44,8 +44,9 @@ use function trim;
  */
 final readonly class BuildContextResolver
 {
-    public function __construct(private CiDetector $ciDetector)
-    {
+    public function __construct(
+        private CiDetector $ciDetector,
+    ) {
     }
 
     public function resolve(): BuildContext

--- a/src/Event/InitialTestSuiteWasFinished.php
+++ b/src/Event/InitialTestSuiteWasFinished.php
@@ -40,8 +40,9 @@ namespace Infection\Event;
  */
 final readonly class InitialTestSuiteWasFinished
 {
-    public function __construct(private string $outputText)
-    {
+    public function __construct(
+        private string $outputText,
+    ) {
     }
 
     public function getOutputText(): string

--- a/src/Event/MutantProcessWasFinished.php
+++ b/src/Event/MutantProcessWasFinished.php
@@ -43,8 +43,9 @@ use Infection\Mutant\MutantExecutionResult;
  */
 class MutantProcessWasFinished
 {
-    public function __construct(private readonly MutantExecutionResult $executionResult)
-    {
+    public function __construct(
+        private readonly MutantExecutionResult $executionResult,
+    ) {
     }
 
     public function getExecutionResult(): MutantExecutionResult

--- a/src/Event/MutationGenerationWasStarted.php
+++ b/src/Event/MutationGenerationWasStarted.php
@@ -40,8 +40,9 @@ namespace Infection\Event;
  */
 final readonly class MutationGenerationWasStarted
 {
-    public function __construct(private int $mutableFilesCount)
-    {
+    public function __construct(
+        private int $mutableFilesCount,
+    ) {
     }
 
     public function getMutableFilesCount(): int

--- a/src/Event/MutationTestingWasStarted.php
+++ b/src/Event/MutationTestingWasStarted.php
@@ -42,8 +42,10 @@ use Infection\Process\Runner\ProcessRunner;
  */
 final readonly class MutationTestingWasStarted
 {
-    public function __construct(private int $mutationCount, private ProcessRunner $processRunner)
-    {
+    public function __construct(
+        private int $mutationCount,
+        private ProcessRunner $processRunner,
+    ) {
     }
 
     public function getMutationCount(): int

--- a/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
@@ -46,8 +46,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final readonly class CiInitialTestsConsoleLoggerSubscriber implements EventSubscriber
 {
-    public function __construct(private OutputInterface $output, private TestFrameworkAdapter $testFrameworkAdapter)
-    {
+    public function __construct(
+        private OutputInterface $output,
+        private TestFrameworkAdapter $testFrameworkAdapter,
+    ) {
     }
 
     public function onInitialTestSuiteWasStarted(InitialTestSuiteWasStarted $event): void

--- a/src/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiMutationGeneratingConsoleLoggerSubscriber.php
@@ -43,8 +43,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final readonly class CiMutationGeneratingConsoleLoggerSubscriber implements EventSubscriber
 {
-    public function __construct(private OutputInterface $output)
-    {
+    public function __construct(
+        private OutputInterface $output,
+    ) {
     }
 
     public function onMutationGenerationWasStarted(MutationGenerationWasStarted $event): void

--- a/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php
+++ b/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php
@@ -44,8 +44,10 @@ use Symfony\Component\Finder\Finder;
  */
 final readonly class CleanUpAfterMutationTestingFinishedSubscriber implements EventSubscriber
 {
-    public function __construct(private Filesystem $filesystem, private string $tmpDir)
-    {
+    public function __construct(
+        private Filesystem $filesystem,
+        private string $tmpDir,
+    ) {
     }
 
     public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void

--- a/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactory.php
+++ b/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactory.php
@@ -43,8 +43,11 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final readonly class CleanUpAfterMutationTestingFinishedSubscriberFactory implements SubscriberFactory
 {
-    public function __construct(private bool $debug, private Filesystem $fileSystem, private string $tmpDir)
-    {
+    public function __construct(
+        private bool $debug,
+        private Filesystem $fileSystem,
+        private string $tmpDir,
+    ) {
     }
 
     public function create(OutputInterface $output): EventSubscriber

--- a/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriber.php
@@ -52,8 +52,11 @@ final readonly class InitialTestsConsoleLoggerSubscriber implements EventSubscri
 {
     private ProgressBar $progressBar;
 
-    public function __construct(private OutputInterface $output, private TestFrameworkAdapter $testFrameworkAdapter, private bool $debug)
-    {
+    public function __construct(
+        private OutputInterface $output,
+        private TestFrameworkAdapter $testFrameworkAdapter,
+        private bool $debug,
+    ) {
         $this->progressBar = new ProgressBar($this->output);
         $this->progressBar->setFormat('verbose');
     }

--- a/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriberFactory.php
@@ -43,8 +43,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final readonly class InitialTestsConsoleLoggerSubscriberFactory implements SubscriberFactory
 {
-    public function __construct(private bool $skipProgressBar, private TestFrameworkAdapter $testFrameworkAdapter, private bool $debug)
-    {
+    public function __construct(
+        private bool $skipProgressBar,
+        private TestFrameworkAdapter $testFrameworkAdapter,
+        private bool $debug,
+    ) {
     }
 
     public function create(OutputInterface $output): EventSubscriber

--- a/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriber.php
@@ -48,8 +48,9 @@ final readonly class MutationGeneratingConsoleLoggerSubscriber implements EventS
 {
     private ProgressBar $progressBar;
 
-    public function __construct(private OutputInterface $output)
-    {
+    public function __construct(
+        private OutputInterface $output,
+    ) {
         $this->progressBar = new ProgressBar($this->output);
         $this->progressBar->setFormat('Processing source code files: %current%/%max%');
     }

--- a/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriberFactory.php
@@ -42,8 +42,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final readonly class MutationGeneratingConsoleLoggerSubscriberFactory implements SubscriberFactory
 {
-    public function __construct(private bool $skipProgressBar)
-    {
+    public function __construct(
+        private bool $skipProgressBar,
+    ) {
     }
 
     public function create(OutputInterface $output): EventSubscriber

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -76,8 +76,8 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
         private readonly ResultsCollector $resultsCollector,
         private readonly DiffColorizer $diffColorizer,
         private readonly FederatedLogger $mutationTestingResultsLogger,
-        private readonly bool $showMutations)
-    {
+        private readonly bool $showMutations,
+    ) {
     }
 
     public function onMutationTestingWasStarted(MutationTestingWasStarted $event): void

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
@@ -53,8 +53,8 @@ final readonly class MutationTestingConsoleLoggerSubscriberFactory implements Su
         private DiffColorizer $diffColorizer,
         private FederatedLogger $mutationTestingResultsLogger,
         private bool $showMutations,
-        private OutputFormatter $formatter)
-    {
+        private OutputFormatter $formatter,
+    ) {
     }
 
     public function create(OutputInterface $output): EventSubscriber

--- a/src/Event/Subscriber/MutationTestingResultsLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingResultsLoggerSubscriber.php
@@ -43,8 +43,9 @@ use Infection\Logger\MutationTestingResultsLogger;
  */
 final readonly class MutationTestingResultsLoggerSubscriber implements EventSubscriber
 {
-    public function __construct(private MutationTestingResultsLogger $logger)
-    {
+    public function __construct(
+        private MutationTestingResultsLogger $logger,
+    ) {
     }
 
     public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void

--- a/src/Event/Subscriber/MutationTestingResultsLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingResultsLoggerSubscriberFactory.php
@@ -43,8 +43,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final readonly class MutationTestingResultsLoggerSubscriberFactory implements SubscriberFactory
 {
-    public function __construct(private MutationTestingResultsLogger $logger)
-    {
+    public function __construct(
+        private MutationTestingResultsLogger $logger,
+    ) {
     }
 
     public function create(OutputInterface $output): EventSubscriber

--- a/src/Event/Subscriber/SubscriberRegisterer.php
+++ b/src/Event/Subscriber/SubscriberRegisterer.php
@@ -43,8 +43,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final readonly class SubscriberRegisterer
 {
-    public function __construct(private EventDispatcher $eventDispatcher, private ChainSubscriberFactory $subscriberRegistry)
-    {
+    public function __construct(
+        private EventDispatcher $eventDispatcher,
+        private ChainSubscriberFactory $subscriberRegistry,
+    ) {
     }
 
     public function registerSubscribers(OutputInterface $output): void

--- a/src/FileSystem/Locator/RootsFileLocator.php
+++ b/src/FileSystem/Locator/RootsFileLocator.php
@@ -55,8 +55,10 @@ final class RootsFileLocator implements Locator
     /**
      * @param string[] $roots
      */
-    public function __construct(array $roots, private readonly Filesystem $filesystem)
-    {
+    public function __construct(
+        array $roots,
+        private readonly Filesystem $filesystem,
+    ) {
         Assert::allString($roots);
 
         $this->roots = $roots;

--- a/src/FileSystem/Locator/RootsFileOrDirectoryLocator.php
+++ b/src/FileSystem/Locator/RootsFileOrDirectoryLocator.php
@@ -54,8 +54,10 @@ final class RootsFileOrDirectoryLocator implements Locator
     /**
      * @param string[] $roots
      */
-    public function __construct(array $roots, private readonly Filesystem $filesystem)
-    {
+    public function __construct(
+        array $roots,
+        private readonly Filesystem $filesystem,
+    ) {
         Assert::allString($roots);
 
         $this->roots = $roots;

--- a/src/FileSystem/SourceFileFilter.php
+++ b/src/FileSystem/SourceFileFilter.php
@@ -58,8 +58,10 @@ class SourceFileFilter implements FileFilter
     /**
      * @param string[] $excludeDirectories
      */
-    public function __construct(string $filter, private readonly array $excludeDirectories)
-    {
+    public function __construct(
+        string $filter,
+        private readonly array $excludeDirectories,
+    ) {
         $this->filters = array_filter(array_map(
             'trim',
             explode(',', $filter),

--- a/src/Logger/ConsoleLogger.php
+++ b/src/Logger/ConsoleLogger.php
@@ -86,8 +86,9 @@ final class ConsoleLogger extends AbstractLogger
         LogLevel::NOTICE => 'note',
     ];
 
-    public function __construct(private readonly IO $io)
-    {
+    public function __construct(
+        private readonly IO $io,
+    ) {
     }
 
     /**

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -52,8 +52,11 @@ use function strlen;
  */
 final readonly class DebugFileLogger implements LineMutationTestingResultsLogger
 {
-    public function __construct(private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector, private bool $onlyCoveredMode)
-    {
+    public function __construct(
+        private MetricsCalculator $metricsCalculator,
+        private ResultsCollector $resultsCollector,
+        private bool $onlyCoveredMode,
+    ) {
     }
 
     public function getLogLines(): array

--- a/src/Logger/FileLogger.php
+++ b/src/Logger/FileLogger.php
@@ -52,8 +52,12 @@ final readonly class FileLogger implements MutationTestingResultsLogger
 {
     public const ALLOWED_PHP_STREAMS = ['php://stdout', 'php://stderr'];
 
-    public function __construct(private string $filePath, private Filesystem $fileSystem, private LineMutationTestingResultsLogger $lineLogger, private LoggerInterface $logger)
-    {
+    public function __construct(
+        private string $filePath,
+        private Filesystem $fileSystem,
+        private LineMutationTestingResultsLogger $lineLogger,
+        private LoggerInterface $logger,
+    ) {
     }
 
     public function log(): void

--- a/src/Logger/FileLoggerFactory.php
+++ b/src/Logger/FileLoggerFactory.php
@@ -50,8 +50,17 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class FileLoggerFactory
 {
-    public function __construct(private readonly MetricsCalculator $metricsCalculator, private readonly ResultsCollector $resultsCollector, private readonly Filesystem $filesystem, private readonly string $logVerbosity, private readonly bool $debugMode, private readonly bool $onlyCoveredCode, private readonly LoggerInterface $logger, private readonly StrykerHtmlReportBuilder $strykerHtmlReportBuilder, private readonly ?string $loggerProjectRootDirectory)
-    {
+    public function __construct(
+        private readonly MetricsCalculator $metricsCalculator,
+        private readonly ResultsCollector $resultsCollector,
+        private readonly Filesystem $filesystem,
+        private readonly string $logVerbosity,
+        private readonly bool $debugMode,
+        private readonly bool $onlyCoveredCode,
+        private readonly LoggerInterface $logger,
+        private readonly StrykerHtmlReportBuilder $strykerHtmlReportBuilder,
+        private readonly ?string $loggerProjectRootDirectory,
+    ) {
     }
 
     public function createFromLogEntries(Logs $logConfig): MutationTestingResultsLogger

--- a/src/Logger/GitHub/GitDiffFileProvider.php
+++ b/src/Logger/GitHub/GitDiffFileProvider.php
@@ -53,8 +53,9 @@ class GitDiffFileProvider
 {
     final public const DEFAULT_BASE = 'origin/master';
 
-    public function __construct(private readonly ShellCommandLineExecutor $shellCommandLineExecutor)
-    {
+    public function __construct(
+        private readonly ShellCommandLineExecutor $shellCommandLineExecutor,
+    ) {
     }
 
     /**

--- a/src/Logger/GitHubAnnotationsLogger.php
+++ b/src/Logger/GitHubAnnotationsLogger.php
@@ -49,8 +49,10 @@ final class GitHubAnnotationsLogger implements LineMutationTestingResultsLogger
 {
     public const DEFAULT_OUTPUT = 'php://stdout';
 
-    public function __construct(private readonly ResultsCollector $resultsCollector, private ?string $loggerProjectRootDirectory)
-    {
+    public function __construct(
+        private readonly ResultsCollector $resultsCollector,
+        private ?string $loggerProjectRootDirectory,
+    ) {
         if ($loggerProjectRootDirectory === null) {
             if (($projectRootDirectory = getenv('GITHUB_WORKSPACE')) === false) {
                 $projectRootDirectory = trim((string) shell_exec('git rev-parse --show-toplevel'));

--- a/src/Logger/GitLabCodeQualityLogger.php
+++ b/src/Logger/GitLabCodeQualityLogger.php
@@ -49,8 +49,10 @@ use function trim;
  */
 final class GitLabCodeQualityLogger implements LineMutationTestingResultsLogger
 {
-    public function __construct(private readonly ResultsCollector $resultsCollector, private ?string $loggerProjectRootDirectory)
-    {
+    public function __construct(
+        private readonly ResultsCollector $resultsCollector,
+        private ?string $loggerProjectRootDirectory,
+    ) {
         if ($loggerProjectRootDirectory === null) {
             if (($projectRootDirectory = getenv('CI_PROJECT_DIR')) === false) {
                 $projectRootDirectory = trim((string) shell_exec('git rev-parse --show-toplevel'));

--- a/src/Logger/Html/HtmlFileLogger.php
+++ b/src/Logger/Html/HtmlFileLogger.php
@@ -43,8 +43,9 @@ use function Safe\json_encode;
  */
 final readonly class HtmlFileLogger implements LineMutationTestingResultsLogger
 {
-    public function __construct(private StrykerHtmlReportBuilder $strykerHtmlReportBuilder)
-    {
+    public function __construct(
+        private StrykerHtmlReportBuilder $strykerHtmlReportBuilder,
+    ) {
     }
 
     public function getLogLines(): array

--- a/src/Logger/Html/StrykerHtmlReportBuilder.php
+++ b/src/Logger/Html/StrykerHtmlReportBuilder.php
@@ -93,8 +93,10 @@ final readonly class StrykerHtmlReportBuilder
     private const PLUS_LENGTH = 1;
     private const DIFF_HEADERS_LINES_COUNT = 1;
 
-    public function __construct(private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector)
-    {
+    public function __construct(
+        private MetricsCalculator $metricsCalculator,
+        private ResultsCollector $resultsCollector,
+    ) {
     }
 
     public function build(): array

--- a/src/Logger/Http/Response.php
+++ b/src/Logger/Http/Response.php
@@ -48,8 +48,10 @@ final class Response
 
     private readonly int $statusCode;
 
-    public function __construct(int $statusCode, private readonly string $body)
-    {
+    public function __construct(
+        int $statusCode,
+        private readonly string $body,
+    ) {
         Assert::range(
             $statusCode,
             self::HTTP_OK,

--- a/src/Logger/Http/StrykerDashboardClient.php
+++ b/src/Logger/Http/StrykerDashboardClient.php
@@ -44,8 +44,10 @@ use function sprintf;
  */
 class StrykerDashboardClient
 {
-    public function __construct(private readonly StrykerCurlClient $client, private readonly LoggerInterface $logger)
-    {
+    public function __construct(
+        private readonly StrykerCurlClient $client,
+        private readonly LoggerInterface $logger,
+    ) {
     }
 
     public function sendReport(

--- a/src/Logger/JsonLogger.php
+++ b/src/Logger/JsonLogger.php
@@ -47,8 +47,11 @@ use const JSON_THROW_ON_ERROR;
  */
 final readonly class JsonLogger implements LineMutationTestingResultsLogger
 {
-    public function __construct(private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector, private bool $onlyCoveredMode)
-    {
+    public function __construct(
+        private MetricsCalculator $metricsCalculator,
+        private ResultsCollector $resultsCollector,
+        private bool $onlyCoveredMode,
+    ) {
     }
 
     /**

--- a/src/Logger/PerMutatorLogger.php
+++ b/src/Logger/PerMutatorLogger.php
@@ -59,8 +59,10 @@ final readonly class PerMutatorLogger implements LineMutationTestingResultsLogge
 {
     private const ROUND_PRECISION = 2;
 
-    public function __construct(private MetricsCalculator $metricsCalculator, private ResultsCollector $resultsCollector)
-    {
+    public function __construct(
+        private MetricsCalculator $metricsCalculator,
+        private ResultsCollector $resultsCollector,
+    ) {
     }
 
     public function getLogLines(): array

--- a/src/Logger/StrykerLogger.php
+++ b/src/Logger/StrykerLogger.php
@@ -53,8 +53,15 @@ use function sprintf;
  */
 final readonly class StrykerLogger implements MutationTestingResultsLogger
 {
-    public function __construct(private BuildContextResolver $buildContextResolver, private StrykerApiKeyResolver $strykerApiKeyResolver, private StrykerDashboardClient $strykerDashboardClient, private MetricsCalculator $metricsCalculator, private StrykerHtmlReportBuilder $strykerHtmlReportBuilder, private StrykerConfig $strykerConfig, private LoggerInterface $logger)
-    {
+    public function __construct(
+        private BuildContextResolver $buildContextResolver,
+        private StrykerApiKeyResolver $strykerApiKeyResolver,
+        private StrykerDashboardClient $strykerDashboardClient,
+        private MetricsCalculator $metricsCalculator,
+        private StrykerHtmlReportBuilder $strykerHtmlReportBuilder,
+        private StrykerConfig $strykerConfig,
+        private LoggerInterface $logger,
+    ) {
     }
 
     public function log(): void

--- a/src/Logger/StrykerLoggerFactory.php
+++ b/src/Logger/StrykerLoggerFactory.php
@@ -51,8 +51,12 @@ use Psr\Log\LoggerInterface;
  */
 class StrykerLoggerFactory
 {
-    public function __construct(private readonly MetricsCalculator $metricsCalculator, private readonly StrykerHtmlReportBuilder $strykerHtmlReportBuilder, private readonly CiDetector $ciDetector, private readonly LoggerInterface $logger)
-    {
+    public function __construct(
+        private readonly MetricsCalculator $metricsCalculator,
+        private readonly StrykerHtmlReportBuilder $strykerHtmlReportBuilder,
+        private readonly CiDetector $ciDetector,
+        private readonly LoggerInterface $logger,
+    ) {
     }
 
     public function createFromLogEntries(Logs $logConfig): ?MutationTestingResultsLogger

--- a/src/Logger/SummaryFileLogger.php
+++ b/src/Logger/SummaryFileLogger.php
@@ -45,8 +45,9 @@ use Infection\Metrics\MetricsCalculator;
  */
 final readonly class SummaryFileLogger implements LineMutationTestingResultsLogger
 {
-    public function __construct(private MetricsCalculator $metricsCalculator)
-    {
+    public function __construct(
+        private MetricsCalculator $metricsCalculator,
+    ) {
     }
 
     public function getLogLines(): array

--- a/src/Logger/SummaryJsonLogger.php
+++ b/src/Logger/SummaryJsonLogger.php
@@ -44,8 +44,9 @@ use const JSON_THROW_ON_ERROR;
  */
 final readonly class SummaryJsonLogger implements LineMutationTestingResultsLogger
 {
-    public function __construct(private MetricsCalculator $metricsCalculator)
-    {
+    public function __construct(
+        private MetricsCalculator $metricsCalculator,
+    ) {
     }
 
     /**

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -51,8 +51,12 @@ use function strlen;
  */
 final readonly class TextFileLogger implements LineMutationTestingResultsLogger
 {
-    public function __construct(private ResultsCollector $resultsCollector, private bool $debugVerbosity, private bool $onlyCoveredMode, private bool $debugMode)
-    {
+    public function __construct(
+        private ResultsCollector $resultsCollector,
+        private bool $debugVerbosity,
+        private bool $onlyCoveredMode,
+        private bool $debugMode,
+    ) {
     }
 
     public function getLogLines(): array

--- a/src/Metrics/Calculator.php
+++ b/src/Metrics/Calculator.php
@@ -49,8 +49,14 @@ final class Calculator
 
     private ?float $coveredMutationScoreIndicator = null;
 
-    public function __construct(private readonly int $roundingPrecision, private readonly int $killedCount, private readonly int $errorCount, private readonly int $timedOutCount, private readonly int $notTestedCount, private readonly int $totalCount)
-    {
+    public function __construct(
+        private readonly int $roundingPrecision,
+        private readonly int $killedCount,
+        private readonly int $errorCount,
+        private readonly int $timedOutCount,
+        private readonly int $notTestedCount,
+        private readonly int $totalCount,
+    ) {
     }
 
     public static function fromMetrics(MetricsCalculator $calculator): self

--- a/src/Metrics/FilteringResultsCollector.php
+++ b/src/Metrics/FilteringResultsCollector.php
@@ -48,8 +48,10 @@ class FilteringResultsCollector implements Collector
     /**
      * @param array<string, mixed> $targetDetectionStatuses
      */
-    public function __construct(private readonly Collector $targetCollector, private readonly array $targetDetectionStatuses)
-    {
+    public function __construct(
+        private readonly Collector $targetCollector,
+        private readonly array $targetDetectionStatuses,
+    ) {
     }
 
     public function collect(MutantExecutionResult ...$executionResults): void

--- a/src/Metrics/FilteringResultsCollectorFactory.php
+++ b/src/Metrics/FilteringResultsCollectorFactory.php
@@ -43,8 +43,9 @@ use Infection\Mutant\DetectionStatus;
  */
 final readonly class FilteringResultsCollectorFactory
 {
-    public function __construct(private TargetDetectionStatusesProvider $statusesProvider)
-    {
+    public function __construct(
+        private TargetDetectionStatusesProvider $statusesProvider,
+    ) {
     }
 
     public function create(Collector $targetCollector): ?Collector

--- a/src/Metrics/MetricsCalculator.php
+++ b/src/Metrics/MetricsCalculator.php
@@ -55,8 +55,9 @@ class MetricsCalculator implements Collector
 
     private ?Calculator $calculator = null;
 
-    public function __construct(private readonly int $roundingPrecision)
-    {
+    public function __construct(
+        private readonly int $roundingPrecision,
+    ) {
         foreach (DetectionStatus::ALL as $status) {
             $this->countByStatus[$status] = 0;
         }

--- a/src/Metrics/MinMsiChecker.php
+++ b/src/Metrics/MinMsiChecker.php
@@ -45,8 +45,11 @@ class MinMsiChecker
 {
     private const VALUE_OVER_REQUIRED_TOLERANCE = 2;
 
-    public function __construct(private readonly bool $ignoreMsiWithNoMutations, private readonly float $minMsi, private readonly float $minCoveredCodeMsi)
-    {
+    public function __construct(
+        private readonly bool $ignoreMsiWithNoMutations,
+        private readonly float $minMsi,
+        private readonly float $minCoveredCodeMsi,
+    ) {
     }
 
     /**

--- a/src/Metrics/TargetDetectionStatusesProvider.php
+++ b/src/Metrics/TargetDetectionStatusesProvider.php
@@ -49,8 +49,12 @@ use function iterator_to_array;
  */
 class TargetDetectionStatusesProvider
 {
-    public function __construct(private readonly Logs $logConfig, private readonly string $logVerbosity, private readonly bool $onlyCoveredMode, private readonly bool $showMutations)
-    {
+    public function __construct(
+        private readonly Logs $logConfig,
+        private readonly string $logVerbosity,
+        private readonly bool $onlyCoveredMode,
+        private readonly bool $showMutations,
+    ) {
     }
 
     /**

--- a/src/Mutant/Mutant.php
+++ b/src/Mutant/Mutant.php
@@ -50,8 +50,13 @@ class Mutant
      * @param Deferred<string> $diff
      * @param Deferred<string> $prettyPrintedOriginalCode
      */
-    public function __construct(private readonly string $mutantFilePath, private readonly Mutation $mutation, private readonly Deferred $mutatedCode, private readonly Deferred $diff, private readonly Deferred $prettyPrintedOriginalCode)
-    {
+    public function __construct(
+        private readonly string $mutantFilePath,
+        private readonly Mutation $mutation,
+        private readonly Deferred $mutatedCode,
+        private readonly Deferred $diff,
+        private readonly Deferred $prettyPrintedOriginalCode,
+    ) {
     }
 
     public function getFilePath(): string

--- a/src/Mutant/MutantCodeFactory.php
+++ b/src/Mutant/MutantCodeFactory.php
@@ -47,8 +47,9 @@ use PhpParser\PrettyPrinterAbstract;
  */
 class MutantCodeFactory
 {
-    public function __construct(private readonly PrettyPrinterAbstract $printer)
-    {
+    public function __construct(
+        private readonly PrettyPrinterAbstract $printer,
+    ) {
     }
 
     public function createCode(Mutation $mutation): string

--- a/src/Mutant/MutantExecutionResultFactory.php
+++ b/src/Mutant/MutantExecutionResultFactory.php
@@ -50,8 +50,9 @@ class MutantExecutionResultFactory
 {
     private const PROCESS_MIN_ERROR_CODE = 100;
 
-    public function __construct(private readonly TestFrameworkAdapter $testFrameworkAdapter)
-    {
+    public function __construct(
+        private readonly TestFrameworkAdapter $testFrameworkAdapter,
+    ) {
     }
 
     public function createFromProcess(MutantProcess $mutantProcess): MutantExecutionResult

--- a/src/Mutant/MutantFactory.php
+++ b/src/Mutant/MutantFactory.php
@@ -54,8 +54,12 @@ class MutantFactory
      */
     private array $printedFileCache = [];
 
-    public function __construct(private readonly string $tmpDir, private readonly Differ $differ, private readonly PrettyPrinterAbstract $printer, private readonly MutantCodeFactory $mutantCodeFactory)
-    {
+    public function __construct(
+        private readonly string $tmpDir,
+        private readonly Differ $differ,
+        private readonly PrettyPrinterAbstract $printer,
+        private readonly MutantCodeFactory $mutantCodeFactory,
+    ) {
     }
 
     public function create(Mutation $mutation): Mutant

--- a/src/Mutation/FileMutationGenerator.php
+++ b/src/Mutation/FileMutationGenerator.php
@@ -54,8 +54,14 @@ use Webmozart\Assert\Assert;
  */
 class FileMutationGenerator
 {
-    public function __construct(private readonly FileParser $parser, private readonly NodeTraverserFactory $traverserFactory, private readonly LineRangeCalculator $lineRangeCalculator, private readonly FilesDiffChangedLines $filesDiffChangedLines, private readonly bool $isForGitDiffLines, private readonly ?string $gitDiffBase)
-    {
+    public function __construct(
+        private readonly FileParser $parser,
+        private readonly NodeTraverserFactory $traverserFactory,
+        private readonly LineRangeCalculator $lineRangeCalculator,
+        private readonly FilesDiffChangedLines $filesDiffChangedLines,
+        private readonly bool $isForGitDiffLines,
+        private readonly ?string $gitDiffBase,
+    ) {
     }
 
     /**

--- a/src/Mutator/IgnoreConfig.php
+++ b/src/Mutator/IgnoreConfig.php
@@ -52,8 +52,9 @@ class IgnoreConfig
     /**
      * @param string[] $patterns
      */
-    public function __construct(private readonly array $patterns)
-    {
+    public function __construct(
+        private readonly array $patterns,
+    ) {
         if ($patterns !== []) {
             $this->hashtable = array_flip($patterns);
         }

--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -61,8 +61,10 @@ final readonly class IgnoreMutator implements Mutator
     /**
      * @param Mutator<TNode> $mutator
      */
-    public function __construct(private IgnoreConfig $config, private Mutator $mutator)
-    {
+    public function __construct(
+        private IgnoreConfig $config,
+        private Mutator $mutator,
+    ) {
     }
 
     public static function getDefinition(): Definition

--- a/src/Mutator/NoopMutator.php
+++ b/src/Mutator/NoopMutator.php
@@ -50,8 +50,9 @@ final readonly class NoopMutator implements Mutator
     /**
      * @param Mutator<TNode> $mutator
      */
-    public function __construct(private Mutator $mutator)
-    {
+    public function __construct(
+        private Mutator $mutator,
+    ) {
     }
 
     public static function getDefinition(): Definition

--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -57,8 +57,9 @@ final readonly class ArrayItemRemoval implements ConfigurableMutator
     use GetConfigClassName;
     use GetMutatorName;
 
-    public function __construct(private ArrayItemRemovalConfig $config)
-    {
+    public function __construct(
+        private ArrayItemRemovalConfig $config,
+    ) {
     }
 
     public static function getDefinition(): Definition

--- a/src/PhpParser/FileParser.php
+++ b/src/PhpParser/FileParser.php
@@ -46,8 +46,9 @@ use Throwable;
  */
 class FileParser
 {
-    public function __construct(private readonly Parser $parser)
-    {
+    public function __construct(
+        private readonly Parser $parser,
+    ) {
     }
 
     /**

--- a/src/PhpParser/Visitor/IgnoreAllMutationsAnnotationReaderVisitor.php
+++ b/src/PhpParser/Visitor/IgnoreAllMutationsAnnotationReaderVisitor.php
@@ -51,8 +51,10 @@ final class IgnoreAllMutationsAnnotationReaderVisitor extends NodeVisitorAbstrac
     /**
      * @param SplObjectStorage<object, mixed> $ignoredNodes
      */
-    public function __construct(private readonly ChangingIgnorer $changingIgnorer, private readonly SplObjectStorage $ignoredNodes)
-    {
+    public function __construct(
+        private readonly ChangingIgnorer $changingIgnorer,
+        private readonly SplObjectStorage $ignoredNodes,
+    ) {
     }
 
     public function enterNode(Node $node): ?Node

--- a/src/PhpParser/Visitor/MutationCollectorVisitor.php
+++ b/src/PhpParser/Visitor/MutationCollectorVisitor.php
@@ -50,8 +50,9 @@ final class MutationCollectorVisitor extends NodeVisitorAbstract
      */
     private array $mutationChunks = [];
 
-    public function __construct(private readonly NodeMutationGenerator $mutationGenerator)
-    {
+    public function __construct(
+        private readonly NodeMutationGenerator $mutationGenerator,
+    ) {
     }
 
     public function beforeTraverse(array $nodes): ?array

--- a/src/PhpParser/Visitor/MutatorVisitor.php
+++ b/src/PhpParser/Visitor/MutatorVisitor.php
@@ -45,8 +45,9 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class MutatorVisitor extends NodeVisitorAbstract
 {
-    public function __construct(private readonly Mutation $mutation)
-    {
+    public function __construct(
+        private readonly Mutation $mutation,
+    ) {
     }
 
     public function leaveNode(Node $node)

--- a/src/PhpParser/Visitor/NonMutableNodesIgnorerVisitor.php
+++ b/src/PhpParser/Visitor/NonMutableNodesIgnorerVisitor.php
@@ -48,8 +48,9 @@ final class NonMutableNodesIgnorerVisitor extends NodeVisitorAbstract
     /**
      * @param NodeIgnorer[] $nodeIgnorers
      */
-    public function __construct(private readonly array $nodeIgnorers)
-    {
+    public function __construct(
+        private readonly array $nodeIgnorers,
+    ) {
     }
 
     public function enterNode(Node $node)

--- a/src/Process/Factory/InitialTestsRunProcessFactory.php
+++ b/src/Process/Factory/InitialTestsRunProcessFactory.php
@@ -45,8 +45,9 @@ use Symfony\Component\Process\Process;
  */
 class InitialTestsRunProcessFactory
 {
-    public function __construct(private readonly TestFrameworkAdapter $testFrameworkAdapter)
-    {
+    public function __construct(
+        private readonly TestFrameworkAdapter $testFrameworkAdapter,
+    ) {
     }
 
     /**

--- a/src/Process/Factory/MutantProcessFactory.php
+++ b/src/Process/Factory/MutantProcessFactory.php
@@ -50,8 +50,12 @@ use Symfony\Component\Process\Process;
 class MutantProcessFactory
 {
     // TODO: is it necessary for the timeout to be an int?
-    public function __construct(private readonly TestFrameworkAdapter $testFrameworkAdapter, private readonly float $timeout, private readonly EventDispatcher $eventDispatcher, private readonly MutantExecutionResultFactory $resultFactory)
-    {
+    public function __construct(
+        private readonly TestFrameworkAdapter $testFrameworkAdapter,
+        private readonly float $timeout,
+        private readonly EventDispatcher $eventDispatcher,
+        private readonly MutantExecutionResultFactory $resultFactory,
+    ) {
     }
 
     public function createProcessForMutant(Mutant $mutant, string $testFrameworkExtraOptions = ''): MutantProcess

--- a/src/Process/MutantProcess.php
+++ b/src/Process/MutantProcess.php
@@ -50,8 +50,10 @@ class MutantProcess implements ProcessBearer
 
     private bool $timedOut = false;
 
-    public function __construct(private readonly Process $process, private readonly Mutant $mutant)
-    {
+    public function __construct(
+        private readonly Process $process,
+        private readonly Mutant $mutant,
+    ) {
         $this->callback = static function (): void {};
     }
 

--- a/src/Process/Runner/IndexedProcessBearer.php
+++ b/src/Process/Runner/IndexedProcessBearer.php
@@ -40,7 +40,9 @@ namespace Infection\Process\Runner;
  */
 final class IndexedProcessBearer
 {
-    public function __construct(public int $threadIndex, public ProcessBearer $processBearer)
-    {
+    public function __construct(
+        public int $threadIndex,
+        public ProcessBearer $processBearer,
+    ) {
     }
 }

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -48,8 +48,10 @@ use Symfony\Component\Process\Process;
  */
 class InitialTestsRunner
 {
-    public function __construct(private readonly InitialTestsRunProcessFactory $processBuilder, private readonly EventDispatcher $eventDispatcher)
-    {
+    public function __construct(
+        private readonly InitialTestsRunProcessFactory $processBuilder,
+        private readonly EventDispatcher $eventDispatcher,
+    ) {
     }
 
     /**

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -58,8 +58,17 @@ class MutationTestingRunner
     /**
      * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
      */
-    public function __construct(private readonly MutantProcessFactory $processFactory, private readonly MutantFactory $mutantFactory, private readonly ProcessRunner $processRunner, private readonly EventDispatcher $eventDispatcher, private readonly Filesystem $fileSystem, private readonly DiffSourceCodeMatcher $diffSourceCodeMatcher, private readonly bool $runConcurrently, private readonly float $timeout, private readonly array $ignoreSourceCodeMutatorsMap)
-    {
+    public function __construct(
+        private readonly MutantProcessFactory $processFactory,
+        private readonly MutantFactory $mutantFactory,
+        private readonly ProcessRunner $processRunner,
+        private readonly EventDispatcher $eventDispatcher,
+        private readonly Filesystem $fileSystem,
+        private readonly DiffSourceCodeMatcher $diffSourceCodeMatcher,
+        private readonly bool $runConcurrently,
+        private readonly float $timeout,
+        private readonly array $ignoreSourceCodeMutatorsMap,
+    ) {
     }
 
     /**

--- a/src/Process/Runner/ParallelProcessRunner.php
+++ b/src/Process/Runner/ParallelProcessRunner.php
@@ -70,8 +70,10 @@ final class ParallelProcessRunner implements ProcessRunner
     /**
      * @param int $poll Delay (in milliseconds) to wait in-between two polls
      */
-    public function __construct(private readonly int $threadCount, private readonly int $poll = self::POLL_WAIT_IN_MS)
-    {
+    public function __construct(
+        private readonly int $threadCount,
+        private readonly int $poll = self::POLL_WAIT_IN_MS,
+    ) {
     }
 
     public function stop(): void

--- a/src/Reflection/AnonymousClassReflection.php
+++ b/src/Reflection/AnonymousClassReflection.php
@@ -42,8 +42,9 @@ use ReflectionClass;
  */
 final readonly class AnonymousClassReflection implements ClassReflection
 {
-    private function __construct(private ReflectionClass $reflectionClass)
-    {
+    private function __construct(
+        private ReflectionClass $reflectionClass,
+    ) {
     }
 
     /**

--- a/src/Reflection/CoreClassReflection.php
+++ b/src/Reflection/CoreClassReflection.php
@@ -43,8 +43,9 @@ use ReflectionException;
  */
 final readonly class CoreClassReflection implements ClassReflection
 {
-    private function __construct(private ReflectionClass $reflectionClass)
-    {
+    private function __construct(
+        private ReflectionClass $reflectionClass,
+    ) {
     }
 
     /**

--- a/src/Reflection/Visibility.php
+++ b/src/Reflection/Visibility.php
@@ -43,8 +43,9 @@ final readonly class Visibility
     public const PUBLIC = 'public';
     public const PROTECTED = 'protected';
 
-    private function __construct(private string $variant)
-    {
+    private function __construct(
+        private string $variant,
+    ) {
     }
 
     public static function asPublic(): self

--- a/src/Resource/Listener/PerformanceLoggerSubscriber.php
+++ b/src/Resource/Listener/PerformanceLoggerSubscriber.php
@@ -55,8 +55,8 @@ final readonly class PerformanceLoggerSubscriber implements EventSubscriber
         private TimeFormatter $timeFormatter,
         private MemoryFormatter $memoryFormatter,
         private int $threadCount,
-        private OutputInterface $output)
-    {
+        private OutputInterface $output,
+    ) {
     }
 
     public function onApplicationExecutionWasStarted(ApplicationExecutionWasStarted $event): void

--- a/src/Resource/Memory/MemoryLimiter.php
+++ b/src/Resource/Memory/MemoryLimiter.php
@@ -48,8 +48,11 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class MemoryLimiter
 {
-    public function __construct(private readonly Filesystem $fileSystem, private readonly string $phpIniPath, private readonly MemoryLimiterEnvironment $environment)
-    {
+    public function __construct(
+        private readonly Filesystem $fileSystem,
+        private readonly string $phpIniPath,
+        private readonly MemoryLimiterEnvironment $environment,
+    ) {
     }
 
     public function limitMemory(string $processOutput, TestFrameworkAdapter $adapter): void

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -47,8 +47,15 @@ use Symfony\Component\Process\Process;
  */
 abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
 {
-    public function __construct(private readonly string $testFrameworkExecutable, private readonly InitialConfigBuilder $initialConfigBuilder, private readonly MutationConfigBuilder $mutationConfigBuilder, private readonly CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder, private readonly VersionParser $versionParser, private readonly CommandLineBuilder $commandLineBuilder, private ?string $version = null)
-    {
+    public function __construct(
+        private readonly string $testFrameworkExecutable,
+        private readonly InitialConfigBuilder $initialConfigBuilder,
+        private readonly MutationConfigBuilder $mutationConfigBuilder,
+        private readonly CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder,
+        private readonly VersionParser $versionParser,
+        private readonly CommandLineBuilder $commandLineBuilder,
+        private ?string $version = null,
+    ) {
     }
 
     abstract public function testsPass(string $output): bool;

--- a/src/TestFramework/AdapterInstallationDecider.php
+++ b/src/TestFramework/AdapterInstallationDecider.php
@@ -52,8 +52,9 @@ final readonly class AdapterInstallationDecider
         TestFrameworkTypes::PHPSPEC => 'Infection\TestFramework\PhpSpec\PhpSpecAdapter',
     ];
 
-    public function __construct(private QuestionHelper $questionHelper)
-    {
+    public function __construct(
+        private QuestionHelper $questionHelper,
+    ) {
     }
 
     public function shouldBeInstalled(string $adapterName, IO $io): bool

--- a/src/TestFramework/AdapterInstaller.php
+++ b/src/TestFramework/AdapterInstaller.php
@@ -53,8 +53,9 @@ final readonly class AdapterInstaller
     // 2 minutes
     private const TIMEOUT = 120.0;
 
-    public function __construct(private ComposerExecutableFinder $composerExecutableFinder)
-    {
+    public function __construct(
+        private ComposerExecutableFinder $composerExecutableFinder,
+    ) {
     }
 
     public function install(string $adapterName): void

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -54,8 +54,9 @@ final readonly class TestFrameworkConfigLocator implements TestFrameworkConfigLo
         'dist.yml',
     ];
 
-    public function __construct(private string $configDir)
-    {
+    public function __construct(
+        private string $configDir,
+    ) {
     }
 
     public function locate(string $testFrameworkName, ?string $customDir = null): string

--- a/src/TestFramework/Coverage/CoveredTraceProvider.php
+++ b/src/TestFramework/Coverage/CoveredTraceProvider.php
@@ -45,8 +45,11 @@ use Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder;
  */
 final readonly class CoveredTraceProvider implements TraceProvider
 {
-    public function __construct(private TraceProvider $primaryTraceProvider, private JUnitTestExecutionInfoAdder $testFileDataAdder, private FileFilter $bufferedFilter)
-    {
+    public function __construct(
+        private TraceProvider $primaryTraceProvider,
+        private JUnitTestExecutionInfoAdder $testFileDataAdder,
+        private FileFilter $bufferedFilter,
+    ) {
     }
 
     /**

--- a/src/TestFramework/Coverage/JUnit/JUnitReportLocator.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitReportLocator.php
@@ -57,8 +57,10 @@ class JUnitReportLocator
 
     private ?string $jUnitPath = null;
 
-    public function __construct(private readonly string $coveragePath, string $defaultJUnitPath)
-    {
+    public function __construct(
+        private readonly string $coveragePath,
+        string $defaultJUnitPath,
+    ) {
         $this->defaultJUnitPath = Path::canonicalize($defaultJUnitPath);
     }
 

--- a/src/TestFramework/Coverage/JUnit/JUnitTestCaseTimeAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestCaseTimeAdder.php
@@ -49,8 +49,9 @@ final readonly class JUnitTestCaseTimeAdder
     /**
      * @param TestLocation[] $tests
      */
-    public function __construct(private array $tests)
-    {
+    public function __construct(
+        private array $tests,
+    ) {
     }
 
     public function getTotalTestTime(): float

--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -50,8 +50,10 @@ class JUnitTestExecutionInfoAdder
 {
     private const MAX_EXPLODE_PARTS = 2;
 
-    public function __construct(private readonly TestFrameworkAdapter $adapter, private readonly TestFileDataProvider $testFileDataProvider)
-    {
+    public function __construct(
+        private readonly TestFrameworkAdapter $adapter,
+        private readonly TestFileDataProvider $testFileDataProvider,
+    ) {
     }
 
     /**

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -50,8 +50,9 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
 {
     private ?SafeDOMXPath $xPath = null;
 
-    public function __construct(private readonly JUnitReportLocator $jUnitLocator)
-    {
+    public function __construct(
+        private readonly JUnitReportLocator $jUnitLocator,
+    ) {
     }
 
     /**

--- a/src/TestFramework/Coverage/JUnit/MemoizedTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/MemoizedTestFileDataProvider.php
@@ -47,8 +47,9 @@ final class MemoizedTestFileDataProvider implements TestFileDataProvider
      */
     private array $cache = [];
 
-    public function __construct(private readonly TestFileDataProvider $provider)
-    {
+    public function __construct(
+        private readonly TestFileDataProvider $provider,
+    ) {
     }
 
     public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData

--- a/src/TestFramework/Coverage/JUnit/TestFileTimeData.php
+++ b/src/TestFramework/Coverage/JUnit/TestFileTimeData.php
@@ -40,7 +40,9 @@ namespace Infection\TestFramework\Coverage\JUnit;
  */
 final class TestFileTimeData
 {
-    public function __construct(public string $path, public float $time)
-    {
+    public function __construct(
+        public string $path,
+        public float $time,
+    ) {
     }
 }

--- a/src/TestFramework/Coverage/ProxyTrace.php
+++ b/src/TestFramework/Coverage/ProxyTrace.php
@@ -54,8 +54,10 @@ class ProxyTrace implements Trace
     /**
      * @param Deferred<TestLocations> $lazyTestLocations
      */
-    public function __construct(private readonly SplFileInfo $sourceFile, private readonly ?Deferred $lazyTestLocations = null)
-    {
+    public function __construct(
+        private readonly SplFileInfo $sourceFile,
+        private readonly ?Deferred $lazyTestLocations = null,
+    ) {
     }
 
     public function getSourceFileInfo(): SplFileInfo

--- a/src/TestFramework/Coverage/SourceMethodLineRange.php
+++ b/src/TestFramework/Coverage/SourceMethodLineRange.php
@@ -40,8 +40,10 @@ namespace Infection\TestFramework\Coverage;
  */
 final readonly class SourceMethodLineRange
 {
-    public function __construct(private int $startLine, private int $endLine)
-    {
+    public function __construct(
+        private int $startLine,
+        private int $endLine,
+    ) {
     }
 
     public function getStartLine(): int

--- a/src/TestFramework/Coverage/TestLocations.php
+++ b/src/TestFramework/Coverage/TestLocations.php
@@ -47,8 +47,10 @@ final class TestLocations
      * @param array<int, array<int, TestLocation>> $byLine
      * @param array<string, SourceMethodLineRange> $byMethod
      */
-    public function __construct(private array $byLine = [], private readonly array $byMethod = [])
-    {
+    public function __construct(
+        private array $byLine = [],
+        private readonly array $byMethod = [],
+    ) {
     }
 
     /**

--- a/src/TestFramework/Coverage/UncoveredTraceProvider.php
+++ b/src/TestFramework/Coverage/UncoveredTraceProvider.php
@@ -42,8 +42,9 @@ namespace Infection\TestFramework\Coverage;
  */
 final readonly class UncoveredTraceProvider implements TraceProvider
 {
-    public function __construct(private BufferedSourceFileFilter $bufferedFilter)
-    {
+    public function __construct(
+        private BufferedSourceFileFilter $bufferedFilter,
+    ) {
     }
 
     /**

--- a/src/TestFramework/Coverage/UnionTraceProvider.php
+++ b/src/TestFramework/Coverage/UnionTraceProvider.php
@@ -43,8 +43,11 @@ namespace Infection\TestFramework\Coverage;
  */
 final readonly class UnionTraceProvider implements TraceProvider
 {
-    public function __construct(private TraceProvider $coveredTraceProvider, private TraceProvider $uncoveredTraceProvider, private bool $onlyCovered)
-    {
+    public function __construct(
+        private TraceProvider $coveredTraceProvider,
+        private TraceProvider $uncoveredTraceProvider,
+        private bool $onlyCovered,
+    ) {
     }
 
     /**

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php
@@ -57,8 +57,9 @@ class IndexXmlCoverageLocator
 
     private ?string $indexPath = null;
 
-    public function __construct(private readonly string $coveragePath)
-    {
+    public function __construct(
+        private readonly string $coveragePath,
+    ) {
         $this->defaultIndexPath = Path::canonicalize($coveragePath . '/coverage-xml/index.xml');
     }
 

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
@@ -44,8 +44,9 @@ use Infection\TestFramework\SafeDOMXPath;
  */
 class IndexXmlCoverageParser
 {
-    public function __construct(private readonly bool $isForGitDiffLines)
-    {
+    public function __construct(
+        private readonly bool $isForGitDiffLines,
+    ) {
     }
 
     /**

--- a/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProvider.php
@@ -48,8 +48,11 @@ use function Safe\file_get_contents;
  */
 class PhpUnitXmlCoverageTraceProvider implements TraceProvider
 {
-    public function __construct(private readonly IndexXmlCoverageLocator $indexLocator, private readonly IndexXmlCoverageParser $indexParser, private readonly XmlCoverageParser $parser)
-    {
+    public function __construct(
+        private readonly IndexXmlCoverageLocator $indexLocator,
+        private readonly IndexXmlCoverageParser $indexParser,
+        private readonly XmlCoverageParser $parser,
+    ) {
     }
 
     /**

--- a/src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
@@ -58,8 +58,12 @@ class SourceFileInfoProvider
 {
     private ?SafeDOMXPath $xPath = null;
 
-    public function __construct(private readonly string $coverageIndexPath, private readonly string $coverageDir, private readonly string $relativeCoverageFilePath, private readonly string $projectSource)
-    {
+    public function __construct(
+        private readonly string $coverageIndexPath,
+        private readonly string $coverageDir,
+        private readonly string $relativeCoverageFilePath,
+        private readonly string $projectSource,
+    ) {
     }
 
     /**

--- a/src/TestFramework/Coverage/XmlReport/TestLocator.php
+++ b/src/TestFramework/Coverage/XmlReport/TestLocator.php
@@ -48,8 +48,9 @@ use Webmozart\Assert\Assert;
  */
 class TestLocator
 {
-    public function __construct(private readonly TestLocations $testLocations)
-    {
+    public function __construct(
+        private readonly TestLocations $testLocations,
+    ) {
     }
 
     public function hasTests(): bool

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -58,8 +58,16 @@ final readonly class Factory
     /**
      * @param array<string, array<string, mixed>> $installedExtensions
      */
-    public function __construct(private string $tmpDir, private string $projectDir, private TestFrameworkConfigLocatorInterface $configLocator, private TestFrameworkFinder $testFrameworkFinder, private string $jUnitFilePath, private Configuration $infectionConfig, private SourceFileFilter $sourceFileFilter, private array $installedExtensions)
-    {
+    public function __construct(
+        private string $tmpDir,
+        private string $projectDir,
+        private TestFrameworkConfigLocatorInterface $configLocator,
+        private TestFrameworkFinder $testFrameworkFinder,
+        private string $jUnitFilePath,
+        private Configuration $infectionConfig,
+        private SourceFileFilter $sourceFileFilter,
+        private array $installedExtensions,
+    ) {
     }
 
     public function create(string $adapterName, bool $skipCoverage): TestFrameworkAdapter

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -57,8 +57,13 @@ class MutationConfigBuilder extends ConfigBuilder
 
     private ?DOMDocument $dom = null;
 
-    public function __construct(private readonly string $tmpDir, private readonly string $originalXmlConfigContent, private readonly XmlConfigurationManipulator $configManipulator, private readonly string $projectDir, private readonly JUnitTestCaseSorter $jUnitTestCaseSorter)
-    {
+    public function __construct(
+        private readonly string $tmpDir,
+        private readonly string $originalXmlConfigContent,
+        private readonly XmlConfigurationManipulator $configManipulator,
+        private readonly string $projectDir,
+        private readonly JUnitTestCaseSorter $jUnitTestCaseSorter,
+    ) {
     }
 
     /**

--- a/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
+++ b/src/TestFramework/PhpUnit/Config/Path/PathReplacer.php
@@ -48,8 +48,10 @@ use function trim;
  */
 final readonly class PathReplacer
 {
-    public function __construct(private Filesystem $filesystem, private ?string $phpUnitConfigDir = null)
-    {
+    public function __construct(
+        private Filesystem $filesystem,
+        private ?string $phpUnitConfigDir = null,
+    ) {
     }
 
     public function replaceInNode(DOMElement|DOMNode $domElement): void

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -58,8 +58,10 @@ use Webmozart\Assert\Assert;
  */
 final readonly class XmlConfigurationManipulator
 {
-    public function __construct(private PathReplacer $pathReplacer, private string $phpUnitConfigDir)
-    {
+    public function __construct(
+        private PathReplacer $pathReplacer,
+        private string $phpUnitConfigDir,
+    ) {
     }
 
     public function replaceWithAbsolutePaths(SafeDOMXPath $xPath): void

--- a/src/TestFramework/SafeDOMXPath.php
+++ b/src/TestFramework/SafeDOMXPath.php
@@ -50,8 +50,9 @@ final readonly class SafeDOMXPath
 {
     private DOMXPath $xPath;
 
-    public function __construct(private DOMDocument $document)
-    {
+    public function __construct(
+        private DOMDocument $document,
+    ) {
         $this->xPath = new DOMXPath($document);
     }
 

--- a/tests/phpunit/EnvVariableManipulation/EnvBackup.php
+++ b/tests/phpunit/EnvVariableManipulation/EnvBackup.php
@@ -46,8 +46,9 @@ final class EnvBackup
     /**
      * @param array<string, string> $environmentVariables
      */
-    private function __construct(private array $environmentVariables)
-    {
+    private function __construct(
+        private array $environmentVariables,
+    ) {
     }
 
     public static function createSnapshot(): self

--- a/tests/phpunit/FileSystem/Finder/MockVendor.php
+++ b/tests/phpunit/FileSystem/Finder/MockVendor.php
@@ -72,8 +72,10 @@ final class MockVendor
      */
     private $vendorBinBat;
 
-    public function __construct(private readonly string $tmpDir, private readonly Filesystem $fileSystem)
-    {
+    public function __construct(
+        private readonly string $tmpDir,
+        private readonly Filesystem $fileSystem,
+    ) {
         $vendorDir = $this->tmpDir . '/vendor';
         $this->vendorBinDir = $vendorDir . '/bin';
 

--- a/tests/phpunit/PhpParser/FileParserTest.php
+++ b/tests/phpunit/PhpParser/FileParserTest.php
@@ -276,8 +276,10 @@ final class FileParserTest extends TestCase
     private static function createFileInfo(string $path, string $contents): SplFileInfo
     {
         return new class($path, $contents) extends SplFileInfo {
-            public function __construct(string $path, private readonly string $contents)
-            {
+            public function __construct(
+                string $path,
+                private readonly string $contents,
+            ) {
                 parent::__construct($path, $path, $path);
             }
 

--- a/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
@@ -244,8 +244,9 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
         return new class($nodeClass) extends NodeVisitorAbstract {
             private $isPartOfSignature;
 
-            public function __construct(private readonly string $nodeClassUnderTest)
-            {
+            public function __construct(
+                private readonly string $nodeClassUnderTest,
+            ) {
             }
 
             public function leaveNode(Node $node): void
@@ -267,8 +268,9 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
         return new class($nodeClass) extends NodeVisitorAbstract {
             public $spyCalled = false;
 
-            public function __construct(private readonly string $nodeClassUnderTest)
-            {
+            public function __construct(
+                private readonly string $nodeClassUnderTest,
+            ) {
             }
 
             public function leaveNode(Node $node): void


### PR DESCRIPTION
Apply https://github.com/kubawerlos/php-cs-fixer-custom-fixers?tab=readme-ov-file#multilinepromotedpropertiesfixer

Unfortunately, we can't integrate it in our system (at least for now) because this is a plugin and such fixer doesn't exist in PHP-CS-Fixer itself, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6325

The problem with this (or any other) plugin that it requires `php-cs-fixer` to be installed:

https://github.com/kubawerlos/php-cs-fixer-custom-fixers/blob/217f467dce9713f6482415396f34241ad6e0916d/composer.json#L16

but we use PHAR distribution of PHP-CS-Fixer instead of a composer package, so this will result in a duplicate to be installed.

----

This issue was found by @vudaltsov during his Stream about supporting functions mutation, see (RU) https://www.youtube.com/watch?v=UTaRm_sZr_w

Thanks Valentin!