### PR TITLE
test: Make BenchmarkTest more resilient

### DIFF
--- a/tests/phpunit/BenchmarkTest.php
+++ b/tests/phpunit/BenchmarkTest.php
@@ -42,7 +42,7 @@ use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-use function Safe\realpath;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
@@ -91,12 +91,12 @@ final class BenchmarkTest extends TestCase
     public static function provideBenchmarks(): iterable
     {
         yield 'MutationGenerator' => [
-            realpath(self::BENCHMARK_DIR . '/MutationGenerator/generate-mutations.php'),
+            Path::canonicalize(self::BENCHMARK_DIR . '/MutationGenerator/generate-mutations.php'),
             self::BENCHMARK_DIR . '/MutationGenerator/sources',
         ];
 
         yield 'Tracing' => [
-            realpath(self::BENCHMARK_DIR . '/Tracing/provide-traces.php'),
+            Path::canonicalize(self::BENCHMARK_DIR . '/Tracing/provide-traces.php'),
             self::BENCHMARK_DIR . '/Tracing/sources',
         ];
     }


### PR DESCRIPTION
Prompted by the following failure in the pipeline in another PR:

```
Run make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=bin/infection
touch -c vendor/phpunit/phpunit/phpunit
vendor/phpunit/phpunit/phpunit --group e2e


An error occurred inside PHPUnit.

Message:  An error occurred
Location: /home/runner/work/infection/infection/vendor/thecodingmachine/safe/generated/Exceptions/FilesystemException.php:9

#0 /home/runner/work/infection/infection/vendor/thecodingmachine/safe/generated/8.2/filesystem.php(1494): Safe\Exceptions\FilesystemException::createFromPhpError()
#1 /home/runner/work/infection/infection/tests/phpunit/BenchmarkTest.php(94): Safe\realpath()
#2 /home/runner/work/infection/infection/vendor/phpunit/phpunit/src/Metadata/Api/DataProvider.php(183): Infection\Tests\BenchmarkTest::provideBenchmarks()
#3 /home/runner/work/infection/infection/vendor/phpunit/phpunit/src/Metadata/Api/DataProvider.php(69): PHPUnit\Metadata\Api\DataProvider->dataProvidedByMethods()
#4 /home/runner/work/infection/infection/vendor/phpunit/phpunit/src/Framework/TestBuilder.php(47): PHPUnit\Metadata\Api\DataProvider->providedData()
#5 /home/runner/work/infection/infection/vendor/phpunit/phpunit/src/Framework/TestSuite.php(508): PHPUnit\Framework\TestBuilder->build()
#6 /home/runner/work/infection/infection/vendor/phpunit/phpunit/src/Framework/TestSuite.php(109): PHPUnit\Framework\TestSuite->addTestMethod()
#7 /home/runner/work/infection/infection/vendor/phpunit/phpunit/src/Framework/TestSuite.php(209): PHPUnit\Framework\TestSuite::fromClassReflector()
#8 /home/runner/work/infection/infection/vendor/phpunit/phpunit/src/Framework/TestSuite.php(230): PHPUnit\Framework\TestSuite->addTestSuite()
#9 /home/runner/work/infection/infection/vendor/phpunit/phpunit/src/TextUI/Configuration/Xml/TestSuiteMapper.php(105): PHPUnit\Framework\TestSuite->addTestFile()
#10 /home/runner/work/infection/infection/vendor/phpunit/phpunit/src/TextUI/Configuration/TestSuiteBuilder.php(75): PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper->map()
#11 /home/runner/work/infection/infection/vendor/phpunit/phpunit/src/TextUI/Application.php(412): PHPUnit\TextUI\Configuration\TestSuiteBuilder->build()
#12 /home/runner/work/infection/infection/vendor/phpunit/phpunit/src/TextUI/Application.php(182): PHPUnit\TextUI\Application->buildTestSuite()
#13 /home/runner/work/infection/infection/vendor/phpunit/phpunit/phpunit(104): PHPUnit\TextUI\Application->run()
#14 {main}
make: *** [Makefile:184: test-e2e-phpunit] Error 255
```

Despite the test `BenchmarkTest` not being executed by `phpunit --group e2e`, it appears its data provider is still executed. The failure was caused because one of the sources did not exist resulting in `Safe\realpath()` failing as above.

In this PR I replace it with `Path::canonicalize()`: checking that those sources exist should be done (and is done) in the test.