### PR TITLE
Do not allow new timed-out mutants for PRs thanks to `--max-timeouts=0`

### DIFF
--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -61,6 +61,7 @@ jobs:
                     --git-diff-lines \
                     --git-diff-base=origin/$GITHUB_BASE_REF \
                     --ignore-msi-with-no-mutations \
+                    --max-timeouts=0 \
                     --min-msi=100 \
                     --min-covered-msi=100
 


### PR DESCRIPTION
Context: https://github.com/infection/site/pull/294/files#diff-029878b32ca90c281fecb4b024d4d7ec25195dcbc8a4c0b2f25cccc81e676a10R74