### PR TITLE
feat(SourceCollector): Introduce a cached source collector

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -120,6 +120,7 @@ use Infection\Resource\Memory\MemoryLimiter;
 use Infection\Resource\Memory\MemoryLimiterEnvironment;
 use Infection\Resource\Time\Stopwatch;
 use Infection\Resource\Time\TimeFormatter;
+use Infection\Source\Collector\CachedSourceCollector;
 use Infection\Source\Collector\LazySourceCollector;
 use Infection\Source\Collector\SourceCollector;
 use Infection\Source\Collector\SourceCollectorFactory;
@@ -584,10 +585,12 @@ final class Container extends DIContainer
                 static function () use ($container): SourceCollector {
                     $configuration = $container->getConfiguration();
 
-                    return $container->get(SourceCollectorFactory::class)->create(
-                        $configuration->configurationPathname,
-                        $configuration->source,
-                        $configuration->sourceFilter,
+                    return new CachedSourceCollector(
+                        $container->get(SourceCollectorFactory::class)->create(
+                            $configuration->configurationPathname,
+                            $configuration->source,
+                            $configuration->sourceFilter,
+                        ),
                     );
                 },
             ),

--- a/src/Source/Collector/CachedSourceCollector.php
+++ b/src/Source/Collector/CachedSourceCollector.php
@@ -35,16 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Source\Collector;
 
-use function array_map;
-use function count;
-use function dirname;
-use Infection\Configuration\SourceFilter\PlainFilter;
-use Infection\FileSystem\Finder\Iterator\RealPathFilterIterator;
-use Iterator;
-use function Pipeline\take;
-use Symfony\Component\Filesystem\Path;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\Iterator\PathFilterIterator;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
@@ -66,7 +56,7 @@ final class CachedSourceCollector implements SourceCollector
 
     public function isFiltered(): bool
     {
-        if (null === $this->filtered) {
+        if ($this->filtered === null) {
             $this->filtered = $this->decoratedCollector->isFiltered();
         }
 

--- a/tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php
+++ b/tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php
@@ -90,27 +90,6 @@ final class BasicSourceCollectorTest extends FileSystemTestCase
     }
 
     /**
-     * @param non-empty-string[] $sourceDirectories
-     * @param non-empty-string[] $excludedFilesOrDirectories
-     */
-    #[DataProvider('sourceFilesProvider')]
-    public function test_it_memoizes_the_result(
-        array $sourceDirectories,
-        array $excludedFilesOrDirectories,
-    ): void {
-        $collector = new BasicSourceCollector(
-            $sourceDirectories,
-            $excludedFilesOrDirectories,
-            null,
-        );
-
-        $first = $collector->collect();
-        $second = $collector->collect();
-
-        $this->assertSame($first, $second);
-    }
-
-    /**
      * @return iterable<string, array{string[], string[], list<string>}>
      */
     public static function sourceFilesProvider(): iterable

--- a/tests/phpunit/Source/Collector/CachedSourceCollectorTest.php
+++ b/tests/phpunit/Source/Collector/CachedSourceCollectorTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Source\Collector;
+
+use Infection\Source\Collector\CachedSourceCollector;
+use Infection\Source\Collector\SourceCollector;
+use Infection\Tests\Fixtures\Finder\MockSplFileInfo;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CachedSourceCollector::class)]
+final class CachedSourceCollectorTest extends TestCase
+{
+    private SourceCollector&MockObject $decoratedCollectorMock;
+
+    private CachedSourceCollector $collector;
+
+    protected function setUp(): void
+    {
+        $this->decoratedCollectorMock = $this->createMock(SourceCollector::class);
+
+        $this->collector = new CachedSourceCollector(
+            $this->decoratedCollectorMock,
+        );
+    }
+
+    public function test_it_caches_the_is_filtered_call(): void
+    {
+        $expected = true;
+
+        $this->decoratedCollectorMock
+            ->expects($this->once())
+            ->method('isFiltered')
+            ->willReturn($expected);
+        $this->decoratedCollectorMock
+            ->expects($this->never())
+            ->method('collect');
+
+        $actual1 = $this->collector->isFiltered();
+        $actual2 = $this->collector->isFiltered();
+
+        $this->assertSame($expected, $actual1);
+        $this->assertSame($actual1, $actual2);
+    }
+
+    public function test_it_caches_the_collected_files(): void
+    {
+        $expected = [
+            new MockSplFileInfo('src/File1.php'),
+            new MockSplFileInfo('src/File2.php'),
+        ];
+
+        $this->decoratedCollectorMock
+            ->expects($this->never())
+            ->method('isFiltered');
+        $this->decoratedCollectorMock
+            ->expects($this->once())
+            ->method('collect')
+            ->willReturn($expected);
+
+        $actual1 = $this->collector->collect();
+        $actual2 = $this->collector->collect();
+
+        $this->assertSame($expected, $actual1);
+        $this->assertSame($actual1, $actual2);
+    }
+}


### PR DESCRIPTION
Introduces `CachedSourceCollector` which avoids to have the memoization logic within `BasicSourceCollector`, which would need to be duplicated in `GitDiffSourceCollector` if we were to update its implementation to no longer us `BasicSourceCollector`.