### PR TITLE
Smarter `IncrementInteger` mutator

### DIFF
--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -308,5 +308,35 @@ final class IncrementIntegerTest extends BaseMutatorTestCase
                 if (preg_mAtch() != 1) {}
                 PHP,
         ];
+
+        yield 'It increments return value above 1 on not-equal comparison for userland function' => [
+            <<<'PHP'
+                <?php
+
+                if (doFoo() != 1) {}
+                PHP,
+            <<<'PHP'
+                <?php
+
+                if (doFoo() != 2) {
+                }
+                PHP,
+        ];
+
+        yield 'It increments return value above 1 on not-equal comparison for dynamic function call' => [
+            <<<'PHP'
+                <?php
+
+                $fn = 'doFoo';
+                if ($fn() != 1) {}
+                PHP,
+            <<<'PHP'
+                <?php
+
+                $fn = 'doFoo';
+                if ($fn() != 2) {
+                }
+                PHP,
+        ];
     }
 }

--- a/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
+++ b/tests/phpunit/Mutator/Number/IncrementIntegerTest.php
@@ -284,5 +284,29 @@ final class IncrementIntegerTest extends BaseMutatorTestCase
                 PHP
             ,
         ];
+
+        yield 'It does not increment preg_match() return value above 1 on identical comparison' => [
+            <<<"PHP"
+                <?php
+
+                if (preg_match() === 1) {}
+                PHP,
+        ];
+
+        yield 'It does not increment preg_match() return value above 1 on equal comparison' => [
+            <<<"PHP"
+                <?php
+
+                if (preg_match() == 1) {}
+                PHP,
+        ];
+
+        yield 'It does not increment preg_match() return value above 1 on not-equal comparison' => [
+            <<<"PHP"
+                <?php
+
+                if (preg_mAtch() != 1) {}
+                PHP,
+        ];
     }
 }


### PR DESCRIPTION
closes https://github.com/infection/infection/issues/2185

counterpart of https://github.com/infection/infection/pull/2204 which prevented decrementing below the lower bound.

---


there are a few more functions which could also use the same logic.. since those are used rarely I think we should not take them into consideration

<img width="1285" alt="grafik" src="https://github.com/user-attachments/assets/f9938b56-2a6f-4dd0-bde5-3f001cc3d25d" />
