### PR TITLE
ProtectedVisibility: Don't mutate method in final class

### DIFF
--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -94,7 +94,10 @@ final class ProtectedVisibility implements Mutator
             return false;
         }
 
-        if ($node->isFinal()) {
+        /** @var ClassReflection $class */
+        $class = $node->getAttribute(ReflectionVisitor::REFLECTION_CLASS_KEY);
+
+        if ($node->isFinal() || $class !== null && $class->isFinal()) {
             return false;
         }
 

--- a/src/Reflection/AnonymousClassReflection.php
+++ b/src/Reflection/AnonymousClassReflection.php
@@ -79,6 +79,11 @@ final readonly class AnonymousClassReflection implements ClassReflection
         return '';
     }
 
+    public function isFinal(): bool
+    {
+        return $this->reflectionClass->isFinal();
+    }
+
     private static function hasMethodRecursively(
         ReflectionClass $reflectionClass,
         string $methodName,

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -43,4 +43,6 @@ interface ClassReflection
     public function hasParentMethodWithVisibility(string $methodName, Visibility $visibility): bool;
 
     public function getName(): string;
+
+    public function isFinal(): bool;
 }

--- a/src/Reflection/CoreClassReflection.php
+++ b/src/Reflection/CoreClassReflection.php
@@ -75,4 +75,9 @@ final readonly class CoreClassReflection implements ClassReflection
     {
         return $this->reflectionClass->getName();
     }
+
+    public function isFinal(): bool
+    {
+        return $this->reflectionClass->isFinal();
+    }
 }

--- a/src/Reflection/NullReflection.php
+++ b/src/Reflection/NullReflection.php
@@ -49,4 +49,9 @@ final class NullReflection implements ClassReflection
     {
         return '';
     }
+
+    public function isFinal(): bool
+    {
+        return false;
+    }
 }

--- a/tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-class.php
+++ b/tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-class.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ProtectedVisibilityFinal;
+
+final class FinalTest
+{
+    protected function foo(int $param, $test = 1) : bool
+    {
+        echo 1;
+        return false;
+    }
+}

--- a/tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-enum.php
+++ b/tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-enum.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ProtectedVisibilityFinal;
+
+enum TestEnum
+{
+    protected function &foo(int $param, $test = 1) : bool
+    {
+        echo 1;
+        return false;
+    }
+}

--- a/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -84,6 +84,10 @@ final class ProtectedVisibilityTest extends BaseMutatorTestCase
             MutatorFixturesProvider::getFixtureFileContent(self::class, 'pv-final-class.php'),
         ];
 
+        yield 'It does not mutate method in enum (implicit final)' => [
+            MutatorFixturesProvider::getFixtureFileContent(self::class, 'pv-final-enum.php'),
+        ];
+
         yield 'It does not mutate abstract protected to private' => [
             MutatorFixturesProvider::getFixtureFileContent(self::class, 'pv-abstract.php'),
         ];

--- a/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+++ b/tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
@@ -76,8 +76,12 @@ final class ProtectedVisibilityTest extends BaseMutatorTestCase
             ,
         ];
 
-        yield 'It does not mutate final flag' => [
+        yield 'It does not mutate final method' => [
             MutatorFixturesProvider::getFixtureFileContent(self::class, 'pv-final.php'),
+        ];
+
+        yield 'It does not mutate method in final class' => [
+            MutatorFixturesProvider::getFixtureFileContent(self::class, 'pv-final-class.php'),
         ];
 
         yield 'It does not mutate abstract protected to private' => [


### PR DESCRIPTION
In final classes it does not make a difference whether methods are protected of private.
