### PR TITLE
More resilient StopwatchTest

### DIFF
--- a/tests/phpunit/Resource/Time/StopwatchTest.php
+++ b/tests/phpunit/Resource/Time/StopwatchTest.php
@@ -69,7 +69,8 @@ final class StopwatchTest extends TestCase
 
         $actualTimeInSeconds = $this->stopwatch->stop();
 
-        $this->assertSame($expectedTime, round($actualTimeInSeconds, 2));
+        // on macOS m4 pro we need a small delta to account for the precision of the timer
+        $this->assertEqualsWithDelta($expectedTime, round($actualTimeInSeconds, 2), 0.02);
     }
 
     public function test_it_cannot_be_started_twice(): void


### PR DESCRIPTION
the test previously constantly failed on my mac with:

```
➜  infection git:(master) ✗ vendor/bin/phpunit /Users/staabm/workspace/infection/tests/phpunit/Resource/Time/StopwatchTest.php
Xdebug: [Step Debug] Could not connect to debugging client. Tried: 127.0.0.1:9003 (through xdebug.client_host/xdebug.client_port).
PHPUnit 11.5.17 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.28
Configuration: /Users/staabm/workspace/infection/phpunit.xml.dist
Random Seed:   1749064627

F...                                                                4 / 4 (100%)

Time: 00:01.023, Memory: 12.00 MB

There was 1 failure:

1) Infection\Tests\Resource\Time\StopwatchTest::test_it_returns_the_time_took_on_stop with data set "nominal" (1000000, 1.0)
Failed asserting that 1.01 matches expected 1.0.

/Users/staabm/workspace/infection/tests/phpunit/Resource/Time/StopwatchTest.php:72

FAILURES!
Tests: 4, Assertions: 4, Failures: 1.
```