### PR TITLE
fix: Make the source file collector yield a list

### DIFF
--- a/src/FileSystem/SourceFileCollector.php
+++ b/src/FileSystem/SourceFileCollector.php
@@ -59,12 +59,16 @@ class SourceFileCollector
             return [];
         }
 
-        return Finder::create()
+        $files = Finder::create()
             ->in($sourceDirectories)
             ->exclude($excludedFilesOrDirectories)
             ->notPath($excludedFilesOrDirectories)
             ->files()
             ->name('*.php')
         ;
+
+        foreach ($files as $file) {
+            yield $file;
+        }
     }
 }

--- a/tests/phpunit/FileSystem/SourceFileCollector/SourceFileCollectorTest.php
+++ b/tests/phpunit/FileSystem/SourceFileCollector/SourceFileCollectorTest.php
@@ -63,7 +63,7 @@ final class SourceFileCollectorTest extends TestCase
 
         $files = (new SourceFileCollector())->collectFiles($sourceDirectories, $excludedFilesOrDirectories);
 
-        $files = take($files)->toList();
+        $files = take($files)->toAssoc();
 
         $this->assertSame(
             $expected,


### PR DESCRIPTION
In `Infection\TestFramework\Factory`, we have:

```php
/**
 * Get only those source files that will be mutated to use them in coverage whitelist
 *
 * @return list<SplFileInfo>
 */
private function getFilteredSourceFilesToMutate(): array
{
    if ($this->sourceFileFilter->getFilters() === []) {
        return [];
    }

    /** @var list<SplFileInfo> $files */
    $files = iterator_to_array($this->sourceFileFilter->filter($this->infectionConfig->getSourceFiles()));

    return $files;
}
```

And the test in `SourceFileCollectorTest` was hitting at least that it was desired that the yielded values of `SourceFileCollector` would give a list.

However, the unit test was incorrect, as `take($files)->toList()`, as you can imagine, gives a list, regardless of what the yielded keys are.

I am not 100% sure we should update the downstream code or make explicit that `SourceFileCollector` yields a `iterable<string, SplFileInfo>` instead. Neither do I think that this is an error that PHPStan can capture (I could not find anything about PHPStan checking iterables for _lists_, i.e. yielding an iterable with guarantee that no value is lost due to a duplicate key).

Either way, I think this is a (minor) problem, I'm happy to adjust the PR to fix it the other way around if you prefer.