### PR TITLE
Fix PHPStan running out of memory during initial static analysis

### DIFF
--- a/tests/phpunit/EngineTest.php
+++ b/tests/phpunit/EngineTest.php
@@ -359,7 +359,7 @@ final class EngineTest extends TestCase
             ->expects($this->once())
             ->method('limitMemory')
             ->with('test output', $adapter)
-            ->willReturnCallback(function () use (&$callOrder): void {
+            ->willReturnCallback(static function () use (&$callOrder): void {
                 $callOrder[] = 'limitMemory';
             })
         ;
@@ -369,7 +369,7 @@ final class EngineTest extends TestCase
             ->expects($this->once())
             ->method('generate')
             ->with(false, [])
-            ->willReturnCallback(function () use (&$callOrder) {
+            ->willReturnCallback(static function () use (&$callOrder) {
                 $callOrder[] = 'generate';
 
                 return [];

--- a/tests/phpunit/EngineTest.php
+++ b/tests/phpunit/EngineTest.php
@@ -44,10 +44,12 @@ use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Metrics\MetricsCalculator;
 use Infection\Metrics\MinMsiChecker;
 use Infection\Mutation\MutationGenerator;
+use Infection\Process\Runner\InitialStaticAnalysisRunner;
 use Infection\Process\Runner\InitialTestsFailed;
 use Infection\Process\Runner\InitialTestsRunner;
 use Infection\Process\Runner\MutationTestingRunner;
 use Infection\Resource\Memory\MemoryLimiter;
+use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\TestFramework\Coverage\CoverageChecker;
 use Infection\TestFramework\TestFrameworkExtraOptionsFilter;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -263,6 +265,249 @@ final class EngineTest extends TestCase
 
         $testFrameworkExtraOptionsFilter = $this->createMock(TestFrameworkExtraOptionsFilter::class);
         $testFrameworkExtraOptionsFilter->expects($this->never())->method($this->anything());
+
+        $engine = new Engine(
+            $config,
+            $adapter,
+            $coverageChecker,
+            $eventDispatcher,
+            $initialTestsRunner,
+            $memoryLimiter,
+            $mutationGenerator,
+            $mutationTestingRunner,
+            $minMsiChecker,
+            $consoleOutput,
+            $metricsCalculator,
+            $testFrameworkExtraOptionsFilter,
+        );
+
+        $engine->execute();
+    }
+
+    public function test_memory_limiter_is_applied_after_static_analysis_when_enabled(): void
+    {
+        $config = $this->createMock(Configuration::class);
+        $config
+            ->expects($this->once())
+            ->method('shouldSkipInitialTests')
+            ->willReturn(false)
+        ;
+        $config
+            ->expects($this->once())
+            ->method('isStaticAnalysisEnabled')
+            ->willReturn(true)
+        ;
+
+        $adapter = $this->createMock(TestFrameworkAdapter::class);
+
+        $coverageChecker = $this->createMock(CoverageChecker::class);
+        $coverageChecker
+            ->expects($this->once())
+            ->method('checkCoverageHasBeenGenerated')
+        ;
+
+        $eventDispatcher = $this->createMock(EventDispatcher::class);
+        $eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
+
+        $initialTestProcess = $this->createMock(Process::class);
+        $initialTestProcess
+            ->expects($this->once())
+            ->method('isSuccessful')
+            ->willReturn(true)
+        ;
+        $initialTestProcess
+            ->expects($this->once())
+            ->method('getCommandLine')
+            ->willReturn('/tmp/bar')
+        ;
+        $initialTestProcess
+            ->expects($this->exactly(2))
+            ->method('getOutput')
+            ->willReturn('test output')
+        ;
+
+        $staticAnalysisProcess = $this->createMock(Process::class);
+        $staticAnalysisProcess
+            ->expects($this->once())
+            ->method('isSuccessful')
+            ->willReturn(true)
+        ;
+
+        $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
+        $initialTestsRunner
+            ->expects($this->once())
+            ->method('run')
+            ->willReturn($initialTestProcess)
+        ;
+
+        $initialStaticAnalysisRunner = $this->createMock(InitialStaticAnalysisRunner::class);
+        $initialStaticAnalysisRunner
+            ->expects($this->once())
+            ->method('run')
+            ->willReturn($staticAnalysisProcess)
+        ;
+
+        $staticAnalysisToolAdapter = $this->createMock(StaticAnalysisToolAdapter::class);
+
+        $callOrder = [];
+
+        $memoryLimiter = $this->createMock(MemoryLimiter::class);
+        $memoryLimiter
+            ->expects($this->once())
+            ->method('limitMemory')
+            ->with('test output', $adapter)
+            ->willReturnCallback(function () use (&$callOrder): void {
+                $callOrder[] = 'limitMemory';
+            })
+        ;
+
+        $mutationGenerator = $this->createMock(MutationGenerator::class);
+        $mutationGenerator
+            ->expects($this->once())
+            ->method('generate')
+            ->with(false, [])
+            ->willReturnCallback(function () use (&$callOrder) {
+                $callOrder[] = 'generate';
+
+                return [];
+            })
+        ;
+
+        $mutationTestingRunner = $this->createMock(MutationTestingRunner::class);
+        $mutationTestingRunner
+            ->expects($this->once())
+            ->method('run')
+            ->with($this->callback(static fn (iterable $input): bool => true))
+        ;
+
+        $consoleOutput = $this->createMock(ConsoleOutput::class);
+
+        $minMsiChecker = $this->createMock(MinMsiChecker::class);
+        $minMsiChecker
+            ->expects($this->once())
+            ->method('checkMetrics')
+            ->with(100, 80.0, 85.0, $consoleOutput)
+        ;
+
+        $metricsCalculator = $this->createMock(MetricsCalculator::class);
+        $metricsCalculator
+            ->expects($this->once())
+            ->method('getTestedMutantsCount')
+            ->willReturn(100)
+        ;
+        $metricsCalculator
+            ->expects($this->once())
+            ->method('getMutationScoreIndicator')
+            ->willReturn(80.0)
+        ;
+        $metricsCalculator
+            ->expects($this->once())
+            ->method('getCoveredCodeMutationScoreIndicator')
+            ->willReturn(85.0)
+        ;
+
+        $testFrameworkExtraOptionsFilter = $this->createMock(TestFrameworkExtraOptionsFilter::class);
+
+        $engine = new Engine(
+            $config,
+            $adapter,
+            $coverageChecker,
+            $eventDispatcher,
+            $initialTestsRunner,
+            $memoryLimiter,
+            $mutationGenerator,
+            $mutationTestingRunner,
+            $minMsiChecker,
+            $consoleOutput,
+            $metricsCalculator,
+            $testFrameworkExtraOptionsFilter,
+            $initialStaticAnalysisRunner,
+            $staticAnalysisToolAdapter,
+        );
+
+        $engine->execute();
+
+        // Verify that limitMemory is called before mutation generation
+        $this->assertSame(['limitMemory', 'generate'], $callOrder);
+    }
+
+    public function test_memory_limiter_is_not_applied_when_initial_tests_are_skipped(): void
+    {
+        $config = $this->createMock(Configuration::class);
+        $config
+            ->expects($this->once())
+            ->method('shouldSkipInitialTests')
+            ->willReturn(true)
+        ;
+
+        $adapter = $this->createMock(TestFrameworkAdapter::class);
+
+        $coverageChecker = $this->createMock(CoverageChecker::class);
+        $coverageChecker
+            ->expects($this->once())
+            ->method('checkCoverageExists')
+        ;
+
+        $eventDispatcher = $this->createMock(EventDispatcher::class);
+        $eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
+
+        $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
+        $initialTestsRunner->expects($this->never())->method($this->anything());
+
+        $memoryLimiter = $this->createMock(MemoryLimiter::class);
+        $memoryLimiter->expects($this->never())->method('limitMemory');
+
+        $mutationGenerator = $this->createMock(MutationGenerator::class);
+        $mutationGenerator
+            ->expects($this->once())
+            ->method('generate')
+            ->with(false, [])
+            ->willReturn([])
+        ;
+
+        $mutationTestingRunner = $this->createMock(MutationTestingRunner::class);
+        $mutationTestingRunner
+            ->expects($this->once())
+            ->method('run')
+            ->with($this->callback(static fn (iterable $input): bool => true))
+        ;
+
+        $consoleOutput = $this->createMock(ConsoleOutput::class);
+        $consoleOutput
+            ->expects($this->once())
+            ->method('logSkippingInitialTests')
+        ;
+
+        $minMsiChecker = $this->createMock(MinMsiChecker::class);
+        $minMsiChecker
+            ->expects($this->once())
+            ->method('checkMetrics')
+        ;
+
+        $metricsCalculator = $this->createMock(MetricsCalculator::class);
+        $metricsCalculator
+            ->expects($this->once())
+            ->method('getTestedMutantsCount')
+            ->willReturn(0)
+        ;
+        $metricsCalculator
+            ->expects($this->once())
+            ->method('getMutationScoreIndicator')
+            ->willReturn(0.0)
+        ;
+        $metricsCalculator
+            ->expects($this->once())
+            ->method('getCoveredCodeMutationScoreIndicator')
+            ->willReturn(0.0)
+        ;
+
+        $testFrameworkExtraOptionsFilter = $this->createMock(TestFrameworkExtraOptionsFilter::class);
 
         $engine = new Engine(
             $config,


### PR DESCRIPTION
## Summary
Fixes #2417 - PHPStan running out of memory when using `--static-analysis-tool=phpstan`

## Problem
The MemoryLimiter was applying memory restrictions calculated from the test suite run **before** the initial PHPStan analysis executed. This caused PHPStan to inherit overly restrictive memory limits (e.g., 24MB) and crash with "Allowed memory size exhausted" errors.

## Root Cause
In `Engine::execute()`, the flow was:
1. Run initial test suite → calculate memory usage
2. **Apply memory limit to php.ini** ← Problem happens here
3. Run PHPStan (inherits the restrictive limit)
4. Run mutation testing

## Solution
Move the `limitMemory()` call to execute **after** both initial runs complete:
1. Run initial test suite → store output
2. Run PHPStan (unrestricted memory)
3. **Apply memory limit** ← Moved here
4. Run mutation testing (gets the limit as intended)

## Changes
- Modified `Engine::runInitialTestSuite()` to return test output instead of applying limits immediately
- Moved `limitMemory()` call in `Engine::execute()` to after `runInitialStaticAnalysis()`
- Added null check for scenarios where initial tests are skipped

## Testing
- ✅ Unit tests pass (EngineTest, MemoryLimiterTest)
- ✅ Verified [with bug reproducer](https://github.com/infection/infection/issues/2417#issuecomment-3374458076) - PHPStan v2.1.29 completes successfully
- ✅ Mutation testing still receives memory limits as intended

## Impact
- No breaking changes
- No configuration changes needed for users
- Memory limiter still functions correctly for mutation testing processes