### PR TITLE
Add phpbench.json to export-ignore list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@
 /docker-compose.yml     export-ignore
 /infection.json5        export-ignore
 /Makefile               export-ignore
+/phpbench.json          export-ignore
 /phpunit.xml.dist       export-ignore
 /phpunit_autoreview.xml export-ignore
 /psalm.xml              export-ignore


### PR DESCRIPTION
This PR:

- [ ] ~~Adds new feature ...~~ maybe improvements..

PHPBench was introduced in #2516.
phpbench.json is no longer needed in the distribution, just like other QA tool configuration files.


<!--
Remove if not relevant
-->


<!--
- Replace this comment by a detailed description of what your PR is solving.
- Use labels for different kinds of PR like `performance`, `feature`, etc.
- Use Milestone to show when this code is going to be released.

Deprecations? don't forget to update UPGRADE-*.md files
-->