### PR TITLE
fix(git): Pass the option correctly to the git process

### DIFF
--- a/src/Git/CommandLineGit.php
+++ b/src/Git/CommandLineGit.php
@@ -115,8 +115,7 @@ final readonly class CommandLineGit implements Git
             'diff',
             $base,
             '--unified=0',
-            '--diff-filter',
-            $diffFilter,
+            '--diff-filter=' . $diffFilter,
         ]);
 
         $lines = explode(PHP_EOL, $filter);

--- a/tests/phpunit/Git/CommandLineGitTest.php
+++ b/tests/phpunit/Git/CommandLineGitTest.php
@@ -133,7 +133,7 @@ final class CommandLineGitTest extends TestCase
     ): void {
         $this->commandLineMock
             ->method('execute')
-            ->with(['git', 'diff', 'main', '--unified=0', '--diff-filter', 'AM'])
+            ->with(['git', 'diff', 'main', '--unified=0', '--diff-filter=AM'])
             ->willReturn($diff);
 
         $actual = $this->git->getChangedLinesRangesByFileRelativePaths('AM', 'main');


### PR DESCRIPTION
Related to https://github.com/infection/infection/issues/2622.

AFAIK the canonical way to pass an option is `--long-name=value`. In our case this is not a problem because `git` supports both, but we might as well use the correct form.