### PR TITLE
refactor(git): Remove dead code

### DIFF
--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -129,6 +129,13 @@ parameters:
             count: 1
             path: ../tests/phpunit/TestingUtility/FS.php
 
+        # This is a false-positive. It should be fixed by having a clearer API.
+        -
+            message: "#\\$gitDiffBase.+FilesDiffChangedLines::contains\\(\\)#"
+            identifier: argument.type
+            count: 1
+            path: ../src/Mutator/NodeMutationGenerator.php
+
         # We are explicitly testing the guards here
         -
             identifier: argument.type

--- a/src/Differ/FilesDiffChangedLines.php
+++ b/src/Differ/FilesDiffChangedLines.php
@@ -52,10 +52,10 @@ class FilesDiffChangedLines
     ) {
     }
 
-    public function contains(string $fileRealPath, int $mutationStartLine, int $mutationEndLine, ?string $gitDiffBase): bool
+    public function contains(string $fileRealPath, int $mutationStartLine, int $mutationEndLine, string $gitDiffBase): bool
     {
         $this->memoizedFilesChangedLinesMap ??= $this->diffChangedLinesParser->parse(
-            $this->diffFileProvider->provideWithLines($gitDiffBase ?? $this->diffFileProvider->provideDefaultBase()),
+            $this->diffFileProvider->provideWithLines($gitDiffBase),
         );
 
         foreach ($this->memoizedFilesChangedLinesMap[$fileRealPath] ?? [] as $changedLinesRange) {


### PR DESCRIPTION
If we are in a git diff, then the base branch is already fetched at the time the `Configuration` object is created. It needs to be nullable however because it will be `null` if no git filter is provided.

This will hopefully be fixed soonish by a better design (still drafting #2381), but meanwhile this removes any potential confusion (at least in the context of where this is needed/used).