### PR TITLE
test: Add the RemoveUndesiredAttributesVisitor PhpParser visitor utility

### DIFF
--- a/tests/phpunit/PhpParser/Visitor/VisitorTestCase.php
+++ b/tests/phpunit/PhpParser/Visitor/VisitorTestCase.php
@@ -40,10 +40,12 @@ use Infection\Tests\TestingUtility\PhpParser\NodeDumper\NodeDumper;
 use Infection\Tests\TestingUtility\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitor;
 use Infection\Tests\TestingUtility\PhpParser\Visitor\KeepOnlyDesiredAttributesVisitor\KeepOnlyDesiredAttributesVisitor;
 use Infection\Tests\TestingUtility\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitor;
+use Infection\Tests\TestingUtility\PhpParser\Visitor\RemoveUndesiredAttributesVisitor\RemoveUndesiredAttributesVisitor;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use PHPUnit\Framework\TestCase;
+use function sprintf;
 
 abstract class VisitorTestCase extends TestCase
 {
@@ -90,6 +92,30 @@ abstract class VisitorTestCase extends TestCase
 
         $nodeTraverser = new NodeTraverser(
             new AddIdToTraversedNodesVisitor(),
+        );
+        $nodeTraverser->traverse($nodes);
+    }
+
+    /**
+     * @param Node[]|Node $nodeOrNodes
+     */
+    final protected function removeUndesiredAttributes(
+        array|Node $nodeOrNodes,
+        string ...$attributes,
+    ): void {
+        $nodes = (array) $nodeOrNodes;
+
+        $this->assertNotContains(
+            MarkTraversedNodesAsVisitedVisitor::VISITED_ATTRIBUTE,
+            $attributes,
+            sprintf(
+                'The attribute "%s" is never printed hence should not be removed. To display all nodes adjust NodeDumper `::dump()` method call instead.',
+                MarkTraversedNodesAsVisitedVisitor::VISITED_ATTRIBUTE,
+            ),
+        );
+
+        $nodeTraverser = new NodeTraverser(
+            new RemoveUndesiredAttributesVisitor(...$attributes),
         );
         $nodeTraverser->traverse($nodes);
     }

--- a/tests/phpunit/TestingUtility/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitor.php
+++ b/tests/phpunit/TestingUtility/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitor.php
@@ -35,67 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestingUtility\PhpParser\Visitor\AddIdToTraversedNodesVisitor;
 
-<<<<<<<< HEAD:tests/phpunit/PhpParser/Visitor/VisitorTestCase.php
-use Infection\Testing\SingletonContainer;
-use Infection\Tests\TestingUtility\PhpParser\NodeDumper\NodeDumper;
-use Infection\Tests\TestingUtility\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitor;
-use Infection\Tests\TestingUtility\PhpParser\Visitor\KeepOnlyDesiredAttributesVisitor\KeepOnlyDesiredAttributesVisitor;
-use Infection\Tests\TestingUtility\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitor;
-use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\Parser;
-use PHPUnit\Framework\TestCase;
-
-abstract class VisitorTestCase extends TestCase
-{
-    protected Parser $parser;
-
-    protected NodeDumper $dumper;
-
-    protected function setUp(): void
-    {
-        $this->parser = $this->createParser();
-        $this->dumper = $this->createDumper();
-    }
-
-    protected function createParser(): Parser
-    {
-        return SingletonContainer::getContainer()->getParser();
-    }
-
-    protected function createDumper(): NodeDumper
-    {
-        return new NodeDumper();
-    }
-
-    /**
-     * @param Node[]|Node $nodeOrNodes
-     */
-    final protected function addIdsToNodes(array|Node $nodeOrNodes): void
-    {
-        $nodes = (array) $nodeOrNodes;
-
-        $nodeTraverser = new NodeTraverser(
-            new AddIdToTraversedNodesVisitor(),
-        );
-        $nodeTraverser->traverse($nodes);
-    }
-
-    /**
-     * @param Node[]|Node $nodeOrNodes
-     */
-    final protected function keepOnlyDesiredAttributes(
-        array|Node $nodeOrNodes,
-        string ...$attributes,
-    ): void {
-        $nodes = (array) $nodeOrNodes;
-
-        $nodeTraverser = new NodeTraverser(
-            new KeepOnlyDesiredAttributesVisitor(
-                MarkTraversedNodesAsVisitedVisitor::VISITED_ATTRIBUTE,
-                ...$attributes,
-            ),
-========
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
@@ -133,8 +72,6 @@ final class AddIdToTraversedNodesVisitor extends NodeVisitorAbstract
         $node->setAttribute(
             self::NODE_ID_ATTRIBUTE,
             $this->sequence->next(),
->>>>>>>> upstream/master:tests/phpunit/TestingUtility/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitor.php
         );
-        $nodeTraverser->traverse($nodes);
     }
 }

--- a/tests/phpunit/TestingUtility/PhpParser/Visitor/RemoveUndesiredAttributesVisitor/RemoveUndesiredAttributesVisitor.php
+++ b/tests/phpunit/TestingUtility/PhpParser/Visitor/RemoveUndesiredAttributesVisitor/RemoveUndesiredAttributesVisitor.php
@@ -33,10 +33,41 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\PhpParser\Visitor\VisitorCollectorIntegration;
+namespace Infection\Tests\TestingUtility\PhpParser\Visitor\RemoveUndesiredAttributesVisitor;
 
+use function array_diff_key;
+use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
+use function Safe\array_flip;
 
-final class NullNodeVisitor extends NodeVisitorAbstract
+/**
+ * Utility visitor which allows removing the specified attributes.
+ */
+final class RemoveUndesiredAttributesVisitor extends NodeVisitorAbstract
 {
+    /**
+     * @var array<string, mixed>
+     */
+    private readonly array $undesiredAttributesAsKeys;
+
+    public function __construct(
+        string ...$attributes,
+    ) {
+        $this->undesiredAttributesAsKeys = array_flip($attributes);
+    }
+
+    public function enterNode(Node $node): void
+    {
+        $this->removeUndesiredAttributes($node);
+    }
+
+    private function removeUndesiredAttributes(Node $node): void
+    {
+        $desiredAttributes = array_diff_key(
+            $node->getAttributes(),
+            $this->undesiredAttributesAsKeys,
+        );
+
+        $node->setAttributes($desiredAttributes);
+    }
 }

--- a/tests/phpunit/TestingUtility/PhpParser/Visitor/RemoveUndesiredAttributesVisitor/RemoveUndesiredAttributesVisitorTest.php
+++ b/tests/phpunit/TestingUtility/PhpParser/Visitor/RemoveUndesiredAttributesVisitor/RemoveUndesiredAttributesVisitorTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestingUtility\PhpParser\Visitor\RemoveUndesiredAttributesVisitor;
+
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(RemoveUndesiredAttributesVisitor::class)]
+final class RemoveUndesiredAttributesVisitorTest extends VisitorTestCase
+{
+    /**
+     * @param array<string, mixed> $initialAttributes
+     * @param list<string> $undesiredAttributes
+     * @param array<string, mixed> $expectedAttributes
+     */
+    #[DataProvider('attributeProvider')]
+    public function test_it_removes_the_undesired_attributes(
+        array $initialAttributes,
+        array $undesiredAttributes,
+        array $expectedAttributes,
+    ): void {
+        $node = new Node\Stmt\Expression(
+            new Node\Expr\Assign(
+                new Node\Expr\Variable('x'),
+                new Node\Scalar\Int_(42),
+            ),
+            $initialAttributes,
+        );
+
+        $visitor = new RemoveUndesiredAttributesVisitor(...$undesiredAttributes);
+
+        (new NodeTraverser($visitor))->traverse([$node]);
+
+        $actualAttributes = $node->getAttributes();
+
+        $this->assertSame($expectedAttributes, $actualAttributes);
+    }
+
+    public static function attributeProvider(): iterable
+    {
+        yield 'no attributes' => [
+            'initialAttributes' => [],
+            'undesiredAttributes' => [],
+            'expectedAttributes' => [],
+        ];
+
+        yield 'remove one attribute' => [
+            'initialAttributes' => [
+                'custom_key_1' => 'value1',
+                'custom_key_2' => 'value2',
+                'custom_key_3' => 'value3',
+            ],
+            'undesiredAttributes' => ['custom_key_2'],
+            'expectedAttributes' => [
+                'custom_key_1' => 'value1',
+                'custom_key_3' => 'value3',
+            ],
+        ];
+
+        yield 'remove multiple attributes' => [
+            'initialAttributes' => [
+                'custom_key_1' => 'value1',
+                'custom_key_2' => 'value2',
+                'custom_key_3' => 'value3',
+            ],
+            'undesiredAttributes' => ['custom_key_2', 'custom_key_3'],
+            'expectedAttributes' => [
+                'custom_key_1' => 'value1',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR introduces a `RemoveUndesiredAttributesVisitor`.

This was originally part of #2780 but stripped out of it as unused. To be seen if we need this in a near future, if we don't, we can just close the PR.
