### PR TITLE
feat: add support for sebastian/diff v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "sanmai/duoclock": "^0.1.0",
         "sanmai/later": "^0.1.7",
         "sanmai/pipeline": "^7.2",
-        "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/console": "^6.4 || ^7.0 || ^8.0",
         "symfony/filesystem": "^6.4 || ^7.0 || ^8.0",
         "symfony/finder": "^6.4 || ^7.0 || ^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87d509bafc8610571a70e16f0c59cac1",
+    "content-hash": "4f606029f3902519afd99f15da6cc5cb",
     "packages": [
         {
             "name": "colinodell/json5",


### PR DESCRIPTION
Previous MR: https://github.com/infection/infection/pull/2022

From https://github.com/sebastianbergmann/diff/releases/tag/8.0.0:
```
Removed

    This component is no longer supported on PHP 8.3
```