### PR TITLE
feat: Make PlainFilter null if contains no values

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -693,9 +693,7 @@ final class RunCommand extends BaseCommand
     {
         $value = trim((string) $input->getOption(self::OPTION_FILTER));
 
-        return $value === ''
-            ? null
-            : PlainFilter::create($value);
+        return PlainFilter::tryToCreate($value);
     }
 
     private static function getGitFilter(InputInterface $input): ?IncompleteGitDiffFilter

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -369,7 +369,7 @@ class ConfigurationFactory
         array $sourceDirectories,
     ): ?PlainFilter {
         if ($sourceFilter instanceof GitDiffFilter) {
-            return PlainFilter::create(
+            return PlainFilter::tryToCreate(
                 $this->git->getChangedFileRelativePaths(
                     $sourceFilter->value,
                     $sourceFilter->base,

--- a/src/Configuration/SourceFilter/PlainFilter.php
+++ b/src/Configuration/SourceFilter/PlainFilter.php
@@ -37,6 +37,7 @@ namespace Infection\Configuration\SourceFilter;
 
 use function array_filter;
 use function array_map;
+use function count;
 use function explode;
 
 /**
@@ -45,7 +46,7 @@ use function explode;
 final readonly class PlainFilter implements SourceFilter
 {
     /**
-     * @param non-empty-string[] $values
+     * @param non-empty-array<non-empty-string> $values
      */
     public function __construct(
         public array $values,
@@ -53,16 +54,26 @@ final readonly class PlainFilter implements SourceFilter
     }
 
     /**
-     * @param non-empty-string $value A comma separated list of paths to exclude.
+     * @param string $value A comma separated list of paths to exclude.
      */
-    public static function create(string $value): self
+    public static function tryToCreate(string $value): ?self
     {
-        return new self(
-            array_filter(
-                array_map(
-                    trim(...),
-                    explode(',', $value),
-                ),
+        $values = self::parseValues($value);
+
+        return count($values) === 0
+            ? null
+            : new self($values);
+    }
+
+    /**
+     * @return non-empty-string[]
+     */
+    private static function parseValues(string $value): array
+    {
+        return array_filter(
+            array_map(
+                trim(...),
+                explode(',', $value),
             ),
         );
     }

--- a/src/FileSystem/SourceFileCollector.php
+++ b/src/FileSystem/SourceFileCollector.php
@@ -69,7 +69,7 @@ class SourceFileCollector
         private readonly array $excludedFilesOrDirectories,
         private readonly ?PlainFilter $filter,
     ) {
-        $this->filtered = count($this->filter->values ?? []) !== 0;
+        $this->filtered = $this->filter !== null;
     }
 
     public function isFiltered(): bool
@@ -170,10 +170,9 @@ class SourceFileCollector
     private function filter(Iterator $iterator): Iterator
     {
         // TODO: could use Finder::setFilter() instead!
-        if ($this->isFiltered()) {
+        if ($this->filter !== null) {
             $iterator = new RealPathFilterIterator(
                 $iterator,
-                // @phpstan-ignore property.nonObject
                 $this->filter->values,
                 [],
             );

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -238,7 +238,7 @@ final class ConfigurationFactoryTest extends TestCase
         $defaultConfiguration = new Configuration(
             processTimeout: 10,
             sourceDirectories: [],
-            sourceFilesFilter: PlainFilter::create('f(AM, reference(master), []) = src/a.php,src/b.php'),
+            sourceFilesFilter: PlainFilter::tryToCreate('f(AM, reference(master), []) = src/a.php,src/b.php'),
             sourceFilesExcludes: [],
             logs: $defaultLogs,
             logVerbosity: LogVerbosity::NONE,
@@ -1057,7 +1057,7 @@ final class ConfigurationFactoryTest extends TestCase
             $defaultScenario
                 ->forSourceFilter(
                     sourceFilter: new IncompleteGitDiffFilter('AD', null),
-                    expectedSourceFilesFilter: PlainFilter::create('f(AD, reference(test/default), []) = src/a.php,src/b.php'),
+                    expectedSourceFilesFilter: PlainFilter::tryToCreate('f(AD, reference(test/default), []) = src/a.php,src/b.php'),
                     expectedIsForGitDiffLines: true,
                     expectedDiffBase: 'reference(test/default)',
                     expectedDiffFilter: 'AD',
@@ -1068,7 +1068,7 @@ final class ConfigurationFactoryTest extends TestCase
             $defaultScenario
                 ->forSourceFilter(
                     sourceFilter: new IncompleteGitDiffFilter('AD', 'upstream/main'),
-                    expectedSourceFilesFilter: PlainFilter::create('f(AD, reference(upstream/main), []) = src/a.php,src/b.php'),
+                    expectedSourceFilesFilter: PlainFilter::tryToCreate('f(AD, reference(upstream/main), []) = src/a.php,src/b.php'),
                     expectedIsForGitDiffLines: true,
                     expectedDiffBase: 'reference(upstream/main)',
                     expectedDiffFilter: 'AD',

--- a/tests/phpunit/Configuration/SourceFilter/PlainFilterTest.php
+++ b/tests/phpunit/Configuration/SourceFilter/PlainFilterTest.php
@@ -49,9 +49,9 @@ final class PlainFilterTest extends TestCase
     #[DataProvider('valueProvider')]
     public function test_it_can_parse_and_normalize_string_filter(
         string $value,
-        PlainFilter $expected,
+        ?PlainFilter $expected,
     ): void {
-        $actual = PlainFilter::create($value);
+        $actual = PlainFilter::tryToCreate($value);
 
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
@@ -68,7 +68,7 @@ final class PlainFilterTest extends TestCase
 
         yield 'blank like string' => [
             ',',
-            new PlainFilter([]),
+            null,
         ];
 
         yield 'spaces & untrimmed string' => [


### PR DESCRIPTION
Transform `PlainFilter::create()` to `::tryToCreate()`. This allows us to harden the type of `PlainFilter#values` to be a non-empty array.

Side note: "tryCreate" would be more idiomatic in C#/.net, Java or JS, but I don't find that omitting the "to" brings that much clarity and makes the code less expressive IMO.