### PR TITLE
Kill timed out mutants in `DiffColorizer`

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -19,6 +19,18 @@ parameters:
 			path: ../src/Container.php
 
 		-
+			message: '#^Variable \$end might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: ../src/Differ/DiffColorizer.php
+
+		-
+			message: '#^Variable \$start might not be defined\.$#'
+			identifier: variable.undefined
+			count: 3
+			path: ../src/Differ/DiffColorizer.php
+
+		-
 			message: '#^Parameter \#1 \$iterator of class Symfony\\Component\\Finder\\Iterator\\PathFilterIterator constructor expects Iterator\<string, Symfony\\Component\\Finder\\SplFileInfo\>, Iterator\<mixed, Infection\\TestFramework\\Coverage\\Trace\|SplFileInfo\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Differ/DiffColorizer.php
+++ b/src/Differ/DiffColorizer.php
@@ -105,10 +105,10 @@ class DiffColorizer
             }
         }
 
-        $end = $start;
-
-        while ($end < $previousLineLength && mb_strrpos($nextLine, $t = mb_substr($previousLine, $end), $start) !== ($nextLineLength - mb_strlen($t))) {
-            ++$end;
+        for ($end = $start; $end < $previousLineLength; ++$end) {
+            if (mb_strrpos($nextLine, $t = mb_substr($previousLine, $end), $start) === ($nextLineLength - mb_strlen($t))) {
+                break;
+            }
         }
 
         $return = $previousLine;

--- a/src/Differ/DiffColorizer.php
+++ b/src/Differ/DiffColorizer.php
@@ -99,10 +99,10 @@ class DiffColorizer
         $previousLineLength = mb_strlen($previousLine);
         $nextLineLength = mb_strlen($nextLine);
 
-        $start = $previousLineLength;
-
-        while ($start !== 0 && mb_strpos($nextLine, mb_substr($previousLine, 0, $start)) !== 0) {
-            --$start;
+        for ($start = $previousLineLength; $start !== 0; --$start) {
+            if (mb_strpos($nextLine, mb_substr($previousLine, 0, $start)) === 0) {
+                break;
+            }
         }
 
         $end = $start;

--- a/src/Differ/DiffColorizer.php
+++ b/src/Differ/DiffColorizer.php
@@ -106,7 +106,8 @@ class DiffColorizer
         }
 
         for ($end = $start; $end < $previousLineLength; ++$end) {
-            if (mb_strrpos($nextLine, $t = mb_substr($previousLine, $end), $start) === ($nextLineLength - mb_strlen($t))) {
+            $t = mb_substr($previousLine, $end);
+            if (mb_strrpos($nextLine, $t, $start) === ($nextLineLength - mb_strlen($t))) {
                 break;
             }
         }

--- a/src/Differ/DiffColorizer.php
+++ b/src/Differ/DiffColorizer.php
@@ -107,6 +107,7 @@ class DiffColorizer
 
         for ($end = $start; $end < $previousLineLength; ++$end) {
             $t = mb_substr($previousLine, $end);
+
             if (mb_strrpos($nextLine, $t, $start) === ($nextLineLength - mb_strlen($t))) {
                 break;
             }


### PR DESCRIPTION
run `php bin/infection --filter=src/Differ/DiffColorizer.php`..

before this PR:

```
79 mutations were generated:
      60 mutants were killed by Test Framework
       5 mutants were configured to be ignored
       9 covered mutants were not detected
       5 time outs were encountered
```

after this PR:
```
73 mutations were generated:
      59 mutants were killed by Test Framework
       5 mutants were configured to be ignored
       9 covered mutants were not detected
```

=> killed 5 timeouts

---

running infection with `php bin/infection --threads=2 --filter=src/Differ/DiffColorizer.php` (2 threads as the GitHub Actions do it)

before: `Time: 36s. Memory: 18.00MB. Threads: 2`
after: `Time: 22s. Memory: 18.00MB. Threads: 2`
