### PR TITLE
Support NullSafe PropertyFetch/MethodCall in ArrayItem mutator

### DIFF
--- a/src/Mutator/Boolean/ArrayItem.php
+++ b/src/Mutator/Boolean/ArrayItem.php
@@ -99,8 +99,10 @@ final class ArrayItem implements Mutator
         return
             // __get() can have side-effects
             $node instanceof Node\Expr\PropertyFetch
+            || $node instanceof Node\Expr\NullsafePropertyFetch
             // these clearly can have side-effects
             || $node instanceof Node\Expr\MethodCall
+            || $node instanceof Node\Expr\NullsafeMethodCall
             || $node instanceof Node\Expr\FuncCall;
     }
 }

--- a/tests/phpunit/Mutator/Boolean/ArrayItemTest.php
+++ b/tests/phpunit/Mutator/Boolean/ArrayItemTest.php
@@ -69,6 +69,21 @@ final class ArrayItemTest extends BaseMutatorTestCase
             ,
         ];
 
+        yield 'It mutates double arrow operator to a greater than comparison when operands can have side-effects and right is null safe property' => [
+            <<<'PHP'
+                <?php
+
+                [$a => $b?->bar];
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                [$a > $b?->bar];
+                PHP
+            ,
+        ];
+
         yield 'It mutates double arrow operator to a greater than comparison when operands can have side-effects and left is method call' => [
             <<<'PHP'
                 <?php
@@ -80,6 +95,21 @@ final class ArrayItemTest extends BaseMutatorTestCase
                 <?php
 
                 [$a->foo() > $b->bar()];
+                PHP
+            ,
+        ];
+
+        yield 'It mutates double arrow operator to a greater than comparison when operands can have side-effects and right is null safe method call' => [
+            <<<'PHP'
+                <?php
+
+                [$a => $b?->bar()];
+                PHP
+            ,
+            <<<'PHP'
+                <?php
+
+                [$a > $b?->bar()];
                 PHP
             ,
         ];


### PR DESCRIPTION
before this PR we missed to mutate null-safe variants