### PR TITLE
Check minimum PHPStan version before starting MT logic (fail fast) if `--static-analysis-tool=phpstan` is used

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -605,6 +605,10 @@ final class RunCommand extends BaseCommand
 
         $config = $container->getConfiguration();
 
+        if ($config->isStaticAnalysisEnabled()) {
+            $container->getStaticAnalysisToolAdapter()->assertMinimumVersionSatisfied();
+        }
+
         $container->getFileSystem()->mkdir($config->getTmpDir());
 
         LogVerbosity::convertVerbosityLevel($io->getInput(), $consoleOutput);

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -84,6 +84,7 @@ final readonly class Engine
 
     /**
      * @throws InitialTestsFailed
+     * @throws InitialStaticAnalysisRunFailed
      * @throws MinMsiCheckFailed
      */
     public function execute(): void
@@ -148,8 +149,6 @@ final readonly class Engine
 
         Assert::notNull($this->initialStaticAnalysisRunner);
         Assert::notNull($this->staticAnalysisToolAdapter);
-
-        // todo [phpstan-integration] see $container->getCoverageChecker()->checkCoverageRequirements(); - make the same for --skip-initial-static-analysis-run and --static-analysis-cache
 
         //        if ($this->config->shouldSkipInitialTests()) {
         //            $this->consoleOutput->logSkippingInitialTests();

--- a/src/StaticAnalysis/StaticAnalysisToolAdapter.php
+++ b/src/StaticAnalysis/StaticAnalysisToolAdapter.php
@@ -52,4 +52,6 @@ interface StaticAnalysisToolAdapter
     public function createMutantProcessFactory(): LazyMutantProcessFactory;
 
     public function getVersion(): string;
+
+    public function assertMinimumVersionSatisfied(): void;
 }

--- a/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php
@@ -35,15 +35,19 @@ declare(strict_types=1);
 
 namespace Infection\Tests\StaticAnalysis\PHPStan\Adapter;
 
+use Generator;
 use Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter;
 use Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory;
 use Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\VersionParser;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use function sprintf;
 
 #[Group('integration')]
 #[CoversClass(PHPStanAdapter::class)]
@@ -98,5 +102,89 @@ final class PHPStanAdapterTest extends TestCase
             PHPStanMutantProcessFactory::class,
             $this->adapter->createMutantProcessFactory(),
         );
+    }
+
+    #[DataProvider('provideValidVersions')]
+    public function test_it_accepts_valid_versions(string $version): void
+    {
+        $adapter = new PHPStanAdapter(
+            $this->mutantExecutionResultFactory,
+            '/path/to/phpstan',
+            $this->commandLineBuilder,
+            new VersionParser(),
+            31.0,
+            $version,
+        );
+
+        // This should not throw an exception
+        $adapter->assertMinimumVersionSatisfied();
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[DataProvider('provideInvalidVersions')]
+    public function test_it_rejects_invalid_versions(string $version): void
+    {
+        $adapter = new PHPStanAdapter(
+            $this->mutantExecutionResultFactory,
+            '/path/to/phpstan',
+            $this->commandLineBuilder,
+            new VersionParser(),
+            31.0,
+            $version,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Infection requires PHPStan version >=1.12.27 or >=2.1.17, but "%s" is installed.',
+            $version,
+        ));
+
+        $adapter->assertMinimumVersionSatisfied();
+    }
+
+    public static function provideValidVersions(): Generator
+    {
+        yield 'major version 3' => ['3.0.0'];
+
+        yield 'major version 2 with valid patch' => ['2.1.17'];
+
+        yield 'major version 2 with higher minor' => ['2.2.0'];
+
+        yield 'major version 1 with valid patch' => ['1.12.27'];
+
+        yield 'major version 1 with valid patch 2' => ['1.12.28'];
+
+        yield 'major version 1 with higher minor' => ['1.13.0'];
+
+        yield 'dev version 1.12.x' => ['1.12.x-dev@asgar3'];
+
+        yield 'dev version 1.13.x' => ['1.13.x-dev@cfa0299'];
+
+        yield 'dev version 2.1.x' => ['2.1.x-dev@cfa0299'];
+
+        yield 'dev version 2.2.x' => ['2.2.x-dev@cfa0299'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideInvalidVersions(): iterable
+    {
+        yield 'major version 2 with too low minor' => ['2.0.17'];
+
+        yield 'major version 2 with too low patch' => ['2.1.1'];
+
+        yield 'major version 2 with too low minor and patch' => ['2.0.0'];
+
+        yield 'major version 1 with too low patch' => ['1.12.26'];
+
+        yield 'major version 1 with too low minor and patch' => ['1.11.0'];
+
+        yield 'major version 0' => ['0.12.0'];
+
+        yield 'dev version 1.0.x' => ['1.0.x-dev@cfa0299'];
+
+        yield 'dev version 2.0.x' => ['2.0.x-dev@cfa0299'];
     }
 }


### PR DESCRIPTION
Also, considered https://getcomposer.org/doc/07-runtime.md#knowing-whether-package-x-is-installed-in-version-y

```php
\Composer\InstalledVersions::satisfies(new VersionParser, 'vendor/package', '2.0.*');
\Composer\InstalledVersions::satisfies(new VersionParser, 'psr/log-implementation', '^1.0');
```

but decided not to use it, because

- it requires one more package
- we had many issues when `Composer\InstalledVersions` is not present on user's installation. We need to add `if (!class_exists())` and then it's impossible to get the version. So implemented a very basic custom logic

