### PR TITLE
cs: Enable class_attributes_separation PHP-CS-Fixer rule

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -110,6 +110,7 @@ return (new Config())
         'blank_line_between_import_groups' => false,
         'compact_nullable_type_declaration' => true,
         'concat_space' => ['spacing' => 'one'],
+        'class_attributes_separation' => true,
         'fully_qualified_strict_types' => [
             'import_symbols' => true,
         ],

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -80,6 +80,7 @@ final class RunCommand extends BaseCommand
 
     /** @var string */
     public const OPTION_SHOW_MUTATIONS = 'show-mutations';
+
     /** @var string */
     private const OPTION_TEST_FRAMEWORK = 'test-framework';
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -58,14 +58,21 @@ class Configuration
     ];
 
     private readonly float $timeout;
+
     /** @var string[] */
     private readonly array $sourceDirectories;
+
     private readonly string $logVerbosity;
+
     /** @var array<string, Mutator<Node>> */
     private readonly array $mutators;
+
     private readonly string $testFramework;
+
     private readonly ?string $staticAnalysisTool;
+
     private ?float $minMsi = null;
+
     private readonly int $threadCount;
 
     /**

--- a/src/Configuration/Entry/Source.php
+++ b/src/Configuration/Entry/Source.php
@@ -44,6 +44,7 @@ final class Source
 {
     /** @var string[] */
     private readonly array $directories;
+
     /** @var string[] */
     private readonly array $excludes;
 

--- a/src/Configuration/Schema/SchemaConfiguration.php
+++ b/src/Configuration/Schema/SchemaConfiguration.php
@@ -48,6 +48,7 @@ use Webmozart\Assert\Assert;
 final class SchemaConfiguration
 {
     private readonly ?float $timeout;
+
     private readonly ?string $testFramework;
 
     /**

--- a/src/Configuration/Schema/SchemaConfigurationLoader.php
+++ b/src/Configuration/Schema/SchemaConfigurationLoader.php
@@ -48,10 +48,13 @@ final readonly class SchemaConfigurationLoader
         self::DEFAULT_DIST_JSON5_CONFIG_FILE,
         self::DEFAULT_DIST_JSON_CONFIG_FILE,
     ];
+
     public const DEFAULT_JSON5_CONFIG_FILE = 'infection.json5';
 
     private const DEFAULT_DIST_JSON5_CONFIG_FILE = 'infection.json5.dist';
+
     private const DEFAULT_DIST_JSON_CONFIG_FILE = 'infection.json.dist';
+
     private const DEFAULT_JSON_CONFIG_FILE = 'infection.json';
 
     public function __construct(

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -47,6 +47,7 @@ use function sprintf;
 class ConsoleOutput
 {
     private const RUNNING_WITH_DEBUGGER_NOTE = 'You are running Infection with %s enabled.';
+
     private const MIN_MSI_CAN_GET_INCREASED_NOTICE = 'The %s is %s%% percentage points over the required %s. Consider increasing the required %s percentage the next time you run Infection.';
 
     public function __construct(

--- a/src/Console/IO.php
+++ b/src/Console/IO.php
@@ -47,6 +47,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class IO extends SymfonyStyle
 {
     private readonly InputInterface $input;
+
     private readonly OutputInterface $output;
 
     public function __construct(InputInterface $input, OutputInterface $output)

--- a/src/Console/Input/MsiParser.php
+++ b/src/Console/Input/MsiParser.php
@@ -54,6 +54,7 @@ final class MsiParser
     use CannotBeInstantiated;
 
     public const DEFAULT_PRECISION = 2;
+
     private const EXPLODE_PARTS = 2;
 
     public static function detectPrecision(?string ...$values): int

--- a/src/Console/LogVerbosity.php
+++ b/src/Console/LogVerbosity.php
@@ -48,7 +48,9 @@ final class LogVerbosity
     use CannotBeInstantiated;
 
     public const DEBUG = 'all';
+
     public const NORMAL = 'default';
+
     public const NONE = 'none';
 
     /**

--- a/src/Console/OutputFormatter/FormatterName.php
+++ b/src/Console/OutputFormatter/FormatterName.php
@@ -41,6 +41,7 @@ namespace Infection\Console\OutputFormatter;
 final class FormatterName
 {
     public const DOT = 'dot';
+
     public const PROGRESS = 'progress';
 
     public const ALL = [

--- a/src/Container.php
+++ b/src/Container.php
@@ -172,37 +172,69 @@ use Webmozart\Assert\Assert;
 final class Container
 {
     public const DEFAULT_CONFIG_FILE = null;
+
     public const DEFAULT_MUTATORS_INPUT = '';
+
     public const DEFAULT_SHOW_MUTATIONS = 20;
+
     public const DEFAULT_LOG_VERBOSITY = LogVerbosity::NORMAL;
+
     public const DEFAULT_DEBUG = false;
+
     public const DEFAULT_ONLY_COVERED = false;
+
     public const DEFAULT_FORMATTER_NAME = FormatterName::DOT;
+
     public const DEFAULT_MUTANT_ID = null;
+
     public const DEFAULT_GIT_DIFF_FILTER = null;
+
     public const DEFAULT_GIT_DIFF_LINES = false;
+
     public const DEFAULT_GIT_DIFF_BASE = null;
+
     public const DEFAULT_USE_GITHUB_LOGGER = null;
+
     public const DEFAULT_GITLAB_LOGGER_PATH = null;
+
     public const DEFAULT_LOGGER_PROJECT_ROOT_DIRECTORY = null;
+
     public const DEFAULT_HTML_LOGGER_PATH = null;
+
     public const DEFAULT_USE_NOOP_MUTATORS = false;
+
     public const DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES = false;
+
     public const DEFAULT_NO_PROGRESS = false;
+
     public const DEFAULT_FORCE_PROGRESS = false;
+
     public const DEFAULT_EXISTING_COVERAGE_PATH = null;
+
     public const DEFAULT_INITIAL_TESTS_PHP_OPTIONS = null;
+
     public const DEFAULT_SKIP_INITIAL_TESTS = false;
+
     public const DEFAULT_IGNORE_MSI_WITH_NO_MUTATIONS = false;
+
     public const DEFAULT_MIN_MSI = null;
+
     public const DEFAULT_MIN_COVERED_MSI = null;
+
     public const DEFAULT_MSI_PRECISION = MsiParser::DEFAULT_PRECISION;
+
     public const DEFAULT_TEST_FRAMEWORK = null;
+
     public const DEFAULT_STATIC_ANALYSIS_TOOL = null;
+
     public const DEFAULT_TEST_FRAMEWORK_EXTRA_OPTIONS = null;
+
     public const DEFAULT_FILTER = '';
+
     public const DEFAULT_THREAD_COUNT = null;
+
     public const DEFAULT_DRY_RUN = false;
+
     public const DEFAULT_MAP_SOURCE_CLASS_TO_TEST_STRATEGY = null;
 
     /**

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -67,6 +67,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
     private const PAD_LENGTH = 8;
 
     private const LOW_QUALITY_THRESHOLD = 50;
+
     private const MEDIUM_QUALITY_THRESHOLD = 90;
 
     private int $mutationCount = 0;

--- a/src/Logger/ConsoleLogger.php
+++ b/src/Logger/ConsoleLogger.php
@@ -56,6 +56,7 @@ use Webmozart\Assert\Assert;
 final class ConsoleLogger extends AbstractLogger
 {
     private const INFO = 'info';
+
     private const ERROR = 'error';
 
     private const VERBOSITY_LEVEL_MAP = [

--- a/src/Logger/Html/StrykerHtmlReportBuilder.php
+++ b/src/Logger/Html/StrykerHtmlReportBuilder.php
@@ -91,6 +91,7 @@ final readonly class StrykerHtmlReportBuilder
     ];
 
     private const PLUS_LENGTH = 1;
+
     private const DIFF_HEADERS_LINES_COUNT = 1;
 
     public function __construct(

--- a/src/Logger/Http/Response.php
+++ b/src/Logger/Http/Response.php
@@ -43,7 +43,9 @@ use Webmozart\Assert\Assert;
 final class Response
 {
     public const HTTP_OK = 200;
+
     public const HTTP_CREATED = 201;
+
     public const HTTP_MAX_ERROR_CODE = 599;
 
     private readonly int $statusCode;

--- a/src/Mutant/DetectionStatus.php
+++ b/src/Mutant/DetectionStatus.php
@@ -45,13 +45,21 @@ final class DetectionStatus
     use CannotBeInstantiated;
 
     public const KILLED_BY_TESTS = 'killed by tests';
+
     public const KILLED_BY_STATIC_ANALYSIS = 'killed by SA';
+
     public const ESCAPED = 'escaped';
+
     public const ERROR = 'error';
+
     public const TIMED_OUT = 'timed out';
+
     public const SKIPPED = 'skipped';
+
     public const SYNTAX_ERROR = 'syntax error';
+
     public const NOT_COVERED = 'not covered';
+
     public const IGNORED = 'ignored';
 
     public const ALL = [

--- a/src/Mutant/MutantExecutionResult.php
+++ b/src/Mutant/MutantExecutionResult.php
@@ -51,6 +51,7 @@ use Webmozart\Assert\Assert;
 class MutantExecutionResult
 {
     private readonly string $detectionStatus;
+
     private readonly string $mutatorClass;
 
     /**

--- a/src/Mutation/Mutation.php
+++ b/src/Mutation/Mutation.php
@@ -54,9 +54,12 @@ use Webmozart\Assert\Assert;
 class Mutation
 {
     private readonly string $mutatorClass;
+
     /** @var array<string|int|float> */
     private readonly array $attributes;
+
     private readonly bool $coveredByTests;
+
     private ?float $nominalTimeToTest = null;
 
     private ?string $hash = null;

--- a/src/Mutation/MutationAttributeKeys.php
+++ b/src/Mutation/MutationAttributeKeys.php
@@ -45,10 +45,15 @@ final class MutationAttributeKeys
     use CannotBeInstantiated;
 
     public const START_LINE = 'startLine';
+
     public const END_LINE = 'endLine';
+
     public const START_TOKEN_POS = 'startTokenPos';
+
     public const END_TOKEN_POS = 'endTokenPos';
+
     public const START_FILE_POS = 'startFilePos';
+
     public const END_FILE_POS = 'endFilePos';
 
     public const ALL = [

--- a/src/Mutator/MutatorResolver.php
+++ b/src/Mutator/MutatorResolver.php
@@ -53,9 +53,11 @@ use stdClass;
 final class MutatorResolver
 {
     private const IGNORE_SETTING = 'ignore';
+
     private const IGNORE_SOURCE_CODE_BY_REGEX_SETTING = 'ignoreSourceCodeByRegex';
 
     private const GLOBAL_IGNORE_SETTING = 'global-ignore';
+
     private const GLOBAL_IGNORE_SOURCE_CODE_BY_REGEX_SETTING = 'global-ignoreSourceCodeByRegex';
 
     /**

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -60,9 +60,12 @@ class NodeMutationGenerator
     private readonly array $mutators;
 
     private Node $currentNode;
+
     /** @var TestLocation[]|null */
     private ?array $testsMemoized = null;
+
     private ?bool $isOnFunctionSignatureMemoized = null;
+
     private ?bool $isInsideFunctionMemoized = null;
 
     /**

--- a/src/Mutator/Removal/ArrayItemRemovalConfig.php
+++ b/src/Mutator/Removal/ArrayItemRemovalConfig.php
@@ -51,6 +51,7 @@ final class ArrayItemRemovalConfig implements MutatorConfig
     ];
 
     private readonly string $remove;
+
     private readonly int $limit;
 
     /**

--- a/src/PhpParser/Visitor/ReflectionVisitor.php
+++ b/src/PhpParser/Visitor/ReflectionVisitor.php
@@ -52,10 +52,15 @@ use Webmozart\Assert\Assert;
 final class ReflectionVisitor extends NodeVisitorAbstract
 {
     public const STRICT_TYPES_KEY = 'isStrictTypes';
+
     public const REFLECTION_CLASS_KEY = 'reflectionClass';
+
     public const IS_INSIDE_FUNCTION_KEY = 'isInsideFunction';
+
     public const IS_ON_FUNCTION_SIGNATURE = 'isOnFunctionSignature';
+
     public const FUNCTION_SCOPE_KEY = 'functionScope';
+
     public const FUNCTION_NAME = 'functionName';
 
     /** @var array<int, Node> */

--- a/src/Reflection/Visibility.php
+++ b/src/Reflection/Visibility.php
@@ -41,6 +41,7 @@ namespace Infection\Reflection;
 final readonly class Visibility
 {
     public const PUBLIC = 'public';
+
     public const PROTECTED = 'protected';
 
     private function __construct(

--- a/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
+++ b/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
@@ -55,6 +55,7 @@ use function version_compare;
 final class PHPStanAdapter implements StaticAnalysisToolAdapter
 {
     private const VERSION_1 = 1;
+
     private const VERSION_2 = 2;
 
     public function __construct(

--- a/src/TestFramework/Coverage/CoverageChecker.php
+++ b/src/TestFramework/Coverage/CoverageChecker.php
@@ -56,7 +56,9 @@ use function strtolower;
 class CoverageChecker
 {
     private const PHPUNIT = 'phpunit';
+
     private const CODECEPTION = 'codeception';
+
     private readonly string $frameworkAdapterName;
 
     public function __construct(

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php
@@ -44,6 +44,7 @@ use function Safe\preg_match;
 final class XmlConfigurationVersionProvider
 {
     private const LAST_LEGACY_VERSION = '9.2';
+
     private const NEXT_MAINSTREAM_VERSION = '9.3';
 
     public function provide(SafeDOMXPath $xPath): string

--- a/src/TestFramework/TestFrameworkTypes.php
+++ b/src/TestFramework/TestFrameworkTypes.php
@@ -47,7 +47,9 @@ use Webmozart\Assert\Assert;
 final class TestFrameworkTypes
 {
     public const PHPUNIT = 'phpunit';
+
     public const PHPSPEC = 'phpspec';
+
     public const CODECEPTION = 'codeception';
 
     /**

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -85,8 +85,11 @@ final class E2ETest extends TestCase
      * This group must be excluded from E2E testing to avoid endless recursive testing loop situation.
      */
     private const EXCLUDED_GROUP = 'integration';
+
     private const MAX_FAILING_COMPOSER_INSTALL = 5;
+
     private const EXPECT_ERROR = 1;
+
     private const EXPECT_SUCCESS = 0;
 
     /**

--- a/tests/phpunit/FileSystem/Finder/MockVendor.php
+++ b/tests/phpunit/FileSystem/Finder/MockVendor.php
@@ -45,6 +45,7 @@ use Symfony\Component\Filesystem\Filesystem;
 final class MockVendor
 {
     public const VENDOR = 'phptester';
+
     public const PACKAGE = 'awesome-php-tester';
 
     /**

--- a/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
@@ -334,6 +334,7 @@ final class ReflectionVisitorTest extends BaseVisitorTestCase
     {
         return new class extends NodeVisitorAbstract {
             public ?ClassReflection $fooReflectionClass = null;
+
             public ?ClassReflection $createAnonymousClassReflectionClass = null;
 
             public function enterNode(Node $node): ?int

--- a/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php
@@ -59,6 +59,7 @@ final class PHPStanAdapterTest extends TestCase
     private commandLineBuilder&MockObject $commandLineBuilder;
 
     private PHPStanMutantExecutionResultFactory&MockObject $mutantExecutionResultFactory;
+
     private Filesystem&MockObject $fileSystem;
 
     protected function setUp(): void

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProviderTest.php
@@ -52,8 +52,11 @@ use function Safe\unlink;
 final class JUnitTestFileDataProviderTest extends TestCase
 {
     private const JUNIT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit.xml';
+
     private const JUNIT_DIFF_FORMAT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit2.xml';
+
     private const JUNIT_FEATURE_FORMAT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit_feature.xml';
+
     private const JUNIT_CODECEPTION_CEST_FORMAT = __DIR__ . '/../../../Fixtures/Files/phpunit/junit_codeception_cest.xml';
 
     /**

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -57,9 +57,13 @@ final class PhpUnitAdapterTest extends TestCase
     private $adapter;
 
     private $pcovDirectoryProvider;
+
     private $initialConfigBuilder;
+
     private $mutationConfigBuilder;
+
     private $cliArgumentsBuilder;
+
     private $commandLineBuilder;
 
     protected function setUp(): void

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -67,7 +67,9 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
     public const HASH = 'a1b2c3';
 
     private const FIXTURES = __DIR__ . '/../../../../Fixtures/Files/phpunit';
+
     private const ORIGINAL_FILE_PATH = '/original/file/path';
+
     private const MUTATED_FILE_PATH = '/mutated/file/path';
 
     /**


### PR DESCRIPTION
In https://github.com/infection/infection/pull/2243#discussion_r2162159805 was suggested to enable [`class_attributes_separation`](https://cs.symfony.com/doc/rules/class_notation/class_attributes_separation.html)

I have no opinion on the PR, feel free to merge or close whatever you think