### PR TITLE
chore(cs): Do not convert PHPDoc to comments

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -150,6 +150,8 @@ return (new Config())
         'phpdoc_align' => [
             'align' => 'left',
         ],
+        // Allow inline Psalm suppress statements
+        'phpdoc_to_comment' => false,
         'php_unit_dedicate_assert' => true,
         'php_unit_method_casing' => [
             'case' => 'snake_case',


### PR DESCRIPTION
Some Pslam errors are better suppressed within the file where finer control is possible rather than in `psalm.xml`. However, it is currently not possible as PHP-CS-Fixer will execute the following transformation:

```diff
-- /** @psalm-suppress InvalidArgument **/
++ // @psalm-suppress InvalidArgument
```

But Psalm does not understand those statements when they are simple PHP comments.