### PR TITLE
test(ast): Add a test for the VisitorTestCase

### DIFF
--- a/tests/phpunit/PhpParser/Visitor/IgnoreAllMutationsAnnotationReaderVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/IgnoreAllMutationsAnnotationReaderVisitorTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\PhpParser\Visitor;
 use Infection\PhpParser\Visitor\IgnoreAllMutationsAnnotationReaderVisitor;
 use Infection\PhpParser\Visitor\IgnoreNode\ChangingIgnorer;
 use Infection\PhpParser\Visitor\NonMutableNodesIgnorerVisitor;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
 use Infection\Tests\TestingUtility\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitor;
 use PhpParser\NodeTraverser;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/phpunit/PhpParser/Visitor/IgnoreNode/AbstractMethodIgnorerTest.php
+++ b/tests/phpunit/PhpParser/Visitor/IgnoreNode/AbstractMethodIgnorerTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\PhpParser\Visitor\IgnoreNode;
 
 use Infection\PhpParser\Visitor\IgnoreNode\AbstractMethodIgnorer;
 use Infection\PhpParser\Visitor\NonMutableNodesIgnorerVisitor;
-use Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
 use Infection\Tests\TestingUtility\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitor;
 use PhpParser\NodeTraverser;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/phpunit/PhpParser/Visitor/IgnoreNode/ChangingIgnorer/ChangingIgnorerTest.php
+++ b/tests/phpunit/PhpParser/Visitor/IgnoreNode/ChangingIgnorer/ChangingIgnorerTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\PhpParser\Visitor\IgnoreNode\ChangingIgnorer;
 
 use Infection\PhpParser\Visitor\IgnoreNode\ChangingIgnorer;
 use Infection\PhpParser\Visitor\NonMutableNodesIgnorerVisitor;
-use Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
 use Infection\Tests\TestingUtility\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitor;
 use PhpParser\NodeTraverser;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/phpunit/PhpParser/Visitor/IgnoreNode/InterfaceIgnorerTest.php
+++ b/tests/phpunit/PhpParser/Visitor/IgnoreNode/InterfaceIgnorerTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\PhpParser\Visitor\IgnoreNode;
 
 use Infection\PhpParser\Visitor\IgnoreNode\InterfaceIgnorer;
 use Infection\PhpParser\Visitor\NonMutableNodesIgnorerVisitor;
-use Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
 use Infection\Tests\TestingUtility\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitor;
 use PhpParser\NodeTraverser;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/phpunit/PhpParser/Visitor/NextConnectingVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/NextConnectingVisitorTest.php
@@ -39,6 +39,7 @@ use function array_map;
 use function explode;
 use function implode;
 use Infection\PhpParser\Visitor\NextConnectingVisitor;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\NodeTraverser;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitor/NonMutableNodesIgnorerVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/NonMutableNodesIgnorerVisitor/NonMutableNodesIgnorerVisitorTest.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\PhpParser\Visitor\NonMutableNodesIgnorerVisitor;
 
 use Infection\PhpParser\Visitor\NonMutableNodesIgnorerVisitor;
-use Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
 use Infection\Tests\TestingUtility\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitor;
 use PhpParser\NodeTraverser;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/phpunit/PhpParser/Visitor/README.md
+++ b/tests/phpunit/PhpParser/Visitor/README.md
@@ -26,9 +26,7 @@ Create your test class by extending `VisitorTestCase`:
 
 namespace Infection\Tests\PhpParser\Visitor;
 
-use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
-use YourNamespace\YourVisitor;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;use PHPUnit\Framework\Attributes\CoversClass;use PHPUnit\Framework\Attributes\DataProvider;use YourNamespace\YourVisitor;
 
 #[CoversClass(YourVisitor::class)]
 final class YourVisitorTest extends VisitorTestCase

--- a/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\PhpParser\Visitor;
 
 use Infection\PhpParser\Visitor\ReflectionVisitor;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
 use Infection\Tests\TestingUtility\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitor;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;

--- a/tests/phpunit/PhpParser/Visitor/VisitorCollectorIntegration/VisitorCollectorIntegrationTest.php
+++ b/tests/phpunit/PhpParser/Visitor/VisitorCollectorIntegration/VisitorCollectorIntegrationTest.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\PhpParser\Visitor\VisitorCollectorIntegration;
 
 use Infection\Testing\SingletonContainer;
-use Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
 use Infection\Tests\TestingUtility\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitor;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/phpunit/PhpParser/Visitor/VisitorTestCase/ConcreteVisitorTestCase.php
+++ b/tests/phpunit/PhpParser/Visitor/VisitorTestCase/ConcreteVisitorTestCase.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+
+use PhpParser\Node;
+
+final class ConcreteVisitorTestCase extends VisitorTestCase
+{
+    /**
+     * @return Node\Stmt[]
+     */
+    public function parseCode(string $code): array
+    {
+        return $this->parse($code);
+    }
+
+    /**
+     * @param Node[]|Node $nodeOrNodes
+     *
+     * @return array<positive-int|0, Node>
+     */
+    public function addIdsToNodesPublic(array|Node $nodeOrNodes): array
+    {
+        return $this->addIdsToNodes($nodeOrNodes);
+    }
+
+    /**
+     * @param Node[]|Node $nodeOrNodes
+     */
+    public function keepOnlyDesiredAttributesPublic(
+        array|Node $nodeOrNodes,
+        string ...$attributes,
+    ): void {
+        $this->keepOnlyDesiredAttributes($nodeOrNodes, ...$attributes);
+    }
+}

--- a/tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCase.php
+++ b/tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCase.php
@@ -33,7 +33,7 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\PhpParser\Visitor;
+namespace Infection\Tests\PhpParser\Visitor\VisitorTestCase;
 
 use Infection\Testing\SingletonContainer;
 use Infection\Tests\TestingUtility\PhpParser\NodeDumper\NodeDumper;

--- a/tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php
+++ b/tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+
+use Infection\Tests\TestingUtility\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitor;
+use PhpParser\Node;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(VisitorTestCase::class)]
+final class VisitorTestCaseTest extends TestCase
+{
+    private ConcreteVisitorTestCase $testCase;
+
+    protected function setUp(): void
+    {
+        $this->testCase = new ConcreteVisitorTestCase('test');
+        $this->testCase->setUp();
+    }
+
+    public function test_parse_returns_non_null_nodes(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            $a = 1;
+            PHP;
+
+        $nodes = $this->testCase->parseCode($code);
+
+        $this->assertCount(1, $nodes);
+    }
+
+    public function test_add_ids_to_nodes_returns_map_with_node_ids(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            $a = 1;
+            $b = 2;
+            PHP;
+
+        $nodes = $this->testCase->parseCode($code);
+
+        $nodesById = $this->testCase->addIdsToNodesPublic($nodes);
+
+        $this->assertIsArray($nodesById);
+        $this->assertNotEmpty($nodesById);
+
+        foreach ($nodesById as $id => $node) {
+            $this->assertIsInt($id);
+            $this->assertGreaterThanOrEqual(0, $id);
+            $this->assertInstanceOf(Node::class, $node);
+            $this->assertSame($id, AddIdToTraversedNodesVisitor::getNodeId($node));
+        }
+    }
+
+    public function test_keep_only_desired_attributes_filters_attributes(): void
+    {
+        $code = <<<'PHP'
+            <?php
+
+            $a = 1;
+            PHP;
+
+        $nodes = $this->testCase->parseCode($code);
+
+        $firstNode = $nodes[0];
+
+        $firstNode->setAttribute('custom1', 'value1');
+        $firstNode->setAttribute('custom2', 'value2');
+        $firstNode->setAttribute('custom3', 'value3');
+
+        $this->testCase->keepOnlyDesiredAttributesPublic(
+            [$firstNode],
+            'custom1',
+            'custom3',
+        );
+
+        $expected = [
+            'custom1' => 'value1',
+            'custom3' => 'value3',
+        ];
+
+        $actual = $firstNode->getAttributes();
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/phpunit/TestingUtility/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php
+++ b/tests/phpunit/TestingUtility/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestingUtility\PhpParser\Visitor\AddIdToTraversedNodesVisitor;
 
-use Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;

--- a/tests/phpunit/TestingUtility/PhpParser/Visitor/KeepOnlyDesiredAttributesVisitor/KeepOnlyDesiredAttributesVisitorTest.php
+++ b/tests/phpunit/TestingUtility/PhpParser/Visitor/KeepOnlyDesiredAttributesVisitor/KeepOnlyDesiredAttributesVisitorTest.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestingUtility\PhpParser\Visitor\KeepOnlyDesiredAttributesVisitor;
 
-use Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/phpunit/TestingUtility/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php
+++ b/tests/phpunit/TestingUtility/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestingUtility\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor;
 
-use Infection\Tests\PhpParser\Visitor\VisitorTestCase;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PHPUnit\Framework\Attributes\CoversClass;


### PR DESCRIPTION
Add a (basic) test for `VisitorTestCase`.

It is a utility that is used quite a lot and for which its behaviour may be subject to change, it is easier to ensure it works as expected with a dedicated test rather than relying on any test case implementing it potentially failing after a change.