### PR TITLE
test: Skip slow self-test under xdebug coverage

### DIFF
--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -146,6 +146,10 @@ final class E2ETest extends TestCase
             ]));
         }
 
+        if (extension_loaded('xdebug')) {
+            $this->markTestSkipped('Skipping slow test under xdebug');
+        }
+
         $output = $this->runInfection(self::EXPECT_SUCCESS, [
             '--test-framework-options=--exclude-group=' . self::EXCLUDED_GROUP,
         ]);


### PR DESCRIPTION
## Description

The `test_it_runs_on_itself` test runs Infection on its own codebase, taking 3-4 minutes under xdebug coverage. This dominates E2E test time and negates benefits of parallel test execution if we ever add one. 

## Changes

Skip this test when xdebug is loaded. It still runs under pcov where it completes much faster.

## Checklist

- [x] Appropriate labels applied (e.g. `performance`, `feature`).

