### PR TITLE
refactor(test): Use the GNU diff long option name

### DIFF
--- a/tests/e2e/Composer_Xdebug_Handler_Version_1/run_tests.bash
+++ b/tests/e2e/Composer_Xdebug_Handler_Version_1/run_tests.bash
@@ -17,4 +17,4 @@ else
     php $INFECTION
 fi
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log

--- a/tests/e2e/Exclude_Mutations_By_Regex/run_tests.bash
+++ b/tests/e2e/Exclude_Mutations_By_Regex/run_tests.bash
@@ -11,4 +11,4 @@ else
     php $INFECTION
 fi
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log

--- a/tests/e2e/Exec_Path/run_tests.bash
+++ b/tests/e2e/Exec_Path/run_tests.bash
@@ -57,6 +57,6 @@ tputx sgr0
 
 PATH=$PATH:bin run "../../../bin/infection --quiet"
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log
 
 rm -vfr coverage

--- a/tests/e2e/PCOV_PHPUnit8/run_tests.bash
+++ b/tests/e2e/PCOV_PHPUnit8/run_tests.bash
@@ -46,5 +46,5 @@ set -e pipefail
 
 run "../../../bin/infection"
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log
 

--- a/tests/e2e/PHPStan_Custom_Executable_Path/run_tests.bash
+++ b/tests/e2e/PHPStan_Custom_Executable_Path/run_tests.bash
@@ -8,4 +8,4 @@ composer install --no-interaction --working-dir=tools
 
 php $INFECTION --static-analysis-tool=phpstan --no-progress --threads=2
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log

--- a/tests/e2e/PHPStan_Integration/run_tests.bash
+++ b/tests/e2e/PHPStan_Integration/run_tests.bash
@@ -6,4 +6,4 @@ set -e pipefail
 
 php $INFECTION --no-progress --threads=2
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log

--- a/tests/e2e/PHPUnit11/run_tests.bash
+++ b/tests/e2e/PHPUnit11/run_tests.bash
@@ -16,4 +16,4 @@ else
     php $INFECTION
 fi
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log

--- a/tests/e2e/PHPUnit12/run_tests.bash
+++ b/tests/e2e/PHPUnit12/run_tests.bash
@@ -16,4 +16,4 @@ else
     php $INFECTION
 fi
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log

--- a/tests/e2e/Profiles_Ignore_Combination/run_tests.bash
+++ b/tests/e2e/Profiles_Ignore_Combination/run_tests.bash
@@ -11,4 +11,4 @@ else
     php $INFECTION
 fi
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log

--- a/tests/e2e/Variables_Order_EGPCS/run_tests.bash
+++ b/tests/e2e/Variables_Order_EGPCS/run_tests.bash
@@ -15,4 +15,4 @@ if [[ -v GOLDEN ]]; then
    cp -v infection.log expected-output.txt
 fi
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log

--- a/tests/e2e/Without_Git/run_tests.bash
+++ b/tests/e2e/Without_Git/run_tests.bash
@@ -31,4 +31,4 @@ composer install
 
 docker run -t -v "$PWD":/opt -w /opt php:8.2-alpine vendor/bin/infection --coverage=infection-coverage
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log

--- a/tests/e2e/YieldValue/run_tests.bash
+++ b/tests/e2e/YieldValue/run_tests.bash
@@ -11,4 +11,4 @@ else
     php $INFECTION
 fi
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log

--- a/tests/e2e/standard_script.bash
+++ b/tests/e2e/standard_script.bash
@@ -11,4 +11,4 @@ else
     php $INFECTION
 fi
 
-diff -w expected-output.txt infection.log
+diff --ignore-all-space expected-output.txt infection.log


### PR DESCRIPTION
It is more understandable and since it is not something that one needs to type there is no reason to be lazy there.