### PR TITLE
refactor: Leverage the OperatingSystem utility

### DIFF
--- a/src/FileSystem/Finder/Iterator/RealPathFilterIterator.php
+++ b/src/FileSystem/Finder/Iterator/RealPathFilterIterator.php
@@ -35,10 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\FileSystem\Finder\Iterator;
 
-use const DIRECTORY_SEPARATOR;
+use Infection\Framework\OperatingSystem;
 use function preg_quote;
 use ReturnTypeWillChange;
-use function str_replace;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Iterator\MultiplePcreFilterIterator;
 
 /**
@@ -61,8 +61,8 @@ final class RealPathFilterIterator extends MultiplePcreFilterIterator
     {
         $filename = $this->current()->getRealPath();
 
-        if ('\\' === DIRECTORY_SEPARATOR) {
-            $filename = str_replace('\\', '/', (string) $filename);
+        if (OperatingSystem::isWindows()) {
+            $filename = Path::normalize((string) $filename);
         }
 
         return $this->isAccepted($filename);

--- a/src/Framework/OperatingSystem.php
+++ b/src/Framework/OperatingSystem.php
@@ -45,6 +45,11 @@ final class OperatingSystem
 {
     use CannotBeInstantiated;
 
+    public static function isMacOs(): bool
+    {
+        return PHP_OS_FAMILY === 'Darwin';
+    }
+
     public static function isWindows(): bool
     {
         return PHP_OS_FAMILY === 'Windows';

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\Console;
 use function array_merge;
 use function basename;
 use Composer\Autoload\ClassLoader;
-use const DIRECTORY_SEPARATOR;
 use function extension_loaded;
 use function file_exists;
 use function function_exists;
@@ -251,7 +250,7 @@ final class E2ETest extends TestCase
                 ++self::$countFailingComposerInstall;
                 $this->markTestSkipped($e->getMessage());
             } catch (FinderException $e) {
-                if (DIRECTORY_SEPARATOR !== '\\') {
+                if (!OperatingSystem::isWindows()) {
                     throw $e;
                 }
 

--- a/tests/phpunit/FileSystem/Finder/MockVendor.php
+++ b/tests/phpunit/FileSystem/Finder/MockVendor.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\FileSystem\Finder;
 
 use function array_filter;
-use const DIRECTORY_SEPARATOR;
 use function implode;
+use Infection\Framework\OperatingSystem;
 use const PHP_EOL;
 use function Safe\file_put_contents;
 use Symfony\Component\Filesystem\Filesystem;
@@ -103,7 +103,7 @@ final class MockVendor
     {
         $this->emptyVendorBin();
 
-        if ('\\' === DIRECTORY_SEPARATOR) {
+        if (OperatingSystem::isWindows()) {
             // Use an empty batch script to disable finding the main script
             file_put_contents($this->vendorBinBat, '@ECHO OFF');
         } else {

--- a/tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php
@@ -35,13 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Tests\FileSystem\Finder;
 
-use const DIRECTORY_SEPARATOR;
 use function explode;
 use Generator;
 use function getenv;
 use Infection\FileSystem\Finder\ComposerExecutableFinder;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder;
+use Infection\Framework\OperatingSystem;
 use Infection\TestFramework\TestFrameworkTypes;
 use Infection\Tests\EnvVariableManipulation\BacksUpEnvironmentVariables;
 use Infection\Tests\FileSystem\FileSystemTestCase;
@@ -129,7 +129,7 @@ final class StaticAnalysisToolExecutableFinderTest extends FileSystemTestCase
 
         $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder);
 
-        if ('\\' === DIRECTORY_SEPARATOR) {
+        if (OperatingSystem::isWindows()) {
             // The main script must be found from the .bat file
             $expected = realpath('vendor/phpunit/phpunit/phpunit');
         } else {
@@ -168,7 +168,7 @@ final class StaticAnalysisToolExecutableFinderTest extends FileSystemTestCase
 
         $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder);
 
-        if ('\\' === DIRECTORY_SEPARATOR) {
+        if (OperatingSystem::isWindows()) {
             // This .bat has no code, so main script will not be found
             $expected = $mock->getVendorBinBat();
         } else {

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -35,12 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Tests\FileSystem\Finder;
 
-use const DIRECTORY_SEPARATOR;
 use function explode;
 use function getenv;
 use Infection\FileSystem\Finder\ComposerExecutableFinder;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
+use Infection\Framework\OperatingSystem;
 use Infection\TestFramework\TestFrameworkTypes;
 use Infection\Tests\EnvVariableManipulation\BacksUpEnvironmentVariables;
 use Infection\Tests\FileSystem\FileSystemTestCase;
@@ -134,7 +134,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
 
         $frameworkFinder = new TestFrameworkFinder($this->composerFinder);
 
-        if ('\\' === DIRECTORY_SEPARATOR) {
+        if (OperatingSystem::isWindows()) {
             // The main script must be found from the .bat file
             $expected = realpath('vendor/phpunit/phpunit/phpunit');
         } else {
@@ -173,7 +173,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
 
         $frameworkFinder = new TestFrameworkFinder($this->composerFinder);
 
-        if ('\\' === DIRECTORY_SEPARATOR) {
+        if (OperatingSystem::isWindows()) {
             // This .bat has no code, so main script will not be found
             $expected = $mock->getVendorBinBat();
         } else {

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php
@@ -37,9 +37,9 @@ namespace Infection\Tests\TestFramework\Coverage\JUnit;
 
 use const DIRECTORY_SEPARATOR;
 use Infection\FileSystem\Locator\FileNotFound;
+use Infection\Framework\OperatingSystem;
 use Infection\TestFramework\Coverage\JUnit\JUnitReportLocator;
 use Infection\Tests\FileSystem\FileSystemTestCase;
-use const PHP_OS_FAMILY;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -92,7 +92,7 @@ final class JUnitReportLocatorTest extends FileSystemTestCase
 
     public function test_it_can_locate_the_default_junit_file_with_the_wrong_case(): void
     {
-        if (PHP_OS_FAMILY !== 'Darwin') {
+        if (!OperatingSystem::isMacOs()) {
             $this->markTestSkipped('Cannot test this on case-sensitive OS');
         }
 

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php
@@ -37,9 +37,9 @@ namespace Infection\Tests\TestFramework\Coverage\XmlReport;
 
 use const DIRECTORY_SEPARATOR;
 use Infection\FileSystem\Locator\FileNotFound;
+use Infection\Framework\OperatingSystem;
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocator;
 use Infection\Tests\FileSystem\FileSystemTestCase;
-use const PHP_OS_FAMILY;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -89,7 +89,7 @@ final class IndexXmlCoverageLocatorTest extends FileSystemTestCase
 
     public function test_it_can_locate_the_default_index_file_with_the_wrong_case(): void
     {
-        if (PHP_OS_FAMILY !== 'Darwin') {
+        if (!OperatingSystem::isMacOs()) {
             $this->markTestSkipped('Cannot test this on case-sensitive OS');
         }
 

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -35,8 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpUnit\Adapter;
 
-use const DIRECTORY_SEPARATOR;
 use Infection\Config\ValueProvider\PCOVDirectoryProvider;
+use Infection\Framework\OperatingSystem;
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
@@ -237,7 +237,7 @@ final class PhpUnitAdapterTest extends TestCase
                 '-d',
                 'memory_limit=-1',
                 '-d',
-                '\\' === DIRECTORY_SEPARATOR ? 'pcov.directory="."' : "pcov.directory='.'",
+                OperatingSystem::isWindows() ? 'pcov.directory="."' : "pcov.directory='.'",
             ], [
                 '--group=default', '--coverage-xml=/tmp/coverage-xml', '--log-junit=/tmp/infection/junit.xml',
             ])


### PR DESCRIPTION
I could find more cases that can leverage the `OperatingSystem` utility introduced in #2505.
