### PR TITLE
Add threads=max to infection.json5

### DIFF
--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -58,7 +58,6 @@ jobs:
               run: |
                   git fetch origin $GITHUB_BASE_REF
                   php bin/infection \
-                    --threads=max \
                     --git-diff-lines \
                     --git-diff-base=origin/$GITHUB_BASE_REF \
                     --ignore-msi-with-no-mutations \

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -77,7 +77,7 @@ jobs:
         env:
           INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
         run: |
-          php bin/infection --threads=max \
+          php bin/infection \
             --skip-initial-tests \
             --min-msi=$MIN_MSI \
             --min-covered-msi=$MIN_COVERED_MSI \

--- a/infection.json5
+++ b/infection.json5
@@ -1,6 +1,7 @@
 {
     "$schema": "./resources/schema.json",
     "timeout": 25,
+    "threads": "max",
     "source": {
         "directories": [
             "src"


### PR DESCRIPTION
It doesn't make sense to run Infection with 1 thread (default) as we have 5k+ mutants

we don't need to pass it as cli option anymore

before

```
bin/infection --threads=max
```

after:

```
bin/infection
```

if you want to override it, just use

```
bin/infection --threads=<any value>
```
