### PR TITLE
refactor(git): Remove unnecessary cache

### DIFF
--- a/src/Git/CommandLineGit.php
+++ b/src/Git/CommandLineGit.php
@@ -56,26 +56,20 @@ use Webmozart\Assert\Assert;
  *
  * Implementation of the Git contract leveraging the git binary via processes.
  */
-final class CommandLineGit implements Git
+final readonly class CommandLineGit implements Git
 {
     // https://github.com/infection/infection/issues/2611
     private const DEFAULT_SYMBOLIC_REFERENCE = 'refs/remotes/origin/HEAD';
 
     private const MATCH_INDEX = 1;
 
-    private ?string $defaultBase = null;
-
     public function __construct(
-        private readonly ShellCommandLineExecutor $shellCommandLineExecutor,
+        private ShellCommandLineExecutor $shellCommandLineExecutor,
     ) {
     }
 
     public function getDefaultBase(): string
     {
-        if ($this->defaultBase !== null) {
-            return $this->defaultBase;
-        }
-
         // see https://www.reddit.com/r/git/comments/jbdb7j/comment/lpdk30e/
         try {
             return $this->shellCommandLineExecutor->execute([
@@ -85,11 +79,12 @@ final class CommandLineGit implements Git
             ]);
         } catch (ProcessException) {
             // e.g. no symbolic ref might be configured for a remote named "origin"
-            // TODO: we could log the failure to figure it out somewhere...
-        }
 
-        // unable to figure it out, return the default
-        return $this->defaultBase = Git::FALLBACK_BASE;
+            // TODO: we could log the failure to figure it out somewhere...
+
+            // unable to figure it out, return the default
+            return Git::FALLBACK_BASE;
+        }
     }
 
     public function getChangedFileRelativePaths(string $diffFilter, string $base, array $sourceDirectories): string


### PR DESCRIPTION
Related to #2622.

The value is resolved once, like for the filter, hence there is no need to cache it.