### PR TITLE
ci: Merge MT workflow jobs to reduce runner overhead

### DIFF
--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -18,8 +18,8 @@ on:
       - main
       - master
   pull_request:
-#    paths:
-#      - '.github/workflows/mt.yaml'
+    paths:
+      - '.github/workflows/mt.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Description

Combines coverage collection and mutation testing into a single job by calling setup-php twice. This eliminates the overhead of bootstrapping a second runner, redundant checkout, duplicate composer install, and artifact upload/download.

| Approach          | Jobs                           | Wall Time    |
|-------------------|--------------------------------|--------------|
| Previous (2 jobs) | Coverage: 47s, Mutation: 5m 8s | 5m 59s total |
| New (1 job)       | Combined                       | 5m 32s total |

Savings: 27 seconds (~8%)

> as suggested by @staabm in PR #2810

## Changes

- Also adds pull_request trigger for workflow file changes to enable testing modifications before merging.

## Checklist

- [x] Tests added/updated
- [x] Appropriate labels applied (e.g. `performance`, `feature`).


