### PR TITLE
fix: Remove dead code

### DIFF
--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -73,8 +73,6 @@ final readonly class Factory
     public function create(string $adapterName, bool $skipCoverage): TestFrameworkAdapter
     {
         if ($adapterName === TestFrameworkTypes::PHPUNIT) {
-            $filteredSourceFilesToMutate = $this->getFilteredSourceFilesToMutate();
-
             $phpUnitConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPUNIT);
 
             return PhpUnitAdapterFactory::create(


### PR DESCRIPTION
This variable was inlined in #2694 but introduced back by accident in #2693 (without removing the inlined code – so the variable is now unused).