### PR TITLE
test(benchmark): Enusure any lazy state is executed

### DIFF
--- a/tests/benchmark/Tracing/create-main.php
+++ b/tests/benchmark/Tracing/create-main.php
@@ -36,11 +36,22 @@ declare(strict_types=1);
 namespace Infection\Benchmark\Tracing;
 
 use Closure;
+use function function_exists;
 use Infection\Container;
+use Infection\TestFramework\Coverage\Trace;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Output\NullOutput;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
+
+if (!function_exists('Infection\Benchmark\Tracing\fetchTraceLazyState')) {
+    function fetchTraceLazyState(Trace $trace): void
+    {
+        $trace->getSourceFileInfo();
+        $trace->hasTests();
+        $trace->getTests();
+    }
+}
 
 /**
  * @param positive-int $maxCount
@@ -61,13 +72,13 @@ return static function (int $maxCount): Closure {
         $count = 0;
 
         foreach ($traceProvider->provideTraces() as $trace) {
+            fetchTraceLazyState($trace);
+
             ++$count;
 
             if ($count >= $maxCount) {
                 break;
             }
-
-            // Continue
         }
 
         return $count;


### PR DESCRIPTION
When I first created #2452 I was testing against some uncommitted work where the trace state was lazily evaluated, hence just iterating over the traces was not doing much, a lot more computation was only triggered once accessing the trace test.

I thought this would apply to the existing benchmark, but it appears the `JUnitTestExecutionInfoAdder`, which is executed by `CoveredTraceProvider`, load any lazy data to do its own thing. In other words, once the provider yields a trace, the state of the trace is fully initialised.

As a result, whilst I think this PR still has value because it has the merit of making it explicit, it does not result in any chance in the profile.

For good measure I also checked for the mutation but we do not have any lazy state there.

This PR is the last of #2452, which closes a 3 weeks journey :)