### PR TITLE
Added `per-mutator.md` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /devTools/Docker*.json
 /infection-cache
 /infection.log
+/per-mutator.md
 /phpunit.xml
 /tests/benchmark/*/coverage/
 /tests/benchmark/*/sources/


### PR DESCRIPTION
Accidentally I had this file committed into multiple PRs already. lets ignore the "default"-filename for this logfile to ease contributing