### PR TITLE
refactor(SourceCollector): Simplify the SourceCollectorFactory

### DIFF
--- a/src/Source/Collector/SourceCollectorFactory.php
+++ b/src/Source/Collector/SourceCollectorFactory.php
@@ -41,7 +41,6 @@ use Infection\Configuration\SourceFilter\GitDiffFilter;
 use Infection\Configuration\SourceFilter\PlainFilter;
 use Infection\Configuration\SourceFilter\SourceFilter;
 use Infection\Git\Git;
-use Infection\Source\Exception\NoSourceFound;
 use InvalidArgumentException;
 use function sprintf;
 use const true;
@@ -60,25 +59,6 @@ final readonly class SourceCollectorFactory
      * @param non-empty-string $configurationPathname
      */
     public function create(
-        string $configurationPathname,
-        Source $source,
-        ?SourceFilter $sourceFilter,
-    ): SourceCollector {
-        return new LazySourceCollector(
-            fn () => $this->createCollector(
-                $configurationPathname,
-                $source,
-                $sourceFilter,
-            ),
-        );
-    }
-
-    /**
-     * @param non-empty-string $configurationPathname
-     *
-     * @throws NoSourceFound
-     */
-    private function createCollector(
         string $configurationPathname,
         Source $source,
         ?SourceFilter $sourceFilter,

--- a/tests/phpunit/Source/Collector/SourceCollectorFactoryTest.php
+++ b/tests/phpunit/Source/Collector/SourceCollectorFactoryTest.php
@@ -44,7 +44,6 @@ use Infection\Configuration\SourceFilter\SourceFilter;
 use Infection\Git\Git;
 use Infection\Source\Collector\BasicSourceCollector;
 use Infection\Source\Collector\GitDiffSourceCollector;
-use Infection\Source\Collector\LazySourceCollector;
 use Infection\Source\Collector\SourceCollector;
 use Infection\Source\Collector\SourceCollectorFactory;
 use InvalidArgumentException;
@@ -68,22 +67,18 @@ final class SourceCollectorFactoryTest extends TestCase
             $this->createMock(Git::class),
         );
 
+        if ($exceptionOrExpectedCollectorClassName instanceof Exception) {
+            $this->expectExceptionObject($exceptionOrExpectedCollectorClassName);
+        }
+
         $actual = $factory->create(
             '/path/to/project',
             new Source(['src', 'lib'], ['vendor', 'tests']),
             $sourceFilter,
         );
 
-        $this->assertInstanceOf(LazySourceCollector::class, $actual);
-
-        if ($exceptionOrExpectedCollectorClassName instanceof Exception) {
-            $this->expectExceptionObject($exceptionOrExpectedCollectorClassName);
-        }
-
-        $innerCollectorClassName = $actual->getCollector();
-
         if (!($exceptionOrExpectedCollectorClassName instanceof Exception)) {
-            $this->assertInstanceOf($exceptionOrExpectedCollectorClassName, $innerCollectorClassName);
+            $this->assertSame($actual::class, $exceptionOrExpectedCollectorClassName);
         }
     }
 


### PR DESCRIPTION
I did not like much how `SourceCollectorFactory` got complicated and harder to test in #2697.

In #2699 I kinda auto-piloted in a similar solution. But actually, I think it makes more sense to delegate that wiring of the laziness to the container.

`SourceCollectorFactory` is about creating the right source collector based on the filter used. The rest: laziness, caching, etc. are how we want to wire the different services, which IMO is better off left to the container configuration.

This also means if tomorrow the container supports laziness, the factory won't change. If you need the factory for tests but don't want any of the laziness or caching, this will also be possible.