### PR TITLE
refactor(ClassName): Consolidate utilities into a ClassName utility

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -1505,3 +1505,9 @@ parameters:
 			identifier: argument.templateType
 			count: 2
 			path: ../tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php
+
+		-
+			message: '#getShortClassName#'
+			identifier: argument.type
+			count: 1
+			path: ../src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -138,16 +138,11 @@ parameters:
         -
             identifier: shipmonk.deadMethod
             path: ../tests/benchmark/*/*Bench.php
-#
-#        # We are testing user input values hence by design they may not fit the specified type
-#        -
-#            message: '#\$testFramework#'
-#            identifier: argument.type
-#            path: ../tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
-#        -
-#            message: '#\$staticAnalysisTool#'
-#            identifier: argument.type
-#            path: ../tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+
+        # PHPStan is (understandably) a bit confused at class-names of classes that do not exist.
+        -
+            identifier: argument.type
+            path: ../tests/phpunit/Framework/ClassNameTest.php
 
     level: 8
     paths:

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -311,7 +311,7 @@ class ConfigurationFactory
     }
 
     /**
-     * @param array<string, mixed[]> $resolvedMutatorsMap
+     * @param array<class-string, mixed[]> $resolvedMutatorsMap
      *
      * @return array<string, array<int, string>>
      */

--- a/src/Framework/ClassName.php
+++ b/src/Framework/ClassName.php
@@ -33,8 +33,10 @@
 
 declare(strict_types=1);
 
-namespace Infection\Testing;
+namespace Infection\Framework;
 
+use function end;
+use function explode;
 use Infection\CannotBeInstantiated;
 use function Safe\preg_match;
 use function Safe\preg_replace;
@@ -44,20 +46,33 @@ use function str_replace;
 /**
  * @internal
  */
-final class SourceTestClassNameScheme
+final class ClassName
 {
     use CannotBeInstantiated;
 
-    public static function getSourceClassName(string $testCaseClassName): string
+    /**
+     * @param class-string $className
+     *
+     * @return non-empty-string
+     */
+    public static function getShortClassName(string $className): string
     {
-        if (preg_match('/(Infection\\\\Tests\\\\.*)Test$/', $testCaseClassName, $matches) === 1) {
+        $parts = explode('\\', $className);
+
+        /** @phpstan-ignore return.type */
+        return end($parts);
+    }
+
+    public static function getCanonicalSourceClassName(string $testClassName): string
+    {
+        if (preg_match('/(Infection\\\\Tests\\\\.*)Test$/', $testClassName, $matches) === 1) {
             return str_replace('Infection\\Tests\\', 'Infection\\', $matches[1]);
         }
 
-        return $testCaseClassName;
+        return $testClassName;
     }
 
-    public static function getTestClassName(string $sourceClassName): string
+    public static function getCanonicalTestClassName(string $sourceClassName): string
     {
         if (str_contains($sourceClassName, 'Infection\\Tests')) {
             return $sourceClassName . 'Test';

--- a/src/Mutator/MutatorFactory.php
+++ b/src/Mutator/MutatorFactory.php
@@ -35,8 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Mutator;
 
-use function end;
-use function explode;
+use Infection\Framework\ClassName;
 use function is_a;
 use PhpParser\Node;
 use function sprintf;
@@ -93,11 +92,12 @@ final class MutatorFactory
         return $mutators;
     }
 
+    /**
+     * @param class-string $className
+     */
     public static function getMutatorNameForClassName(string $className): string
     {
-        $parts = explode('\\', $className);
-
-        return end($parts);
+        return ClassName::getShortClassName($className);
     }
 
     /**

--- a/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
@@ -37,9 +37,9 @@ namespace Infection\TestFramework\PhpUnit\CommandLine;
 
 use function array_key_exists;
 use function count;
-use function end;
 use function explode;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
+use Infection\Framework\ClassName;
 use function is_numeric;
 use function preg_quote;
 use function sprintf;
@@ -93,7 +93,7 @@ final class FilterBuilder
 
                 // This may or not have the provider key.
                 $testMethod = self::getMethod($rawTestMethod, $testFrameworkVersion, $optimizationLevel);
-                $shortClassName = self::getShortClassName($testCaseClassName);
+                $shortClassName = ClassName::getShortClassName($testCaseClassName);
 
                 $test = $optimizationLevel >= self::DROP_TEST_CASE_OPTIMIZATION_LEVEL
                     ? $testMethod
@@ -165,13 +165,6 @@ final class FilterBuilder
         }
 
         return $rawTestMethod;
-    }
-
-    private static function getShortClassName(string $className): string
-    {
-        $parts = explode('\\', $className);
-
-        return end($parts);
     }
 
     /**

--- a/src/Testing/BaseMutatorTestCase.php
+++ b/src/Testing/BaseMutatorTestCase.php
@@ -40,6 +40,7 @@ use function array_key_exists;
 use function array_shift;
 use function count;
 use function implode;
+use Infection\Framework\ClassName;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\ProfileList;
 use Infection\PhpParser\NodeTraverserFactory;
@@ -129,7 +130,7 @@ abstract class BaseMutatorTestCase extends TestCase
 
     protected function getTestedMutatorClassName(): string
     {
-        return SourceTestClassNameScheme::getSourceClassName(static::class);
+        return ClassName::getCanonicalSourceClassName(static::class);
     }
 
     /**

--- a/tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
+++ b/tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
@@ -40,7 +40,7 @@ use function array_map;
 use function array_values;
 use function class_exists;
 use Infection\CannotBeInstantiated;
-use Infection\Testing\SourceTestClassNameScheme;
+use Infection\Framework\ClassName;
 use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
 use function iterator_to_array;
 use PHPUnit\Framework\TestCase;
@@ -88,7 +88,7 @@ final class EnvTestCasesProvider
      */
     private static function envTestCaseTuple(string $className): ?array
     {
-        $testCaseClass = SourceTestClassNameScheme::getTestClassName($className);
+        $testCaseClass = ClassName::getCanonicalTestClassName($className);
 
         if (!class_exists($testCaseClass)) {
             // No test case could be find for this source file

--- a/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\AutoReview\IntegrationGroup;
 
 use function class_exists;
 use Infection\CannotBeInstantiated;
-use Infection\Testing\SourceTestClassNameScheme;
+use Infection\Framework\ClassName;
 use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
 use Infection\Tests\Console\E2ETest;
 use Infection\Tests\FileSystem\FileSystemTestCase;
@@ -111,7 +111,7 @@ final class IntegrationGroupProvider
      */
     private static function ioTestCaseTuple(string $className): ?array
     {
-        $testCaseClass = SourceTestClassNameScheme::getTestClassName($className);
+        $testCaseClass = ClassName::getCanonicalTestClassName($className);
 
         if (!class_exists($testCaseClass)) {
             // No test case could be found for this source file

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -92,7 +92,6 @@ use Infection\Testing\MutatorName;
 use Infection\Testing\SimpleMutation;
 use Infection\Testing\SimpleMutationsCollectorVisitor;
 use Infection\Testing\SingletonContainer;
-use Infection\Testing\SourceTestClassNameScheme;
 use Infection\Testing\StringNormalizer;
 use Infection\Tests\AutoReview\ConcreteClassReflector;
 use Infection\Tests\TestingUtility\PHPUnit\DataProviderFactory;
@@ -143,7 +142,6 @@ final class ProjectCodeProvider
         SimpleMutation::class,
         StringNormalizer::class,
         Source::class,
-        SourceTestClassNameScheme::class,
         SimpleMutationsCollectorVisitor::class,
         SingletonContainer::class,
     ];

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
@@ -41,9 +41,9 @@ use function array_key_exists;
 use function array_map;
 use function class_exists;
 use function in_array;
+use Infection\Framework\ClassName;
 use Infection\StreamWrapper\IncludeInterceptor;
 use Infection\Testing\SingletonContainer;
-use Infection\Testing\SourceTestClassNameScheme;
 use function is_executable;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
@@ -72,7 +72,7 @@ final class ProjectCodeTest extends TestCase
     #[DataProviderExternal(ProjectCodeProvider::class, 'concreteSourceClassesProvider')]
     public function test_all_concrete_classes_have_tests(string $className): void
     {
-        $testClassName = SourceTestClassNameScheme::getTestClassName($className);
+        $testClassName = ClassName::getCanonicalTestClassName($className);
 
         if (in_array($className, ProjectCodeProvider::NON_TESTED_CONCRETE_CLASSES, true) === false
             && in_array($className, ProjectCodeProvider::CONCRETE_CLASSES_WITH_TESTS_IN_DIFFERENT_LOCATION, true) === false

--- a/tests/phpunit/Framework/ClassNameTest.php
+++ b/tests/phpunit/Framework/ClassNameTest.php
@@ -33,20 +33,58 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\AutoReview;
+namespace Infection\Tests\Framework;
 
-use Infection\Testing\SourceTestClassNameScheme;
+use Closure;
+use Infection\Framework\ClassName;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(SourceTestClassNameScheme::class)]
-final class SourceTestClassNameSchemeTest extends TestCase
+#[CoversClass(ClassName::class)]
+final class ClassNameTest extends TestCase
 {
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('classNameProvider')]
+    public function test_it_can_get_a_class_short_name(
+        string $className,
+        string $expectedShortName,
+    ): void {
+        $actual = ClassName::getShortClassName($className);
+
+        $this->assertSame($expectedShortName, $actual);
+    }
+
+    public static function classNameProvider(): iterable
+    {
+        yield 'nominal' => [
+            ClassName::class,
+            'ClassName',
+        ];
+
+        yield 'UTF-8' => [
+            'Webmozarts\ClassName\Ütf8',
+            'Ütf8',
+        ];
+
+        yield 'emoji' => [
+            'Webmozarts\ClassName\Special😋Class',
+            'Special😋Class',
+        ];
+
+        yield 'root namespace' => [
+            Closure::class,
+            'Closure',
+        ];
+    }
+
     public function test_it_can_give_the_source_class_name_for_a_test_case_class(): void
     {
         $this->assertSame(
             'Infection\Acme\Foo',
-            SourceTestClassNameScheme::getSourceClassName('Infection\Tests\Acme\FooTest'),
+            ClassName::getCanonicalSourceClassName('Infection\Tests\Acme\FooTest'),
         );
     }
 
@@ -54,7 +92,7 @@ final class SourceTestClassNameSchemeTest extends TestCase
     {
         $this->assertSame(
             'Infection\Acme\Foo',
-            SourceTestClassNameScheme::getSourceClassName('Infection\Acme\Foo'),
+            ClassName::getCanonicalSourceClassName('Infection\Acme\Foo'),
         );
     }
 
@@ -62,7 +100,7 @@ final class SourceTestClassNameSchemeTest extends TestCase
     {
         $this->assertSame(
             'Infection\Tests\Acme\FooTest',
-            SourceTestClassNameScheme::getTestClassName('Infection\Acme\Foo'),
+            ClassName::getCanonicalTestClassName('Infection\Acme\Foo'),
         );
     }
 
@@ -70,7 +108,7 @@ final class SourceTestClassNameSchemeTest extends TestCase
     {
         $this->assertSame(
             'Infection\Tests\Acme\FooTest',
-            SourceTestClassNameScheme::getTestClassName('Infection\Tests\Acme\Foo'),
+            ClassName::getCanonicalTestClassName('Infection\Tests\Acme\Foo'),
         );
     }
 }


### PR DESCRIPTION
While working on #2591 I noticed several things:

- We have a need to get a class short name in multiple places. I already noticed it in `FilterBuilder` in the past but at that time it was a bit overkill or I was a bit undecided about introducing a utility class.
- We have `SourceTestClassName` which is internal but now is part of the source code as it may end up being used (indirectly, via the `BaseMutatorTest`) for custom mutators.
- in #2591 I need to extend the beahviour of `SourceTestClassName`.

This PR proposes to consolidate all of thus under a `ClassName` utility. It:

- Introduces `::getShortName()` and leverages it.
- Renames `SourceTestClassName` to `ClassName`.
- Renames `::getSourceClassName()` to `::getCanonicalSourceClassName()` and likewise for test. It may confuse briefly what "canonical" refers to in this context, but the fact is that this is not a super all purpose generic utility: it is quite specific to infection and our naming conventions. Hence, canonical here refers to our "normally expected value following our conventions". I'll also update the documentation in an upcoming PR.