### PR TITLE
Increase min MSI values

### DIFF
--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -24,8 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MIN_MSI: 72.16
-  MIN_COVERED_MSI: 86.48
+  MIN_MSI: 77.0
+  MIN_COVERED_MSI: 87.0
 
 jobs:
   tests:


### PR DESCRIPTION
Because now we have the following notice:

```
! [NOTE] The MSI is 5.1% percentage points over the required MSI. Consider increasing the required MSI percentage the next time you run Infection.
```

and actual values are:

```
 Metrics:
    Mutation Score Indicator (MSI): 77%
    Mutation Code Coverage: 88%
    Covered Code MSI: 87%
```

