### PR TITLE
Allow to skip running PHPStan for particular mutators

### DIFF
--- a/src/Process/Factory/LazyMutantProcessFactory.php
+++ b/src/Process/Factory/LazyMutantProcessFactory.php
@@ -44,4 +44,6 @@ use Infection\Process\MutantProcess;
 interface LazyMutantProcessFactory
 {
     public function create(Mutant $mutant): MutantProcess;
+
+    public function supports(Mutant $mutant): bool;
 }

--- a/src/Process/MutantProcessContainer.php
+++ b/src/Process/MutantProcessContainer.php
@@ -68,7 +68,8 @@ class MutantProcessContainer
     public function hasNext(): bool
     {
         return array_key_exists($this->currentProcessIndex, $this->lazyMutantProcessCreators)
-            && $this->getCurrentMutantProcessDetectionStatus() === DetectionStatus::ESCAPED;
+            && $this->getCurrentMutantProcessDetectionStatus() === DetectionStatus::ESCAPED
+            && $this->lazyMutantProcessCreators[$this->currentProcessIndex]->supports($this->getCurrent()->getMutant());
     }
 
     public function createNext(): MutantProcess

--- a/src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php
+++ b/src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php
@@ -35,7 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\StaticAnalysis\PHPStan\Process;
 
+use function in_array;
 use Infection\Mutant\Mutant;
+use Infection\Mutator\Boolean\InstanceOf_;
 use Infection\Process\Factory\LazyMutantProcessFactory;
 use Infection\Process\MutantProcess;
 use Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory;
@@ -69,6 +71,21 @@ final class PHPStanMutantProcessFactory implements LazyMutantProcessFactory
             $process,
             $mutant,
             $this->mutantExecutionResultFactory,
+        );
+    }
+
+    public function supports(Mutant $mutant): bool
+    {
+        $mutatorClass = $mutant->getMutation()->getMutatorClass();
+
+        return !in_array(
+            $mutatorClass,
+            [
+                // In PHPStan, it always produces "Left|Right side of && is always true" or "If condition is always true."
+                // https://phpstan.org/r/a9736cca-dc3a-4033-8f2a-80dbc13951b9
+                InstanceOf_::class,
+            ],
+            true,
         );
     }
 

--- a/tests/e2e/PHPStan_Integration/infection.json5
+++ b/tests/e2e/PHPStan_Integration/infection.json5
@@ -7,8 +7,7 @@
         ]
     },
     "logs": {
-        "summary": "infection.log",
-        "text": "infection.text.log",
+        "summary": "infection.log"
     },
     "tmpDir": "."
 }

--- a/tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php
+++ b/tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php
@@ -260,6 +260,11 @@ final class ParallelProcessRunnerTest extends TestCase
                             $this->mutantExecutionResultFactory,
                         );
                     }
+
+                    public function supports(Mutant $mutant): bool
+                    {
+                        return true;
+                    }
                 },
             ],
         );


### PR DESCRIPTION
I've analyzed 200+ mutations in BetterReflection (https://github.com/Roave/BetterReflection/pull/1510) and there are many cases where PHPStan kills a mutant while it should **not** - those are false-positives (meaning we get killed mutant but in fact it can be escaped/not well testes), for example:

```diff
@@ @@
             if ($reflection instanceof ReflectionFunction && $this->containsLine($reflection, $lineNumber)) {
                 return $reflection;
             }
-            if ($reflection instanceof ReflectionConstant && $this->containsLine($reflection, $lineNumber)) {
+            if (true && $this->containsLine($reflection, $lineNumber)) {
                 return $reflection;
             }
         }

$ '/app/vendor/bin/phpstan' '--tmp-file=/tmp/infection/mutant.a99f5bbe9bbbb1514da2bdbe5e315d5c.infection.php' '--instead-of=/app/src/Util/FindReflectionOnLine.php' '--error-format=json' '--no-progress' '-vv'

PHPStan error: Left side of && is always true.
```

In PHPStan, it always produces "Left|Right side of && is always true" or "If condition is always true."

See https://phpstan.org/r/a9736cca-dc3a-4033-8f2a-80dbc13951b9

So it doesn't make sense for `InstanceOf_` mutator to try to kill it by PHPStan, because it will always be killed while tests can be with the whole.

- [ ] Try to generate temp `phpstan.hash.neon` file for each Mutant and disable not needed phpstan checks by specifying error identified (https://phpstan.org/blog/phpstan-1-11-errors-identifiers-phpstan-pro-reboot)