### PR TITLE
test(autoreview): Allow public readonly properties

### DIFF
--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
@@ -241,7 +241,8 @@ final class ProjectCodeTest extends TestCase
             ),
             array_filter(
                 $properties,
-                static fn (ReflectionProperty $property): bool => $property->class === $className,
+                static fn (ReflectionProperty $property): bool => $property->class === $className
+                    && !$property->isReadOnly(),
             ),
         );
 


### PR DESCRIPTION
I think public properties are fine if they are readonly, either directly (i.e. `public readonly`) or because the class is readonly.