### PR TITLE
Don't mutate true/false in conditions

### DIFF
--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -95,6 +95,15 @@ final class FalseValue implements Mutator
             return false;
         }
 
+        if (
+            $parentNode instanceof Node\Expr\BinaryOp\Equal
+            || $parentNode instanceof Node\Expr\BinaryOp\NotEqual
+            || $parentNode instanceof Node\Expr\BinaryOp\Identical
+            || $parentNode instanceof Node\Expr\BinaryOp\NotIdentical
+        ) {
+            return false;
+        }
+
         return true;
     }
 }

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -109,6 +109,15 @@ final class TrueValue implements ConfigurableMutator
             return false;
         }
 
+        if (
+            $parentNode instanceof Node\Expr\BinaryOp\Equal
+            || $parentNode instanceof Node\Expr\BinaryOp\NotEqual
+            || $parentNode instanceof Node\Expr\BinaryOp\Identical
+            || $parentNode instanceof Node\Expr\BinaryOp\NotIdentical
+        ) {
+            return false;
+        }
+
         if (!$grandParentNode instanceof Node\Expr\FuncCall || !$grandParentNode->name instanceof Node\Name) {
             return true;
         }

--- a/tests/e2e/Provide_Existing_Coverage/expected-output_phpunit.txt
+++ b/tests/e2e/Provide_Existing_Coverage/expected-output_phpunit.txt
@@ -1,4 +1,4 @@
-Total: 8
+Total: 7
 
 Killed mutants:
 ===============
@@ -14,9 +14,6 @@ Line 12
 
 Mutator: PublicVisibility
 Line 12
-
-Mutator: FalseValue
-Line 14
 
 Mutator: NotIdentical
 Line 14

--- a/tests/e2e/Skip_Initial_Tests/expected-output_phpunit.txt
+++ b/tests/e2e/Skip_Initial_Tests/expected-output_phpunit.txt
@@ -1,4 +1,4 @@
-Total: 8
+Total: 7
 
 Killed mutants:
 ===============
@@ -14,9 +14,6 @@ Line 12
 
 Mutator: PublicVisibility
 Line 12
-
-Mutator: FalseValue
-Line 14
 
 Mutator: NotIdentical
 Line 14

--- a/tests/phpunit/Mutator/Boolean/FalseValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/FalseValueTest.php
@@ -98,6 +98,50 @@ final class FalseValueTest extends BaseMutatorTestCase
             ,
         ];
 
+        yield 'It does not mutate in conditions to prevent overlap with equal' => [
+            <<<'PHP'
+                <?php
+
+                if ($x == false) {
+                } else {
+                }
+                PHP
+            ,
+        ];
+
+        yield 'It does not mutate in conditions to prevent overlap with not-equal' => [
+            <<<'PHP'
+                <?php
+
+                if ($x != false) {
+                } else {
+                }
+                PHP
+            ,
+        ];
+
+        yield 'It does not mutate in conditions to prevent overlap with identical' => [
+            <<<'PHP'
+                <?php
+
+                if ($x === false) {
+                } else {
+                }
+                PHP
+            ,
+        ];
+
+        yield 'It does not mutate in conditions to prevent overlap with not-identical' => [
+            <<<'PHP'
+                <?php
+
+                if ($x !== false) {
+                } else {
+                }
+                PHP
+            ,
+        ];
+
         yield 'It mutates all caps false to true' => [
             <<<'PHP'
                 <?php

--- a/tests/phpunit/Mutator/Boolean/TrueValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/TrueValueTest.php
@@ -123,6 +123,50 @@ final class TrueValueTest extends BaseMutatorTestCase
             ,
         ];
 
+        yield 'It does not mutate in conditions to prevent overlap with equal' => [
+            <<<'PHP'
+                <?php
+
+                if ($x == true) {
+                } else {
+                }
+                PHP
+            ,
+        ];
+
+        yield 'It does not mutate in conditions to prevent overlap with not-equal' => [
+            <<<'PHP'
+                <?php
+
+                if ($x != true) {
+                } else {
+                }
+                PHP
+            ,
+        ];
+
+        yield 'It does not mutate in conditions to prevent overlap with identical' => [
+            <<<'PHP'
+                <?php
+
+                if ($x === true) {
+                } else {
+                }
+                PHP
+            ,
+        ];
+
+        yield 'It does not mutate in conditions to prevent overlap with not-identical' => [
+            <<<'PHP'
+                <?php
+
+                if ($x !== true) {
+                } else {
+                }
+                PHP
+            ,
+        ];
+
         yield 'It mutates all caps true to false' => [
             <<<'PHP'
                 <?php


### PR DESCRIPTION
before this PR the following example

```php
class Foo {
    function doFoo($x) {
        if ($x == true) {
            $y = 1;
        } else {
            $y = 0;
        }
    }
}
```

yielded the following mutants

```diff
1) /Users/staabm/workspace/infection/src/Foo.php:42    [M] TrueValue

@@ @@
 {
     function doFoo($x)
     {
-        if ($x == true) {
+        if ($x == false) {
             $y = 1;
         } else {
             $y = 0;


2) /Users/staabm/workspace/infection/src/Foo.php:42    [M] AssignmentEqual

@@ @@
 {
     function doFoo($x)
     {
-        if ($x == true) {
+        if ($x = true) {
             $y = 1;
         } else {
             $y = 0;


3) /Users/staabm/workspace/infection/src/Foo.php:42    [M] Equal

@@ @@
 {
     function doFoo($x)
     {
-        if ($x == true) {
+        if ($x != true) {
             $y = 1;
         } else {
             $y = 0;


4) /Users/staabm/workspace/infection/src/Foo.php:43    [M] IncrementInteger

@@ @@
     function doFoo($x)
     {
         if ($x == true) {
-            $y = 1;
+            $y = 2;
         } else {
             $y = 0;
         }
     }
 }

```

as you can see mutating true/false in a condition which is also mutated with `==`, `!=` etc is redundant.
after this PR we have one less redundant mutation

refs https://github.com/infection/infection/pull/2137