### PR TITLE
Cleanup TestFrameworkConfigPathProviderTest

### DIFF
--- a/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -104,12 +104,10 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
         $this->locatorMock
             ->expects($this->exactly(3))
             ->method('locate')
-            ->will(
-                $this->onConsecutiveCalls(
-                    $this->throwException(new Exception()),
-                    $this->throwException(new Exception()),
-                    '',
-                ),
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new Exception()),
+                $this->throwException(new Exception()),
+                '',
             );
 
         $inputPhpUnitPath = realpath(__DIR__ . '/../../Fixtures/Files/phpunit');
@@ -132,11 +130,9 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
         $this->locatorMock
             ->expects($this->exactly(2))
             ->method('locate')
-            ->will(
-                $this->onConsecutiveCalls(
-                    $this->throwException(new Exception()),
-                    '',
-                ),
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new Exception()),
+                '',
             );
 
         $this->consoleMock
@@ -161,12 +157,10 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
         $this->locatorMock
             ->expects($this->exactly(3))
             ->method('locate')
-            ->will(
-                $this->onConsecutiveCalls(
-                    $this->throwException(new Exception()),
-                    $this->throwException(new Exception()),
-                    '',
-                ),
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new Exception()),
+                $this->throwException(new Exception()),
+                '',
             );
 
         $path = $this->provider->get(


### PR DESCRIPTION
fixes 3 PHPUnit deprecations to unlock our path to PHPUnit 12.x

```
1) Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_automatically_guesses_path
onConsecutiveCalls() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->onConsecutiveCalls())

/Users/m.staab/Documents/GitHub/infection/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php:130

2) Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_validates_incorrect_dir
onConsecutiveCalls() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->onConsecutiveCalls())

/Users/m.staab/Documents/GitHub/infection/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php:155

3) Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_asks_question_if_no_config_is_found_in_current_dir
onConsecutiveCalls() is deprecated and will be removed in PHPUnit 12. Use $double->willReturn() instead of $double->will($this->onConsecutiveCalls())
```