### PR TITLE
Support null-safe method calls in MethodCallRemoval mutator

### DIFF
--- a/src/Mutator/Removal/MethodCallRemoval.php
+++ b/src/Mutator/Removal/MethodCallRemoval.php
@@ -78,6 +78,9 @@ final class MethodCallRemoval implements Mutator
             return false;
         }
 
-        return $node->expr instanceof Node\Expr\MethodCall || $node->expr instanceof Node\Expr\StaticCall;
+        return $node->expr instanceof Node\Expr\MethodCall
+            || $node->expr instanceof Node\Expr\NullsafeMethodCall
+            || $node->expr instanceof Node\Expr\StaticCall
+        ;
     }
 }

--- a/tests/phpunit/Mutator/Removal/MethodCallRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/MethodCallRemovalTest.php
@@ -116,6 +116,22 @@ final class MethodCallRemovalTest extends BaseMutatorTestCase
                 PHP,
         ];
 
+        yield 'It remove a null-safe method call with parameters' => [
+            <<<'PHP'
+                <?php
+
+                $foo?->bar(3, 4);
+                $a = 3;
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $a = 3;
+                PHP
+            ,
+        ];
+
         yield 'It does not remove a method call that is assigned to something' => [
             <<<'PHP'
                 <?php


### PR DESCRIPTION
This PR:

- [ ] Adds new feature ...
- [x] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

While getting used to the codebase I had a look into existing mutators.
If I am not mistaken I think the `MethodCallRemoval` mutator currently misses to work on [null-safe method calls](https://php.watch/versions/8.0/null-safe-operator)