### PR TITLE
Make ArrayItem mutator less evil

### DIFF
--- a/src/Mutator/Boolean/ArrayItem.php
+++ b/src/Mutator/Boolean/ArrayItem.php
@@ -56,7 +56,7 @@ final class ArrayItem implements Mutator
             <<<'TXT'
                 Replaces a key-value pair (`[$key => $value]`) array declaration with a value array declaration
                 (`[$key > $value]`) where the key or the value are potentially impure (i.e. have a side-effect);
-                For example `[foo() => $b->bar]`.
+                For example `[$this->foo() => $b->bar]`.
                 TXT
             ,
             MutatorCategory::SEMANTIC_REDUCTION,
@@ -97,10 +97,9 @@ final class ArrayItem implements Mutator
     private function isNodeWithSideEffects(Node $node): bool
     {
         return
-            // __get() can have side-effects
+            // __get() can have side effects
             $node instanceof Node\Expr\PropertyFetch
-            // these clearly can have side-effects
-            || $node instanceof Node\Expr\MethodCall
-            || $node instanceof Node\Expr\FuncCall;
+            // only stuff that can have side effects, and can be tested
+            || $node instanceof Node\Expr\MethodCall;
     }
 }

--- a/tests/phpunit/Mutator/Boolean/ArrayItemTest.php
+++ b/tests/phpunit/Mutator/Boolean/ArrayItemTest.php
@@ -84,17 +84,20 @@ final class ArrayItemTest extends BaseMutatorTestCase
             ,
         ];
 
-        yield 'It mutates double arrow operator to a greater than comparison when operands can have side-effects and left is function call' => [
+        yield 'It does not mutate double arrow operator to a greater than comparison when key is function call' => [
             <<<'PHP'
                 <?php
 
                 [foo() => $b->bar];
                 PHP
             ,
+        ];
+
+        yield 'It does not mutate double arrow operator to a greater than comparison when value is function call' => [
             <<<'PHP'
                 <?php
 
-                [foo() > $b->bar];
+                [$b->bar => foo()];
                 PHP
             ,
         ];


### PR DESCRIPTION
This PR:

- [ ] Fixes #2293 by making this mutator less obnoxious for no good reason

I guess I wanted to see if mutating out function calls make sense, and, well, today these mutations are largely a waste of time and better covered by unwrapping mutations.
