### PR TITLE
test(benchmark): Fix typo in the printed message

### DIFF
--- a/tests/benchmark/MutationGenerator/profile.php
+++ b/tests/benchmark/MutationGenerator/profile.php
@@ -121,7 +121,7 @@ if ($count === 0) {
 
 $output->writeln(
     sprintf(
-        '%d mutations generated.',
+        '%d mutation(s) generated.',
         $count,
     ),
 );

--- a/tests/benchmark/Tracing/profile.php
+++ b/tests/benchmark/Tracing/profile.php
@@ -122,7 +122,7 @@ if (!is_int($count) || $count === 0) {
 
 $output->writeln(
     sprintf(
-        '%d traces generated.',
+        '%d trace(s) generated.',
         $count,
     ),
 );


### PR DESCRIPTION
There can be 0 or 1 mutation/trace generated too.
