### PR TITLE
refactor(git): Make DiffChangedLinesParser I/O-less

### DIFF
--- a/src/Differ/DiffChangedLinesParser.php
+++ b/src/Differ/DiffChangedLinesParser.php
@@ -40,7 +40,6 @@ use function count;
 use function explode;
 use function Safe\preg_match;
 use function Safe\preg_split;
-use function Safe\realpath;
 use function sprintf;
 use function str_starts_with;
 use Webmozart\Assert\Assert;
@@ -56,8 +55,8 @@ class DiffChangedLinesParser
     /**
      * Returned result example:
      *   [
-     *       /path/to/src/File1.php => [ChangedLinesRange(1, 2)]
-     *       /path/to/src/File2.php => [ChangedLinesRange(1, 20), ChangedLinesRange(33, 33),]
+     *       src/File1.php => [ChangedLinesRange(1, 2)]
+     *       src/File2.php => [ChangedLinesRange(1, 20), ChangedLinesRange(33, 33),]
      *   ]
      *
      * Diff provided by command line: `git diff --unified=0 --diff-filter=AM master | grep -v -e '^[+-]' -e '^index'`
@@ -82,7 +81,7 @@ class DiffChangedLinesParser
                     sprintf('Source file can not be found in the following diff line: "%s"', $line),
                 );
 
-                $filePath = realpath($matches[self::MATCH_INDEX]);
+                $filePath = $matches[self::MATCH_INDEX];
             } elseif (str_starts_with((string) $line, '@@ ')) {
                 Assert::string($filePath, sprintf('Real path for file from diff can not be calculated. Diff: %s', $unifiedGreppedDiff));
 

--- a/src/FileSystem/FakeFileSystem.php
+++ b/src/FileSystem/FakeFileSystem.php
@@ -59,6 +59,11 @@ final class FakeFileSystem extends FileSystem
         throw new DomainException('Unexpected call.');
     }
 
+    public function realPath(string $filename): string
+    {
+        throw new DomainException('Unexpected call.');
+    }
+
     public function isReadableDirectory(string $filename): bool
     {
         throw new DomainException('Unexpected call.');

--- a/src/FileSystem/FileSystem.php
+++ b/src/FileSystem/FileSystem.php
@@ -38,6 +38,7 @@ namespace Infection\FileSystem;
 use function is_dir;
 use function is_file;
 use function is_readable;
+use function Safe\realpath;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 use Symfony\Component\Finder\Finder;
 
@@ -54,6 +55,11 @@ class FileSystem extends SymfonyFilesystem
     public function isReadableDirectory(string $filename): bool
     {
         return is_dir($filename) && is_readable($filename);
+    }
+
+    public function realPath(string $filename): string
+    {
+        return realpath($filename);
     }
 
     public function createFinder(): Finder

--- a/tests/phpunit/Differ/DiffChangedLinesParserTest.php
+++ b/tests/phpunit/Differ/DiffChangedLinesParserTest.php
@@ -40,11 +40,8 @@ use Infection\Differ\ChangedLinesRange;
 use Infection\Differ\DiffChangedLinesParser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-use function Safe\realpath;
 
-#[Group('integration')]
 #[CoversClass(DiffChangedLinesParser::class)]
 final class DiffChangedLinesParserTest extends TestCase
 {
@@ -79,7 +76,7 @@ final class DiffChangedLinesParserTest extends TestCase
                 @@ -1207,0 +1213,5 @@ final class Container
                 DIFF,
             [
-                realpath('src/Container.php') => [
+                'src/Container.php' => [
                     new ChangedLinesRange(38, 38),
                     new ChangedLinesRange(534, 535),
                     new ChangedLinesRange(538, 540),
@@ -100,13 +97,13 @@ final class DiffChangedLinesParserTest extends TestCase
                 @@ -0,0 +1,18 @@
                 DIFF,
             [
-                realpath('src/Container.php') => [
+                'src/Container.php' => [
                     new ChangedLinesRange(38, 38),
                     new ChangedLinesRange(534, 535),
                     new ChangedLinesRange(538, 540),
                     new ChangedLinesRange(1213, 1217),
                 ],
-                realpath('src/Differ/FilesDiffChangedLines.php') => [
+                'src/Differ/FilesDiffChangedLines.php' => [
                     new ChangedLinesRange(1, 18),
                 ],
             ],
@@ -121,7 +118,7 @@ final class DiffChangedLinesParserTest extends TestCase
                 @@ -50 +51 @@ interface Git
                 DIFF,
             [
-                realpath(__DIR__ . '/../../../src/Git/Git.php') => [
+                'src/Git/Git.php' => [
                     new ChangedLinesRange(51, 51),
                 ],
             ],
@@ -137,7 +134,7 @@ final class DiffChangedLinesParserTest extends TestCase
                 @@ -0,0 +1,5 @@
                 DIFF,
             [
-                realpath(__DIR__ . '/../../../src/Git/CommandLineGit.php') => [
+                'src/Git/CommandLineGit.php' => [
                     new ChangedLinesRange(1, 5),
                 ],
             ],
@@ -153,7 +150,7 @@ final class DiffChangedLinesParserTest extends TestCase
                 @@ -15234,0 +15238,10 @@ final class CommandLineGitTest
                 DIFF,
             [
-                realpath(__DIR__ . '/../../../tests/phpunit/Git/CommandLineGitTest.php') => [
+                'tests/phpunit/Git/CommandLineGitTest.php' => [
                     new ChangedLinesRange(10001, 10003),
                     new ChangedLinesRange(15238, 15247),
                 ],
@@ -180,13 +177,13 @@ final class DiffChangedLinesParserTest extends TestCase
                 @@ -200 +202,3 @@ final class CommandLineGitTest
                 DIFF,
             [
-                realpath(__DIR__ . '/../../../src/Git/Git.php') => [
+                'src/Git/Git.php' => [
                     new ChangedLinesRange(11, 12),
                 ],
-                realpath(__DIR__ . '/../../../src/Git/CommandLineGit.php') => [
+                'src/Git/CommandLineGit.php' => [
                     new ChangedLinesRange(21, 25),
                 ],
-                realpath(__DIR__ . '/../../../tests/phpunit/Git/CommandLineGitTest.php') => [
+                'tests/phpunit/Git/CommandLineGitTest.php' => [
                     new ChangedLinesRange(101, 101),
                     new ChangedLinesRange(202, 204),
                 ],
@@ -205,7 +202,7 @@ final class DiffChangedLinesParserTest extends TestCase
                 @@ -50 +54 @@ final class CommandLineGit
                 DIFF,
             [
-                realpath(__DIR__ . '/../../../src/Git/CommandLineGit.php') => [
+                'src/Git/CommandLineGit.php' => [
                     new ChangedLinesRange(6, 6),
                     new ChangedLinesRange(14, 14),
                     new ChangedLinesRange(28, 28),
@@ -223,7 +220,7 @@ final class DiffChangedLinesParserTest extends TestCase
                 @@ -42,0 +43,8 @@ interface Git
                 DIFF,
             [
-                realpath(__DIR__ . '/../../../src/Git/Git.php') => [
+                'src/Git/Git.php' => [
                     new ChangedLinesRange(43, 50),
                 ],
             ],
@@ -243,7 +240,7 @@ final class DiffChangedLinesParserTest extends TestCase
                 @@ -75,0 +82,10 @@ final class CommandLineGitTest
                 DIFF,
             [
-                realpath(__DIR__ . '/../../../tests/phpunit/Git/CommandLineGitTest.php') => [
+                'tests/phpunit/Git/CommandLineGitTest.php' => [
                     new ChangedLinesRange(11, 11),
                     new ChangedLinesRange(22, 24),
                     new ChangedLinesRange(34, 38),


### PR DESCRIPTION
While inlining `DiffChangedLinesParser` as per #2622, I stumbled on the issue that it uses `realpath()`, which meant that the docs of the method were incorrect (and fixed in #2641).

It may be a bit controversial, but I think it's the wrong place where to introduce this filesystem dependency. This would allow the git adapter to remain more agnostic. The reason why we need this real path is due to the usage in `FilesDiffChangedLines`, and it would change if `FilesDiffChangedLines` takes a non-absolute path, so IMO it makes more sense for `FilesDiffChangedLines` to take care of that task.
