### PR TITLE
refactor: Reduce the coupling of the coverage report on the filesystem

### DIFF
--- a/src/Container/Builder/IndexXmlCoverageParserBuilder.php
+++ b/src/Container/Builder/IndexXmlCoverageParserBuilder.php
@@ -37,6 +37,7 @@ namespace Infection\Container\Builder;
 
 use DIContainer\Builder;
 use Infection\Configuration\Configuration;
+use Infection\FileSystem\FileSystem;
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser;
 
 /**
@@ -47,6 +48,7 @@ final readonly class IndexXmlCoverageParserBuilder implements Builder
 {
     public function __construct(
         private Configuration $configuration,
+        private FileSystem $fileSystem,
     ) {
     }
 
@@ -54,6 +56,7 @@ final readonly class IndexXmlCoverageParserBuilder implements Builder
     {
         return new IndexXmlCoverageParser(
             isSourceFiltered: $this->configuration->sourceFilter !== null,
+            fileSystem: $this->fileSystem,
         );
     }
 }

--- a/src/FileSystem/FileSystem.php
+++ b/src/FileSystem/FileSystem.php
@@ -41,8 +41,10 @@ use function is_file;
 use function is_readable;
 use function method_exists;
 use function restore_error_handler;
+use Safe\Exceptions\FilesystemException;
 use function Safe\realpath;
 use function set_error_handler;
+use function sprintf;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 use Symfony\Component\Finder\Finder;
@@ -62,9 +64,22 @@ class FileSystem extends SymfonyFilesystem
         return is_dir($filename) && is_readable($filename);
     }
 
+    /**
+     * @throws IOException
+     */
     public function realPath(string $filename): string
     {
-        return realpath($filename);
+        try {
+            return realpath($filename);
+        } catch (FilesystemException $exception) {
+            throw new IOException(
+                sprintf(
+                    'Could not resolve the path "%s".',
+                    $filename,
+                ),
+                previous: $exception,
+            );
+        }
     }
 
     /**

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\TestFramework\Coverage\XmlReport;
 
 use DOMElement;
+use Infection\FileSystem\FileSystem;
 use Infection\Source\Exception\NoSourceFound;
 use Infection\TestFramework\SafeDOMXPath;
 use function sprintf;
@@ -49,6 +50,7 @@ class IndexXmlCoverageParser
 {
     public function __construct(
         private readonly bool $isSourceFiltered,
+        private readonly FileSystem $fileSystem,
     ) {
     }
 
@@ -95,6 +97,7 @@ class IndexXmlCoverageParser
                 $coverageBasePath,
                 $relativeCoverageFilePath,
                 $projectSource,
+                $this->fileSystem,
             );
         }
     }

--- a/src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
+++ b/src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
@@ -39,12 +39,12 @@ use function array_filter;
 use const DIRECTORY_SEPARATOR;
 use function file_exists;
 use function implode;
+use Infection\FileSystem\FileSystem;
 use Infection\TestFramework\SafeDOMXPath;
-use Safe\Exceptions\FilesystemException;
 use function Safe\file_get_contents;
-use function Safe\realpath;
 use function sprintf;
 use function str_replace;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\SplFileInfo;
 use function trim;
@@ -62,6 +62,7 @@ class SourceFileInfoProvider
         private readonly string $coverageDir,
         private readonly string $relativeCoverageFilePath,
         private readonly string $projectSource,
+        private readonly FileSystem $fileSystem,
     ) {
     }
 
@@ -120,8 +121,8 @@ class SourceFileInfoProvider
         );
 
         try {
-            $realPath = realpath($path);
-        } catch (FilesystemException) {
+            $realPath = $this->fileSystem->realPath($path);
+        } catch (IOException) {
             $coverageFilePath = Path::canonicalize(
                 $this->coverageDir . DIRECTORY_SEPARATOR . $this->relativeCoverageFilePath,
             );

--- a/tests/phpunit/Container/Builder/IndexXmlCoverageParserBuilderTest.php
+++ b/tests/phpunit/Container/Builder/IndexXmlCoverageParserBuilderTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\Container\Builder;
 
 use Infection\Configuration\SourceFilter\PlainFilter;
 use Infection\Container\Builder\IndexXmlCoverageParserBuilder;
+use Infection\FileSystem\FakeFileSystem;
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser;
 use Infection\Tests\Configuration\ConfigurationBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -52,7 +53,10 @@ final class IndexXmlCoverageParserBuilderTest extends TestCase
             ->withSourceFilter(null)
             ->build();
 
-        $parser = (new IndexXmlCoverageParserBuilder($configuration))->build();
+        $parser = (new IndexXmlCoverageParserBuilder(
+            $configuration,
+            new FakeFileSystem(),
+        ))->build();
 
         $this->assertFalse($this->getIsSourceFiltered($parser));
     }
@@ -63,7 +67,10 @@ final class IndexXmlCoverageParserBuilderTest extends TestCase
             ->withSourceFilter(new PlainFilter(['src/']))
             ->build();
 
-        $parser = (new IndexXmlCoverageParserBuilder($configuration))->build();
+        $parser = (new IndexXmlCoverageParserBuilder(
+            $configuration,
+            new FakeFileSystem(),
+        ))->build();
 
         $this->assertTrue($this->getIsSourceFiltered($parser));
     }

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser;
 
 use function array_diff;
+use Infection\FileSystem\FileSystem;
 use Infection\Source\Exception\NoSourceFound;
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser;
 use Infection\TestFramework\Coverage\XmlReport\InvalidCoverage;
@@ -50,7 +51,6 @@ use PHPUnit\Framework\TestCase;
 use function Safe\file_get_contents;
 use function Safe\preg_replace;
 use function sprintf;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Traversable;
 
@@ -62,14 +62,17 @@ final class IndexXmlCoverageParserTest extends TestCase
 
     private static ?string $fixturesOldXmlFileName = null;
 
-    private Filesystem $filesystem;
+    private FileSystem $fileSystem;
 
     private IndexXmlCoverageParser $parser;
 
     protected function setUp(): void
     {
-        $this->filesystem = new Filesystem();
-        $this->parser = new IndexXmlCoverageParser(false);
+        $this->fileSystem = new FileSystem();
+        $this->parser = new IndexXmlCoverageParser(
+            false,
+            $this->fileSystem,
+        );
     }
 
     #[DataProvider('coverageProvider')]
@@ -126,7 +129,7 @@ final class IndexXmlCoverageParserTest extends TestCase
     public function test_it_errors_when_no_lines_were_executed(string $xml): void
     {
         $filename = __DIR__ . '/generated_index.xml';
-        $this->filesystem->dumpFile($filename, $xml);
+        $this->fileSystem->dumpFile($filename, $xml);
 
         $this->expectException(NoSourceFound::class);
 
@@ -140,11 +143,14 @@ final class IndexXmlCoverageParserTest extends TestCase
     public function test_it_errors_for_git_diff_lines_mode_when_no_lines_were_executed(string $xml): void
     {
         $filename = __DIR__ . '/generated_index.xml';
-        $this->filesystem->dumpFile($filename, $xml);
+        $this->fileSystem->dumpFile($filename, $xml);
 
         $this->expectException(NoSourceFound::class);
 
-        (new IndexXmlCoverageParser(true))->parse(
+        (new IndexXmlCoverageParser(
+            true,
+            $this->fileSystem,
+        ))->parse(
             $filename,
             __DIR__,
         );
@@ -236,7 +242,7 @@ final class IndexXmlCoverageParserTest extends TestCase
             XML;
 
         $filename = __DIR__ . '/generated_index.xml';
-        $this->filesystem->dumpFile($filename, $xml);
+        $this->fileSystem->dumpFile($filename, $xml);
 
         // Note that the result is lazy, hence the exception is not thrown (yet).
         $sources = $this->parser->parse(
@@ -280,7 +286,7 @@ final class IndexXmlCoverageParserTest extends TestCase
 
         self::$fixturesXmlFileName = Path::canonicalize(XmlCoverageFixtures::FIXTURES_COVERAGE_DIR . '/generated_index.xml');
 
-        (new Filesystem())->dumpFile(self::$fixturesXmlFileName, $correctedXml);
+        (new FileSystem())->dumpFile(self::$fixturesXmlFileName, $correctedXml);
 
         return self::$fixturesXmlFileName;
     }
@@ -307,7 +313,7 @@ final class IndexXmlCoverageParserTest extends TestCase
 
         self::$fixturesOldXmlFileName = Path::canonicalize(XmlCoverageFixtures::FIXTURES_OLD_COVERAGE_DIR . '/generated_index.xml');
 
-        (new Filesystem())->dumpFile(self::$fixturesOldXmlFileName, $correctedXml);
+        (new FileSystem())->dumpFile(self::$fixturesOldXmlFileName, $correctedXml);
 
         return self::$fixturesOldXmlFileName;
     }

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProviderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProviderTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Coverage\XmlReport;
 
+use Infection\FileSystem\FileSystem;
 use Infection\TestFramework\Coverage\XmlReport\InvalidCoverage;
 use Infection\TestFramework\Coverage\XmlReport\SourceFileInfoProvider;
 use Infection\Tests\Fixtures\TestFramework\PhpUnit\Coverage\XmlCoverageFixtures;
@@ -61,6 +62,7 @@ final class SourceFileInfoProviderTest extends TestCase
             $coverageDir,
             $relativeCoverageFilePath,
             $projectSource,
+            new FileSystem(),
         );
 
         $this->assertSame($expectedSourceFilePath, $provider->provideFileInfo()->getRealPath());
@@ -79,6 +81,7 @@ final class SourceFileInfoProviderTest extends TestCase
             '/path/to/coverage-dir',
             'zeroLevel.php.xml',
             'projectSource',
+            new FileSystem(),
         );
 
         try {
@@ -106,6 +109,7 @@ final class SourceFileInfoProviderTest extends TestCase
             XmlCoverageFixtures::FIXTURES_COVERAGE_DIR,
             'zeroLevel.php.xml',
             $incorrectCoverageSrcDir,
+            new FileSystem(),
         );
 
         try {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParserTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParserTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Coverage\XmlReport;
 
+use Infection\FileSystem\FileSystem;
 use Infection\TestFramework\Coverage\XmlReport\SourceFileInfoProvider;
 use Infection\TestFramework\Coverage\XmlReport\XmlCoverageParser;
 use Infection\TestFramework\SafeDOMXPath;
@@ -166,6 +167,7 @@ final class XmlCoverageParserTest extends TestCase
                     $fixture->coverageDir,
                     $fixture->relativeCoverageFilePath,
                     $fixture->projectSource,
+                    new FileSystem(),
                 ),
                 $fixture->normalizedTests,
             ];

--- a/tests/phpunit/TestFramework/Tracing/PHPUnitCoverageTracerTest.php
+++ b/tests/phpunit/TestFramework/Tracing/PHPUnitCoverageTracerTest.php
@@ -40,6 +40,7 @@ use function file_exists;
 use function implode;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\FileSystem\FileSystem;
 use Infection\TestFramework\Coverage\CoveredTraceProvider;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
@@ -85,7 +86,10 @@ final class PHPUnitCoverageTracerTest extends TestCase
         $this->provider = new CoveredTraceProvider(
             new PhpUnitXmlCoverageTraceProvider(
                 indexLocator: new FixedLocator($coveragePath . '/xml/index.xml'),
-                indexParser: new IndexXmlCoverageParser(isSourceFiltered: false),
+                indexParser: new IndexXmlCoverageParser(
+                    isSourceFiltered: false,
+                    fileSystem: new FileSystem(),
+                ),
                 parser: new XmlCoverageParser(),
             ),
             new JUnitTestExecutionInfoAdder(


### PR DESCRIPTION
## Description

Part of the difficulty with setting up tests for the code coverage is the fact that `SourceFileInfoProvider` uses `realpath()`, and that it uses it a path it constructs internally.

This PR introduces injects `FileSystem` to `SourceFileInfoProvider` to use this service to get the real path. This will allow us to mock the filesystem for that location (and I will, but in a separate PR).

## Motivation

I'm hitting a wall with https://github.com/infection/infection/pull/2815. The problem is not new: setting up a comprehensive test for the code coverage is hard and it is something we've struggled with. Even when you have the whole coverage reports, depending on the part you test it is insufficient: the source files need to exist as well and the paths need to match.

## Identified issues

Currently, there is three places which relies on the filesystem in a hard way (i.e. without a `Filesystem` like abstraction allowing us to mock something):

- `SourceFileInfoProvider::retrieveSourceFileInfo()` which depends on `realpath()` – fixed in this PR.
- `SafeDOMXPath::fromFile()` which is used in:
  - `JUnitTestFileDataProvider::getXPath()` – the file used is from the injected `ReportLocator $jUnitLocator`, so mocking is possible here.
  - `IndexXmlCoverageParser::parse()` – the file used is the `$coverageIndexPath` argument of the `parse()` method – we can work around that (e.g. dumping a file at a specific location).

So the only problematic piece actually is `SourceFileInfoProvider::retrieveSourceFileInfo()`, which is taken care of with this PR.

## Note regarding the solution

I do not like this solution. Currently `SourceFileInfoProvider` is more of a value object, I do not like to inject services to a value object.

Nonetheless, I do not see any other solution without a change of architecture, and the change of architecture is what I'm trying to do... So I see it as a necessary (temporary) evil, and I do not plan to leave it like so long.

## Changes

This PR only introduces the filesystem. Adapting the tests to leverage the introduced mocking abilities will be done separately.
