### PR TITLE
fix(git): Explicitly disable any pager

### DIFF
--- a/src/Git/CommandLineGit.php
+++ b/src/Git/CommandLineGit.php
@@ -85,6 +85,7 @@ final readonly class CommandLineGit implements Git
             array_merge(
                 [
                     'git',
+                    '--no-pager',
                     'diff',
                     $base,
                     '--no-color',
@@ -242,6 +243,7 @@ final readonly class CommandLineGit implements Git
             array_merge(
                 [
                     'git',
+                    '--no-pager',
                     'diff',
                     $base,
                     '--no-color',

--- a/tests/phpunit/Git/CommandLineGitTest.php
+++ b/tests/phpunit/Git/CommandLineGitTest.php
@@ -105,7 +105,18 @@ final class CommandLineGitTest extends TestCase
         $this->commandLineMock
             ->method('execute')
             ->with(
-                ['git', 'diff', 'main', '--no-color', '--diff-filter=AM', '--name-only', '--', 'app/', 'my lib/'],
+                [
+                    'git',
+                    '--no-pager',
+                    'diff',
+                    'main',
+                    '--no-color',
+                    '--diff-filter=AM',
+                    '--name-only',
+                    '--',
+                    'app/',
+                    'my lib/',
+                ],
             )
             ->willReturn(
                 Str::toSystemLineEndings(
@@ -137,7 +148,18 @@ final class CommandLineGitTest extends TestCase
 
         $this->commandLineMock
             ->method('execute')
-            ->with(['git', 'diff', 'main', '--no-color', '--unified=0', '--diff-filter=AM', '--', 'src', 'lib'])
+            ->with([
+                'git',
+                '--no-pager',
+                'diff',
+                'main',
+                '--no-color',
+                '--unified=0',
+                '--diff-filter=AM',
+                '--',
+                'src',
+                'lib',
+            ])
             ->willReturn($diff);
 
         $actual = $this->git->getChangedLinesRangesByFileRelativePaths(


### PR DESCRIPTION
A user could enforce a pager:

```shell
git config pager.diff always
```

In which case the output of our diff is incorrect even in non-interactive environments.