### PR TITLE
Prevent overlap of ArrayItemRemoval with IfNegation

### DIFF
--- a/src/Mutator/Removal/ArrayItemRemoval.php
+++ b/src/Mutator/Removal/ArrayItemRemoval.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Mutator\Removal;
 
 use function count;
+use function in_array;
 use Infection\Mutator\ConfigurableMutator;
 use Infection\Mutator\Definition;
 use Infection\Mutator\GetConfigClassName;
@@ -141,8 +142,20 @@ final readonly class ArrayItemRemoval implements ConfigurableMutator
             return false;
         }
 
-        if ($parent instanceof Node\Arg && ParentConnector::findParent($parent) instanceof Node\Attribute) {
-            return false;
+        if ($parent instanceof Node\Arg) {
+            $grandParent = ParentConnector::findParent($parent);
+
+            if ($grandParent instanceof Node\Attribute) {
+                return false;
+            }
+
+            if (
+                $grandParent instanceof Node\Expr\FuncCall
+                && $grandParent->name instanceof Node\Name
+                && in_array($grandParent->name->toString(), ['in_array', 'array_key_exists'], true)
+            ) {
+                return false;
+            }
         }
 
         // Don't mutate destructured values in foreach loops

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
@@ -128,5 +128,31 @@ final class ArrayItemRemovalTest extends BaseMutatorTestCase
         yield 'It does not mutate destructured array values in foreach loops' => [
             '<?php foreach ($items as [, $value]) {}',
         ];
+
+        yield 'It does not mutate in_array to prevent overlap with IfNegation' => [
+            '<?php if (in_array($a, [$b])) {}',
+        ];
+
+        yield 'It does not mutate array_key_exists to prevent overlap with IfNegation' => [
+            '<?php if (array_key_exists($a, [$b])) {}',
+        ];
+
+        yield 'It mutates arg of a userland function' => [
+            '<?php if (doFoo($a, [$b])) {}',
+            "<?php\n\nif (doFoo(\$a, [])) {\n}",
+        ];
+
+        yield 'It mutates arg of a dynamic function call' => [
+            '<?php
+                $fn = "doFoo";
+                if ($fn($a, [$b])) {}',
+            <<<'PHP'
+                <?php
+
+                $fn = "doFoo";
+                if ($fn($a, [])) {
+                }
+                PHP,
+        ];
     }
 }

--- a/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
@@ -137,6 +137,11 @@ final class ArrayItemRemovalTest extends BaseMutatorTestCase
             '<?php if (array_key_exists($a, [$b])) {}',
         ];
 
+        yield 'It mutates array_search which does not return bool, therefore not overlaps with IfNegation' => [
+            '<?php if (array_search($a, [$b])) {}',
+            "<?php\n\nif (array_search(\$a, [])) {\n}",
+        ];
+
         yield 'It mutates arg of a userland function' => [
             '<?php if (doFoo($a, [$b])) {}',
             "<?php\n\nif (doFoo(\$a, [])) {\n}",


### PR DESCRIPTION
Prevent a redundant mutation, which overlaps with `IfNegation`.

refs https://github.com/infection/infection/issues/2186