### PR TITLE
Fix a MethodCallRemoval test

### DIFF
--- a/tests/phpunit/Mutator/Removal/MethodCallRemovalTest.php
+++ b/tests/phpunit/Mutator/Removal/MethodCallRemovalTest.php
@@ -136,7 +136,7 @@ final class MethodCallRemovalTest extends BaseMutatorTestCase
             <<<'PHP'
                 <?php
 
-                $b = foo();
+                $b = $this->foo();
                 $a = 3;
                 PHP
             ,


### PR DESCRIPTION
made the test-case reflect its description.

I guess its a copy/paste error originating from `FunctionCallRemovalTest`