### PR TITLE
refactor(benchmark): Make instrumentors return an integer

### DIFF
--- a/tests/benchmark/BlackfireInstrumentor.php
+++ b/tests/benchmark/BlackfireInstrumentor.php
@@ -49,14 +49,7 @@ use Webmozart\Assert\Assert;
  */
 final class BlackfireInstrumentor implements Instrumentor
 {
-    /**
-     * @template T
-     *
-     * @param Closure(): T $main
-     *
-     * @return T
-     */
-    public function profile(Closure $main, SymfonyStyle $io): mixed
+    public function profile(Closure $main, SymfonyStyle $io): int
     {
         self::check($io);
 

--- a/tests/benchmark/DummyInstrumentor.php
+++ b/tests/benchmark/DummyInstrumentor.php
@@ -40,7 +40,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class DummyInstrumentor implements Instrumentor
 {
-    public function profile(Closure $main, SymfonyStyle $io): mixed
+    public function profile(Closure $main, SymfonyStyle $io): int
     {
         return $main();
     }

--- a/tests/benchmark/Instrumentor.php
+++ b/tests/benchmark/Instrumentor.php
@@ -41,9 +41,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 interface Instrumentor
 {
     /**
-     * @template T
-     *
-     * @param Closure(): T $main
+     * @param Closure():(positive-int|0) $main
      */
-    public function profile(Closure $main, SymfonyStyle $io): mixed;
+    public function profile(Closure $main, SymfonyStyle $io): int;
 }

--- a/tests/benchmark/MutationGenerator/profile.php
+++ b/tests/benchmark/MutationGenerator/profile.php
@@ -111,7 +111,7 @@ $debug = $input->getOption(DEBUG_OPT);
 $instrumentor = InstrumentorFactory::create($debug);
 
 $count = $instrumentor->profile(
-    static fn (): int => $generateMutations($maxMutationsCount),
+    static fn () => $generateMutations($maxMutationsCount),
     $io,
 );
 

--- a/tests/benchmark/Tracing/profile.php
+++ b/tests/benchmark/Tracing/profile.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Benchmark\Tracing;
 
 use Infection\Benchmark\InstrumentorFactory;
-use function is_int;
 use LogicException;
 use const PHP_INT_MAX;
 use function sprintf;
@@ -116,7 +115,7 @@ $count = $instrumentor->profile(
     $io,
 );
 
-if (!is_int($count) || $count === 0) {
+if ($count === 0) {
     throw new LogicException('Something went wrong, no traces were actually generated.');
 }
 


### PR DESCRIPTION
I don't really see a use case to return something else and it makes it easy to solve the deprecated Blackfire `--samples` option later (see https://github.com/infection/infection/pull/2517). 