### PR TITLE
Update the pipeline library to version 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "ondram/ci-detector": "^4.1.0",
         "sanmai/duoclock": "^0.1.0",
         "sanmai/later": "^0.1.7",
-        "sanmai/pipeline": "^6.16",
+        "sanmai/pipeline": "^6.22 || ^7.0",
         "sebastian/diff": "^3.0.2 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "symfony/console": "^6.4 || ^7.0",
         "symfony/filesystem": "^6.4 || ^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c11a530ef16cba1d69e81aa8046ee196",
+    "content-hash": "3b42b76d28c6aecd4728517f0c1dd3d6",
     "packages": [
         {
             "name": "colinodell/json5",
@@ -1084,16 +1084,16 @@
         },
         {
             "name": "sanmai/pipeline",
-            "version": "6.21",
+            "version": "7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sanmai/pipeline.git",
-                "reference": "6d729c0b0c662010d84cdea9b99f90a65ae4cf5e"
+                "reference": "b760e0f670555507fbdd0659f739f2ccf625a052"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/6d729c0b0c662010d84cdea9b99f90a65ae4cf5e",
-                "reference": "6d729c0b0c662010d84cdea9b99f90a65ae4cf5e",
+                "url": "https://api.github.com/repos/sanmai/pipeline/zipball/b760e0f670555507fbdd0659f739f2ccf625a052",
+                "reference": "b760e0f670555507fbdd0659f739f2ccf625a052",
                 "shasum": ""
             },
             "require": {
@@ -1101,6 +1101,7 @@
             },
             "require-dev": {
                 "ergebnis/composer-normalize": "^2.8",
+                "esi/phpunit-coverage-check": ">2",
                 "friendsofphp/php-cs-fixer": "^3.17",
                 "infection/infection": ">=0.30.3",
                 "league/pipeline": "^0.3 || ^1.0",
@@ -1109,6 +1110,7 @@
                 "phpstan/phpstan": "^2",
                 "phpunit/phpunit": ">=9.4 <12",
                 "sanmai/phpstan-rules": "^0.3.0",
+                "sanmai/phpunit-double-colon-syntax": "^0.1.1",
                 "vimeo/psalm": ">=2"
             },
             "type": "library",
@@ -1138,7 +1140,7 @@
             "description": "General-purpose collections pipeline",
             "support": {
                 "issues": "https://github.com/sanmai/pipeline/issues",
-                "source": "https://github.com/sanmai/pipeline/tree/6.21"
+                "source": "https://github.com/sanmai/pipeline/tree/7.0"
             },
             "funding": [
                 {
@@ -1146,7 +1148,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-16T04:06:56+00:00"
+            "time": "2025-07-23T10:09:26+00:00"
         },
         {
             "name": "sebastian/diff",


### PR DESCRIPTION
This PR:

- [x] Updates sanmai/pipeline to version 7

This is a major version bump because of a [pair of breaking changes](https://github.com/sanmai/pipeline/pull/232):
 - `toArrayPreservingKeys` is gone in favor `toAssoc` (the former has been deprecated for a while)
 -  `toArray` now require a parameter

We do not use either methods, I replaced them earlier with `toList` and `toAssoc`.