### PR TITLE
Prevent use of deprecated PHPUnit `$this->isType('string')`

### DIFF
--- a/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
+++ b/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
@@ -107,7 +107,7 @@ final class MutantProcessContainerFactoryTest extends TestCase
             ->with(
                 $tests,
                 $mutantFilePath,
-                $this->isType('string'),
+                $this->isString(),
                 $originalFilePath,
                 $testFrameworkExtraOptions,
             )


### PR DESCRIPTION
see

```
3 tests triggered 3 PHPUnit deprecations:

1) Infection\Tests\Process\Factory\MutantProcessContainerFactoryTest::test_it_creates_a_process_with_timeout@slow tests do not get more time than factory-timeout with data (40.0, 10.0, 40)
isType('string') is deprecated and will be removed in PHPUnit 13. Please use the isString() method instead.

/Users/m.staab/dvl/infection/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php:59

2) Infection\Tests\Process\Factory\MutantProcessContainerFactoryTest::test_it_creates_a_process_with_timeout@minimum timeout on a fast test with data (5.05, 0.01, 90)
isType('string') is deprecated and will be removed in PHPUnit 13. Please use the isString() method instead.

/Users/m.staab/dvl/infection/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php:59

3) Infection\Tests\Process\Factory\MutantProcessContainerFactoryTest::test_it_creates_a_process_with_timeout@allows 5x more time than test-execution with data (30.0, 5.0, 90)
isType('string') is deprecated and will be removed in PHPUnit 13. Please use the isString() method instead.

/Users/m.staab/dvl/infection/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php:59
```