### PR TITLE
Don't mutate identical/not-identical in ternary

### DIFF
--- a/src/Mutator/ConditionalNegotiation/Identical.php
+++ b/src/Mutator/ConditionalNegotiation/Identical.php
@@ -39,6 +39,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
+use Infection\PhpParser\Visitor\ParentConnector;
 use PhpParser\Node;
 
 /**
@@ -78,6 +79,12 @@ final class Identical implements Mutator
 
     public function canMutate(Node $node): bool
     {
+        $parentNode = ParentConnector::findParent($node);
+
+        if ($parentNode instanceof Node\Expr\Ternary) {
+            return false;
+        }
+
         return $node instanceof Node\Expr\BinaryOp\Identical;
     }
 }

--- a/src/Mutator/ConditionalNegotiation/NotIdentical.php
+++ b/src/Mutator/ConditionalNegotiation/NotIdentical.php
@@ -39,6 +39,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
+use Infection\PhpParser\Visitor\ParentConnector;
 use PhpParser\Node;
 
 /**
@@ -80,6 +81,12 @@ final class NotIdentical implements Mutator
 
     public function canMutate(Node $node): bool
     {
+        $parentNode = ParentConnector::findParent($node);
+
+        if ($parentNode instanceof Node\Expr\Ternary) {
+            return false;
+        }
+
         return $node instanceof Node\Expr\BinaryOp\NotIdentical;
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/IdenticalTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/IdenticalTest.php
@@ -86,5 +86,13 @@ final class IdenticalTest extends BaseMutatorTestCase
                 PHP
             ,
         ];
+
+        yield 'It does not mutate inside ternary to prevent overlap with TernaryMutator' => [
+            <<<'PHP'
+                <?php
+                $x === false ? 'yes' : 'no';
+                PHP
+            ,
+        ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/NotIdenticalTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/NotIdenticalTest.php
@@ -86,5 +86,13 @@ final class NotIdenticalTest extends BaseMutatorTestCase
                 PHP
             ,
         ];
+
+        yield 'It does not mutate inside ternary to prevent overlap with TernaryMutator' => [
+            <<<'PHP'
+                <?php
+                $x !== false ? 'yes' : 'no';
+                PHP
+            ,
+        ];
     }
 }


### PR DESCRIPTION
similar to https://github.com/infection/infection/pull/2138

prevents one redundant mutation per ternary which uses a `===` or `!==` in its condition.
this was noticed in https://github.com/infection/infection/pull/2137

refs https://github.com/infection/infection/issues/2111