### PR TITLE
refactor: Exclude the container from Infection

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -7,6 +7,7 @@
             "src"
         ],
         excludes: [
+            "/^Container.php$/",
             "FileSystem/DummyFileSystem.php",
             "FileSystem/DummySymfony5FileSystem.php",
             "FileSystem/DummySymfony6FileSystem.php",


### PR DESCRIPTION
I am a bit tired of false-positives like reported in https://github.com/infection/infection/pull/2764:

```
Warning: Escaped Mutant for Mutator "NotIdentical":

@@ @@
     {
         $container = new self([
             IndexXmlCoverageParser::class => static fn (self $container): IndexXmlCoverageParser => new IndexXmlCoverageParser(
-                isSourceFiltered: $container->getConfiguration()->sourceFilter !== null,
+                isSourceFiltered: $container->getConfiguration()->sourceFilter === null,
             ),
             Tracer::class => static fn (self $container) => new TraceProviderAdapterTracer(
                 $container->getTraceProvider(),
```

Technically it is correct, but covering this would require expensive integration tests, and in general we do not test the wiring of the services directly.