### PR TITLE
test(event): Fix ChainSubscriberFactoryTest missed refactor and clean up baseline

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -739,12 +739,6 @@ parameters:
 			path: ../tests/phpunit/Environment/StrykerApiKeyResolverTest.php
 
 		-
-			rawMessage: 'Method Infection\Event\Subscriber\ChainSubscriberFactory::create() invoked with 1 parameter, 0 required.'
-			identifier: arguments.count
-			count: 2
-			path: ../tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php
-
-		-
 			rawMessage: 'Call to an undefined method object::setFilter().'
 			identifier: method.notFound
 			count: 1

--- a/tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php
+++ b/tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php
@@ -51,7 +51,7 @@ final class ChainSubscriberFactoryTest extends TestCase
     {
         $factory = new ChainSubscriberFactory();
 
-        $subscribers = $factory->create(new FakeOutput());
+        $subscribers = $factory->create();
 
         $this->assertCount(
             0,
@@ -75,7 +75,7 @@ final class ChainSubscriberFactoryTest extends TestCase
             new DummySubscriberFactory($subscriber3),
         );
 
-        $subscribers = $factory->create($output);
+        $subscribers = $factory->create();
 
         if ($subscribers instanceof Traversable) {
             $subscribers = iterator_to_array($subscribers, false);


### PR DESCRIPTION
## Description
This PR fixes a missed refactor in `ChainSubscriberFactoryTest.php` that was overlooked during the changes in #2940.

## Changes
- **tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php**:
    - Updated `create()` calls to remove the unnecessary `$output` argument.
- **devTools/phpstan-baseline.neon**:
    - Removed the ignored errors related to `ChainSubscriberFactoryTest`.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
- [ ] Appropriate labels applied

## Related issues
Fixes a follow-up issue from #2940
