### PR TITLE
Re-implement ContainerTest as a PHPStan rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,8 @@
     "autoload-dev": {
         "psr-4": {
             "Infection\\Benchmark\\": "tests/benchmark",
-            "Infection\\Tests\\": "tests/phpunit"
+            "Infection\\Tests\\": "tests/phpunit",
+            "Infection\\DevTools\\": "devTools/"
         },
         "classmap": [
             "tests/autoloaded"

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -2,6 +2,9 @@ includes:
     - ../vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - phpstan-baseline.neon
 
+rules:
+    - Infection\DevTools\PHPStan\Rules\InfectionContainerRule
+
 parameters:
     tmpDir: ../build/cache/phpstan-src
     inferPrivatePropertyTypeFromConstructor: true
@@ -137,6 +140,7 @@ parameters:
     paths:
         - ../src
         - ../tests/phpunit
+        - ./PHPStan/
     excludePaths:
         - %currentWorkingDirectory%/src/FileSystem/DummyFileSystem.php
         - %currentWorkingDirectory%/src/CustomMutator/templates/__Name__.php


### PR DESCRIPTION
creates a new PHPStan rule which errors when code tries to invoke `new Container()` directly, instead of using `SingletonContainer->getContainer()` instead.

the old test was pretty rough, as it [false-positives on e.g. public class references](https://github.com/infection/infection/pull/2216#discussion_r2151709538). The new rule is working on AST, which means it only hits the `new`-keyword

the previous unit test traversed a big part of the filesystem tree and loaded every class found via reflection.
instead we now use the 'standard' PHPStan way of things, meaning static reflection and re-analyzing only when necessary etc.