### PR TITLE
Use/Suggest `executionOrder="defects,random"` for phpunit.xml

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
          xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
          colors="true"
-         executionOrder="random"
+         executionOrder="defects,random"
          failOnWarning="true"
          failOnRisky="true"
          requireCoverageMetadata="true"

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -160,7 +160,7 @@ class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements MemoryUsage
             $recommendations = sprintf(
                 "%s\n\n%s\n\n%s",
                 "Infection runs the test suite in a RANDOM order. Make sure your tests do not have hidden dependencies.\n\n"
-                . 'You can add these attributes to `phpunit.xml` to check it: <phpunit executionOrder="random" resolveDependencies="true" ...',
+                . 'You can add these attributes to `phpunit.xml` to check it: <phpunit executionOrder="defects,random" resolveDependencies="true" ...',
                 'If you don\'t want to let Infection run tests in a random order, set the `executionOrder` to some value, for example <phpunit executionOrder="default"',
                 parent::getInitialTestsFailRecommendations($commandLine),
             );

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -143,7 +143,7 @@ class InitialConfigBuilder implements ConfigBuilder
             return;
         }
 
-        if ($this->addAttributeIfNotSet('executionOrder', 'random', $xPath)) {
+        if ($this->addAttributeIfNotSet('executionOrder', 'defects,random', $xPath)) {
             $this->addAttributeIfNotSet('resolveDependencies', 'true', $xPath);
         }
     }


### PR DESCRIPTION
when re-running a test-suite which failed before it makes a lot of sense to run the previously failed tests first.
that way we validate whether the already known problems are gone and in addition we also shorten the feedback loop.

on my machine re-running a previously failed test-suite, in the scenario when it will fail again after this PR 