### PR TITLE
test(benchmark): Add a benchmark for XML file loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,12 @@ benchmark_tracing: vendor $(BENCHMARK_TRACING_SUBMODULE) $(BENCHMARK_TRACING_COV
 	vendor/bin/phpbench run tests/benchmark/Tracing $(PHPBENCH_REPORTS)
 	composer dump
 
+.PHONY: benchmark_dom_loading
+benchmark_dom_loading: vendor $(BENCHMARK_TRACING_SUBMODULE) $(BENCHMARK_TRACING_COVERAGE_DIR)
+	composer dump --classmap-authoritative --quiet
+	vendor/bin/phpbench run tests/benchmark/DOMDocument --report=aggregate --report=benchmark_compare
+	composer dump
+
 
 .PHONY: autoreview
 autoreview: 	 	## Runs various checks (static analysis & AutoReview test suite)

--- a/tests/benchmark/DOMDocument/DOMDocumentBench.php
+++ b/tests/benchmark/DOMDocument/DOMDocumentBench.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Benchmark\DOMDocument;
+
+use Closure;
+use DOMDocument;
+use DOMXPath;
+use Infection\TestFramework\SafeDOMXPath;
+use PhpBench\Attributes\Revs;
+use Symfony\Component\Filesystem\Path;
+use function file_get_contents;
+use function Safe\preg_replace;
+use const PHP_INT_MAX;
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Iterations;
+use Webmozart\Assert\Assert;
+
+final class DOMDocumentBench
+{
+    private const FAT_XML = __DIR__.'/../Tracing/coverage/xml/index.xml';
+
+    private int $nodeCount;
+
+    /**
+     * Mimics `SafeDomXPath::fromFile()` drafted in #2558. In this scenario,
+     * the XML may have a namespace, but we have no practical way to remove it.
+     * Hence, we need to register the namespace and adapt the queries.
+     *
+     * @see SafeDOMXPath
+     * @link https://github.com/infection/infection/pull/2558
+     */
+    #[Iterations(10)]
+    #[Revs(100)]
+    #[AfterMethods('tearDown')]
+    public function benchLoadFromFile(): void
+    {
+        $document = new DOMDocument();
+        @$document->load(self::FAT_XML);
+
+        $xPath = new DOMXPath($document);
+        $xPath->registerNamespace(
+            'p',
+            $document->documentElement->namespaceURI,
+        );
+
+        $this->nodeCount = $xPath->query('//p:test')->count();
+    }
+
+    /**
+     * Mimics the existing `SafeDomXPath::fromString()`. In this scenario we
+     * first have to fetch the XML content and then remove the namespace to
+     * keep the queries lean.
+     *
+     * @see SafeDOMXPath
+     * @see XPathFactory
+     */
+    #[Iterations(10)]
+    #[Revs(100)]
+    #[AfterMethods('tearDown')]
+    public function benchLoadFromString(): void
+    {
+        $xml = file_get_contents(self::FAT_XML);
+        $cleanedXml = preg_replace('/xmlns=\".*?\"/', '', $xml);
+
+        $document = new DOMDocument();
+        @$document->loadXML($cleanedXml);
+
+        $xPath = new DOMXPath($document);
+
+        $this->nodeCount = $xPath->query('//test')->count();
+    }
+
+    public function tearDown(): void
+    {
+        Assert::greaterThan(
+            $this->nodeCount,
+            0,
+            'No node queried.',
+        );
+    }
+}


### PR DESCRIPTION
⚠️ This PR is to provide a reproducible benchmark and publish the results, it should not be merged!. ⚠️ 

While working on #2543, I was wondering if there was a difference between loading the `DOMDocument` from the file directly instead of loading the file first, and then passing its XML.

Without getting into the performance details, there is a definite usage difference: namespaces. If you load the `DOMDocument` from the file, you cannot (efficiently) remove a potential namespace, hence your XPath queries sucks because they get bloated with that namespace. On the other hand, if you do load from the XML string, then you can use a regex to cleanup any potential namespace removing that problem.

This benchmark aims at figuring out if there is any performance difference between the two approaches. The approach is as follows:

- I picked the `index.xml` from the PHPUnit XML coverage of the Tracing, which is 4.9M. It is not monstrous, but I think good enough. I did not pick the JUnit report (which is bigger) because the latter does not have a namespace, which is not the case we are interested in AFAIK.
- The execution of the code being compared takes 20-30ms. While testing some numbers, I found that at low iterations/revolutions, there was a high variance (anywhere from .2% to 30%). This means that for a couple of executions, one may observe very different results. To prevent this, I bumped quite a bit the number of revolutions (so that the benchmarked script takes longer) and iterations (so that the chances of a process being impacted are lower).

You can execute the benchmark with `make benchmark_dom_loading`.

<details>
<summary>Benchmark results</summary>

```
\Infection\Benchmark\DOMDocument\DOMDocumentBench

    benchLoadFromFile.......................I9 - Mo29.722ms (±2.69%)
    benchLoadFromString.....................I9 - Mo31.131ms (±2.50%)

Subjects: 2, Assertions: 0, Failures: 0, Errors: 0
+------------------+---------------------+-----+------+-----+----------+----------+--------+
| benchmark        | subject             | set | revs | its | mem_peak | mode     | rstdev |
+------------------+---------------------+-----+------+-----+----------+----------+--------+
| DOMDocumentBench | benchLoadFromFile   |     | 100  | 10  | 23.299mb | 29.722ms | ±2.69% |
| DOMDocumentBench | benchLoadFromString |     | 100  | 10  | 33.654mb | 31.131ms | ±2.50% |
+------------------+---------------------+-----+------+-----+----------+----------+--------+

DOMDocumentBench
================

Average iteration times by variant

31.1ms    │ ▆ █
27.2ms    │ █ █
23.3ms    │ █ █
19.5ms    │ █ █
15.6ms    │ █ █
11.7ms    │ █ █
7.8ms     │ █ █
3.9ms     │ █ █
          └─────
            1 2

[█ <current>]

1: benchLoadFromFile   2: benchLoadFromString

Memory by variant

33.7mb    │   █
29.4mb    │   █
25.2mb    │ ▅ █
21.0mb    │ █ █
16.8mb    │ █ █
12.6mb    │ █ █
8.4mb     │ █ █
4.2mb     │ █ █
          └─────
            1 2

[█ <current>]

1: benchLoadFromFile   2: benchLoadFromString

+------------------------+-------------------+-----------------+
|                        | time (kde mode)   | memory          |
+------------------------+-------------------+-----------------+
| subject                | Tag: <current>    | Tag: <current>  |
+------------------------+-------------------+-----------------+
| benchLoadFromFile ()   | 29.722ms (±2.69%) | 23.299mb        |
| benchLoadFromString () | 31.131ms (±2.50%) | 33.654mb        |
+------------------------+-------------------+-----------------+
```

</details>

**TL:DR; Loading from the file is 4.5% faster and 30% more memory efficient.**
