### PR TITLE
Fix StrykerDashboardClientTest not using data-provided data

### DIFF
--- a/tests/phpunit/Logger/Http/StrykerDashboardClientTest.php
+++ b/tests/phpunit/Logger/Http/StrykerDashboardClientTest.php
@@ -79,7 +79,7 @@ final class StrykerDashboardClientTest extends TestCase
     }
 
     #[DataProvider('provideResponseStatusCodes')]
-    public function test_it_can_send_a_report_with_expected_response_status_code(): void
+    public function test_it_can_send_a_report_with_expected_response_status_code(int $statusCode): void
     {
         $this->clientMock
             ->expects($this->once())
@@ -90,7 +90,7 @@ final class StrykerDashboardClientTest extends TestCase
                 self::API_KEY,
                 '{"mutationScore": 80.31}',
             )
-            ->willReturn(new Response(201, 'Report received!'))
+            ->willReturn(new Response($statusCode, 'Report received!'))
         ;
 
         $this->dashboardClient->sendReport(


### PR DESCRIPTION
while this test declares a data-provider it did not use the data provided and instead just used hardcoded values