### PR TITLE
Replace deprecated SplObjectStorage methods with alternatives

### DIFF
--- a/src/PhpParser/Visitor/IgnoreAllMutationsAnnotationReaderVisitor.php
+++ b/src/PhpParser/Visitor/IgnoreAllMutationsAnnotationReaderVisitor.php
@@ -62,7 +62,7 @@ final class IgnoreAllMutationsAnnotationReaderVisitor extends NodeVisitorAbstrac
         foreach ($node->getComments() as $comment) {
             if (str_contains($comment->getText(), self::IGNORE_ALL_MUTATIONS_ANNOTATION)) {
                 $this->changingIgnorer->startIgnoring();
-                $this->ignoredNodes->attach($node);
+                $this->ignoredNodes->offsetSet($node);
             }
         }
 
@@ -71,8 +71,8 @@ final class IgnoreAllMutationsAnnotationReaderVisitor extends NodeVisitorAbstrac
 
     public function leaveNode(Node $node): ?Node
     {
-        if ($this->ignoredNodes->contains($node)) {
-            $this->ignoredNodes->detach($node);
+        if ($this->ignoredNodes->offsetExists($node)) {
+            $this->ignoredNodes->offsetUnset($node);
             $this->changingIgnorer->stopIgnoring();
         }
 


### PR DESCRIPTION
Fixes the following deprecation messages:

```
Deprecated: Method SplObjectStorage::contains() is deprecated since 8.5,
use method SplObjectStorage::offsetExists() instead in src/PhpParser/
Visitor/IgnoreAllMutationsAnnotationReaderVisitor.php on line 74

Deprecated: Method SplObjectStorage::detach() is deprecated since 8.5,
use method SplObjectStorage::offsetUnset() instead in src/PhpParser/
Visitor/IgnoreAllMutationsAnnotationReaderVisitor.php on line 75

Deprecated: Method SplObjectStorage::attach() is deprecated since 8.5,
use method SplObjectStorage::offsetSet() instead in src/PhpParser/
Visitor/IgnoreAllMutationsAnnotationReaderVisitor.php on line 65
```