### PR TITLE
ci: Declare timeout for GitHub Actions job execution

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -65,6 +66,7 @@ jobs:
   tests-status:
     name: Autoreview Status
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: tests
     if: always()
     steps:

--- a/.github/workflows/conductor.yaml
+++ b/.github/workflows/conductor.yaml
@@ -14,6 +14,7 @@ jobs:
   conductor:
     name: Private Packagist Conductor
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     env:
       COMPOSER_AUTH: ${{ secrets.CONDUCTOR_COMPOSER_AUTH }}
 

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -15,6 +15,7 @@ jobs:
   coding-standards:
     name: Coding Standards
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   tests:
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -135,6 +136,7 @@ jobs:
   tests-status:
       name: E2E Tests Status
       runs-on: ubuntu-latest
+      timeout-minutes: 30
       needs: tests
       if: always()
       steps:

--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
     tests:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
 
         strategy:
             matrix:
@@ -63,6 +64,7 @@ jobs:
     tests-status:
         name: Annotations Status
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         needs: tests
         if: always()
         steps:

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -30,6 +30,7 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     name: Infection complete run on Infection
 
@@ -91,6 +92,7 @@ jobs:
   tests-status:
       name: Mutation Testing Status
       runs-on: ubuntu-latest
+      timeout-minutes: 30
       needs: tests
       if: always()
       steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ jobs:
   release:
     name: Upload PHAR and signature
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       -
         name: Checkout

--- a/.github/workflows/require-tests.yaml
+++ b/.github/workflows/require-tests.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: infection/tests-checker-action@v1.0.3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   tests:
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -107,6 +108,7 @@ jobs:
   tests-status:
     name: Unit & Integration Tests Status
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: tests
     if: always()
     steps:


### PR DESCRIPTION
the default of 6h is way to long and can produce a overlong queue in case of endless loop bugs

---

looked into it, because there is [currently a E2E test endless running](https://github.com/infection/infection/actions/runs/15845415150/job/44666330784) which does not end and burns unnecessary resources