### PR TITLE
Smarter `Throw_` mutator

### DIFF
--- a/src/Mutator/Operator/Throw_.php
+++ b/src/Mutator/Operator/Throw_.php
@@ -39,6 +39,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\GetMutatorName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
+use Infection\PhpParser\Visitor\ParentConnector;
 use PhpParser\Node;
 
 /**
@@ -91,6 +92,24 @@ final class Throw_ implements Mutator
 
     public function canMutate(Node $node): bool
     {
-        return $node instanceof Node\Expr\Throw_;
+        if (!$node instanceof Node\Expr\Throw_) {
+            return false;
+        }
+
+        $parentNode = ParentConnector::findParent($node);
+
+        if ($parentNode instanceof Node\MatchArm && $parentNode->conds === null) {
+            return false;
+        }
+
+        if ($parentNode instanceof Node\Stmt\Expression) {
+            $grandParent = ParentConnector::findParent($parentNode);
+
+            if ($grandParent instanceof Node\Stmt\Case_ && $grandParent->cond === null) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/phpunit/Mutator/Operator/Throw_Test.php
+++ b/tests/phpunit/Mutator/Operator/Throw_Test.php
@@ -68,5 +68,72 @@ final class Throw_Test extends BaseMutatorTestCase
                 PHP
             ,
         ];
+
+        yield 'It mutates throw in match non-default arm' => [
+            <<<'PHP'
+                <?php
+
+                match ($x) {
+                    0 => throw new \Exception(),
+                    default => '',
+                };
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                match ($x) {
+                    0 => new \Exception(),
+                    default => '',
+                };
+                PHP,
+        ];
+
+        yield 'It does not mutate throw in match default arm to prevent overlap with MatchArmRemoval' => [
+            <<<'PHP'
+                <?php
+
+                match ($x) {
+                    default => throw new \Exception(),
+                };
+                PHP
+            ,
+        ];
+
+        yield 'It mutates throw in switch non-default case' => [
+            <<<'PHP'
+                <?php
+
+                switch ($x) {
+                    case true:
+                        throw new \Exception();
+                    default:
+                        $s = '';
+                }
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                switch ($x) {
+                    case true:
+                        new \Exception();
+                    default:
+                        $s = '';
+                }
+                PHP,
+        ];
+
+        yield 'It does not mutate throw in switch default-arm to prevent overlap with SharedCaseRemoval' => [
+            <<<'PHP'
+                <?php
+
+                switch ($x) {
+                    case true: $s = ''; break;
+                    default: throw new \Exception();
+                }
+                PHP
+            ,
+        ];
     }
 }


### PR DESCRIPTION
prevent overlap with MatchArmRemoval, SharedCaseRemoval

refs https://github.com/infection/infection/issues/2261#issuecomment-3015095709

Related to

- https://github.com/infection/infection/issues/2184