### PR TITLE
refactor(event): Remove the need to pass the output to the event subscriber factories

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -739,58 +739,10 @@ parameters:
 			path: ../tests/phpunit/Environment/StrykerApiKeyResolverTest.php
 
 		-
-			rawMessage: 'Parameter #1 $output of class Infection\Tests\Fixtures\Event\IONullSubscriber constructor expects Symfony\Component\Console\Output\OutputInterface, Infection\Tests\Fixtures\Console\FakeOutput given.'
-			identifier: argument.type
-			count: 3
-			path: ../tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php
-
-		-
-			rawMessage: 'Parameter #1 $output of method Infection\Event\Subscriber\ChainSubscriberFactory::create() expects Symfony\Component\Console\Output\OutputInterface, Infection\Tests\Fixtures\Console\FakeOutput given.'
-			identifier: argument.type
+			rawMessage: 'Method Infection\Event\Subscriber\ChainSubscriberFactory::create() invoked with 1 parameter, 0 required.'
+			identifier: arguments.count
 			count: 2
 			path: ../tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php
-
-		-
-			rawMessage: 'Parameter #1 $output of method Infection\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberFactory::create() expects Symfony\Component\Console\Output\OutputInterface, Infection\Tests\Fixtures\Console\FakeOutput given.'
-			identifier: argument.type
-			count: 2
-			path: ../tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php
-
-		-
-			rawMessage: 'Parameter #1 $output of method Infection\Event\Subscriber\InitialStaticAnalysisRunConsoleLoggerSubscriberFactory::create() expects Symfony\Component\Console\Output\OutputInterface, Infection\Tests\Fixtures\Console\FakeOutput given.'
-			identifier: argument.type
-			count: 1
-			path: ../tests/phpunit/Event/Subscriber/InitialStaticAnalysisRunConsoleLoggerSubscriberFactoryTest.php
-
-		-
-			rawMessage: 'Parameter #1 $output of method Infection\Event\Subscriber\InitialTestsConsoleLoggerSubscriberFactory::create() expects Symfony\Component\Console\Output\OutputInterface, Infection\Tests\Fixtures\Console\FakeOutput given.'
-			identifier: argument.type
-			count: 1
-			path: ../tests/phpunit/Event/Subscriber/InitialTestsConsoleLoggerSubscriberFactoryTest.php
-
-		-
-			rawMessage: 'Parameter #1 $output of method Infection\Event\Subscriber\MutationGeneratingConsoleLoggerSubscriberFactory::create() expects Symfony\Component\Console\Output\OutputInterface, Infection\Tests\Fixtures\Console\FakeOutput given.'
-			identifier: argument.type
-			count: 1
-			path: ../tests/phpunit/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriberFactoryTest.php
-
-		-
-			rawMessage: 'Parameter #1 $output of method Infection\Event\Subscriber\MutationTestingResultsLoggerSubscriberFactory::create() expects Symfony\Component\Console\Output\OutputInterface, Infection\Tests\Fixtures\Console\FakeOutput given.'
-			identifier: argument.type
-			count: 1
-			path: ../tests/phpunit/Event/Subscriber/MutationTestingResultsLoggerSubscriberFactoryTest.php
-
-		-
-			rawMessage: 'Parameter #1 $output of method Infection\Event\Subscriber\PerformanceLoggerSubscriberFactory::create() expects Symfony\Component\Console\Output\OutputInterface, Infection\Tests\Fixtures\Console\FakeOutput given.'
-			identifier: argument.type
-			count: 1
-			path: ../tests/phpunit/Event/Subscriber/PerformanceLoggerSubscriberFactoryTest.php
-
-		-
-			rawMessage: 'Parameter #1 $output of method Infection\Event\Subscriber\SubscriberRegisterer::registerSubscribers() expects Symfony\Component\Console\Output\OutputInterface, Infection\Tests\Fixtures\Console\FakeOutput given.'
-			identifier: argument.type
-			count: 2
-			path: ../tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php
 
 		-
 			rawMessage: 'Call to an undefined method object::setFilter().'

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -20,6 +20,15 @@ parameters:
             count: 1
             path: ../src/Mutant/MutantExecutionResult.php
 
+        # It would be nice to properly address those; They are false positives, but we did not figure
+        # out how to properly configure PHPStan to understand it.
+        -
+            message: "#^Instantiated class Infection\\\\Tests\\\\Fixtures\\\\Console\\\\FakeOutput not found\\.$#"
+            path:  ../tests/*
+        -
+            message: "#^.*expects Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface, Infection\\\\Tests\\\\Fixtures\\\\Console\\\\FakeOutput given\\.$#"
+            path:  ../tests/*
+
         # tests
         - '#Dynamic call to static method PHPUnit\\Framework\\.*::.*#'
         - '#Method Infection\\Tests\\.*::.*\(\) return type has no value type specified in iterable type iterable#'
@@ -27,10 +36,6 @@ parameters:
             message: '#Do not (use|return|assign) magic number (.)#'
             paths:
                 - ../tests/*
-        -
-            message: "#^Instantiated class Infection\\\\Tests\\\\Fixtures\\\\Console\\\\FakeOutput not found\\.$#"
-            count: 11
-            path:  ../tests/*
         -
             message: '#^Call to method PHPUnit\\Framework\\Assert::assertNotFalse\(\) with SimpleXMLElement and ''Expected dumped…'' will always evaluate to true\.$#'
             path: ../tests/*

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -583,7 +583,7 @@ final class RunCommand extends BaseCommand
 
         LogVerbosity::convertVerbosityLevel($io->getInput(), $consoleOutput);
 
-        $container->getSubscriberRegisterer()->registerSubscribers($io->getOutput());
+        $container->getSubscriberRegisterer()->registerSubscribers();
 
         $container->getEventDispatcher()->dispatch(new ApplicationExecutionWasStarted());
     }

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -405,6 +405,7 @@ final class Container extends DIContainer
                     $config->noProgress,
                     $container->getTestFrameworkAdapter(),
                     $config->isDebugEnabled,
+                    $container->getOutput(),
                 );
             },
             InitialStaticAnalysisRunConsoleLoggerSubscriberFactory::class => static function (self $container): InitialStaticAnalysisRunConsoleLoggerSubscriberFactory {
@@ -414,10 +415,12 @@ final class Container extends DIContainer
                     $config->noProgress,
                     $config->isDebugEnabled,
                     $container->getStaticAnalysisToolAdapter(),
+                    $container->getOutput(),
                 );
             },
             MutationGeneratingConsoleLoggerSubscriberFactory::class => static fn (self $container): MutationGeneratingConsoleLoggerSubscriberFactory => new MutationGeneratingConsoleLoggerSubscriberFactory(
                 $container->getConfiguration()->noProgress,
+                $container->getOutput(),
             ),
             MutationTestingResultsCollectorSubscriberFactory::class => static fn (self $container): MutationTestingResultsCollectorSubscriberFactory => new MutationTestingResultsCollectorSubscriberFactory(
                 ...array_filter([
@@ -439,6 +442,7 @@ final class Container extends DIContainer
                     $container->getMutationAnalysisLogger(),
                     !$config->mutateOnlyCoveredCode(),
                     $config->timeoutsAsEscaped,
+                    $container->getOutput(),
                 );
             },
             PerformanceLoggerSubscriberFactory::class => static fn (self $container): PerformanceLoggerSubscriberFactory => new PerformanceLoggerSubscriberFactory(
@@ -446,6 +450,7 @@ final class Container extends DIContainer
                 $container->getTimeFormatter(),
                 $container->getMemoryFormatter(),
                 $container->getConfiguration()->threadCount,
+                $container->getOutput(),
             ),
             FileMutationGenerator::class => static fn (self $container): FileMutationGenerator => new FileMutationGenerator(
                 $container->getFileParser(),

--- a/src/Event/Subscriber/ChainSubscriberFactory.php
+++ b/src/Event/Subscriber/ChainSubscriberFactory.php
@@ -35,8 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Symfony\Component\Console\Output\OutputInterface;
-
 /**
  * @internal
  */
@@ -55,10 +53,10 @@ final readonly class ChainSubscriberFactory
     /**
      * @return iterable<EventSubscriber>
      */
-    public function create(OutputInterface $output): iterable
+    public function create(): iterable
     {
         foreach ($this->factories as $factory) {
-            yield $factory->create($output);
+            yield $factory->create();
         }
     }
 }

--- a/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactory.php
+++ b/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactory.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -50,7 +49,7 @@ final readonly class CleanUpAfterMutationTestingFinishedSubscriberFactory implem
     ) {
     }
 
-    public function create(OutputInterface $output): EventSubscriber
+    public function create(): EventSubscriber
     {
         return $this->debug
             ? new NullSubscriber()

--- a/src/Event/Subscriber/DispatchPcntlSignalSubscriberFactory.php
+++ b/src/Event/Subscriber/DispatchPcntlSignalSubscriberFactory.php
@@ -35,14 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Symfony\Component\Console\Output\OutputInterface;
-
 /**
  * @internal
  */
 final class DispatchPcntlSignalSubscriberFactory implements SubscriberFactory
 {
-    public function create(OutputInterface $output): EventSubscriber
+    public function create(): EventSubscriber
     {
         return new DispatchPcntlSignalSubscriber();
     }

--- a/src/Event/Subscriber/InitialStaticAnalysisRunConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/InitialStaticAnalysisRunConsoleLoggerSubscriberFactory.php
@@ -47,16 +47,20 @@ final readonly class InitialStaticAnalysisRunConsoleLoggerSubscriberFactory impl
         private bool $skipProgressBar,
         private bool $debug,
         private StaticAnalysisToolAdapter $staticAnalysisToolAdapter,
+        private OutputInterface $output,
     ) {
     }
 
-    public function create(OutputInterface $output): EventSubscriber
+    public function create(): EventSubscriber
     {
         return $this->skipProgressBar
-            ? new CiInitialStaticAnalysisRunConsoleLoggerSubscriber($this->staticAnalysisToolAdapter, $output)
+            ? new CiInitialStaticAnalysisRunConsoleLoggerSubscriber(
+                $this->staticAnalysisToolAdapter,
+                $this->output,
+            )
             : new InitialStaticAnalysisRunConsoleLoggerSubscriber(
                 $this->staticAnalysisToolAdapter,
-                $output,
+                $this->output,
                 $this->debug,
             );
     }

--- a/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/InitialTestsConsoleLoggerSubscriberFactory.php
@@ -47,15 +47,19 @@ final readonly class InitialTestsConsoleLoggerSubscriberFactory implements Subsc
         private bool $skipProgressBar,
         private TestFrameworkAdapter $testFrameworkAdapter,
         private bool $debug,
+        private OutputInterface $output,
     ) {
     }
 
-    public function create(OutputInterface $output): EventSubscriber
+    public function create(): EventSubscriber
     {
         return $this->skipProgressBar
-            ? new CiInitialTestsConsoleLoggerSubscriber($output, $this->testFrameworkAdapter)
+            ? new CiInitialTestsConsoleLoggerSubscriber(
+                $this->output,
+                $this->testFrameworkAdapter,
+            )
             : new InitialTestsConsoleLoggerSubscriber(
-                $output,
+                $this->output,
                 $this->testFrameworkAdapter,
                 $this->debug,
             )

--- a/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriberFactory.php
@@ -44,14 +44,15 @@ final readonly class MutationGeneratingConsoleLoggerSubscriberFactory implements
 {
     public function __construct(
         private bool $skipProgressBar,
+        private OutputInterface $output,
     ) {
     }
 
-    public function create(OutputInterface $output): EventSubscriber
+    public function create(): EventSubscriber
     {
         return $this->skipProgressBar
-            ? new CiMutationGeneratingConsoleLoggerSubscriber($output)
-            : new MutationGeneratingConsoleLoggerSubscriber($output)
+            ? new CiMutationGeneratingConsoleLoggerSubscriber($this->output)
+            : new MutationGeneratingConsoleLoggerSubscriber($this->output)
         ;
     }
 }

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactory.php
@@ -56,13 +56,14 @@ final readonly class MutationTestingConsoleLoggerSubscriberFactory implements Su
         private MutationAnalysisLogger $logger,
         private bool $withUncovered,
         private bool $withTimeouts,
+        private OutputInterface $output,
     ) {
     }
 
-    public function create(OutputInterface $output): EventSubscriber
+    public function create(): EventSubscriber
     {
         return new MutationTestingConsoleLoggerSubscriber(
-            $output,
+            $this->output,
             $this->logger,
             $this->metricsCalculator,
             $this->resultsCollector,

--- a/src/Event/Subscriber/MutationTestingResultsCollectorSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingResultsCollectorSubscriberFactory.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Event\Subscriber;
 
 use Infection\Metrics\Collector;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @internal
@@ -51,7 +50,7 @@ final readonly class MutationTestingResultsCollectorSubscriberFactory implements
         $this->collectors = $collectors;
     }
 
-    public function create(OutputInterface $output): EventSubscriber
+    public function create(): EventSubscriber
     {
         return new MutationTestingResultsCollectorSubscriber(
             ...$this->collectors,

--- a/src/Event/Subscriber/MutationTestingResultsLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/MutationTestingResultsLoggerSubscriberFactory.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Event\Subscriber;
 
 use Infection\Reporter\Reporter;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @internal
@@ -48,7 +47,7 @@ final readonly class MutationTestingResultsLoggerSubscriberFactory implements Su
     ) {
     }
 
-    public function create(OutputInterface $output): EventSubscriber
+    public function create(): EventSubscriber
     {
         return new MutationTestingResultsLoggerSubscriber(
             $this->reporter,

--- a/src/Event/Subscriber/PerformanceLoggerSubscriberFactory.php
+++ b/src/Event/Subscriber/PerformanceLoggerSubscriberFactory.php
@@ -51,17 +51,18 @@ final readonly class PerformanceLoggerSubscriberFactory implements SubscriberFac
         private TimeFormatter $timeFormatter,
         private MemoryFormatter $memoryFormatter,
         private int $threadCount,
+        private OutputInterface $output,
     ) {
     }
 
-    public function create(OutputInterface $output): EventSubscriber
+    public function create(): EventSubscriber
     {
         return new PerformanceLoggerSubscriber(
             $this->stopwatch,
             $this->timeFormatter,
             $this->memoryFormatter,
             $this->threadCount,
-            $output,
+            $this->output,
         );
     }
 }

--- a/src/Event/Subscriber/StopInfectionOnSigintSignalSubscriberFactory.php
+++ b/src/Event/Subscriber/StopInfectionOnSigintSignalSubscriberFactory.php
@@ -35,14 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Symfony\Component\Console\Output\OutputInterface;
-
 /**
  * @internal
  */
 final class StopInfectionOnSigintSignalSubscriberFactory implements SubscriberFactory
 {
-    public function create(OutputInterface $output): EventSubscriber
+    public function create(): EventSubscriber
     {
         return new StopInfectionOnSigintSignalSubscriber();
     }

--- a/src/Event/Subscriber/SubscriberFactory.php
+++ b/src/Event/Subscriber/SubscriberFactory.php
@@ -35,12 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Symfony\Component\Console\Output\OutputInterface;
-
 /**
  * @internal
  */
 interface SubscriberFactory
 {
-    public function create(OutputInterface $output): EventSubscriber;
+    public function create(): EventSubscriber;
 }

--- a/src/Event/Subscriber/SubscriberRegisterer.php
+++ b/src/Event/Subscriber/SubscriberRegisterer.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Event\Subscriber;
 
 use Infection\Event\EventDispatcher\EventDispatcher;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @internal
@@ -49,9 +48,9 @@ final readonly class SubscriberRegisterer
     ) {
     }
 
-    public function registerSubscribers(OutputInterface $output): void
+    public function registerSubscribers(): void
     {
-        foreach ($this->subscriberRegistry->create($output) as $subscriber) {
+        foreach ($this->subscriberRegistry->create() as $subscriber) {
             $this->eventDispatcher->addSubscriber($subscriber);
         }
     }

--- a/tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\Event\Subscriber;
 use Infection\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriber;
 use Infection\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberFactory;
 use Infection\Event\Subscriber\NullSubscriber;
-use Infection\Tests\Fixtures\Console\FakeOutput;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -68,7 +67,7 @@ final class CleanUpAfterMutationTestingFinishedSubscriberFactoryTest extends Tes
             '/path/to/tmp',
         );
 
-        $subscriber = $factory->create(new FakeOutput());
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(CleanUpAfterMutationTestingFinishedSubscriber::class, $subscriber);
     }
@@ -81,7 +80,7 @@ final class CleanUpAfterMutationTestingFinishedSubscriberFactoryTest extends Tes
             '/path/to/tmp',
         );
 
-        $subscriber = $factory->create(new FakeOutput());
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(NullSubscriber::class, $subscriber);
     }

--- a/tests/phpunit/Event/Subscriber/DispatchPcntlSignalSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/DispatchPcntlSignalSubscriberFactoryTest.php
@@ -40,16 +40,13 @@ use Infection\Event\Subscriber\DispatchPcntlSignalSubscriberFactory;
 use Infection\Event\Subscriber\EventSubscriber;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Output\OutputInterface;
 
 #[CoversClass(DispatchPcntlSignalSubscriberFactory::class)]
 final class DispatchPcntlSignalSubscriberFactoryTest extends TestCase
 {
     public function test_it_creates_a_subscriber(): void
     {
-        $outputMock = $this->createMock(OutputInterface::class);
-
-        $subscriber = (new DispatchPcntlSignalSubscriberFactory())->create($outputMock);
+        $subscriber = (new DispatchPcntlSignalSubscriberFactory())->create();
 
         $this->assertInstanceOf(DispatchPcntlSignalSubscriber::class, $subscriber);
         $this->assertInstanceOf(EventSubscriber::class, $subscriber);

--- a/tests/phpunit/Event/Subscriber/InitialStaticAnalysisRunConsoleLoggerSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/InitialStaticAnalysisRunConsoleLoggerSubscriberFactoryTest.php
@@ -67,9 +67,10 @@ final class InitialStaticAnalysisRunConsoleLoggerSubscriberFactoryTest extends T
             true,
             $debug,
             $this->staticAnalysisToolAdapter,
+            new FakeOutput(),
         );
 
-        $subscriber = $factory->create(new FakeOutput());
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(CiInitialStaticAnalysisRunConsoleLoggerSubscriber::class, $subscriber);
     }
@@ -77,19 +78,20 @@ final class InitialStaticAnalysisRunConsoleLoggerSubscriberFactoryTest extends T
     #[DataProvider('debugProvider')]
     public function test_it_creates_a_regular_subscriber_if_does_not_skip_the_progress_bar(bool $debug): void
     {
-        $factory = new InitialStaticAnalysisRunConsoleLoggerSubscriberFactory(
-            false,
-            $debug,
-            $this->staticAnalysisToolAdapter,
-        );
-
         $outputMock = $this->createMock(OutputInterface::class);
         $outputMock
             ->method('isDecorated')
             ->willReturn(false)
         ;
 
-        $subscriber = $factory->create($outputMock);
+        $factory = new InitialStaticAnalysisRunConsoleLoggerSubscriberFactory(
+            false,
+            $debug,
+            $this->staticAnalysisToolAdapter,
+            $outputMock,
+        );
+
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(InitialStaticAnalysisRunConsoleLoggerSubscriber::class, $subscriber);
     }

--- a/tests/phpunit/Event/Subscriber/InitialTestsConsoleLoggerSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/InitialTestsConsoleLoggerSubscriberFactoryTest.php
@@ -67,9 +67,10 @@ final class InitialTestsConsoleLoggerSubscriberFactoryTest extends TestCase
             true,
             $this->testFrameworkAdapterMock,
             $debug,
+            new FakeOutput(),
         );
 
-        $subscriber = $factory->create(new FakeOutput());
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(CiInitialTestsConsoleLoggerSubscriber::class, $subscriber);
     }
@@ -77,19 +78,20 @@ final class InitialTestsConsoleLoggerSubscriberFactoryTest extends TestCase
     #[DataProvider('debugProvider')]
     public function test_it_creates_a_regular_subscriber_if_does_not_skip_the_progress_bar(bool $debug): void
     {
-        $factory = new InitialTestsConsoleLoggerSubscriberFactory(
-            false,
-            $this->testFrameworkAdapterMock,
-            $debug,
-        );
-
         $outputMock = $this->createMock(OutputInterface::class);
         $outputMock
             ->method('isDecorated')
             ->willReturn(false)
         ;
 
-        $subscriber = $factory->create($outputMock);
+        $factory = new InitialTestsConsoleLoggerSubscriberFactory(
+            false,
+            $this->testFrameworkAdapterMock,
+            $debug,
+            $outputMock,
+        );
+
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(InitialTestsConsoleLoggerSubscriber::class, $subscriber);
     }

--- a/tests/phpunit/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationGeneratingConsoleLoggerSubscriberFactoryTest.php
@@ -48,24 +48,30 @@ final class MutationGeneratingConsoleLoggerSubscriberFactoryTest extends TestCas
 {
     public function test_it_creates_a_ci_subscriber_if_skips_the_progress_bar(): void
     {
-        $factory = new MutationGeneratingConsoleLoggerSubscriberFactory(true);
+        $factory = new MutationGeneratingConsoleLoggerSubscriberFactory(
+            true,
+            new FakeOutput(),
+        );
 
-        $subscriber = $factory->create(new FakeOutput());
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(CiMutationGeneratingConsoleLoggerSubscriber::class, $subscriber);
     }
 
     public function test_it_creates_a_regular_subscriber_if_does_not_skip_the_progress_bar(): void
     {
-        $factory = new MutationGeneratingConsoleLoggerSubscriberFactory(false);
-
         $outputMock = $this->createMock(OutputInterface::class);
         $outputMock
             ->method('isDecorated')
             ->willReturn(false)
         ;
 
-        $subscriber = $factory->create($outputMock);
+        $factory = new MutationGeneratingConsoleLoggerSubscriberFactory(
+            false,
+            $outputMock,
+        );
+
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(MutationGeneratingConsoleLoggerSubscriber::class, $subscriber);
     }

--- a/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberFactoryTest.php
@@ -92,6 +92,12 @@ final class MutationTestingConsoleLoggerSubscriberFactoryTest extends TestCase
     #[DataProvider('showMutationsProvider')]
     public function test_it_creates_a_subscriber(?int $numberOfShownMutations): void
     {
+        $outputMock = $this->createMock(OutputInterface::class);
+        $outputMock
+            ->method('isDecorated')
+            ->willReturn(false)
+        ;
+
         $factory = new MutationTestingConsoleLoggerSubscriberFactory(
             $this->metricsCalculatorMock,
             $this->resultsCollectorMock,
@@ -101,15 +107,10 @@ final class MutationTestingConsoleLoggerSubscriberFactoryTest extends TestCase
             new FakeMutationAnalysisLogger(),
             withUncovered: true,
             withTimeouts: false,
+            output: $outputMock,
         );
 
-        $outputMock = $this->createMock(OutputInterface::class);
-        $outputMock
-            ->method('isDecorated')
-            ->willReturn(false)
-        ;
-
-        $subscriber = $factory->create($outputMock);
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(MutationTestingConsoleLoggerSubscriber::class, $subscriber);
     }
@@ -147,9 +148,10 @@ final class MutationTestingConsoleLoggerSubscriberFactoryTest extends TestCase
             $outputFormatter,
             withUncovered: false,
             withTimeouts: false,
+            output: $output,
         );
 
-        $subscriber = $factory->create($output);
+        $subscriber = $factory->create();
 
         $dispatcher = new SyncEventDispatcher();
         $dispatcher->addSubscriber($subscriber);
@@ -201,9 +203,10 @@ final class MutationTestingConsoleLoggerSubscriberFactoryTest extends TestCase
             $outputFormatter,
             withUncovered: false,
             withTimeouts: true,
+            output: $output,
         );
 
-        $subscriber = $factory->create($output);
+        $subscriber = $factory->create();
 
         $dispatcher = new SyncEventDispatcher();
         $dispatcher->addSubscriber($subscriber);

--- a/tests/phpunit/Event/Subscriber/MutationTestingResultsCollectorSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingResultsCollectorSubscriberFactoryTest.php
@@ -40,7 +40,6 @@ use Infection\Event\Subscriber\MutationTestingResultsCollectorSubscriberFactory;
 use Infection\Metrics\Collector;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Output\OutputInterface;
 
 #[CoversClass(MutationTestingResultsCollectorSubscriberFactory::class)]
 final class MutationTestingResultsCollectorSubscriberFactoryTest extends TestCase
@@ -52,13 +51,7 @@ final class MutationTestingResultsCollectorSubscriberFactoryTest extends TestCas
             $this->createMock(Collector::class),
         );
 
-        $outputMock = $this->createMock(OutputInterface::class);
-        $outputMock
-            ->expects($this->never())
-            ->method($this->anything())
-        ;
-
-        $subscriber = $factory->create($outputMock);
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(MutationTestingResultsCollectorSubscriber::class, $subscriber);
     }

--- a/tests/phpunit/Event/Subscriber/MutationTestingResultsLoggerSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingResultsLoggerSubscriberFactoryTest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\Event\Subscriber;
 use Infection\Event\Subscriber\MutationTestingResultsLoggerSubscriber;
 use Infection\Event\Subscriber\MutationTestingResultsLoggerSubscriberFactory;
 use Infection\Reporter\Reporter;
-use Infection\Tests\Fixtures\Console\FakeOutput;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -53,7 +52,7 @@ final class MutationTestingResultsLoggerSubscriberFactoryTest extends TestCase
             $logger,
         );
 
-        $subscriber = $factory->create(new FakeOutput());
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(MutationTestingResultsLoggerSubscriber::class, $subscriber);
     }

--- a/tests/phpunit/Event/Subscriber/PerformanceLoggerSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/PerformanceLoggerSubscriberFactoryTest.php
@@ -54,9 +54,10 @@ final class PerformanceLoggerSubscriberFactoryTest extends TestCase
             new TimeFormatter(),
             new MemoryFormatter(),
             1,
+            new FakeOutput(),
         );
 
-        $subscriber = $factory->create(new FakeOutput());
+        $subscriber = $factory->create();
 
         $this->assertInstanceOf(PerformanceLoggerSubscriber::class, $subscriber);
     }

--- a/tests/phpunit/Event/Subscriber/StopInfectionOnSigintSignalSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/StopInfectionOnSigintSignalSubscriberFactoryTest.php
@@ -40,16 +40,13 @@ use Infection\Event\Subscriber\StopInfectionOnSigintSignalSubscriber;
 use Infection\Event\Subscriber\StopInfectionOnSigintSignalSubscriberFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Output\OutputInterface;
 
 #[CoversClass(StopInfectionOnSigintSignalSubscriberFactory::class)]
 final class StopInfectionOnSigintSignalSubscriberFactoryTest extends TestCase
 {
     public function test_it_creates_a_subscriber(): void
     {
-        $outputMock = $this->createMock(OutputInterface::class);
-
-        $subscriber = (new StopInfectionOnSigintSignalSubscriberFactory())->create($outputMock);
+        $subscriber = (new StopInfectionOnSigintSignalSubscriberFactory())->create();
 
         $this->assertInstanceOf(StopInfectionOnSigintSignalSubscriber::class, $subscriber);
         $this->assertInstanceOf(EventSubscriber::class, $subscriber);

--- a/tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php
+++ b/tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php
@@ -38,7 +38,6 @@ namespace Infection\Tests\Event\Subscriber;
 use Infection\Event\Subscriber\ChainSubscriberFactory;
 use Infection\Event\Subscriber\NullSubscriber;
 use Infection\Event\Subscriber\SubscriberRegisterer;
-use Infection\Tests\Fixtures\Console\FakeOutput;
 use Infection\Tests\Fixtures\Event\DummySubscriberFactory;
 use Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -71,7 +70,7 @@ final class SubscriberRegistererTest extends TestCase
         // Sanity check
         $this->assertCount(0, $this->eventDispatcher->getSubscribers());
 
-        $registerer->registerSubscribers(new FakeOutput());
+        $registerer->registerSubscribers();
 
         $this->assertSame(
             [
@@ -93,7 +92,7 @@ final class SubscriberRegistererTest extends TestCase
         // Sanity check
         $this->assertCount(0, $this->eventDispatcher->getSubscribers());
 
-        $registerer->registerSubscribers(new FakeOutput());
+        $registerer->registerSubscribers();
 
         $this->assertCount(0, $this->eventDispatcher->getSubscribers());
     }

--- a/tests/phpunit/Fixtures/Event/DummySubscriberFactory.php
+++ b/tests/phpunit/Fixtures/Event/DummySubscriberFactory.php
@@ -14,7 +14,7 @@ final readonly class DummySubscriberFactory implements SubscriberFactory
     {
     }
 
-    public function create(OutputInterface $output): EventSubscriber
+    public function create(): EventSubscriber
     {
         return $this->subscriber;
     }


### PR DESCRIPTION
At the time `SubscriberRegisterer::registerSubscribers()` is called, the `Container` output instance is already configured with the one coming from `RunCommand`. As a result, the output passed to `::registerSubscribers()` is the same instance as the one contained by the container.

This means we could instead allow the subscriber factories to get the output injected as usual, like done in the rest of the application, instead of requiring it to be passed via `SubscriberFactory::create()`.

