### PR TITLE
cs: Fix trailing whitespace check of a fixture file

### DIFF
--- a/devTools/check_trailing_whitespaces.sh
+++ b/devTools/check_trailing_whitespaces.sh
@@ -29,7 +29,7 @@ files_with_trailing_spaces=$(
         ':!tests/e2e/*' \
         ':!tests/phpunit/Framework/StrTest.php' \
         ':!tests/phpunit/StringNormalizerTest.php' \
-        ':!tests/phpunit/Fixtures/Files/phpunit/format-whitespace/original-phpunit.xml' \
+        ':!tests/phpunit/TestFramework/PhpUnit/Config/Builder/Fixtures/format-whitespace/original-phpunit.xml' \
         ':!tests/benchmark/Tracing/benchmark-source' \
         ':!tests/benchmark/MutationGenerator/sources.tar.gz' \
     | sort -fh

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/Fixtures/format-whitespace/original-phpunit.xml
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/Fixtures/format-whitespace/original-phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit cacheResult="false"
          colors="false"
-         
+
          stderr="false" stopOnFailure="true">
 
     <testsuites>


### PR DESCRIPTION
In #2823 I forgot to adjust the `devTools/check_trailing_whitespaces.sh` configuration which lead to the `original-phpunit.xml` to be modified.

This PR fixes the configuration and restores the previous version of the content of `original-phpunit.xml`.