### PR TITLE
[POC] Run InitialTestSuite/InitialStaticAnalysis only when mutations found

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -552,7 +552,6 @@ final class Container extends DIContainer
                         ? new DummyFileSystem()
                         : $container->getFileSystem(),
                     $container->getDiffSourceCodeMatcher(),
-                    $configuration->noProgress(),
                     $configuration->getProcessTimeout(),
                     $configuration->getIgnoreSourceCodeMutatorsMap(),
                     $configuration->getMutantId(),

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -41,7 +41,6 @@ use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\MutantProcessWasFinished;
 use Infection\Event\MutationTestingWasFinished;
 use Infection\Event\MutationTestingWasStarted;
-use Infection\IterableCounter;
 use Infection\Mutant\Mutant;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutant\MutantFactory;
@@ -67,7 +66,6 @@ class MutationTestingRunner
         private readonly EventDispatcher $eventDispatcher,
         private readonly Filesystem $fileSystem,
         private readonly DiffSourceCodeMatcher $diffSourceCodeMatcher,
-        private readonly bool $runConcurrently,
         private readonly float $timeout,
         private readonly array $ignoreSourceCodeMutatorsMap,
         private readonly ?string $mutantId = null,
@@ -77,9 +75,8 @@ class MutationTestingRunner
     /**
      * @param iterable<Mutation> $mutations
      */
-    public function run(iterable $mutations, string $testFrameworkExtraOptions): void
+    public function run(iterable $mutations, int $numberOfMutants, string $testFrameworkExtraOptions): void
     {
-        $numberOfMutants = IterableCounter::bufferAndCountIfNeeded($mutations, $this->runConcurrently);
         $this->eventDispatcher->dispatch(new MutationTestingWasStarted($numberOfMutants, $this->processRunner));
 
         $processContainers = take($mutations)

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -45,6 +45,7 @@ use Infection\Differ\DiffSourceCodeMatcher;
 use Infection\Event\MutantProcessWasFinished;
 use Infection\Event\MutationTestingWasFinished;
 use Infection\Event\MutationTestingWasStarted;
+use Infection\IterableCounter;
 use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutant\MutantFactory;
@@ -127,7 +128,6 @@ final class MutationTestingRunnerTest extends TestCase
             $this->eventDispatcher,
             $this->fileSystemMock,
             $this->diffSourceCodeMatcher,
-            false,
             self::TIMEOUT,
             [],
         );
@@ -144,7 +144,8 @@ final class MutationTestingRunnerTest extends TestCase
             ->with($this->emptyIterable())
         ;
 
-        $this->runner->run($mutations, $testFrameworkExtraOptions);
+        $numberOfMutants = IterableCounter::bufferAndCountIfNeeded($mutations, false);
+        $this->runner->run($mutations, $numberOfMutants, $testFrameworkExtraOptions);
 
         $this->assertAreSameEvents(
             [
@@ -220,7 +221,8 @@ final class MutationTestingRunnerTest extends TestCase
             ->with($this->iterableContaining([$process0, $process1]))
         ;
 
-        $this->runner->run($mutations, $testFrameworkExtraOptions);
+        $numberOfMutants = IterableCounter::bufferAndCountIfNeeded($mutations, false);
+        $this->runner->run($mutations, $numberOfMutants, $testFrameworkExtraOptions);
 
         $ignoredMutantCount = 2;
 
@@ -303,13 +305,13 @@ final class MutationTestingRunnerTest extends TestCase
             $this->eventDispatcher,
             $this->fileSystemMock,
             $this->diffSourceCodeMatcher,
-            false,
             self::TIMEOUT,
             [],
             'fd952823181329ed33260b45eb3aa956', // mutation with index 0
         );
 
-        $this->runner->run($mutations, $testFrameworkExtraOptions);
+        $numberOfMutants = IterableCounter::bufferAndCountIfNeeded($mutations, false);
+        $this->runner->run($mutations, $numberOfMutants, $testFrameworkExtraOptions);
 
         $this->assertAreSameEvents(
             [
@@ -384,12 +386,12 @@ final class MutationTestingRunnerTest extends TestCase
             $this->eventDispatcher,
             $this->fileSystemMock,
             new DiffSourceCodeMatcher(),
-            true,
             100.0,
             [],
         );
 
-        $this->runner->run($mutations, $testFrameworkExtraOptions);
+        $numberOfMutants = IterableCounter::bufferAndCountIfNeeded($mutations, true);
+        $this->runner->run($mutations, $numberOfMutants, $testFrameworkExtraOptions);
 
         $this->assertAreSameEvents(
             [
@@ -446,14 +448,14 @@ final class MutationTestingRunnerTest extends TestCase
             $this->eventDispatcher,
             $this->fileSystemMock,
             new DiffSourceCodeMatcher(),
-            true,
             100.0,
             [
                 'For_' => ['Assert::.*'],
             ],
         );
 
-        $this->runner->run($mutations, $testFrameworkExtraOptions);
+        $numberOfMutants = IterableCounter::bufferAndCountIfNeeded($mutations, true);
+        $this->runner->run($mutations, $numberOfMutants, $testFrameworkExtraOptions);
 
         $this->assertAreSameEvents(
             [
@@ -511,7 +513,6 @@ final class MutationTestingRunnerTest extends TestCase
             $this->eventDispatcher,
             $this->fileSystemMock,
             new DiffSourceCodeMatcher(),
-            true,
             100.0,
             [
                 'For_' => ['Assert::.*'],
@@ -519,7 +520,8 @@ final class MutationTestingRunnerTest extends TestCase
             'mutant-id-1',
         );
 
-        $this->runner->run($mutations, $testFrameworkExtraOptions);
+        $numberOfMutants = IterableCounter::bufferAndCountIfNeeded($mutations, true);
+        $this->runner->run($mutations, $numberOfMutants, $testFrameworkExtraOptions);
 
         $this->assertAreSameEvents(
             [
@@ -544,7 +546,6 @@ final class MutationTestingRunnerTest extends TestCase
             $this->eventDispatcher,
             $this->fileSystemMock,
             $this->diffSourceCodeMatcher,
-            true,
             100.0,
             [
                 'For_' => ['Assert::.*'],
@@ -591,12 +592,12 @@ final class MutationTestingRunnerTest extends TestCase
             $this->eventDispatcher,
             $this->fileSystemMock,
             new DiffSourceCodeMatcher(),
-            true,
             100.0,
             [],
         );
 
-        $this->runner->run($mutations, '');
+        $numberOfMutants = IterableCounter::bufferAndCountIfNeeded($mutations, true);
+        $this->runner->run($mutations, $numberOfMutants, '');
     }
 
     public function test_it_dispatches_events_even_when_no_mutations_is_given(): void
@@ -620,7 +621,8 @@ final class MutationTestingRunnerTest extends TestCase
             ->with($this->emptyIterable())
         ;
 
-        $this->runner->run($mutations, $testFrameworkExtraOptions);
+        $numberOfMutants = IterableCounter::bufferAndCountIfNeeded($mutations, true);
+        $this->runner->run($mutations, $numberOfMutants, $testFrameworkExtraOptions);
 
         $this->assertAreSameEvents(
             [


### PR DESCRIPTION
initial static test run and initial static analysis run can take up to ten's of minutes (in phpstan-src) case.

since phpstan-src uses only very few [self-implemented mutators tailored for real world problems in the PHPStan api](https://github.com/phpstan/build-infection/tree/1.x/src/Infection) we see a few PRs coming in, in which no mutations will be generated at all (which is fine).

but since initial test/static analysis processes still take a lot of time, our CI is working 15 minutes, to finally conclude that no mutations have been found and nothing needs to be killed.

with this PR we are proposing running the initial processes only after we identified that actual mutations could be found.

please take this PR as a inspiration for discussion.