### PR TITLE
test: Use a bigger epsilon delta in TestLocationBucketSorterTest

### DIFF
--- a/tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTest.php
@@ -67,7 +67,7 @@ final class TestLocationBucketSorterTest extends TestCase
      *
      * @var float
      */
-    private const EPSILON = 0.001;
+    private const EPSILON = 0.0001;
 
     public function test_it_sorts(): void
     {


### PR DESCRIPTION
from time to time the apple M4 pro is too fast which makes tests fail with:

```
         There was 1 failure:                                                                                           
                                                                                                                        
         1)                                                                                                             
         Infection\Tests\TestFramework\Coverage\JUnit\TestLocationBucketSorterTest::test_it_sorts_faster_than_quicksort 
         with data set "Ten times the minimal amount of locations" (ArrayIterator Object ())                            
         Failed asserting that 0.0008718967437744141 is greater than 0.001.                                             
                                                                                                                        
         /Users/m.staab/Documents/GitHub/infection/tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTe
         st.php:225                                                                                                     
         /Users/m.staab/Documents/GitHub/infection/tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTe
         st.php:199                                                                                                     
```