### PR TITLE
test: Update the PHPUnit9 coverage data

### DIFF
--- a/tests/e2e/PHPUnit_09-3/tests/Covered/CalculatorTest.php
+++ b/tests/e2e/PHPUnit_09-3/tests/Covered/CalculatorTest.php
@@ -3,10 +3,11 @@
 namespace Infection\E2ETests\PHPUnit_09_3\Tests\Covered;
 
 use Infection\E2ETests\PHPUnit_09_3\Covered\Calculator;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(Calculator::class)]
+/**
+ * @covers Infection\E2ETests\PHPUnit_09_3\Covered\Calculator
+ */
 class CalculatorTest extends TestCase
 {
     private Calculator $calculator;

--- a/tests/e2e/PHPUnit_09-3/tests/Covered/FunctionsTest.php
+++ b/tests/e2e/PHPUnit_09-3/tests/Covered/FunctionsTest.php
@@ -2,12 +2,13 @@
 
 namespace Infection\E2ETests\PHPUnit_09_3\Tests\Covered;
 
-use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 use function Infection\E2ETests\PHPUnit_09_3\Covered\formatName;
 
-#[CoversFunction('Infection\E2ETests\PHPUnit_09_3\Covered\formatName')]
+/**
+ * @covers Infection\E2ETests\PHPUnit_09_3\Covered\formatName
+ */
 class FunctionsTest extends TestCase
 {
     public function test_format_name_with_both_names(): void

--- a/tests/e2e/PHPUnit_09-3/tests/Covered/UserServiceTest.php
+++ b/tests/e2e/PHPUnit_09-3/tests/Covered/UserServiceTest.php
@@ -4,13 +4,12 @@ namespace Infection\E2ETests\PHPUnit_09_3\Tests\Covered;
 
 use Infection\E2ETests\PHPUnit_09_3\Covered\LoggerTrait;
 use Infection\E2ETests\PHPUnit_09_3\Covered\UserService;
-use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversTrait;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-#[CoversTrait(LoggerTrait::class)]
-#[CoversClass(UserService::class)]
+/**
+ * @covers Infection\E2ETests\PHPUnit_09_3\Covered\LoggerTrait
+ * @covers Infection\E2ETests\PHPUnit_09_3\Covered\UserService
+ */
 class UserServiceTest extends TestCase
 {
     private UserService $service;


### PR DESCRIPTION
The attributes do not cause failure, but PHPUnit does not understand them either.