### PR TITLE
test(ast): Allow to label specific nodes

### DIFF
--- a/tests/phpunit/PhpParser/Visitor/VisitorTestCaseLabelTest.php
+++ b/tests/phpunit/PhpParser/Visitor/VisitorTestCaseLabelTest.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\PhpParser\Visitor;
+
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Return_;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(VisitorTestCase::class)]
+final class VisitorTestCaseLabelTest extends VisitorTestCase
+{
+    public function test_labelNodes_returns_only_labeled_nodes(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            function foo() {  // @label:Stmt_Function:foo-function
+                $x = 1;
+                return $x;  // @label:Stmt_Return:return-stmt
+            }
+            PHP;
+
+        $nodes = $this->labelNodes($this->parse($code));
+
+        $this->assertCount(2, $nodes);
+        $this->assertArrayHasKey('foo-function', $nodes);
+        $this->assertArrayHasKey('return-stmt', $nodes);
+
+        $fooFunction = $nodes['foo-function'];
+        $this->assertInstanceOf(Function_::class, $fooFunction);
+        $this->assertSame('foo', $fooFunction->name->toString());
+
+        $returnStmt = $nodes['return-stmt'];
+        $this->assertInstanceOf(Return_::class, $returnStmt);
+    }
+
+    public function test_addIdsToNodes_returns_both_numeric_ids_and_labels(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            function bar() {  // @label:Stmt_Function:bar-func
+                return 42;
+            }
+            PHP;
+
+        $nodes = $this->addIdsToNodes($this->parse($code));
+
+        // Should contain numeric IDs
+        $this->assertArrayHasKey(0, $nodes);
+
+        // Should also contain label
+        $this->assertArrayHasKey('bar-func', $nodes);
+
+        // Labeled node should be accessible via both keys
+        $barFunc = $nodes['bar-func'];
+        $this->assertInstanceOf(Function_::class, $barFunc);
+    }
+
+    public function test_addIdsToNodes_without_labels_returns_only_numeric_ids(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            function baz() {
+                return 99;
+            }
+            PHP;
+
+        $nodes = $this->addIdsToNodes($this->parse($code));
+
+        // Should contain numeric IDs
+        $this->assertArrayHasKey(0, $nodes);
+
+        // Should not have any string keys
+        foreach (array_keys($nodes) as $key) {
+            $this->assertIsInt($key);
+        }
+    }
+
+    public function test_complex_labeling_scenario(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            class Foo {  // @label:Stmt_Class:foo-class
+                public function bar($items) {  // @label:Stmt_ClassMethod:bar-method
+                    // @label:Expr_Variable:items-param
+                    return $items[0];
+                }
+            }
+            PHP;
+
+        $nodes = $this->labelNodes($this->parse($code));
+
+        $this->assertCount(3, $nodes);
+
+        $fooClass = $nodes['foo-class'];
+        $this->assertInstanceOf(Class_::class, $fooClass);
+        $this->assertSame('Foo', $fooClass->name->toString());
+
+        $barMethod = $nodes['bar-method'];
+        $this->assertInstanceOf(ClassMethod::class, $barMethod);
+        $this->assertSame('bar', $barMethod->name->toString());
+
+        $itemsParam = $nodes['items-param'];
+        $this->assertInstanceOf(Variable::class, $itemsParam);
+        $this->assertSame('items', $itemsParam->name);
+    }
+
+    public function test_labelNodes_with_multiple_labels_on_same_line_different_types(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            $result = getValue();  // @label:Expr_Assign:assignment @label:Expr_FuncCall:call
+            PHP;
+
+        $nodes = $this->labelNodes($this->parse($code));
+
+        $this->assertArrayHasKey('assignment', $nodes);
+        $this->assertInstanceOf(Assign::class, $nodes['assignment']);
+
+        $this->assertArrayHasKey('call', $nodes);
+    }
+
+    public function test_labelNodes_with_prefix_and_suffix_comments(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            // @label:Stmt_Function:prefix-func
+            function foo() {
+                $x = 1;  // @label:Expr_Variable:suffix-var
+            }
+            PHP;
+
+        $nodes = $this->labelNodes($this->parse($code));
+
+        $this->assertCount(2, $nodes);
+        $this->assertArrayHasKey('prefix-func', $nodes);
+        $this->assertArrayHasKey('suffix-var', $nodes);
+
+        $this->assertInstanceOf(Function_::class, $nodes['prefix-func']);
+        $this->assertInstanceOf(Variable::class, $nodes['suffix-var']);
+    }
+
+    public function test_labelNodes_with_block_comments(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            /* @label:Stmt_Function:block-func */
+            function test() {}
+            PHP;
+
+        $nodes = $this->labelNodes($this->parse($code));
+
+        $this->assertCount(1, $nodes);
+        $this->assertArrayHasKey('block-func', $nodes);
+        $this->assertInstanceOf(Function_::class, $nodes['block-func']);
+    }
+
+    public function test_labelNodes_allows_hyphens_and_underscores(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            function foo() {  // @label:Stmt_Function:my-func_123
+            }
+            PHP;
+
+        $nodes = $this->labelNodes($this->parse($code));
+
+        $this->assertArrayHasKey('my-func_123', $nodes);
+        $this->assertInstanceOf(Function_::class, $nodes['my-func_123']);
+    }
+}

--- a/tests/phpunit/TestingUtility/PhpParser/LabelParser/LabelParser.php
+++ b/tests/phpunit/TestingUtility/PhpParser/LabelParser/LabelParser.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestingUtility\PhpParser\LabelParser;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use RuntimeException;
+use function preg_match;
+use function preg_match_all;
+use function sprintf;
+
+/**
+ * Extracts and validates @label annotations from comments in PhpParser nodes.
+ *
+ * Label format: @label:NodeType:Label
+ * Example: @label:Expr_Variable:my-var
+ */
+final class LabelParser
+{
+    private const LABEL_PATTERN = '/@label:([^:]+):([^\s]+)/';
+    private const LABEL_NAME_PATTERN = '/^[a-zA-Z][a-zA-Z0-9_-]*$/';
+
+    /**
+     * @param Node[] $nodes
+     */
+    public function parseLabelsFromNodes(array $nodes): ParsedLabels
+    {
+        $parsedLabels = new ParsedLabels();
+
+        // Create a visitor to collect labels from all nodes
+        $visitor = new class($parsedLabels, $this) extends NodeVisitorAbstract {
+            public function __construct(
+                private readonly ParsedLabels $parsedLabels,
+                private readonly LabelParser $labelParser,
+            ) {
+            }
+
+            public function enterNode(Node $node): void
+            {
+                $this->labelParser->extractLabelsFromNode($node, $this->parsedLabels);
+            }
+        };
+
+        $traverser = new NodeTraverser($visitor);
+        $traverser->traverse($nodes);
+
+        return $parsedLabels;
+    }
+
+    public function extractLabelsFromNode(Node $node, ParsedLabels $parsedLabels): void
+    {
+        $nodeStartLine = $node->getStartLine();
+
+        if ($nodeStartLine === -1) {
+            return; // Node has no line information
+        }
+
+        foreach ($node->getComments() as $comment) {
+            $commentStartLine = $comment->getStartLine();
+            $commentEndLine = $comment->getEndLine();
+
+            // PhpParser attaches comments to nodes in complex ways.
+            // We simply store labels based on the comment's line number.
+            // The visitor will handle matching labels to nodes by checking
+            // both the node's line and the line before it.
+            $targetLine = $commentEndLine;
+
+            // Extract all @label patterns from the comment
+            $text = $comment->getText();
+            $matches = [];
+            preg_match_all(self::LABEL_PATTERN, $text, $matches, PREG_SET_ORDER);
+
+            foreach ($matches as $match) {
+                $fullMatch = $match[0];
+                $nodeType = $match[1];
+                $label = $match[2];
+
+                // Validate label name format
+                if (preg_match(self::LABEL_NAME_PATTERN, $label) !== 1) {
+                    throw new RuntimeException(
+                        sprintf(
+                            'Invalid label name "%s" at line %d. Labels must match /^[a-zA-Z][a-zA-Z0-9_-]*$/',
+                            $label,
+                            $targetLine,
+                        ),
+                    );
+                }
+
+                // Convert node type to FQN and validate it exists
+                $fqn = NodeTypeConverter::convertToFqn($nodeType, $label, $targetLine);
+
+                // Add to parsed labels (this also checks for duplicates)
+                $parsedLabels->addLabel($label, $fqn, $targetLine);
+            }
+        }
+    }
+}

--- a/tests/phpunit/TestingUtility/PhpParser/LabelParser/LabelParserTest.php
+++ b/tests/phpunit/TestingUtility/PhpParser/LabelParser/LabelParserTest.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestingUtility\PhpParser\LabelParser;
+
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Function_;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
+
+#[CoversClass(LabelParser::class)]
+#[CoversClass(ParsedLabels::class)]
+#[CoversClass(NodeTypeConverter::class)]
+final class LabelParserTest extends VisitorTestCase
+{
+    public function test_it_parses_suffix_comments(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            function foo() {  // @label:Stmt_Function:foo-func
+                $x = 1;  // @label:Expr_Variable:x-var
+            }
+            PHP;
+
+        $nodes = $this->parse($code);
+        $parser = new LabelParser();
+        $result = $parser->parseLabelsFromNodes($nodes);
+
+        $this->assertFalse($result->isEmpty());
+
+        // Function is on line 3
+        $labelsLine3 = $result->getLabelsForLine(3);
+        $this->assertNotNull($labelsLine3);
+        $this->assertArrayHasKey(Function_::class, $labelsLine3);
+        $this->assertSame('foo-func', $labelsLine3[Function_::class]);
+
+        // Variable is on line 4
+        $labelsLine4 = $result->getLabelsForLine(4);
+        $this->assertNotNull($labelsLine4);
+        $this->assertArrayHasKey(Variable::class, $labelsLine4);
+        $this->assertSame('x-var', $labelsLine4[Variable::class]);
+    }
+
+    public function test_it_parses_prefix_comments(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            // @label:Stmt_Function:bar-func
+            function bar() {
+                // @label:Expr_Variable:y-var
+                $y = 2;
+            }
+            PHP;
+
+        $nodes = $this->parse($code);
+        $parser = new LabelParser();
+        $result = $parser->parseLabelsFromNodes($nodes);
+
+        $this->assertFalse($result->isEmpty());
+
+        // Function is on line 4, but label is on line 3 (prefix)
+        $labelsLine4 = $result->getLabelsForLine(4);
+        $this->assertNotNull($labelsLine4);
+        $this->assertArrayHasKey(Function_::class, $labelsLine4);
+        $this->assertSame('bar-func', $labelsLine4[Function_::class]);
+
+        // Variable is on line 6, but label is on line 5 (prefix)
+        $labelsLine6 = $result->getLabelsForLine(6);
+        $this->assertNotNull($labelsLine6);
+        $this->assertArrayHasKey(Variable::class, $labelsLine6);
+        $this->assertSame('y-var', $labelsLine6[Variable::class]);
+    }
+
+    public function test_it_parses_block_comments(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            /* @label:Stmt_Function:baz-func */
+            function baz() {}
+            PHP;
+
+        $nodes = $this->parse($code);
+        $parser = new LabelParser();
+        $result = $parser->parseLabelsFromNodes($nodes);
+
+        $this->assertFalse($result->isEmpty());
+
+        $labelsLine4 = $result->getLabelsForLine(4);
+        $this->assertNotNull($labelsLine4);
+        $this->assertArrayHasKey(Function_::class, $labelsLine4);
+        $this->assertSame('baz-func', $labelsLine4[Function_::class]);
+    }
+
+    public function test_it_returns_empty_for_no_labels(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            function foo() {
+                $x = 1;
+            }
+            PHP;
+
+        $nodes = $this->parse($code);
+        $parser = new LabelParser();
+        $result = $parser->parseLabelsFromNodes($nodes);
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function test_it_allows_hyphens_and_underscores_in_labels(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            function foo() {  // @label:Stmt_Function:foo-func_123
+                return 1;
+            }
+            PHP;
+
+        $nodes = $this->parse($code);
+        $parser = new LabelParser();
+        $result = $parser->parseLabelsFromNodes($nodes);
+
+        $labelsLine3 = $result->getLabelsForLine(3);
+        $this->assertNotNull($labelsLine3);
+        $this->assertSame('foo-func_123', $labelsLine3[Function_::class]);
+    }
+
+    #[DataProvider('invalidLabelNameProvider')]
+    public function test_it_rejects_invalid_label_names(
+        string $code,
+        string $expectedMessage,
+    ): void {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $nodes = $this->parse($code);
+        $parser = new LabelParser();
+        $parser->parseLabelsFromNodes($nodes);
+    }
+
+    public static function invalidLabelNameProvider(): iterable
+    {
+        yield 'starts with number' => [
+            <<<'PHP'
+                <?php
+                function foo() {  // @label:Stmt_Function:123invalid
+                }
+                PHP,
+            'Invalid label name "123invalid" at line 2. Labels must match /^[a-zA-Z][a-zA-Z0-9_-]*$/',
+        ];
+
+        yield 'contains special characters' => [
+            <<<'PHP'
+                <?php
+                function foo() {  // @label:Stmt_Function:invalid@label
+                }
+                PHP,
+            'Invalid label name "invalid@label" at line 2. Labels must match /^[a-zA-Z][a-zA-Z0-9_-]*$/',
+        ];
+    }
+
+    public function test_it_throws_on_duplicate_labels(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            function foo() {  // @label:Stmt_Function:my-label
+            }
+
+            function bar() {  // @label:Stmt_Function:my-label
+            }
+            PHP;
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Duplicate label "my-label" found at lines 3 and 6. Each label must be unique within a traversal.');
+
+        $nodes = $this->parse($code);
+        $parser = new LabelParser();
+        $parser->parseLabelsFromNodes($nodes);
+    }
+
+    public function test_it_throws_on_invalid_node_type(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            function foo() {  // @label:Invalid_NodeType:my-label
+            }
+            PHP;
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid node type "Invalid_NodeType" for label "my-label" at line 3. Expected a valid PhpParser node type (e.g., Expr_Variable, Stmt_Function).');
+
+        $nodes = $this->parse($code);
+        $parser = new LabelParser();
+        $parser->parseLabelsFromNodes($nodes);
+    }
+}

--- a/tests/phpunit/TestingUtility/PhpParser/LabelParser/NodeTypeConverter.php
+++ b/tests/phpunit/TestingUtility/PhpParser/LabelParser/NodeTypeConverter.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestingUtility\PhpParser\LabelParser;
+
+use RuntimeException;
+use function class_exists;
+use function rtrim;
+use function sprintf;
+use function str_ends_with;
+use function str_replace;
+
+/**
+ * Converts NodeDumper format node types to fully qualified class names.
+ *
+ * Examples:
+ *   - Expr_Variable -> PhpParser\Node\Expr\Variable
+ *   - Expr_Cast_Int -> PhpParser\Node\Expr\Cast\Int_
+ *   - Stmt_Function -> PhpParser\Node\Stmt\Function_
+ *   - Scalar_String_ -> PhpParser\Node\Scalar\String_
+ */
+final class NodeTypeConverter
+{
+    /**
+     * @param string $nodeType Node type in NodeDumper format (e.g., "Expr_Variable")
+     * @param string $label Label name for error messages
+     * @param int $line Line number for error messages
+     *
+     * @return class-string Fully qualified class name
+     */
+    public static function convertToFqn(string $nodeType, string $label, int $line): string
+    {
+        // Check if the input ends with an underscore
+        // If so, that underscore is part of the class name, not a separator
+        $hasTrailingUnderscore = str_ends_with($nodeType, '_');
+
+        // If it has a trailing underscore, remove it for processing
+        if ($hasTrailingUnderscore) {
+            $nodeType = rtrim($nodeType, '_');
+        }
+
+        // Convert underscore-separated format to namespace format
+        // Example: Expr_Variable -> Expr\Variable
+        $namespacedType = str_replace('_', '\\', $nodeType);
+
+        // Add back the trailing underscore if it was present in the input
+        if ($hasTrailingUnderscore) {
+            $namespacedType .= '_';
+        }
+
+        // Prepend PhpParser\Node namespace
+        $fqn = 'PhpParser\\Node\\' . $namespacedType;
+
+        // Try the converted FQN
+        if (class_exists($fqn)) {
+            return $fqn;
+        }
+
+        // Some node classes have trailing underscores for PHP reserved keywords
+        // even if the input doesn't specify it (e.g., Stmt_Function -> Function_)
+        // Try adding a trailing underscore if we haven't already
+        if (!$hasTrailingUnderscore) {
+            $fqnWithUnderscore = $fqn . '_';
+
+            if (class_exists($fqnWithUnderscore)) {
+                return $fqnWithUnderscore;
+            }
+        }
+
+        // Neither worked, throw exception
+        throw new RuntimeException(
+            sprintf(
+                'Invalid node type "%s" for label "%s" at line %d. Expected a valid PhpParser node type (e.g., Expr_Variable, Stmt_Function).',
+                $nodeType,
+                $label,
+                $line,
+            ),
+        );
+    }
+}
+

--- a/tests/phpunit/TestingUtility/PhpParser/LabelParser/NodeTypeConverterTest.php
+++ b/tests/phpunit/TestingUtility/PhpParser/LabelParser/NodeTypeConverterTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestingUtility\PhpParser\LabelParser;
+
+use PhpParser\Node\Expr\Cast\Int_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Function_;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(NodeTypeConverter::class)]
+final class NodeTypeConverterTest extends TestCase
+{
+    #[DataProvider('validNodeTypeProvider')]
+    public function test_it_converts_valid_node_types_to_fqn(
+        string $nodeType,
+        string $expectedFqn,
+    ): void {
+        $actual = NodeTypeConverter::convertToFqn($nodeType, 'test-label', 1);
+
+        $this->assertSame($expectedFqn, $actual);
+    }
+
+    public static function validNodeTypeProvider(): iterable
+    {
+        yield 'simple expression' => [
+            'Expr_Variable',
+            Variable::class,
+        ];
+
+        yield 'statement with trailing underscore' => [
+            'Stmt_Function',
+            Function_::class,
+        ];
+
+        yield 'nested namespace' => [
+            'Expr_Cast_Int',
+            Int_::class,
+        ];
+
+        yield 'scalar with trailing underscore' => [
+            'Scalar_String_',
+            String_::class,
+        ];
+    }
+
+    #[DataProvider('invalidNodeTypeProvider')]
+    public function test_it_throws_exception_for_invalid_node_types(
+        string $nodeType,
+        string $label,
+        int $line,
+        string $expectedMessage,
+    ): void {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        NodeTypeConverter::convertToFqn($nodeType, $label, $line);
+    }
+
+    public static function invalidNodeTypeProvider(): iterable
+    {
+        yield 'nonexistent node type' => [
+            'Expr_NonExistent',
+            'my-label',
+            5,
+            'Invalid node type "Expr_NonExistent" for label "my-label" at line 5. Expected a valid PhpParser node type (e.g., Expr_Variable, Stmt_Function).',
+        ];
+
+        yield 'typo in node type' => [
+            'Expr_Variabel',
+            'typo-label',
+            10,
+            'Invalid node type "Expr_Variabel" for label "typo-label" at line 10. Expected a valid PhpParser node type (e.g., Expr_Variable, Stmt_Function).',
+        ];
+
+        yield 'completely invalid' => [
+            'NotANode',
+            'invalid',
+            1,
+            'Invalid node type "NotANode" for label "invalid" at line 1. Expected a valid PhpParser node type (e.g., Expr_Variable, Stmt_Function).',
+        ];
+    }
+}

--- a/tests/phpunit/TestingUtility/PhpParser/LabelParser/ParsedLabels.php
+++ b/tests/phpunit/TestingUtility/PhpParser/LabelParser/ParsedLabels.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestingUtility\PhpParser\LabelParser;
+
+use RuntimeException;
+use function array_key_exists;
+use function count;
+use function sprintf;
+
+/**
+ * Stores parsed label data mapping lines to node types and labels.
+ *
+ * Structure:
+ * - lineToLabels: [line => [FQN => label]]
+ * - labelToLine: [label => line] for duplicate detection
+ */
+final class ParsedLabels
+{
+    /**
+     * @var array<int, array<class-string, string>>
+     */
+    private array $lineToLabels = [];
+
+    /**
+     * @var array<string, int>
+     */
+    private array $labelToLine = [];
+
+    /**
+     * @param class-string $fqn
+     */
+    public function addLabel(string $label, string $fqn, int $line): void
+    {
+        // Check for duplicate labels
+        if (array_key_exists($label, $this->labelToLine)) {
+            $firstLine = $this->labelToLine[$label];
+
+            throw new RuntimeException(
+                sprintf(
+                    'Duplicate label "%s" found at lines %d and %d. Each label must be unique within a traversal.',
+                    $label,
+                    $firstLine,
+                    $line,
+                ),
+            );
+        }
+
+        // Store the label
+        if (!array_key_exists($line, $this->lineToLabels)) {
+            $this->lineToLabels[$line] = [];
+        }
+
+        $this->lineToLabels[$line][$fqn] = $label;
+        $this->labelToLine[$label] = $line;
+    }
+
+    public function isEmpty(): bool
+    {
+        return count($this->lineToLabels) === 0;
+    }
+
+    /**
+     * @return array<class-string, string>|null
+     */
+    public function getLabelsForLine(int $line): ?array
+    {
+        return $this->lineToLabels[$line] ?? null;
+    }
+
+    /**
+     * @return array<int, array<class-string, string>>
+     */
+    public function getAllLineToLabels(): array
+    {
+        return $this->lineToLabels;
+    }
+}

--- a/tests/phpunit/TestingUtility/PhpParser/Visitor/AssignLabelsToNodesVisitor/AssignLabelsToNodesVisitor.php
+++ b/tests/phpunit/TestingUtility/PhpParser/Visitor/AssignLabelsToNodesVisitor/AssignLabelsToNodesVisitor.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestingUtility\PhpParser\Visitor\AssignLabelsToNodesVisitor;
+
+use Infection\Tests\TestingUtility\PhpParser\LabelParser\ParsedLabels;
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use RuntimeException;
+use function array_key_exists;
+use function sprintf;
+
+/**
+ * Visitor that assigns labels to nodes based on parsed label data.
+ *
+ * Labels are stored as node attributes and can be retrieved via getNodeLabel().
+ */
+final class AssignLabelsToNodesVisitor extends NodeVisitorAbstract
+{
+    public const NODE_LABEL_ATTRIBUTE = 'nodeLabel';
+
+    /**
+     * @var array<string, Node>
+     */
+    private array $labeledNodes = [];
+
+    /**
+     * @var array<int, array<class-string, string>> Remaining unmatched labels
+     */
+    private array $unmatchedLabels;
+
+    /**
+     * @var array<int, array<class-string, true>> Track which types have been matched per line
+     */
+    private array $matchedTypesPerLine = [];
+
+    public function __construct(
+        private readonly ParsedLabels $parsedLabels,
+    ) {
+        $this->unmatchedLabels = $parsedLabels->getAllLineToLabels();
+    }
+
+    public static function getNodeLabel(Node $node): ?string
+    {
+        return $node->getAttribute(self::NODE_LABEL_ATTRIBUTE);
+    }
+
+    public function enterNode(Node $node): void
+    {
+        $line = $node->getStartLine();
+
+        if ($line === -1) {
+            return; // Node has no line information
+        }
+
+        // Check for labels on this line AND the line before (for prefix comments)
+        $linesToCheck = [$line];
+
+        if ($line > 1) {
+            $linesToCheck[] = $line - 1;
+        }
+
+        foreach ($linesToCheck as $lineToCheck) {
+            $labelsForLine = $this->parsedLabels->getLabelsForLine($lineToCheck);
+
+            if ($labelsForLine === null) {
+                continue; // No labels for this line
+            }
+
+            // Check each label on this line
+            foreach ($labelsForLine as $fqn => $label) {
+                $this->processLabel($node, $line, $lineToCheck, $fqn, $label);
+            }
+        }
+    }
+
+    private function processLabel(Node $node, int $nodeLine, int $labelLine, string $fqn, string $label): void
+    {
+        // Check if this node matches the FQN
+        if (!$node instanceof $fqn) {
+            return;
+        }
+
+        // Check if we already matched a node of this type on this label's line
+        if (array_key_exists($labelLine, $this->matchedTypesPerLine)
+            && array_key_exists($fqn, $this->matchedTypesPerLine[$labelLine])
+        ) {
+            throw new RuntimeException(
+                sprintf(
+                    'Multiple nodes of type "%s" found on line %d for label "%s". Please restructure the code to have one node per line, or use a prefix comment on a separate line.',
+                    $this->getShortNodeType($fqn),
+                    $labelLine,
+                    $label,
+                ),
+            );
+        }
+
+        // Mark this type as matched on the label's line
+        if (!array_key_exists($labelLine, $this->matchedTypesPerLine)) {
+            $this->matchedTypesPerLine[$labelLine] = [];
+        }
+
+        $this->matchedTypesPerLine[$labelLine][$fqn] = true;
+
+        // Store label in node attribute
+        $node->setAttribute(self::NODE_LABEL_ATTRIBUTE, $label);
+
+        // Add to labeled nodes map
+        $this->labeledNodes[$label] = $node;
+
+        // Remove from unmatched labels
+        unset($this->unmatchedLabels[$labelLine][$fqn]);
+
+        if (count($this->unmatchedLabels[$labelLine]) === 0) {
+            unset($this->unmatchedLabels[$labelLine]);
+        }
+    }
+
+    /**
+     * @return array<string, Node>
+     */
+    public function getLabeledNodes(): array
+    {
+        // Validate all labels were matched
+        foreach ($this->unmatchedLabels as $line => $nodeTypeToLabel) {
+            foreach ($nodeTypeToLabel as $fqn => $label) {
+                throw new RuntimeException(
+                    sprintf(
+                        'No node of type "%s" found for label "%s" at line %d',
+                        $this->getShortNodeType($fqn),
+                        $label,
+                        $line,
+                    ),
+                );
+            }
+        }
+
+        return $this->labeledNodes;
+    }
+
+    /**
+     * Convert FQN back to short node type for error messages.
+     *
+     * PhpParser\Node\Expr\Variable -> Expr_Variable
+     * PhpParser\Node\Stmt\Function_ -> Stmt_Function (removes trailing underscore)
+     *
+     * @param class-string $fqn
+     */
+    private function getShortNodeType(string $fqn): string
+    {
+        $shortType = str_replace('PhpParser\\Node\\', '', $fqn);
+        $shortType = str_replace('\\', '_', $shortType);
+
+        // Remove trailing underscore from reserved keyword class names
+        // (e.g., Function_, String_, Int_)
+        return rtrim($shortType, '_');
+    }
+}

--- a/tests/phpunit/TestingUtility/PhpParser/Visitor/AssignLabelsToNodesVisitor/AssignLabelsToNodesVisitorTest.php
+++ b/tests/phpunit/TestingUtility/PhpParser/Visitor/AssignLabelsToNodesVisitor/AssignLabelsToNodesVisitorTest.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\TestingUtility\PhpParser\Visitor\AssignLabelsToNodesVisitor;
+
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+use Infection\Tests\TestingUtility\PhpParser\LabelParser\LabelParser;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeTraverser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use RuntimeException;
+
+#[CoversClass(AssignLabelsToNodesVisitor::class)]
+final class AssignLabelsToNodesVisitorTest extends VisitorTestCase
+{
+    public function test_it_assigns_labels_to_nodes(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            function foo() {  // @label:Stmt_Function:foo-func
+                return 1;  // @label:Stmt_Return:return-stmt
+            }
+            PHP;
+
+        $nodes = $this->parse($code);
+
+        $labelParser = new LabelParser();
+        $parsedLabels = $labelParser->parseLabelsFromNodes($nodes);
+
+        $visitor = new AssignLabelsToNodesVisitor($parsedLabels);
+        (new NodeTraverser($visitor))->traverse($nodes);
+
+        $labeledNodes = $visitor->getLabeledNodes();
+
+        $this->assertCount(2, $labeledNodes);
+        $this->assertArrayHasKey('foo-func', $labeledNodes);
+        $this->assertArrayHasKey('return-stmt', $labeledNodes);
+
+        $fooFunc = $labeledNodes['foo-func'];
+        $this->assertInstanceOf(Function_::class, $fooFunc);
+        $this->assertSame('foo-func', AssignLabelsToNodesVisitor::getNodeLabel($fooFunc));
+
+        $returnStmt = $labeledNodes['return-stmt'];
+        $this->assertInstanceOf(Return_::class, $returnStmt);
+        $this->assertSame('return-stmt', AssignLabelsToNodesVisitor::getNodeLabel($returnStmt));
+    }
+
+    public function test_it_throws_when_multiple_nodes_of_same_type_on_line(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            $x = $y;  // @label:Expr_Variable:first-var
+            PHP;
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Multiple nodes of type "Expr_Variable" found on line 3 for label "first-var". Please restructure the code to have one node per line, or use a prefix comment on a separate line.');
+
+        $nodes = $this->parse($code);
+
+        $labelParser = new LabelParser();
+        $parsedLabels = $labelParser->parseLabelsFromNodes($nodes);
+
+        $visitor = new AssignLabelsToNodesVisitor($parsedLabels);
+        (new NodeTraverser($visitor))->traverse($nodes);
+        $visitor->getLabeledNodes();
+    }
+
+    public function test_it_throws_when_node_type_not_found_on_line(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            $x = 1;  // @label:Stmt_Function:my-func
+            PHP;
+
+        $nodes = $this->parse($code);
+
+        $labelParser = new LabelParser();
+        $parsedLabels = $labelParser->parseLabelsFromNodes($nodes);
+
+        $visitor = new AssignLabelsToNodesVisitor($parsedLabels);
+        (new NodeTraverser($visitor))->traverse($nodes);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No node of type "Stmt_Function" found for label "my-func" at line 3');
+
+        $visitor->getLabeledNodes();
+    }
+
+    public function test_it_allows_multiple_labels_for_different_types_on_same_line(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            $x = foo();  // @label:Expr_Variable:x-var @label:Expr_FuncCall:call
+            PHP;
+
+        $nodes = $this->parse($code);
+
+        $labelParser = new LabelParser();
+        $parsedLabels = $labelParser->parseLabelsFromNodes($nodes);
+
+        $visitor = new AssignLabelsToNodesVisitor($parsedLabels);
+        (new NodeTraverser($visitor))->traverse($nodes);
+
+        $labeledNodes = $visitor->getLabeledNodes();
+
+        $this->assertCount(2, $labeledNodes);
+        $this->assertArrayHasKey('x-var', $labeledNodes);
+        $this->assertArrayHasKey('call', $labeledNodes);
+
+        $xVar = $labeledNodes['x-var'];
+        $this->assertInstanceOf(Variable::class, $xVar);
+
+        // Note: FuncCall would be Expr\FuncCall but the test code uses an undefined function
+        // which PhpParser represents as Name, not FuncCall in this context
+        $this->assertArrayHasKey('call', $labeledNodes);
+    }
+
+    public function test_it_handles_prefix_comments(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            // @label:Expr_Variable:first-var
+            $x = $y;
+            PHP;
+
+        $nodes = $this->parse($code);
+
+        $labelParser = new LabelParser();
+        $parsedLabels = $labelParser->parseLabelsFromNodes($nodes);
+
+        $visitor = new AssignLabelsToNodesVisitor($parsedLabels);
+        (new NodeTraverser($visitor))->traverse($nodes);
+
+        $labeledNodes = $visitor->getLabeledNodes();
+
+        $this->assertCount(1, $labeledNodes);
+        $this->assertArrayHasKey('first-var', $labeledNodes);
+
+        $xVar = $labeledNodes['first-var'];
+        $this->assertInstanceOf(Variable::class, $xVar);
+    }
+}


### PR DESCRIPTION
List of places spotted that can leverage this:

- `MarkTraversedEligibleNodesAsVisitedVisitor`
- `FullyQualifiedClassNameManipulatorTest`
- `NextConnectingVisitorTest`

<hr/>

## Description

This is a follow up of https://github.com/infection/infection/pull/2948.

The current `VisitorTestCase::addIdsToNodes()` returns nodes indexed by sequential numeric IDs (0, 1, 2, ...). When the parsed code changes, all IDs shift, causing tests to break even if the specific node under test didn't change.

This PR introduces a feature to allow labelling specific nodes via comments in the test code. Labels serve as stable identifiers that don't change when unrelated code is modified.

```php
<?php

function foo() {  // @label:Stmt_Function:foo-function
    $x = 1;  // @label:Expr_Variable:x-var
    return $x;  // @label:Stmt_Return:return-stmt
}
```

There is still value in the sequential IDs as they are automated and can be used when dumping the AST, but those labels can offer a better API for when one wants to select a specific node.


## Reviewer Notes

I had a look at the code, I briefly let Claude do its thing after babysitting its specs. Not happy with it, I'll update it when I get. a chance, but on principle it works.