### PR TITLE
Use `pull_request_target` instead of `pull_request` event

### DIFF
--- a/.github/workflows/require-tests.yaml
+++ b/.github/workflows/require-tests.yaml
@@ -1,7 +1,7 @@
 name: 'Require tests if source code is changed'
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
This fixes issue:

```
HttpError: Resource not accessible by integration
            at /home/runner/work/_actions/infection/tests-checker-action/v1.0.2/webpack:/typescript-action/node_modules/@octokit/request/dist-node/index.js:86:1
```

solution from: https://github.com/orgs/community/discussions/57878#discussioncomment-6168449

> The problem is that your workflow is running for a pull_request event. For PRs from forks the GITHUB_TOKEN gets read-only permissions (so people can't make PRs to do malicious stuff in the target repository).

----

Tested with a fork here: https://github.com/mrafalkoitr/random-php-tests/pull/3

it works
