### PR TITLE
refactor(tests): More flexible mutant mutation assertion

### DIFF
--- a/tests/phpunit/Mutant/MutantAssertions.php
+++ b/tests/phpunit/Mutant/MutantAssertions.php
@@ -55,7 +55,7 @@ trait MutantAssertions
         string $originalCode,
     ): void {
         $this->assertSame($expectedFilePath, $mutant->getFilePath());
-        $this->assertSame($expectedMutation, $mutant->getMutation());
+        $this->assertEquals($expectedMutation, $mutant->getMutation());
         $this->assertSame($expectedMutatedCode, $mutant->getMutatedCode()->get());
         $this->assertSame($expectedDiff, $mutant->getDiff()->get());
         $this->assertSame($expectedCoveredByTests, $mutant->isCoveredByTest());


### PR DESCRIPTION
`Mutation` has a lot of state, hence its `MutationAssertions` (which we never implemented) would be quite verbose. To cut on this boilerplate, at the time, we used:

```php
// tests/phpunit/Mutant/MutantAssertions.php

$this->assertSame($expectedMutation, $mutant->getMutation());
```

It is quite restrictive. Now that object states are properly compared (see #2487), we can loosen that comparison. With #2488 it will be easy to create a new `Mutation` object hence comparing two mutants without requiring having the same mutation instance will be handy.