### PR TITLE
Rename `MutantExecutionResultFactory` to `TestFrameworkMutantExecutionResultFactory` and add interface

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -37,6 +37,12 @@ parameters:
 			path: ../src/Logger/Html/StrykerHtmlReportBuilder.php
 
 		-
+			message: '#^Unused Infection\\Mutant\\MutantExecutionResultFactory\:\:createFromProcess$#'
+			identifier: shipmonk.deadMethod
+			count: 1
+			path: ../src/Mutant/MutantExecutionResultFactory.php
+
+		-
 			message: '#^Parameter \#1 \$array of function array_intersect expects an array of values castable to string, list\<PhpParser\\Node\\Expr\|string\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Container.php
+++ b/src/Container.php
@@ -92,8 +92,8 @@ use Infection\Metrics\MinMsiChecker;
 use Infection\Metrics\ResultsCollector;
 use Infection\Metrics\TargetDetectionStatusesProvider;
 use Infection\Mutant\MutantCodeFactory;
-use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Mutant\MutantFactory;
+use Infection\Mutant\TestFrameworkMutantExecutionResultFactory;
 use Infection\Mutation\FileMutationGenerator;
 use Infection\Mutation\MutationGenerator;
 use Infection\Mutator\MutatorFactory;
@@ -544,7 +544,7 @@ final class Container
             TestFrameworkExtraOptionsFilter::class => static fn (): TestFrameworkExtraOptionsFilter => new TestFrameworkExtraOptionsFilter(),
             AdapterInstallationDecider::class => static fn (): AdapterInstallationDecider => new AdapterInstallationDecider(new QuestionHelper()),
             AdapterInstaller::class => static fn (): AdapterInstaller => new AdapterInstaller(new ComposerExecutableFinder()),
-            MutantExecutionResultFactory::class => static fn (self $container): MutantExecutionResultFactory => new MutantExecutionResultFactory($container->getTestFrameworkAdapter()),
+            TestFrameworkMutantExecutionResultFactory::class => static fn (self $container): TestFrameworkMutantExecutionResultFactory => new TestFrameworkMutantExecutionResultFactory($container->getTestFrameworkAdapter()),
             FormatterFactory::class => static fn (self $container): FormatterFactory => new FormatterFactory($container->getOutput()),
             DiffSourceCodeMatcher::class => static fn (): DiffSourceCodeMatcher => new DiffSourceCodeMatcher(),
             ShellCommandLineExecutor::class => static fn (): ShellCommandLineExecutor => new ShellCommandLineExecutor(),
@@ -1106,9 +1106,9 @@ final class Container
         return $this->get(AdapterInstaller::class);
     }
 
-    public function getMutantExecutionResultFactory(): MutantExecutionResultFactory
+    public function getMutantExecutionResultFactory(): TestFrameworkMutantExecutionResultFactory
     {
-        return $this->get(MutantExecutionResultFactory::class);
+        return $this->get(TestFrameworkMutantExecutionResultFactory::class);
     }
 
     public function getCiDetector(): CiDetector

--- a/src/Mutant/MutantExecutionResultFactory.php
+++ b/src/Mutant/MutantExecutionResultFactory.php
@@ -35,91 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Mutant;
 
-use Infection\AbstractTestFramework\SyntaxErrorAware;
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Process\MutantProcess;
-use function sprintf;
-use Symfony\Component\Process\Process;
-use Webmozart\Assert\Assert;
 
 /**
  * @internal
- * @final
  */
-class MutantExecutionResultFactory
+interface MutantExecutionResultFactory
 {
-    private const PROCESS_MIN_ERROR_CODE = 100;
-
-    public function __construct(
-        private readonly TestFrameworkAdapter $testFrameworkAdapter,
-    ) {
-    }
-
-    public function createFromProcess(MutantProcess $mutantProcess): MutantExecutionResult
-    {
-        $process = $mutantProcess->getProcess();
-        $mutant = $mutantProcess->getMutant();
-        $mutation = $mutant->getMutation();
-
-        return new MutantExecutionResult(
-            $process->getCommandLine(),
-            $this->retrieveProcessOutput($process),
-            $this->retrieveDetectionStatus($mutantProcess),
-            $mutant->getDiff(),
-            $mutation->getHash(),
-            $mutation->getMutatorClass(),
-            $mutation->getMutatorName(),
-            $mutation->getOriginalFilePath(),
-            $mutation->getOriginalStartingLine(),
-            $mutation->getOriginalEndingLine(),
-            $mutation->getOriginalStartFilePosition(),
-            $mutation->getOriginalEndFilePosition(),
-            $mutant->getPrettyPrintedOriginalCode(),
-            $mutant->getMutatedCode(),
-            $mutant->getTests(),
-        );
-    }
-
-    private function retrieveProcessOutput(Process $process): string
-    {
-        Assert::true(
-            $process->isTerminated(),
-            sprintf(
-                'Cannot retrieve a non-terminated process output. Got "%s"',
-                $process->getStatus(),
-            ),
-        );
-
-        return $process->getOutput();
-    }
-
-    private function retrieveDetectionStatus(MutantProcess $mutantProcess): string
-    {
-        if (!$mutantProcess->getMutant()->isCoveredByTest()) {
-            return DetectionStatus::NOT_COVERED;
-        }
-
-        if ($mutantProcess->isTimedOut()) {
-            return DetectionStatus::TIMED_OUT;
-        }
-
-        $process = $mutantProcess->getProcess();
-
-        if ($process->getExitCode() > self::PROCESS_MIN_ERROR_CODE) {
-            // See \Symfony\Component\Process\Process::$exitCodes
-            return DetectionStatus::ERROR;
-        }
-
-        $output = $this->retrieveProcessOutput($process);
-
-        if ($process->getExitCode() === 0 && $this->testFrameworkAdapter->testsPass($output)) {
-            return DetectionStatus::ESCAPED;
-        }
-
-        if ($this->testFrameworkAdapter instanceof SyntaxErrorAware && $this->testFrameworkAdapter->isSyntaxError($output)) {
-            return DetectionStatus::SYNTAX_ERROR;
-        }
-
-        return DetectionStatus::KILLED;
-    }
+    public function createFromProcess(MutantProcess $mutantProcess): MutantExecutionResult;
 }

--- a/src/Mutant/TestFrameworkMutantExecutionResultFactory.php
+++ b/src/Mutant/TestFrameworkMutantExecutionResultFactory.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Mutant;
+
+use Infection\AbstractTestFramework\SyntaxErrorAware;
+use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\Process\MutantProcess;
+use function sprintf;
+use Symfony\Component\Process\Process;
+use Webmozart\Assert\Assert;
+
+/**
+ * @internal
+ * @final
+ */
+class TestFrameworkMutantExecutionResultFactory
+{
+    private const PROCESS_MIN_ERROR_CODE = 100;
+
+    public function __construct(
+        private readonly TestFrameworkAdapter $testFrameworkAdapter,
+    ) {
+    }
+
+    public function createFromProcess(MutantProcess $mutantProcess): MutantExecutionResult
+    {
+        $process = $mutantProcess->getProcess();
+        $mutant = $mutantProcess->getMutant();
+        $mutation = $mutant->getMutation();
+
+        return new MutantExecutionResult(
+            $process->getCommandLine(),
+            $this->retrieveProcessOutput($process),
+            $this->retrieveDetectionStatus($mutantProcess),
+            $mutant->getDiff(),
+            $mutation->getHash(),
+            $mutation->getMutatorClass(),
+            $mutation->getMutatorName(),
+            $mutation->getOriginalFilePath(),
+            $mutation->getOriginalStartingLine(),
+            $mutation->getOriginalEndingLine(),
+            $mutation->getOriginalStartFilePosition(),
+            $mutation->getOriginalEndFilePosition(),
+            $mutant->getPrettyPrintedOriginalCode(),
+            $mutant->getMutatedCode(),
+            $mutant->getTests(),
+        );
+    }
+
+    private function retrieveProcessOutput(Process $process): string
+    {
+        Assert::true(
+            $process->isTerminated(),
+            sprintf(
+                'Cannot retrieve a non-terminated process output. Got "%s"',
+                $process->getStatus(),
+            ),
+        );
+
+        return $process->getOutput();
+    }
+
+    private function retrieveDetectionStatus(MutantProcess $mutantProcess): string
+    {
+        if (!$mutantProcess->getMutant()->isCoveredByTest()) {
+            return DetectionStatus::NOT_COVERED;
+        }
+
+        if ($mutantProcess->isTimedOut()) {
+            return DetectionStatus::TIMED_OUT;
+        }
+
+        $process = $mutantProcess->getProcess();
+
+        if ($process->getExitCode() > self::PROCESS_MIN_ERROR_CODE) {
+            // See \Symfony\Component\Process\Process::$exitCodes
+            return DetectionStatus::ERROR;
+        }
+
+        $output = $this->retrieveProcessOutput($process);
+
+        if ($process->getExitCode() === 0 && $this->testFrameworkAdapter->testsPass($output)) {
+            return DetectionStatus::ESCAPED;
+        }
+
+        if ($this->testFrameworkAdapter instanceof SyntaxErrorAware && $this->testFrameworkAdapter->isSyntaxError($output)) {
+            return DetectionStatus::SYNTAX_ERROR;
+        }
+
+        return DetectionStatus::KILLED;
+    }
+}

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -43,8 +43,8 @@ use Infection\Event\MutationTestingWasStarted;
 use Infection\IterableCounter;
 use Infection\Mutant\Mutant;
 use Infection\Mutant\MutantExecutionResult;
-use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Mutant\MutantFactory;
+use Infection\Mutant\TestFrameworkMutantExecutionResultFactory;
 use Infection\Mutation\Mutation;
 use Infection\Process\Factory\MutantProcessFactory;
 use Infection\Process\MutantProcess;
@@ -63,7 +63,7 @@ class MutationTestingRunner
     public function __construct(
         private readonly MutantProcessFactory $processFactory,
         private readonly MutantFactory $mutantFactory,
-        private readonly MutantExecutionResultFactory $mutantExecutionResultFactory,
+        private readonly TestFrameworkMutantExecutionResultFactory $mutantExecutionResultFactory,
         private readonly ProcessRunner $processRunner,
         private readonly EventDispatcher $eventDispatcher,
         private readonly Filesystem $fileSystem,

--- a/tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Mutant;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Mutant\DetectionStatus;
-use Infection\Mutant\MutantExecutionResultFactory;
+use Infection\Mutant\TestFrameworkMutantExecutionResultFactory;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\Loop\For_;
 use Infection\PhpParser\MutatedNode;
@@ -50,8 +50,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
-#[CoversClass(MutantExecutionResultFactory::class)]
-final class MutantExecutionResultFactoryTest extends TestCase
+#[CoversClass(TestFrameworkMutantExecutionResultFactory::class)]
+final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 {
     use MutantExecutionResultAssertions;
 
@@ -61,7 +61,7 @@ final class MutantExecutionResultFactoryTest extends TestCase
     private $testFrameworkAdapterMock;
 
     /**
-     * @var MutantExecutionResultFactory
+     * @var TestFrameworkMutantExecutionResultFactory
      */
     private $resultFactory;
 
@@ -69,7 +69,7 @@ final class MutantExecutionResultFactoryTest extends TestCase
     {
         $this->testFrameworkAdapterMock = $this->createMock(TestFrameworkAdapter::class);
 
-        $this->resultFactory = new MutantExecutionResultFactory($this->testFrameworkAdapterMock);
+        $this->resultFactory = new TestFrameworkMutantExecutionResultFactory($this->testFrameworkAdapterMock);
     }
 
     public function test_it_can_create_a_result_from_a_non_covered_mutant_process(): void

--- a/tests/phpunit/Process/Factory/MutantProcessFactoryTest.php
+++ b/tests/phpunit/Process/Factory/MutantProcessFactoryTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Process\Factory;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Mutant\MutantExecutionResult;
-use Infection\Mutant\MutantExecutionResultFactory;
+use Infection\Mutant\TestFrameworkMutantExecutionResultFactory;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\Loop\For_;
 use Infection\PhpParser\MutatedNode;
@@ -117,7 +117,7 @@ final class MutantProcessFactoryTest extends TestCase
             ->method($this->anything())
         ;
 
-        $resultFactoryMock = $this->createMock(MutantExecutionResultFactory::class);
+        $resultFactoryMock = $this->createMock(TestFrameworkMutantExecutionResultFactory::class);
         $resultFactoryMock
             ->method('createFromProcess')
             ->willReturn($executionResultMock)

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -45,8 +45,8 @@ use Infection\Event\MutantProcessWasFinished;
 use Infection\Event\MutationTestingWasFinished;
 use Infection\Event\MutationTestingWasStarted;
 use Infection\Mutant\MutantExecutionResult;
-use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Mutant\MutantFactory;
+use Infection\Mutant\TestFrameworkMutantExecutionResultFactory;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\Loop\For_;
 use Infection\PhpParser\MutatedNode;
@@ -82,7 +82,7 @@ final class MutationTestingRunnerTest extends TestCase
     private $mutantFactoryMock;
 
     /**
-     * @var MutantExecutionResultFactory|MockObject
+     * @var TestFrameworkMutantExecutionResultFactory|MockObject
      */
     private $mutationExecutionResultFactory;
 
@@ -110,7 +110,7 @@ final class MutationTestingRunnerTest extends TestCase
     {
         $this->processFactoryMock = $this->createMock(MutantProcessFactory::class);
         $this->mutantFactoryMock = $this->createMock(MutantFactory::class);
-        $this->mutationExecutionResultFactory = $this->createMock(MutantExecutionResultFactory::class);
+        $this->mutationExecutionResultFactory = $this->createMock(TestFrameworkMutantExecutionResultFactory::class);
         $this->processRunnerMock = $this->createMock(ProcessRunner::class);
         $this->eventDispatcher = new EventDispatcherCollector();
         $this->fileSystemMock = $this->createMock(Filesystem::class);


### PR DESCRIPTION
Extracted from https://github.com/infection/infection/pull/2098 to simplify a big PR

Why?

Because for PHPUnit process and for Static Analysis process (PHPStan in particular) we can not use the same ExecutionResult factory, because

- processes exit with different status codes
- PHPStan uses `stderr` for a lot of "internal" things, we can't rely on it
- because we don't need to parse `stdout` for "passed tests" in case of PHPStan
- and so on

So, each MutantProcess inside MutantProcessContainer (see https://github.com/infection/infection/pull/2096) will have different execution result parsers.
