### PR TITLE
refactor(SourceCollector): Rename `FilesDiffChangedLines`

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -121,7 +121,7 @@ use Infection\Resource\Memory\MemoryLimiterEnvironment;
 use Infection\Resource\Time\Stopwatch;
 use Infection\Resource\Time\TimeFormatter;
 use Infection\Source\Exception\NoSourceFound;
-use Infection\Source\Matcher\GitDiffChangedLines;
+use Infection\Source\Matcher\GitDiffSourceLineMatcher;
 use Infection\Source\Matcher\NullSourceLineMatcher;
 use Infection\Source\Matcher\SourceLineMatcher;
 use Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator;
@@ -570,7 +570,7 @@ final class Container extends DIContainer
                     return new NullSourceLineMatcher();
                 }
 
-                return new GitDiffChangedLines(
+                return new GitDiffSourceLineMatcher(
                     $container->getGit(),
                     $container->getFileSystem(),
                     $gitDiffBase,

--- a/src/Source/Matcher/GitDiffSourceLineMatcher.php
+++ b/src/Source/Matcher/GitDiffSourceLineMatcher.php
@@ -43,7 +43,7 @@ use Infection\Source\Exception\NoSourceFound;
 /**
  * @internal
  */
-final class GitDiffChangedLines implements SourceLineMatcher
+final class GitDiffSourceLineMatcher implements SourceLineMatcher
 {
     /** @var array<string, list<ChangedLinesRange>> */
     private ?array $memoizedFilesChangedLinesMap = null;

--- a/tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php
+++ b/tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php
@@ -38,15 +38,15 @@ namespace Infection\Tests\Source\Matcher;
 use Infection\Differ\ChangedLinesRange;
 use Infection\FileSystem\FileSystem;
 use Infection\Git\Git;
-use Infection\Source\Matcher\GitDiffChangedLines;
+use Infection\Source\Matcher\GitDiffSourceLineMatcher;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use function sprintf;
 
-#[CoversClass(GitDiffChangedLines::class)]
-final class GitDiffChangedLinesTest extends TestCase
+#[CoversClass(GitDiffSourceLineMatcher::class)]
+final class GitDiffSourceLineMatcherTest extends TestCase
 {
     private FileSystem&MockObject $fileSystemStub;
 
@@ -62,7 +62,7 @@ final class GitDiffChangedLinesTest extends TestCase
 
     public function test_it_memoizes_parsed_results(): void
     {
-        $filesDiffChangedLines = new GitDiffChangedLines(
+        $matcher = new GitDiffSourceLineMatcher(
             $this->createGitStub([]),
             $this->fileSystemStub,
             'main',
@@ -70,10 +70,10 @@ final class GitDiffChangedLinesTest extends TestCase
             ['src', 'lib'],
         );
 
-        $filesDiffChangedLines->touches('/path/to/File.php', 1, 1);
+        $matcher->touches('/path/to/File.php', 1, 1);
 
         // the second call should reuse memoized results cached previously
-        $filesDiffChangedLines->touches('/path/to/File.php', 1, 1);
+        $matcher->touches('/path/to/File.php', 1, 1);
     }
 
     /**
@@ -89,7 +89,7 @@ final class GitDiffChangedLinesTest extends TestCase
         int $mutationEndLine,
         bool $expected,
     ): void {
-        $filesDiffChangedLines = new GitDiffChangedLines(
+        $matcher = new GitDiffSourceLineMatcher(
             $this->createGitStub($changedLinesRangesByFilePathname),
             $this->fileSystemStub,
             'main',
@@ -97,7 +97,7 @@ final class GitDiffChangedLinesTest extends TestCase
             ['src', 'lib'],
         );
 
-        $actual = $filesDiffChangedLines->touches(
+        $actual = $matcher->touches(
             $fileRealPath,
             $mutationStartLine,
             $mutationEndLine,


### PR DESCRIPTION
This class was renamed into `GitDiffChangedLines` in #2689 but I think `GitDiffSourceLineMatcher` would be a more correct name.