### PR TITLE
Don't mutate false/true in ternary

### DIFF
--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -76,12 +76,25 @@ final class FalseValue implements Mutator
 
     public function canMutate(Node $node): bool
     {
-        $parentNode = ParentConnector::findParent($node);
-
-        if (!$node instanceof Node\Expr\ConstFetch || $parentNode instanceof Node\Stmt\Switch_) {
+        if (!$node instanceof Node\Expr\ConstFetch) {
             return false;
         }
 
-        return $node->name->toLowerString() === 'false';
+        if ($node->name->toLowerString() !== 'false') {
+            return false;
+        }
+
+        $parentNode = ParentConnector::findParent($node);
+        $grandParentNode = $parentNode !== null ? ParentConnector::findParent($parentNode) : null;
+
+        if ($parentNode instanceof Node\Stmt\Switch_) {
+            return false;
+        }
+
+        if ($grandParentNode instanceof Node\Expr\Ternary) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -105,6 +105,10 @@ final class TrueValue implements ConfigurableMutator
             return false;
         }
 
+        if ($grandParentNode instanceof Node\Expr\Ternary) {
+            return false;
+        }
+
         if (!$grandParentNode instanceof Node\Expr\FuncCall || !$grandParentNode->name instanceof Node\Name) {
             return true;
         }

--- a/tests/phpunit/Mutator/Boolean/FalseValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/FalseValueTest.php
@@ -89,6 +89,15 @@ final class FalseValueTest extends BaseMutatorTestCase
             ,
         ];
 
+        yield 'It does not mutate in ternary condition to prevent overlap with TernaryMutator' => [
+            <<<'PHP'
+                <?php
+
+                $x == false ? 'yes' : 'no';
+                PHP
+            ,
+        ];
+
         yield 'It mutates all caps false to true' => [
             <<<'PHP'
                 <?php

--- a/tests/phpunit/Mutator/Boolean/TrueValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/TrueValueTest.php
@@ -114,6 +114,15 @@ final class TrueValueTest extends BaseMutatorTestCase
                 PHP,
         ];
 
+        yield 'It does not mutate in ternary condition to prevent overlap with TernaryMutator' => [
+            <<<'PHP'
+                <?php
+
+                $x == true ? 'yes' : 'no';
+                PHP
+            ,
+        ];
+
         yield 'It mutates all caps true to false' => [
             <<<'PHP'
                 <?php


### PR DESCRIPTION
I think we should not mutate true/false in ternary expression, since a separate TernaryMutator exists for this exact case.

prevents one redundant mutation per ternary which uses a `true` or `false` in its condition.
this was noticed in https://github.com/infection/infection/pull/2137

refs https://github.com/infection/infection/issues/2111