### PR TITLE
refactor: Allow to pass a SourceFilter to the Configuration

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -41,7 +41,7 @@ use Infection\Configuration\Entry\Logs;
 use Infection\Configuration\Entry\PhpStan;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Entry\Source;
-use Infection\Configuration\SourceFilter\PlainFilter;
+use Infection\Configuration\SourceFilter\SourceFilter;
 use Infection\Mutator\Mutator;
 use Infection\StaticAnalysis\StaticAnalysisToolTypes;
 use Infection\TestFramework\TestFrameworkTypes;
@@ -71,7 +71,7 @@ readonly class Configuration
     public function __construct(
         public float $processTimeout,
         public Source $source,
-        public ?PlainFilter $sourceFilesFilter,
+        public ?SourceFilter $sourceFilter,
         public Logs $logs,
         public string $logVerbosity,
         public string $tmpDir,

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -157,7 +157,7 @@ class ConfigurationFactory
         return new Configuration(
             processTimeout: $schema->timeout ?? self::DEFAULT_TIMEOUT,
             source: $schema->source,
-            sourceFilesFilter: $this->convertToPlainFilter(
+            sourceFilter: $this->convertToPlainFilter(
                 $sourceFilter,
                 $schema->source->directories,
             ),

--- a/src/Container.php
+++ b/src/Container.php
@@ -587,7 +587,7 @@ final class Container extends DIContainer
                     $configuration->configurationPathname,
                     $configuration->source->directories,
                     $configuration->source->excludes,
-                    $configuration->sourceFilesFilter,
+                    $configuration->sourceFilter,
                 );
             },
         ]);

--- a/tests/phpunit/Configuration/ConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/ConfigurationBuilder.php
@@ -45,6 +45,7 @@ use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Entry\Source;
 use Infection\Configuration\Entry\StrykerConfig;
 use Infection\Configuration\SourceFilter\PlainFilter;
+use Infection\Configuration\SourceFilter\SourceFilter;
 use Infection\Mutator\IgnoreConfig;
 use Infection\Mutator\IgnoreMutator;
 use Infection\Mutator\Mutator;
@@ -66,7 +67,7 @@ final class ConfigurationBuilder
     private function __construct(
         private float $timeout,
         private Source $source,
-        private ?PlainFilter $sourceFilesFilter,
+        private ?SourceFilter $sourceFilter,
         private Logs $logs,
         private string $logVerbosity,
         private string $tmpDir,
@@ -109,7 +110,7 @@ final class ConfigurationBuilder
         return new self(
             timeout: $configuration->processTimeout,
             source: $configuration->source,
-            sourceFilesFilter: $configuration->sourceFilesFilter,
+            sourceFilter: $configuration->sourceFilter,
             logs: $configuration->logs,
             logVerbosity: $configuration->logVerbosity,
             tmpDir: $configuration->tmpDir,
@@ -154,7 +155,7 @@ final class ConfigurationBuilder
         return new self(
             timeout: 10.0,
             source: new Source(),
-            sourceFilesFilter: null,
+            sourceFilter: null,
             logs: Logs::createEmpty(),
             logVerbosity: 'none',
             tmpDir: '/tmp/infection',
@@ -200,7 +201,7 @@ final class ConfigurationBuilder
                 ['src', 'lib'],
                 ['vendor', 'tests'],
             ),
-            sourceFilesFilter: new PlainFilter([
+            sourceFilter: new PlainFilter([
                 'src/Foo.php',
                 'src/Bar.php',
             ]),
@@ -303,10 +304,10 @@ final class ConfigurationBuilder
         return $clone;
     }
 
-    public function withSourceFilesFilter(?PlainFilter $sourceFilesFilter): self
+    public function withSourceFilter(?SourceFilter $sourceFilter): self
     {
         $clone = clone $this;
-        $clone->sourceFilesFilter = $sourceFilesFilter;
+        $clone->sourceFilter = $sourceFilter;
 
         return $clone;
     }
@@ -603,7 +604,7 @@ final class ConfigurationBuilder
         return new Configuration(
             processTimeout: $this->timeout,
             source: $this->source,
-            sourceFilesFilter: $this->sourceFilesFilter,
+            sourceFilter: $this->sourceFilter,
             logs: $this->logs,
             logVerbosity: $this->logVerbosity,
             tmpDir: $this->tmpDir,

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryScenario.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryScenario.php
@@ -609,7 +609,7 @@ final class ConfigurationFactoryScenario
             )
             ->withExpected(
                 ConfigurationBuilder::from($this->expected)
-                    ->withSourceFilesFilter($expectedSourceFilesFilter)
+                    ->withSourceFilter($expectedSourceFilesFilter)
                     ->withIsForGitDiffLines($expectedIsForGitDiffLines)
                     ->withGitDiffBase($expectedDiffBase)
                     ->withGitDiffFilter($expectedDiffFilter)

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -238,7 +238,7 @@ final class ConfigurationFactoryTest extends TestCase
         $defaultConfiguration = new Configuration(
             processTimeout: 10,
             source: new Source(),
-            sourceFilesFilter: PlainFilter::tryToCreate('f(AM, reference(master), []) = src/a.php,src/b.php'),
+            sourceFilter: PlainFilter::tryToCreate('f(AM, reference(master), []) = src/a.php,src/b.php'),
             logs: $defaultLogs,
             logVerbosity: LogVerbosity::NONE,
             tmpDir: sys_get_temp_dir() . '/infection',
@@ -1143,7 +1143,7 @@ final class ConfigurationFactoryTest extends TestCase
                 expected: ConfigurationBuilder::withMinimalTestData()
                     ->withTimeout(10)
                     ->withSourceDirectories('src/')
-                    ->withSourceFilesFilter(
+                    ->withSourceFilter(
                         new PlainFilter([
                             'src/Foo.php',
                             'src/Bar.php',


### PR DESCRIPTION
In the future we will be able to pass the `GitDiffFilter` directly instead of converting it to a `PlainFilter`.