### PR TITLE
Cleanup MemoizedCiDetector, NullCiDetector

### DIFF
--- a/src/CI/MemoizedCiDetector.php
+++ b/src/CI/MemoizedCiDetector.php
@@ -37,8 +37,6 @@ namespace Infection\CI;
 
 use OndraM\CiDetector\Ci\CiInterface;
 use OndraM\CiDetector\CiDetector;
-use OndraM\CiDetector\Env;
-use ReflectionClass;
 
 /**
  * @internal
@@ -52,18 +50,6 @@ final class MemoizedCiDetector extends CiDetector
      * @var CiInterface|false|null
      */
     private $ci = false;
-
-    public static function fromEnvironment(Env $environment): CiDetector
-    {
-        $detector = new self();
-
-        // TODO: this is an ugly hack to due to a design flaw in ondram\ci-detector
-        //  See https://github.com/OndraM/ci-detector/pull/65
-        $environmentReflection = (new ReflectionClass(CiDetector::class))->getProperty('environment');
-        $environmentReflection->setValue($detector, $environment);
-
-        return $detector;
-    }
 
     protected function detectCurrentCiServer(): ?CiInterface
     {

--- a/src/CI/MemoizedCiDetector.php
+++ b/src/CI/MemoizedCiDetector.php
@@ -60,7 +60,6 @@ final class MemoizedCiDetector extends CiDetector
         // TODO: this is an ugly hack to due to a design flaw in ondram\ci-detector
         //  See https://github.com/OndraM/ci-detector/pull/65
         $environmentReflection = (new ReflectionClass(CiDetector::class))->getProperty('environment');
-        $environmentReflection->setAccessible(true);
         $environmentReflection->setValue($detector, $environment);
 
         return $detector;

--- a/src/CI/NullCiDetector.php
+++ b/src/CI/NullCiDetector.php
@@ -37,7 +37,6 @@ namespace Infection\CI;
 
 use OndraM\CiDetector\Ci\CiInterface;
 use OndraM\CiDetector\CiDetector;
-use OndraM\CiDetector\Env;
 use OndraM\CiDetector\Exception\CiNotDetectedException;
 
 /**
@@ -45,11 +44,6 @@ use OndraM\CiDetector\Exception\CiNotDetectedException;
  */
 final class NullCiDetector extends CiDetector
 {
-    public static function fromEnvironment(Env $environment): CiDetector
-    {
-        return new self();
-    }
-
     public function isCiDetected(): bool
     {
         return false;


### PR DESCRIPTION
stumbled over this class because of a PHPStorm warning

<img width="749" alt="grafik" src="https://github.com/user-attachments/assets/febc14df-411e-4c75-8edb-354e5f930745" />

----

see https://www.php.net/manual/en/reflectionproperty.setaccessible.php

> As of PHP 8.1.0, calling this method has no effect; all properties are accessible by default. 

----

looking at https://github.com/OndraM/ci-detector/pull/65 it seems we no longer need this whole method