### PR TITLE
refactor(Tracer): Remove the unused Tracer::hasTrace method

### DIFF
--- a/src/TestFramework/Tracing/TraceProviderAdapterTracer.php
+++ b/src/TestFramework/Tracing/TraceProviderAdapterTracer.php
@@ -77,11 +77,6 @@ final class TraceProviderAdapterTracer implements Tracer
     ) {
     }
 
-    public function hasTrace(SplFileInfo $fileInfo): bool
-    {
-        return $this->tryToTrace($fileInfo) !== null;
-    }
-
     public function trace(SplFileInfo $fileInfo): Trace
     {
         $trace = $this->tryToTrace($fileInfo);

--- a/src/TestFramework/Tracing/Tracer.php
+++ b/src/TestFramework/Tracing/Tracer.php
@@ -47,8 +47,6 @@ use Symfony\Component\Finder\SplFileInfo;
  */
 interface Tracer
 {
-    public function hasTrace(SplFileInfo $fileInfo): bool;
-
     /**
      * Beware! Whilst the absence of Trace guarantees the absence of tests, its reciprocal is false.
      * A trace may end up being empty.

--- a/tests/benchmark/MutationGenerator/create-main.php
+++ b/tests/benchmark/MutationGenerator/create-main.php
@@ -69,11 +69,6 @@ if (!function_exists('Infection\Benchmark\MutationGenerator\collectSources')) {
 if (!class_exists(EmptyTraceTracer::class, false)) {
     final readonly class EmptyTraceTracer implements Tracer
     {
-        public function hasTrace(SplFileInfo $fileInfo): bool
-        {
-            return true;
-        }
-
         public function trace(SplFileInfo $fileInfo): Trace
         {
             require_once $fileInfo->getRealPath();

--- a/tests/benchmark/Tracing/create-main.php
+++ b/tests/benchmark/Tracing/create-main.php
@@ -42,6 +42,7 @@ use function count;
 use function function_exists;
 use Infection\Container;
 use Infection\TestFramework\Coverage\CoveredTraceProvider;
+use Infection\TestFramework\Tracing\Trace\EmptyTrace;
 use Infection\TestFramework\Tracing\Trace\Trace;
 use Infection\TestFramework\Tracing\Tracer;
 use function iterator_to_array;
@@ -145,11 +146,12 @@ return static function (int $maxCount, float $percentage = 1.): Closure {
         $count = 0;
 
         foreach ($sourcesSubset as $source) {
-            if (!$tracer->hasTrace($source)) {
+            $trace = $tracer->trace($source);
+
+            if ($trace instanceof EmptyTrace) {
                 continue;
             }
 
-            $trace = $tracer->trace($source);
             fetchTraceLazyState($trace);
 
             ++$count;

--- a/tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php
@@ -158,10 +158,6 @@ final class FileMutationGeneratorTest extends TestCase
             ->method('hasTests');
 
         $this->tracerMock
-            ->method('hasTrace')
-            ->with($fileInfoMock)
-            ->willReturn(true);
-        $this->tracerMock
             ->method('trace')
             ->with($fileInfoMock)
             ->willReturn($traceMock);

--- a/tests/phpunit/TestFramework/Tracing/DummyTracer.php
+++ b/tests/phpunit/TestFramework/Tracing/DummyTracer.php
@@ -42,11 +42,6 @@ use Symfony\Component\Finder\SplFileInfo;
 
 final class DummyTracer implements Tracer
 {
-    public function hasTrace(SplFileInfo $fileInfo): bool
-    {
-        return true;
-    }
-
     public function trace(SplFileInfo $fileInfo): Trace
     {
         return new EmptyTrace($fileInfo);

--- a/tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php
+++ b/tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php
@@ -82,13 +82,8 @@ final class TraceProviderAdapterTracerTest extends TestCase
             ->method('provideTraces')
             ->willReturn($traces);
 
-        $this->assertTrue($this->tracer->hasTrace($fileInfo1));
         $this->assertSame($trace1, $this->tracer->trace($fileInfo1));
-
-        $this->assertTrue($this->tracer->hasTrace($fileInfo2));
         $this->assertSame($trace2, $this->tracer->trace($fileInfo2));
-
-        $this->assertFalse($this->tracer->hasTrace($unknownFileInfo));
 
         $this->expectExceptionObject(
             new NoTraceFound(
@@ -133,25 +128,20 @@ final class TraceProviderAdapterTracerTest extends TestCase
         $this->assertSame(0, $tracesIterator->getIndex());
         $this->assertFalse($tracesIterator->hasYieldedAnyValue());
 
-        $this->assertTrue($this->tracer->hasTrace($fileInfo1));
         $this->assertSame($trace1, $this->tracer->trace($fileInfo1));
-
-        $this->assertSame(1, $tracesIterator->getIndex());
         $this->assertTrue($tracesIterator->hasYieldedAnyValue());
 
-        $this->assertTrue($this->tracer->hasTrace($fileInfo2));
         $this->assertSame($trace2, $this->tracer->trace($fileInfo2));
 
         $this->assertSame(2, $tracesIterator->getIndex());
 
-        $this->assertFalse($this->tracer->hasTrace($unknownFileInfo));
         // We exhaust the remainder of the iterator by looking for a non-existent trace
+        $this->expectToThrow(fn () => $this->tracer->trace($unknownFileInfo));
         $this->assertSame(4, $tracesIterator->getIndex());
 
         $this->expectToThrow(fn () => $this->tracer->trace($unknownFileInfo));
 
         // We still can fetch traces despite the generator being exhausted
-        $this->assertTrue($this->tracer->hasTrace($fileInfo3));
         $this->assertSame($trace3, $this->tracer->trace($fileInfo3));
     }
 
@@ -162,8 +152,6 @@ final class TraceProviderAdapterTracerTest extends TestCase
         $this->traceProviderMock
             ->method('provideTraces')
             ->willReturn([]);
-
-        $this->tracer->hasTrace($fileInfo);
 
         $this->expectExceptionObject(
             new NoTraceFound(


### PR DESCRIPTION
Thanks to #2740, we no longer need this method which is great because we otherwise had two points (`::hasTrace()` and `::trace()`) which may consume a stream underneath which makes the implementation ever so slightly more complex, when unneeded.