### PR TITLE
Show uncovered mutants to output when `--with-uncovered` is used

### DIFF
--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -82,7 +82,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
         private readonly DiffColorizer $diffColorizer,
         private readonly FederatedLogger $mutationTestingResultsLogger,
         private readonly ?int $numberOfShownMutations,
-        private readonly bool $showMutationScoreIndicator,
+        private readonly bool $withUncovered,
     ) {
         $this->numberOfMutationsBudget = $this->numberOfShownMutations;
     }
@@ -108,7 +108,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
         if ($this->numberOfMutationsBudget !== 0) {
             $this->showMutations($this->resultsCollector->getEscapedExecutionResults(), 'Escaped');
 
-            if ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
+            if ($this->withUncovered) {
                 $this->showMutations($this->resultsCollector->getNotCoveredExecutionResults(), 'Not covered');
             }
         }
@@ -229,7 +229,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
 
         $this->output->writeln(['', 'Metrics:']);
 
-        if ($this->showMutationScoreIndicator) {
+        if ($this->withUncovered) {
             $this->output->writeln(
                 $this->addIndentation("Mutation Score Indicator (MSI): <{$msiTag}>{$mutationScoreIndicator}%</{$msiTag}>"),
             );

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
@@ -54,7 +54,7 @@ final readonly class MutationTestingConsoleLoggerSubscriberFactory implements Su
         private FederatedLogger $mutationTestingResultsLogger,
         private ?int $numberOfShownMutations,
         private OutputFormatter $formatter,
-        private bool $showMutationScoreIndicator,
+        private bool $withUncovered,
     ) {
     }
 
@@ -68,7 +68,7 @@ final readonly class MutationTestingConsoleLoggerSubscriberFactory implements Su
             $this->diffColorizer,
             $this->mutationTestingResultsLogger,
             $this->numberOfShownMutations,
-            $this->showMutationScoreIndicator,
+            $this->withUncovered,
         );
     }
 }

--- a/src/Metrics/TargetDetectionStatusesProvider.php
+++ b/src/Metrics/TargetDetectionStatusesProvider.php
@@ -83,6 +83,10 @@ class TargetDetectionStatusesProvider
             yield DetectionStatus::ESCAPED;
         }
 
+        if (!$this->onlyCoveredMode) {
+            yield DetectionStatus::NOT_COVERED;
+        }
+
         $strykerConfig = $this->logConfig->getStrykerConfig();
         $isStrykerFullReportEnabled = $strykerConfig !== null && $strykerConfig->isForFullReport();
 

--- a/tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php
+++ b/tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php
@@ -134,6 +134,25 @@ final class TargetDetectionStatusesProviderTest extends TestCase
         );
     }
 
+    public function test_it_provides_not_covered_when_with_uncovered_option_is_used(): void
+    {
+        $logs = $this->createMock(Logs::class);
+
+        $provider = new TargetDetectionStatusesProvider(
+            $logs,
+            logVerbosity: LogVerbosity::NORMAL,
+            onlyCoveredMode: false,
+            numberOfShownMutations: 0,
+        );
+
+        $this->assertProvides(
+            [
+                DetectionStatus::NOT_COVERED,
+            ],
+            $provider->get(),
+        );
+    }
+
     public function test_it_includes_escaped_when_requested(): void
     {
         $logs = $this->createMock(Logs::class);


### PR DESCRIPTION
Fixes https://github.com/infection/infection/issues/2442

There are many issues with our loggers and collectors that need to be addressed separately, but the main confusion was: we have many different things affecting what mutants needs to be shown in logs/console:

- `--logger-*` options.  (also affect collectors)
- `--log-verbosity=*`  (also affect collectors)
- `-v|-vv`
- `--debug`
- `--show-mutations=x` (also affect collectors)
- `--with-uncovered` (also affect collectors)

That is very confusing.

Issue number one with  #2442 that decision to show or not to show uncovered mutants was made by `-v` - this has been changed and now controller by `--with-uncovered` option. Additionally, if `--show-mutations=0` (disabled) - no uncovered mutants will be shown, so it's clear now.

Issue number two is that we have a separate class that controls what statuses are being collected: `TargetDetectionStatusesProvider`, and it's very confusing that it affects different parts of the system. We do have a TODO (related to https://github.com/infection/infection/pull/1430) to improve it, but this is out of the scope of this bugfix:

https://github.com/infection/infection/blob/9965d1f6e372bdca7992d7b2e9526e77765b27ff/src/Metrics/TargetDetectionStatusesProvider.php#L73

So, now it works this way:

- `bin/infection` - uncovered are not shown
- `bin/infection --with-uncovered` - uncovered are shown
- `bin/infection --with-uncovered --show-mutations=0` - uncovered are not shown