### PR TITLE
chore(PHP-CS-Fixer): Fix cache file location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ BOX_URL="https://github.com/humbug/box/releases/download/4.5.1/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
 PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.65.0/php-cs-fixer.phar"
-PHP_CS_FIXER_CACHE=.php_cs.cache
 
 PHPSTAN=./vendor/bin/phpstan
 RECTOR=./vendor/bin/rector
@@ -70,14 +69,14 @@ check_trailing_whitespaces:
 .PHONY: cs
 cs:	  	 	## Runs PHP-CS-Fixer
 cs: $(PHP_CS_FIXER)
-	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE) --diff
+	$(PHP_CS_FIXER) fix -v --diff
 	LC_ALL=C sort -u .gitignore -o .gitignore
 	$(MAKE) check_trailing_whitespaces
 
 .PHONY: cs-check
 cs-check:		## Runs PHP-CS-Fixer in dry-run mode
 cs-check: $(PHP_CS_FIXER)
-	$(PHP_CS_FIXER) fix -v --cache-file=$(PHP_CS_FIXER_CACHE) --diff --dry-run
+	$(PHP_CS_FIXER) fix -v --diff --dry-run
 	LC_ALL=C sort -c -u .gitignore
 	$(MAKE) check_trailing_whitespaces
 


### PR DESCRIPTION
#2497 was not sufficient: we actually explicitly specify the cache file via the command which meant the location set in the configuration was overwritten.

I didn't realise this in #2497 as I thought the cache file used was the default once hence I did not think of checking the Makefile.