### PR TITLE
test(event): Fix incorrect phpdoc

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -751,18 +751,6 @@ parameters:
 			path: ../tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
 
 		-
-			message: '#^Parameter \#1 \$expectedEvents of method Infection\\Tests\\Process\\Runner\\MutationTestingRunnerTest\:\:assertAreSameEvents\(\) expects array\<.+\\MutationTestingWasFinished\|.+\\MutationTestingWasStarted\>, array\<int, \(.+\\MutantProcessWasFinished&PHPUnit\\Framework\\MockObject\\MockObject\)\|.+\\MutationTestingWasFinished\|.+\\MutationTestingWasStarted\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: ../tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
-
-		-
-			message: '#^Parameter \#1 \$expectedEvents of method Infection\\Tests\\Process\\Runner\\MutationTestingRunnerTest\:\:assertAreSameEvents\(\) expects array\<.+\\MutationTestingWasFinished\|.+\\MutationTestingWasStarted\>, array\<int, .+\\MutantProcessWasFinished\|.+\\MutationTestingWasFinished\|.+\\MutationTestingWasStarted\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: ../tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
-
-		-
 			message: '#^Parameter \#1 \$className of static method Infection\\Reflection\\AnonymousClassReflection\:\:fromClassName\(\) expects class\-string, string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -662,8 +662,8 @@ final class MutationTestingRunnerTest extends TestCase
     }
 
     /**
-     * @param array<MutationTestingWasStarted|MutationTestingWasFinished> $expectedEvents
-     * @param array<MutationTestingWasStarted|MutationTestingWasFinished> $actualEvents
+     * @param array<MutationTestingWasStarted|MutationTestingWasFinished|MutantProcessWasFinished> $expectedEvents
+     * @param array<MutationTestingWasStarted|MutationTestingWasFinished|MutantProcessWasFinished> $actualEvents
      */
     private function assertAreSameEvents(array $expectedEvents, array $actualEvents): void
     {


### PR DESCRIPTION
This PR fixes the incorrect PHPDoc: an event was missing.