### PR TITLE
fix: break legend into 2 lines

### DIFF
--- a/src/Console/OutputFormatter/DotFormatter.php
+++ b/src/Console/OutputFormatter/DotFormatter.php
@@ -63,8 +63,8 @@ final class DotFormatter extends AbstractOutputFormatter
             '<killed>.</killed>: killed by tests, '
             . '<killed-by-static-analysis>A</killed-by-static-analysis>: killed by SA, '
             . '<escaped>M</escaped>: escaped, '
-            . '<uncovered>U</uncovered>: uncovered, '
-            . '<with-error>E</with-error>: fatal error, '
+            . '<uncovered>U</uncovered>: uncovered',
+            '<with-error>E</with-error>: fatal error, '
             . '<with-syntax-error>X</with-syntax-error>: syntax error, '
             . '<timeout>T</timeout>: timed out, '
             . '<skipped>S</skipped>: skipped, '

--- a/tests/phpunit/Console/OutputFormatter/DotFormatterTest.php
+++ b/tests/phpunit/Console/OutputFormatter/DotFormatterTest.php
@@ -59,8 +59,8 @@ final class DotFormatterTest extends TestCase
             '<killed>.</killed>: killed by tests, '
             . '<killed-by-static-analysis>A</killed-by-static-analysis>: killed by SA, '
             . '<escaped>M</escaped>: escaped, '
-            . '<uncovered>U</uncovered>: uncovered, '
-            . '<with-error>E</with-error>: fatal error, '
+            . '<uncovered>U</uncovered>: uncovered',
+            '<with-error>E</with-error>: fatal error, '
             . '<with-syntax-error>X</with-syntax-error>: syntax error, '
             . '<timeout>T</timeout>: timed out, '
             . '<skipped>S</skipped>: skipped, '
@@ -206,7 +206,8 @@ final class DotFormatterTest extends TestCase
         $this->assertSame(str_replace("\n", PHP_EOL,
             <<<'TXT'
 
-                .: killed by tests, A: killed by SA, M: escaped, U: uncovered, E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
+                .: killed by tests, A: killed by SA, M: escaped, U: uncovered
+                E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
 
                 ..................................................   ( 50 / 127)
                 ..................................................   (100 / 127)
@@ -235,7 +236,8 @@ final class DotFormatterTest extends TestCase
         $this->assertSame(str_replace("\n", PHP_EOL,
             <<<'TXT'
 
-                .: killed by tests, A: killed by SA, M: escaped, U: uncovered, E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
+                .: killed by tests, A: killed by SA, M: escaped, U: uncovered
+                E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
 
                 ..................................................   (   50)
                 ..................................................   (  100)
@@ -273,8 +275,8 @@ final class DotFormatterTest extends TestCase
             '<killed>.</killed>: killed by tests, '
             . '<killed-by-static-analysis>A</killed-by-static-analysis>: killed by SA, '
             . '<escaped>M</escaped>: escaped, '
-            . '<uncovered>U</uncovered>: uncovered, '
-            . '<with-error>E</with-error>: fatal error, '
+            . '<uncovered>U</uncovered>: uncovered',
+            '<with-error>E</with-error>: fatal error, '
             . '<with-syntax-error>X</with-syntax-error>: syntax error, '
             . '<timeout>T</timeout>: timed out, '
             . '<skipped>S</skipped>: skipped, '


### PR DESCRIPTION
before this PR the legend was a pretty long line

<img width="1129" alt="grafik" src="https://github.com/user-attachments/assets/0a137905-8c2a-48f2-b2c6-e9247901502d" />

in contrast to most output which seems to be aligned in ~60 chars columns, it stood out and felt overly long.
after this PR the line is wrapped so it does feel more in-line with the sorrounding text

<img width="736" alt="grafik" src="https://github.com/user-attachments/assets/71a02ee8-85d6-45c1-9797-a0252abfc146" />

----

in the end its just cosmetics, but maybe you prefer the newer look in the same way as I do.
I am also fine with closing the PR - no strong feelings on my end