### PR TITLE
refactor: Remove usage of the default container values

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -798,12 +798,16 @@ final class RunCommand extends BaseCommand
         }
     }
 
+    /**
+     * @param non-empty-string|null $gitDiffFilter
+     * @param non-empty-string|null $gitDiffBase
+     */
     private static function assertGitBaseHasRequiredFilter(
         ?string $gitDiffFilter,
         ?string $gitDiffBase,
     ): void {
-        if ($gitDiffBase !== Container::DEFAULT_GIT_DIFF_BASE
-            && $gitDiffFilter === Container::DEFAULT_GIT_DIFF_FILTER
+        if ($gitDiffBase !== null
+            && $gitDiffFilter === null
         ) {
             throw new InvalidArgumentException(
                 sprintf(


### PR DESCRIPTION
This PR removes the user of the `Container` default values. Indeed, in this method does not really care about those default values, what it's checking is that the required values are present.