### PR TITLE
perf(git): Throw an exception when no change in the git diff is found

### DIFF
--- a/src/Differ/FilesDiffChangedLines.php
+++ b/src/Differ/FilesDiffChangedLines.php
@@ -37,6 +37,7 @@ namespace Infection\Differ;
 
 use Infection\FileSystem\FileSystem;
 use Infection\Git\Git;
+use Infection\Git\NoFilesInDiffToMutate;
 
 /**
  * @internal
@@ -55,6 +56,9 @@ class FilesDiffChangedLines
     ) {
     }
 
+    /**
+     * @throws NoFilesInDiffToMutate
+     */
     public function contains(string $fileRealPath, int $mutationStartLine, int $mutationEndLine): bool
     {
         foreach ($this->getChangedLinesRanges($fileRealPath) as $changedLinesRange) {
@@ -67,6 +71,8 @@ class FilesDiffChangedLines
     }
 
     /**
+     * @throws NoFilesInDiffToMutate
+     *
      * @return list<ChangedLinesRange>
      */
     private function getChangedLinesRanges(string $fileRealPath): array
@@ -77,6 +83,8 @@ class FilesDiffChangedLines
     }
 
     /**
+     * @throws NoFilesInDiffToMutate
+     *
      * @return array<string, list<ChangedLinesRange>>
      */
     private function getFilesChangedLinesRanges(): array

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -41,6 +41,7 @@ use Infection\Configuration\Configuration;
 use Infection\Console\ConsoleOutput;
 use Infection\Event\ApplicationExecutionWasFinished;
 use Infection\Event\EventDispatcher\EventDispatcher;
+use Infection\Git\NoFilesInDiffToMutate;
 use Infection\Metrics\MetricsCalculator;
 use Infection\Metrics\MinMsiChecker;
 use Infection\Metrics\MinMsiCheckFailed;
@@ -211,6 +212,7 @@ final readonly class Engine
      * @throws TooManyReportsFound
      * @throws ReportLocationThrowable
      * @throws TestFileNameNotFoundException
+     * @throws NoFilesInDiffToMutate
      */
     private function runMutationAnalysis(): void
     {

--- a/src/Git/CommandLineGit.php
+++ b/src/Git/CommandLineGit.php
@@ -185,6 +185,10 @@ final readonly class CommandLineGit implements Git
             }
         }
 
+        if (count($resultMap) === 0) {
+            throw NoFilesInDiffToMutate::create();
+        }
+
         return $resultMap;
     }
 

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -107,7 +107,9 @@ interface Git
      *
      * @param string $diffFilter E.g. 'AM'.
      *
-     * @return array<string, list<ChangedLinesRange>>
+     * @throws NoFilesInDiffToMutate
+     *
+     * @return non-empty-array<string, list<ChangedLinesRange>>
      */
     public function getChangedLinesRangesByFileRelativePaths(string $diffFilter, string $base): array;
 

--- a/src/Mutation/FileMutationGenerator.php
+++ b/src/Mutation/FileMutationGenerator.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Mutation;
 
 use Infection\Differ\FilesDiffChangedLines;
+use Infection\Git\NoFilesInDiffToMutate;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\NodeMutationGenerator;
 use Infection\PhpParser\FileParser;
@@ -67,6 +68,7 @@ class FileMutationGenerator
      * @param Mutator<Node>[] $mutators
      * @param NodeIgnorer[] $nodeIgnorers
      *
+     * @throws NoFilesInDiffToMutate
      * @throws UnparsableFile
      *
      * @return iterable<Mutation>

--- a/src/Mutation/MutationGenerator.php
+++ b/src/Mutation/MutationGenerator.php
@@ -39,6 +39,7 @@ use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\MutableFileWasProcessed;
 use Infection\Event\MutationGenerationWasFinished;
 use Infection\Event\MutationGenerationWasStarted;
+use Infection\Git\NoFilesInDiffToMutate;
 use Infection\IterableCounter;
 use Infection\Mutator\Mutator;
 use Infection\PhpParser\UnparsableFile;
@@ -90,6 +91,7 @@ class MutationGenerator
      * @throws TooManyReportsFound
      * @throws ReportLocationThrowable
      * @throws TestFileNameNotFoundException
+     * @throws NoFilesInDiffToMutate
      *
      * @return iterable<Mutation>
      */

--- a/src/Mutator/NodeMutationGenerator.php
+++ b/src/Mutator/NodeMutationGenerator.php
@@ -38,6 +38,7 @@ namespace Infection\Mutator;
 use function count;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\Differ\FilesDiffChangedLines;
+use Infection\Git\NoFilesInDiffToMutate;
 use Infection\Mutation\Mutation;
 use Infection\PhpParser\MutatedNode;
 use Infection\PhpParser\Visitor\ReflectionVisitor;
@@ -91,6 +92,8 @@ class NodeMutationGenerator
     }
 
     /**
+     * @throws NoFilesInDiffToMutate
+     *
      * @return iterable<Mutation>
      */
     public function generate(Node $node): iterable

--- a/src/PhpParser/Visitor/MutationCollectorVisitor.php
+++ b/src/PhpParser/Visitor/MutationCollectorVisitor.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\PhpParser\Visitor;
 
+use Infection\Git\NoFilesInDiffToMutate;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\NodeMutationGenerator;
 use PhpParser\Node;
@@ -62,6 +63,11 @@ final class MutationCollectorVisitor extends NodeVisitorAbstract
         return null;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @throws NoFilesInDiffToMutate
+     */
     public function leaveNode(Node $node): ?Node
     {
         $this->mutationChunks[] = $this->mutationGenerator->generate($node);

--- a/tests/phpunit/Git/CommandLineGitTest.php
+++ b/tests/phpunit/Git/CommandLineGitTest.php
@@ -124,13 +124,17 @@ final class CommandLineGitTest extends TestCase
     }
 
     /**
-     * @param array<string, array<int, ChangedLinesRange>> $expected
+     * @param array<string, array<int, ChangedLinesRange>>|class-string<Exception> $expected
      */
     #[DataProvider('gitChangedLinesRangesProvider')]
     public function test_it_get_the_changed_lines_ranges_by_files_relative_paths(
         string $diff,
-        array $expected,
+        array|string $expected,
     ): void {
+        if (is_string($expected)) {
+            $this->expectException($expected);
+        }
+
         $this->commandLineMock
             ->method('execute')
             ->with(['git', 'diff', 'main', '--unified=0', '--diff-filter=AM'])
@@ -138,14 +142,16 @@ final class CommandLineGitTest extends TestCase
 
         $actual = $this->git->getChangedLinesRangesByFileRelativePaths('AM', 'main');
 
-        $this->assertEquals($expected, $actual);
+        if (!is_string($expected)) {
+            $this->assertEquals($expected, $actual);
+        }
     }
 
     public static function gitChangedLinesRangesProvider(): iterable
     {
         yield 'empty diff' => [
             '',
-            [],
+            NoFilesInDiffToMutate::class,
         ];
 
         yield '5 lines removed at L10 in old file, 7 lines added starting at L12 in new file' => [
@@ -182,7 +188,7 @@ final class CommandLineGitTest extends TestCase
                 +++ b/src/Container.php
                 @@ -10,5 +10,0 @@ line change example
                 DIFF,
-            [],
+            NoFilesInDiffToMutate::class,
         ];
 
         yield 'single line in old file, 2 lines in new file (count of 1 omitted in old)' => [
@@ -284,7 +290,7 @@ final class CommandLineGitTest extends TestCase
                 +++ b/src/Container.php
                 @@ -1,18 +0,0 @@ line change example
                 DIFF,
-            [],
+            NoFilesInDiffToMutate::class,
         ];
 
         yield 'single line added at beginning of file (count of 1 omitted)' => [
@@ -308,7 +314,7 @@ final class CommandLineGitTest extends TestCase
                 +++ b/src/Container.php
                 @@ -1 +1,0 @@ line change example
                 DIFF,
-            [],
+            NoFilesInDiffToMutate::class,
         ];
 
         yield 'one file with added lines in different places' => [


### PR DESCRIPTION
Extracted from #2648.

I'm marking this as a `perf` rather than `fix` because in practice the only thing that changes is that we bail out earlier.