### PR TITLE
Test forgotten PhpStan value object

### DIFF
--- a/tests/phpunit/Configuration/ConfigurationAssertions.php
+++ b/tests/phpunit/Configuration/ConfigurationAssertions.php
@@ -122,6 +122,8 @@ trait ConfigurationAssertions
             $expectedPhpUnit->getConfigDir(),
             $expectedPhpUnit->getCustomPath(),
         );
+        $this->assertSame($expectedPhpStan->getConfigDir(), $configuration->getPhpStan()->getConfigDir());
+        $this->assertSame($expectedPhpStan->getCustomPath(), $configuration->getPhpStan()->getCustomPath());
         $this->assertEqualsWithDelta($expectedMutators, $configuration->getMutators(), 10.);
         $this->assertSame($expectedTestFramework, $configuration->getTestFramework());
         $this->assertSame($expectedBootstrap, $configuration->getBootstrap());

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -291,7 +291,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -853,7 +853,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -963,7 +963,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/config/phpunit-dir',
                 'config/phpunit',
             ),
-            new PhpStan('config/phpunit-dir', 'bin/phpstan'),
+            new PhpStan('/path/to/config/phpstan-dir', 'bin/phpstan'),
             (static fn (): array => [
                 'TrueValue' => new TrueValue(new TrueValueConfig([])),
             ])(),
@@ -1075,7 +1075,7 @@ final class ConfigurationFactoryTest extends TestCase
                 '/path/to/config/phpunit-dir',
                 'config/phpunit',
             ),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             (static fn (): array => [
                 'CustomMutator' => new CustomMutator(),
             ])(),
@@ -1161,7 +1161,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -1245,7 +1245,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             $expectedTmpDir,
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -1265,7 +1265,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             MapSourceClassToTestStrategy::SIMPLE,
             null,
-            StaticAnalysisToolTypes::PHPSTAN,
+            null, // static analysis tool
             null, // $mutantId
         ];
     }
@@ -1330,7 +1330,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -1414,7 +1414,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit($expectedPhpUnitConfigDir, null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -1499,7 +1499,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -1597,7 +1597,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -1706,7 +1706,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -1746,7 +1746,7 @@ final class ConfigurationFactoryTest extends TestCase
                 Logs::createEmpty(),
                 '',
                 new PhpUnit('/path/to', null),
-                new PhpStan(null, null),
+                new PhpStan('/path/to', null),
                 $ignoreMsiWithNoMutationsFromSchemaConfiguration,
                 null,
                 null,
@@ -1791,7 +1791,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -1811,7 +1811,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             MapSourceClassToTestStrategy::SIMPLE,
             null,
-            StaticAnalysisToolTypes::PHPSTAN,
+            null, // static analysis tool
             null, // $mutantId
         ];
     }
@@ -1831,7 +1831,7 @@ final class ConfigurationFactoryTest extends TestCase
                 Logs::createEmpty(),
                 '',
                 new PhpUnit('/path/to', null),
-                new PhpStan(null, null),
+                new PhpStan('/path/to', null),
                 null,
                 $minMsiFromSchemaConfiguration,
                 null,
@@ -1876,7 +1876,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -1896,7 +1896,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             MapSourceClassToTestStrategy::SIMPLE,
             null,
-            StaticAnalysisToolTypes::PHPSTAN,
+            null, // static analysis tool
             null, // $mutantId
         ];
     }
@@ -1916,7 +1916,7 @@ final class ConfigurationFactoryTest extends TestCase
                 Logs::createEmpty(),
                 '',
                 new PhpUnit('/path/to', null),
-                new PhpStan(null, null),
+                new PhpStan('/path/to', null),
                 null,
                 null,
                 $minCoveredMsiFromSchemaConfiguration,
@@ -1961,7 +1961,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -1981,7 +1981,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             null, // MapSourceClassToTestStrategy::SIMPLE,
             null,
-            StaticAnalysisToolTypes::PHPSTAN,
+            null, // static analysis tool
             null, // $mutantId
         ];
     }
@@ -2047,7 +2047,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             $expectedTestFramework,
             null,
@@ -2067,7 +2067,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             MapSourceClassToTestStrategy::SIMPLE,
             null,
-            StaticAnalysisToolTypes::PHPSTAN,
+            null, // static analysis tool
             null, // $mutantId
         ];
     }
@@ -2132,7 +2132,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -2152,7 +2152,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             MapSourceClassToTestStrategy::SIMPLE,
             null,
-            StaticAnalysisToolTypes::PHPSTAN,
+            null, // static analysis tool
             null, // $mutantId
         ];
     }
@@ -2218,7 +2218,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             $configTestFramework,
             null,
@@ -2238,7 +2238,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             MapSourceClassToTestStrategy::SIMPLE,
             null,
-            StaticAnalysisToolTypes::PHPSTAN,
+            null, // static analysis tool
             null, // $mutantId
         ];
     }
@@ -2303,7 +2303,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             $configTestFramework,
             null,
@@ -2323,7 +2323,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             MapSourceClassToTestStrategy::SIMPLE,
             null,
-            StaticAnalysisToolTypes::PHPSTAN,
+            null, // static analysis tool
             null, // $mutantId
         ];
     }
@@ -2394,7 +2394,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             $expectedMutators,
             'phpunit',
             null,
@@ -2414,7 +2414,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             MapSourceClassToTestStrategy::SIMPLE,
             null,
-            StaticAnalysisToolTypes::PHPSTAN,
+            null, // static analysis tool
             null, // $mutantId
         ];
     }
@@ -2482,7 +2482,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             [
                 'MethodCallRemoval' => new MethodCallRemoval(),
             ],
@@ -2504,7 +2504,7 @@ final class ConfigurationFactoryTest extends TestCase
             false,
             MapSourceClassToTestStrategy::SIMPLE,
             null,
-            StaticAnalysisToolTypes::PHPSTAN,
+            null, // static analysis tool
             null, // $mutantId
         ];
     }
@@ -2590,7 +2590,7 @@ final class ConfigurationFactoryTest extends TestCase
             'none',
             sys_get_temp_dir() . '/infection',
             new PhpUnit('/path/to', null),
-            new PhpStan(null, null),
+            new PhpStan('/path/to', null),
             self::getDefaultMutators(),
             'phpunit',
             null,
@@ -2610,7 +2610,7 @@ final class ConfigurationFactoryTest extends TestCase
             true,
             MapSourceClassToTestStrategy::SIMPLE,
             null,
-            StaticAnalysisToolTypes::PHPSTAN,
+            null, // static analysis tool
             null, // $mutantId
         ];
     }


### PR DESCRIPTION
Found that I forgot to add PHPStan value object to assertions, and tests were incorrect because of this. Fixed.

<img width="324" alt="image" src="https://github.com/user-attachments/assets/461137f9-db6c-42b9-8b6e-8b7a920cdb09" />
