### PR TITLE
docs(git): Document our decision on not couting a renamed file as having all of its lines changed

### DIFF
--- a/tests/phpunit/Git/CommandLineGitTest.php
+++ b/tests/phpunit/Git/CommandLineGitTest.php
@@ -577,6 +577,12 @@ final class CommandLineGitTest extends TestCase
                 --- a/src/Container.php
                 +++ b/src/LegacyContainer.php
                 DIFF,
+            // There is no new or updated code, hence nothing to mutate.
+            // While discussing this, we thought _maybe_ there was a very narrow edge case
+            // where this _may_ not be true, but it is not compelling enough to change
+            // our stance on it.
+            // Also note that if other files used the moved file path or symbols, we can
+            // expect their usage to change hence to be picked up in the diff.
             NoSourceFound::class,
         ];
 


### PR DESCRIPTION
I stumbled upon this case in ##2658 and wanted to shed some light on it.

As a reminder, currently if a file is renamed, none of its lines appears in the diff meaning there is no line to mutate. There was a question of whether this is correct.

We decided that we cannot see a case where we would want to change that behaviour. Whilst the test is already there, this PR adds a comment to document that this is a conscious decision.

<hr/>

_Originally post_

Title: fix(git): Count all lines of a renamed file as modified

Currently if a file is renamed, whilst it is listed as part of the changed files, hence parsed, we do not compute any changed lines.

This PR fixes that, but it begs the question: is it what we want?