### PR TITLE
test: Silence output when dumping the autoloader for the benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ profile:
 
 .PHONY: profile_mutation_generator
 profile_mutation_generator: vendor $(BENCHMARK_MUTATION_GENERATOR_SOURCES)
-	composer dump --classmap-authoritative
+	composer dump --classmap-authoritative --quiet
 	blackfire run \
 		--samples=5 \
 		--title="MutationGenerator" \
@@ -131,7 +131,7 @@ profile_mutation_generator: vendor $(BENCHMARK_MUTATION_GENERATOR_SOURCES)
 
 .PHONY: profile_tracing
 profile_tracing: vendor $(BENCHMARK_TRACING_SUBMODULE) $(BENCHMARK_TRACING_COVERAGE_DIR)
-	composer dump --classmap-authoritative
+	composer dump --classmap-authoritative --quiet
 	blackfire run \
 		--samples=5 \
 		--title="Tracing" \


### PR DESCRIPTION
Because we have the following in our `composer.json`:

```json
    "autoload-dev": {
        "psr-4": {
            "Infection\\Benchmark\\": "tests/benchmark",
```

The following code:

- `tests/benchmark/MutationGenerator/sources/`
- `tests/benchmark/Tracing/benchmark-source/`

is included. As a result, when we execute `composer dump --classmap-authoritative` as part of the benchmark scripts, we get a wall of warnings as the code in those directories do not follow the classmap (hence is skipped).

I can't find a nice way to address this without trading off convenience (we do not want to have to manually include every single source code file under `tests/benchmark`). Hence, my proposal is to add `--quiet` to silence those warnings.