### PR TITLE
perf: Fix non-cached usage of version_compare in FilterBuilder

### DIFF
--- a/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
@@ -105,7 +105,7 @@ final class FilterBuilder
          *
          * we need to translate to the old format because this is what PHPUnit <10 and >=10 understands from CLI `--filter` option
          */
-        if (version_compare($testFrameworkVersion, '10', '>=')) {
+        if (self::isPhpUnit10OrHigher($testFrameworkVersion)) {
             $methodNameParts = explode('#', $methodNameWithDataProviderResult, self::MAX_EXPLODE_PARTS);
 
             if (count($methodNameParts) > 1) {
@@ -120,5 +120,16 @@ final class FilterBuilder
         }
 
         return $methodNameWithDataProviderResult;
+    }
+
+    private static function isPhpUnit10OrHigher(string $testFrameworkVersion): bool
+    {
+        static $versions = [];
+
+        if (!array_key_exists($testFrameworkVersion, $versions)) {
+            $versions[$testFrameworkVersion] = version_compare($testFrameworkVersion, '10', '>=');
+        }
+
+        return $versions[$testFrameworkVersion];
     }
 }


### PR DESCRIPTION
I came across this while implementing #2407.

I fixed it in this specific place, but I wonder if we should have a more generic utility like a `MemoizedVersionCompare`, but that would be more suited in a separate PR.