### PR TITLE
Do not fail Infection when project has 0 tests

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -58,6 +58,7 @@ use Infection\Metrics\MinMsiCheckFailed;
 use Infection\Process\Runner\InitialTestsFailed;
 use Infection\Resource\Processor\CpuCoresCountProvider;
 use Infection\TestFramework\Coverage\XmlReport\NoLineExecutedInDiffLinesMode;
+use Infection\TestFramework\Coverage\XmlReport\NoTestsInProject;
 use Infection\TestFramework\MapSourceClassToTestStrategy;
 use Infection\TestFramework\TestFrameworkTypes;
 use InvalidArgumentException;
@@ -403,7 +404,7 @@ final class RunCommand extends BaseCommand
             $engine->execute();
 
             return true;
-        } catch (NoFilesInDiffToMutate|NoLineExecutedInDiffLinesMode $e) {
+        } catch (NoFilesInDiffToMutate|NoLineExecutedInDiffLinesMode|NoTestsInProject $e) {
             $io->success($e->getMessage());
 
             return true;

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
@@ -97,6 +97,12 @@ class IndexXmlCoverageParser
      */
     private static function assertHasExecutedLines(SafeDOMXPath $xPath, bool $isForGitDiffLines): void
     {
+        $testsNode = $xPath->query('/phpunit/project/tests')->item(0);
+
+        if ($testsNode !== null && !$testsNode->hasChildNodes()) {
+            throw NoTestsInProject::create();
+        }
+
         $lineCoverage = $xPath->query('/phpunit/project/directory[1]/totals/lines')->item(0);
 
         if (

--- a/src/TestFramework/Coverage/XmlReport/NoTestsInProject.php
+++ b/src/TestFramework/Coverage/XmlReport/NoTestsInProject.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\TestFramework\Coverage\XmlReport;
+
+use Exception;
+
+/**
+ * @internal
+ */
+final class NoTestsInProject extends Exception
+{
+    public static function create(): self
+    {
+        return new self('No tests in the project, skipping mutation analysis.');
+    }
+}

--- a/tests/e2e/No_Tests/README.md
+++ b/tests/e2e/No_Tests/README.md
@@ -1,0 +1,9 @@
+## Summary
+
+Infection should not fail if a project has no tests at all.
+
+Case: when the project is being bootstrapped, it can have 0 tests.
+
+PHPUnit returns 0 exit code, saying "No tests executed!".
+
+Infection should not fail in this case as well, so that CI passes.

--- a/tests/e2e/No_Tests/composer.json
+++ b/tests/e2e/No_Tests/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "No_Tests\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
     }
 }

--- a/tests/e2e/No_Tests/composer.json
+++ b/tests/e2e/No_Tests/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.6.20"
+    },
+    "autoload": {
+        "psr-4": {
+            "No_Tests\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "No_Tests\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/e2e/No_Tests/expected-output.txt
+++ b/tests/e2e/No_Tests/expected-output.txt
@@ -1,0 +1,10 @@
+Total: 0
+
+Killed: 0
+Errored: 0
+Syntax Errors: 0
+Escaped: 0
+Timed Out: 0
+Skipped: 0
+Ignored: 0
+Not Covered: 0

--- a/tests/e2e/No_Tests/infection.json5
+++ b/tests/e2e/No_Tests/infection.json5
@@ -1,0 +1,13 @@
+{
+    "$schema": "../../../resources/schema.json",
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/No_Tests/phpunit.xml
+++ b/tests/e2e/No_Tests/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/tests/e2e/No_Tests/run_tests.bash
+++ b/tests/e2e/No_Tests/run_tests.bash
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+readonly INFECTION=../../../${1}
+
+set -e pipefail
+
+php $INFECTION

--- a/tests/e2e/No_Tests/src/SourceClass.php
+++ b/tests/e2e/No_Tests/src/SourceClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace No_Tests;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        return 'hello';
+    }
+}

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParserTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParserTest.php
@@ -39,6 +39,7 @@ use function array_diff;
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser;
 use Infection\TestFramework\Coverage\XmlReport\NoLineExecuted;
 use Infection\TestFramework\Coverage\XmlReport\NoLineExecutedInDiffLinesMode;
+use Infection\TestFramework\Coverage\XmlReport\NoTestsInProject;
 use Infection\TestFramework\Coverage\XmlReport\SourceFileInfoProvider;
 use Infection\Tests\Fixtures\TestFramework\PhpUnit\Coverage\XmlCoverageFixture;
 use Infection\Tests\Fixtures\TestFramework\PhpUnit\Coverage\XmlCoverageFixtures;
@@ -153,6 +154,31 @@ final class IndexXmlCoverageParserTest extends TestCase
         $this->assertCoverageFixtureSame(
             XmlCoverageFixtures::providePhpUnit6Fixtures(),
             $sourceFilesData,
+        );
+    }
+
+    public function test_it_errors_when_project_has_no_tests(): void
+    {
+        $xml = <<<'XML'
+            <?xml version="1.0"?>
+            <phpunit xmlns="http://schema.phpunit.de/coverage/1.0">
+              <build time="Mon Apr 10 20:06:19 GMT+0000 2017" phpunit="6.1.0" coverage="5.1.0">
+                <runtime name="PHP" version="7.1.0" url="https://secure.php.net/"/>
+                <driver name="xdebug" version="2.5.1"/>
+              </build>
+              <project source="/path/to/src">
+                <tests />
+              </project>
+              <!-- The rest of the file has been removed for this test-->
+            </phpunit>
+            XML;
+
+        $this->expectException(NoTestsInProject::class);
+
+        $this->parser->parse(
+            '/path/to/index.xml',
+            $xml,
+            XmlCoverageFixtures::FIXTURES_COVERAGE_DIR,
         );
     }
 

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/NoTestsInProjectTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/NoTestsInProjectTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestFramework\Coverage\XmlReport;
+
+use Infection\TestFramework\Coverage\XmlReport\NoTestsInProject;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NoTestsInProject::class)]
+final class NoTestsInProjectTest extends TestCase
+{
+    public function test_it_can_create_an_instance(): void
+    {
+        $exception = NoTestsInProject::create();
+
+        $expectedMessage = <<<'MSG'
+            No tests in the project, skipping mutation analysis.
+            MSG;
+
+        $this->assertSame($expectedMessage, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+    }
+}


### PR DESCRIPTION
Infection should not fail if a project has no tests at all.

Case: when the project is being bootstrapped, it can have 0 tests. Imagine a case when a project template is created.

PHPUnit returns 0 exit code, saying "No tests executed!".

Infection should not fail in this case as well, so that CI passes.