### PR TITLE
test(ast): Improve the ParentConnectorTest

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -1114,12 +1114,6 @@ parameters:
 			rawMessage: 'Call to internal method PHPUnit\Framework\TestCase::addToAssertionCount() from outside its root namespace PHPUnit.'
 			identifier: method.internal
 			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php
-
-		-
-			rawMessage: 'Call to internal method PHPUnit\Framework\TestCase::addToAssertionCount() from outside its root namespace PHPUnit.'
-			identifier: method.internal
-			count: 1
 			path: ../tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
 
 		-


### PR DESCRIPTION
Improves the test of `ParentConnector` by testing its behaviour in a more realistic environment instead of artificially testing setAttributes/getAttributes().

I also added a test to capture the behaviour of `ParentConnectingVisitor`. It is thrid-party code (from PHP-Parser), but as much as to ensure it behaves as we expect, it also allows to show its effects in the generated AST.