### PR TITLE
test: Remove dependency of the benchmark sources for end-to-end tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,6 @@ COMMIT_HASH=$(shell git rev-parse --short HEAD)
 BENCHMARK_MUTATION_GENERATOR_SOURCES=tests/benchmark/MutationGenerator/sources
 BENCHMARK_TRACING_COVERAGE=tests/benchmark/Tracing/coverage
 BENCHMARK_TRACING_SOURCES=tests/benchmark/Tracing/sources
-BENCHMARK_SOURCES=$(BENCHMARK_MUTATION_GENERATOR_SOURCES) \
-				  $(BENCHMARK_TRACING_COVERAGE) \
-				  $(BENCHMARK_TRACING_SOURCES)
 
 E2E_PHPUNIT_GROUP=integration,e2e
 PHPUNIT_GROUP=default
@@ -182,7 +179,7 @@ test-e2e: test-e2e-phpunit
 
 .PHONY: test-e2e-phpunit
 test-e2e-phpunit:	## Runs PHPUnit-enabled subset of end-to-end tests
-test-e2e-phpunit: $(PHPUNIT) $(BENCHMARK_SOURCES) vendor
+test-e2e-phpunit: $(PHPUNIT) vendor
 	$(PHPUNIT) --group $(E2E_PHPUNIT_GROUP)
 
 .PHONY: test-e2e-docker


### PR DESCRIPTION
The end-to-end tests do not execute the benchmarks (neither they should).

I did see this issue while working on #2452, but left it alone because I thought of introducing tests of some sorts to ensure we do not break the benchmarks over time.

This is still in my mind, but I think that will be likely other tests, i.e. not executed as part of the end-to-end tests. So for now, we can fix this issue which is a blocker for #2476 and #2452.
