### PR TITLE
fix(Tracer): Throw an appropriate exception when no trace could be found

### DIFF
--- a/src/TestFramework/Tracing/Throwable/NoTraceFound.php
+++ b/src/TestFramework/Tracing/Throwable/NoTraceFound.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\TestFramework\Tracing\Throwable;
+
+use RuntimeException;
+use function sprintf;
+
+/**
+ * @internal
+ */
+final class NoTraceFound extends RuntimeException
+{
+    public static function forFile(string $pathname): self
+    {
+        return new self(
+            sprintf(
+                'Could not find any trace for file "%s".',
+                $pathname,
+            ),
+        );
+    }
+}

--- a/tests/phpunit/TestFramework/Tracing/Throwable/NoTraceFoundTest.php
+++ b/tests/phpunit/TestFramework/Tracing/Throwable/NoTraceFoundTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestFramework\Tracing\Throwable;
+
+use Infection\TestFramework\Tracing\Throwable\NoTraceFound;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NoTraceFound::class)]
+final class NoTraceFoundTest extends TestCase
+{
+    public function test_it_can_be_created_for_a_file_not_found(): void
+    {
+        $expected = new NoTraceFound(
+            'Could not find any trace for file "/path/to/file.php".',
+        );
+
+        $actual = NoTraceFound::forFile('/path/to/file.php');
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php
+++ b/tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Tracing;
 
 use ArrayIterator;
+use Infection\TestFramework\Tracing\Throwable\NoTraceFound;
 use Infection\TestFramework\Tracing\Trace\Trace;
 use Infection\TestFramework\Tracing\TraceProvider;
 use Infection\TestFramework\Tracing\TraceProviderAdapterTracer;
@@ -48,7 +49,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\SplFileInfo;
-use Webmozart\Assert\InvalidArgumentException;
 
 #[CoversClass(TraceProviderAdapterTracer::class)]
 final class TraceProviderAdapterTracerTest extends TestCase
@@ -89,7 +89,13 @@ final class TraceProviderAdapterTracerTest extends TestCase
         $this->assertSame($trace2, $this->tracer->trace($fileInfo2));
 
         $this->assertFalse($this->tracer->hasTrace($unknownFileInfo));
-        $this->expectException(InvalidArgumentException::class);
+
+        $this->expectExceptionObject(
+            new NoTraceFound(
+                'Could not find any trace for file "unknown".',
+            ),
+        );
+
         $this->tracer->trace($unknownFileInfo);
     }
 
@@ -157,7 +163,15 @@ final class TraceProviderAdapterTracerTest extends TestCase
             ->method('provideTraces')
             ->willReturn([]);
 
-        $this->assertFalse($this->tracer->hasTrace($fileInfo));
+        $this->tracer->hasTrace($fileInfo);
+
+        $this->expectExceptionObject(
+            new NoTraceFound(
+                'Could not find any trace.',
+            ),
+        );
+
+        $this->tracer->trace($fileInfo);
     }
 
     /**


### PR DESCRIPTION
This is a bit more helpful than a generic `InvalidArgumentException`.