### PR TITLE
Set ignore config when `--mutants` is used and config has `global-ignoreSourceCodeByRegex`

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -217,6 +217,10 @@ class ConfigurationFactory
             $mutatorsList = $schemaMutators;
         } else {
             $mutatorsList = array_fill_keys($parsedMutatorsInput, true);
+
+            if (array_key_exists('global-ignoreSourceCodeByRegex', $schemaMutators)) {
+                $mutatorsList['global-ignoreSourceCodeByRegex'] = $schemaMutators['global-ignoreSourceCodeByRegex'];
+            }
         }
 
         return $this->mutatorResolver->resolve($mutatorsList);

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -265,7 +265,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
-            '',
+            '', // mutators input
             null,
             null,
             '',
@@ -772,6 +772,7 @@ final class ConfigurationFactoryTest extends TestCase
         yield 'mutators from config & input' => self::createValueForMutators(
             [
                 '@default' => true,
+                'global-ignoreSourceCodeByRegex' => ['Assert::.*'],
                 'MethodCallRemoval' => (object) [
                     'ignore' => [
                         'Infection\FileSystem\Finder\SourceFilesFinder::__construct::63',
@@ -780,10 +781,14 @@ final class ConfigurationFactoryTest extends TestCase
             ],
             'AssignmentEqual,EqualIdentical',
             false,
-            (static fn (): array => [
+            [
                 'AssignmentEqual' => new AssignmentEqual(),
                 'EqualIdentical' => new EqualIdentical(),
-            ])(),
+            ],
+            [
+                'AssignmentEqual' => ['Assert::.*'],
+                'EqualIdentical' => ['Assert::.*'],
+            ],
         );
 
         yield 'with source files' => [
@@ -2304,12 +2309,14 @@ final class ConfigurationFactoryTest extends TestCase
 
     /**
      * @param array<string, Mutator> $expectedMutators
+     * @param array<string, array<int, string>> $expectedIgnoreSourceCodeMutatorsMap
      */
     private static function createValueForMutators(
         array $configMutators,
         string $inputMutators,
         bool $useNoopMutatos,
         array $expectedMutators,
+        array $expectedIgnoreSourceCodeMutatorsMap = [],
     ): array {
         return [
             false,
@@ -2382,7 +2389,7 @@ final class ConfigurationFactoryTest extends TestCase
             null,
             false,
             null,
-            [],
+            $expectedIgnoreSourceCodeMutatorsMap,
             false,
             MapSourceClassToTestStrategy::SIMPLE,
             null,


### PR DESCRIPTION
Fixes a bug with with `--mutators=MethodCallRemoval` usage, `global-ignoreSourceCodeByRegex` was lost resulting in not needed mutants to be created.

