### PR TITLE
Add `--fail-without-result-cache` to PHPStan process

### DIFF
--- a/src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php
+++ b/src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php
@@ -98,6 +98,7 @@ final class PHPStanMutantProcessFactory implements LazyMutantProcessFactory
                 '--error-format=json',
                 '--no-progress',
                 '-vv',
+                '--fail-without-result-cache',
                 // todo [phpstan-integration] --stop-on-first-error
             ],
         );

--- a/tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php
@@ -107,6 +107,7 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 '--error-format=json',
                 '--no-progress',
                 '-vv',
+                '--fail-without-result-cache',
             ])
             ->willReturn(['/usr/bin/php', '/path/to/phpstan'])
         ;


### PR DESCRIPTION
As @staab suggested, this will help us to identify issues where for some reason there is no result cache, while we expect it to be.

It's ok that PHPStan will fail with exit code = 2, because Ondrej is creating a special error format handler for Infection where if Mutant is killed, PHPStan will return exit code 66.

Exit code 2 will mean mutant is not killed, but PHPStan failed its execution (we will mark it not as `A`, but as for example `E` (error))
