### PR TITLE
Fix "Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect"

### DIFF
--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
@@ -94,9 +94,6 @@ final class SchemaConfigurationFileTest extends TestCase
 
         $decodedContentsReflection = (new ReflectionClass(
             SchemaConfigurationFile::class))->getProperty('decodedContents');
-        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
-            $decodedContentsReflection->setAccessible(true);
-        }
         $decodedContentsReflection->setValue($config, $expectedValue);
 
         $this->assertSame($expectedValue, $config->getDecodedContents());

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
@@ -94,7 +94,9 @@ final class SchemaConfigurationFileTest extends TestCase
 
         $decodedContentsReflection = (new ReflectionClass(
             SchemaConfigurationFile::class))->getProperty('decodedContents');
-        $decodedContentsReflection->setAccessible(true);
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            $decodedContentsReflection->setAccessible(true);
+        }
         $decodedContentsReflection->setValue($config, $expectedValue);
 
         $this->assertSame($expectedValue, $config->getDecodedContents());

--- a/tests/phpunit/Configuration/Schema/SchemaValidatorTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaValidatorTest.php
@@ -170,7 +170,9 @@ final class SchemaValidatorTest extends TestCase
         $configReflection = new ReflectionClass(SchemaConfigurationFile::class);
 
         $decodedContentsReflection = $configReflection->getProperty('decodedContents');
-        $decodedContentsReflection->setAccessible(true);
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            $decodedContentsReflection->setAccessible(true);
+        }
         $decodedContentsReflection->setValue($config, $decodedContents);
 
         return $config;

--- a/tests/phpunit/Configuration/Schema/SchemaValidatorTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaValidatorTest.php
@@ -170,9 +170,6 @@ final class SchemaValidatorTest extends TestCase
         $configReflection = new ReflectionClass(SchemaConfigurationFile::class);
 
         $decodedContentsReflection = $configReflection->getProperty('decodedContents');
-        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
-            $decodedContentsReflection->setAccessible(true);
-        }
         $decodedContentsReflection->setValue($config, $decodedContents);
 
         return $config;

--- a/tests/phpunit/Logger/FileLoggerFactoryTest.php
+++ b/tests/phpunit/Logger/FileLoggerFactoryTest.php
@@ -337,10 +337,6 @@ final class FileLoggerFactoryTest extends TestCase
         $this->assertInstanceOf(FederatedLogger::class, $logger);
 
         $loggersReflection = (new ReflectionClass(FederatedLogger::class))->getProperty('loggers');
-        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
-            $loggersReflection->setAccessible(true);
-        }
-
         $loggers = $loggersReflection->getValue($logger);
 
         $fileLoggerDecoratedLogger = (new ReflectionClass(FileLogger::class))->getProperty('lineLogger');

--- a/tests/phpunit/Logger/FileLoggerFactoryTest.php
+++ b/tests/phpunit/Logger/FileLoggerFactoryTest.php
@@ -340,9 +340,6 @@ final class FileLoggerFactoryTest extends TestCase
         $loggers = $loggersReflection->getValue($logger);
 
         $fileLoggerDecoratedLogger = (new ReflectionClass(FileLogger::class))->getProperty('lineLogger');
-        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
-            $fileLoggerDecoratedLogger->setAccessible(true);
-        }
 
         $actualLoggerClasses = array_map(
             static function ($logger) use ($fileLoggerDecoratedLogger): string {

--- a/tests/phpunit/Logger/FileLoggerFactoryTest.php
+++ b/tests/phpunit/Logger/FileLoggerFactoryTest.php
@@ -337,12 +337,16 @@ final class FileLoggerFactoryTest extends TestCase
         $this->assertInstanceOf(FederatedLogger::class, $logger);
 
         $loggersReflection = (new ReflectionClass(FederatedLogger::class))->getProperty('loggers');
-        $loggersReflection->setAccessible(true);
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            $loggersReflection->setAccessible(true);
+        }
 
         $loggers = $loggersReflection->getValue($logger);
 
         $fileLoggerDecoratedLogger = (new ReflectionClass(FileLogger::class))->getProperty('lineLogger');
-        $fileLoggerDecoratedLogger->setAccessible(true);
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            $fileLoggerDecoratedLogger->setAccessible(true);
+        }
 
         $actualLoggerClasses = array_map(
             static function ($logger) use ($fileLoggerDecoratedLogger): string {

--- a/tests/phpunit/Mutator/MutatorFactoryTest.php
+++ b/tests/phpunit/Mutator/MutatorFactoryTest.php
@@ -199,7 +199,9 @@ final class MutatorFactoryTest extends TestCase
         $this->assertCount(count($expectedMutatorClassNames), $actualMutators);
 
         $decoratedMutatorReflection = (new ReflectionClass(IgnoreMutator::class))->getProperty('mutator');
-        $decoratedMutatorReflection->setAccessible(true);
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            $decoratedMutatorReflection->setAccessible(true);
+        }
 
         foreach (array_values($actualMutators) as $index => $mutator) {
             $this->assertInstanceOf(Mutator::class, $mutator);

--- a/tests/phpunit/Mutator/MutatorFactoryTest.php
+++ b/tests/phpunit/Mutator/MutatorFactoryTest.php
@@ -199,10 +199,6 @@ final class MutatorFactoryTest extends TestCase
         $this->assertCount(count($expectedMutatorClassNames), $actualMutators);
 
         $decoratedMutatorReflection = (new ReflectionClass(IgnoreMutator::class))->getProperty('mutator');
-        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
-            $decoratedMutatorReflection->setAccessible(true);
-        }
-
         foreach (array_values($actualMutators) as $index => $mutator) {
             $this->assertInstanceOf(Mutator::class, $mutator);
 

--- a/tests/phpunit/Mutator/MutatorFactoryTest.php
+++ b/tests/phpunit/Mutator/MutatorFactoryTest.php
@@ -199,6 +199,7 @@ final class MutatorFactoryTest extends TestCase
         $this->assertCount(count($expectedMutatorClassNames), $actualMutators);
 
         $decoratedMutatorReflection = (new ReflectionClass(IgnoreMutator::class))->getProperty('mutator');
+
         foreach (array_values($actualMutators) as $index => $mutator) {
             $this->assertInstanceOf(Mutator::class, $mutator);
 

--- a/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php
+++ b/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php
@@ -153,9 +153,6 @@ final class AbstractValueToNullReturnValueTest extends TestCase
     private function invokeMethod(Node $mockNode)
     {
         $reflectionMethod = new ReflectionMethod(AbstractValueToNullReturnValue::class, 'isNullReturnValueAllowed');
-        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
-            $reflectionMethod->setAccessible(true);
-        }
 
         return $reflectionMethod->invoke($this->testSubject, $mockNode);
     }

--- a/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php
+++ b/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php
@@ -153,7 +153,9 @@ final class AbstractValueToNullReturnValueTest extends TestCase
     private function invokeMethod(Node $mockNode)
     {
         $reflectionMethod = new ReflectionMethod(AbstractValueToNullReturnValue::class, 'isNullReturnValueAllowed');
-        $reflectionMethod->setAccessible(true);
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            $reflectionMethod->setAccessible(true);
+        }
 
         return $reflectionMethod->invoke($this->testSubject, $mockNode);
     }


### PR DESCRIPTION
fixes

```
10 tests triggered 2 PHP deprecations:

1) /home/runner/work/infection/infection/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php:156
Method ReflectionMethod::setAccessible() is deprecated since 8.5, as it has no effect

Triggered by:

* Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::test_attribute_not_found
  /home/runner/work/infection/infection/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php:60

* Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::test_return_type_is_node_identifier
  /home/runner/work/infection/infection/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php:65

* Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::test_return_type_is_node_name
  /home/runner/work/infection/infection/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php:102

* Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::test_return_type_is_not_node_name
  /home/runner/work/infection/infection/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php:115

* Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::test_return_type_is_nullable
  /home/runner/work/infection/infection/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php:89

* Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::test_return_type_is_scalar_typehint
  /home/runner/work/infection/infection/tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php:78

2) /home/runner/work/infection/infection/tests/phpunit/Mutator/MutatorFactoryTest.php:202
Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect
```

`setAccessible` is a no-op since 8.1 - see https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
