### PR TITLE
test: Remove dead code

### DIFF
--- a/tests/phpunit/Mutator/Arithmetic/ShiftRightTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/ShiftRightTest.php
@@ -78,16 +78,4 @@ final class ShiftRightTest extends BaseMutatorTestCase
                 PHP,
         ];
     }
-
-    public function test_replaces_post_decrement(): void
-    {
-        $code = '<?php $a = 1; $a >> 2;';
-        $mutations = $this->mutate($code);
-
-        $expectedMutatedCode = <<<'PHP'
-            <?php $a = 1; $a << 2;
-            PHP;
-
-        $this->assertSame($expectedMutatedCode, $mutations[0]);
-    }
 }


### PR DESCRIPTION
The deleted test is already present in the data provider with the label `It mutates shift right`.