### PR TITLE
Improve LogicalOrTest / drop mutator ignores

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -26,20 +26,5 @@
             "Assert::.*"
         ],
         "@default": true,
-        "InstanceOf_": {
-            ignore: [
-                "Infection\\Mutator\\Boolean\\LogicalOr::canMutate"
-            ]
-        },
-        "LogicalAnd": {
-            ignore: [
-                "Infection\\Mutator\\Boolean\\LogicalOr::canMutate"
-            ]
-        },
-        "LogicalOr": {
-            ignore: [
-                "Infection\\Mutator\\Boolean\\LogicalOr::canMutate"
-            ]
-        }
     }
 }

--- a/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
@@ -747,5 +747,35 @@ final class LogicalOrTest extends BaseMutatorTestCase
                 PHP
             ,
         ];
+
+        yield 'It mutates left-side instanceof or non-instanceof expression' => [
+            <<<'PHP'
+                <?php
+
+                $var = $node instanceof \Countable || $i > 5;
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $var = $node instanceof \Countable && $i > 5;
+                PHP
+            ,
+        ];
+
+        yield 'It mutates right-side instanceof or non-instanceof expression' => [
+            <<<'PHP'
+                <?php
+
+                $var = $i > 5 || $node instanceof \Countable;
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                $var = $i > 5 && $node instanceof \Countable;
+                PHP
+            ,
+        ];
     }
 }


### PR DESCRIPTION
after mutators got smarter in recent PRs, I think we should remove the config based ignores and instead accept the remaining escaped mutants.

the config ignores which get deleted made mutations invisible in https://github.com/infection/infection/pull/2243 which would have been useful to have.