### PR TITLE
README.md - Bump PHP version to 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Minimum PHP version: 8.1.0](https://img.shields.io/badge/php-8.1.0%2B-blue.svg)](https://packagist.org/packages/infection/infection)
+[![Minimum PHP version: 8.2.0](https://img.shields.io/badge/php-8.2.0%2B-blue.svg)](https://packagist.org/packages/infection/infection)
 [![Latest Stable Version](https://poser.pugx.org/infection/infection/v/stable)](https://packagist.org/packages/infection/infection)
 [![Continuous Integration](https://github.com/infection/infection/workflows/Continuous%20Integration/badge.svg)](https://github.com/infection/infection/actions)
 [![Build Status](https://travis-ci.org/infection/infection.svg?branch=master)](https://travis-ci.org/infection/infection)


### PR DESCRIPTION
It seems forgot to do it  😢 in #2018 and #2020

