### PR TITLE
refactor: Move IterableCounter to a dedicated namespace

### DIFF
--- a/src/Framework/Iterable/IterableCounter.php
+++ b/src/Framework/Iterable/IterableCounter.php
@@ -33,9 +33,10 @@
 
 declare(strict_types=1);
 
-namespace Infection;
+namespace Infection\Framework\Iterable;
 
 use function count;
+use Infection\CannotBeInstantiated;
 use Infection\Console\OutputFormatter\AbstractOutputFormatter;
 use function is_array;
 use function iterator_to_array;

--- a/src/Mutation/MutationGenerator.php
+++ b/src/Mutation/MutationGenerator.php
@@ -39,7 +39,7 @@ use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\MutableFileWasProcessed;
 use Infection\Event\MutationGenerationWasFinished;
 use Infection\Event\MutationGenerationWasStarted;
-use Infection\IterableCounter;
+use Infection\Framework\Iterable\IterableCounter;
 use Infection\Mutator\Mutator;
 use Infection\PhpParser\UnparsableFile;
 use Infection\PhpParser\Visitor\IgnoreNode\NodeIgnorer;

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -41,7 +41,7 @@ use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\MutantProcessWasFinished;
 use Infection\Event\MutationTestingWasFinished;
 use Infection\Event\MutationTestingWasStarted;
-use Infection\IterableCounter;
+use Infection\Framework\Iterable\IterableCounter;
 use Infection\Mutant\Mutant;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutant\MutantFactory;

--- a/tests/phpunit/Framework/Iterable/IterableCounterTest.php
+++ b/tests/phpunit/Framework/Iterable/IterableCounterTest.php
@@ -33,10 +33,10 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests;
+namespace Infection\Tests\Framework\Iterable;
 
 use ArrayIterator;
-use Infection\IterableCounter;
+use Infection\Framework\Iterable\IterableCounter;
 use Iterator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
In #2708 and likely upcoming PRs, we will have more `iterable` related utility, so I moving this to a dedicated namespace for better organisation.