### PR TITLE
test(SafeDOMXPath): Add missing integration group

### DIFF
--- a/tests/phpunit/TestFramework/SafeDOMXPath/SafeDOMXPathTest.php
+++ b/tests/phpunit/TestFramework/SafeDOMXPath/SafeDOMXPathTest.php
@@ -41,11 +41,13 @@ use Infection\TestFramework\SafeDOMXPath;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use function Safe\file_get_contents;
 use function sprintf;
 use Symfony\Component\Filesystem\Path;
 
+#[Group('integration')]
 #[CoversClass(SafeDOMXPath::class)]
 final class SafeDOMXPathTest extends TestCase
 {


### PR DESCRIPTION
In #2591, as we now correctly some test cases, our autoreview noticed the missing group attribute for this test.

This PR fixes it outside to clarify that it this change is distinct from the feature introduced by #2591.