### PR TITLE
Get rid of unnecessary iterator_to_array() call

### DIFF
--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -247,7 +247,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
     {
         $hasLoggers = false;
 
-        /** @var FileLogger[] $fileLogger */
+        /** @var FileLogger $fileLogger */
         foreach ($this->getFileLoggers($this->mutationTestingResultsLogger->getLoggers()) as $fileLogger) {
             if (!$hasLoggers) {
                 $this->output->writeln(['', 'Generated Reports:']);


### PR DESCRIPTION
IIRC `iterator_to_array()` creates a unncessary copy of the underlying structure