### PR TITLE
refactor(SourceCollector): Leverage the GitDiffFilter to configure GitDiffSourceLineMatcher

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -64,8 +64,6 @@ readonly class Configuration
     /**
      * @param array<string, Mutator<Node>> $mutators
      * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
-     * @param non-empty-string|null $gitDiffBase
-     * @param non-empty-string|null $gitDiffFilter
      * @param non-empty-string $configurationPathname
      */
     public function __construct(
@@ -98,8 +96,6 @@ readonly class Configuration
         public bool $isDryRun,
         public array $ignoreSourceCodeMutatorsMap,
         public bool $executeOnlyCoveringTestCases,
-        public ?string $gitDiffBase,
-        public ?string $gitDiffFilter,
         public ?string $mapSourceClassToTestStrategy,
         public ?string $loggerProjectRootDirectory,
         public ?string $staticAnalysisTool,

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -184,12 +184,6 @@ class ConfigurationFactory
             isDryRun: $dryRun,
             ignoreSourceCodeMutatorsMap: $ignoreSourceCodeMutatorsMap,
             executeOnlyCoveringTestCases: $executeOnlyCoveringTestCases,
-            gitDiffBase: $sourceFilter instanceof GitDiffFilter
-                ? $sourceFilter->base
-                : null,
-            gitDiffFilter: $sourceFilter instanceof GitDiffFilter
-                ? $sourceFilter->value
-                : null,
             mapSourceClassToTestStrategy: $mapSourceClassToTestStrategy,
             loggerProjectRootDirectory: $loggerProjectRootDirectory,
             staticAnalysisTool: $resultStaticAnalysisTool,

--- a/tests/phpunit/Configuration/ConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/ConfigurationBuilder.php
@@ -60,8 +60,6 @@ final class ConfigurationBuilder
     /**
      * @param array<string, Mutator<Node>> $mutators
      * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
-     * @param non-empty-string $gitDiffBase
-     * @param non-empty-string $gitDiffFilter
      * @param non-empty-string $configPathname
      */
     private function __construct(
@@ -94,8 +92,6 @@ final class ConfigurationBuilder
         private bool $dryRun,
         private array $ignoreSourceCodeMutatorsMap,
         private bool $executeOnlyCoveringTestCases,
-        private ?string $gitDiffBase,
-        private ?string $gitDiffFilter,
         private ?string $mapSourceClassToTestStrategy,
         private ?string $loggerProjectRootDirectory,
         private ?string $staticAnalysisTool,
@@ -138,8 +134,6 @@ final class ConfigurationBuilder
             dryRun: $configuration->isDryRun,
             ignoreSourceCodeMutatorsMap: $configuration->ignoreSourceCodeMutatorsMap,
             executeOnlyCoveringTestCases: $configuration->executeOnlyCoveringTestCases,
-            gitDiffBase: $configuration->gitDiffBase,
-            gitDiffFilter: $configuration->gitDiffFilter,
             mapSourceClassToTestStrategy: $configuration->mapSourceClassToTestStrategy,
             loggerProjectRootDirectory: $configuration->loggerProjectRootDirectory,
             staticAnalysisTool: $configuration->staticAnalysisTool,
@@ -180,8 +174,6 @@ final class ConfigurationBuilder
             dryRun: false,
             ignoreSourceCodeMutatorsMap: [],
             executeOnlyCoveringTestCases: false,
-            gitDiffBase: null,
-            gitDiffFilter: null,
             mapSourceClassToTestStrategy: null,
             loggerProjectRootDirectory: null,
             staticAnalysisTool: null,
@@ -246,8 +238,6 @@ final class ConfigurationBuilder
                 'Foo\\Bar' => ['.*test.*'],
             ],
             executeOnlyCoveringTestCases: true,
-            gitDiffBase: 'origin/master',
-            gitDiffFilter: 'AM',
             mapSourceClassToTestStrategy: MapSourceClassToTestStrategy::SIMPLE,
             loggerProjectRootDirectory: '/var/www/project',
             staticAnalysisTool: StaticAnalysisToolTypes::PHPSTAN,
@@ -522,28 +512,6 @@ final class ConfigurationBuilder
         return $clone;
     }
 
-    /**
-     * @param non-empty-string|null $gitDiffBase
-     */
-    public function withGitDiffBase(?string $gitDiffBase): self
-    {
-        $clone = clone $this;
-        $clone->gitDiffBase = $gitDiffBase;
-
-        return $clone;
-    }
-
-    /**
-     * @param non-empty-string|null $gitDiffFilter
-     */
-    public function withGitDiffFilter(?string $gitDiffFilter): self
-    {
-        $clone = clone $this;
-        $clone->gitDiffFilter = $gitDiffFilter;
-
-        return $clone;
-    }
-
     public function withMapSourceClassToTestStrategy(?string $mapSourceClassToTestStrategy): self
     {
         $clone = clone $this;
@@ -619,8 +587,6 @@ final class ConfigurationBuilder
             isDryRun: $this->dryRun,
             ignoreSourceCodeMutatorsMap: $this->ignoreSourceCodeMutatorsMap,
             executeOnlyCoveringTestCases: $this->executeOnlyCoveringTestCases,
-            gitDiffBase: $this->gitDiffBase,
-            gitDiffFilter: $this->gitDiffFilter,
             mapSourceClassToTestStrategy: $this->mapSourceClassToTestStrategy,
             loggerProjectRootDirectory: $this->loggerProjectRootDirectory,
             staticAnalysisTool: $this->staticAnalysisTool,

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryScenario.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryScenario.php
@@ -592,15 +592,9 @@ final class ConfigurationFactoryScenario
             );
     }
 
-    /**
-     * @param non-empty-string|null $expectedDiffBase
-     * @param non-empty-string|null $expectedDiffFilter
-     */
     public function forSourceFilter(
         PlainFilter|IncompleteGitDiffFilter|null $sourceFilter,
         ?SourceFilter $expectedSourceFilter,
-        ?string $expectedDiffBase,
-        ?string $expectedDiffFilter,
     ): self {
         return $this
             ->withInput(
@@ -610,8 +604,6 @@ final class ConfigurationFactoryScenario
             ->withExpected(
                 ConfigurationBuilder::from($this->expected)
                     ->withSourceFilter($expectedSourceFilter)
-                    ->withGitDiffBase($expectedDiffBase)
-                    ->withGitDiffFilter($expectedDiffFilter)
                     ->build(),
             );
     }

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -264,8 +264,6 @@ final class ConfigurationFactoryTest extends TestCase
             isDryRun: false,
             ignoreSourceCodeMutatorsMap: [],
             executeOnlyCoveringTestCases: true,
-            gitDiffBase: 'reference(master)',
-            gitDiffFilter: 'AM',
             mapSourceClassToTestStrategy: MapSourceClassToTestStrategy::SIMPLE,
             loggerProjectRootDirectory: null,
             staticAnalysisTool: null,
@@ -1027,8 +1025,6 @@ final class ConfigurationFactoryTest extends TestCase
                 ->forSourceFilter(
                     sourceFilter: null,
                     expectedSourceFilter: null,
-                    expectedDiffBase: null,
-                    expectedDiffFilter: null,
                 ),
         ];
 
@@ -1043,8 +1039,6 @@ final class ConfigurationFactoryTest extends TestCase
                         'src/Foo.php',
                         'src/Bar.php',
                     ]),
-                    expectedDiffBase: null,
-                    expectedDiffFilter: null,
                 ),
         ];
 
@@ -1053,8 +1047,6 @@ final class ConfigurationFactoryTest extends TestCase
                 ->forSourceFilter(
                     sourceFilter: new IncompleteGitDiffFilter('AD', null),
                     expectedSourceFilter: new GitDiffFilter('AD', 'reference(test/default)'),
-                    expectedDiffBase: 'reference(test/default)',
-                    expectedDiffFilter: 'AD',
                 ),
         ];
 
@@ -1063,8 +1055,6 @@ final class ConfigurationFactoryTest extends TestCase
                 ->forSourceFilter(
                     sourceFilter: new IncompleteGitDiffFilter('AD', 'upstream/main'),
                     expectedSourceFilter: new GitDiffFilter('AD', 'reference(upstream/main)'),
-                    expectedDiffBase: 'reference(upstream/main)',
-                    expectedDiffFilter: 'AD',
                 ),
         ];
 


### PR DESCRIPTION
This allows us to avoid to have to duplicate the information in `Configuration` and have those safe guards when accessing those values.