### PR TITLE
Introduce `--logger-text` option to enforce text logger file path

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -132,6 +132,8 @@ final class RunCommand extends BaseCommand
 
     private const OPTION_LOGGER_HTML = 'logger-html';
 
+    private const OPTION_LOGGER_TEXT = 'logger-text';
+
     private const OPTION_USE_NOOP_MUTATORS = 'noop';
 
     private const OPTION_EXECUTE_ONLY_COVERING_TEST_CASES = 'only-covering-test-cases';
@@ -332,6 +334,12 @@ final class RunCommand extends BaseCommand
                 'Path to HTML report file, similar to PHPUnit HTML report.',
             )
             ->addOption(
+                self::OPTION_LOGGER_TEXT,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Path to text report file.',
+            )
+            ->addOption(
                 self::OPTION_USE_NOOP_MUTATORS,
                 null,
                 InputOption::VALUE_NONE,
@@ -464,6 +472,7 @@ final class RunCommand extends BaseCommand
         $initialTestsPhpOptions = trim((string) $input->getOption(self::OPTION_INITIAL_TESTS_PHP_OPTIONS));
         $gitlabFileLogPath = trim((string) $input->getOption(self::OPTION_LOGGER_GITLAB));
         $htmlFileLogPath = trim((string) $input->getOption(self::OPTION_LOGGER_HTML));
+        $textLogFilePath = trim((string) $input->getOption(self::OPTION_LOGGER_TEXT));
         $loggerProjectRootDirectory = $input->getOption(self::OPTION_LOGGER_PROJECT_ROOT_DIRECTORY);
 
         /** @var string|null $minMsi */
@@ -574,6 +583,7 @@ final class RunCommand extends BaseCommand
             $commandHelper->getUseGitHubLogger(),
             $gitlabFileLogPath === '' ? Container::DEFAULT_GITLAB_LOGGER_PATH : $gitlabFileLogPath,
             $htmlFileLogPath === '' ? Container::DEFAULT_HTML_LOGGER_PATH : $htmlFileLogPath,
+            $textLogFilePath === '' ? Container::DEFAULT_TEXT_LOGGER_PATH : $textLogFilePath,
             (bool) $input->getOption(self::OPTION_USE_NOOP_MUTATORS),
             (bool) $input->getOption(self::OPTION_EXECUTE_ONLY_COVERING_TEST_CASES),
             $commandHelper->getMapSourceClassToTest(),

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -118,6 +118,7 @@ class ConfigurationFactory
         ?bool $useGitHubLogger,
         ?string $gitlabLogFilePath,
         ?string $htmlLogFilePath,
+        ?string $textLogFilePath,
         bool $useNoopMutators,
         bool $executeOnlyCoveringTestCases,
         ?string $mapSourceClassToTestStrategy,
@@ -156,7 +157,7 @@ class ConfigurationFactory
             ),
             $this->retrieveFilter($filter, $gitDiffFilter, $isForGitDiffLines, $gitDiffBase, $schema->getSource()->getDirectories()),
             $schema->getSource()->getExcludes(),
-            $this->retrieveLogs($schema->getLogs(), $configDir, $useGitHubLogger, $gitlabLogFilePath, $htmlLogFilePath),
+            $this->retrieveLogs($schema->getLogs(), $configDir, $useGitHubLogger, $gitlabLogFilePath, $htmlLogFilePath, $textLogFilePath),
             $logVerbosity,
             $namespacedTmpDir,
             $this->retrievePhpUnit($schema, $configDir),
@@ -373,7 +374,7 @@ class ConfigurationFactory
         return $this->gitDiffFileProvider->provide($gitDiffFilter, $baseBranch, $sourceDirectories);
     }
 
-    private function retrieveLogs(Logs $logs, string $configDir, ?bool $useGitHubLogger, ?string $gitlabLogFilePath, ?string $htmlLogFilePath): Logs
+    private function retrieveLogs(Logs $logs, string $configDir, ?bool $useGitHubLogger, ?string $gitlabLogFilePath, ?string $htmlLogFilePath, ?string $textLogFilePath): Logs
     {
         if ($useGitHubLogger === null) {
             $useGitHubLogger = $this->detectCiGithubActions();
@@ -389,6 +390,10 @@ class ConfigurationFactory
 
         if ($htmlLogFilePath !== null) {
             $logs->setHtmlLogFilePath($htmlLogFilePath);
+        }
+
+        if ($textLogFilePath !== null) {
+            $logs->setTextLogFilePath($textLogFilePath);
         }
 
         return new Logs(

--- a/src/Configuration/Entry/Logs.php
+++ b/src/Configuration/Entry/Logs.php
@@ -42,7 +42,7 @@ namespace Infection\Configuration\Entry;
 class Logs
 {
     public function __construct(
-        private readonly ?string $textLogFilePath,
+        private ?string $textLogFilePath,
         private ?string $htmlLogFilePath,
         private readonly ?string $summaryLogFilePath,
         private readonly ?string $jsonLogFilePath,
@@ -89,6 +89,11 @@ class Logs
     public function setHtmlLogFilePath(string $htmlLogFilePath): void
     {
         $this->htmlLogFilePath = $htmlLogFilePath;
+    }
+
+    public function setTextLogFilePath(string $textLogFilePath): void
+    {
+        $this->textLogFilePath = $textLogFilePath;
     }
 
     public function getSummaryLogFilePath(): ?string

--- a/src/Container.php
+++ b/src/Container.php
@@ -192,6 +192,8 @@ final class Container extends DIContainer
 
     public const DEFAULT_HTML_LOGGER_PATH = null;
 
+    public const DEFAULT_TEXT_LOGGER_PATH = null;
+
     public const DEFAULT_USE_NOOP_MUTATORS = false;
 
     public const DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES = false;
@@ -590,6 +592,7 @@ final class Container extends DIContainer
         ?bool $useGitHubLogger = self::DEFAULT_USE_GITHUB_LOGGER,
         ?string $gitlabLogFilePath = self::DEFAULT_GITLAB_LOGGER_PATH,
         ?string $htmlLogFilePath = self::DEFAULT_HTML_LOGGER_PATH,
+        ?string $textLogFilePath = self::DEFAULT_TEXT_LOGGER_PATH,
         bool $useNoopMutators = self::DEFAULT_USE_NOOP_MUTATORS,
         bool $executeOnlyCoveringTestCases = self::DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES,
         ?string $mapSourceClassToTestStrategy = self::DEFAULT_MAP_SOURCE_CLASS_TO_TEST_STRATEGY,
@@ -664,6 +667,7 @@ final class Container extends DIContainer
                 $useGitHubLogger,
                 $gitlabLogFilePath,
                 $htmlLogFilePath,
+                $textLogFilePath,
                 $useNoopMutators,
                 $executeOnlyCoveringTestCases,
                 $mapSourceClassToTestStrategy,

--- a/tests/benchmark/Tracing/provide-traces-closure.php
+++ b/tests/benchmark/Tracing/provide-traces-closure.php
@@ -74,6 +74,7 @@ $container = Container::create()->withValues(
     Container::DEFAULT_USE_GITHUB_LOGGER,
     Container::DEFAULT_GITLAB_LOGGER_PATH,
     Container::DEFAULT_HTML_LOGGER_PATH,
+    Container::DEFAULT_TEXT_LOGGER_PATH,
     true,
     Container::DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES,
     Container::DEFAULT_MAP_SOURCE_CLASS_TO_TEST_STRATEGY,

--- a/tests/phpunit/Configuration/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactoryTest.php
@@ -153,6 +153,7 @@ final class ConfigurationFactoryTest extends TestCase
         ?bool $inputUseGitHubAnnotationsLogger = true,
         ?string $inputGitlabLogFilePath = null,
         ?string $inputHtmlLogFilePath = null,
+        ?string $inputTextLogFilePath = null,
         bool $inputUseNoopMutators = false,
         int $inputMsiPrecision = 2,
         int $expectedTimeout = 10,
@@ -226,6 +227,7 @@ final class ConfigurationFactoryTest extends TestCase
                 $inputUseGitHubAnnotationsLogger,
                 $inputGitlabLogFilePath,
                 $inputHtmlLogFilePath,
+                $inputTextLogFilePath,
                 $inputUseNoopMutators,
                 $inputExecuteOnlyCoveringTestCases,
                 $mapSourceClassToTest,
@@ -335,6 +337,7 @@ final class ConfigurationFactoryTest extends TestCase
                 false,
                 null,
                 null,
+                null,
                 false,
                 false,
                 null,
@@ -383,6 +386,42 @@ final class ConfigurationFactoryTest extends TestCase
         );
 
         yield 'null html file log path in config and CLI' => self::createValueForHtmlLogFilePath(
+            null,
+            null,
+            null,
+        );
+
+        yield 'null text file log path with existing path from config file' => self::createValueForTextLogFilePath(
+            '/from-config.text',
+            null,
+            '/from-config.text',
+        );
+
+        yield 'absolute text file log path' => self::createValueForTextLogFilePath(
+            '/path/to/from-config.text',
+            null,
+            '/path/to/from-config.text',
+        );
+
+        yield 'relative text file log path' => self::createValueForTextLogFilePath(
+            'relative/path/to/from-config.text',
+            null,
+            '/path/to/relative/path/to/from-config.text',
+        );
+
+        yield 'override text file log path from CLI option with existing path from config file' => self::createValueForTextLogFilePath(
+            '/from-config.text',
+            '/from-cli.text',
+            '/from-cli.text',
+        );
+
+        yield 'set text file log path from CLI option when config file has no setting' => self::createValueForTextLogFilePath(
+            null,
+            '/from-cli.text',
+            '/from-cli.text',
+        );
+
+        yield 'null text file log path in config and CLI' => self::createValueForTextLogFilePath(
             null,
             null,
             null,
@@ -1645,6 +1684,61 @@ final class ConfigurationFactoryTest extends TestCase
                 new Logs(
                     null,
                     $htmlFileLogPathInConfig,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false,
+                    null,
+                    null,
+                ),
+                '',
+                new PhpUnit(null, null),
+                new PhpStan(null, null),
+                null,
+                null,
+                null,
+                [],
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function createValueForTextLogFilePath(?string $textFileLogPathInConfig, ?string $textFileLogPathFromCliOption, ?string $expectedTextFileLogPath): array
+    {
+        $expectedLogs = new Logs(
+            $expectedTextFileLogPath,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            true,
+            null,
+            null,
+        );
+
+        return [
+            'inputTextLogFilePath' => $textFileLogPathFromCliOption,
+            'expectedLogs' => $expectedLogs,
+            'schema' => new SchemaConfiguration(
+                '/path/to/infection.json',
+                null,
+                new Source([], []),
+                new Logs(
+                    $textFileLogPathInConfig,
+                    null,
                     null,
                     null,
                     null,


### PR DESCRIPTION
Allows the usage of `--logger-text` option when running Infection, to override the "logs.text" option from the configuration file.

This PR:

- [X] Adds new feature ...
- [X] Covered by tests
- [X] Doc PR: https://github.com/infection/site/pull/285

I'm coming from https://github.com/phpstan/phpstan-doctrine/pull/686/files#r2416912180 — I like to work with a text log file when running Infection locally, however it makes sense to use `php://stdout` when running it in the pipeline. Adding this console option allows to override the option set in the configuration file.

I did not find an existing test for the `--logger-html` option, to create a similar test for this newly added option. What should I do?

If the PR is ok for you, I'll add a PR to update the documentation.