### PR TITLE
refactor: Allow to override a Container service on the fly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "nikic/php-parser": "^5.6.2",
         "ondram/ci-detector": "^4.1.0",
         "psr/log": "^2.0 || ^3.0",
-        "sanmai/di-container": "^0.1.4",
+        "sanmai/di-container": "^0.1.12",
         "sanmai/duoclock": "^0.1.0",
         "sanmai/later": "^0.1.7",
         "sanmai/pipeline": "^7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8743a3ff2810add65c5cc0323c92f83",
+    "content-hash": "87d509bafc8610571a70e16f0c59cac1",
     "packages": [
         {
             "name": "colinodell/json5",

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -145,7 +145,6 @@ use Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
 use Infection\TestFramework\Coverage\JUnit\MemoizedTestFileDataProvider;
 use Infection\TestFramework\Coverage\JUnit\TestFileDataProvider;
-use Infection\TestFramework\Coverage\Locator\ReportLocator;
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocator;
 use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser;
 use Infection\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProvider;
@@ -1085,10 +1084,10 @@ final class Container extends DIContainer
     /**
      * @template T of object
      *
-     * @param string|class-string<T> $id
+     * @param non-empty-string|class-string<T> $id
      * @param T|(Closure(static): T) $value
      */
-    public function withService(string $id, object $value): self
+    public function cloneWithService(string $id, object $value): self
     {
         $clone = clone $this;
 
@@ -1217,11 +1216,13 @@ final class Container extends DIContainer
     }
 
     /**
-     * @param class-string<object> $id
-     * @param callable(static): object $value
+     * @template T of object
+     *
+     * @param non-empty-string|class-string<T> $id
+     * @param Closure(static): T $value
      */
     private function offsetSet(string $id, callable $value): void
     {
-        $this->set($id, $value);
+        $this->bind($id, $value);
     }
 }

--- a/tests/benchmark/MutationGenerator/create-main.php
+++ b/tests/benchmark/MutationGenerator/create-main.php
@@ -96,7 +96,7 @@ return static function (int $maxCount): Closure {
     );
 
     $fileMutationGenerator = Container::create()
-        ->withService(
+        ->cloneWithService(
             Tracer::class,
             new EmptyTraceTracer(),
         )

--- a/tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php
+++ b/tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php
@@ -62,7 +62,7 @@ final class FileMutationGeneratorIntegrationTest extends TestCase
         $mutators = [new Plus()];
 
         $mutationGenerator = SingletonContainer::getContainer()
-            ->withService(
+            ->cloneWithService(
                 Tracer::class,
                 new DummyTracer(),
             )


### PR DESCRIPTION
Follow through with the idea from https://github.com/infection/infection/pull/2868#discussion_r2732940983 which was also attempted in https://github.com/infection/infection/pull/2837.

I didn't manage to make it work for the Tracer yet as this requires to have a configuration file ready too, which I didn't really want to do (maybe we could have it optional at some point?), so I left it out for now.

The idea is to be able to selectively override a service, allowing us to still use the Container to get a specific service instead of instantiating it ourselves. On one hand this makes those tests more brittle as Container changes have a wider impact, but it also helps with having those integration tests behaviour closer to how our application is configured.