### PR TITLE
test: Do not mark the Container as covered

### DIFF
--- a/tests/phpunit/ContainerTest.php
+++ b/tests/phpunit/ContainerTest.php
@@ -43,7 +43,7 @@ use Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable;
 use Infection\Testing\SingletonContainer;
 use Infection\Tests\Reflection\ContainerReflection;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -52,7 +52,7 @@ use function sprintf;
 use Symfony\Component\Console\Output\NullOutput;
 use Webmozart\Assert\InvalidArgumentException as AssertException;
 
-#[CoversClass(Container::class)]
+#[CoversNothing]
 #[Group('integration')]
 final class ContainerTest extends TestCase
 {


### PR DESCRIPTION
## Description

We have some service definitions being covered by tests due to `ContainerTest` creating code coverage.


## Changes

- Replacement for #2765.

## Reviewer Notes

Personally I'm not really willing to go test all the services registered of the container: it sounds like a lot of work, for not much value, and likely very brittle test (how are you gonna test efficiently the laziness or caching?).

The overall soundness of the configuration _is_ tested, at least partially, via integration tests for some services and end to end tests. But it is not something I really want to add mutation testing on top of.

If someone believes strongly against it though, it's not something I really want to argue over and I can leave it alone.
