### PR TITLE
ReflectionVisitorTest is more type safe

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -1627,12 +1627,6 @@ parameters:
 			path: ../tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitorTest.php
 
 		-
-			message: '#^Property Infection\\Tests\\PhpParser\\Visitor\\ReflectionVisitorTest\:\:\$spyVisitor has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
-
-		-
 			message: '#^Static property Infection\\Tests\\Process\\Runner\\InitialTestsRunnerTest\:\:\$phpBin \(string\) does not accept string\|false\.$#'
 			identifier: assign.propertyType
 			count: 1

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -1627,67 +1627,7 @@ parameters:
 			path: ../tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitorTest.php
 
 		-
-			message: '#^Method Infection\\Tests\\PhpParser\\Visitor\\ReflectionVisitorTest\:\:getInsideFunctionSpyVisitor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
-
-		-
-			message: '#^Method Infection\\Tests\\PhpParser\\Visitor\\ReflectionVisitorTest\:\:getPartOfSignatureSpyVisitor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
-
-		-
-			message: '#^Method Infection\\Tests\\PhpParser\\Visitor\\ReflectionVisitorTest\:\:getReflectionClassSpyVisitor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
-
-		-
-			message: '#^Method Infection\\Tests\\PhpParser\\Visitor\\ReflectionVisitorTest\:\:getReflectionClassesSpyVisitor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
-
-		-
-			message: '#^Method Infection\\Tests\\PhpParser\\Visitor\\ReflectionVisitorTest\:\:getSpyVisitor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
-
-		-
 			message: '#^Property Infection\\Tests\\PhpParser\\Visitor\\ReflectionVisitorTest\:\:\$spyVisitor has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
-
-		-
-			message: '#^Property PhpParser\\NodeVisitorAbstract@anonymous/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest\.php\:244\:\:\$isPartOfSignature has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
-
-		-
-			message: '#^Property PhpParser\\NodeVisitorAbstract@anonymous/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest\.php\:268\:\:\$spyCalled has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
-
-		-
-			message: '#^Property PhpParser\\NodeVisitorAbstract@anonymous/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest\.php\:287\:\:\$isInsideFunction has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
-
-		-
-			message: '#^Property PhpParser\\NodeVisitorAbstract@anonymous/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest\.php\:326\:\:\$createAnonymousClassReflectionClass has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
-
-		-
-			message: '#^Property PhpParser\\NodeVisitorAbstract@anonymous/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest\.php\:326\:\:\$fooReflectionClass has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
 			path: ../tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -1597,34 +1597,10 @@ parameters:
 			path: ../tests/phpunit/PhpParser/Visitor/IgnoreNode/BaseNodeIgnorerTestCase.php
 
 		-
-			message: '#^Property Infection\\Tests\\PhpParser\\Visitor\\IgnoreNode\\IgnoreSpyVisitor\:\:\$nodeCounter has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/IgnoreNode/IgnoreSpyVisitor.php
-
-		-
 			message: '#^Parameter \#2 \$originalFileAst of class Infection\\Mutation\\Mutation constructor expects array\<PhpParser\\Node\>, array\<PhpParser\\Node\\Stmt\>\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php
-
-		-
-			message: '#^Method Infection\\Tests\\PhpParser\\Visitor\\NonMutableNodesIgnorerVisitorTest\:\:getSpyVisitor\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitorTest.php
-
-		-
-			message: '#^Property Infection\\Tests\\PhpParser\\Visitor\\NonMutableNodesIgnorerVisitorTest\:\:\$spyVisitor has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitorTest.php
-
-		-
-			message: '#^Property PhpParser\\NodeVisitorAbstract@anonymous/tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitorTest\.php\:74\:\:\$nodesVisitedCount has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitorTest.php
 
 		-
 			message: '#^Static property Infection\\Tests\\Process\\Runner\\InitialTestsRunnerTest\:\:\$phpBin \(string\) does not accept string\|false\.$#'

--- a/tests/phpunit/PhpParser/Visitor/IgnoreNode/IgnoreSpyVisitor.php
+++ b/tests/phpunit/PhpParser/Visitor/IgnoreNode/IgnoreSpyVisitor.php
@@ -42,7 +42,7 @@ use PhpParser\NodeVisitorAbstract;
 
 final class IgnoreSpyVisitor extends NodeVisitorAbstract
 {
-    public $nodeCounter = 0;
+    public int $nodeCounter = 0;
 
     private $failureCallBack;
 

--- a/tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitorTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\PhpParser\Visitor;
 use Infection\PhpParser\Visitor\IgnoreNode\NodeIgnorer;
 use Infection\PhpParser\Visitor\NonMutableNodesIgnorerVisitor;
 use PhpParser\Node;
+use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
@@ -46,7 +47,10 @@ use PHPUnit\Framework\Attributes\Group;
 #[CoversClass(NonMutableNodesIgnorerVisitor::class)]
 final class NonMutableNodesIgnorerVisitorTest extends BaseVisitorTestCase
 {
-    private $spyVisitor;
+    /**
+     * @var NodeVisitor&object{nodesVisitedCount: int}
+     */
+    private NodeVisitor $spyVisitor;
 
     protected function setUp(): void
     {
@@ -66,22 +70,20 @@ final class NonMutableNodesIgnorerVisitorTest extends BaseVisitorTestCase
             }
             PHP
         );
-        $this->assertSame(0, $this->spyVisitor->getNumberOfNodesVisited());
+        $this->assertSame(0, $this->spyVisitor->nodesVisitedCount);
     }
 
-    private function getSpyVisitor()
+    /**
+     * @return NodeVisitor&object{nodesVisitedCount: int}
+     */
+    private function getSpyVisitor(): NodeVisitor
     {
         return new class extends NodeVisitorAbstract {
-            private $nodesVisitedCount = 0;
+            public int $nodesVisitedCount = 0;
 
             public function leaveNode(Node $node): void
             {
                 ++$this->nodesVisitedCount;
-            }
-
-            public function getNumberOfNodesVisited(): int
-            {
-                return $this->nodesVisitedCount;
             }
         };
     }

--- a/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
@@ -56,7 +56,10 @@ use PHPUnit\Framework\Attributes\Group;
 #[CoversClass(ReflectionVisitor::class)]
 final class ReflectionVisitorTest extends BaseVisitorTestCase
 {
-    private $spyVisitor;
+    /**
+     * @var NodeVisitor&object{isInsideFunction: bool}
+     */
+    private NodeVisitor $spyVisitor;
 
     protected function setUp(): void
     {

--- a/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
@@ -309,7 +309,7 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
     private function getReflectionClassSpyVisitor(): NodeVisitor
     {
         return new class extends NodeVisitorAbstract {
-            public ClassReflection|null $reflectionClass = null;
+            public ?ClassReflection $reflectionClass = null;
 
             public function enterNode(Node $node): ?int
             {
@@ -330,8 +330,8 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
     private function getReflectionClassesSpyVisitor(): NodeVisitor
     {
         return new class extends NodeVisitorAbstract {
-            public ClassReflection|null $fooReflectionClass = null;
-            public ClassReflection|null $createAnonymousClassReflectionClass = null;
+            public ?ClassReflection $fooReflectionClass = null;
+            public ?ClassReflection $createAnonymousClassReflectionClass = null;
 
             public function enterNode(Node $node): ?int
             {

--- a/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
@@ -51,7 +51,6 @@ use PhpParser\NodeVisitorAbstract;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use ReflectionClass;
 
 #[Group('integration')]
 #[CoversClass(ReflectionVisitor::class)]
@@ -81,7 +80,7 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
             ],
         );
 
-        $this->assertSame($expected, $spyVisitor->isPartOfSignature());
+        $this->assertSame($expected, $spyVisitor->isPartOfSignature);
     }
 
     #[DataProvider('isPartOfSignatureFlagWithAttributesProvider')]
@@ -93,7 +92,7 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
 
         $this->parseAndTraverse($code, $spyVisitor);
 
-        $this->assertSame($expected, $spyVisitor->isPartOfSignature());
+        $this->assertSame($expected, $spyVisitor->isPartOfSignature);
     }
 
     public function test_it_detects_if_it_is_traversing_inside_class_method(): void
@@ -239,10 +238,13 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
         yield [Node\Expr\Array_::class, false];             // []
     }
 
-    private function getPartOfSignatureSpyVisitor(string $nodeClass)
+    /**
+     * @return NodeVisitor&object{isPartOfSignature: bool}
+     */
+    private function getPartOfSignatureSpyVisitor(string $nodeClass): NodeVisitor
     {
         return new class($nodeClass) extends NodeVisitorAbstract {
-            private $isPartOfSignature;
+            public bool $isPartOfSignature;
 
             public function __construct(
                 private readonly string $nodeClassUnderTest,
@@ -255,18 +257,16 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
                     $this->isPartOfSignature = $node->getAttribute(ReflectionVisitor::IS_ON_FUNCTION_SIGNATURE, false);
                 }
             }
-
-            public function isPartOfSignature(): bool
-            {
-                return $this->isPartOfSignature;
-            }
         };
     }
 
-    private function getSpyVisitor(string $nodeClass)
+    /**
+     * @return NodeVisitor&object{spyCalled: bool}
+     */
+    private function getSpyVisitor(string $nodeClass): NodeVisitor
     {
         return new class($nodeClass) extends NodeVisitorAbstract {
-            public $spyCalled = false;
+            public bool $spyCalled = false;
 
             public function __construct(
                 private readonly string $nodeClassUnderTest,
@@ -282,10 +282,13 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
         };
     }
 
-    private function getInsideFunctionSpyVisitor()
+    /**
+     * @return NodeVisitor&object{isInsideFunction: bool}
+     */
+    private function getInsideFunctionSpyVisitor(): NodeVisitor
     {
         return new class extends NodeVisitorAbstract {
-            public $isInsideFunction = false;
+            public bool $isInsideFunction = false;
 
             public function enterNode(Node $node): ?int
             {
@@ -300,13 +303,13 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
         };
     }
 
-    private function getReflectionClassSpyVisitor()
+    /**
+     * @return NodeVisitor&object{reflectionClass: ClassReflection|null}
+     */
+    private function getReflectionClassSpyVisitor(): NodeVisitor
     {
         return new class extends NodeVisitorAbstract {
-            /**
-             * @var ReflectionClass
-             */
-            public $reflectionClass;
+            public ClassReflection|null $reflectionClass = null;
 
             public function enterNode(Node $node): ?int
             {
@@ -321,11 +324,14 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
         };
     }
 
-    private function getReflectionClassesSpyVisitor()
+    /**
+     * @return NodeVisitor&object{fooReflectionClass: ClassReflection|null, createAnonymousClassReflectionClass: ClassReflection|null}
+     */
+    private function getReflectionClassesSpyVisitor(): NodeVisitor
     {
         return new class extends NodeVisitorAbstract {
-            public $fooReflectionClass;
-            public $createAnonymousClassReflectionClass;
+            public ClassReflection|null $fooReflectionClass = null;
+            public ClassReflection|null $createAnonymousClassReflectionClass = null;
 
             public function enterNode(Node $node): ?int
             {


### PR DESCRIPTION
cleaning up phpstan baseline errors by using proper return intersection types.

at the same time makes PHPStorm aware of the returned objects and there public properties so it now started to provide autocompletion