### PR TITLE
Canonicalize file pathnames in tracing logic

### DIFF
--- a/src/TestFramework/Tracing/TraceProviderAdapterTracer.php
+++ b/src/TestFramework/Tracing/TraceProviderAdapterTracer.php
@@ -108,7 +108,7 @@ final class TraceProviderAdapterTracer implements Tracer
 
     private function tryToTrace(SplFileInfo $fileInfo): ?Trace
     {
-        $sourcePathname = $fileInfo->getPathname();
+        $sourcePathname = Path::canonicalize($fileInfo->getPathname());
 
         return array_key_exists($sourcePathname, $this->indexedTraces)
             ? $this->indexedTraces[$sourcePathname]
@@ -136,7 +136,7 @@ final class TraceProviderAdapterTracer implements Tracer
 
             $this->isEmpty = false;
 
-            $traceSourcePathname = $trace->getSourceFileInfo()->getPathname();
+            $traceSourcePathname = Path::canonicalize($trace->getSourceFileInfo()->getPathname());
             $this->indexedTraces[$traceSourcePathname] = $trace;
 
             if ($traceSourcePathname === $sourcePathname) {


### PR DESCRIPTION
## Description

Added `Path::canonicalize` to the trace logic to make the file collector work on Windows systems.

## Changes

Changed `src/TestFramework/Tracing/TraceProviderAdapterTracer.php`.

## Reviewer Notes

Needs to be checked on unix.

## Related issues

Fixes https://github.com/infection/infection/issues/2770.