### PR TITLE
Killed timed-out mutant in ExcludeDirsProvider

### DIFF
--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -113,7 +113,7 @@ final readonly class ExcludeDirsProvider
         $question->setAutocompleterValues($autocompleteValues);
         $question->setValidator($this->getValidator(new RootsFileOrDirectoryLocator($sourceDirs, $this->filesystem)));
 
-        while (($dir = $this->questionHelper->ask($io->getInput(), $io->getOutput(), $question)) !== '') {
+        while ($dir = $this->questionHelper->ask($io->getInput(), $io->getOutput(), $question)) {
             $excludedDirs[] = $dir;
         }
 


### PR DESCRIPTION
`bin/infection --threads=8 --filter=src/Config/ValueProvider/ExcludeDirsProvider.php`

before this PR:
> Time: 44s. Memory: 18.00MB. Threads: 8

after this PR:
> Time: 19s. Memory: 18.00MB. Threads: 8