### PR TITLE
ci: Enable OPcache for mutation testing workflow

### DIFF
--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -13,7 +13,6 @@
 name: Mutation Testing
 
 on:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

- Split mutation testing into two stages: coverage collection and mutation testing
- Enable OPcache CLI in the mutation testing stage
- Use GitHub artifacts to pass coverage between jobs

## Why

The mutation testing stage doesn't need pcov/xdebug - it only consumes pre-collected coverage data. By splitting the workflow:

1. **Coverage job**: Uses pcov to collect coverage (OPcache incompatible)
2. **Mutation testing job**: Uses `coverage: none` + OPcache + file cache

Based on #2807 benchmarks, JIT provides 40-67% performance improvement for CPU-intensive workloads like mutation testing. We'll see how [file-backed OPcache affects this workload](https://github.com/infection/infection/pull/2810#issuecomment-3723471260) in just a moment.

### Actual benchmarks


#### mt.yaml

| Configuration               | Infection Time | Total Time | vs Baseline |
|-----------------------------|----------------|------------|-------------|
| Baseline (pcov, no opcache) | 7m 27s         | ~8m 14s    | -           |
| Split + JIT                 | 11m 25s        | ~12m 31s   | +52% slower |
| Split + file_cache          | 4m 58s         | ~5m 58s    | -33% faster |
| Split + file_cache (run 2)  | 5m 4s          | ~6m 4s     | -31% faster |

#### mt-annotations.yaml

| Configuration         | Total Time | vs Baseline                       |
|-----------------------|------------|-----------------------------------|
| Baseline (single job) | ~40-50s    | -                                 |
| Split + file_cache    | ~1m 23s    | slower (expected - full coverage) |

(going to revert this one)

## How we did it

Coverage is passed between jobs via `actions/upload-artifact` and `actions/download-artifact`.

## Affected workflows

- `mt.yaml` - Full mutation testing on push to main/master

## Checklist

- [x] Appropriate labels applied (e.g. `performance`, `feature`).
