### PR TITLE
fix: Fix the tracing adapter service for Widows

### DIFF
--- a/src/TestFramework/Tracing/TraceProviderAdapterTracer.php
+++ b/src/TestFramework/Tracing/TraceProviderAdapterTracer.php
@@ -108,7 +108,8 @@ final class TraceProviderAdapterTracer implements Tracer
 
     private function tryToTrace(SplFileInfo $fileInfo): ?Trace
     {
-        $sourcePathname = Path::canonicalize($fileInfo->getPathname());
+        $sourcePathname = $fileInfo->getRealPath();
+        Assert::notFalse($sourcePathname);
 
         return array_key_exists($sourcePathname, $this->indexedTraces)
             ? $this->indexedTraces[$sourcePathname]
@@ -136,7 +137,9 @@ final class TraceProviderAdapterTracer implements Tracer
 
             $this->isEmpty = false;
 
-            $traceSourcePathname = Path::canonicalize($trace->getSourceFileInfo()->getPathname());
+            $traceSourcePathname = $trace->getSourceFileInfo()->getRealPath();
+            Assert::notFalse($traceSourcePathname);
+
             $this->indexedTraces[$traceSourcePathname] = $trace;
 
             if ($traceSourcePathname === $sourcePathname) {


### PR DESCRIPTION
## Description

The `Tracer` is using `TraceProviderAdapterTracer` and `TraceProvider` to generate all the traces and match the search one by path. Currently, this does not work on vanilla Windows (no WSL2).

## The issue

When we collect the source files, we make the paths of the source directories absolute. If we have:

```json
// infection.json5
"source": {
  "directories": ["src"]
}
```

Then we will make `src` absolute based on the location of the cofiguration file:

```php
Path::makeAbsolute(
  'C:/Users/path/to/project',
  'src',
);
// => 'C:/Users/path/to/project/src'
```

So we will end up configuring the Symfony Finder like so:

We will do something like:

```php
Finder::create()
  ->files()
  ->in(['C:/Users/path/to/project/src'])
```

It seems the Symfony Finder does not really care about the root in the sense that it will not change it, it will construct the pathname with it without further processing, resulting in files with the following pathname:

```
C:/Users/path/to/project/src\Admin\Admin.php
```

Meanwhile, when we create `SplFileInfo` instances for the source files found in the coverage (see `XmlCoverageParser`), we use the real path.

As a result, we end up with two `SplFileInfo` objects pointing at the same file, but for which the path is not identical due to how they were constructed.

## Changes

This PR addresses the issue by using the realpath instead of the pathname. I suspect we could hit a similar issue with symlinks, but it would be a lot of efforts to check properly and I'm not willing to dive into that rabbit hole. So I left it as a note in the test.

- Fixes #2770.
- Closes #2789 (this PR replaces it).

