### PR TITLE
refactor(Str): consolidate the remaining lines normalization utilities

### DIFF
--- a/src/Framework/Str.php
+++ b/src/Framework/Str.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Framework;
 
+use function array_map;
 use function array_values;
 use function count;
 use function explode;
@@ -86,11 +87,33 @@ final class Str
         );
     }
 
-    public static function trimLineReturns(string $string): string
+    /**
+     * Trim the whitespace from the end of all lines. The line endings are
+     * replaced by the unix line ending.
+     */
+    public static function rTrimLines(string $value): string
+    {
+        return implode(
+            "\n",
+            array_map(
+                rtrim(...),
+                explode(
+                    "\n",
+                    self::toUnixLineEndings($value),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Removes all lines and removes leading and trailing blank lines. Line
+     * endings are replaced by the system line endings.
+     */
+    public static function removeOuterBlankLines(string $value): string
     {
         $lines = explode(
             "\n",
-            str_replace("\r\n", "\n", $string),
+            str_replace("\r\n", "\n", $value),
         );
         $linesCount = count($lines);
 

--- a/src/Logger/GitLabCodeQualityLogger.php
+++ b/src/Logger/GitLabCodeQualityLogger.php
@@ -71,7 +71,9 @@ final class GitLabCodeQualityLogger implements LineMutationTestingResultsLogger
                 'fingerprint' => $escapedExecutionResult->getMutantHash(),
                 'check_name' => $escapedExecutionResult->getMutatorName(),
                 'description' => 'Escaped Mutant for Mutator ' . $escapedExecutionResult->getMutatorName(),
-                'content' => Str::convertToUtf8(Str::trimLineReturns($escapedExecutionResult->getMutantDiff())),
+                'content' => Str::convertToUtf8(
+                    Str::removeOuterBlankLines($escapedExecutionResult->getMutantDiff()),
+                ),
                 'categories' => ['Escaped Mutant'],
                 'location' => [
                     /* @phpstan-ignore-next-line expects string, string|null given */

--- a/src/Logger/Html/StrykerHtmlReportBuilder.php
+++ b/src/Logger/Html/StrykerHtmlReportBuilder.php
@@ -252,14 +252,16 @@ final readonly class StrykerHtmlReportBuilder
                 return [
                     'id' => $result->getMutantHash(),
                     'mutatorName' => $result->getMutatorName(),
-                    'replacement' => Str::convertToUtf8(Str::trimLineReturns(ltrim($replacement))),
+                    'replacement' => Str::convertToUtf8(Str::removeOuterBlankLines(ltrim($replacement))),
                     'description' => $this->getMutatorDescription($result->getMutatorName(), $result->getMutatorClass()),
                     'location' => [
                         'start' => ['line' => $result->getOriginalStartingLine(), 'column' => $startingColumn],
                         'end' => ['line' => $endingLine, 'column' => $endingColumn],
                     ],
                     'status' => self::DETECTION_STATUS_MAP[$result->getDetectionStatus()->value],
-                    'statusReason' => Str::convertToUtf8(Str::trimLineReturns($result->getProcessOutput())),
+                    'statusReason' => Str::convertToUtf8(
+                        Str::removeOuterBlankLines($result->getProcessOutput()),
+                    ),
                     'coveredBy' => array_unique(array_map(
                         fn (TestLocation $testLocation): string => $this->buildTestMethodId($testLocation->getMethod()),
                         $result->getTests(),

--- a/src/Logger/JsonLogger.php
+++ b/src/Logger/JsonLogger.php
@@ -106,8 +106,10 @@ final readonly class JsonLogger implements LineMutationTestingResultsLogger
                     'originalFilePath' => $mutantProcess->getOriginalFilePath(),
                     'originalStartLine' => $mutantProcess->getOriginalStartingLine(),
                 ],
-                'diff' => Str::convertToUtf8(Str::trimLineReturns($mutantProcess->getMutantDiff())),
-                'processOutput' => Str::convertToUtf8(Str::trimLineReturns($mutantProcess->getProcessOutput())),
+                'diff' => Str::convertToUtf8(Str::removeOuterBlankLines($mutantProcess->getMutantDiff())),
+                'processOutput' => Str::convertToUtf8(
+                    Str::removeOuterBlankLines($mutantProcess->getProcessOutput()),
+                ),
             ];
         }
 

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -168,7 +168,7 @@ final readonly class TextFileLogger implements LineMutationTestingResultsLogger
 
             $lines[] = self::getMutatorLine($index, $executionResult);
             $lines[] = '';
-            $lines[] = Str::trimLineReturns($executionResult->getMutantDiff());
+            $lines[] = Str::removeOuterBlankLines($executionResult->getMutantDiff());
 
             if ($this->debugMode) {
                 $lines[] = '';
@@ -221,7 +221,7 @@ final readonly class TextFileLogger implements LineMutationTestingResultsLogger
             PHP_EOL,
             array_map(
                 static fn (string $line): string => '  ' . $line,
-                explode(PHP_EOL, Str::trimLineReturns($value)),
+                explode(PHP_EOL, Str::removeOuterBlankLines($value)),
             ),
         );
     }

--- a/tests/phpunit/Console/ConsoleOutputTest.php
+++ b/tests/phpunit/Console/ConsoleOutputTest.php
@@ -37,8 +37,8 @@ namespace Infection\Tests\Console;
 
 use Infection\Console\ConsoleOutput;
 use Infection\Console\IO;
+use Infection\Framework\Str;
 use Infection\Logger\ConsoleLogger;
-use function Infection\Tests\normalize_trailing_spaces;
 use const PHP_EOL;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -87,7 +87,7 @@ final class ConsoleOutputTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($this->output->fetch()),
+            Str::rTrimLines($this->output->fetch()),
         );
     }
 
@@ -103,7 +103,7 @@ final class ConsoleOutputTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($this->output->fetch()),
+            Str::rTrimLines($this->output->fetch()),
         );
     }
 
@@ -117,7 +117,7 @@ final class ConsoleOutputTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($this->output->fetch()),
+            Str::rTrimLines($this->output->fetch()),
         );
     }
 
@@ -134,7 +134,7 @@ final class ConsoleOutputTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($this->output->fetch()),
+            Str::rTrimLines($this->output->fetch()),
         );
     }
 
@@ -154,7 +154,7 @@ final class ConsoleOutputTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($this->output->fetch()),
+            Str::rTrimLines($this->output->fetch()),
         );
     }
 
@@ -174,7 +174,7 @@ final class ConsoleOutputTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($this->output->fetch()),
+            Str::rTrimLines($this->output->fetch()),
         );
     }
 }

--- a/tests/phpunit/Helpers.php
+++ b/tests/phpunit/Helpers.php
@@ -35,10 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests;
 
-use function array_map;
-use function explode;
-use function implode;
-use Infection\Framework\Str;
 use function random_int;
 use function Safe\realpath;
 use function str_replace;
@@ -48,17 +44,6 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use function sys_get_temp_dir;
-
-function normalize_trailing_spaces(string $value): string
-{
-    return implode(
-        "\n",
-        array_map(
-            'rtrim',
-            explode("\n", Str::toUnixLineEndings($value)),
-        ),
-    );
-}
 
 /**
  * Creates a temporary directory.

--- a/tests/phpunit/Logger/ConsoleLoggerTest.php
+++ b/tests/phpunit/Logger/ConsoleLoggerTest.php
@@ -37,8 +37,8 @@ namespace Infection\Tests\Logger;
 
 use DateTimeImmutable as UnsafeDateTimeImmutable;
 use Infection\Console\IO;
+use Infection\Framework\Str;
 use Infection\Logger\ConsoleLogger;
-use function Infection\Tests\normalize_trailing_spaces;
 use InvalidArgumentException;
 use const PHP_EOL;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -140,7 +140,7 @@ final class ConsoleLoggerTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($output->fetch()),
+            Str::rTrimLines($output->fetch()),
         );
 
         $logger->log(LogLevel::WARNING, 'message', ['block' => true]);
@@ -152,7 +152,7 @@ final class ConsoleLoggerTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($output->fetch()),
+            Str::rTrimLines($output->fetch()),
         );
 
         $logger->log(LogLevel::ERROR, 'message', ['block' => true]);
@@ -164,7 +164,7 @@ final class ConsoleLoggerTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($output->fetch()),
+            Str::rTrimLines($output->fetch()),
         );
     }
 

--- a/tests/phpunit/Logger/CreateMetricsCalculator.php
+++ b/tests/phpunit/Logger/CreateMetricsCalculator.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Logger;
 
+use Infection\Framework\Str;
 use Infection\Metrics\Collector;
 use Infection\Metrics\MetricsCalculator;
 use Infection\Metrics\ResultsCollector;
@@ -43,7 +44,6 @@ use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutator\Loop\For_;
 use Infection\Mutator\Regex\PregQuote;
 use Infection\Testing\MutatorName;
-use function Infection\Tests\normalize_trailing_spaces;
 use function Later\now;
 
 trait CreateMetricsCalculator
@@ -186,17 +186,19 @@ trait CreateMetricsCalculator
             'bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"',
             'process output',
             $detectionStatus,
-            now(normalize_trailing_spaces(
-                <<<DIFF
-                    --- Original
-                    +++ New
-                    @@ @@
+            now(
+                Str::rTrimLines(
+                    <<<DIFF
+                        --- Original
+                        +++ New
+                        @@ @@
 
-                    - echo 'original';
-                    + echo '$echoMutatedMessage';
+                        - echo 'original';
+                        + echo '$echoMutatedMessage';
 
-                    DIFF,
-            )),
+                        DIFF,
+                ),
+            ),
             'a1b2c3',
             $mutatorClassName,
             MutatorName::getName($mutatorClassName),

--- a/tests/phpunit/Logger/Html/StrykerHtmlReportBuilderTest.php
+++ b/tests/phpunit/Logger/Html/StrykerHtmlReportBuilderTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Logger\Html;
 use function array_map;
 use function implode;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
+use Infection\Framework\Str;
 use Infection\Logger\Html\StrykerHtmlReportBuilder;
 use Infection\Metrics\Collector;
 use Infection\Metrics\MetricsCalculator;
@@ -49,7 +50,6 @@ use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Removal\ArrayItemRemoval;
 use Infection\Mutator\Removal\MethodCallRemoval;
 use Infection\Testing\MutatorName;
-use function Infection\Tests\normalize_trailing_spaces;
 use JsonSchema\Validator;
 use function Later\now;
 use const PHP_EOL;
@@ -468,7 +468,7 @@ final class StrykerHtmlReportBuilderTest extends TestCase
             'bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"',
             $processOutput,
             $detectionStatus,
-            now(normalize_trailing_spaces($diff)),
+            now(Str::rTrimLines($diff)),
             $mutantHash,
             $mutatorClassName,
             $mutatorName ?? MutatorName::getName($mutatorClassName),

--- a/tests/phpunit/Metrics/MinMsiCheckerTest.php
+++ b/tests/phpunit/Metrics/MinMsiCheckerTest.php
@@ -37,10 +37,10 @@ namespace Infection\Tests\Metrics;
 
 use Infection\Console\ConsoleOutput;
 use Infection\Console\IO;
+use Infection\Framework\Str;
 use Infection\Logger\ConsoleLogger;
 use Infection\Metrics\MinMsiChecker;
 use Infection\Metrics\MinMsiCheckFailed;
-use function Infection\Tests\normalize_trailing_spaces;
 use const PHP_EOL;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -127,7 +127,7 @@ final class MinMsiCheckerTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($this->output->fetch()),
+            Str::rTrimLines($this->output->fetch()),
         );
     }
 
@@ -146,7 +146,7 @@ final class MinMsiCheckerTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($this->output->fetch()),
+            Str::rTrimLines($this->output->fetch()),
         );
     }
 
@@ -168,7 +168,7 @@ final class MinMsiCheckerTest extends TestCase
 
                 TXT
             ,
-            normalize_trailing_spaces($this->output->fetch()),
+            Str::rTrimLines($this->output->fetch()),
         );
     }
 


### PR DESCRIPTION
 It seems I was too hasty in #2504 and made some incorrect assumptions. So this PR limits its scope a great deal and only does the following:

- Replaces `normalize_trailing_spaces()` by `Str::rTrimLines()`. Unlike the original proposal of naming it `normalize()` or `trimLines()`, I added the `r` prefix since we are doing an `rtrim()` and not a `trim()`.
- Renamed `Str::trimLineReturns()` into `::removeOuterBlankLines()` which better describes what it does.
- Add a lot more tests.

Further improvements will be done separately.