### PR TITLE
refactor(Str): Rework `::removeOuterBlankLines()`

### DIFF
--- a/src/Framework/Str.php
+++ b/src/Framework/Str.php
@@ -105,14 +105,14 @@ final class Str
     }
 
     /**
-     * Removes all lines and removes leading and trailing blank lines. Line
+     * Trims the whitespace from the end of all lines and removes the leading and trailing blank lines. Line
      * endings are replaced by the unix line endings.
      */
-    public static function removeOuterBlankLines(string $value): string
+    public static function cleanForDisplay(string $value): string
     {
         $lines = explode(
             "\n",
-            self::toUnixLineEndings($value),
+            self::rTrimLines($value),
         );
         $linesCount = count($lines);
 
@@ -120,7 +120,7 @@ final class Str
         for ($i = 0; $i < $linesCount; ++$i) {
             $line = $lines[$i];
 
-            if (trim($line) === '') {
+            if ($line === '') {
                 unset($lines[$i]);
 
                 continue;
@@ -136,7 +136,7 @@ final class Str
         for ($i = $linesCount - 1; $i >= 0; --$i) {
             $line = $lines[$i];
 
-            if (trim($line) === '') {
+            if ($line === '') {
                 unset($lines[$i]);
 
                 continue;

--- a/src/Logger/GitLabCodeQualityLogger.php
+++ b/src/Logger/GitLabCodeQualityLogger.php
@@ -72,7 +72,7 @@ final class GitLabCodeQualityLogger implements LineMutationTestingResultsLogger
                 'check_name' => $escapedExecutionResult->getMutatorName(),
                 'description' => 'Escaped Mutant for Mutator ' . $escapedExecutionResult->getMutatorName(),
                 'content' => Str::convertToUtf8(
-                    Str::removeOuterBlankLines($escapedExecutionResult->getMutantDiff()),
+                    Str::cleanForDisplay($escapedExecutionResult->getMutantDiff()),
                 ),
                 'categories' => ['Escaped Mutant'],
                 'location' => [

--- a/src/Logger/Html/StrykerHtmlReportBuilder.php
+++ b/src/Logger/Html/StrykerHtmlReportBuilder.php
@@ -252,7 +252,7 @@ final readonly class StrykerHtmlReportBuilder
                 return [
                     'id' => $result->getMutantHash(),
                     'mutatorName' => $result->getMutatorName(),
-                    'replacement' => Str::convertToUtf8(Str::removeOuterBlankLines(ltrim($replacement))),
+                    'replacement' => Str::convertToUtf8(Str::cleanForDisplay(ltrim($replacement))),
                     'description' => $this->getMutatorDescription($result->getMutatorName(), $result->getMutatorClass()),
                     'location' => [
                         'start' => ['line' => $result->getOriginalStartingLine(), 'column' => $startingColumn],
@@ -260,7 +260,7 @@ final readonly class StrykerHtmlReportBuilder
                     ],
                     'status' => self::DETECTION_STATUS_MAP[$result->getDetectionStatus()->value],
                     'statusReason' => Str::convertToUtf8(
-                        Str::removeOuterBlankLines($result->getProcessOutput()),
+                        Str::cleanForDisplay($result->getProcessOutput()),
                     ),
                     'coveredBy' => array_unique(array_map(
                         fn (TestLocation $testLocation): string => $this->buildTestMethodId($testLocation->getMethod()),

--- a/src/Logger/JsonLogger.php
+++ b/src/Logger/JsonLogger.php
@@ -106,9 +106,9 @@ final readonly class JsonLogger implements LineMutationTestingResultsLogger
                     'originalFilePath' => $mutantProcess->getOriginalFilePath(),
                     'originalStartLine' => $mutantProcess->getOriginalStartingLine(),
                 ],
-                'diff' => Str::convertToUtf8(Str::removeOuterBlankLines($mutantProcess->getMutantDiff())),
+                'diff' => Str::convertToUtf8(Str::cleanForDisplay($mutantProcess->getMutantDiff())),
                 'processOutput' => Str::convertToUtf8(
-                    Str::removeOuterBlankLines($mutantProcess->getProcessOutput()),
+                    Str::cleanForDisplay($mutantProcess->getProcessOutput()),
                 ),
             ];
         }

--- a/src/Logger/TextFileLogger.php
+++ b/src/Logger/TextFileLogger.php
@@ -168,7 +168,7 @@ final readonly class TextFileLogger implements LineMutationTestingResultsLogger
 
             $lines[] = self::getMutatorLine($index, $executionResult);
             $lines[] = '';
-            $lines[] = Str::removeOuterBlankLines($executionResult->getMutantDiff());
+            $lines[] = Str::cleanForDisplay($executionResult->getMutantDiff());
 
             if ($this->debugMode) {
                 $lines[] = '';
@@ -221,7 +221,7 @@ final readonly class TextFileLogger implements LineMutationTestingResultsLogger
             PHP_EOL,
             array_map(
                 static fn (string $line): string => '  ' . $line,
-                explode("\n", Str::removeOuterBlankLines($value)),
+                explode("\n", Str::cleanForDisplay($value)),
             ),
         );
     }

--- a/tests/phpunit/Framework/StrTest.php
+++ b/tests/phpunit/Framework/StrTest.php
@@ -113,14 +113,14 @@ final class StrTest extends TestCase
     }
 
     #[DataProvider('trimLinesProvider')]
-    public function test_it_trims_blank_lines_and_replaces_the_line_endings_by_the_unix_line_ending(
+    public function test_it_rtrim_lines_trims_blank_lines_and_replaces_the_line_endings_by_the_unix_line_ending(
         string $value,
         string $expectedTrimmedLines,
-        ?string $expectedTrimmedBlankLines = null,
+        ?string $expectedCleanedLines = null,
     ): void {
-        $expected = $expectedTrimmedBlankLines ?? $expectedTrimmedLines;
+        $expected = $expectedCleanedLines ?? $expectedTrimmedLines;
 
-        $actual = Str::removeOuterBlankLines($value);
+        $actual = Str::cleanForDisplay($value);
 
         $this->assertSame($expected, $actual);
     }
@@ -145,7 +145,6 @@ final class StrTest extends TestCase
         yield 'string without line endings with spaces' => [
             ' Hello world! ',
             ' Hello world!',
-            ' Hello world! ',
         ];
 
         yield 'string with only Unix/Linux (LF) line endings' => [
@@ -225,10 +224,10 @@ final class StrTest extends TestCase
             $value = <<<TXT
 
                 $s
-                {$s}Hello...$s 
+                {$s}Hello...$s
 
                 $s
-                $s...World!$s 
+                $s...World!$s
                 $s
 
                 TXT;
@@ -244,29 +243,29 @@ final class StrTest extends TestCase
 
                 TXT;
 
-            $expectedTrimmedBlankLines = <<<TXT
-                {$s}Hello...$s$s
+            $expectedCleanedLines = <<<TXT
+                {$s}Hello...
 
-                $s
-                $s...World!$s$s
+
+                $s...World!
                 TXT;
 
             yield 'string with leading, trailing & in-between line endings and spaces and blank lines – Unix/Linux (LF) line endings' => [
                 $value,
                 $expectedTrimmedLines,
-                $expectedTrimmedBlankLines,
+                $expectedCleanedLines,
             ];
 
             yield 'string with leading, trailing & in-between line endings and spaces and blank lines – Windows (CRLF) line endings' => [
                 str_replace("\n", "\r\n", $value),
                 $expectedTrimmedLines,
-                $expectedTrimmedBlankLines,
+                $expectedCleanedLines,
             ];
 
             yield 'string with leading, trailing & in-between line endings and spaces and blank lines – Classic MacOS (CRLF) line endings' => [
                 str_replace("\n", "\r", $value),
                 $expectedTrimmedLines,
-                $expectedTrimmedBlankLines,
+                $expectedCleanedLines,
             ];
         })();
     }


### PR DESCRIPTION
Closes #2528.

As discussed in the linked issue, in terms of usage it makes little sense for `::removeOuterBlankLines()` to not trimming the trailing whitespaces of lines.

However, this may also be a bit confusing as the method name suggests no such thing. As discussed, we decided to go with the name `::cleanForDisplay()` which is not the best description for _what it does_, but at least better conveys the _intent_.