### PR TITLE
perf: Add missing composer dump when profilig the tracing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ profile_mutation_generator: vendor $(BENCHMARK_MUTATION_GENERATOR_SOURCES)
 
 .PHONY: profile_tracing
 profile_tracing: vendor $(BENCHMARK_TRACING_SOURCES) $(BENCHMARK_TRACING_COVERAGE)
+	composer dump --classmap-authoritative
 	blackfire run \
 		--samples=5 \
 		--title="Tracing" \


### PR DESCRIPTION
It does mean this statement is executed twice when executing `make profile`, but I do not think it's a problem.