### PR TITLE
refactor: Move the filter building into a dedicated class

### DIFF
--- a/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\TestFramework\PhpUnit\CommandLine;
+
+use function array_key_exists;
+use function count;
+use function end;
+use function explode;
+use Infection\AbstractTestFramework\Coverage\TestLocation;
+use function is_numeric;
+use function preg_quote;
+use function sprintf;
+use function version_compare;
+
+/**
+ * @internal
+ */
+final class FilterBuilder
+{
+    private const MAX_EXPLODE_PARTS = 2;
+
+    /**
+     * @param non-empty-array<TestLocation> $tests
+     *
+     * @return list<string>
+     */
+    public static function createFilters(
+        array $tests,
+        string $testFrameworkVersion,
+    ): array {
+        $usedTestCases = [];
+        $filters = [];
+
+        foreach ($tests as $testLocation) {
+            $testCaseString = $testLocation->getMethod();
+
+            $partsDelimitedByColons = explode('::', $testCaseString, self::MAX_EXPLODE_PARTS);
+
+            if (count($partsDelimitedByColons) > 1) {
+                $methodNameWithDataProvider = self::getMethodNameWithDataProvider($partsDelimitedByColons[1], $testFrameworkVersion);
+
+                $testClassFullyQualifiedClassName = $partsDelimitedByColons[0];
+
+                $parts = explode('\\', $testClassFullyQualifiedClassName);
+                $classNameWithoutNamespace = end($parts);
+
+                $testCaseString = sprintf('%s::%s', $classNameWithoutNamespace, $methodNameWithDataProvider);
+            }
+
+            if (array_key_exists($testCaseString, $usedTestCases)) {
+                continue;
+            }
+
+            $usedTestCases[$testCaseString] = true;
+
+            $filter = preg_quote($testCaseString, '/');
+            $filters[] = $filter;
+        }
+
+        return $filters;
+    }
+
+    private static function getMethodNameWithDataProvider(
+        string $methodNameWithDataProvider,
+        string $testFrameworkVersion,
+    ): string {
+        $methodNameWithDataProviderResult = $methodNameWithDataProvider;
+
+        /*
+         * in PHPUnit >=10 data providers with keys are stored as `Class\\test_method#some key` or `Class\\test_method#0`
+         * in PHPUnit <10 data providers with keys are stored as `Class\\test_method with data set "some key"` or `Class\\test_method with data set #0`
+         *
+         * we need to translate to the old format because this is what PHPUnit <10 and >=10 understands from CLI `--filter` option
+         */
+        if (version_compare($testFrameworkVersion, '10', '>=')) {
+            $methodNameParts = explode('#', $methodNameWithDataProviderResult, self::MAX_EXPLODE_PARTS);
+
+            if (count($methodNameParts) > 1) {
+                [$methodName, $dataProviderKey] = $methodNameParts;
+
+                if (!is_numeric($dataProviderKey)) {
+                    $methodNameWithDataProviderResult = sprintf('%s with data set "%s"', $methodName, $dataProviderKey);
+                } else {
+                    $methodNameWithDataProviderResult = sprintf('%s with data set #%s', $methodName, $dataProviderKey);
+                }
+            }
+        }
+
+        return $methodNameWithDataProviderResult;
+    }
+}

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -77,6 +77,7 @@ use Infection\TestFramework\Coverage\NodeLineRangeData;
 use Infection\TestFramework\Coverage\SourceMethodLineRange;
 use Infection\TestFramework\Coverage\TestLocations;
 use Infection\TestFramework\MapSourceClassToTestStrategy;
+use Infection\TestFramework\PhpUnit\CommandLine\FilterBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder as PhpUnitInitalConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder as PhpUnitMutationConfigBuilder;
 use Infection\Testing\BaseMutatorTestCase;
@@ -143,6 +144,7 @@ final class ProjectCodeProvider
      * For example, test cases that are in a child directory.
      */
     public const CONCRETE_CLASSES_WITH_TESTS_IN_DIFFERENT_LOCATION = [
+        FilterBuilder::class,
         SourceFileCollector::class,
     ];
 

--- a/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -36,15 +36,21 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpUnit\CommandLine;
 
 use function array_map;
+use function array_merge;
+use Closure;
 use Generator;
+use function implode;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\TestFramework\PhpUnit\CommandLine\ArgumentsAndOptionsBuilder;
+use Infection\TestFramework\PhpUnit\CommandLine\FilterBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use function sprintf;
 use Symfony\Component\Finder\SplFileInfo;
 
 #[CoversClass(ArgumentsAndOptionsBuilder::class)]
+#[CoversClass(FilterBuilder::class)]
 final class ArgumentsAndOptionsBuilderTest extends TestCase
 {
     public function test_it_can_build_the_command_without_extra_options(): void
@@ -117,8 +123,12 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
     }
 
     #[DataProvider('provideTestCases')]
-    public function test_it_can_build_the_command_with_filter_option_for_covering_tests_for_mutant(bool $executeOnlyCoveringTestCases, array $testCases, string $phpUnitVersion, ?string $expectedFilterOptionValue = null): void
-    {
+    public function test_it_can_build_the_command_with_filter_option_for_covering_tests_for_mutant(
+        bool $executeOnlyCoveringTestCases,
+        array $testCases,
+        string $phpUnitVersion,
+        ?string $expectedFilterOptionValue,
+    ): void {
         $configPath = '/the config/path';
 
         $builder = new ArgumentsAndOptionsBuilder($executeOnlyCoveringTestCases, [], null);
@@ -129,186 +139,393 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
             '--path=/a path/with spaces',
         ];
 
-        if ($executeOnlyCoveringTestCases) {
+        if ($executeOnlyCoveringTestCases && $expectedFilterOptionValue !== null) {
             $expectedArgumentsAndOptions[] = '--filter';
             $expectedArgumentsAndOptions[] = $expectedFilterOptionValue;
         }
 
-        $this->assertSame(
-            $expectedArgumentsAndOptions,
-            $builder->buildForMutant(
-                $configPath,
-                '--path=/a path/with spaces',
-                array_map(
-                    static fn (string $testCase): TestLocation => TestLocation::forTestMethod($testCase),
-                    $testCases,
-                ),
-                $phpUnitVersion,
+        $actual = $builder->buildForMutant(
+            $configPath,
+            '--path=/a path/with spaces',
+            array_map(
+                static fn (string $testCase): TestLocation => TestLocation::forTestMethod($testCase),
+                $testCases,
             ),
+            $phpUnitVersion,
         );
+
+        $this->assertSame($expectedArgumentsAndOptions, $actual);
     }
 
     public static function provideTestCases(): Generator
     {
+        $phpunit9 = '9.5';
+        $phpunit10 = '10.1';
+
         yield '--only-covering-test-cases is disabled' => [
             false,
             [
-                'App\Test::test_case1',
+                'App\ServiceTest::test_case1',
             ],
-            '9.5',
+            $phpunit9,
+            null,
         ];
 
-        yield '1 test case' => [
+        yield 'single test' => [
             true,
             [
-                'App\Test::test_case1',
+                'App\ServiceTest::test_case1',
             ],
-            '9.5',
-            '/Test\:\:test_case1/',
+            $phpunit9,
+            '/ServiceTest\:\:test_case1/',
         ];
 
-        yield '2 test cases' => [
+        yield 'multiple tests of the same test case' => [
             true,
             [
-                'App\Test::test_case1',
-                'App\Test::test_case2',
+                'App\ServiceTest::test_case1',
+                'App\ServiceTest::test_case2',
             ],
-            '9.5',
-            '/Test\:\:test_case1|Test\:\:test_case2/',
+            $phpunit9,
+            '/ServiceTest\:\:test_case1|ServiceTest\:\:test_case2/',
         ];
 
-        yield '1 simple test case, 1 with data set and special character >' => [
+        yield 'multiple tests with multiple test cases' => [
             true,
             [
-                'App\Test::test_case1 with data set "With special character >"',
-                'App\Test::test_case2',
+                'App\ServiceUnitTest::test_case1',
+                'App\ServiceUnitTest::test_case2',
+                'App\ServiceIntegrationTest::test_case1',
+                'App\ServiceIntegrationTest::test_case2',
             ],
-            '9.5',
-            '/Test\:\:test_case1 with data set "With special character \\>"|Test\:\:test_case2/',
+            $phpunit9,
+            '/ServiceUnitTest\:\:test_case1|ServiceUnitTest\:\:test_case2|ServiceIntegrationTest\:\:test_case1|ServiceIntegrationTest\:\:test_case2/',
         ];
 
-        yield '1 simple test case, 1 with data set and special character @' => [
+        yield 'multiple tests with multiple test cases with identical test case short names' => [
             true,
             [
-                'App\Test::test_case1 with data set "With special character @"',
-                'App\Test::test_case2',
+                'App\Unit\ServiceTest::test_case1',
+                'App\Unit\ServiceTest::test_case2',
+                'App\Integration\ServiceTest::test_case1',
+                'App\Integration\ServiceTest::test_case2',
             ],
-            '9.5',
-            '/Test\:\:test_case1 with data set "With special character @"|Test\:\:test_case2/',
+            $phpunit9,
+            '/ServiceTest\:\:test_case1|ServiceTest\:\:test_case2/',
         ];
 
-        yield '2 data sets from data provider for the same test case' => [
+        yield 'single test from a data provider item (<=PHPUnit9)' => [
             true,
             [
-                'App\Test::test_case1 with data set "#1"',
-                'App\Test::test_case1 with data set "#2"',
+                'App\ServiceTest::test_case1 with data set "#1"',
             ],
-            '9.5',
-            '/Test\:\:test_case1 with data set "\#1"|Test\:\:test_case1 with data set "\#2"/',
+            $phpunit9,
+            '/ServiceTest\:\:test_case1 with data set "\#1"/',
         ];
 
-        yield '1 data set from data provider "With special char \\"' => [
+        yield 'single test from a data provider item (>=PHPUnit10)' => [
             true,
             [
-                'App\Test::test_case1 with data set "With special char \\"',
+                'App\ServiceTest::test_case1##1',
             ],
-            '9.5',
-            '/Test\:\:test_case1 with data set "With special char \\\\"/',
+            $phpunit10,
+            '/ServiceTest\:\:test_case1 with data set "\#1"/',
         ];
 
-        yield '1 data set from data provider "With special chars ::"' => [
+        yield 'multiple tests from the same data provider (<=PHPUnit9)' => [
             true,
             [
-                'App\Test::test_case1 with data set "With special chars ::"',
+                'App\ServiceTest::test_case with data set "#1"',
+                'App\ServiceTest::test_case with data set "#2"',
             ],
-            '9.5',
-            '/Test\:\:test_case1 with data set "With special chars \:\:"/',
+            $phpunit9,
+            '/ServiceTest\:\:test_case with data set "\#1"|ServiceTest\:\:test_case with data set "\#2"/',
         ];
 
-        yield '1 test case - PHPUnit10' => [
+        yield 'multiple tests from the same data provider (>=PHPUnit10)' => [
             true,
             [
-                'App\Test::test_case1',
+                'App\ServiceTest::test_case##1',
+                'App\ServiceTest::test_case##2',
             ],
-            '10.1',
-            '/Test\:\:test_case1/',
+            $phpunit10,
+            '/ServiceTest\:\:test_case with data set "\#1"|ServiceTest\:\:test_case with data set "\#2"/',
         ];
 
-        yield '2 test cases - PHPUnit10' => [
+        yield 'multiple tests from a data provider of the same test case (<=PHPUnit9)' => [
             true,
             [
-                'App\Test::test_case1',
-                'App\Test::test_case2',
+                'App\ServiceTest::test_case1 with data set "#1"',
+                'App\ServiceTest::test_case2 with data set "#1"',
             ],
-            '10.1',
-            '/Test\:\:test_case1|Test\:\:test_case2/',
+            $phpunit9,
+            '/ServiceTest\:\:test_case1 with data set "\#1"|ServiceTest\:\:test_case2 with data set "\#1"/',
         ];
 
-        yield '1 simple test case, 1 with data set and special character > - PHPUnit10' => [
+        yield 'multiple tests from a data provider of the same test case (>=PHPUnit10)' => [
             true,
             [
-                'App\Test::test_case1#With special character >',
-                'App\Test::test_case2',
+                'App\ServiceTest::test_case1##1',
+                'App\ServiceTest::test_case2##1',
             ],
-            '10.1',
-            '/Test\:\:test_case1 with data set "With special character \\>"|Test\:\:test_case2/',
+            $phpunit10,
+            '/ServiceTest\:\:test_case1 with data set "\#1"|ServiceTest\:\:test_case2 with data set "\#1"/',
         ];
 
-        yield '1 simple test case, 1 with data set and special character @ - PHPUnit10' => [
+        yield 'multiple tests with multiple test cases and multiple data provider items (<=PHPUnit9)' => [
             true,
             [
-                'App\Test::test_case1#With special character @',
-                'App\Test::test_case2',
+                'App\ServiceUnitTest::test_case1 with data set "#1"',
+                'App\ServiceUnitTest::test_case1 with data set "#2"',
+                'App\ServiceUnitTest::test_case2',
+                'App\ServiceUnitTest::test_case3',
+                'App\ServiceIntegrationTest::test_case1',
+                'App\ServiceIntegrationTest::test_case2',
+                'App\ServiceIntegrationTest::test_case3 with data set "#1"',
+                'App\ServiceIntegrationTest::test_case3 with data set "#2"',
             ],
-            '10.1',
-            '/Test\:\:test_case1 with data set "With special character @"|Test\:\:test_case2/',
+            $phpunit9,
+            '/ServiceUnitTest\:\:test_case1 with data set "\#1"|ServiceUnitTest\:\:test_case1 with data set "\#2"|ServiceUnitTest\:\:test_case2|ServiceUnitTest\:\:test_case3|ServiceIntegrationTest\:\:test_case1|ServiceIntegrationTest\:\:test_case2|ServiceIntegrationTest\:\:test_case3 with data set "\#1"|ServiceIntegrationTest\:\:test_case3 with data set "\#2"/',
         ];
 
-        yield '2 data sets from data provider for the same test case - PHPUnit10' => [
+        yield 'multiple tests with multiple test cases and multiple data provider items (>=PHPUnit10)' => [
             true,
             [
-                'App\Test::test_case1##1',
-                'App\Test::test_case1##2',
+                'App\ServiceUnitTest::test_case1##1',
+                'App\ServiceUnitTest::test_case1##2',
+                'App\ServiceUnitTest::test_case2',
+                'App\ServiceUnitTest::test_case3',
+                'App\ServiceIntegrationTest::test_case1',
+                'App\ServiceIntegrationTest::test_case2',
+                'App\ServiceIntegrationTest::test_case3##1',
+                'App\ServiceIntegrationTest::test_case3##2',
             ],
-            '10.1',
-            '/Test\:\:test_case1 with data set "\#1"|Test\:\:test_case1 with data set "\#2"/',
+            $phpunit10,
+            '/ServiceUnitTest\:\:test_case1 with data set "\#1"|ServiceUnitTest\:\:test_case1 with data set "\#2"|ServiceUnitTest\:\:test_case2|ServiceUnitTest\:\:test_case3|ServiceIntegrationTest\:\:test_case1|ServiceIntegrationTest\:\:test_case2|ServiceIntegrationTest\:\:test_case3 with data set "\#1"|ServiceIntegrationTest\:\:test_case3 with data set "\#2"/',
         ];
 
-        yield '1 data set from data provider "With special char \\" - PHPUnit10' => [
+        yield 'test from a data provider with a special character (<=PHPUnit9)' => [
             true,
             [
-                'App\Test::test_case1#With special char \\"',
+                'App\ServiceTest::test_case1 with data set "With special character >@&\\::"',
+                'App\ServiceTest::test_case2',
             ],
-            '10.1',
-            '/Test\:\:test_case1 with data set "With special char \\\\""/',
+            $phpunit9,
+            '/ServiceTest\:\:test_case1 with data set "With special character \\>@&\\\\\\:\\:"|ServiceTest\:\:test_case2/',
         ];
 
-        yield '1 data set from data provider "With special chars ::" - PHPUnit10' => [
+        yield 'test from a data provider with a special character (>=PHPUnit10)' => [
             true,
             [
-                'App\Test::test_case1#With special chars ::',
+                'App\ServiceTest::test_case1#With special character >@&\\::',
+                'App\ServiceTest::test_case2',
             ],
-            '10.1',
-            '/Test\:\:test_case1 with data set "With special chars \:\:"/',
+            $phpunit10,
+            '/ServiceTest\:\:test_case1 with data set "With special character \\>@&\\\\\\:\\:"|ServiceTest\:\:test_case2/',
         ];
 
-        yield '1 test case from data provider with numeric data provider keys - PHPUnit10' => [
+        yield 'too many tests; all from the same test case' => [
             true,
-            [
-                'App\Test::test_case1#0',
-                'App\Test::test_case1#1',
-            ],
-            '10.5',
-            '/Test\:\:test_case1 with data set \#0|Test\:\:test_case1 with data set \#1/',
+            self::createArray(
+                static fn (int $index) => 'App\ServiceTest::test_case' . $index,
+                1000,
+            ),
+            $phpunit9,
+            sprintf(
+                '/%s/',
+                implode(
+                    '|',
+                    self::createArray(
+                        static fn (int $index) => 'ServiceTest\:\:test_case' . $index,
+                        1000,
+                    ),
+                ),
+            ),
         ];
 
-        yield '1 test case from data provider with leading numbers in the key string - PHPUnit10' => [
+        yield 'too many tests; all from a different test case' => [
             true,
-            [
-                'App\Test::test_case1#123a',
-            ],
-            '10.5',
-            '/Test\:\:test_case1 with data set "123a"/',
+            self::createArray(
+                static fn (int $index) => 'App\Service1Test::test_something' . $index,
+                1000,
+            ),
+            $phpunit9,
+            sprintf(
+                '/%s/',
+                implode(
+                    '|',
+                    self::createArray(
+                        static fn (int $index) => 'Service1Test\:\:test_something' . $index,
+                        1000,
+                    ),
+                ),
+            ),
         ];
+
+        yield 'too many tests; all from data providers (<=PHPUnit9)' => [
+            true,
+            self::createArray(
+                static fn (int $index) => 'App\ServiceTest::test_case with data set "#' . $index . '"',
+                1000,
+            ),
+            $phpunit9,
+            sprintf(
+                '/%s/',
+                implode(
+                    '|',
+                    self::createArray(
+                        static fn (int $index) => 'ServiceTest\:\:test_case with data set "\#' . $index . '"',
+                        1000,
+                    ),
+                ),
+            ),
+        ];
+
+        yield 'too many tests; all from data providers (>=PHPUnit10)' => [
+            true,
+            self::createArray(
+                static fn (int $index) => 'App\ServiceTest::test_case##' . $index,
+                1000,
+            ),
+            $phpunit10,
+            sprintf(
+                '/%s/',
+                implode(
+                    '|',
+                    self::createArray(
+                        static fn (int $index) => 'ServiceTest\:\:test_case with data set "\#' . $index . '"',
+                        1000,
+                    ),
+                ),
+            ),
+        ];
+
+        yield 'too many tests; mixed data providers and regular tests (<=PHPUnit9)' => [
+            true,
+            array_merge(
+                self::createArray(
+                    static fn (int $index) => 'App\ServiceTest::test_regular' . $index,
+                    500,
+                ),
+                self::createArray(
+                    static fn (int $index) => 'App\ServiceTest::test_provider with data set "#' . $index . '"',
+                    500,
+                ),
+            ),
+            $phpunit9,
+            sprintf(
+                '/%s/',
+                implode(
+                    '|',
+                    array_merge(
+                        self::createArray(
+                            static fn (int $index) => 'ServiceTest\:\:test_regular' . $index,
+                            500,
+                        ),
+                        self::createArray(
+                            static fn (int $index) => 'ServiceTest\:\:test_provider with data set "\#' . $index . '"',
+                            500,
+                        ),
+                    ),
+                ),
+            ),
+        ];
+
+        yield 'too many tests; multiple test cases with mixed methods' => [
+            true,
+            array_merge(
+                self::createArray(
+                    static fn (int $index) => 'App\Service' . ($index % 10) . 'Test::test_method' . $index,
+                    1000,
+                ),
+            ),
+            $phpunit9,
+            sprintf(
+                '/%s/',
+                implode(
+                    '|',
+                    self::createArray(
+                        static fn (int $index) => 'Service' . ($index % 10) . 'Test\:\:test_method' . $index,
+                        1000,
+                    ),
+                ),
+            ),
+        ];
+
+        yield 'too many tests; identical short names from different namespaces' => [
+            true,
+            self::createArray(
+                static fn (int $index) => 'App\Namespace' . ($index % 5) . '\ServiceTest::test_method' . $index,
+                1000,
+            ),
+            $phpunit9,
+            sprintf(
+                '/%s/',
+                implode(
+                    '|',
+                    self::createArray(
+                        static fn (int $index) => 'ServiceTest\:\:test_method' . $index,
+                        1000,
+                    ),
+                ),
+            ),
+        ];
+
+        yield 'too many tests; with special characters in data sets (<=PHPUnit9)' => [
+            true,
+            self::createArray(
+                static fn (int $index) => 'App\ServiceTest::test_case with data set "Special >@&\\::' . $index . '"',
+                1000,
+            ),
+            $phpunit9,
+            sprintf(
+                '/%s/',
+                implode(
+                    '|',
+                    self::createArray(
+                        static fn (int $index) => 'ServiceTest\:\:test_case with data set "Special \\>@&\\\\\\:\\:' . $index . '"',
+                        1000,
+                    ),
+                ),
+            ),
+        ];
+
+        yield 'too many tests; with very long test names' => [
+            true,
+            self::createArray(
+                static fn (int $index) => 'App\ServiceTest::test_this_is_a_very_long_test_method_name_that_might_cause_issues_with_command_line_length_limits_' . $index,
+                1000,
+            ),
+            $phpunit9,
+            sprintf(
+                '/%s/',
+                implode(
+                    '|',
+                    self::createArray(
+                        static fn (int $index) => 'ServiceTest\:\:test_this_is_a_very_long_test_method_name_that_might_cause_issues_with_command_line_length_limits_' . $index,
+                        1000,
+                    ),
+                ),
+            ),
+        ];
+    }
+
+    /**
+     * @template T
+     *
+     * @param Closure(int<0,max>):T $createItem
+     * @param positive-int $count
+     *
+     * @return list<T>
+     */
+    private static function createArray(Closure $createItem, int $count): array
+    {
+        $items = [];
+
+        for ($i = 0; $i < $count; ++$i) {
+            $items[] = $createItem($i);
+        }
+
+        return $items;
     }
 }


### PR DESCRIPTION
This PR is a preparatory step for #2407 and moves building the filter option into a dedicated class and add some tests to make it easier to highlight the upcoming changes.