### PR TITLE
Run PHPUnit worker process with Xdebug protection against endless loops

### DIFF
--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -97,7 +97,7 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         string $extraOptions,
     ): array {
         return $this->getCommandLine(
-            [],
+            ['-d xdebug.mode=develop', '-d xdebug.max_nesting_level=1000'],
             $this->argumentsAndOptionsBuilder->buildForMutant(
                 $this->buildMutationConfigFile(
                     $coverageTests,


### PR DESCRIPTION
POC!

running `INFECTION_ALLOW_XDEBUG=1 php bin/infection --debug --skip-initial-tests --coverage=build/logs --filter=src/FileSystem/Locator/RootsFileLocator.php --threads=8` with this PR ends the endless running test and infection returns after **1 second**.

running it without `INFECTION_ALLOW_XDEBUG=1` takes 25 seconds (the process timeout kills the process).

using `INFECTION_ALLOW_XDEBUG=1` for that purpose is non-sense of course, buts its the small hack to demonstrate how we could utilize `-d xdebug.max_nesting_level=1000` to end endless running mutations earlier.

---

the mutation which triggers the problem is:

```diff
9) /Users/m.staab/Documents/GitHub/infection/src/FileSystem/Locator/RootsFileLocator.php:115    [M] FunctionCallRemoval

@@ @@
         try {
             return $this->locate(current($fileNames));
         } catch (FileNotFound) {
-            array_shift($fileNames);
+            
             return $this->innerLocateOneOf($fileNames);
         }
     }
 }
```

since we likely have xdebug in the system (e.g. for coverage information), we might also make use of it for this feature. wdyt?