### PR TITLE
Generate a prettified JSON5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "ext-libxml": "*",
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.0",
+        "arokettu/json5-builder": "^1.0",
         "colinodell/json5": "^2.2 || ^3.0",
         "composer/xdebug-handler": "^2.0 || ^3.0",
         "fidry/cpu-core-counter": "^0.4.0 || ^0.5.0 || ^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,69 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c67f4439e430e2485b7f8581e1172da9",
+    "content-hash": "c53700ba142d2624c29a6e67acba3f47",
     "packages": [
+        {
+            "name": "arokettu/json5-builder",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/arokettu/json5-builder.git",
+                "reference": "1db9eea2da094e252a32498a408bc0fd505f1994"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/arokettu/json5-builder/zipball/1db9eea2da094e252a32498a408bc0fd505f1994",
+                "reference": "1db9eea2da094e252a32498a408bc0fd505f1994",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "arokettu/json": "^2.1",
+                "colinodell/json5": "^3.0",
+                "phpunit/phpunit": "^10.5",
+                "psy/psysh": "*",
+                "sandfox.dev/code-standard": "^1.2025.03.27",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Arokettu\\Json5\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anton Smirnov",
+                    "email": "sandfox+composer@sandfox.me",
+                    "homepage": "https://sandfox.me/",
+                    "role": "developer"
+                }
+            ],
+            "description": "JSON5 config builder/encoder",
+            "homepage": "https://sandfox.dev/php/json5-builder.html",
+            "keywords": [
+                "JSON5",
+                "builder",
+                "config",
+                "configuration",
+                "encode"
+            ],
+            "support": {
+                "chat": "https://gitter.im/arokettu/community",
+                "docs": "https://json5-builder.readthedocs.io/",
+                "issues": "https://gitlab.com/sandfox/json5-builder/-/issues",
+                "source": "https://gitlab.com/sandfox/json5-builder"
+            },
+            "time": "2025-04-26T20:15:26+00:00"
+        },
         {
             "name": "colinodell/json5",
             "version": "v3.0.0",

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Command;
 
+use Arokettu\Json5\Json5Encoder;
 use Composer\InstalledVersions;
 use function count;
 use function file_exists;
@@ -53,15 +54,12 @@ use Infection\Console\IO;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use Infection\TestFramework\TestFrameworkTypes;
-use const JSON_PRETTY_PRINT;
-use const JSON_UNESCAPED_SLASHES;
 use OutOfBoundsException;
 use RuntimeException;
 use function Safe\file_get_contents;
 use function Safe\file_put_contents;
 use function Safe\glob;
 use function Safe\json_decode;
-use function Safe\json_encode;
 use function sprintf;
 use stdClass;
 use function str_starts_with;
@@ -230,7 +228,7 @@ final class ConfigureCommand extends BaseCommand
 
         file_put_contents(
             SchemaConfigurationLoader::DEFAULT_JSON5_CONFIG_FILE,
-            json_encode($configObject, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+            Json5Encoder::encode($configObject),
         );
     }
 


### PR DESCRIPTION
This PR:

- [x] Adds new feature ...
- [ ] Covered by tests
- [ ] Doc PR: doesn't need to be documented

A small contribution should you choose to accept it. 

Current scope: quoteless keys. Possible future scope: default comments like.

```php
        /*
         * Explicitly add the default profile to the list of mutators, as even if it is
         * empty by default, it is not. If it would actually contain the default profile
         * by default, it would make the profiles feature more obvious to configure.
         */
        $configObject->mutators = [
            // this commentAfter will appear in JSON5
            '@default' => new CommentDecorator(true, commentAfter: 'Explicitly add the default profile'),
        ];
```

the generated config would look like:

```json5
{
    $schema: "https://raw.githubusercontent.com/infection/infection/master/resources/schema.json",
    source: {
        directories: [
            "src",
        ],
    },
    logs: {
        text: "reports/infection.log",
    },
    mutators: {
        '@default': true, // Explicitly add the default profile
    },
}
```

P.S. I can't find if your config generation is tested currently