### PR TITLE
refactor: Fix the Factory filtered source PHPStan warnings

### DIFF
--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -45,7 +45,6 @@ use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory;
 use InvalidArgumentException;
 use function is_a;
-use function iterator_to_array;
 use SplFileInfo;
 use function sprintf;
 use Webmozart\Assert\Assert;
@@ -132,25 +131,12 @@ final readonly class Factory
     /**
      * Get only those source files that will be mutated to use them in coverage whitelist
      *
-     * @return list<SplFileInfo>
+     * @return SplFileInfo[]
      */
     private function getFilteredSourceFilesToMutate(): array
     {
-        // TODO: this looks incorrect to me... But it is what it is right now.
-        if (!$this->sourceCollector->isFiltered()) {
-            return [];
-        }
-
-        /**
-         * TODO: fix this warning, it is legit...
-         * @var list<SplFileInfo> $files
-         * @psalm-suppress InvalidArgument
-         * @phpstan-ignore varTag.type
-         */
-        $files = iterator_to_array(
-            $this->sourceCollector->collect(),
-        );
-
-        return $files;
+        return $this->sourceCollector->isFiltered()
+            ? $this->sourceCollector->collect()
+            : [];
     }
 }

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -60,7 +60,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
 {
     /**
      * @param string[] $sourceDirectories
-     * @param list<SplFileInfo> $filteredSourceFilesToMutate
+     * @param SplFileInfo[] $filteredSourceFilesToMutate
      */
     public static function create(
         string $testFrameworkExecutable,

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -53,7 +53,7 @@ use function sprintf;
 final readonly class ArgumentsAndOptionsBuilder implements CommandLineArgumentsAndOptionsBuilder
 {
     /**
-     * @param list<SplFileInfo> $filteredSourceFilesToMutate
+     * @param SplFileInfo[] $filteredSourceFilesToMutate
      */
     public function __construct(
         private bool $executeOnlyCoveringTestCases,

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -54,7 +54,7 @@ class InitialConfigBuilder implements ConfigBuilder
 
     /**
      * @param string[] $srcDirs
-     * @param list<string> $filteredSourceFilesToMutate
+     * @param string[] $filteredSourceFilesToMutate
      */
     public function __construct(
         private readonly string $tmpDir,

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -162,7 +162,7 @@ final readonly class XmlConfigurationManipulator
 
     /**
      * @param string[] $srcDirs
-     * @param list<string> $filteredSourceFilesToMutate
+     * @param string[] $filteredSourceFilesToMutate
      */
     public function addOrUpdateLegacyCoverageWhitelistNodes(SafeDOMXPath $xPath, array $srcDirs, array $filteredSourceFilesToMutate): void
     {
@@ -171,7 +171,7 @@ final readonly class XmlConfigurationManipulator
 
     /**
      * @param string[] $srcDirs
-     * @param list<string> $filteredSourceFilesToMutate
+     * @param string[] $filteredSourceFilesToMutate
      */
     public function addOrUpdateCoverageIncludeNodes(SafeDOMXPath $xPath, array $srcDirs, array $filteredSourceFilesToMutate): void
     {
@@ -180,7 +180,7 @@ final readonly class XmlConfigurationManipulator
 
     /**
      * @param string[] $srcDirs
-     * @param list<string> $filteredSourceFilesToMutate
+     * @param string[] $filteredSourceFilesToMutate
      */
     public function addOrUpdateSourceIncludeNodes(SafeDOMXPath $xPath, array $srcDirs, array $filteredSourceFilesToMutate): void
     {
@@ -235,7 +235,7 @@ final readonly class XmlConfigurationManipulator
 
     /**
      * @param string[] $srcDirs
-     * @param list<string> $filteredSourceFilesToMutate
+     * @param string[] $filteredSourceFilesToMutate
      */
     private function addOrUpdateCoverageNodes(string $parentName, string $listName, SafeDOMXPath $xPath, array $srcDirs, array $filteredSourceFilesToMutate): void
     {


### PR DESCRIPTION
`Factory::getFilteredSourceFilesToMutate()` was documenting returning a `list<SplFileInfo>` whilst in practice we were returning a `SplFileInfo[]`.

In general, I'm personally in favour of stricter types, so I am bias in favour of `list<SplFileInfo>`. However, this is yet another operation to do on top of all the files collected, which is why I made `SourceCollector::collect()` return a `SplFileInfo[]` instead of a `list<SplFileInfo>`.

I investigated if we really needed a list, and it turns out we do not. This is a good news because it means we do not have a hidden bug and that we can safely change `list<SplFileInfo>` to `SplFileInfo[]`. This is what this PR does.