### PR TITLE
Don't mutate greater/smaller-than in ternary

### DIFF
--- a/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanNegotiation.php
@@ -39,6 +39,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
+use Infection\PhpParser\Visitor\ParentConnector;
 use PhpParser\Node;
 
 /**
@@ -78,6 +79,12 @@ final class GreaterThanNegotiation implements Mutator
 
     public function canMutate(Node $node): bool
     {
+        $parentNode = ParentConnector::findParent($node);
+
+        if ($parentNode instanceof Node\Expr\Ternary) {
+            return false;
+        }
+
         return $node instanceof Node\Expr\BinaryOp\Greater;
     }
 }

--- a/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiation.php
@@ -39,6 +39,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
+use Infection\PhpParser\Visitor\ParentConnector;
 use PhpParser\Node;
 
 /**
@@ -78,6 +79,12 @@ final class GreaterThanOrEqualToNegotiation implements Mutator
 
     public function canMutate(Node $node): bool
     {
+        $parentNode = ParentConnector::findParent($node);
+
+        if ($parentNode instanceof Node\Expr\Ternary) {
+            return false;
+        }
+
         return $node instanceof Node\Expr\BinaryOp\GreaterOrEqual;
     }
 }

--- a/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanNegotiation.php
@@ -39,6 +39,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
+use Infection\PhpParser\Visitor\ParentConnector;
 use PhpParser\Node;
 
 /**
@@ -78,6 +79,12 @@ final class LessThanNegotiation implements Mutator
 
     public function canMutate(Node $node): bool
     {
+        $parentNode = ParentConnector::findParent($node);
+
+        if ($parentNode instanceof Node\Expr\Ternary) {
+            return false;
+        }
+
         return $node instanceof Node\Expr\BinaryOp\Smaller;
     }
 }

--- a/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
+++ b/src/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiation.php
@@ -39,6 +39,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
+use Infection\PhpParser\Visitor\ParentConnector;
 use PhpParser\Node;
 
 /**
@@ -78,6 +79,12 @@ final class LessThanOrEqualToNegotiation implements Mutator
 
     public function canMutate(Node $node): bool
     {
+        $parentNode = ParentConnector::findParent($node);
+
+        if ($parentNode instanceof Node\Expr\Ternary) {
+            return false;
+        }
+
         return $node instanceof Node\Expr\BinaryOp\SmallerOrEqual;
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanNegotiationTest.php
@@ -68,5 +68,13 @@ final class GreaterThanNegotiationTest extends BaseMutatorTestCase
                 PHP
             ,
         ];
+
+        yield 'It does not mutate inside ternary to prevent overlap with TernaryMutator' => [
+            <<<'PHP'
+                <?php
+                $x > 6 ? 'yes' : 'no';
+                PHP
+            ,
+        ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiationTest.php
@@ -68,5 +68,13 @@ final class GreaterThanOrEqualToNegotiationTest extends BaseMutatorTestCase
                 PHP
             ,
         ];
+
+        yield 'It does not mutate inside ternary to prevent overlap with TernaryMutator' => [
+            <<<'PHP'
+                <?php
+                $x >= 6 ? 'yes' : 'no';
+                PHP
+            ,
+        ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/LessThanNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/LessThanNegotiationTest.php
@@ -68,5 +68,13 @@ final class LessThanNegotiationTest extends BaseMutatorTestCase
                 PHP
             ,
         ];
+
+        yield 'It does not mutate inside ternary to prevent overlap with TernaryMutator' => [
+            <<<'PHP'
+                <?php
+                $x < 6 ? 'yes' : 'no';
+                PHP
+            ,
+        ];
     }
 }

--- a/tests/phpunit/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiationTest.php
+++ b/tests/phpunit/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiationTest.php
@@ -68,5 +68,13 @@ final class LessThanOrEqualToNegotiationTest extends BaseMutatorTestCase
                 PHP
             ,
         ];
+
+        yield 'It does not mutate inside ternary to prevent overlap with TernaryMutator' => [
+            <<<'PHP'
+                <?php
+                $x <= 6 ? 'yes' : 'no';
+                PHP
+            ,
+        ];
     }
 }


### PR DESCRIPTION
similar to https://github.com/infection/infection/pull/2138

prevents one redundant mutation per ternary which uses a `<` or `<=`, `>`, `>=` in its condition.
this was noticed in https://github.com/infection/infection/pull/2137

refs https://github.com/infection/infection/issues/2111