### PR TITLE
ci: Fix composer cache key for E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -72,9 +72,9 @@ jobs:
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }} }}
+          key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }}-${{ hashFiles('tests/e2e/*/composer.*') }}
           restore-keys: |
-            composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }} }}-
+            composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.dependencies }}-
             composer-${{ runner.os }}-${{ matrix.php-version }}-
             composer-${{ runner.os }}-
             composer-


### PR DESCRIPTION
## Description

The E2E workflow cache was not being updated because:

1. Cache key didn't include E2E test dependencies hash
2. Exact key match caused GitHub Actions to skip saving updated cache
3. E2E tests require different PHPUnit versions (9.x, 10.x, 11.x, 12.x) that weren't in the main project's cache

This caused a bunch of packages to be downloaded on every run.

Long-running jobs affected (7+ minutes):
- https://github.com/infection/infection/actions/runs/20766243415/job/59632896145


## Changes

- Add `hashFiles('tests/e2e/*/composer.*')` to cache key
- Fix malformed restore-key pattern (extra `}}`)

Now the cache will:
- Restore from best available prefix match
- Save updated cache when E2E dependencies change

