### PR TITLE
fix: Rename the exclude parameter of the SourceFileCollector

### DIFF
--- a/src/FileSystem/SourceFileCollector.php
+++ b/src/FileSystem/SourceFileCollector.php
@@ -47,13 +47,13 @@ class SourceFileCollector
 {
     /**
      * @param string[] $sourceDirectories
-     * @param string[] $excludeDirectories
+     * @param string[] $excludedFilesOrDirectories
      *
      * @return iterable<SplFileInfo>
      */
     public function collectFiles(
         array $sourceDirectories,
-        array $excludeDirectories,
+        array $excludedFilesOrDirectories,
     ): iterable {
         if ($sourceDirectories === []) {
             return [];
@@ -61,8 +61,8 @@ class SourceFileCollector
 
         return Finder::create()
             ->in($sourceDirectories)
-            ->exclude($excludeDirectories)
-            ->notPath($excludeDirectories)
+            ->exclude($excludedFilesOrDirectories)
+            ->notPath($excludedFilesOrDirectories)
             ->files()
             ->name('*.php')
         ;

--- a/tests/phpunit/FileSystem/SourceFileCollectorTest.php
+++ b/tests/phpunit/FileSystem/SourceFileCollectorTest.php
@@ -54,11 +54,11 @@ final class SourceFileCollectorTest extends TestCase
     private const FIXTURES = __DIR__ . '/../Fixtures/Files/SourceFileCollector';
 
     #[DataProvider('sourceFilesProvider')]
-    public function test_it_can_collect_files(array $sourceDirectories, array $excludedFiles, array $expected): void
+    public function test_it_can_collect_files(array $sourceDirectories, array $excludedFilesOrDirectories, array $expected): void
     {
         $root = self::FIXTURES;
 
-        $files = (new SourceFileCollector())->collectFiles($sourceDirectories, $excludedFiles);
+        $files = (new SourceFileCollector())->collectFiles($sourceDirectories, $excludedFilesOrDirectories);
 
         $files = take($files)->toList();
 


### PR DESCRIPTION
This parameter was named `$excludeDirectories` but it is incorrect as we allow, use and document files too.

This PR renames this parameter to avoid further confusion.
