### PR TITLE
UX: More verbose "Running initial test suite" in CI

### DIFF
--- a/src/Event/InitialTestSuiteWasFinished.php
+++ b/src/Event/InitialTestSuiteWasFinished.php
@@ -41,6 +41,7 @@ namespace Infection\Event;
 final readonly class InitialTestSuiteWasFinished
 {
     public function __construct(
+        private bool $errored,
         private string $outputText,
     ) {
     }
@@ -48,5 +49,10 @@ final readonly class InitialTestSuiteWasFinished
     public function getOutputText(): string
     {
         return $this->outputText;
+    }
+
+    public function hasErrored(): bool
+    {
+        return $this->errored;
     }
 }

--- a/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
@@ -78,7 +78,9 @@ final class CiInitialTestsConsoleLoggerSubscriber implements EventSubscriber
 
     public function onInitialTestSuiteWasFinished(InitialTestSuiteWasFinished $event): void
     {
-        $this->output->writeln(sprintf('Ran %d tests.', $this->numberOfCompletedTests));
+        if (!$event->hasErrored()) {
+            $this->output->writeln(sprintf('Ran %d tests.', $this->numberOfCompletedTests));
+        }
     }
 
     public function onInitialTestCaseWasCompleted(InitialTestCaseWasCompleted $event): void

--- a/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/CiInitialTestsConsoleLoggerSubscriber.php
@@ -36,6 +36,8 @@ declare(strict_types=1);
 namespace Infection\Event\Subscriber;
 
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\Event\InitialTestCaseWasCompleted;
+use Infection\Event\InitialTestSuiteWasFinished;
 use Infection\Event\InitialTestSuiteWasStarted;
 use InvalidArgumentException;
 use function sprintf;
@@ -44,11 +46,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
-final readonly class CiInitialTestsConsoleLoggerSubscriber implements EventSubscriber
+final class CiInitialTestsConsoleLoggerSubscriber implements EventSubscriber
 {
+    private int $numberOfCompletedTests = 0;
+
     public function __construct(
-        private OutputInterface $output,
-        private TestFrameworkAdapter $testFrameworkAdapter,
+        private readonly OutputInterface $output,
+        private readonly TestFrameworkAdapter $testFrameworkAdapter,
     ) {
     }
 
@@ -70,5 +74,15 @@ final readonly class CiInitialTestsConsoleLoggerSubscriber implements EventSubsc
                 $version,
             ),
         ]);
+    }
+
+    public function onInitialTestSuiteWasFinished(InitialTestSuiteWasFinished $event): void
+    {
+        $this->output->writeln(sprintf('Ran %d tests.', $this->numberOfCompletedTests));
+    }
+
+    public function onInitialTestCaseWasCompleted(InitialTestCaseWasCompleted $event): void
+    {
+        ++$this->numberOfCompletedTests;
     }
 }

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -79,7 +79,7 @@ class InitialTestsRunner
             $this->eventDispatcher->dispatch(new InitialTestCaseWasCompleted());
         });
 
-        $this->eventDispatcher->dispatch(new InitialTestSuiteWasFinished($process->getOutput()));
+        $this->eventDispatcher->dispatch(new InitialTestSuiteWasFinished($process->getExitCode() !== 0, $process->getOutput()));
 
         return $process;
     }

--- a/tests/phpunit/Event/InitialTestSuiteWasFinishedTest.php
+++ b/tests/phpunit/Event/InitialTestSuiteWasFinishedTest.php
@@ -37,17 +37,31 @@ namespace Infection\Tests\Event;
 
 use Infection\Event\InitialTestSuiteWasFinished;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(InitialTestSuiteWasFinished::class)]
 final class InitialTestSuiteWasFinishedTest extends TestCase
 {
-    public function test_it_exposes_its_output(): void
+    #[DataProvider('provideEvents')]
+    public function test_it_exposes_its_output_and_error(bool $errored, string $output, InitialTestSuiteWasFinished $event): void
     {
-        $text = 'foo-bar-baz';
+        $this->assertSame($output, $event->getOutputText());
+        $this->assertSame($errored, $event->hasErrored());
+    }
 
-        $class = new InitialTestSuiteWasFinished($text);
+    public static function provideEvents(): iterable
+    {
+        yield [
+            false,
+            'foo-bar-baz',
+            new InitialTestSuiteWasFinished(false, 'foo-bar-baz'),
+        ];
 
-        $this->assertSame($text, $class->getOutputText());
+        yield [
+            true,
+            'foo-bar-baz',
+            new InitialTestSuiteWasFinished(true, 'foo-bar-baz'),
+        ];
     }
 }

--- a/tests/phpunit/Event/Subscriber/InitialTestsConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/InitialTestsConsoleLoggerSubscriberTest.php
@@ -109,6 +109,6 @@ final class InitialTestsConsoleLoggerSubscriberTest extends TestCase
         $dispatcher = new SyncEventDispatcher();
         $dispatcher->addSubscriber(new InitialTestsConsoleLoggerSubscriber($output, $testFramework, true));
 
-        $dispatcher->dispatch(new InitialTestSuiteWasFinished($processText));
+        $dispatcher->dispatch(new InitialTestSuiteWasFinished(true, $processText));
     }
 }


### PR DESCRIPTION
Indicate how many tests have been ran

before this PR:
```
 ➜  php-rocket git:(last-query) ✗ vendor/bin/infection --git-diff-lines --git-diff-base=origin/master --show-mutations --no-ansi --debug
Xdebug: [Step Debug] Could not connect to debugging client. Tried: localhost:9003 (through xdebug.client_host/xdebug.client_port).

    ____      ____          __  _
   /  _/___  / __/__  _____/ /_(_)___  ____
   / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \
 _/ // / / / __/  __/ /__/ /_/ / /_/ / / / /
/___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/

#StandWithUkraine

Infection - PHP Mutation Testing Framework version 0.29.8


Running initial test suite...

PHPUnit version: 10.5.47
 [OK] No covered lines in diff found, skipping mutation analysis.                                                       
        
 ```

after this PR:
```
 vendor/bin/infection --git-diff-lines --git-diff-base=origin/master --show-mutations --no-ansi --debug
Xdebug: [Step Debug] Could not connect to debugging client. Tried: localhost:9003 (through xdebug.client_host/xdebug.client_port).

    ____      ____          __  _
   /  _/___  / __/__  _____/ /_(_)___  ____
   / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \
 _/ // / / / __/  __/ /__/ /_/ / /_/ / / / /
/___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/

#StandWithUkraine

Infection - PHP Mutation Testing Framework version 0.29.8


Running initial test suite...

PHPUnit version: 10.5.47
Ran 310 tests.
 [OK] No covered lines in diff found, skipping mutation analysis.                 
 ```

note the `Ran 310 tests.` output.

closes https://github.com/infection/infection/issues/2254