### PR TITLE
cs: Disable the `php_unit_strict` PHP-CS-Fixer rule

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -157,7 +157,7 @@ return (new Config())
             'case' => 'snake_case',
         ],
         'php_unit_set_up_tear_down_visibility' => true,
-        'php_unit_strict' => true,
+        'php_unit_strict' => false,
         'phpdoc_order_by_value' => [
             'annotations' => ['covers'],
         ],


### PR DESCRIPTION
Extracting this in a separate PR as I realise it may be worth its own justification/discussion and is creeping up in several PRs (#2482 and #2481).

The reasoning behind this rule is well funded: you should compare scalar values strictly. However, it also applies it to object and I think this is a lot more debatable.

First thing first, in _defence_ of this rule, using `::assertEquals()` on PHP objects may have unintended outcomes as the objects properties will be loosely compared (demo in https://3v4l.org/KKVvX).

_However_, there is several reasons why I don't think it's a good idea as the alternative, this requires to explicitly compare objects states (see `ConfigurationAssertions`, `LogsAssertions`, etc.) which is a lot of boilerplate AND verbose. Also, since we now have strict type properties in PHP, I think it is a lot less of an issue. The main problematic case remaining is for nullable properties.

Additionally, I think it can be partially solved a different way. For instance at Webmozarts we are using https://github.com/webmozarts/strict-phpunit/ to make those comparison strict.