### PR TITLE
refactor(tests): Rename `MutantBuider::build()` to `::materialize()`

### DIFF
--- a/tests/phpunit/Mutant/MutantBuilder.php
+++ b/tests/phpunit/Mutant/MutantBuilder.php
@@ -42,7 +42,7 @@ use function Later\now;
 
 final class MutantBuilder
 {
-    public static function build(
+    public static function materialize(
         string $mutantFilePath = '/path/to/mutant',
         ?Mutation $mutation = null,
         string $mutatedCode = 'mutated code',

--- a/tests/phpunit/Mutant/MutantExecutionResultTest.php
+++ b/tests/phpunit/Mutant/MutantExecutionResultTest.php
@@ -117,7 +117,7 @@ final class MutantExecutionResultTest extends TestCase
         $originalCode = '<?php $a = 1;';
         $mutatedCode = '<?php $a = 1;';
 
-        $mutant = MutantBuilder::build(
+        $mutant = MutantBuilder::materialize(
             '/path/to/mutant',
             new Mutation(
                 $originalFilePath = 'path/to/Foo.php',

--- a/tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php
@@ -98,7 +98,7 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::build(
+            MutantBuilder::materialize(
                 '/path/to/mutant',
                 new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
@@ -172,7 +172,7 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::build(
+            MutantBuilder::materialize(
                 '/path/to/mutant',
                 new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
@@ -258,7 +258,7 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::build(
+            MutantBuilder::materialize(
                 '/path/to/mutant',
                 new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
@@ -345,7 +345,7 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::build(
+            MutantBuilder::materialize(
                 '/path/to/mutant',
                 new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
@@ -432,7 +432,7 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::build(
+            MutantBuilder::materialize(
                 '/path/to/mutant',
                 new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
@@ -528,7 +528,7 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::build(
+            MutantBuilder::materialize(
                 '/path/to/mutant',
                 new Mutation(
                     $originalFilePath = 'path/to/Foo.php',

--- a/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
+++ b/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
@@ -58,7 +58,7 @@ final class MutantProcessContainerFactoryTest extends TestCase
     #[DataProvider('timeoutDataProvider')]
     public function test_it_creates_a_process_with_timeout(float $expectedProcessTimeout, float $testLocationExecutionTime, int $processFactoryTimeout): void
     {
-        $mutant = MutantBuilder::build(
+        $mutant = MutantBuilder::materialize(
             $mutantFilePath = '/path/to/mutant',
             new Mutation(
                 $originalFilePath = 'path/to/Foo.php',

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -174,20 +174,20 @@ final class MutationTestingRunnerTest extends TestCase
                 [$mutation3],
             ))
             ->willReturnOnConsecutiveCalls(
-                $mutant0 = MutantBuilder::build(
+                $mutant0 = MutantBuilder::materialize(
                     '/path/to/mutant0',
                     $mutation0,
                     'mutated code 0',
                 ),
-                $mutant1 = MutantBuilder::build(
+                $mutant1 = MutantBuilder::materialize(
                     '/path/to/mutant1',
                     $mutation1,
                     'mutated code 1',
                 ),
-                MutantBuilder::build(
+                MutantBuilder::materialize(
                     mutation: $mutation2,
                 ),
-                MutantBuilder::build(
+                MutantBuilder::materialize(
                     mutation: $mutation3,
                 ),
             )
@@ -263,7 +263,7 @@ final class MutationTestingRunnerTest extends TestCase
                 [$mutation0],
             ))
             ->willReturnOnConsecutiveCalls(
-                $mutant0 = MutantBuilder::build(
+                $mutant0 = MutantBuilder::materialize(
                     '/path/to/mutant0',
                     $mutation0,
                     'mutated code 0',
@@ -337,12 +337,12 @@ final class MutationTestingRunnerTest extends TestCase
                 [$mutation1],
             ))
             ->willReturnOnConsecutiveCalls(
-                $mutant0 = MutantBuilder::build(
+                $mutant0 = MutantBuilder::materialize(
                     '/path/to/mutant0',
                     $mutation0,
                     'mutated code 0',
                 ),
-                $mutant1 = MutantBuilder::build(
+                $mutant1 = MutantBuilder::materialize(
                     '/path/to/mutant1',
                     $mutation1,
                     'mutated code 1',
@@ -408,7 +408,7 @@ final class MutationTestingRunnerTest extends TestCase
 
         $testFrameworkExtraOptions = '--filter=acme/FooTest.php';
 
-        $mutant = MutantBuilder::build(
+        $mutant = MutantBuilder::materialize(
             '/path/to/mutant0',
             $mutation0,
             'mutated code 0',
@@ -473,7 +473,7 @@ final class MutationTestingRunnerTest extends TestCase
 
         $testFrameworkExtraOptions = '--filter=acme/FooTest.php';
 
-        $mutant = MutantBuilder::build(
+        $mutant = MutantBuilder::materialize(
             '/path/to/mutant0',
             $mutation0,
             'mutated code 0',
@@ -553,7 +553,7 @@ final class MutationTestingRunnerTest extends TestCase
 
         $mutation = $this->createMutation(0);
 
-        $mutant = MutantBuilder::build(
+        $mutant = MutantBuilder::materialize(
             mutation: $mutation,
             mutatedCode: 'mutated code 0',
         );
@@ -635,7 +635,7 @@ final class MutationTestingRunnerTest extends TestCase
     {
         $mutation = $this->createMutation(0, coveredByTests: false);
 
-        $mutant = MutantBuilder::build(mutation: $mutation);
+        $mutant = MutantBuilder::materialize(mutation: $mutation);
 
         $result = $this->invokeMethod('uncoveredByTest', $mutant);
 

--- a/tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php
@@ -84,7 +84,7 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::build(
+            MutantBuilder::materialize(
                 '/path/to/mutant',
                 new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
@@ -160,7 +160,7 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::build(
+            MutantBuilder::materialize(
                 '/path/to/mutant',
                 new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
@@ -240,7 +240,7 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::build(
+            MutantBuilder::materialize(
                 '/path/to/mutant',
                 new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
@@ -321,7 +321,7 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::build(
+            MutantBuilder::materialize(
                 '/path/to/mutant',
                 new Mutation(
                     $originalFilePath = 'path/to/Foo.php',

--- a/tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php
@@ -56,7 +56,7 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
 {
     public function test_it_creates_a_process_with_timeout(): void
     {
-        $mutant = MutantBuilder::build(
+        $mutant = MutantBuilder::materialize(
             $mutantFilePath = '/path/to/mutant',
             new Mutation(
                 $originalFilePath = 'path/to/Foo.php',
@@ -153,7 +153,7 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
 
     public function test_it_creates_a_process_with_multiple_options(): void
     {
-        $mutant = MutantBuilder::build(
+        $mutant = MutantBuilder::materialize(
             $mutantFilePath = '/path/to/mutant',
             new Mutation(
                 $originalFilePath = 'path/to/Foo.php',
@@ -251,7 +251,7 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
 
     public function test_it_creates_a_process_without_options(): void
     {
-        $mutant = MutantBuilder::build(
+        $mutant = MutantBuilder::materialize(
             $mutantFilePath = '/path/to/mutant',
             new Mutation(
                 $originalFilePath = 'path/to/Foo.php',


### PR DESCRIPTION
Extracted from #2488.

Not too crazy about the name, but it should be removed in the future so not a big deal.