### PR TITLE
refactor: Rename the console options to be more consistent

### DIFF
--- a/src/Command/ListSourcesCommand.php
+++ b/src/Command/ListSourcesCommand.php
@@ -37,7 +37,7 @@ namespace Infection\Command;
 
 use function array_map;
 use Infection\Command\Option\ConfigurationOption;
-use Infection\Command\Option\FilterOptions;
+use Infection\Command\Option\SourceFilterOptions;
 use Infection\Console\IO;
 use Infection\Logger\ConsoleLogger;
 use Infection\Source\Collector\SourceCollector;
@@ -59,7 +59,7 @@ final class ListSourcesCommand extends BaseCommand
     protected function configure(): void
     {
         ConfigurationOption::addOption($this);
-        FilterOptions::addOption($this);
+        SourceFilterOptions::addOption($this);
 
         $this->setDescription(
             'Finds the paths of the collected source files.',
@@ -71,8 +71,8 @@ final class ListSourcesCommand extends BaseCommand
         $container = $this->getApplication()->getContainer()->withValues(
             logger: new ConsoleLogger($io),
             output: $io->getOutput(),
-            configFile: ConfigurationOption::parse($io),
-            sourceFilter: FilterOptions::getSourceFilter($io),
+            configFile: ConfigurationOption::get($io),
+            sourceFilter: SourceFilterOptions::get($io),
         );
 
         $filePaths = self::collectPaths(

--- a/src/Command/Option/ConfigurationOption.php
+++ b/src/Command/Option/ConfigurationOption.php
@@ -71,7 +71,7 @@ final class ConfigurationOption
     /**
      * @return non-empty-string|null
      */
-    public static function parse(IO $io): ?string
+    public static function get(IO $io): ?string
     {
         $value = trim((string) $io->getInput()->getOption(self::NAME));
 

--- a/src/Command/Option/SourceFilterOptions.php
+++ b/src/Command/Option/SourceFilterOptions.php
@@ -52,7 +52,7 @@ use Webmozart\Assert\Assert;
 /**
  * @internal
  */
-final class FilterOptions
+final class SourceFilterOptions
 {
     use CannotBeInstantiated;
 
@@ -106,7 +106,7 @@ final class FilterOptions
             );
     }
 
-    public static function getSourceFilter(IO $io): PlainFilter|IncompleteGitDiffFilter|null
+    public static function get(IO $io): PlainFilter|IncompleteGitDiffFilter|null
     {
         $input = $io->getInput();
 

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -38,7 +38,7 @@ namespace Infection\Command;
 use function extension_loaded;
 use function implode;
 use Infection\Command\Option\ConfigurationOption;
-use Infection\Command\Option\FilterOptions;
+use Infection\Command\Option\SourceFilterOptions;
 use Infection\Configuration\Configuration;
 use Infection\Configuration\Schema\SchemaConfigurationLoader;
 use Infection\Console\ConsoleOutput;
@@ -246,7 +246,7 @@ final class RunCommand extends BaseCommand
                 Container::DEFAULT_MUTATORS_INPUT,
             );
 
-        FilterOptions::addOption($this)
+        SourceFilterOptions::addOption($this)
             ->addOption(
                 self::OPTION_FORMATTER,
                 null,
@@ -382,7 +382,7 @@ final class RunCommand extends BaseCommand
         // say "do not use a config". If this becomes possible in the future,
         // though, it will likely be a `--no-config` option rather than relying
         // on this value to be set to an empty string.
-        $configFile = ConfigurationOption::parse($io);
+        $configFile = ConfigurationOption::get($io);
 
         $container = $this->createContainer($configFile, $io, $logger);
 
@@ -508,7 +508,7 @@ final class RunCommand extends BaseCommand
             staticAnalysisToolOptions: $staticAnalysisToolOptions === ''
                 ? Container::DEFAULT_STATIC_ANALYSIS_TOOL_OPTIONS
                 : $staticAnalysisToolOptions,
-            sourceFilter: FilterOptions::getSourceFilter($io),
+            sourceFilter: SourceFilterOptions::get($io),
             threadCount: $commandHelper->getThreadCount(),
             // To keep in sync with Container::DEFAULT_DRY_RUN
             dryRun: (bool) $input->getOption(self::OPTION_DRY_RUN),

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -41,7 +41,7 @@ use function in_array;
 use Infection\CannotBeInstantiated;
 use Infection\Command\ConfigureCommand;
 use Infection\Command\Option\ConfigurationOption;
-use Infection\Command\Option\FilterOptions;
+use Infection\Command\Option\SourceFilterOptions;
 use Infection\Config\ConsoleHelper;
 use Infection\Config\Guesser\SourceDirGuesser;
 use Infection\Configuration\Entry\Logs;
@@ -141,7 +141,7 @@ final class ProjectCodeProvider
         FakeSourceFilter::class,
         FileSystem::class,
         FixedSourceCollector::class,
-        FilterOptions::class,
+        SourceFilterOptions::class,
         FormatterName::class,
         GitDiffFilter::class,
         GitDiffSourceCollector::class,


### PR DESCRIPTION
I find this pattern makes it a bit easier to name the options in a systemic and consistent way.