### PR TITLE
Use executionOrder="defects,random" for phpunit.xml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
-        "phpunit/phpunit": "^11.5",
+        "phpunit/phpunit": "^11.5.27",
         "rector/rector": "^2.0",
         "shipmonk/dead-code-detector": "^0.12.0",
         "shipmonk/name-collision-detector": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5760d86d18980706408db12f2aa74019",
+    "content-hash": "c11a530ef16cba1d69e81aa8046ee196",
     "packages": [
         {
             "name": "colinodell/json5",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
          xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
          colors="true"
-         executionOrder="random"
+         executionOrder="defects,random"
          failOnWarning="true"
          failOnRisky="true"
          requireCoverageMetadata="true"


### PR DESCRIPTION
when re-running a test-suite which failed before it makes a lot of sense to run the previously failed tests first.
that way we validate whether the already known problems are gone and in addition we also shorten the feedback loop.


extracted from https://github.com/infection/infection/pull/2267