### PR TITLE
refactor(Str): Optimize the implementation of `Str::cleanForDisplay()`

### DIFF
--- a/src/Framework/Str.php
+++ b/src/Framework/Str.php
@@ -41,6 +41,7 @@ use function count;
 use function explode;
 use function implode;
 use Infection\CannotBeInstantiated;
+use LogicException;
 use const PHP_EOL;
 use function Safe\mb_convert_encoding;
 use function strtr;
@@ -184,6 +185,6 @@ final class Str
             }
         }
 
-        return $firstNonEmptyLineIndex;
+        throw new LogicException('This should never happen!');
     }
 }


### PR DESCRIPTION
I don't think benchmarks are necessary for such a limited utility function, but I doubt it would be less performant, and it is more readable that way.