### PR TITLE
refactor(git): Remove confusing fallback

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -389,15 +389,15 @@ class ConfigurationFactory
     private function retrieveFilter(
         string $filter,
         ?string $gitDiffFilter,
-        bool $isForGitDiffLines,
+        bool $useGitDiff,
         ?string $gitBase,
         array $sourceDirectories,
     ): string {
-        if ($gitDiffFilter === null && !$isForGitDiffLines) {
+        if ($gitDiffFilter === null && !$useGitDiff) {
             return $filter;
         }
 
-        $gitDiffFilter ??= 'AM';
+        Assert::notNull($gitDiffFilter);
         Assert::notNull($gitBase);
 
         return $this->git->getChangedFileRelativePaths($gitDiffFilter, $gitBase, $sourceDirectories);


### PR DESCRIPTION
Addresses the feedback of https://github.com/infection/infection/pull/2618/files#r2586971034.

This is actually a great spot because the original piece of code was confusing and my changes only removed some confusion. Eventually though, I could simplify things (see #2650) where, to keep things simpler, `$isForGitDiffLines` which previously corresponded to the user passing `--git-diff-filter`, is sorted in `RunCommand` and no longer forwarded to `ConfigurationFactory`.

As a result, this means this confusing piece of code is actually dead code.