### PR TITLE
test(e2e): Limit the dependencies modified when installing Paratest for the e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -92,7 +92,7 @@ jobs:
         run: composer update --no-interaction --prefer-dist --no-progress --prefer-lowest
 
       - name: Try to install paratest for parallel test execution
-        run: composer require --dev brianium/paratest:^7.8.4 --no-interaction --no-progress || true
+        run: composer require --dev brianium/paratest:^7.8.4 --with-all-dependencies --minimal-changes --no-interaction --no-progress || true
 
       - name: Cache E2E tests dependencies
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Description

Address a [post-merge review comment](https://github.com/infection/infection/pull/2801#discussion_r2668936051).

## Changes

Add installation flags.

## Checklist

- [x] Appropriate labels applied (e.g. `performance`, `feature`).
