### PR TITLE
ci: Enable PHP OPcache and JIT for benchmark workflow 

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -28,6 +28,8 @@ jobs:
         with:
           php-version: '8.4'
           tools: composer
+          coverage: none
+          ini-values: opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=100M
 
       - name: Install dependencies
         uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
@@ -49,6 +51,8 @@ jobs:
             with:
                 php-version: '8.4'
                 tools: composer
+                coverage: none
+                ini-values: opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=100M
 
           - name: Install dependencies
             uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1


### PR DESCRIPTION
## Summary

- Disable Xdebug via `coverage: none` to remove any possible profiling overhead
- Enable OPcache for CLI with `opcache.enable_cli=1`
- Enable JIT tracing mode with 100M buffer for CPU-intensive workloads

This reduces the time necessary to run benchmarks from 6 minutes to 2 minutes just so that y'all don't have to wait for it to finish last.

| Job        | Before (avg) | After (JIT) | Improvement |
|------------|--------------|-------------|-------------|
| Tests      | 15 sec       | 9 sec       | 40% faster   |
| Benchmarks | 6m 25s       | 2m 9s       | 67% faster :exploding_head:  |


## Why

The benchmark workflow was running without PHP performance optimizations. PHPBench performs CPU-intensive AST parsing and mutation generation - exactly the workload where JIT provides significant improvements (30-50% for CPU-bound tasks according to PHP documentation).

## Changes

Both `tests` and `benchmarks` jobs now use:
```yaml
coverage: none
ini-values: opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=100M
```

## References

- PHP 8.4 JIT changes: https://php.watch/versions/8.4/opcache-jit-ini-default-changes
- JIT setup guide: https://stitcher.io/blog/php-8-jit-setup
- setup-php action: https://github.com/shivammathur/setup-php

## Checklist

- [x] Appropriate labels applied (e.g. `performance`, `feature`).

