### PR TITLE
Smarter `TrueValue`/`FalseValue` mutator

### DIFF
--- a/src/Mutator/Boolean/FalseValue.php
+++ b/src/Mutator/Boolean/FalseValue.php
@@ -85,11 +85,16 @@ final class FalseValue implements Mutator
         }
 
         $parentNode = ParentConnector::findParent($node);
-        $grandParentNode = $parentNode !== null ? ParentConnector::findParent($parentNode) : null;
+
+        if ($parentNode instanceof Node\Expr\Match_) {
+            return false;
+        }
 
         if ($parentNode instanceof Node\Stmt\Switch_) {
             return false;
         }
+
+        $grandParentNode = $parentNode !== null ? ParentConnector::findParent($parentNode) : null;
 
         if ($grandParentNode instanceof Node\Expr\Ternary) {
             return false;

--- a/src/Mutator/Boolean/TrueValue.php
+++ b/src/Mutator/Boolean/TrueValue.php
@@ -99,11 +99,16 @@ final class TrueValue implements ConfigurableMutator
         }
 
         $parentNode = ParentConnector::findParent($node);
-        $grandParentNode = $parentNode !== null ? ParentConnector::findParent($parentNode) : null;
+
+        if ($parentNode instanceof Node\Expr\Match_) {
+            return false;
+        }
 
         if ($parentNode instanceof Node\Stmt\Switch_) {
             return false;
         }
+
+        $grandParentNode = $parentNode !== null ? ParentConnector::findParent($parentNode) : null;
 
         if ($grandParentNode instanceof Node\Expr\Ternary) {
             return false;

--- a/tests/phpunit/Mutator/Boolean/FalseValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/FalseValueTest.php
@@ -80,11 +80,24 @@ final class FalseValueTest extends BaseMutatorTestCase
             ,
         ];
 
-        yield 'It does not mutate switch false to true' => [
+        yield 'It does not mutate switch(false) to true' => [
             <<<'PHP'
                 <?php
 
                 switch (false) {}
+                PHP
+            ,
+        ];
+
+        yield 'It does not mutate match(false) to true to prevent overlap with MatchArmRemoval' => [
+            <<<'PHP'
+                <?php
+
+                match(false) {
+                    $count > 0 && $count <=10 => 'small',
+                    $count <=50 => 'medium',
+                    $count >50 => 'huge',
+                };
                 PHP
             ,
         ];

--- a/tests/phpunit/Mutator/Boolean/FalseValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/FalseValueTest.php
@@ -94,9 +94,9 @@ final class FalseValueTest extends BaseMutatorTestCase
                 <?php
 
                 match(false) {
-                    $count > 0 && $count <=10 => 'small',
-                    $count <=50 => 'medium',
-                    $count >50 => 'huge',
+                    $count > 0 && $count <= 10 => 'small',
+                    $count <= 50 => 'medium',
+                    $count > 50 => 'huge',
                 };
                 PHP
             ,

--- a/tests/phpunit/Mutator/Boolean/TrueValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/TrueValueTest.php
@@ -172,7 +172,7 @@ final class TrueValueTest extends BaseMutatorTestCase
                 <?php
 
                 match(true) {
-                    $count > 0 && $count <=10 => 'small',
+                    $count > 0 && $count <= 10 => 'small',
                     $count <= 50 => 'medium',
                     $count > 50 => 'huge',
                 };

--- a/tests/phpunit/Mutator/Boolean/TrueValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/TrueValueTest.php
@@ -173,8 +173,8 @@ final class TrueValueTest extends BaseMutatorTestCase
 
                 match(true) {
                     $count > 0 && $count <=10 => 'small',
-                    $count <=50 => 'medium',
-                    $count >50 => 'huge',
+                    $count <= 50 => 'medium',
+                    $count > 50 => 'huge',
                 };
                 PHP
             ,

--- a/tests/phpunit/Mutator/Boolean/TrueValueTest.php
+++ b/tests/phpunit/Mutator/Boolean/TrueValueTest.php
@@ -167,6 +167,19 @@ final class TrueValueTest extends BaseMutatorTestCase
             ,
         ];
 
+        yield 'It does not mutate match(true) to prevent overlap with MatchArmRemoval' => [
+            <<<'PHP'
+                <?php
+
+                match(true) {
+                    $count > 0 && $count <=10 => 'small',
+                    $count <=50 => 'medium',
+                    $count >50 => 'huge',
+                };
+                PHP
+            ,
+        ];
+
         yield 'It mutates all caps true to false' => [
             <<<'PHP'
                 <?php


### PR DESCRIPTION
to prevent overlap with `MatchArmRemoval`

closes https://github.com/infection/infection/issues/2234