### PR TITLE
refactor(SafeDOMXPath): Remove magic property handling for the document

### DIFF
--- a/src/TestFramework/SafeDOMXPath.php
+++ b/src/TestFramework/SafeDOMXPath.php
@@ -44,22 +44,15 @@ use Webmozart\Assert\Assert;
 
 /**
  * @internal
- *
- * @property DOMDocument $document
  */
 final readonly class SafeDOMXPath
 {
     private DOMXPath $xPath;
 
     public function __construct(
-        private DOMDocument $document,
+        public DOMDocument $document,
     ) {
         $this->xPath = new DOMXPath($document);
-    }
-
-    public function __get(string $property): DOMDocument
-    {
-        return $this->$property;
     }
 
     public static function fromFile(


### PR DESCRIPTION
I don't see any advantage over having a public readonly property.

Extracted from #2585 as this [PR] refactor is trivial and the former may require more actions.