### PR TITLE
Add new processes to kill mutant to the queue if PHPUnit doesn't kill a Mutant

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -121,6 +121,12 @@ parameters:
 			path: ../src/PhpParser/Visitor/ReflectionVisitor.php
 
 		-
+			message: '#^Parameter &\$bucket by\-ref type of method Infection\\Process\\Runner\\ParallelProcessRunner\:\:fillBucketOnce\(\) expects array\<Infection\\Process\\MutantProcessContainer\>, array\<Infection\\Process\\MutantProcessContainer\|null\> given\.$#'
+			identifier: parameterByRef.type
+			count: 1
+			path: ../src/Process/Runner/ParallelProcessRunner.php
+
+		-
 			message: '#^Parameter \#2 \$paths of method Composer\\Autoload\\ClassLoader\:\:setPsr4\(\) expects list\<string\>\|string, array\<string\> given\.$#'
 			identifier: argument.type
 			count: 1


### PR DESCRIPTION
Follow-up for https://github.com/infection/infection/pull/2096

If in the `MutantProcessContainer`, the first and required PHPUnit process doesn't kill a mutant, build the next "killer process" and run it in parallel to try to kill the same Mutator.

Notes:

- `ParallelProcessRunner` is reused - we need to queue processes as soon as they are created so they are executed in parallel


----

How I've tested it:

in `Container.php`, I've added:

```diff
MutantProcessContainerFactory::class => static fn (self $container): MutantProcessContainerFactory => new MutantProcessContainerFactory(
    $container->getTestFrameworkAdapter(),
    $container->getConfiguration()->getProcessTimeout(),
    $container->getMutantExecutionResultFactory(),
    [
+        new class($container->getMutantExecutionResultFactory()) implements LazyMutantProcessCreator {
+            public function __construct(private MutantExecutionResultFactory $mutantExecutionResultFactory)
+            {
+            }
+
+            public function createMutantProcess(Mutant $mutant): MutantProcess
+            {
+                return new MutantProcess(
+                    new Process(['echo', '1']),
+                    $mutant,
+                    $this->mutantExecutionResultFactory,
+                );
+            }
+        },
    ],
),
```

and this process is executed now for any Escaped mutant.
