### PR TITLE
Update test data providers to use more  readable style

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -331,12 +331,6 @@ parameters:
 			path: ../tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
 
 		-
-			message: '#^Static property Infection\\Tests\\AutoReview\\IntegrationGroup\\IntegrationGroupProvider\:\:\$ioTestCaseClassesTuple \(array\<array\<string\>\>\|null\) does not accept array\<array\<bool\|string\>\>\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: ../tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
-
-		-
 			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
@@ -103,7 +103,7 @@ final class IntegrationGroupProvider
      */
     private static function classNameFileNameTuple(string $className): iterable
     {
-        yield $className => (new ReflectionClass($className))->getFileName();
+        yield $className => (new ReflectionClass($className))->getFileName() ?: '';
     }
 
     /**

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -335,9 +335,6 @@ final class ProjectCodeProvider
         );
     }
 
-    /**
-     * @return class-string
-     */
     private static function castSplFileInfoToFQCN(SplFileInfo $file): string
     {
         return sprintf(


### PR DESCRIPTION
This PR:

- [x] Replaces hard-to-parse `array_values(array_filter(array_map(` constructions with more expressive and readable syntax
