### PR TITLE
Smarter `LogicalNot` mutator

### DIFF
--- a/src/Mutator/Boolean/LogicalNot.php
+++ b/src/Mutator/Boolean/LogicalNot.php
@@ -80,6 +80,10 @@ final class LogicalNot implements Mutator
             return false;
         }
 
+        if ($node->expr instanceof Node\Expr\Match_) {
+            return false;
+        }
+
         // e.g. "!!someFunc()"
         $isDoubledLogicalNot = ($node->expr instanceof Node\Expr\BooleanNot)
             || ParentConnector::findParent($node) instanceof Node\Expr\BooleanNot;

--- a/tests/phpunit/Mutator/Boolean/LogicalNotTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalNotTest.php
@@ -80,6 +80,18 @@ final class LogicalNotTest extends BaseMutatorTestCase
                 PHP
             ,
         ];
+
+        yield 'It does not remove negation on match() to prevent overlap with MatchArmRemoval' => [
+            <<<'PHP'
+                <?php
+
+                $matched = !match ($potionItem->getTypeId()){
+                    ItemTypeIds::POTION, ItemTypeIds::LINGERING_POTION => true,
+                    default => false,
+                };
+                PHP
+            ,
+        ];
     }
 
     public function test_it_mutates_logical_not(): void


### PR DESCRIPTION
Similar to https://github.com/infection/infection/pull/2280

to prevent overlap with `MatchArmRemoval`
