### PR TITLE
refactor: Fix names and harden the phpdoc for the schema file

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -481,12 +481,6 @@ parameters:
 			path: ../tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
 
 		-
-			message: '#^Method Infection\\Tests\\FileSystem\\Locator\\RootsFileOrDirectoryLocatorTest\:\:test_it_can_locate_files\(\) has parameter \$roots with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php
-
-		-
 			message: '#^Parameter \#2 \$input of method Infection\\Tests\\FileSystem\\SourceFileFilterTest\:\:assertFiltersExpectedInput\(\) expects iterable\<Infection\\TestFramework\\Coverage\\Trace\>, IteratorIterator\<mixed, Infection\\Tests\\Fixtures\\MockSplFileInfo, Traversable\<mixed, Infection\\Tests\\Fixtures\\MockSplFileInfo\>\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -650,7 +650,7 @@ final class RunCommand extends BaseCommand
     private function runConfigurationCommand(Locator $locator, IO $io): void
     {
         try {
-            $locator->locateOneOf(SchemaConfigurationLoader::POSSIBLE_DEFAULT_CONFIG_FILES);
+            $locator->locateOneOf(SchemaConfigurationLoader::POSSIBLE_DEFAULT_CONFIG_FILE_NAMES);
         } catch (FileNotFound|FileOrDirectoryNotFound) {
             $configureCommand = $this->getApplication()->find('configure');
 

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -135,7 +135,7 @@ class ConfigurationFactory
         ?string $staticAnalysisTool,
         ?string $mutantId,
     ): Configuration {
-        $configDir = dirname($schema->file);
+        $configDir = dirname($schema->pathname);
 
         $namespacedTmpDir = $this->retrieveTmpDir($schema, $configDir);
 
@@ -357,7 +357,7 @@ class ConfigurationFactory
     private function collectFiles(SchemaConfiguration $schema): iterable
     {
         $source = $schema->source;
-        $schemaDirname = dirname($schema->file);
+        $schemaDirname = dirname($schema->pathname);
 
         $mapToAbsolutePath = static fn (string $path) => Path::isAbsolute($path)
             ? $path

--- a/src/Configuration/Schema/InvalidFile.php
+++ b/src/Configuration/Schema/InvalidFile.php
@@ -48,7 +48,7 @@ final class InvalidFile extends UnexpectedValueException
     {
         return new self(sprintf(
             'The file "%s" could not be found or is not a file.',
-            $config->getPath(),
+            $config->getPathname(),
         ));
     }
 
@@ -56,7 +56,7 @@ final class InvalidFile extends UnexpectedValueException
     {
         return new self(sprintf(
             'The file "%s" is not readable.',
-            $config->getPath(),
+            $config->getPathname(),
         ));
     }
 
@@ -64,7 +64,7 @@ final class InvalidFile extends UnexpectedValueException
     {
         return new self(sprintf(
             'Could not retrieve the contents of the file "%s".',
-            $config->getPath(),
+            $config->getPathname(),
         ));
     }
 
@@ -76,7 +76,7 @@ final class InvalidFile extends UnexpectedValueException
         return new self(
             sprintf(
                 'Could not parse the JSON file "%s": %s',
-                $config->getPath(),
+                $config->getPathname(),
                 $error,
             ),
             0,

--- a/src/Configuration/Schema/InvalidSchema.php
+++ b/src/Configuration/Schema/InvalidSchema.php
@@ -59,7 +59,7 @@ final class InvalidSchema extends UnexpectedValueException
 
         return new self(sprintf(
             '"%s" does not match the expected JSON schema%s',
-            $config->getPath(),
+            $config->getPathname(),
             $errors === []
                 ? '.'
                 : ':' . PHP_EOL . ' - ' . implode(PHP_EOL . ' - ', $errors),

--- a/src/Configuration/Schema/SchemaConfiguration.php
+++ b/src/Configuration/Schema/SchemaConfiguration.php
@@ -49,12 +49,13 @@ use Webmozart\Assert\Assert;
 final readonly class SchemaConfiguration
 {
     /**
+     * @param non-empty-string $pathname
      * @param array<string, mixed> $mutators
      * @param TestFrameworkTypes::*|null $testFramework
      * @param StaticAnalysisToolTypes::*|null $staticAnalysisTool
      */
     public function __construct(
-        public string $file,
+        public string $pathname,
         public ?float $timeout,
         public Source $source,
         public Logs $logs,

--- a/src/Configuration/Schema/SchemaConfigurationFactory.php
+++ b/src/Configuration/Schema/SchemaConfigurationFactory.php
@@ -54,10 +54,13 @@ use Webmozart\Assert\Assert;
  */
 class SchemaConfigurationFactory
 {
-    public function create(string $path, stdClass $rawConfig): SchemaConfiguration
+    /**
+     * @param non-empty-string $pathname
+     */
+    public function create(string $pathname, stdClass $rawConfig): SchemaConfiguration
     {
         return new SchemaConfiguration(
-            file: $path,
+            pathname: $pathname,
             timeout: self::getTimeout($rawConfig),
             source: self::createSource($rawConfig->source),
             logs: self::createLogs($rawConfig->logs ?? new stdClass()),

--- a/src/Configuration/Schema/SchemaConfigurationFile.php
+++ b/src/Configuration/Schema/SchemaConfigurationFile.php
@@ -49,14 +49,20 @@ final class SchemaConfigurationFile
 {
     private ?stdClass $decodedContents = null;
 
+    /**
+     * @param non-empty-string $pathname
+     */
     public function __construct(
-        private readonly string $path,
+        private readonly string $pathname,
     ) {
     }
 
-    public function getPath(): string
+    /**
+     * @return non-empty-string
+     */
+    public function getPathname(): string
     {
-        return $this->path;
+        return $this->pathname;
     }
 
     /**
@@ -68,15 +74,15 @@ final class SchemaConfigurationFile
             return $this->decodedContents;
         }
 
-        if (!is_file($this->path)) {
+        if (!is_file($this->pathname)) {
             throw InvalidFile::createForFileNotFound($this);
         }
 
-        if (!is_readable($this->path)) {
+        if (!is_readable($this->pathname)) {
             throw InvalidFile::createForFileNotReadable($this);
         }
 
-        $contents = file_get_contents($this->path);
+        $contents = file_get_contents($this->pathname);
 
         try {
             return $this->decodedContents = json5_decode($contents);

--- a/src/Configuration/Schema/SchemaConfigurationFileLoader.php
+++ b/src/Configuration/Schema/SchemaConfigurationFileLoader.php
@@ -46,14 +46,17 @@ class SchemaConfigurationFileLoader
     ) {
     }
 
-    public function loadFile(string $file): SchemaConfiguration
+    /**
+     * @param non-empty-string $pathname
+     */
+    public function loadFile(string $pathname): SchemaConfiguration
     {
-        $rawConfig = new SchemaConfigurationFile($file);
+        $rawConfig = new SchemaConfigurationFile($pathname);
 
         $this->schemaValidator->validate($rawConfig);
 
         return $this->factory->create(
-            $rawConfig->getPath(),
+            $rawConfig->getPathname(),
             $rawConfig->getDecodedContents(),
         );
     }

--- a/src/Configuration/Schema/SchemaConfigurationLoader.php
+++ b/src/Configuration/Schema/SchemaConfigurationLoader.php
@@ -42,7 +42,7 @@ use Infection\FileSystem\Locator\Locator;
  */
 final readonly class SchemaConfigurationLoader
 {
-    public const POSSIBLE_DEFAULT_CONFIG_FILES = [
+    public const POSSIBLE_DEFAULT_CONFIG_FILE_NAMES = [
         self::DEFAULT_JSON5_CONFIG_FILE,
         self::DEFAULT_JSON_CONFIG_FILE,
         self::DEFAULT_DIST_JSON5_CONFIG_FILE,
@@ -64,12 +64,12 @@ final readonly class SchemaConfigurationLoader
     }
 
     /**
-     * @param string[] $potentialPaths
+     * @param non-empty-string[] $potentialFileNames
      */
-    public function loadConfiguration(array $potentialPaths): SchemaConfiguration
+    public function loadConfiguration(array $potentialFileNames): SchemaConfiguration
     {
         return $this->fileLoader->loadFile(
-            $this->locator->locateOneOf($potentialPaths),
+            $this->locator->locateOneOf($potentialFileNames),
         );
     }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -653,7 +653,7 @@ final class Container extends DIContainer
                 array_filter(
                     [
                         $configFile,
-                        ...SchemaConfigurationLoader::POSSIBLE_DEFAULT_CONFIG_FILES,
+                        ...SchemaConfigurationLoader::POSSIBLE_DEFAULT_CONFIG_FILE_NAMES,
                     ],
                 ),
             ),

--- a/src/FileSystem/Locator/Locator.php
+++ b/src/FileSystem/Locator/Locator.php
@@ -43,16 +43,22 @@ interface Locator
     /**
      * Determine the realpath of the given file or directory located.
      *
+     * @param non-empty-string $fileName
+     *
      * @throws FileNotFound|FileOrDirectoryNotFound
+     *
+     * @return non-empty-string
      */
     public function locate(string $fileName): string;
 
     /**
      * Determine the realpath of the first file or directory located.
      *
-     * @param string[] $fileNames
+     * @param non-empty-string[] $fileNames
      *
      * @throws FileNotFound|FileOrDirectoryNotFound
+     *
+     * @return non-empty-string
      */
     public function locateOneOf(array $fileNames): string;
 }

--- a/src/FileSystem/Locator/RootsFileLocator.php
+++ b/src/FileSystem/Locator/RootsFileLocator.php
@@ -94,7 +94,9 @@ final readonly class RootsFileLocator implements Locator
     }
 
     /**
-     * @param string[] $fileNames
+     * @param non-empty-string[] $fileNames
+     *
+     * @return non-empty-string|null
      */
     private function innerLocateOneOf(array $fileNames): ?string
     {

--- a/src/FileSystem/Locator/RootsFileOrDirectoryLocator.php
+++ b/src/FileSystem/Locator/RootsFileOrDirectoryLocator.php
@@ -91,7 +91,9 @@ final readonly class RootsFileOrDirectoryLocator implements Locator
     }
 
     /**
-     * @param string[] $fileNames
+     * @param non-empty-string[] $fileNames
+     *
+     * @return non-empty-string|null
      */
     private function innerLocateOneOf(array $fileNames): ?string
     {

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -118,7 +118,7 @@ final class ConfigurationFactoryTest extends TestCase
     public function test_it_throws_exception_when_not_known_static_analysis_tool_used_as_input(): void
     {
         $schema = new SchemaConfiguration(
-            file: '/path/to/infection.json',
+            pathname: '/path/to/infection.json',
             timeout: null,
             source: new Source([], []),
             logs: Logs::createEmpty(),
@@ -190,7 +190,7 @@ final class ConfigurationFactoryTest extends TestCase
         $defaultLogs = $defaultLogsBuilder->build();
 
         $defaultSchema = new SchemaConfiguration(
-            file: '/path/to/infection.json',
+            pathname: '/path/to/infection.json',
             timeout: null,
             source: new Source([], []),
             logs: Logs::createEmpty(),

--- a/tests/phpunit/Configuration/Schema/InvalidSchemaTest.php
+++ b/tests/phpunit/Configuration/Schema/InvalidSchemaTest.php
@@ -66,22 +66,22 @@ final class InvalidSchemaTest extends TestCase
 
     public static function configWithErrorsProvider(): iterable
     {
-        $path = '/path/to/config';
+        $pathname = '/path/to/config';
 
         yield 'no error' => [
-            new SchemaConfigurationFile($path),
+            new SchemaConfigurationFile($pathname),
             [],
             '"/path/to/config" does not match the expected JSON schema.',
         ];
 
         yield 'pseudo empty error' => [
-            new SchemaConfigurationFile($path),
+            new SchemaConfigurationFile($pathname),
             ['', ''],
             '"/path/to/config" does not match the expected JSON schema.',
         ];
 
         yield 'one error' => [
-            new SchemaConfigurationFile($path),
+            new SchemaConfigurationFile($pathname),
             ['Error message'],
             <<<'ERROR'
                 "/path/to/config" does not match the expected JSON schema:
@@ -90,7 +90,7 @@ final class InvalidSchemaTest extends TestCase
         ];
 
         yield 'multiple errors' => [
-            new SchemaConfigurationFile($path),
+            new SchemaConfigurationFile($pathname),
             [
                 'First error message',
                 'Second error message',
@@ -103,7 +103,7 @@ final class InvalidSchemaTest extends TestCase
         ];
 
         yield 'worst case' => [
-            new SchemaConfigurationFile($path),
+            new SchemaConfigurationFile($pathname),
             [
                 ' First error message ',
                 '',

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationBuilder.php
@@ -47,12 +47,13 @@ use Infection\TestFramework\TestFrameworkTypes;
 final class SchemaConfigurationBuilder
 {
     /**
+     * @param non-empty-string $pathname
      * @param array<string, mixed> $mutators
      * @param TestFrameworkTypes::*|null $testFramework
      * @param StaticAnalysisToolTypes::*|null $staticAnalysisTool
      */
     private function __construct(
-        private string $file,
+        private string $pathname,
         private ?float $timeout,
         private Source $source,
         private Logs $logs,
@@ -76,7 +77,7 @@ final class SchemaConfigurationBuilder
     public static function from(SchemaConfiguration $schema): self
     {
         return new self(
-            file: $schema->file,
+            pathname: $schema->pathname,
             timeout: $schema->timeout,
             source: $schema->source,
             logs: $schema->logs,
@@ -100,7 +101,7 @@ final class SchemaConfigurationBuilder
     public static function withMinimalTestData(): self
     {
         return new self(
-            file: '/path/to/infection.json',
+            pathname: '/path/to/infection.json',
             timeout: null,
             source: new Source([], []),
             logs: Logs::createEmpty(),
@@ -124,7 +125,7 @@ final class SchemaConfigurationBuilder
     public static function withCompleteTestData(): self
     {
         return new self(
-            file: '/complete/path/infection.json',
+            pathname: '/complete/path/infection.json',
             timeout: 10.0,
             source: new Source(['src', 'lib'], ['vendor', 'tests']),
             logs: new Logs(
@@ -156,10 +157,13 @@ final class SchemaConfigurationBuilder
         );
     }
 
-    public function withFile(string $file): self
+    /**
+     * @param non-empty-string $pathname
+     */
+    public function withPathname(string $pathname): self
     {
         $clone = clone $this;
-        $clone->file = $file;
+        $clone->pathname = $pathname;
 
         return $clone;
     }
@@ -312,7 +316,7 @@ final class SchemaConfigurationBuilder
     public function build(): SchemaConfiguration
     {
         return new SchemaConfiguration(
-            file: $this->file,
+            pathname: $this->pathname,
             timeout: $this->timeout,
             source: $this->source,
             logs: $this->logs,

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php
@@ -97,7 +97,7 @@ final class SchemaConfigurationFileLoaderTest extends TestCase
     private static function createRawConfigWithPathArgument(string $path): Constraint
     {
         return new Callback(static function (SchemaConfigurationFile $config) use ($path): bool {
-            self::assertSame($path, $config->getPath());
+            self::assertSame($path, $config->getPathname());
 
             return true;
         });

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
@@ -54,18 +54,18 @@ final class SchemaConfigurationFileTest extends TestCase
 
     public function test_it_can_be_instantiated(): void
     {
-        $path = '/nowhere';
+        $pathname = '/nowhere';
 
-        $config = new SchemaConfigurationFile($path);
+        $config = new SchemaConfigurationFile($pathname);
 
-        $this->assertSame($path, $config->getPath());
+        $this->assertSame($pathname, $config->getPathname());
     }
 
     public function test_its_contents_is_retrieved_lazily(): void
     {
-        $invalidPath = '/nowhere';
+        $invalidPathname = '/nowhere';
 
-        $config = new SchemaConfigurationFile($invalidPath);
+        $config = new SchemaConfigurationFile($invalidPathname);
 
         try {
             $config->getDecodedContents();
@@ -75,10 +75,10 @@ final class SchemaConfigurationFileTest extends TestCase
             $this->addToAssertionCount(1);
         }
 
-        $validPath = self::FIXTURES_DIR . '/file.json';
+        $validPathname = self::FIXTURES_DIR . '/file.json';
         $expectedArrayContents = ['foo' => 'bar'];
 
-        $config = new SchemaConfigurationFile($validPath);
+        $config = new SchemaConfigurationFile($validPathname);
         $actualContents = $config->getDecodedContents();
 
         $this->assertSame($expectedArrayContents, (array) $actualContents);
@@ -99,12 +99,15 @@ final class SchemaConfigurationFileTest extends TestCase
         $this->assertSame($expectedValue, $config->getDecodedContents());
     }
 
+    /**
+     * @param non-empty-string $pathname
+     */
     #[DataProvider('invalidConfigContentsProvider')]
     public function test_it_cannot_retrieve_or_decode_invalid_contents(
-        string $path,
+        string $pathname,
         Exception $expectedException,
     ): void {
-        $config = new SchemaConfigurationFile($path);
+        $config = new SchemaConfigurationFile($pathname);
 
         try {
             $config->getDecodedContents();

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php
@@ -66,29 +66,30 @@ final class SchemaConfigurationLoaderTest extends TestCase
     }
 
     /**
-     * @param string[] $potentialPaths
+     * @param non-empty-string[] $potentialFileNames
+     * @param non-empty-string $expectedPathname
      */
     #[DataProvider('configurationPathsProvider')]
     public function test_it_loads_the_located_file(
-        array $potentialPaths,
-        string $expectedPath,
+        array $potentialFileNames,
+        string $expectedPathname,
         SchemaConfiguration $expectedConfig,
     ): void {
         $this->locatorStub
             ->expects($this->once())
             ->method('locateOneOf')
-            ->with($potentialPaths)
-            ->willReturn($expectedPath)
+            ->with($potentialFileNames)
+            ->willReturn($expectedPathname)
         ;
 
         $this->configFileLoaderStub
             ->expects($this->once())
             ->method('loadFile')
-            ->with($expectedPath)
+            ->with($expectedPathname)
             ->willReturn($expectedConfig)
         ;
 
-        $actualConfig = $this->loader->loadConfiguration($potentialPaths);
+        $actualConfig = $this->loader->loadConfiguration($potentialFileNames);
 
         $this->assertSame($expectedConfig, $actualConfig);
     }
@@ -114,12 +115,6 @@ final class SchemaConfigurationLoaderTest extends TestCase
                 '/path/to/configC',
             ],
             '/path/to/configB',
-            $config,
-        ];
-
-        yield 'empty values' => [
-            [],
-            '',
             $config,
         ];
     }

--- a/tests/phpunit/Configuration/Schema/SchemaValidatorTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaValidatorTest.php
@@ -77,11 +77,11 @@ final class SchemaValidatorTest extends TestCase
 
     public static function configProvider(): iterable
     {
-        $path = '/path/to/config';
+        $pathname = '/path/to/config';
 
         yield 'empty JSON' => [
             self::createConfigWithContents(
-                $path,
+                $pathname,
                 '{}',
             ),
             <<<'ERROR'
@@ -92,7 +92,7 @@ final class SchemaValidatorTest extends TestCase
 
         yield 'invalid timeout' => [
             self::createConfigWithContents(
-                $path,
+                $pathname,
                 '{"timeout": "10"}',
             ),
             <<<'ERROR'
@@ -104,7 +104,7 @@ final class SchemaValidatorTest extends TestCase
 
         yield 'invalid custom mutator' => [
             self::createConfigWithContents(
-                $path,
+                $pathname,
                 <<<'JSON'
                     {
                         "source": {
@@ -124,7 +124,7 @@ final class SchemaValidatorTest extends TestCase
 
         yield 'valid custom mutator' => [
             self::createConfigWithContents(
-                $path,
+                $pathname,
                 <<<'JSON'
                     {
                         "source": {
@@ -141,7 +141,7 @@ final class SchemaValidatorTest extends TestCase
 
         yield 'valid schema' => [
             self::createConfigWithContents(
-                $path,
+                $pathname,
                 <<<'JSON'
                     {
                         "source": {
@@ -154,11 +154,14 @@ final class SchemaValidatorTest extends TestCase
         ];
     }
 
+    /**
+     * @param non-empty-string $pathname
+     */
     private static function createConfigWithContents(
-        string $path,
+        string $pathname,
         string $contents,
     ): SchemaConfigurationFile {
-        $config = new SchemaConfigurationFile($path);
+        $config = new SchemaConfigurationFile($pathname);
 
         $decodedContents = json_decode($contents);
 

--- a/tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php
+++ b/tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php
@@ -66,34 +66,36 @@ final class RootsFileLocatorTest extends TestCase
 
     /**
      * @param string[] $roots
+     * @param non-empty-string $fileName
      */
     #[DataProvider('pathsProvider')]
     public function test_it_can_locate_files(
         array $roots,
-        string $file,
+        string $fileName,
         string $expected,
     ): void {
-        $path = (new RootsFileLocator($roots, $this->filesystem))->locate($file);
+        $actual = (new RootsFileLocator($roots, $this->filesystem))->locate($fileName);
 
         $this->assertSame(
             Path::normalize($expected),
-            Path::normalize($path),
+            Path::normalize($actual),
         );
     }
 
     /**
      * @param string[] $roots
+     * @param non-empty-string $fileName
      */
     #[DataProvider('invalidPathsProvider')]
     public function test_it_throws_an_exception_if_file_or_folder_does_not_exist(
         array $roots,
-        string $file,
+        string $fileName,
         string $expectedErrorMessage,
     ): void {
         $locator = new RootsFileLocator($roots, $this->filesystem);
 
         try {
-            $locator->locate($file);
+            $locator->locate($fileName);
 
             $this->fail('Expected an exception to be thrown.');
         } catch (FileNotFound $exception) {
@@ -105,36 +107,36 @@ final class RootsFileLocatorTest extends TestCase
 
     /**
      * @param string[] $roots
-     * @param string[] $files
+     * @param non-empty-string[] $fileNames
      */
     #[DataProvider('multiplePathsProvider')]
     public function test_it_can_locate_one_of_the_given_files(
         array $roots,
-        array $files,
+        array $fileNames,
         string $expected,
     ): void {
-        $path = (new RootsFileLocator($roots, $this->filesystem))->locateOneOf($files);
+        $actual = (new RootsFileLocator($roots, $this->filesystem))->locateOneOf($fileNames);
 
         $this->assertSame(
             Path::normalize($expected),
-            Path::normalize($path),
+            Path::normalize($actual),
         );
     }
 
     /**
      * @param string[] $roots
-     * @param string[] $files
+     * @param non-empty-string[] $fileNames
      */
     #[DataProvider('multipleInvalidPathsProvider')]
     public function test_locate_any_throws_exception_if_no_file_could_be_found(
         array $roots,
-        array $files,
+        array $fileNames,
         string $expectedErrorMessage,
     ): void {
         $locator = new RootsFileLocator($roots, $this->filesystem);
 
         try {
-            $locator->locateOneOf($files);
+            $locator->locateOneOf($fileNames);
 
             $this->fail('Expected an exception to be thrown.');
         } catch (FileNotFound $exception) {

--- a/tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php
+++ b/tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php
@@ -61,19 +61,25 @@ final class RootsFileOrDirectoryLocatorTest extends TestCase
         $this->filesystem = new Filesystem();
     }
 
+    /**
+     * @param string[] $roots
+     * @param non-empty-string $file
+     * @param non-empty-string $expected
+     */
     #[DataProvider('pathsProvider')]
     public function test_it_can_locate_files(array $roots, string $file, string $expected): void
     {
-        $path = (new RootsFileOrDirectoryLocator($roots, $this->filesystem))->locate($file);
+        $actual = (new RootsFileOrDirectoryLocator($roots, $this->filesystem))->locate($file);
 
         $this->assertSame(
             Path::normalize($expected),
-            Path::normalize($path),
+            Path::normalize($actual),
         );
     }
 
     /**
      * @param string[] $roots
+     * @param non-empty-string $file
      */
     #[DataProvider('invalidPathsProvider')]
     public function test_it_throws_an_exception_if_file_or_folder_does_not_exist(
@@ -96,36 +102,36 @@ final class RootsFileOrDirectoryLocatorTest extends TestCase
 
     /**
      * @param string[] $roots
-     * @param string[] $files
+     * @param non-empty-string[] $fileNames
      */
     #[DataProvider('multiplePathsProvider')]
     public function test_it_can_locate_one_of_the_given_files(
         array $roots,
-        array $files,
+        array $fileNames,
         string $expected,
     ): void {
-        $path = (new RootsFileOrDirectoryLocator($roots, $this->filesystem))->locateOneOf($files);
+        $actual = (new RootsFileOrDirectoryLocator($roots, $this->filesystem))->locateOneOf($fileNames);
 
         $this->assertSame(
             Path::normalize($expected),
-            Path::normalize($path),
+            Path::normalize($actual),
         );
     }
 
     /**
      * @param string[] $roots
-     * @param string[] $files
+     * @param non-empty-string[] $fileNames
      */
     #[DataProvider('multipleInvalidPathsProvider')]
     public function test_locate_any_throws_exception_if_no_file_could_be_found(
         array $roots,
-        array $files,
+        array $fileNames,
         string $expectedErrorMessage,
     ): void {
         $locator = new RootsFileOrDirectoryLocator($roots, $this->filesystem);
 
         try {
-            $locator->locateOneOf($files);
+            $locator->locateOneOf($fileNames);
 
             $this->fail('Expected an exception to be thrown.');
         } catch (FileOrDirectoryNotFound $exception) {


### PR DESCRIPTION
The intent of this PR was:

- To rename `SchemaConfigurationFile#path` to `#pathname` to follow the `SplFileInfo` and `Finder` API.
- Make it `non-empty-string`

Anything else derives from that. I also fixed a few names like if the input parameter is `$fileName` I rename the passed `$path` to `$fileName`.