### PR TITLE
Run the collision detection last

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ profile: vendor $(BENCHMARK_SOURCES)
 
 .PHONY: autoreview
 autoreview: 	 	## Runs various checks (static analysis & AutoReview test suite)
-autoreview: cs-check detect-collisions phpstan psalm validate test-autoreview rector-check
+autoreview: cs-check phpstan psalm validate test-autoreview rector-check detect-collisions
 
 .PHONY: test
 test:		 	## Runs all the tests


### PR DESCRIPTION
So that `make autoreview` gets to fail faster, subtracting the wait time by 5+ seconds. It could very easy mean minutes of the most precious active focus time on every given day.
