### PR TITLE
test: Add missing cases to DotFormatterTest

### DIFF
--- a/tests/phpunit/Console/OutputFormatter/DotFormatterTest.php
+++ b/tests/phpunit/Console/OutputFormatter/DotFormatterTest.php
@@ -57,34 +57,6 @@ final class DotFormatterTest extends TestCase
         $output = new BufferedOutput();
         $formatter = new DotFormatter($output);
 
-        $expected = implode(
-            "\n",
-            [
-                '',
-                implode(
-                    ', ',
-                    [
-                        '<killed>.</killed>: killed by tests',
-                        '<killed-by-static-analysis>A</killed-by-static-analysis>: killed by SA',
-                        '<escaped>M</escaped>: escaped',
-                        '<uncovered>U</uncovered>: uncovered',
-                    ],
-                ),
-                implode(
-                    ', ',
-                    [
-                        '<with-error>E</with-error>: fatal error',
-                        '<with-syntax-error>X</with-syntax-error>: syntax error',
-                        '<timeout>T</timeout>: timed out',
-                        '<skipped>S</skipped>: skipped',
-                        '<ignored>I</ignored>: ignored',
-                    ],
-                ),
-                '',
-                '',
-            ],
-        );
-
         $expected = LineReturnNormalizer::normalize(
             implode(
                 "\n",


### PR DESCRIPTION
Add the missing cases for the `DetectionStatus` for `DotFormatterTest` and leverage the assertion from `EnumBucket` to prevent missing this scenario in the future.
