### PR TITLE
feat: Explicitly require `psr/log`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "justinrainbow/json-schema": "^6.0",
         "nikic/php-parser": "^5.6.2",
         "ondram/ci-detector": "^4.1.0",
+        "psr/log": "^2.0 || ^3.0",
         "sanmai/di-container": "^0.1.4",
         "sanmai/duoclock": "^0.1.0",
         "sanmai/later": "^0.1.7",
@@ -78,6 +79,7 @@
     "require-dev": {
         "ext-simplexml": "*",
         "fidry/makefile": "^1.0",
+        "fig/log-test": "^1.2",
         "phpbench/phpbench": "^1.4",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "488f05741465f112a24895223d406fd8",
+    "content-hash": "d8b30abe6e5d8f5f0c66d2776dc957d2",
     "packages": [
         {
             "name": "colinodell/json5",
@@ -909,30 +909,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -953,9 +953,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "sanmai/di-container",
@@ -2645,6 +2645,55 @@
                 }
             ],
             "time": "2025-02-13T22:15:57+00:00"
+        },
+        {
+            "name": "fig/log-test",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log-test.git",
+                "reference": "83acb6c12875ea4f349dc4fe8b7d8e239c2b3715"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log-test/zipball/83acb6c12875ea4f349dc4fe8b7d8e239c2b3715",
+                "reference": "83acb6c12875ea4f349dc4fe8b7d8e239c2b3715",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0",
+                "psr/log": "^2.0 | ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/",
+                    "role": "Organisation"
+                }
+            ],
+            "description": "Test utilities for the psr/log package that backs the PSR-3 specification.",
+            "keywords": [
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/log-test/issues",
+                "source": "https://github.com/php-fig/log-test/tree/1.2.1"
+            },
+            "time": "2025-11-11T10:33:05+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -5524,5 +5573,5 @@
     "platform-overrides": {
         "php": "8.2.0"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/phpunit/Logger/DummyLogger.php
+++ b/tests/phpunit/Logger/DummyLogger.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\Logger;
 
 use Infection\Framework\Str;
 use Psr\Log\AbstractLogger;
+use Stringable;
 use Webmozart\Assert\Assert;
 
 final class DummyLogger extends AbstractLogger
@@ -46,7 +47,7 @@ final class DummyLogger extends AbstractLogger
      */
     private array $logs = [];
 
-    public function log($level, $message, array $context = []): void
+    public function log(mixed $level, string|Stringable $message, array $context = []): void
     {
         Assert::string($level);
         Assert::string($message);


### PR DESCRIPTION
Previously, we depended on `psr/log`, but this dependency was only constrained indirectly by `composer/xdebug-handler` and `phpbench/phpbench` (the latter being a dev dependency).

There is a break with `psr/log` 2.x regarding the tests, so as of 2.x you also need to require `fig/log`. To avoid this annoyance, I putted the requirement as 2.x minimum.

So TL:DR, this PR:

- Add an explicit requirement on `psr/log` which was otherwise already required.
- Bumps the minimum to drop 1.x.