### PR TITLE
PHPStan integration: drop `--fail-without-result-cache`

### DIFF
--- a/src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php
+++ b/src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php
@@ -100,7 +100,6 @@ final class PHPStanMutantProcessFactory implements LazyMutantProcessFactory
             '--error-format=json',
             '--no-progress',
             '-vv',
-            '--fail-without-result-cache',
             // todo [phpstan-integration] --stop-on-first-error
         ], $this->staticAnalysisToolOptions);
 

--- a/tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php
@@ -107,7 +107,6 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 '--error-format=json',
                 '--no-progress',
                 '-vv',
-                '--fail-without-result-cache',
                 '--memory-limit=-1',
             ])
             ->willReturn(['/usr/bin/php', '/path/to/phpstan'])
@@ -203,7 +202,6 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 '--error-format=json',
                 '--no-progress',
                 '-vv',
-                '--fail-without-result-cache',
                 '--memory-limit=-1',
                 '--level=max',
             ])
@@ -300,7 +298,6 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 '--error-format=json',
                 '--no-progress',
                 '-vv',
-                '--fail-without-result-cache',
             ])
             ->willReturn(['/usr/bin/php', '/path/to/phpstan'])
         ;


### PR DESCRIPTION
drop `--fail-without-result-cache` which does not work when a project contains PHPStan extension classes and those get mutated. these will not create a cache hit and emit the following warning:

```
Result cache not used because extension file /Users/m.staab/dvl/phpstan-doctrine/src/Rules/Doctrine/ORM/QueryBuilderDqlRule.php hash does not match.
```

background story: see https://github.com/phpstan/phpstan-doctrine/pull/686#issuecomment-3376112789 and following