### PR TITLE
Enable `failOnDeprecation="true"` in PHPUnit configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,7 +31,7 @@
         </testsuite>
     </testsuites>
 
-    <source>
+    <source ignoreIndirectDeprecations="true">
         <include>
             <directory>src</directory>
         </include>


### PR DESCRIPTION
to make sure we see deprecations early.

without a failling test these errors are easily overlooked.

I am adding `ignoreIndirectDeprecations="true"` at the same time, so our CI is does not fail for PHP version related runtime deprecation warnings from within `vendor/` folder