### PR TITLE
Use numerically-stable memory-efficient approach for perMutator timings

### DIFF
--- a/src/Metrics/MetricsCalculator.php
+++ b/src/Metrics/MetricsCalculator.php
@@ -36,13 +36,10 @@ declare(strict_types=1);
 namespace Infection\Metrics;
 
 use function array_key_exists;
-use function array_sum;
-use function count;
 use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
 use InvalidArgumentException;
-use function max;
-use function min;
+use Pipeline\Helper\RunningVariance;
 use function sprintf;
 
 /**
@@ -59,12 +56,9 @@ class MetricsCalculator implements Collector
 
     private ?Calculator $calculator = null;
 
-    private float $testsMinimumRuntime = 0.0;
-    private float $testsAverageRuntime = 0.0;
-    private float $testsMaximumRuntime = 0.0;
-    private float $staticAnalysisMinimumRuntime = 0.0;
-    private float $staticAnalysisAverageRuntime = 0.0;
-    private float $staticAnalysisMaximumRuntime = 0.0;
+    private readonly RunningVariance $testRuntimesVariance;
+
+    private readonly RunningVariance $staticAnalysisRuntimesVariance;
 
     public function __construct(
         private readonly int $roundingPrecision,
@@ -72,6 +66,9 @@ class MetricsCalculator implements Collector
         foreach (DetectionStatus::ALL as $status) {
             $this->countByStatus[$status] = 0;
         }
+
+        $this->testRuntimesVariance = new RunningVariance();
+        $this->staticAnalysisRuntimesVariance = new RunningVariance();
     }
 
     public function collect(MutantExecutionResult ...$executionResults): void
@@ -80,9 +77,6 @@ class MetricsCalculator implements Collector
             // Reset the calculator if any result is added
             $this->calculator = null;
         }
-
-        $testRuntimes = [];
-        $staticAnalysisRuntimes = [];
 
         foreach ($executionResults as $executionResult) {
             $detectionStatus = $executionResult->getDetectionStatus();
@@ -98,24 +92,12 @@ class MetricsCalculator implements Collector
             ++$this->countByStatus[$detectionStatus];
 
             if ($detectionStatus === DetectionStatus::KILLED_BY_TESTS) {
-                $testRuntimes[] = $executionResult->getProcessRuntime();
+                $this->testRuntimesVariance->observe($executionResult->getProcessRuntime());
             }
 
             if ($detectionStatus === DetectionStatus::KILLED_BY_STATIC_ANALYSIS) {
-                $staticAnalysisRuntimes[] = $executionResult->getProcessRuntime();
+                $this->staticAnalysisRuntimesVariance->observe($executionResult->getProcessRuntime());
             }
-        }
-
-        if ($testRuntimes !== []) {
-            $this->testsMinimumRuntime = min($testRuntimes);
-            $this->testsAverageRuntime = array_sum($testRuntimes) / count($testRuntimes);
-            $this->testsMaximumRuntime = max($testRuntimes);
-        }
-
-        if ($staticAnalysisRuntimes !== []) {
-            $this->staticAnalysisMinimumRuntime = min($staticAnalysisRuntimes);
-            $this->staticAnalysisAverageRuntime = array_sum($staticAnalysisRuntimes) / count($staticAnalysisRuntimes);
-            $this->staticAnalysisMaximumRuntime = max($staticAnalysisRuntimes);
         }
     }
 
@@ -205,32 +187,32 @@ class MetricsCalculator implements Collector
 
     public function getTestsMinimumRuntime(): float
     {
-        return $this->testsMinimumRuntime;
+        return $this->testRuntimesVariance->getMin();
     }
 
     public function getTestsAverageRuntime(): float
     {
-        return $this->testsAverageRuntime;
+        return $this->testRuntimesVariance->getMean();
     }
 
     public function getTestsMaximumRuntime(): float
     {
-        return $this->testsMaximumRuntime;
+        return $this->testRuntimesVariance->getMax();
     }
 
     public function getStaticAnalysisMinimumRuntime(): float
     {
-        return $this->staticAnalysisMinimumRuntime;
+        return $this->staticAnalysisRuntimesVariance->getMin();
     }
 
     public function getStaticAnalysisAverageRuntime(): float
     {
-        return $this->staticAnalysisAverageRuntime;
+        return $this->staticAnalysisRuntimesVariance->getMean();
     }
 
     public function getStaticAnalysisMaximumRuntime(): float
     {
-        return $this->staticAnalysisMaximumRuntime;
+        return $this->staticAnalysisRuntimesVariance->getMax();
     }
 
     private function getCalculator(): Calculator

--- a/src/Metrics/MetricsCalculator.php
+++ b/src/Metrics/MetricsCalculator.php
@@ -39,6 +39,7 @@ use function array_key_exists;
 use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
 use InvalidArgumentException;
+use function is_nan;
 use Pipeline\Helper\RunningVariance;
 use function sprintf;
 
@@ -187,36 +188,41 @@ class MetricsCalculator implements Collector
 
     public function getTestsMinimumRuntime(): float
     {
-        return $this->testRuntimesVariance->getMin();
+        return self::foldToZero($this->testRuntimesVariance->getMin());
     }
 
     public function getTestsAverageRuntime(): float
     {
-        return $this->testRuntimesVariance->getMean();
+        return self::foldToZero($this->testRuntimesVariance->getMean());
     }
 
     public function getTestsMaximumRuntime(): float
     {
-        return $this->testRuntimesVariance->getMax();
+        return self::foldToZero($this->testRuntimesVariance->getMax());
     }
 
     public function getStaticAnalysisMinimumRuntime(): float
     {
-        return $this->staticAnalysisRuntimesVariance->getMin();
+        return self::foldToZero($this->staticAnalysisRuntimesVariance->getMin());
     }
 
     public function getStaticAnalysisAverageRuntime(): float
     {
-        return $this->staticAnalysisRuntimesVariance->getMean();
+        return self::foldToZero($this->staticAnalysisRuntimesVariance->getMean());
     }
 
     public function getStaticAnalysisMaximumRuntime(): float
     {
-        return $this->staticAnalysisRuntimesVariance->getMax();
+        return self::foldToZero($this->staticAnalysisRuntimesVariance->getMax());
     }
 
     private function getCalculator(): Calculator
     {
         return $this->calculator ??= Calculator::fromMetrics($this);
+    }
+
+    private static function foldToZero(float $value): float
+    {
+        return is_nan($value) ? 0.0 : $value;
     }
 }

--- a/tests/phpunit/Logger/PerMutatorLoggerTest.php
+++ b/tests/phpunit/Logger/PerMutatorLoggerTest.php
@@ -81,7 +81,7 @@ final class PerMutatorLoggerTest extends TestCase
 
                 | Mutator   | Mutations | Killed by Test Framework | Test Timings min/avg/max | Killed by Static Analysis | Static Analysis Timings min/avg/max | Escaped | Errors | Syntax Errors | Timed Out | Skipped | Ignored | MSI (%s) | Covered MSI (%s) |
                 | --------- | --------- | ------------------------ | ------------------------ | ------------------------- | ----------------------------------- | ------- | ------ | ------------- | --------- | ------- | ------- | -------- | ---------------- |
-                | For_      |         8 |                        1 |  0.00 / 0.00 / 0.00 secs |                         0 |             0.00 / 0.00 / 0.00 secs |       1 |      1 |             1 |         1 |       1 |       1 |    66.67 |            80.00 |
+                | For_      |         8 |                        1 |  0.00 / 0.00 / 0.00 secs |                         0 |                NaN / NaN / NaN secs |       1 |      1 |             1 |         1 |       1 |       1 |    66.67 |            80.00 |
                 | PregQuote |         9 |                        1 |  0.00 / 0.00 / 0.00 secs |                         1 |             0.00 / 0.00 / 0.00 secs |       1 |      1 |             1 |         1 |       1 |       1 |    71.43 |            83.33 |
 
                 TXT,

--- a/tests/phpunit/Logger/PerMutatorLoggerTest.php
+++ b/tests/phpunit/Logger/PerMutatorLoggerTest.php
@@ -81,7 +81,7 @@ final class PerMutatorLoggerTest extends TestCase
 
                 | Mutator   | Mutations | Killed by Test Framework | Test Timings min/avg/max | Killed by Static Analysis | Static Analysis Timings min/avg/max | Escaped | Errors | Syntax Errors | Timed Out | Skipped | Ignored | MSI (%s) | Covered MSI (%s) |
                 | --------- | --------- | ------------------------ | ------------------------ | ------------------------- | ----------------------------------- | ------- | ------ | ------------- | --------- | ------- | ------- | -------- | ---------------- |
-                | For_      |         8 |                        1 |  0.00 / 0.00 / 0.00 secs |                         0 |                NaN / NaN / NaN secs |       1 |      1 |             1 |         1 |       1 |       1 |    66.67 |            80.00 |
+                | For_      |         8 |                        1 |  0.00 / 0.00 / 0.00 secs |                         0 |             0.00 / 0.00 / 0.00 secs |       1 |      1 |             1 |         1 |       1 |       1 |    66.67 |            80.00 |
                 | PregQuote |         9 |                        1 |  0.00 / 0.00 / 0.00 secs |                         1 |             0.00 / 0.00 / 0.00 secs |       1 |      1 |             1 |         1 |       1 |       1 |    71.43 |            83.33 |
 
                 TXT,


### PR DESCRIPTION
See: #2164

This PR:

- [x] Changes the timing calculations to use a memory efficient (only a handful of numbers) [Welford’s online algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) that scales to any number of measurements
- [x] Covered by tests

I already had it coded, so... It is just a matter of switching to it. 

The naive algorithm crumbles down with the number of measurements as precision loss grows linearly with the number of samples; for variance and other “two-pass” metrics it can explode much sooner because of catastrophic cancellation. We can now show them too (as well as 68-95-99.7% percentiles), but in this PR I only make the basic switch.