### PR TITLE
chore: Fix the AutoReview PHPUnit configuration

### DIFF
--- a/phpunit_autoreview.xml
+++ b/phpunit_autoreview.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/schema/10.4.xsd"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
          colors="true"
          executionOrder="random"
          stopOnFailure="true"
          failOnWarning="true"
          failOnRisky="true"
+         requireCoverageMetadata="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
          cacheDirectory="./build/cache/phpunit-autoreview"
 >
 

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
@@ -47,6 +47,7 @@ use Infection\Testing\SourceTestClassNameScheme;
 use function is_executable;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionProperty;
@@ -61,9 +62,7 @@ use function sprintf;
 #[CoversNothing]
 final class ProjectCodeTest extends TestCase
 {
-    /**
-     * @requires OSFAMILY Windows Cannot check if the file is executable on Windows
-     */
+    #[RequiresOperatingSystem('^(?!Windows).*$')]
     public function test_infection_bin_is_executable(): void
     {
         $infectionFile = __DIR__ . '/../../../../bin/infection';


### PR DESCRIPTION
- Copy the settings from the PHPUnit configuration file of the regular test suite over to the AutoReview one. Among other things, this displays the following PHPUnit deprecation:

```
There was 1 PHPUnit test runner deprecation:

1) Metadata found in doc-comment for method Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest::test_infection_bin_is_executable(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.
```

- Fix the PHPUnit deprecration by using the corresponding Attribute instead.
