### PR TITLE
fix(benchmark): Limit the number of generated mutations to the max count

### DIFF
--- a/tests/benchmark/MutationGenerator/generate-mutations-closure.php
+++ b/tests/benchmark/MutationGenerator/generate-mutations-closure.php
@@ -91,7 +91,7 @@ return static function (int $maxCount) use ($fileMutationGenerator, $traces, $mu
             ++$count;
 
             if ($count >= $maxCount) {
-                break;
+                break 2;
             }
         }
     }


### PR DESCRIPTION
Previously, executing:

```shell
php tests/benchmark/MutationGenerator/profile.php --debug --max-mutation-count=1
```

was still resulting in 292 mutations generated because we were not breaking the outer loop.