### PR TITLE
MutationProcess timeout is based on test-execution time

### DIFF
--- a/src/Process/Factory/MutantProcessContainerFactory.php
+++ b/src/Process/Factory/MutantProcessContainerFactory.php
@@ -49,7 +49,7 @@ use Symfony\Component\Process\Process;
  */
 class MutantProcessContainerFactory
 {
-    private const TIMEOUT_FACTOR = 10;
+    private const TIMEOUT_FACTOR = 5;
 
     private const TEST_FRAMEWORK_BOOTSTRAP_THRESHOLD = 5;
 

--- a/tests/e2e/TimeoutSkipped/expected-output.txt
+++ b/tests/e2e/TimeoutSkipped/expected-output.txt
@@ -4,8 +4,8 @@ Killed by Test Framework: 2
 Killed by Static Analysis: 0
 Errored: 0
 Syntax Errors: 0
-Escaped: 2
-Timed Out: 1
+Escaped: 3
+Timed Out: 0
 Skipped: 0
 Ignored: 0
 Not Covered: 0

--- a/tests/e2e/TimeoutSkipped/expected-output.txt
+++ b/tests/e2e/TimeoutSkipped/expected-output.txt
@@ -4,8 +4,8 @@ Killed by Test Framework: 2
 Killed by Static Analysis: 0
 Errored: 0
 Syntax Errors: 0
-Escaped: 3
-Timed Out: 0
+Escaped: 2
+Timed Out: 1
 Skipped: 0
 Ignored: 0
 Not Covered: 0

--- a/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
+++ b/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
@@ -155,9 +155,9 @@ final class MutantProcessContainerFactoryTest extends TestCase
     public static function timeoutDataProvider(): iterable
     {
         return [
-            'minimum timeout on a fast test' => [5.1, 0.01, 90],
-            'allows 10x more time than test-execution' => [55.0, 5.0, 90],
-            'slow tests do not get more time than factory-timeout' => [90.0, 10.0, 90],
+            'minimum timeout on a fast test' => [5.05, 0.01, 90],
+            'allows 10x more time than test-execution' => [30.0, 5.0, 90],
+            'slow tests do not get more time than factory-timeout' => [40.0, 10.0, 40],
         ];
     }
 }

--- a/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
+++ b/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
@@ -152,7 +152,7 @@ final class MutantProcessContainerFactoryTest extends TestCase
         $this->assertSame([], $eventDispatcher->getEvents());
     }
 
-    public static function timeoutDataProvider(): array
+    public static function timeoutDataProvider(): iterable
     {
         return [
             'minimum timeout is 5' => [5.0, 0.01, 90],

--- a/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
+++ b/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
@@ -155,8 +155,8 @@ final class MutantProcessContainerFactoryTest extends TestCase
     public static function timeoutDataProvider(): iterable
     {
         return [
-            'minimum timeout is 5' => [5.0, 0.01, 90],
-            'allows 10x more time than test-execution' => [50.0, 5.0, 90],
+            'minimum timeout on a fast test' => [5.1, 0.01, 90],
+            'allows 10x more time than test-execution' => [55.0, 5.0, 90],
             'slow tests do not get more time than factory-timeout' => [90.0, 10.0, 90],
         ];
     }

--- a/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
+++ b/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
@@ -156,7 +156,7 @@ final class MutantProcessContainerFactoryTest extends TestCase
     {
         return [
             'minimum timeout on a fast test' => [5.05, 0.01, 90],
-            'allows 10x more time than test-execution' => [30.0, 5.0, 90],
+            'allows 5x more time than test-execution' => [30.0, 5.0, 90],
             'slow tests do not get more time than factory-timeout' => [40.0, 10.0, 40],
         ];
     }


### PR DESCRIPTION
`MutationTestRunner::takingTooLong` is about skipping mutations from which we forsee they will take longer then 30s timeout because we know on average on how long it takes to run the tests in the test-suite (because tests are slow).

thats a independent feature which I don't want to touch.

---

with this PR we use individual timeouts per mutation (instead of a 30s timeout per se) when we actually run the mutation process based on timings we took on initial test run. 

goal is: on "endless running" mutations we will not loose the whole 30 seconds but way less time, 
as we know that the test-suite is usually able to kill the mutation in X seconds and if we take more then e.g. `min('5-times X', 30)` seconds we can stop trying, as we are likely running a endless-loop.

so I try to use shorter timeouts to speedup the overall process.

when we know that tests for `classX::methodY` usually run in 0.0012 seconds, there is no point in waiting 30seconds (atm we wait ~30_000x longer then it usually takes for this method to run a test)

---

PR

```
5649 mutations were generated:
    4344 mutants were killed by Test Framework
       0 mutants were caught by Static Analysis
     165 mutants were configured to be ignored
     571 mutants were not covered by tests
     545 covered mutants were not detected
       8 errors were encountered
       0 syntax errors were encountered
      16 time outs were encountered
       0 mutants required more time than configured

Metrics:
         Mutation Score Indicator (MSI): 79%
         Mutation Code Coverage: 89%
         Covered Code MSI: 88%

Time: 2m 36s. Memory: 0.19GB. Threads: 8
```

---

Before PR:

```
5645 mutations were generated:
    4341 mutants were killed by Test Framework
       0 mutants were caught by Static Analysis
     165 mutants were configured to be ignored
     571 mutants were not covered by tests
     544 covered mutants were not detected
       8 errors were encountered
       0 syntax errors were encountered
      16 time outs were encountered
       0 mutants required more time than configured

Time: 3m 9s. Memory: 0.18GB. Threads: 8
```

closes https://github.com/infection/infection/pull/2180

relates to https://github.com/infection/infection/issues/2192