### PR TITLE
test(TestPhpExecutableFinder): Introduce a PHP executable finder for tests

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -367,18 +367,6 @@ parameters:
 			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
 
 		-
-			message: '#^Method Infection\\Tests\\BenchmarkTest\:\:getPhpExecutable\(\) should return string but returns string\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: ../tests/phpunit/BenchmarkTest.php
-
-		-
-			message: '#^Property Infection\\Tests\\BenchmarkTest\:\:\$phpExecutable \(string\|null\) does not accept string\|false\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: ../tests/phpunit/BenchmarkTest.php
-
-		-
 			message: '#^Property Infection\\Tests\\CI\\ConfigurableEnv\:\:\$variables has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -1577,12 +1565,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php
-
-		-
-			message: '#^Static property Infection\\Tests\\Process\\Runner\\InitialTestsRunnerTest\:\:\$phpBin \(string\) does not accept string\|false\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: ../tests/phpunit/Process/Runner/InitialTestsRunnerTest.php
 
 		-
 			message: '#^Call to an undefined method Infection\\Event\\MutationTestingWasFinished\|Infection\\Event\\MutationTestingWasStarted\:\:getMutationCount\(\)\.$#'

--- a/tests/phpunit/BenchmarkTest.php
+++ b/tests/phpunit/BenchmarkTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests;
 
+use Infection\Tests\TestingUtility\Process\TestPhpExecutableFinder;
 use function is_dir;
 use const PHP_OS_FAMILY;
 use const PHP_SAPI;
@@ -44,7 +45,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use function Safe\realpath;
 use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
 #[Group('integration')]
@@ -52,11 +52,6 @@ use Symfony\Component\Process\Process;
 final class BenchmarkTest extends TestCase
 {
     private const BENCHMARK_DIR = __DIR__ . '/../benchmark';
-
-    /**
-     * @var string|null
-     */
-    private $phpExecutable;
 
     #[DataProvider('provideBenchmarks')]
     public function test_all_the_benchmarks_can_be_executed(string $path, string $sourcesLocation): void
@@ -76,7 +71,7 @@ final class BenchmarkTest extends TestCase
         $this->assertFileExists($path);
 
         $benchmarkProcess = new Process([
-            $this->getPhpExecutable(),
+            TestPhpExecutableFinder::find(),
             $path,
             '1',
         ]);
@@ -99,10 +94,5 @@ final class BenchmarkTest extends TestCase
             realpath(self::BENCHMARK_DIR . '/Tracing/provide-traces.php'),
             self::BENCHMARK_DIR . '/Tracing/sources',
         ];
-    }
-
-    private function getPhpExecutable(): string
-    {
-        return $this->phpExecutable ??= (new PhpExecutableFinder())->find();
     }
 }

--- a/tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php
+++ b/tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php
@@ -44,30 +44,23 @@ use Infection\Event\InitialStaticAnalysisSubStepWasCompleted;
 use Infection\Process\Factory\InitialStaticAnalysisProcessFactory;
 use Infection\Process\Runner\InitialStaticAnalysisRunner;
 use Infection\Tests\Fixtures\Event\EventDispatcherCollector;
+use Infection\Tests\TestingUtility\Process\TestPhpExecutableFinder;
 use const PHP_SAPI;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
 #[Group('integration')]
 #[CoversClass(InitialStaticAnalysisRunner::class)]
 final class InitialStaticAnalysisRunnerTest extends TestCase
 {
-    private static string $phpBin;
-
     private InitialStaticAnalysisProcessFactory&MockObject $processFactoryMock;
 
     private EventDispatcherCollector $eventDispatcher;
 
     private InitialStaticAnalysisRunner $runner;
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$phpBin = (string) (new PhpExecutableFinder())->find();
-    }
 
     protected function setUp(): void
     {
@@ -109,6 +102,10 @@ final class InitialStaticAnalysisRunnerTest extends TestCase
 
     private function createProcessForCode(string $code): Process
     {
-        return new Process([self::$phpBin, '-r', $code]);
+        return new Process([
+            TestPhpExecutableFinder::find(),
+            '-r',
+            $code,
+        ]);
     }
 }

--- a/tests/phpunit/Process/Runner/InitialTestsRunnerTest.php
+++ b/tests/phpunit/Process/Runner/InitialTestsRunnerTest.php
@@ -45,6 +45,7 @@ use Infection\Event\InitialTestSuiteWasStarted;
 use Infection\Process\Factory\InitialTestsRunProcessFactory;
 use Infection\Process\Runner\InitialTestsRunner;
 use Infection\Tests\Fixtures\Event\EventDispatcherCollector;
+use Infection\Tests\TestingUtility\Process\TestPhpExecutableFinder;
 use const PHP_SAPI;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
@@ -53,18 +54,12 @@ use PHPUnit\Framework\TestCase;
 use function str_contains;
 use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\InputStream;
-use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
 #[Group('integration')]
 #[CoversClass(InitialTestsRunner::class)]
 final class InitialTestsRunnerTest extends TestCase
 {
-    /**
-     * @var string
-     */
-    private static $phpBin;
-
     /**
      * @var InitialTestsRunProcessFactory|MockObject
      */
@@ -79,11 +74,6 @@ final class InitialTestsRunnerTest extends TestCase
      * @var InitialTestsRunner
      */
     private $runner;
-
-    public static function setUpBeforeClass(): void
-    {
-        self::$phpBin = (new PhpExecutableFinder())->find();
-    }
 
     protected function setUp(): void
     {
@@ -175,6 +165,10 @@ final class InitialTestsRunnerTest extends TestCase
 
     private function createProcessForCode(string $code): Process
     {
-        return new Process([self::$phpBin, '-r', $code]);
+        return new Process([
+            TestPhpExecutableFinder::find(),
+            '-r',
+            $code,
+        ]);
     }
 }

--- a/tests/phpunit/TestingUtility/Process/TestPhpExecutableFinder.php
+++ b/tests/phpunit/TestingUtility/Process/TestPhpExecutableFinder.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestingUtility\Process;
+
+use Infection\CannotBeInstantiated;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Webmozart\Assert\Assert;
+
+final class TestPhpExecutableFinder
+{
+    use CannotBeInstantiated;
+
+    private static string $phpExecutable;
+
+    public static function find(): string
+    {
+        if (!isset(self::$phpExecutable)) {
+            self::$phpExecutable = self::lookup();
+        }
+
+        return self::$phpExecutable;
+    }
+
+    private static function lookup(): string
+    {
+        $finder = new PhpExecutableFinder();
+        $executable = $finder->find();
+
+        Assert::notFalse(
+            $executable,
+            'Expected to find a PHP executable. None found.',
+        );
+
+        return $executable;
+    }
+}


### PR DESCRIPTION
This finder denotes itself from a non-test one by the fact that it has a hard assert statement without any actionable documented by the user and that the result is memoized in a static property.

This helps to remove some boilerplate and fix some PHPStan types.