### PR TITLE
refactor: Make the user filter nullable

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -683,11 +683,11 @@ final class RunCommand extends BaseCommand
     }
 
     /**
-     * @return array{string, non-empty-string|null, non-empty-string|null}
+     * @return array{non-empty-string|null, non-empty-string|null, non-empty-string|null}
      */
     private static function getSourceFilters(InputInterface $input): array
     {
-        $filter = trim((string) $input->getOption(self::OPTION_FILTER));
+        $filter = self::getPlainFilter($input);
 
         [$gitDiffFilter, $gitDiffBase] = self::getGitOptions($input);
 
@@ -698,6 +698,18 @@ final class RunCommand extends BaseCommand
             $gitDiffFilter,
             $gitDiffBase,
         ];
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    private static function getPlainFilter(InputInterface $input): ?string
+    {
+        $value = trim((string) $input->getOption(self::OPTION_FILTER));
+
+        return $value === ''
+            ? null
+            : $value;
     }
 
     /**
@@ -804,11 +816,15 @@ final class RunCommand extends BaseCommand
         }
     }
 
+    /**
+     * @param non-empty-string|null $filter
+     * @param non-empty-string|null $gitDiffFilter
+     */
     private static function assertOnlyOneTypeOfFiltering(
-        string $filter,
+        ?string $filter,
         ?string $gitDiffFilter,
     ): void {
-        if ($filter !== '' && $gitDiffFilter !== Container::DEFAULT_GIT_DIFF_BASE) {
+        if ($filter !== null && $gitDiffFilter !== null) {
             throw new InvalidArgumentException(
                 sprintf(
                     'The options "--%s" and "--%s" are mutually exclusive. Use "--%s" for regular filtering or "--%s" for Git-based filtering.',

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -61,6 +61,7 @@ readonly class Configuration
 
     /**
      * @param non-empty-string[] $sourceDirectories
+     * @param non-empty-string|null $sourceFilesFilter
      * @param non-empty-string[] $sourceFilesExcludes
      * @param array<string, Mutator<Node>> $mutators
      * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
@@ -71,7 +72,7 @@ readonly class Configuration
     public function __construct(
         public float $processTimeout,
         public array $sourceDirectories,
-        public string $sourceFilesFilter,
+        public ?string $sourceFilesFilter,
         public array $sourceFilesExcludes,
         public Logs $logs,
         public string $logVerbosity,

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -91,6 +91,7 @@ class ConfigurationFactory
     }
 
     /**
+     * @param non-empty-string|null $filter
      * @param non-empty-string|null $gitDiffFilter
      * @param non-empty-string|null $gitDiffBase
      *
@@ -115,7 +116,7 @@ class ConfigurationFactory
         ?string $testFramework,
         ?string $testFrameworkExtraOptions,
         ?string $staticAnalysisToolOptions,
-        string $filter,
+        ?string $filter,
         ?int $threadCount,
         bool $dryRun,
         ?string $gitDiffFilter,
@@ -348,19 +349,22 @@ class ConfigurationFactory
     }
 
     /**
+     * @param non-empty-string|null $filter
      * @param non-empty-string|null $gitDiffFilter
      * @param non-empty-string[] $sourceDirectories
      * @param non-empty-string|null $gitBase
      *
      * @throws NoSourceFound
+     *
+     * @return non-empty-string|null
      */
     private function retrieveFilter(
-        string $filter,
+        ?string $filter,
         ?string $gitDiffFilter,
         bool $useGitDiff,
         ?string $gitBase,
         array $sourceDirectories,
-    ): string {
+    ): ?string {
         if ($gitDiffFilter === null && !$useGitDiff) {
             return $filter;
         }

--- a/src/Container.php
+++ b/src/Container.php
@@ -223,7 +223,7 @@ final class Container extends DIContainer
 
     public const DEFAULT_STATIC_ANALYSIS_TOOL_OPTIONS = null;
 
-    public const DEFAULT_FILTER = '';
+    public const DEFAULT_FILTER = null;
 
     public const DEFAULT_THREAD_COUNT = null;
 
@@ -598,6 +598,7 @@ final class Container extends DIContainer
 
     /**
      * @param non-empty-string|null $configFile
+     * @param non-empty-string|null $filter
      * @param non-empty-string|null $gitDiffFilter
      * @param non-empty-string|null $gitDiffBase
      */
@@ -623,7 +624,7 @@ final class Container extends DIContainer
         ?string $testFramework = self::DEFAULT_TEST_FRAMEWORK,
         ?string $testFrameworkExtraOptions = self::DEFAULT_TEST_FRAMEWORK_EXTRA_OPTIONS,
         ?string $staticAnalysisToolOptions = self::DEFAULT_STATIC_ANALYSIS_TOOL_OPTIONS,
-        string $filter = self::DEFAULT_FILTER,
+        ?string $filter = self::DEFAULT_FILTER,
         ?int $threadCount = self::DEFAULT_THREAD_COUNT,
         bool $dryRun = self::DEFAULT_DRY_RUN,
         ?string $gitDiffFilter = self::DEFAULT_GIT_DIFF_FILTER,

--- a/src/FileSystem/SourceFileCollector.php
+++ b/src/FileSystem/SourceFileCollector.php
@@ -103,12 +103,13 @@ class SourceFileCollector
      * @param non-empty-string $configurationPathname
      * @param non-empty-string[] $sourceDirectories
      * @param non-empty-string[] $excludedFilesOrDirectories
+     * @param non-empty-string|null $filter
      */
     public static function create(
         string $configurationPathname,
         array $sourceDirectories,
         array $excludedFilesOrDirectories,
-        string $filter,
+        ?string $filter,
     ): self {
         $configurationDirname = dirname($configurationPathname);
 
@@ -147,14 +148,16 @@ class SourceFileCollector
     }
 
     /**
+     * @param non-empty-string|null $filter
+     *
      * @return non-empty-string[]
      */
-    private static function parseFilter(string $filter): array
+    private static function parseFilter(?string $filter): array
     {
         return array_filter(
             array_map(
                 trim(...),
-                explode(',', $filter),
+                explode(',', $filter ?? ''),
             ),
         );
     }

--- a/tests/phpunit/Configuration/ConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/ConfigurationBuilder.php
@@ -55,6 +55,7 @@ final class ConfigurationBuilder
 {
     /**
      * @param non-empty-string[] $sourceDirectories
+     * @param non-empty-string|null $sourceFilesFilter
      * @param non-empty-string[] $sourceFilesExcludes
      * @param array<string, Mutator<Node>> $mutators
      * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
@@ -65,7 +66,7 @@ final class ConfigurationBuilder
     private function __construct(
         private float $timeout,
         private array $sourceDirectories,
-        private string $sourceFilesFilter,
+        private ?string $sourceFilesFilter,
         private array $sourceFilesExcludes,
         private Logs $logs,
         private string $logVerbosity,
@@ -155,7 +156,7 @@ final class ConfigurationBuilder
         return new self(
             timeout: 10.0,
             sourceDirectories: [],
-            sourceFilesFilter: '',
+            sourceFilesFilter: null,
             sourceFilesExcludes: [],
             logs: Logs::createEmpty(),
             logVerbosity: 'none',
@@ -275,7 +276,10 @@ final class ConfigurationBuilder
         return $clone;
     }
 
-    public function withSourceFilesFilter(string $sourceFilesFilter): self
+    /**
+     * @param non-empty-string|null $sourceFilesFilter
+     */
+    public function withSourceFilesFilter(?string $sourceFilesFilter): self
     {
         $clone = clone $this;
         $clone->sourceFilesFilter = $sourceFilesFilter;

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryInputBuilder.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryInputBuilder.php
@@ -40,6 +40,7 @@ use Infection\Configuration\Schema\SchemaConfiguration;
 final class ConfigurationFactoryInputBuilder
 {
     /**
+     * @param non-empty-string|null $filter
      * @param non-empty-string|null $gitDiffFilter
      * @param non-empty-string|null $gitDiffBase
      */
@@ -60,7 +61,7 @@ final class ConfigurationFactoryInputBuilder
         private ?string $testFramework,
         private ?string $testFrameworkExtraOptions,
         private ?string $staticAnalysisToolOptions,
-        private string $filter,
+        private ?string $filter,
         private ?int $threadCount,
         private bool $dryRun,
         private ?string $gitDiffFilter,
@@ -206,7 +207,10 @@ final class ConfigurationFactoryInputBuilder
         return $clone;
     }
 
-    public function withFilter(string $filter): self
+    /**
+     * @param non-empty-string|null $filter
+     */
+    public function withFilter(?string $filter): self
     {
         $clone = clone $this;
         $clone->filter = $filter;
@@ -351,7 +355,7 @@ final class ConfigurationFactoryInputBuilder
      *     14: string|null,
      *     15: string|null,
      *     16: string|null,
-     *     17: string,
+     *     17: non-empty-string|null,
      *     18: int|null,
      *     19: bool,
      *     20: non-empty-string|null,

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryScenario.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryScenario.php
@@ -590,16 +590,18 @@ final class ConfigurationFactoryScenario
     }
 
     /**
+     * @param non-empty-string|null $filter
      * @param non-empty-string|null $gitDiffFilter
      * @param non-empty-string|null $gitDiffBase
+     * @param non-empty-string|null $expectedSourceFilesFilter
      * @param non-empty-string|null $expectedDiffBase
      * @param non-empty-string|null $expectedDiffFilter
      */
     public function forFilter(
-        string $filter,
+        ?string $filter,
         ?string $gitDiffFilter,
         ?string $gitDiffBase,
-        string $expectedSourceFilesFilter,
+        ?string $expectedSourceFilesFilter,
         bool $expectedIsForGitDiffLines,
         ?string $expectedDiffBase,
         ?string $expectedDiffFilter,

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -156,7 +156,7 @@ final class ConfigurationFactoryTest extends TestCase
                 testFramework: TestFrameworkTypes::PHPUNIT,
                 testFrameworkExtraOptions: null,
                 staticAnalysisToolOptions: null,
-                filter: '',
+                filter: null,
                 threadCount: 0,
                 dryRun: false,
                 gitDiffFilter: null,
@@ -220,7 +220,7 @@ final class ConfigurationFactoryTest extends TestCase
             testFramework: null,
             testFrameworkExtraOptions: null,
             staticAnalysisToolOptions: null,
-            filter: '',
+            filter: null,
             threadCount: 1,
             dryRun: false,
             gitDiffFilter: 'AM',
@@ -1030,10 +1030,10 @@ final class ConfigurationFactoryTest extends TestCase
         yield 'without any filters' => [
             $defaultScenario
                 ->forFilter(
-                    filter: '',
+                    filter: null,
                     gitDiffFilter: null,
                     gitDiffBase: null,
-                    expectedSourceFilesFilter: '',
+                    expectedSourceFilesFilter: null,
                     expectedIsForGitDiffLines: false,
                     expectedDiffBase: null,
                     expectedDiffFilter: null,
@@ -1056,7 +1056,7 @@ final class ConfigurationFactoryTest extends TestCase
         yield 'with git filters' => [
             $defaultScenario
                 ->forFilter(
-                    filter: '',
+                    filter: null,
                     gitDiffFilter: 'AD',
                     gitDiffBase: null,
                     expectedSourceFilesFilter: 'f(AD, reference(test/default), []) = src/a.php,src/b.php',
@@ -1069,7 +1069,7 @@ final class ConfigurationFactoryTest extends TestCase
         yield 'with git filters and base branch' => [
             $defaultScenario
                 ->forFilter(
-                    filter: '',
+                    filter: null,
                     gitDiffFilter: 'AD',
                     gitDiffBase: 'upstream/main',
                     expectedSourceFilesFilter: 'f(AD, reference(upstream/main), []) = src/a.php,src/b.php',

--- a/tests/phpunit/FileSystem/SourceFileCollector/SourceFileCollectorTest.php
+++ b/tests/phpunit/FileSystem/SourceFileCollector/SourceFileCollectorTest.php
@@ -239,11 +239,12 @@ final class SourceFileCollectorTest extends FileSystemTestCase
     }
 
     /**
+     * @param non-empty-string|null $filter
      * @param non-empty-string[] $expectedFilters
      */
     #[DataProvider('filterProvider')]
     public function test_it_can_parse_and_normalize_string_filter(
-        string $filter,
+        ?string $filter,
         array $expectedFilters,
         bool $expectedIsFiltered,
     ): void {
@@ -262,8 +263,8 @@ final class SourceFileCollectorTest extends FileSystemTestCase
 
     public static function filterProvider(): iterable
     {
-        yield 'empty' => [
-            '',
+        yield 'null' => [
+            null,
             [],
             false,
         ];
@@ -288,12 +289,13 @@ final class SourceFileCollectorTest extends FileSystemTestCase
     }
 
     /**
+     * @param non-empty-string|null $filter
      * @param string[] $filePaths
      * @param string[] $expected
      */
     #[DataProvider('filteredFilesProvider')]
     public function test_it_filters_the_collected_files(
-        string $filter,
+        ?string $filter,
         array $filePaths,
         array $expected,
     ): void {
@@ -336,7 +338,7 @@ final class SourceFileCollectorTest extends FileSystemTestCase
         ];
 
         yield [
-            '',
+            null,
             [
                 'src/Foo/Test.php',
                 'src/Bar/Baz.php',

--- a/tests/phpunit/TestFramework/Tracing/PHPUnitCoverageTracerTest.php
+++ b/tests/phpunit/TestFramework/Tracing/PHPUnitCoverageTracerTest.php
@@ -101,7 +101,7 @@ final class PHPUnitCoverageTracerTest extends TestCase
                     configurationPathname: self::FIXTURE_DIR,
                     sourceDirectories: [self::FIXTURE_DIR . '/src'],
                     excludedFilesOrDirectories: [],
-                    filter: '',
+                    filter: null,
                 )
                 ->collect(),
             ),


### PR DESCRIPTION
This PR makes the filter given by `--filter` a `non-empty-string|null`. While this does not guarantee that a filter will be applied or not (`--filter=","` will result in an empty filter whilst being a `non-empty-string`), it better conveys that a filter was passed or not.