### PR TITLE
test: Fix the CI

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -1663,12 +1663,6 @@ parameters:
 			path: ../tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php
 
 		-
-			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertStringContainsString\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../tests/phpunit/TestFramework/Coverage/XmlReport/XPathFactoryTest.php
-
-		-
 			message: '#^Cannot call method getSourceMethodRangeByMethod\(\) on Infection\\TestFramework\\Coverage\\TestLocations\|null\.$#'
 			identifier: method.nonObject
 			count: 1

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -54,7 +54,7 @@ class MutationConfigBuilder extends ConfigBuilder
 {
     private ?string $originalBootstrapFile = null;
 
-    private readonly SafeDOMXPath $xPath;
+    private ?SafeDOMXPath $xPath = null;
 
     public function __construct(
         private readonly string $tmpDir,
@@ -122,7 +122,7 @@ class MutationConfigBuilder extends ConfigBuilder
 
     private function getXPath(): SafeDOMXPath
     {
-        if (!isset($this->xPath)) {
+        if ($this->xPath === null) {
             /** @psalm-suppress InaccessibleProperty */
             $this->xPath = SafeDOMXPath::fromString(
                 $this->originalXmlConfigContent,

--- a/tests/phpunit/TestFramework/SafeDOMXPath/SafeDOMXPathTest.php
+++ b/tests/phpunit/TestFramework/SafeDOMXPath/SafeDOMXPathTest.php
@@ -148,15 +148,15 @@ final class SafeDOMXPathTest extends TestCase
 
         $firstElement = $xPath->document->firstElementChild;
 
-        // @phpstan-ignore property.nonObject
         // Beware: this is only the _document_ namespace, not a namespace registered to the XPath.
         $this->assertSame(
             'https://schema.phpunit.de/coverage/1.0',
+            // @phpstan-ignore property.nonObject
             $firstElement->namespaceURI,
             'Expected the document namespace to be left alone.',
         );
-        // @phpstan-ignore property.nonObject
         // Sanity check: ensuring we correctly parsed the XML.
+        // @phpstan-ignore property.nonObject
         $this->assertSame('phpunit', $firstElement->tagName);
 
         // Check that no namespace was registered.
@@ -201,8 +201,8 @@ final class SafeDOMXPathTest extends TestCase
 
         // @phpstan-ignore property.nonObject
         $this->assertNull($firstElement->namespaceURI);
-        // @phpstan-ignore property.nonObject
         // Sanity check: ensuring we correctly parsed the XML.
+        // @phpstan-ignore property.nonObject
         $this->assertSame('phpunit', $firstElement->tagName);
 
         // Since no namespace is registered and the document has no namespace,


### PR DESCRIPTION
Seems like I accidentally broke it in #2559. Somehow I missed the autoreview failure, I thought the failure was only due to the escape mutations which were expected (it was for classes out of scope of the PR).