### PR TITLE
refactor: Make FileParser a final readonly service

### DIFF
--- a/src/PhpParser/FileParser.php
+++ b/src/PhpParser/FileParser.php
@@ -43,12 +43,11 @@ use Throwable;
 
 /**
  * @internal
- * @final
  */
-class FileParser
+final readonly class FileParser
 {
     public function __construct(
-        private readonly Parser $parser,
+        private Parser $parser,
     ) {
     }
 


### PR DESCRIPTION
## Description

`FileParser` has little logic and is an adapter for `PhpParser\Parser` which is already an interface. Mocking part of the system to have more focused unit tests is fine, but I don't think we should over-mock either.

## Changes

- Make `FileParser` final: it was only mocked in `FileMutationGenerator` which was trivial to adapt.
- Make `FileParser` readonly: it is stateless.
