### PR TITLE
Do not check trailing whitespaces on `.DB_Store` on MacOS

### DIFF
--- a/devTools/check_trailing_whitespaces.sh
+++ b/devTools/check_trailing_whitespaces.sh
@@ -28,6 +28,7 @@ files_with_trailing_whitespaces=$(
         -type f \
         -not -name "*.cache" \
         -not -name "*.log" \
+        -not -path "./.DS_Store" \
         -not -path "./.composer/*" \
         -not -path "./.cache/*" \
         -not -path "./.box_dump/*" \


### PR DESCRIPTION
Because it breaks `make cs` and then `make autoreview` stops and doesn't work

Extracted from https://github.com/infection/infection/pull/2074/