### PR TITLE
fix(e2e): Add fork repository for local Without_Git testing

### DIFF
--- a/tests/e2e/Without_Git/run_tests.bash
+++ b/tests/e2e/Without_Git/run_tests.bash
@@ -27,6 +27,16 @@ sed -i "s/\"infection\/infection\": \"dev-master\"/\"infection\/infection\": \"d
 set -e pipefail
 
 rm -f composer.lock
+
+# For local testing on forks, detect the fork's remote URL and add it as a repository
+# This allows Composer to find branches that exist on the fork but not on the main repo
+if [ -z "$GITHUB_EVENT_NAME" ]; then
+  fork_url=$(git -C ../../.. remote get-url origin 2>/dev/null || true)
+  if [ -n "$fork_url" ]; then
+    composer config repositories.fork vcs "$fork_url" --no-interaction
+  fi
+fi
+
 composer install
 
 docker run -t -v "$PWD":/opt -w /opt php:8.4-alpine vendor/bin/infection --coverage=infection-coverage


### PR DESCRIPTION
## Description

When running the `Without_Git` e2e test locally on a fork, Composer fails with:

```
Package infection/infection cannot install dev-fix/my-branch, found infection/infection[...] but it does not match the constraint.
```

The test dynamically rewrites `composer.json` to require `infection/infection` from the current branch. In CI on the main repo, this works because the branch exists on `infection/infection`. But when working on a fork, the branch only exists on the fork (e.g., `example/infection`), not on the main Packagist package.

## The Fix

When running locally (no `GITHUB_EVENT_NAME`), detect the fork's `origin` URL and add it as a VCS repository:

```bash
if [ -z "$GITHUB_EVENT_NAME" ]; then
  fork_url=$(git -C ../../.. remote get-url origin 2>/dev/null || true)
  if [ -n "$fork_url" ]; then
    composer config repositories.fork vcs "$fork_url" --no-interaction
  fi
fi
```

This allows Composer to find branches that exist on the fork but not on the main repo.

## Why This Is Correct

1. **Only activates locally** - The `GITHUB_EVENT_NAME` check ensures CI behavior is unchanged
2. **Dynamic detection** - Uses `git remote get-url origin` to find the fork URL, works for any fork
3. **Graceful fallback** - If `origin` doesn't exist or git fails, it silently continues (will fail at `composer install` as before)
4. **Matches existing pattern** - The script already has fork-detection logic for CI (lines 5-15), this extends it for local use