### PR TITLE
Support `--exclude-source-from-xml-coverage` fast path for PHPUnit 12.5+

### DIFF
--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -187,7 +187,7 @@ class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements MemoryUsage
     }
 
     /**
-     * As of PHPUnit 12.5, the `--exclude-source-from-xml-coverage` is available which removes the `source` element which from the XML report which contained the list of tokens of the source code file.
+     * As of PHPUnit 12.5, the `--exclude-source-from-xml-coverage` is available which removes the `source` element from the XML report which contained the list of tokens of the source code file.
      */
     public static function supportsExcludingSourceFromCoverage(string $version): bool
     {

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php
@@ -378,20 +378,20 @@ final class PhpUnitAdapterTest extends TestCase
     }
 
     #[DataProvider('coverageWithoutSourceProvider')]
-    public function test_supports_coverage_without_source(bool $expected, string $version): void
+    public function test_supports_coverage_without_source(string $version, bool $expected): void
     {
         $this->assertSame($expected, PhpUnitAdapter::supportsExcludingSourceFromCoverage($version));
     }
 
     public static function coverageWithoutSourceProvider(): iterable
     {
-        yield [false, '11.5.599'];
+        yield ['11.5.599', false];
 
-        yield [false, '12.0'];
+        yield ['12.0', false];
 
-        yield [true, '12.5'];
+        yield ['12.5', true];
 
-        yield [true, '13.0'];
+        yield ['13.0', true];
     }
 
     private function getPHPUnitAdapter(string $version = '9.0'): PhpUnitAdapter


### PR DESCRIPTION
requires 
- https://github.com/sebastianbergmann/phpunit/issues/6422
- https://github.com/infection/infection/pull/2607

---

when PHPUnit needs to generate the `<source>` element in coverage-xml reports it spents a considerable amount of time generating the this information. infection does not make use of it though.

therefore we utilize `--exclude-source-from-xml-coverage` which will be available as of PHPUnit 12.5+ to prevent this unnecessary work and speedup the process. on phpstan-src we can see a ~15% speedup of the coverage-xml generation process (which takes up to 1 minute in CI)