### PR TITLE
refactor(logger): Remane leftovers from the formatter -> logger

### DIFF
--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -75,7 +75,7 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
 
     public function __construct(
         private readonly OutputInterface $output,
-        private readonly MutationAnalysisLogger $outputFormatter,
+        private readonly MutationAnalysisLogger $logger,
         private readonly MetricsCalculator $metricsCalculator,
         private readonly ResultsCollector $resultsCollector,
         private readonly DiffColorizer $diffColorizer,
@@ -91,19 +91,19 @@ final class MutationTestingConsoleLoggerSubscriber implements EventSubscriber
     {
         $this->mutationCount = $event->getMutationCount();
 
-        $this->outputFormatter->start($this->mutationCount);
+        $this->logger->start($this->mutationCount);
     }
 
     public function onMutantProcessWasFinished(MutantProcessWasFinished $event): void
     {
         $executionResult = $event->getExecutionResult();
 
-        $this->outputFormatter->advance($executionResult, $this->mutationCount);
+        $this->logger->advance($executionResult, $this->mutationCount);
     }
 
     public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
     {
-        $this->outputFormatter->finish();
+        $this->logger->finish();
 
         if ($this->numberOfMutationsBudget !== 0) {
             $this->showMutations($this->resultsCollector->getEscapedExecutionResults(), 'Escaped');

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
@@ -53,7 +53,7 @@ final readonly class MutationTestingConsoleLoggerSubscriberFactory implements Su
         private DiffColorizer $diffColorizer,
         private FederatedLogger $mutationTestingResultsLogger,
         private ?int $numberOfShownMutations,
-        private MutationAnalysisLogger $formatter,
+        private MutationAnalysisLogger $logger,
         private bool $withUncovered,
         private bool $withTimeouts,
     ) {
@@ -63,7 +63,7 @@ final readonly class MutationTestingConsoleLoggerSubscriberFactory implements Su
     {
         return new MutationTestingConsoleLoggerSubscriber(
             $output,
-            $this->formatter,
+            $this->logger,
             $this->metricsCalculator,
             $this->resultsCollector,
             $this->diffColorizer,

--- a/src/Logger/MutationAnalysis/MutationAnalysisLoggerFactory.php
+++ b/src/Logger/MutationAnalysis/MutationAnalysisLoggerFactory.php
@@ -48,9 +48,9 @@ final readonly class MutationAnalysisLoggerFactory
     ) {
     }
 
-    public function create(MutationAnalysisLoggerName $formatterName): MutationAnalysisLogger
+    public function create(MutationAnalysisLoggerName $name): MutationAnalysisLogger
     {
-        return match ($formatterName) {
+        return match ($name) {
             MutationAnalysisLoggerName::PROGRESS => new ConsoleProgressBarLogger(
                 new ProgressBar($this->output),
             ),

--- a/tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php
@@ -56,7 +56,7 @@ final class ConsoleDotLoggerTest extends TestCase
     public function test_begins_by_displaying_a_legend(): void
     {
         $output = new BufferedOutput();
-        $formatter = new ConsoleDotLogger($output);
+        $logger = new ConsoleDotLogger($output);
 
         $expected = Str::toSystemLineEndings(
             implode(
@@ -88,7 +88,7 @@ final class ConsoleDotLoggerTest extends TestCase
             ),
         );
 
-        $formatter->start(10);
+        $logger->start(10);
 
         $actual = $output->fetch();
 
@@ -101,14 +101,14 @@ final class ConsoleDotLoggerTest extends TestCase
         string $expected,
     ): void {
         $output = new BufferedOutput();
-        $formatter = new ConsoleDotLogger($output);
+        $logger = new ConsoleDotLogger($output);
 
         // Clear the initial output: it is already tested and it would bloat the
         // test to include it.
-        $formatter->start(10);
+        $logger->start(10);
         $output->fetch();
 
-        $formatter->advance(
+        $logger->advance(
             $this->createMutantExecutionResultOfType($detectionStatus),
             10,
         );
@@ -175,11 +175,11 @@ final class ConsoleDotLoggerTest extends TestCase
         $totalMutations = self::ANY_PRIME_NUMBER;
 
         $output = new BufferedOutput();
-        $formatter = new ConsoleDotLogger($output);
-        $formatter->start($totalMutations);
+        $logger = new ConsoleDotLogger($output);
+        $logger->start($totalMutations);
 
         for ($i = 0; $i < $totalMutations; ++$i) {
-            $formatter->advance(
+            $logger->advance(
                 $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
                 $totalMutations,
             );
@@ -207,11 +207,11 @@ final class ConsoleDotLoggerTest extends TestCase
         $totalMutations = self::ANY_PRIME_NUMBER;
 
         $output = new BufferedOutput();
-        $formatter = new ConsoleDotLogger($output);
-        $formatter->start($totalMutations);
+        $logger = new ConsoleDotLogger($output);
+        $logger->start($totalMutations);
 
         for ($i = 0; $i < $totalMutations; ++$i) {
-            $formatter->advance(
+            $logger->advance(
                 $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
                 0,
             );

--- a/tests/phpunit/Logger/MutationAnalysis/MutationAnalysisLoggerFactoryTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/MutationAnalysisLoggerFactoryTest.php
@@ -48,9 +48,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[CoversClass(MutationAnalysisLoggerFactory::class)]
 final class MutationAnalysisLoggerFactoryTest extends TestCase
 {
-    #[DataProvider('formatterProvider')]
+    #[DataProvider('loggerProvider')]
     public function test_it_can_create_all_known_factories(
-        MutationAnalysisLoggerName $formatterName,
+        MutationAnalysisLoggerName $name,
         string $expectedFormatterClassName,
     ): void {
         $outputMock = $this->createMock(OutputInterface::class);
@@ -59,12 +59,12 @@ final class MutationAnalysisLoggerFactoryTest extends TestCase
             ->willReturn(false)
         ;
 
-        $formatter = (new MutationAnalysisLoggerFactory($outputMock))->create($formatterName);
+        $logger = (new MutationAnalysisLoggerFactory($outputMock))->create($name);
 
-        $this->assertInstanceOf($expectedFormatterClassName, $formatter);
+        $this->assertInstanceOf($expectedFormatterClassName, $logger);
     }
 
-    public static function formatterProvider(): iterable
+    public static function loggerProvider(): iterable
     {
         $bucket = EnumBucket::create(MutationAnalysisLoggerName::class);
 


### PR DESCRIPTION
Should have been part of #2877, missed a few cases.
