### PR TITLE
Don't produce mutations for same type comparisons of known global constants

### DIFF
--- a/src/Mutator/Util/AbstractIdenticalComparison.php
+++ b/src/Mutator/Util/AbstractIdenticalComparison.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator\Util;
 
+use function class_exists;
 use function count;
 use function gettype;
 use function in_array;
@@ -43,7 +44,6 @@ use Infection\PhpParser\Visitor\ReflectionVisitor;
 use Infection\Reflection\ClassReflection;
 use function is_numeric;
 use function is_string;
-use const PHP_VERSION_ID;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\CallLike;
@@ -64,8 +64,6 @@ use ReflectionUnionType;
  */
 abstract class AbstractIdenticalComparison implements Mutator
 {
-    private const REFLECTION_CONSTANT_MIN_VERSION = 80400;
-
     /**
      * @var array<string, ReflectionType|null>
      */
@@ -265,15 +263,13 @@ abstract class AbstractIdenticalComparison implements Mutator
 
     private function getGlobalConstantValue(Node\Name $name): mixed
     {
-        if (PHP_VERSION_ID < self::REFLECTION_CONSTANT_MIN_VERSION) {
+        if (!class_exists(ReflectionConstant::class)) {
             return null;
         }
 
         try {
-            // @phpstan-ignore class.notFound
             $reflection = new ReflectionConstant($name->toString());
 
-            // @phpstan-ignore class.notFound
             return $reflection->getValue();
         } catch (ReflectionException) {
             // If the no reflection info exist, we cannot determine the return type

--- a/src/Mutator/Util/AbstractIdenticalComparison.php
+++ b/src/Mutator/Util/AbstractIdenticalComparison.php
@@ -39,6 +39,7 @@ use function count;
 use function gettype;
 use function in_array;
 use Infection\Mutator\Mutator;
+use function is_numeric;
 use const PHP_VERSION_ID;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
@@ -69,6 +70,22 @@ abstract class AbstractIdenticalComparison implements Mutator
 
     protected function isSameTypeIdenticalComparison(Expr\BinaryOp\Equal|Expr\BinaryOp\Identical $comparison): bool
     {
+        if ($comparison->left instanceof Node\Scalar\String_) {
+            if ($comparison->left->value !== '' && !is_numeric($comparison->left->value)) {
+                // you can't type juggle any expression type into a non-numeric&non-empty string
+                // see https://github.com/phpstan/phpstan/issues/13120
+                return true;
+            }
+        }
+
+        if ($comparison->right instanceof Node\Scalar\String_) {
+            if ($comparison->right->value !== '' && !is_numeric($comparison->right->value)) {
+                // you can't type juggle any expression type into a non-numeric&non-empty string
+                // see https://github.com/phpstan/phpstan/issues/13120
+                return true;
+            }
+        }
+
         if (
             $comparison->left instanceof Expr\FuncCall
             && $comparison->right instanceof Expr\FuncCall

--- a/tests/autoloaded/mutator-fixtures/EqualIdentical/non-numeric-non-empty-class-const.php
+++ b/tests/autoloaded/mutator-fixtures/EqualIdentical/non-numeric-non-empty-class-const.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EqualIdenticalNonNumericNonEmptyClassConst;
+
+class Foo {
+    private const BAR = 'baz';
+    public function doFoo($x) {
+        return $x == self::BAR;
+    }
+}

--- a/tests/autoloaded/mutator-fixtures/IdenticalEqual/non-numeric-non-empty-class-const.php
+++ b/tests/autoloaded/mutator-fixtures/IdenticalEqual/non-numeric-non-empty-class-const.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace IdenticalEqualNonNumericNonEmptyClassConst;
+
+class Foo {
+    private const BAR = 'baz';
+    public function doFoo($x) {
+        return $x === self::BAR;
+    }
+}

--- a/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\Mutator\Boolean;
 use Infection\Mutator\Boolean\EqualIdentical;
 use Infection\Testing\BaseMutatorTestCase;
 use Infection\Tests\Mutator\MutatorFixturesProvider;
-use const PHP_VERSION_ID;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -464,40 +463,88 @@ final class EqualIdenticalTest extends BaseMutatorTestCase
                 PHP,
         ];
 
-        if (PHP_VERSION_ID >= 80400) {
-            yield 'It not mutates equal operator into identical operator for known global constants' => [
-                <<<'PHPCODE'
-                    <?php
+        yield 'It not mutates equal operator into identical operator for known global constants' => [
+            <<<'PHPCODE'
+                <?php
 
-                    PHP_SAPI == 'phpdbg';
-                    PHPCODE,
-            ];
+                PHP_SAPI == 'phpdbg';
+                PHPCODE,
+        ];
 
-            yield 'It mutates equal operator into identical operator for unknown global constants' => [
-                <<<'PHPCODE'
-                    <?php
+        yield 'It not mutates equal operator into identical operator for unknown global constants' => [
+            <<<'PHPCODE'
+                <?php
 
-                    NOONE_KNOWS_THIS_CONSTANT == 'phpdbg';
-                    PHPCODE,
-                <<<'PHPCODE'
-                    <?php
+                NOONE_KNOWS_THIS_CONSTANT == 'phpdbg';
+                PHPCODE,
+        ];
 
-                    NOONE_KNOWS_THIS_CONSTANT === 'phpdbg';
-                    PHPCODE,
-            ];
-        } else {
-            yield 'It mutates equal operator into identical for known global constants in PHP 8.3' => [
-                <<<'PHPCODE'
-                    <?php
+        yield 'It mutates equal operator into identical operator for comparison against empty literal string' => [
+            <<<'PHP'
+                <?php
 
-                    PHP_SAPI == 'phpdbg';
-                    PHPCODE,
-                <<<'PHPCODE'
-                    <?php
+                $x == '';
+                PHP,
+            <<<'PHP'
+                <?php
 
-                    PHP_SAPI === 'phpdbg';
-                    PHPCODE,
-            ];
-        }
+                $x === '';
+                PHP,
+        ];
+
+        yield 'It mutates equal operator into identical operator for comparison against empty literal string (inversed)' => [
+            <<<'PHP'
+                <?php
+
+                '' == $x;
+                PHP,
+            <<<'PHP'
+                <?php
+
+                '' === $x;
+                PHP,
+        ];
+
+        yield 'It mutates equal operator into identical operator for comparison against numeric literal string' => [
+            <<<'PHP'
+                <?php
+
+                $x == '123';
+                PHP,
+            <<<'PHP'
+                <?php
+
+                $x === '123';
+                PHP,
+        ];
+
+        yield 'It mutates equal operator into identical operator for comparison against numeric literal string (inversed)' => [
+            <<<'PHP'
+                <?php
+
+                '123' == $x;
+                PHP,
+            <<<'PHP'
+                <?php
+
+                '123' === $x;
+                PHP,
+        ];
+
+        yield 'It not mutates equal operator into identical operator for comparison against non-numeric&non-empty literal string' => [
+            <<<'PHP'
+                <?php
+
+                $x == 'hello';
+                PHP,
+        ];
+
+        yield 'It not mutates equal operator into identical operator for comparison against non-numeric&non-empty literal string (inversed)' => [
+            <<<'PHP'
+                <?php
+
+                'hello' == $x;
+                PHP,
+        ];
     }
 }

--- a/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Mutator\Boolean;
 use Infection\Mutator\Boolean\EqualIdentical;
 use Infection\Testing\BaseMutatorTestCase;
 use Infection\Tests\Mutator\MutatorFixturesProvider;
+use const PHP_VERSION_ID;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -462,6 +463,29 @@ final class EqualIdenticalTest extends BaseMutatorTestCase
                 round() === RegexIterator::USE_KEY;
                 PHP,
         ];
+
+        if (PHP_VERSION_ID >= 80400) {
+            yield 'It not mutates equal operator into identical operator for known int global constants' => [
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_MAJOR_VERSION == 5;
+                    PHPCODE,
+            ];
+        } else {
+            yield 'It mutates equal operator into identical operator for known int global constants (PHP 8.3)' => [
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_MAJOR_VERSION == 5;
+                    PHPCODE,
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_MAJOR_VERSION === 5;
+                    PHPCODE,
+            ];
+        }
 
         yield 'It not mutates equal operator into identical operator for known global constants' => [
             <<<'PHPCODE'

--- a/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Mutator\Boolean;
 use Infection\Mutator\Boolean\EqualIdentical;
 use Infection\Testing\BaseMutatorTestCase;
 use Infection\Tests\Mutator\MutatorFixturesProvider;
+use const PHP_VERSION_ID;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -462,5 +463,28 @@ final class EqualIdenticalTest extends BaseMutatorTestCase
                 round() === RegexIterator::USE_KEY;
                 PHP,
         ];
+
+        if (PHP_VERSION_ID >= 80400) {
+            yield 'It not mutates equal operator into identical operator for known global constants' => [
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_SAPI == 'phpdbg';
+                    PHPCODE,
+            ];
+        } else {
+            yield 'It mutates equal operator into identical for known global constants in PHP 8.3' => [
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_SAPI == 'phpdbg';
+                    PHPCODE,
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_SAPI === 'phpdbg';
+                    PHPCODE,
+            ];
+        }
     }
 }

--- a/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
@@ -473,7 +473,7 @@ final class EqualIdenticalTest extends BaseMutatorTestCase
                     PHPCODE,
             ];
 
-            yield 'It mutates identical operator into equal operator for unknown global constants' => [
+            yield 'It mutates equal operator into identical operator for unknown global constants' => [
                 <<<'PHPCODE'
                     <?php
 

--- a/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
@@ -473,7 +473,7 @@ final class EqualIdenticalTest extends BaseMutatorTestCase
                     PHPCODE,
             ];
         } else {
-            yield 'It mutates equal operator into identical operator for known int global constants (PHP 8.3)' => [
+            yield 'It mutates equal operator into identical operator for global int constants without reflection info (PHP 8.3)' => [
                 <<<'PHPCODE'
                     <?php
 

--- a/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
@@ -570,5 +570,9 @@ final class EqualIdenticalTest extends BaseMutatorTestCase
                 'hello' == $x;
                 PHP,
         ];
+
+        yield 'It not mutates equal operator into identical operator for comparison against non-numeric&non-empty literal string (class constant)' => [
+            MutatorFixturesProvider::getFixtureFileContent(self::class, 'non-numeric-non-empty-class-const.php'),
+        ];
     }
 }

--- a/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
+++ b/tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php
@@ -472,6 +472,19 @@ final class EqualIdenticalTest extends BaseMutatorTestCase
                     PHP_SAPI == 'phpdbg';
                     PHPCODE,
             ];
+
+            yield 'It mutates identical operator into equal operator for unknown global constants' => [
+                <<<'PHPCODE'
+                    <?php
+
+                    NOONE_KNOWS_THIS_CONSTANT == 'phpdbg';
+                    PHPCODE,
+                <<<'PHPCODE'
+                    <?php
+
+                    NOONE_KNOWS_THIS_CONSTANT === 'phpdbg';
+                    PHPCODE,
+            ];
         } else {
             yield 'It mutates equal operator into identical for known global constants in PHP 8.3' => [
                 <<<'PHPCODE'

--- a/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
@@ -459,6 +459,19 @@ final class IdenticalEqualTest extends BaseMutatorTestCase
                     PHP_SAPI === 'phpdbg';
                     PHPCODE,
             ];
+
+            yield 'It mutates identical operator into equal operator for unknown global constants' => [
+                <<<'PHPCODE'
+                    <?php
+
+                    NOONE_KNOWS_THIS_CONSTANT === 'phpdbg';
+                    PHPCODE,
+                <<<'PHPCODE'
+                    <?php
+
+                    NOONE_KNOWS_THIS_CONSTANT == 'phpdbg';
+                    PHPCODE,
+            ];
         } else {
             yield 'It mutates identical operator into equal operator for known global constants in PHP 8.3' => [
                 <<<'PHPCODE'

--- a/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
@@ -460,7 +460,7 @@ final class IdenticalEqualTest extends BaseMutatorTestCase
                     PHPCODE,
             ];
         } else {
-            yield 'It mutates identical operator into equal operator for known global int constants (PHP 8.3)' => [
+            yield 'It mutates identical operator into equal operator for global int constants without reflection info (PHP 8.3)' => [
                 <<<'PHPCODE'
                     <?php
 

--- a/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Mutator\Boolean;
 use Infection\Mutator\Boolean\IdenticalEqual;
 use Infection\Testing\BaseMutatorTestCase;
 use Infection\Tests\Mutator\MutatorFixturesProvider;
+use const PHP_VERSION_ID;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -449,5 +450,28 @@ final class IdenticalEqualTest extends BaseMutatorTestCase
                 round() == RegexIterator::USE_KEY;
                 PHP,
         ];
+
+        if (PHP_VERSION_ID >= 80400) {
+            yield 'It not mutates identical operator into equal operator for known global constants' => [
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_SAPI === 'phpdbg';
+                    PHPCODE,
+            ];
+        } else {
+            yield 'It mutates identical operator into equal operator for known global constants in PHP 8.3' => [
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_SAPI === 'phpdbg';
+                    PHPCODE,
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_SAPI == 'phpdbg';
+                    PHPCODE,
+            ];
+        }
     }
 }

--- a/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Mutator\Boolean;
 use Infection\Mutator\Boolean\IdenticalEqual;
 use Infection\Testing\BaseMutatorTestCase;
 use Infection\Tests\Mutator\MutatorFixturesProvider;
+use const PHP_VERSION_ID;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -449,6 +450,29 @@ final class IdenticalEqualTest extends BaseMutatorTestCase
                 round() == RegexIterator::USE_KEY;
                 PHP,
         ];
+
+        if (PHP_VERSION_ID >= 80400) {
+            yield 'It not mutates identical operator into equal operator for known global int constants' => [
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_MAJOR_VERSION === 5;
+                    PHPCODE,
+            ];
+        } else {
+            yield 'It mutates identical operator into equal operator for known global int constants (PHP 8.3)' => [
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_MAJOR_VERSION === 5;
+                    PHPCODE,
+                <<<'PHPCODE'
+                    <?php
+
+                    PHP_MAJOR_VERSION == 5;
+                    PHPCODE,
+            ];
+        }
 
         yield 'It not mutates identical operator into equal operator for known global constants' => [
             <<<'PHPCODE'

--- a/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\Mutator\Boolean;
 use Infection\Mutator\Boolean\IdenticalEqual;
 use Infection\Testing\BaseMutatorTestCase;
 use Infection\Tests\Mutator\MutatorFixturesProvider;
-use const PHP_VERSION_ID;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -451,40 +450,88 @@ final class IdenticalEqualTest extends BaseMutatorTestCase
                 PHP,
         ];
 
-        if (PHP_VERSION_ID >= 80400) {
-            yield 'It not mutates identical operator into equal operator for known global constants' => [
-                <<<'PHPCODE'
-                    <?php
+        yield 'It not mutates identical operator into equal operator for known global constants' => [
+            <<<'PHPCODE'
+                <?php
 
-                    PHP_SAPI === 'phpdbg';
-                    PHPCODE,
-            ];
+                PHP_SAPI === 'phpdbg';
+                PHPCODE,
+        ];
 
-            yield 'It mutates identical operator into equal operator for unknown global constants' => [
-                <<<'PHPCODE'
-                    <?php
+        yield 'It not mutates identical operator into equal operator for unknown global constants' => [
+            <<<'PHPCODE'
+                <?php
 
-                    NOONE_KNOWS_THIS_CONSTANT === 'phpdbg';
-                    PHPCODE,
-                <<<'PHPCODE'
-                    <?php
+                NOONE_KNOWS_THIS_CONSTANT === 'phpdbg';
+                PHPCODE,
+        ];
 
-                    NOONE_KNOWS_THIS_CONSTANT == 'phpdbg';
-                    PHPCODE,
-            ];
-        } else {
-            yield 'It mutates identical operator into equal operator for known global constants in PHP 8.3' => [
-                <<<'PHPCODE'
-                    <?php
+        yield 'It mutates identical operator into equal operator for comparison against empty literal string' => [
+            <<<'PHP'
+                <?php
 
-                    PHP_SAPI === 'phpdbg';
-                    PHPCODE,
-                <<<'PHPCODE'
-                    <?php
+                $x === '';
+                PHP,
+            <<<'PHP'
+                <?php
 
-                    PHP_SAPI == 'phpdbg';
-                    PHPCODE,
-            ];
-        }
+                $x == '';
+                PHP,
+        ];
+
+        yield 'It mutates identical operator into equal operator for comparison against empty literal string (inversed)' => [
+            <<<'PHP'
+                <?php
+
+                '' === $x;
+                PHP,
+            <<<'PHP'
+                <?php
+
+                '' == $x;
+                PHP,
+        ];
+
+        yield 'It mutates identical operator into equal operator for comparison against numeric literal string' => [
+            <<<'PHP'
+                <?php
+
+                $x === '123';
+                PHP,
+            <<<'PHP'
+                <?php
+
+                $x == '123';
+                PHP,
+        ];
+
+        yield 'It mutates identical operator into equal operator for comparison against numeric literal string (inversed)' => [
+            <<<'PHP'
+                <?php
+
+                '123' === $x;
+                PHP,
+            <<<'PHP'
+                <?php
+
+                '123' == $x;
+                PHP,
+        ];
+
+        yield 'It not mutates identical operator into equal operator for comparison against non-numeric&non-empty literal string' => [
+            <<<'PHP'
+                <?php
+
+                $x === 'hello';
+                PHP,
+        ];
+
+        yield 'It not mutates identical operator into equal operator for comparison against non-numeric&non-empty literal string (inversed)' => [
+            <<<'PHP'
+                <?php
+
+                'hello' === $x;
+                PHP,
+        ];
     }
 }

--- a/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
+++ b/tests/phpunit/Mutator/Boolean/IdenticalEqualTest.php
@@ -557,5 +557,9 @@ final class IdenticalEqualTest extends BaseMutatorTestCase
                 'hello' === $x;
                 PHP,
         ];
+
+        yield 'It not mutates identical operator into equal operator for comparison against non-numeric&non-empty literal string (class constant)' => [
+            MutatorFixturesProvider::getFixtureFileContent(self::class, 'non-numeric-non-empty-class-const.php'),
+        ];
     }
 }


### PR DESCRIPTION
Refs https://github.com/infection/infection/issues/2111

this feature relies on `ReflectionConstant` which is available as of PHP 8.4.
~~In PHP <= 8.3 a mutation will be produced, since we are not able to detect it is not necessary~~
it depends on the value of the string: non-empty&non-numeric strings can be eleminated independent from PHP Version

see https://www.php.net/manual/de/class.reflectionconstant.php
