### PR TITLE
test(git): Use a custom Git implementation for the ConfigurationFactoryTest

### DIFF
--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryGit.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryGit.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Configuration\ConfigurationFactory;
+
+use function count;
+use DomainException;
+use function implode;
+use Infection\Git\Git;
+use function sprintf;
+
+final readonly class ConfigurationFactoryGit implements Git
+{
+    public function __construct(
+        private string $defaultBaseBranch,
+        private string $changedFileRelativePaths,
+    ) {
+    }
+
+    public function getDefaultBaseBranch(): string
+    {
+        return $this->defaultBaseBranch;
+    }
+
+    public function getChangedFileRelativePaths(
+        string $diffFilter,
+        string $baseBranch,
+        array $sourceDirectories,
+    ): string {
+        return sprintf(
+            'f(%s, %s, [%s]) = %s',
+            $diffFilter,
+            $baseBranch,
+            count($sourceDirectories) === 0
+                ? ''
+                : implode(', ', $sourceDirectories),
+            $this->changedFileRelativePaths,
+        );
+    }
+
+    public function provideWithLines(string $baseBranch): string
+    {
+        throw new DomainException('Not implemented.');
+    }
+}

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryGitTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryGitTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Configuration\ConfigurationFactory;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConfigurationFactoryGit::class)]
+final class ConfigurationFactoryGitTest extends TestCase
+{
+    /**
+     * @param string[] $sourceDirectories
+     */
+    #[DataProvider('changedFileRelativePathsProvider')]
+    public function test_it_can_show_the_changed_file_relative_paths(
+        string $changedFileRelativePaths,
+        string $diffFilter,
+        string $baseBranch,
+        array $sourceDirectories,
+        string $expected,
+    ): void {
+        $git = new ConfigurationFactoryGit('unknown', $changedFileRelativePaths);
+
+        $actual = $git->getChangedFileRelativePaths(
+            $diffFilter,
+            $baseBranch,
+            $sourceDirectories,
+        );
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function changedFileRelativePathsProvider(): iterable
+    {
+        yield 'no source directories' => [
+            'src/a.php,src/b.php',
+            'AM',
+            'main',
+            [],
+            'f(AM, main, []) = src/a.php,src/b.php',
+        ];
+
+        yield 'with source directories' => [
+            'src/a.php,src/b.php',
+            'AM',
+            'main',
+            ['src', 'config'],
+            'f(AM, main, [src, config]) = src/a.php,src/b.php',
+        ];
+    }
+}

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -85,7 +85,7 @@ final class ConfigurationFactoryTest extends TestCase
 {
     private const GIT_DEFAULT_BASE_BRANCH = 'test/default';
 
-    private const GIT_DIFF_FILTER_PROVIDER_RESULT = 'src/a.php,src/b.php';
+    private const GIT_DIFF_MODIFIED_FILES = 'src/a.php,src/b.php';
 
     /**
      * @var array<string, Mutator>|null
@@ -1415,7 +1415,7 @@ final class ConfigurationFactoryTest extends TestCase
                     count($sourceDirectories) === 0
                         ? ''
                         : implode(', ', $sourceDirectories),
-                    self::GIT_DIFF_FILTER_PROVIDER_RESULT,
+                    self::GIT_DIFF_MODIFIED_FILES,
                 ),
             );
 
@@ -1426,7 +1426,10 @@ final class ConfigurationFactoryTest extends TestCase
             new MutatorParser(),
             $sourceFilesCollector,
             new DummyCiDetector($ciDetected, $githubActionsDetected),
-            $gitMock,
+            new ConfigurationFactoryGit(
+                self::GIT_DEFAULT_BASE_BRANCH,
+                self::GIT_DIFF_MODIFIED_FILES,
+            ),
         );
     }
 }


### PR DESCRIPTION
Since the Git interface has been introduced in #2623, it is simpler to introduce a dedicated implementation rather than a mock. Indeed, it is easier to maintain the various methods with it as the parameter types and names are part of the constract.
