### PR TITLE
test(autoreview): Do not check enums for public properties

### DIFF
--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -254,6 +254,7 @@ final class ProjectCodeProvider
                 $reflectionClass = new ReflectionClass($className);
 
                 return !$reflectionClass->isInterface()
+                    && !$reflectionClass->isEnum()
                     && !in_array(
                         $className,
                         [


### PR DESCRIPTION
Like an interface, an enum cannot have public properties.

This is blocking the introduction of any enum, like shown in #2468.