### PR TITLE
Introduce dead code detector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^11.5",
         "rector/rector": "^2.0",
+        "shipmonk/dead-code-detector": "^0.12.0",
         "sidz/phpstan-rules": "^0.5.1",
         "symfony/yaml": "^6.4 || ^7.0",
         "thecodingmachine/phpstan-safe-rule": "^1.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c67f4439e430e2485b7f8581e1172da9",
+    "content-hash": "67e3098fc807ebcdb7e184d702c648e4",
     "packages": [
         {
             "name": "colinodell/json5",
@@ -3985,6 +3985,81 @@
             "time": "2024-10-09T05:16:32+00:00"
         },
         {
+            "name": "shipmonk/dead-code-detector",
+            "version": "0.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/shipmonk-rnd/dead-code-detector.git",
+                "reference": "1f0c70ec4e9868c785f6505592dfb01ef53af2ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/shipmonk-rnd/dead-code-detector/zipball/1f0c70ec4e9868c785f6505592dfb01ef53af2ca",
+                "reference": "1f0c70ec4e9868c785f6505592dfb01ef53af2ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.9"
+            },
+            "require-dev": {
+                "composer-runtime-api": "^2.0",
+                "composer/semver": "^3.4",
+                "doctrine/orm": "^2.19 || ^3.0",
+                "editorconfig-checker/editorconfig-checker": "^10.6.0",
+                "ergebnis/composer-normalize": "^2.45.0",
+                "nette/application": "^3.1",
+                "nette/component-model": "^3.0",
+                "nette/utils": "^3.0 || ^4.0",
+                "nikic/php-parser": "^5.4.0",
+                "phpstan/phpstan-phpunit": "^2.0.4",
+                "phpstan/phpstan-strict-rules": "^2.0.3",
+                "phpstan/phpstan-symfony": "^2.0.2",
+                "phpunit/phpunit": "^9.6.22",
+                "shipmonk/composer-dependency-analyser": "^1.8.2",
+                "shipmonk/name-collision-detector": "^2.1.1",
+                "shipmonk/phpstan-rules": "^4.1.0",
+                "slevomat/coding-standard": "^8.16.0",
+                "symfony/contracts": "^2.5 || ^3.0",
+                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+                "symfony/doctrine-bridge": "^5.4 || ^6.0 || ^7.0",
+                "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
+                "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+                "symfony/routing": "^5.4 || ^6.0 || ^7.0",
+                "symfony/validator": "^5.4 || ^6.0 || ^7.0",
+                "twig/twig": "^3.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ShipMonk\\PHPStan\\DeadCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Dead code detector to find unused PHP code via PHPStan extension. Can automatically remove dead PHP code. Supports libraries like Symfony, Doctrine, PHPUnit etc. Detects dead cycles. Can detect dead code that is tested.",
+            "keywords": [
+                "PHPStan",
+                "dead code",
+                "static analysis",
+                "unused code"
+            ],
+            "support": {
+                "issues": "https://github.com/shipmonk-rnd/dead-code-detector/issues",
+                "source": "https://github.com/shipmonk-rnd/dead-code-detector/tree/0.12.0"
+            },
+            "time": "2025-05-16T13:02:10+00:00"
+        },
+        {
             "name": "sidz/phpstan-rules",
             "version": "0.5.1",
             "source": {
@@ -4280,7 +4355,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -3986,16 +3986,16 @@
         },
         {
             "name": "shipmonk/dead-code-detector",
-            "version": "0.12.0",
+            "version": "0.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/dead-code-detector.git",
-                "reference": "1f0c70ec4e9868c785f6505592dfb01ef53af2ca"
+                "reference": "12af219888e245e9f16cd36ab5fe701f2e426a97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/dead-code-detector/zipball/1f0c70ec4e9868c785f6505592dfb01ef53af2ca",
-                "reference": "1f0c70ec4e9868c785f6505592dfb01ef53af2ca",
+                "url": "https://api.github.com/repos/shipmonk-rnd/dead-code-detector/zipball/12af219888e245e9f16cd36ab5fe701f2e426a97",
+                "reference": "12af219888e245e9f16cd36ab5fe701f2e426a97",
                 "shasum": ""
             },
             "require": {
@@ -4055,9 +4055,9 @@
             ],
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/dead-code-detector/issues",
-                "source": "https://github.com/shipmonk-rnd/dead-code-detector/tree/0.12.0"
+                "source": "https://github.com/shipmonk-rnd/dead-code-detector/tree/0.12.1"
             },
-            "time": "2025-05-16T13:02:10+00:00"
+            "time": "2025-05-20T07:02:46+00:00"
         },
         {
             "name": "sidz/phpstan-rules",
@@ -4355,7 +4355,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -37,6 +37,12 @@ parameters:
 			path: ../src/Logger/Html/StrykerHtmlReportBuilder.php
 
 		-
+			message: '#^Unused Infection\\Mutant\\MutantExecutionResult\:\:getOriginalStartingColumn$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../src/Mutant/MutantExecutionResult.php
+
+		-
 			message: '#^Parameter \#1 \$array of function array_intersect expects an array of values castable to string, list\<PhpParser\\Node\\Expr\|string\> given\.$#'
 			identifier: argument.type
 			count: 1
@@ -137,6 +143,18 @@ parameters:
 			identifier: theCodingMachineSafe.function
 			count: 1
 			path: ../src/TestFramework/Coverage/CoverageChecker.php
+
+		-
+			message: '#^Unused Infection\\TestFramework\\Coverage\\ProxyTrace\:\:getRelativePathname$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../src/TestFramework/Coverage/ProxyTrace.php
+
+		-
+			message: '#^Unused Infection\\TestFramework\\Coverage\\Trace\:\:getRelativePathname$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../src/TestFramework/Coverage/Trace.php
 
 		-
 			message: '#^Offset 1 might not exist on array\{0\?\: string, 1\?\: non\-falsy\-string\}\.$#'
@@ -265,8 +283,20 @@ parameters:
 			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
 
 		-
+			message: '#^Unused Infection\\Tests\\AutoReview\\EnvVariableManipulation\\EnvTestCasesProvider\:\:envTestCaseTupleProvider$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
+
+		-
 			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, string given\.$#'
 			identifier: argument.type
+			count: 1
+			path: ../tests/phpunit/AutoReview/Event/SubscriberProvider.php
+
+		-
+			message: '#^Unused Infection\\Tests\\AutoReview\\Event\\SubscriberProvider\:\:subscriberClassesProvider$#'
+			identifier: shipmonk.deadMethod
 			count: 1
 			path: ../tests/phpunit/AutoReview/Event/SubscriberProvider.php
 
@@ -319,6 +349,24 @@ parameters:
 			path: ../tests/phpunit/AutoReview/Makefile/MakefileTest.php
 
 		-
+			message: '#^Unused Infection\\Tests\\AutoReview\\Mutator\\MutatorProvider\:\:concreteMutatorClassesProvider$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/AutoReview/Mutator/MutatorProvider.php
+
+		-
+			message: '#^Unused Infection\\Tests\\AutoReview\\Mutator\\MutatorProvider\:\:configurableMutatorClassesProvider$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/AutoReview/Mutator/MutatorProvider.php
+
+		-
+			message: '#^Unused Infection\\Tests\\AutoReview\\Mutator\\MutatorProvider\:\:mutatorClassesProvider$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/AutoReview/Mutator/MutatorProvider.php
+
+		-
 			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, string given\.$#'
 			identifier: argument.type
 			count: 2
@@ -345,6 +393,42 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, string given\.$#'
 			identifier: argument.type
+			count: 1
+			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+
+		-
+			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:classesTestProvider$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+
+		-
+			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:concreteSourceClassesProvider$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+
+		-
+			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:nonFinalExtensionClasses$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+
+		-
+			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:nonTestedConcreteClassesProvider$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+
+		-
+			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:sourceClassesProvider$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+
+		-
+			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:sourceClassesToCheckForPublicPropertiesProvider$#'
+			identifier: shipmonk.deadMethod
 			count: 1
 			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
 
@@ -1477,6 +1561,12 @@ parameters:
 			path: ../tests/phpunit/Mutator/ProfileListProvider.php
 
 		-
+			message: '#^Unused Infection\\Tests\\Mutator\\ProfileListProvider\:\:profileProvider$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/Mutator/ProfileListProvider.php
+
+		-
 			message: '#^Method Infection\\Tests\\Mutator\\ProfileListTest\:\:test_all_mutator_profiles_are_sorted_lexicographically\(\) has parameter \$profileOrMutators with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1727,6 +1817,18 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/Reflection/AnonymousClassReflectionTest.php
+
+		-
+			message: '#^Unused Infection\\Tests\\Reflection\\ProtChild\:\:foo$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/Reflection/ClassReflectionTestCase.php
+
+		-
+			message: '#^Unused Infection\\Tests\\Reflection\\ProtParent\:\:foo$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../tests/phpunit/Reflection/ClassReflectionTestCase.php
 
 		-
 			message: '#^Parameter \#1 \$className of static method Infection\\Reflection\\CoreClassReflection\:\:fromClassName\(\) expects class\-string, string given\.$#'

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -37,12 +37,6 @@ parameters:
 			path: ../src/Logger/Html/StrykerHtmlReportBuilder.php
 
 		-
-			message: '#^Unused Infection\\Mutant\\MutantExecutionResult\:\:getOriginalStartingColumn$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../src/Mutant/MutantExecutionResult.php
-
-		-
 			message: '#^Parameter \#1 \$array of function array_intersect expects an array of values castable to string, list\<PhpParser\\Node\\Expr\|string\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -145,18 +145,6 @@ parameters:
 			path: ../src/TestFramework/Coverage/CoverageChecker.php
 
 		-
-			message: '#^Unused Infection\\TestFramework\\Coverage\\ProxyTrace\:\:getRelativePathname$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../src/TestFramework/Coverage/ProxyTrace.php
-
-		-
-			message: '#^Unused Infection\\TestFramework\\Coverage\\Trace\:\:getRelativePathname$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../src/TestFramework/Coverage/Trace.php
-
-		-
 			message: '#^Offset 1 might not exist on array\{0\?\: string, 1\?\: non\-falsy\-string\}\.$#'
 			identifier: offsetAccess.notFound
 			count: 1

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -265,20 +265,8 @@ parameters:
 			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
 
 		-
-			message: '#^Unused Infection\\Tests\\AutoReview\\EnvVariableManipulation\\EnvTestCasesProvider\:\:envTestCaseTupleProvider$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
-
-		-
 			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, string given\.$#'
 			identifier: argument.type
-			count: 1
-			path: ../tests/phpunit/AutoReview/Event/SubscriberProvider.php
-
-		-
-			message: '#^Unused Infection\\Tests\\AutoReview\\Event\\SubscriberProvider\:\:subscriberClassesProvider$#'
-			identifier: shipmonk.deadMethod
 			count: 1
 			path: ../tests/phpunit/AutoReview/Event/SubscriberProvider.php
 
@@ -331,24 +319,6 @@ parameters:
 			path: ../tests/phpunit/AutoReview/Makefile/MakefileTest.php
 
 		-
-			message: '#^Unused Infection\\Tests\\AutoReview\\Mutator\\MutatorProvider\:\:concreteMutatorClassesProvider$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../tests/phpunit/AutoReview/Mutator/MutatorProvider.php
-
-		-
-			message: '#^Unused Infection\\Tests\\AutoReview\\Mutator\\MutatorProvider\:\:configurableMutatorClassesProvider$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../tests/phpunit/AutoReview/Mutator/MutatorProvider.php
-
-		-
-			message: '#^Unused Infection\\Tests\\AutoReview\\Mutator\\MutatorProvider\:\:mutatorClassesProvider$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../tests/phpunit/AutoReview/Mutator/MutatorProvider.php
-
-		-
 			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, string given\.$#'
 			identifier: argument.type
 			count: 2
@@ -375,42 +345,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, string given\.$#'
 			identifier: argument.type
-			count: 1
-			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
-
-		-
-			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:classesTestProvider$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
-
-		-
-			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:concreteSourceClassesProvider$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
-
-		-
-			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:nonFinalExtensionClasses$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
-
-		-
-			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:nonTestedConcreteClassesProvider$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
-
-		-
-			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:sourceClassesProvider$#'
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
-
-		-
-			message: '#^Unused Infection\\Tests\\AutoReview\\ProjectCode\\ProjectCodeProvider\:\:sourceClassesToCheckForPublicPropertiesProvider$#'
-			identifier: shipmonk.deadMethod
 			count: 1
 			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
 
@@ -1539,12 +1473,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, string given\.$#'
 			identifier: argument.type
-			count: 1
-			path: ../tests/phpunit/Mutator/ProfileListProvider.php
-
-		-
-			message: '#^Unused Infection\\Tests\\Mutator\\ProfileListProvider\:\:profileProvider$#'
-			identifier: shipmonk.deadMethod
 			count: 1
 			path: ../tests/phpunit/Mutator/ProfileListProvider.php
 

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -79,6 +79,12 @@ parameters:
             identifier: shipmonk.deadMethod
             count: 1
             path: ../src/TestFramework/Coverage/Trace.php
+        # While it's not used yet, left for consistency as we have ending column passed and used
+        -
+            message: '#^Unused Infection\\Mutant\\MutantExecutionResult\:\:getOriginalStartingColumn$#'
+            identifier: shipmonk.deadMethod
+            count: 1
+            path: ../src/Mutant/MutantExecutionResult.php
 
         # tests
         - '#Dynamic call to static method PHPUnit\\Framework\\.*::.*#'

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -65,6 +65,9 @@ parameters:
             path: ../src/Mutator/Extensions/BCMath.php
         -
             identifier: arrayFilter.strict
+        -
+            identifier: shipmonk.deadMethod
+            path: ../src/Testing
 
         # tests
         - '#Dynamic call to static method PHPUnit\\Framework\\.*::.*#'

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -68,6 +68,17 @@ parameters:
         -
             identifier: shipmonk.deadMethod
             path: ../src/Testing
+        # ProxyTrace::getRelativePathname() is used implicitly by PathFilterIterator
+        -
+            message: '#^Unused Infection\\TestFramework\\Coverage\\ProxyTrace\:\:getRelativePathname$#'
+            identifier: shipmonk.deadMethod
+            count: 1
+            path: ../src/TestFramework/Coverage/ProxyTrace.php
+        -
+            message: '#^Unused Infection\\TestFramework\\Coverage\\Trace\:\:getRelativePathname$#'
+            identifier: shipmonk.deadMethod
+            count: 1
+            path: ../src/TestFramework/Coverage/Trace.php
 
         # tests
         - '#Dynamic call to static method PHPUnit\\Framework\\.*::.*#'

--- a/src/Mutant/MutantExecutionResult.php
+++ b/src/Mutant/MutantExecutionResult.php
@@ -148,11 +148,6 @@ class MutantExecutionResult
         return $this->originalEndingLine;
     }
 
-    public function getOriginalStartingColumn(string $originalCode): int
-    {
-        return $this->toColumn($originalCode, $this->originalStartFilePosition);
-    }
-
     public function getOriginalEndingColumn(string $originalCode): int
     {
         return $this->toColumn($originalCode, $this->originalEndFilePosition);

--- a/src/Mutant/MutantExecutionResult.php
+++ b/src/Mutant/MutantExecutionResult.php
@@ -148,6 +148,11 @@ class MutantExecutionResult
         return $this->originalEndingLine;
     }
 
+    public function getOriginalStartingColumn(string $originalCode): int
+    {
+        return $this->toColumn($originalCode, $this->originalStartFilePosition);
+    }
+
     public function getOriginalEndingColumn(string $originalCode): int
     {
         return $this->toColumn($originalCode, $this->originalEndFilePosition);


### PR DESCRIPTION
See https://github.com/shipmonk-rnd/dead-code-detector

Result: no real dead code is found. A bunch of false-positives (reported to the plugin repository) and 2 edge cases - added comments to `phpstan.neon`.

----

- Related to https://github.com/infection/infection/pull/335
- [x] For now in draft as it has false-positives that [I want to ask about](https://github.com/shipmonk-rnd/dead-code-detector/issues/209)
- [x] blocked by https://github.com/infection/infection/pull/2091
- [x] Reported bug/feature request https://github.com/shipmonk-rnd/dead-code-detector/issues/211