### PR TITLE
feat(teamcity): Add the locationHint property for test suites

### DIFF
--- a/src/Logger/MutationAnalysis/TeamCity/TeamCity.php
+++ b/src/Logger/MutationAnalysis/TeamCity/TeamCity.php
@@ -84,7 +84,13 @@ final readonly class TeamCity
     {
         return $this->write(
             MessageName::TEST_SUITE_STARTED,
-            $suite->toAttributes() + ['parentNodeId' => '0'],
+            $suite->toAttributes() + [
+                'parentNodeId' => '0',
+                'locationHint' => sprintf(
+                    'file://%s',
+                    $suite->sourceFilePath,
+                ),
+            ],
         );
     }
 

--- a/tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php
@@ -127,7 +127,7 @@ final class TeamCityLoggerTest extends TestCase
                 $logger->finishAnalysis();
             },
             <<<'TEAM_CITY'
-                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f']
                 ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
@@ -160,7 +160,7 @@ final class TeamCityLoggerTest extends TestCase
                 $logger->finishAnalysis();
             },
             <<<'TEAM_CITY'
-                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f']
                 ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
@@ -193,7 +193,7 @@ final class TeamCityLoggerTest extends TestCase
             },
             <<<'TEAM_CITY'
                 ##teamcity[testCount count='1']
-                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f']
                 ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
@@ -227,7 +227,7 @@ final class TeamCityLoggerTest extends TestCase
                 $logger->finishAnalysis();
             },
             <<<'TEAM_CITY'
-                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f']
                 ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
@@ -278,7 +278,7 @@ final class TeamCityLoggerTest extends TestCase
                 $logger->finishAnalysis();
             },
             <<<'TEAM_CITY'
-                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f']
                 ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
@@ -342,7 +342,7 @@ final class TeamCityLoggerTest extends TestCase
                 $logger->finishAnalysis();
             },
             <<<'TEAM_CITY'
-                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f']
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' parentNodeId='5568c7d4af5ccc7f']
@@ -396,7 +396,7 @@ final class TeamCityLoggerTest extends TestCase
                 $logger->finishAnalysis();
             },
             <<<'TEAM_CITY'
-                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f']
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' parentNodeId='5568c7d4af5ccc7f']
@@ -448,14 +448,14 @@ final class TeamCityLoggerTest extends TestCase
                 $logger->finishAnalysis();
             },
             <<<'TEAM_CITY'
-                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f']
                 ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
 
                 ##teamcity[testSuiteFinished name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f']
 
-                ##teamcity[testSuiteStarted name='src/Service/ContactService.php' nodeId='12f6def551a5aae7' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/ContactService.php' nodeId='12f6def551a5aae7' parentNodeId='0' locationHint='file:///path/to/project/src/Service/ContactService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' nodeId='ea74aba5c3e84a26' parentNodeId='12f6def551a5aae7']
                 ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' nodeId='ea74aba5c3e84a26' message='Mutator: For_|nMutation ID: 0a451675763250c03e95b626f7bcfb7d|nMutation result: killed by tests' details='mutationDiff' duration='120']
@@ -505,11 +505,11 @@ final class TeamCityLoggerTest extends TestCase
                 $logger->finishAnalysis();
             },
             <<<'TEAM_CITY'
-                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f']
 
-                ##teamcity[testSuiteStarted name='src/Service/ContactService.php' nodeId='12f6def551a5aae7' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/ContactService.php' nodeId='12f6def551a5aae7' parentNodeId='0' locationHint='file:///path/to/project/src/Service/ContactService.php']
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' nodeId='ea74aba5c3e84a26' parentNodeId='12f6def551a5aae7']
 
                 ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' nodeId='ea74aba5c3e84a26' message='Mutator: For_|nMutation ID: 0a451675763250c03e95b626f7bcfb7d|nMutation result: killed by tests' details='mutationDiff' duration='120']
@@ -576,12 +576,12 @@ final class TeamCityLoggerTest extends TestCase
                 $logger->finishAnalysis();
             },
             <<<'TEAM_CITY'
-                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f']
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' parentNodeId='5568c7d4af5ccc7f']
 
-                ##teamcity[testSuiteStarted name='src/Service/ContactService.php' nodeId='12f6def551a5aae7' parentNodeId='0']
+                ##teamcity[testSuiteStarted name='src/Service/ContactService.php' nodeId='12f6def551a5aae7' parentNodeId='0' locationHint='file:///path/to/project/src/Service/ContactService.php']
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\TrueValue (e3730421e94b49783edb72f8c94e02dc)' nodeId='02a0e7865ef9a594' parentNodeId='12f6def551a5aae7']
 
                 ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']


### PR DESCRIPTION
Extracted from #2868.

Add the `locationHint` to the TeamCity test suite started messages, which allows you to jump to the source when doing a right click on the file path (no screenshot at the time of writing unfortunately).