### PR TITLE
Cleanup composer.json conflict rules with phpunit/php-code-coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,6 @@
         "webmozart/assert": "^1.11"
     },
     "conflict": {
-        "phpunit/php-code-coverage": ">9,<9.1.4 || >9.2.17,<9.2.21",
         "antecedent/patchwork": "<2.1.25",
         "dg/bypass-finals": "<1.4.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "645d7b167cfe99de8a0edfe03ed8e597",
+    "content-hash": "bf5d6cf21054eac5ee177e789c897199",
     "packages": [
         {
             "name": "colinodell/json5",


### PR DESCRIPTION
as we no longer support PHPUnit 9.x (because of our php min version constraint of 8.2+) this conflict no longer makes sense