### PR TITLE
refactor: Simplify the source filtering API

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -490,18 +490,37 @@ final class RunCommand extends BaseCommand
         $gitDiffBase = $input->getOption(self::OPTION_GIT_DIFF_BASE);
 
         if ($isForGitDiffLines && $gitDiffFilter !== Container::DEFAULT_GIT_DIFF_FILTER) {
-            throw new InvalidArgumentException(sprintf('Cannot pass both "--%s" and "--%s" options: use none or only one of them', self::OPTION_GIT_DIFF_LINES, self::OPTION_GIT_DIFF_FILTER));
+            throw new InvalidArgumentException(
+                sprintf(
+                    'The options "--%s" and "--%s" are mutually exclusive. Please use only one of them.',
+                    self::OPTION_GIT_DIFF_LINES,
+                    self::OPTION_GIT_DIFF_FILTER,
+                ),
+            );
         }
 
         if ($gitDiffBase !== Container::DEFAULT_GIT_DIFF_BASE && $gitDiffFilter === Container::DEFAULT_GIT_DIFF_FILTER && $isForGitDiffLines === Container::DEFAULT_GIT_DIFF_LINES) {
-            throw new InvalidArgumentException(sprintf('Cannot pass "--%s" without "--%s"', self::OPTION_GIT_DIFF_BASE, self::OPTION_GIT_DIFF_FILTER));
+            throw new InvalidArgumentException(
+                sprintf(
+                    'The option "--%s" cannot be used without the option "--%s" or "--%s".',
+                    self::OPTION_GIT_DIFF_BASE,
+                    self::OPTION_GIT_DIFF_LINES,
+                    self::OPTION_GIT_DIFF_FILTER,
+                ),
+            );
         }
 
         $filter = trim((string) $input->getOption(self::OPTION_FILTER));
 
         if ($filter !== '' && $gitDiffFilter !== Container::DEFAULT_GIT_DIFF_BASE) {
             throw new InvalidArgumentException(
-                sprintf('Cannot pass both "--%s" and "--%s" options: use none or only one of them', self::OPTION_FILTER, self::OPTION_GIT_DIFF_FILTER),
+                sprintf(
+                    'The options "--%s" and "--%s" are mutually exclusive. Use "--%s" for regular filtering or "--%s" for Git-based filtering.',
+                    self::OPTION_FILTER,
+                    self::OPTION_GIT_DIFF_FILTER,
+                    self::OPTION_FILTER,
+                    self::OPTION_GIT_DIFF_FILTER,
+                ),
             );
         }
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -37,6 +37,8 @@ namespace Infection\Configuration;
 
 use function array_map;
 use function explode;
+use Infection\Configuration\Entry\GitOptions;
+use Infection\Configuration\Entry\GitSource;
 use Infection\Configuration\Entry\Logs;
 use Infection\Configuration\Entry\PhpStan;
 use Infection\Configuration\Entry\PhpUnit;
@@ -89,7 +91,8 @@ class Configuration
         float $timeout,
         array $sourceDirectories,
         private readonly iterable $sourceFiles,
-        private readonly string $sourceFilesFilter,
+        private readonly ?string $sourceFilter,
+        public readonly ?GitSource $gitSource,
         private readonly array $sourceFilesExcludes,
         private readonly Logs $logs,
         string $logVerbosity,
@@ -117,8 +120,6 @@ class Configuration
         private readonly bool $dryRun,
         private readonly array $ignoreSourceCodeMutatorsMap,
         private readonly bool $executeOnlyCoveringTestCases,
-        private readonly bool $isForGitDiffLines,
-        private readonly ?string $gitDiffBase,
         private readonly ?string $mapSourceClassToTestStrategy,
         private readonly ?string $loggerProjectRootDirectory,
         ?string $staticAnalysisTool,
@@ -164,9 +165,9 @@ class Configuration
         return $this->sourceFiles;
     }
 
-    public function getSourceFilesFilter(): string
+    public function getSourceFilter(): string|GitOptions|null
     {
-        return $this->sourceFilesFilter;
+        return $this->sourceFilter;
     }
 
     /**
@@ -332,12 +333,16 @@ class Configuration
 
     public function isForGitDiffLines(): bool
     {
-        return $this->isForGitDiffLines;
+        return $this->sourceFilter instanceof GitOptions
+            ? $this->sourceFilter->isForDiffLines
+            : false;
     }
 
     public function getGitDiffBase(): ?string
     {
-        return $this->gitDiffBase;
+        return $this->sourceFilter instanceof GitOptions
+            ? $this->sourceFilter->baseBranch
+            : null;
     }
 
     public function getMapSourceClassToTestStrategy(): ?string

--- a/src/Configuration/Entry/GitOptions.php
+++ b/src/Configuration/Entry/GitOptions.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Configuration\Entry;
+
+use Webmozart\Assert\Assert;
+
+final readonly class GitOptions
+{
+    public function __construct(
+        public ?string $filter,
+        public bool $isForDiffLines,
+        public string $baseBranch,
+    ) {
+        if ($filter === null) {
+            Assert::true($isForDiffLines);
+        } else {
+            Assert::false($isForDiffLines);
+        }
+    }
+}

--- a/src/Configuration/Entry/GitSource.php
+++ b/src/Configuration/Entry/GitSource.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Configuration\Entry;
+
+final readonly class GitSource
+{
+    public function __construct(
+        public string $baseBranch,
+        public bool $isForGitDiffLines,
+    ) {
+    }
+}

--- a/src/Container.php
+++ b/src/Container.php
@@ -236,7 +236,7 @@ final class Container extends DIContainer
     {
         $container = new self([
             IndexXmlCoverageParser::class => static fn (self $container): IndexXmlCoverageParser => new IndexXmlCoverageParser(
-                $container->getConfiguration()->isForGitDiffLines(),
+                $container->getConfiguration()->gitSource?->isForDiffLines ?? false,
             ),
             CoveredTraceProvider::class => static fn (self $container): CoveredTraceProvider => new CoveredTraceProvider(
                 $container->getPhpUnitXmlCoverageTraceProvider(),
@@ -253,7 +253,7 @@ final class Container extends DIContainer
                 $container->getConfiguration()->getSourceFiles(),
             ),
             SourceFileFilter::class => static fn (self $container): SourceFileFilter => new SourceFileFilter(
-                $container->getConfiguration()->getSourceFilesFilter(),
+                $container->getConfiguration()->getSourceFilter(),
                 $container->getConfiguration()->getSourceFilesExcludes(),
             ),
             PhpUnitXmlCoverageTraceProvider::class => static fn (self $container): PhpUnitXmlCoverageTraceProvider => new PhpUnitXmlCoverageTraceProvider(
@@ -441,8 +441,8 @@ final class Container extends DIContainer
                     $container->getNodeTraverserFactory(),
                     $container->getLineRangeCalculator(),
                     $container->getFilesDiffChangedLines(),
-                    $configuration->isForGitDiffLines(),
-                    $configuration->getGitDiffBase(),
+                    $configuration->gitSource?->isForDiffLines ?? false,
+                    $configuration->gitSource?->baseBranch,
                 );
             },
             FileLoggerFactory::class => static function (self $container): FileLoggerFactory {

--- a/src/Logger/GitHub/GitDiffFileProvider.php
+++ b/src/Logger/GitHub/GitDiffFileProvider.php
@@ -95,6 +95,8 @@ class GitDiffFileProvider
 
     /**
      * @param string[] $sourceDirectories
+     *
+     * @return string comma-separated list of the relative (to the git root) file paths
      */
     public function provide(string $gitDiffFilter, string $gitDiffBase, array $sourceDirectories): string
     {

--- a/tests/phpunit/Configuration/ConfigurationAssertions.php
+++ b/tests/phpunit/Configuration/ConfigurationAssertions.php
@@ -104,7 +104,7 @@ trait ConfigurationAssertions
             self::normalizePaths($configuration->getSourceFiles()),
             'Failed sourceFiles check',
         );
-        $this->assertSame($expectedFilter, $configuration->getSourceFilesFilter(), 'Failed sourceFilesFilter check');
+        $this->assertSame($expectedFilter, $configuration->getSourceFilter(), 'Failed sourceFilesFilter check');
         $this->assertSame($expectedSourceFilesExcludes, $configuration->getSourceFilesExcludes(), 'Failed sourceFilesExcludes check');
         $this->assertLogsStateIs(
             $configuration->getLogs(),


### PR DESCRIPTION
Currently, we have 4 separate options to manipulate the filtering/git information. The values of those is simply transferred in various places, which is not ideal when those values can be mutually exclusive.

This PR tries to bring a bit more cohesion whilst making the code easier to read. I'll break down the different kind of changes here:

- Introduce a `GitOptions` value object that is meant to hold the values passed from the options of `RunCommand`.
- Since `filter` and the git options are mutually exclusive, and that we now have unions in PHP, I decided to combine them into a "source filter" parameter.
- For the `Configuration`, we want the filter itself (normal or git-based) and pieces of the git information that is used here and there elsewhere. In other words, for the git options, there is two distinct purposes: the filter, and the rest. To clarify this, the 4 options are combined into two:
  - the resolved filter (whether it was the normal one or a git based one)
  - `GitSource` which contains git related information necessary for other places (unrelated to the filter itself)

TODOs:

- [ ] Depends on #2394 
- [ ] Adjust the tests