### PR TITLE
test: Introduce a utility to add a prefix to the titles of a data provider

### DIFF
--- a/tests/phpunit/Logger/Console/BasicConsoleLoggerTest.php
+++ b/tests/phpunit/Logger/Console/BasicConsoleLoggerTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Logger\Console;
 
 use Infection\Logger\Console\BasicConsoleLogger;
+use Infection\Tests\TestingUtility\PHPUnit\DataProviderFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -86,9 +87,10 @@ final class BasicConsoleLoggerTest extends TestCase
 
     public static function logProvider(): iterable
     {
-        foreach (self::provideLogsInNormalVerbosity() as $title => $scenario) {
-            yield '[verbosity=normal] ' . $title => $scenario;
-        }
+        yield from DataProviderFactory::prefix(
+            '[verbosity=normal] ',
+            self::provideLogsInNormalVerbosity(),
+        );
     }
 
     private static function provideLogsInNormalVerbosity(): iterable

--- a/tests/phpunit/TestingUtility/PHPUnit/DataProviderFactory.php
+++ b/tests/phpunit/TestingUtility/PHPUnit/DataProviderFactory.php
@@ -55,4 +55,19 @@ final class DataProviderFactory
             yield $key => [$value];
         }
     }
+
+    /**
+     * @template Key
+     * @template Value
+     *
+     * @param iterable<Key, Value> $dataProvider
+     *
+     * @return iterable<string, Value>
+     */
+    public static function prefix(string $prefix, iterable $dataProvider): iterable
+    {
+        foreach ($dataProvider as $title => $scenario) {
+            yield $prefix . $title => $scenario;
+        }
+    }
 }

--- a/tests/phpunit/TestingUtility/PHPUnit/DataProviderFactoryTest.php
+++ b/tests/phpunit/TestingUtility/PHPUnit/DataProviderFactoryTest.php
@@ -58,4 +58,21 @@ final class DataProviderFactoryTest extends TestCase
 
         $this->assertSame($expected, $actual);
     }
+
+    public function test_it_can_add_a_prefix_to_the_title_of_the_scenarios_of_a_provider(): void
+    {
+        $input = [
+            0 => ['value0'],
+            'key1' => ['value1'],
+        ];
+
+        $expected = [
+            'prefix:0' => ['value0'],
+            'prefix:key1' => ['value1'],
+        ];
+
+        $actual = take(DataProviderFactory::prefix('prefix:', $input))->toAssoc();
+
+        $this->assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
This PR introduces a tiny simple utility for PHPUnit data providers.

This allows to do something like this:

```php


    public static function traceProvider(): iterable
    {
        yield from DataProviderFactory::prefix(
            '[PHPUnit 09] ',
            self::phpUnit09InfoProvider(),
        );

        yield from DataProviderFactory::prefix(
            '[PHPUnit 10] ',
            self::phpUnit10InfoProvider(),
        );
    }
```

I actually wanted to leverage it in `BasicConsoleLoggerTest`, having forgotten that I introduced it in #2815. Having a look, I think `SchemaConfigurationFactoryTest` could also benefit from it but I also don't really want to touch it right now.

The current case does not really justify this utility. It is however, used a lot in #2815 and I would like to get out as much as possible from this PR given how big it is.