### PR TITLE
Bump sanmai/pipeline to 6.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "nikic/php-parser": "^5.3",
         "ondram/ci-detector": "^4.1.0",
         "sanmai/later": "^0.1.1",
-        "sanmai/pipeline": "^5.1 || ^6",
+        "sanmai/pipeline": "^6.16",
         "sebastian/diff": "^3.0.2 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "symfony/console": "^6.4 || ^7.0",
         "symfony/filesystem": "^6.4 || ^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67e3098fc807ebcdb7e184d702c648e4",
+    "content-hash": "a6ae4bd7b0072e311c5e2dc4f59a9f3e",
     "packages": [
         {
             "name": "colinodell/json5",
@@ -975,20 +975,20 @@
         },
         {
             "name": "sanmai/pipeline",
-            "version": "6.12",
+            "version": "6.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sanmai/pipeline.git",
-                "reference": "ad7dbc3f773eeafb90d5459522fbd8f188532e25"
+                "reference": "f32413630904f83b069a7fbdfab34267dbaecdb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/ad7dbc3f773eeafb90d5459522fbd8f188532e25",
-                "reference": "ad7dbc3f773eeafb90d5459522fbd8f188532e25",
+                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/f32413630904f83b069a7fbdfab34267dbaecdb6",
+                "reference": "f32413630904f83b069a7fbdfab34267dbaecdb6",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "ergebnis/composer-normalize": "^2.8",
@@ -997,8 +997,8 @@
                 "league/pipeline": "^0.3 || ^1.0",
                 "phan/phan": ">=1.1",
                 "php-coveralls/php-coveralls": "^2.4.1",
-                "phpstan/phpstan": ">=0.10",
-                "phpunit/phpunit": ">=9.4",
+                "phpstan/phpstan": ">=0.10 <2",
+                "phpunit/phpunit": ">=9.4 <12",
                 "vimeo/psalm": ">=2"
             },
             "type": "library",
@@ -1028,7 +1028,7 @@
             "description": "General-purpose collections pipeline",
             "support": {
                 "issues": "https://github.com/sanmai/pipeline/issues",
-                "source": "https://github.com/sanmai/pipeline/tree/6.12"
+                "source": "https://github.com/sanmai/pipeline/tree/6.16"
             },
             "funding": [
                 {
@@ -1036,7 +1036,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-17T02:22:57+00:00"
+            "time": "2025-06-02T06:36:22+00:00"
         },
         {
             "name": "sebastian/diff",

--- a/tests/phpunit/FileSystem/SourceFileCollectorTest.php
+++ b/tests/phpunit/FileSystem/SourceFileCollectorTest.php
@@ -44,6 +44,7 @@ use function natcasesort;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use function Pipeline\take;
 use function range;
 use Symfony\Component\Filesystem\Path;
 
@@ -59,7 +60,7 @@ final class SourceFileCollectorTest extends TestCase
 
         $files = (new SourceFileCollector())->collectFiles($sourceDirectories, $excludedFiles);
 
-        $files = [...$files];
+        $files = take($files)->toList();
 
         $this->assertSame(
             $expected,

--- a/tests/phpunit/FileSystem/SourceFileCollectorTest.php
+++ b/tests/phpunit/FileSystem/SourceFileCollectorTest.php
@@ -60,7 +60,7 @@ final class SourceFileCollectorTest extends TestCase
 
         $files = (new SourceFileCollector())->collectFiles($sourceDirectories, $excludedFiles);
 
-        $files = take($files)->toArray(); // PHP 7.4 [...$files]
+        $files = [...$files];
 
         $this->assertSame(
             $expected,

--- a/tests/phpunit/FileSystem/SourceFileCollectorTest.php
+++ b/tests/phpunit/FileSystem/SourceFileCollectorTest.php
@@ -44,7 +44,6 @@ use function natcasesort;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use function Pipeline\take;
 use function range;
 use Symfony\Component\Filesystem\Path;
 

--- a/tests/phpunit/FileSystem/SourceFileFilterTest.php
+++ b/tests/phpunit/FileSystem/SourceFileFilterTest.php
@@ -208,7 +208,7 @@ final class SourceFileFilterTest extends TestCase
 
         $actual = take($actual)
             ->map(static fn ($traceOrFileInfo) => $traceOrFileInfo->getRealPath())
-            ->toArray();
+            ->toList();
 
         $this->assertSame($expectedFilePaths, $actual);
     }


### PR DESCRIPTION
## What and Why

This PR:

- [x] Bump sanmai/pipeline to 6.16 so we can use new fancy features (online variance, reservoir sampling)
- [x] Covered by tests

<!--
Remove if not relevant
-->


## Testing Steps

```
git diff --name-only master tests | xargs php vendor/bin/phpunit
```


<!--
- Replace this comment by a detailed description of what your PR is solving.
- Use labels for different kinds of PR like `performance`, `feature`, etc.
- Use Milestone to show when this code is going to be released.

Deprecations? don't forget to update UPGRADE-*.md files
-->