### PR TITLE
Fix PHPUnit 9.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "sanmai/duoclock": "^0.1.0",
         "sanmai/later": "^0.1.7",
         "sanmai/pipeline": "^7.0",
-        "sebastian/diff": "^6.0 || ^7.0",
+        "sebastian/diff": "^5.0 || ^6.0 || ^7.0",
         "symfony/console": "^6.4 || ^7.0",
         "symfony/filesystem": "^6.4 || ^7.0",
         "symfony/finder": "^6.4 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "sanmai/duoclock": "^0.1.0",
         "sanmai/later": "^0.1.7",
         "sanmai/pipeline": "^7.0",
-        "sebastian/diff": "^5.0 || ^6.0 || ^7.0",
+        "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
         "symfony/console": "^6.4 || ^7.0",
         "symfony/filesystem": "^6.4 || ^7.0",
         "symfony/finder": "^6.4 || ^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b700af13cae7f39a37a02e4b8e870866",
+    "content-hash": "a64fa1f2c3f57b00ada6f8b7ff180247",
     "packages": [
         {
             "name": "colinodell/json5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "40f2b515d4d8b9b7fdc85df84f03c0de",
+    "content-hash": "b700af13cae7f39a37a02e4b8e870866",
     "packages": [
         {
             "name": "colinodell/json5",

--- a/tests/e2e/Without_Git/composer.json
+++ b/tests/e2e/Without_Git/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^10",
+        "phpunit/phpunit": "^9",
         "infection/infection": "dev-master"
     },
     "autoload": {

--- a/tests/e2e/Without_Git/composer.json
+++ b/tests/e2e/Without_Git/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^9.6.20",
+        "phpunit/phpunit": "^11",
         "infection/infection": "dev-master"
     },
     "autoload": {

--- a/tests/e2e/Without_Git/composer.json
+++ b/tests/e2e/Without_Git/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^11",
+        "phpunit/phpunit": "^10",
         "infection/infection": "dev-master"
     },
     "autoload": {

--- a/tests/e2e/Without_Git/composer.json
+++ b/tests/e2e/Without_Git/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^9.6.20",
         "infection/infection": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
the tested started failling because with https://github.com/infection/infection/pull/2366 we no longer allow old sebastian/diff releases which in turn are required for old phpunit (unintentional side-effect)