### PR TITLE
refactor(event): Extract MutationTestingConsoleSubscriber::showMetrics() to a reporter

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -118,6 +118,7 @@ use Infection\Reporter\FileLocationReporter;
 use Infection\Reporter\FileReporterFactory;
 use Infection\Reporter\Html\StrykerHtmlReportBuilder;
 use Infection\Reporter\Reporter;
+use Infection\Reporter\ShowMetricsReporter;
 use Infection\Reporter\ShowMutationsReporter;
 use Infection\Reporter\StrykerReporterFactory;
 use Infection\Resource\Listener\PerformanceLoggerSubscriber;
@@ -439,7 +440,6 @@ final class Container extends DIContainer
                 return new MutationTestingConsoleLoggerSubscriber(
                     $output,
                     $container->getMutationAnalysisLogger(),
-                    $container->getMetricsCalculator(),
                     new ShowMutationsReporter(
                         $output,
                         $container->getResultsCollector(),
@@ -448,12 +448,16 @@ final class Container extends DIContainer
                         !$config->mutateOnlyCoveredCode(),
                         $config->timeoutsAsEscaped,
                     ),
+                    new ShowMetricsReporter(
+                        $output,
+                        $container->getMetricsCalculator(),
+                        !$config->mutateOnlyCoveredCode(),
+                    ),
                     new FileLocationReporter(
                         $container->getReporter(),
                         $output,
                         $config->numberOfShownMutations,
                     ),
-                    !$config->mutateOnlyCoveredCode(),
                 );
             },
             PerformanceLoggerSubscriber::class => static fn (self $container): PerformanceLoggerSubscriber => new PerformanceLoggerSubscriber(

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Event\Subscriber;
 
 use function count;
-use function floor;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinishedSubscriber;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationWasStarted;
@@ -49,11 +48,7 @@ use Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationTestingWasStartedSubscriber;
 use Infection\Framework\Iterable\IterableCounter;
 use Infection\Logger\MutationAnalysis\MutationAnalysisLogger;
-use Infection\Metrics\MetricsCalculator;
 use Infection\Reporter\Reporter;
-use function str_pad;
-use const STR_PAD_LEFT;
-use function str_repeat;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -62,12 +57,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MutationTestingConsoleLoggerSubscriber implements MutableFileWasProcessedSubscriber, MutantProcessWasFinishedSubscriber, MutationEvaluationWasStartedSubscriber, MutationTestingWasFinishedSubscriber, MutationTestingWasStartedSubscriber
 {
-    private const PAD_LENGTH = 8;
-
-    private const LOW_QUALITY_THRESHOLD = 50;
-
-    private const MEDIUM_QUALITY_THRESHOLD = 90;
-
     /**
      * @var positive-int|IterableCounter::UNKNOWN_COUNT
      */
@@ -76,10 +65,9 @@ final class MutationTestingConsoleLoggerSubscriber implements MutableFileWasProc
     public function __construct(
         private readonly OutputInterface $output,
         private readonly MutationAnalysisLogger $logger,
-        private readonly MetricsCalculator $metricsCalculator,
         private readonly Reporter $showMutationsReporter,
+        private readonly Reporter $showMetricsReporter,
         private readonly Reporter $reporter,
-        private readonly bool $withUncovered,
     ) {
     }
 
@@ -117,97 +105,9 @@ final class MutationTestingConsoleLoggerSubscriber implements MutableFileWasProc
         $this->logger->finishAnalysis();
 
         $this->showMutationsReporter->report();
-
-        $this->showMetrics();
+        $this->showMetricsReporter->report();
         $this->reporter->report();
 
         $this->output->writeln(['', 'Please note that some mutants will inevitably be harmless (i.e. false positives).']);
-    }
-
-    private function showMetrics(): void
-    {
-        $this->output->writeln(['', '']);
-        $this->output->writeln('<options=bold>' . $this->metricsCalculator->getTotalMutantsCount() . '</options=bold> mutations were generated:');
-        $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getKilledByTestsCount()) . '</options=bold> mutants were killed by Test Framework');
-
-        if ($this->metricsCalculator->getKilledByStaticAnalysisCount() > 0) {
-            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getKilledByStaticAnalysisCount()) . '</options=bold> mutants were caught by Static Analysis');
-        }
-
-        if ($this->metricsCalculator->getIgnoredCount() > 0) {
-            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getIgnoredCount()) . '</options=bold> mutants were configured to be ignored');
-        }
-
-        if ($this->metricsCalculator->getNotTestedCount() > 0) {
-            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getNotTestedCount()) . '</options=bold> mutants were not covered by tests');
-        }
-
-        if ($this->metricsCalculator->getEscapedCount() > 0) {
-            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getEscapedCount()) . '</options=bold> covered mutants were not detected');
-        }
-
-        if ($this->metricsCalculator->getErrorCount() > 0) {
-            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getErrorCount()) . '</options=bold> errors were encountered');
-        }
-
-        if ($this->metricsCalculator->getSyntaxErrorCount() > 0) {
-            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getSyntaxErrorCount()) . '</options=bold> syntax errors were encountered');
-        }
-
-        if ($this->metricsCalculator->getTimedOutCount() > 0) {
-            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getTimedOutCount()) . '</options=bold> time outs were encountered');
-        }
-
-        if ($this->metricsCalculator->getSkippedCount() > 0) {
-            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getSkippedCount()) . '</options=bold> mutants required more time than configured');
-        }
-
-        $mutationScoreIndicator = floor($this->metricsCalculator->getMutationScoreIndicator());
-        $msiTag = $this->getPercentageTag($mutationScoreIndicator);
-
-        $coverageRate = floor($this->metricsCalculator->getCoverageRate());
-        $mutationCoverageTag = $this->getPercentageTag($coverageRate);
-
-        $coveredMsi = floor($this->metricsCalculator->getCoveredCodeMutationScoreIndicator());
-        $coveredMsiTag = $this->getPercentageTag($coveredMsi);
-
-        $this->output->writeln(['', 'Metrics:']);
-
-        if ($this->withUncovered) {
-            $this->output->writeln(
-                $this->addIndentation("Mutation Score Indicator (MSI): <{$msiTag}>{$mutationScoreIndicator}%</{$msiTag}>"),
-            );
-        }
-
-        $this->output->writeln(
-            $this->addIndentation("Mutation Code Coverage: <{$mutationCoverageTag}>{$coverageRate}%</{$mutationCoverageTag}>"),
-        );
-
-        $this->output->writeln(
-            $this->addIndentation("Covered Code MSI: <{$coveredMsiTag}>{$coveredMsi}%</{$coveredMsiTag}>"),
-        );
-    }
-
-    private function getPadded(int|string $subject, int $padLength = self::PAD_LENGTH): string
-    {
-        return str_pad((string) $subject, $padLength, ' ', STR_PAD_LEFT);
-    }
-
-    private function addIndentation(string $string): string
-    {
-        return str_repeat(' ', self::PAD_LENGTH + 1) . $string;
-    }
-
-    private function getPercentageTag(float $percentage): string
-    {
-        if ($percentage >= 0 && $percentage < self::LOW_QUALITY_THRESHOLD) {
-            return 'low';
-        }
-
-        if ($percentage >= self::LOW_QUALITY_THRESHOLD && $percentage < self::MEDIUM_QUALITY_THRESHOLD) {
-            return 'medium';
-        }
-
-        return 'high';
     }
 }

--- a/src/Reporter/ShowMetricsReporter.php
+++ b/src/Reporter/ShowMetricsReporter.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Reporter;
+
+use function floor;
+use Infection\Metrics\MetricsCalculator;
+use function str_pad;
+use const STR_PAD_LEFT;
+use function str_repeat;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final readonly class ShowMetricsReporter implements Reporter
+{
+    private const PAD_LENGTH = 8;
+
+    private const LOW_QUALITY_THRESHOLD = 50;
+
+    private const MEDIUM_QUALITY_THRESHOLD = 90;
+
+    public function __construct(
+        private OutputInterface $output,
+        private MetricsCalculator $metricsCalculator,
+        private bool $withUncovered,
+    ) {
+    }
+
+    public function report(): void
+    {
+        $this->output->writeln(['', '']);
+        $this->output->writeln('<options=bold>' . $this->metricsCalculator->getTotalMutantsCount() . '</options=bold> mutations were generated:');
+        $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getKilledByTestsCount()) . '</options=bold> mutants were killed by Test Framework');
+
+        if ($this->metricsCalculator->getKilledByStaticAnalysisCount() > 0) {
+            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getKilledByStaticAnalysisCount()) . '</options=bold> mutants were caught by Static Analysis');
+        }
+
+        if ($this->metricsCalculator->getIgnoredCount() > 0) {
+            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getIgnoredCount()) . '</options=bold> mutants were configured to be ignored');
+        }
+
+        if ($this->metricsCalculator->getNotTestedCount() > 0) {
+            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getNotTestedCount()) . '</options=bold> mutants were not covered by tests');
+        }
+
+        if ($this->metricsCalculator->getEscapedCount() > 0) {
+            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getEscapedCount()) . '</options=bold> covered mutants were not detected');
+        }
+
+        if ($this->metricsCalculator->getErrorCount() > 0) {
+            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getErrorCount()) . '</options=bold> errors were encountered');
+        }
+
+        if ($this->metricsCalculator->getSyntaxErrorCount() > 0) {
+            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getSyntaxErrorCount()) . '</options=bold> syntax errors were encountered');
+        }
+
+        if ($this->metricsCalculator->getTimedOutCount() > 0) {
+            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getTimedOutCount()) . '</options=bold> time outs were encountered');
+        }
+
+        if ($this->metricsCalculator->getSkippedCount() > 0) {
+            $this->output->writeln('<options=bold>' . $this->getPadded($this->metricsCalculator->getSkippedCount()) . '</options=bold> mutants required more time than configured');
+        }
+
+        $mutationScoreIndicator = floor($this->metricsCalculator->getMutationScoreIndicator());
+        $msiTag = $this->getPercentageTag($mutationScoreIndicator);
+
+        $coverageRate = floor($this->metricsCalculator->getCoverageRate());
+        $mutationCoverageTag = $this->getPercentageTag($coverageRate);
+
+        $coveredMsi = floor($this->metricsCalculator->getCoveredCodeMutationScoreIndicator());
+        $coveredMsiTag = $this->getPercentageTag($coveredMsi);
+
+        $this->output->writeln(['', 'Metrics:']);
+
+        if ($this->withUncovered) {
+            $this->output->writeln(
+                $this->addIndentation("Mutation Score Indicator (MSI): <{$msiTag}>{$mutationScoreIndicator}%</{$msiTag}>"),
+            );
+        }
+
+        $this->output->writeln(
+            $this->addIndentation("Mutation Code Coverage: <{$mutationCoverageTag}>{$coverageRate}%</{$mutationCoverageTag}>"),
+        );
+
+        $this->output->writeln(
+            $this->addIndentation("Covered Code MSI: <{$coveredMsiTag}>{$coveredMsi}%</{$coveredMsiTag}>"),
+        );
+    }
+
+    private function getPadded(int|string $subject, int $padLength = self::PAD_LENGTH): string
+    {
+        return str_pad((string) $subject, $padLength, ' ', STR_PAD_LEFT);
+    }
+
+    private function addIndentation(string $string): string
+    {
+        return str_repeat(' ', self::PAD_LENGTH + 1) . $string;
+    }
+
+    private function getPercentageTag(float $percentage): string
+    {
+        if ($percentage >= 0 && $percentage < self::LOW_QUALITY_THRESHOLD) {
+            return 'low';
+        }
+
+        if ($percentage >= self::LOW_QUALITY_THRESHOLD && $percentage < self::MEDIUM_QUALITY_THRESHOLD) {
+            return 'medium';
+        }
+
+        return 'high';
+    }
+}

--- a/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberTest.php
@@ -40,27 +40,17 @@ use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasF
 use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted;
 use Infection\Event\Subscriber\MutationTestingConsoleLoggerSubscriber;
-use Infection\Framework\Str;
 use Infection\Logger\MutationAnalysis\MutationAnalysisLogger;
-use Infection\Metrics\MetricsCalculator;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Process\Runner\ProcessRunner;
 use Infection\Reporter\Reporter;
 use Infection\Tests\Reporter\NullReporter;
-use const PHP_EOL;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use function Safe\fopen;
-use function Safe\rewind;
-use function Safe\stream_get_contents;
-use function str_replace;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\StreamOutput;
 
 #[Group('integration')]
 #[CoversClass(MutationTestingConsoleLoggerSubscriber::class)]
@@ -68,12 +58,9 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
 {
     private MockObject&MutationAnalysisLogger $logger;
 
-    private MockObject&MetricsCalculator $metricsCalculator;
-
     protected function setUp(): void
     {
         $this->logger = $this->createMock(MutationAnalysisLogger::class);
-        $this->metricsCalculator = $this->createMock(MetricsCalculator::class);
     }
 
     public function test_it_reacts_on_mutation_testing_started(): void
@@ -86,10 +73,9 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
         $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
             $this->createStub(OutputInterface::class),
             $this->logger,
-            $this->metricsCalculator,
             new NullReporter(),
             new NullReporter(),
-            withUncovered: true,
+            new NullReporter(),
         ));
 
         $processRunner = $this->createStub(ProcessRunner::class);
@@ -99,10 +85,6 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
 
     public function test_it_reacts_on_mutation_process_finished(): void
     {
-        $this->metricsCalculator
-            ->expects($this->never())
-            ->method('collect');
-
         $this->logger
             ->expects($this->once())
             ->method('finishEvaluation');
@@ -111,10 +93,9 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
         $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
             $this->createStub(OutputInterface::class),
             $this->logger,
-            $this->metricsCalculator,
             new NullReporter(),
             new NullReporter(),
-            withUncovered: true,
+            new NullReporter(),
         ));
 
         $dispatcher->dispatch(
@@ -134,432 +115,23 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
         $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
             $this->createStub(OutputInterface::class),
             $this->logger,
-            $this->metricsCalculator,
             new NullReporter(),
             new NullReporter(),
-            withUncovered: true,
+            new NullReporter(),
         ));
 
         $dispatcher->dispatch(new MutationTestingWasFinished());
-    }
-
-    public function test_it_does_not_output_escaped_mutants_when_mutation_testing_is_finished_with_no_escaped_mutants(): void
-    {
-        $output = new StreamOutput(fopen('php://memory', 'w'));
-
-        $this->metricsCalculator
-            ->method('getKilledByTestsCount')
-            ->willReturn(0);
-        // less important metrics, only rendered when > 0
-        $this->metricsCalculator
-            ->method('getKilledByStaticAnalysisCount')
-            ->willReturn(0);
-        $this->metricsCalculator
-            ->method('getIgnoredCount')
-            ->willReturn(0);
-        $this->metricsCalculator
-            ->method('getNotTestedCount')
-            ->willReturn(0);
-        $this->metricsCalculator
-            ->method('getEscapedCount')
-            ->willReturn(0);
-        $this->metricsCalculator
-            ->method('getErrorCount')
-            ->willReturn(0);
-        $this->metricsCalculator
-            ->method('getSyntaxErrorCount')
-            ->willReturn(0);
-        $this->metricsCalculator
-            ->method('getTimedOutCount')
-            ->willReturn(0);
-        $this->metricsCalculator
-            ->method('getSkippedCount')
-            ->willReturn(0);
-
-        $dispatcher = new SyncEventDispatcher();
-        $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
-            $output,
-            $this->logger,
-            $this->metricsCalculator,
-            new NullReporter(),
-            new NullReporter(),
-            withUncovered: true,
-        ));
-
-        $dispatcher->dispatch(new MutationTestingWasFinished());
-
-        $this->assertStringContainsString(
-            "\n\nMetrics:\n",
-            $this->getDisplay($output),
-        );
-
-        $this->assertStringContainsString(
-            "\n\n0 mutations were generated:",
-            $this->getDisplay($output),
-        );
-
-        // contains
-        $this->assertStringContainsString(
-            '       0 mutants were killed by Test Framework',
-            $this->getDisplay($output),
-        );
-
-        // not contains
-        $this->assertStringNotContainsString(
-            'mutants were caught by Static Analysis',
-            $this->getDisplay($output),
-        );
-        $this->assertStringNotContainsString(
-            'mutants were configured to be ignored',
-            $this->getDisplay($output),
-        );
-        $this->assertStringNotContainsString(
-            'mutants were not covered by tests',
-            $this->getDisplay($output),
-        );
-        $this->assertStringNotContainsString(
-            'covered mutants were not detected',
-            $this->getDisplay($output),
-        );
-        $this->assertStringNotContainsString(
-            'errors were encountered',
-            $this->getDisplay($output),
-        );
-        $this->assertStringNotContainsString(
-            'syntax errors were encountered',
-            $this->getDisplay($output),
-        );
-        $this->assertStringNotContainsString(
-            'time outs were encountered',
-            $this->getDisplay($output),
-        );
-        $this->assertStringNotContainsString(
-            'mutants required more time than configured',
-            $this->getDisplay($output),
-        );
-    }
-
-    #[DataProvider('metricsProvider')]
-    public function test_it_show_the_metrics(MetricsScenario $scenario): void
-    {
-        $output = new BufferedOutput();
-
-        $this->configureMetricsCalculatorMock($scenario);
-
-        $dispatcher = new SyncEventDispatcher();
-        $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
-            $output,
-            $this->logger,
-            $this->metricsCalculator,
-            new NullReporter(),
-            new NullReporter(),
-            withUncovered: $scenario->withUncovered,
-        ));
-
-        $dispatcher->dispatch(new MutationTestingWasFinished());
-
-        $actual = Str::toUnixLineEndings($output->fetch());
-
-        $this->assertSame($scenario->expected, $actual);
-    }
-
-    public static function metricsProvider(): iterable
-    {
-        $emptyScenario = new MetricsScenario(
-            withUncovered: false,
-            timeoutsAsEscaped: false,
-            killedByTestsCount: 0,
-            killedByStaticAnalysisCount: 0,
-            errorCount: 0,
-            syntaxErrorCount: 0,
-            skippedCount: 0,
-            ignoredCount: 0,
-            escapedCount: 0,
-            timedOutCount: 0,
-            notTestedCount: 0,
-            totalMutantsCount: 0,
-            mutationScoreIndicator: 0.,
-            coverageRate: 0.,
-            coveredCodeMutationScoreIndicator: 0.,
-            expected: <<<'DISPLAY'
-
-
-                0 mutations were generated:
-                       0 mutants were killed by Test Framework
-
-                Metrics:
-                         Mutation Code Coverage: <low>0%</low>
-                         Covered Code MSI: <low>0%</low>
-
-                Please note that some mutants will inevitably be harmless (i.e. false positives).
-
-                DISPLAY,
-        );
-
-        $completeScenario = new MetricsScenario(
-            withUncovered: false,
-            timeoutsAsEscaped: false,
-            killedByTestsCount: 3,
-            killedByStaticAnalysisCount: 2,
-            errorCount: 1,
-            syntaxErrorCount: 10,
-            skippedCount: 2,
-            ignoredCount: 1,
-            escapedCount: 4,
-            timedOutCount: 2,
-            notTestedCount: 3,
-            totalMutantsCount: 6,
-            mutationScoreIndicator: 52.,
-            coverageRate: 42.,
-            coveredCodeMutationScoreIndicator: 74.,
-            expected: <<<'DISPLAY'
-
-
-                6 mutations were generated:
-                       3 mutants were killed by Test Framework
-                       2 mutants were caught by Static Analysis
-                       1 mutants were configured to be ignored
-                       3 mutants were not covered by tests
-                       4 covered mutants were not detected
-                       1 errors were encountered
-                      10 syntax errors were encountered
-                       2 time outs were encountered
-                       2 mutants required more time than configured
-
-                Metrics:
-                         Mutation Code Coverage: <low>42%</low>
-                         Covered Code MSI: <medium>74%</medium>
-
-                Please note that some mutants will inevitably be harmless (i.e. false positives).
-
-                DISPLAY,
-        );
-
-        yield 'no metrics' => $emptyScenario->build();
-
-        yield 'no metrics with uncovered' => $emptyScenario
-            ->withUncovered(true)
-            ->withExpected(
-                <<<'DISPLAY'
-
-
-                    0 mutations were generated:
-                           0 mutants were killed by Test Framework
-
-                    Metrics:
-                             Mutation Score Indicator (MSI): <low>0%</low>
-                             Mutation Code Coverage: <low>0%</low>
-                             Covered Code MSI: <low>0%</low>
-
-                    Please note that some mutants will inevitably be harmless (i.e. false positives).
-
-                    DISPLAY,
-            )
-            ->build();
-
-        yield 'no metrics with timeouts as escaped' => $emptyScenario
-            ->withTimeoutsAsEscaped(true)
-            ->build();
-
-        yield 'all metrics' => $completeScenario->build();
-
-        yield 'all metrics with uncovered' => $completeScenario
-            ->withUncovered(true)
-            ->withExpected(
-                <<<'DISPLAY'
-
-
-                    6 mutations were generated:
-                           3 mutants were killed by Test Framework
-                           2 mutants were caught by Static Analysis
-                           1 mutants were configured to be ignored
-                           3 mutants were not covered by tests
-                           4 covered mutants were not detected
-                           1 errors were encountered
-                          10 syntax errors were encountered
-                           2 time outs were encountered
-                           2 mutants required more time than configured
-
-                    Metrics:
-                             Mutation Score Indicator (MSI): <medium>52%</medium>
-                             Mutation Code Coverage: <low>42%</low>
-                             Covered Code MSI: <medium>74%</medium>
-
-                    Please note that some mutants will inevitably be harmless (i.e. false positives).
-
-                    DISPLAY,
-            )
-            ->build();
-
-        yield 'all metrics with timeouts as escaped' => $completeScenario
-            ->withTimeoutsAsEscaped(true)
-            ->build();
-
-        yield 'it marks all percentages as low if bellow the low threshold' => $emptyScenario
-            ->withUncovered(true)
-            ->withMutationScoreIndicator(49)
-            ->withCoverageRate(49)
-            ->withCoveredCodeMutationScoreIndicator(49)
-            ->withExpected(
-                <<<'DISPLAY'
-
-
-                    0 mutations were generated:
-                           0 mutants were killed by Test Framework
-
-                    Metrics:
-                             Mutation Score Indicator (MSI): <low>49%</low>
-                             Mutation Code Coverage: <low>49%</low>
-                             Covered Code MSI: <low>49%</low>
-
-                    Please note that some mutants will inevitably be harmless (i.e. false positives).
-
-                    DISPLAY,
-            )
-            ->build();
-
-        yield 'it marks all percentages as meidum if above the low threshold' => $emptyScenario
-            ->withUncovered(true)
-            ->withMutationScoreIndicator(50)
-            ->withCoverageRate(50)
-            ->withCoveredCodeMutationScoreIndicator(50)
-            ->withExpected(
-                <<<'DISPLAY'
-
-
-                    0 mutations were generated:
-                           0 mutants were killed by Test Framework
-
-                    Metrics:
-                             Mutation Score Indicator (MSI): <medium>50%</medium>
-                             Mutation Code Coverage: <medium>50%</medium>
-                             Covered Code MSI: <medium>50%</medium>
-
-                    Please note that some mutants will inevitably be harmless (i.e. false positives).
-
-                    DISPLAY,
-            )
-            ->build();
-
-        yield 'it marks all percentages as medium if bellow the high threshold' => $emptyScenario
-            ->withUncovered(true)
-            ->withMutationScoreIndicator(89)
-            ->withCoverageRate(89)
-            ->withCoveredCodeMutationScoreIndicator(89)
-            ->withExpected(
-                <<<'DISPLAY'
-
-
-                    0 mutations were generated:
-                           0 mutants were killed by Test Framework
-
-                    Metrics:
-                             Mutation Score Indicator (MSI): <medium>89%</medium>
-                             Mutation Code Coverage: <medium>89%</medium>
-                             Covered Code MSI: <medium>89%</medium>
-
-                    Please note that some mutants will inevitably be harmless (i.e. false positives).
-
-                    DISPLAY,
-            )
-            ->build();
-
-        yield 'it marks all percentages as high if above the high threshold' => $emptyScenario
-            ->withUncovered(true)
-            ->withMutationScoreIndicator(90)
-            ->withCoverageRate(90)
-            ->withCoveredCodeMutationScoreIndicator(90)
-            ->withExpected(
-                <<<'DISPLAY'
-
-
-                    0 mutations were generated:
-                           0 mutants were killed by Test Framework
-
-                    Metrics:
-                             Mutation Score Indicator (MSI): <high>90%</high>
-                             Mutation Code Coverage: <high>90%</high>
-                             Covered Code MSI: <high>90%</high>
-
-                    Please note that some mutants will inevitably be harmless (i.e. false positives).
-
-                    DISPLAY,
-            )
-            ->build();
-
-        yield 'it marks all percentages based on their respective values' => $emptyScenario
-            ->withUncovered(true)
-            ->withMutationScoreIndicator(40)
-            ->withCoverageRate(60)
-            ->withCoveredCodeMutationScoreIndicator(95)
-            ->withExpected(
-                <<<'DISPLAY'
-
-
-                    0 mutations were generated:
-                           0 mutants were killed by Test Framework
-
-                    Metrics:
-                             Mutation Score Indicator (MSI): <low>40%</low>
-                             Mutation Code Coverage: <medium>60%</medium>
-                             Covered Code MSI: <high>95%</high>
-
-                    Please note that some mutants will inevitably be harmless (i.e. false positives).
-
-                    DISPLAY,
-            )
-            ->build();
-
-        yield 'it rounds all percentages to the next lowest integer' => $emptyScenario
-            ->withUncovered(true)
-            ->withMutationScoreIndicator(40.55555555)
-            ->withCoverageRate(60.55555555)
-            ->withCoveredCodeMutationScoreIndicator(95.5555)
-            ->withExpected(
-                <<<'DISPLAY'
-
-
-                    0 mutations were generated:
-                           0 mutants were killed by Test Framework
-
-                    Metrics:
-                             Mutation Score Indicator (MSI): <low>40%</low>
-                             Mutation Code Coverage: <medium>60%</medium>
-                             Covered Code MSI: <high>95%</high>
-
-                    Please note that some mutants will inevitably be harmless (i.e. false positives).
-
-                    DISPLAY,
-            )
-            ->build();
-
-        yield 'it pads the counts values' => $emptyScenario
-            ->withTotalMutantsCount(10_000)
-            ->withKilledByTestsCount(3)
-            ->withKilledByIgnoredCount(2000)
-            ->withExpected(
-                <<<'DISPLAY'
-
-
-                    10000 mutations were generated:
-                           3 mutants were killed by Test Framework
-                        2000 mutants were configured to be ignored
-
-                    Metrics:
-                             Mutation Code Coverage: <low>0%</low>
-                             Covered Code MSI: <low>0%</low>
-
-                    Please note that some mutants will inevitably be harmless (i.e. false positives).
-
-                    DISPLAY,
-            )
-            ->build();
     }
 
     public function test_it_calls_the_reporter_when_the_mutation_testing_is_finished(): void
     {
         $showMutationsReporterMock = $this->createMock(Reporter::class);
         $showMutationsReporterMock
+            ->expects($this->once())
+            ->method('report');
+
+        $showMetricsReporterMock = $this->createMock(Reporter::class);
+        $showMetricsReporterMock
             ->expects($this->once())
             ->method('report');
 
@@ -571,10 +143,9 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
         $subscriber = new MutationTestingConsoleLoggerSubscriber(
             new NullOutput(),
             $this->logger,
-            $this->metricsCalculator,
             $showMutationsReporterMock,
+            $showMetricsReporterMock,
             $reporterMock,
-            withUncovered: true,
         );
 
         $subscriber->onMutationTestingWasFinished(
@@ -592,64 +163,11 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
         $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
             $this->createStub(OutputInterface::class),
             $this->logger,
-            $this->metricsCalculator,
             new NullReporter(),
             new NullReporter(),
-            withUncovered: true,
+            new NullReporter(),
         ));
 
         $dispatcher->dispatch(new MutationTestingWasFinished());
-    }
-
-    private function configureMetricsCalculatorMock(MetricsScenario $scenario): void
-    {
-        $this->metricsCalculator
-            ->method('getKilledByTestsCount')
-            ->willReturn($scenario->killedByTestsCount);
-        $this->metricsCalculator
-            ->method('getKilledByStaticAnalysisCount')
-            ->willReturn($scenario->killedByStaticAnalysisCount);
-        $this->metricsCalculator
-            ->method('getIgnoredCount')
-            ->willReturn($scenario->ignoredCount);
-        $this->metricsCalculator
-            ->method('getNotTestedCount')
-            ->willReturn($scenario->notTestedCount);
-        $this->metricsCalculator
-            ->method('getEscapedCount')
-            ->willReturn($scenario->escapedCount);
-        $this->metricsCalculator
-            ->method('getErrorCount')
-            ->willReturn($scenario->errorCount);
-        $this->metricsCalculator
-            ->method('getSyntaxErrorCount')
-            ->willReturn($scenario->syntaxErrorCount);
-        $this->metricsCalculator
-            ->method('getTimedOutCount')
-            ->willReturn($scenario->timedOutCount);
-        $this->metricsCalculator
-            ->method('getSkippedCount')
-            ->willReturn($scenario->skippedCount);
-        $this->metricsCalculator
-            ->method('getTotalMutantsCount')
-            ->willReturn($scenario->totalMutantsCount);
-        $this->metricsCalculator
-            ->method('getMutationScoreIndicator')
-            ->willReturn($scenario->mutationScoreIndicator);
-        $this->metricsCalculator
-            ->method('getCoverageRate')
-            ->willReturn($scenario->coverageRate);
-        $this->metricsCalculator
-            ->method('getCoveredCodeMutationScoreIndicator')
-            ->willReturn($scenario->coveredCodeMutationScoreIndicator);
-    }
-
-    private function getDisplay(StreamOutput $output): string
-    {
-        rewind($output->getStream());
-
-        $display = stream_get_contents($output->getStream());
-
-        return str_replace(PHP_EOL, "\n", $display);
     }
 }

--- a/tests/phpunit/Reporter/ShowMetricsReporter/MetricsScenario.php
+++ b/tests/phpunit/Reporter/ShowMetricsReporter/MetricsScenario.php
@@ -33,13 +33,12 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Event\Subscriber;
+namespace Infection\Tests\Reporter\ShowMetricsReporter;
 
 final class MetricsScenario
 {
     public function __construct(
         public bool $withUncovered,
-        public bool $timeoutsAsEscaped,
         public int $killedByTestsCount,
         public int $killedByStaticAnalysisCount,
         public int $errorCount,
@@ -61,14 +60,6 @@ final class MetricsScenario
     {
         $clone = clone $this;
         $clone->withUncovered = $withUncovered;
-
-        return $clone;
-    }
-
-    public function withTimeoutsAsEscaped(bool $timeoutsAsEscaped): self
-    {
-        $clone = clone $this;
-        $clone->timeoutsAsEscaped = $timeoutsAsEscaped;
 
         return $clone;
     }

--- a/tests/phpunit/Reporter/ShowMetricsReporter/ShowMetricsReporterTest.php
+++ b/tests/phpunit/Reporter/ShowMetricsReporter/ShowMetricsReporterTest.php
@@ -1,0 +1,387 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Reporter\ShowMetricsReporter;
+
+use Infection\Framework\Str;
+use Infection\Metrics\MetricsCalculator;
+use Infection\Reporter\Reporter;
+use Infection\Reporter\ShowMetricsReporter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+#[CoversClass(ShowMetricsReporter::class)]
+final class ShowMetricsReporterTest extends TestCase
+{
+    private BufferedOutput $output;
+
+    protected function setUp(): void
+    {
+        $this->output = new BufferedOutput();
+    }
+
+    #[DataProvider('metricsProvider')]
+    public function test_it_show_the_metrics(MetricsScenario $scenario): void
+    {
+        $this->createMetricsCalculator($scenario);
+
+        $reporter = $this->createReporter($scenario);
+        $reporter->report();
+
+        $actual = Str::toUnixLineEndings($this->output->fetch());
+
+        $this->assertSame($scenario->expected, $actual);
+    }
+
+    public static function metricsProvider(): iterable
+    {
+        $emptyScenario = new MetricsScenario(
+            withUncovered: false,
+            killedByTestsCount: 0,
+            killedByStaticAnalysisCount: 0,
+            errorCount: 0,
+            syntaxErrorCount: 0,
+            skippedCount: 0,
+            ignoredCount: 0,
+            escapedCount: 0,
+            timedOutCount: 0,
+            notTestedCount: 0,
+            totalMutantsCount: 0,
+            mutationScoreIndicator: 0.,
+            coverageRate: 0.,
+            coveredCodeMutationScoreIndicator: 0.,
+            expected: <<<'DISPLAY'
+
+
+                0 mutations were generated:
+                       0 mutants were killed by Test Framework
+
+                Metrics:
+                         Mutation Code Coverage: <low>0%</low>
+                         Covered Code MSI: <low>0%</low>
+
+                DISPLAY,
+        );
+
+        $completeScenario = new MetricsScenario(
+            withUncovered: false,
+            killedByTestsCount: 3,
+            killedByStaticAnalysisCount: 2,
+            errorCount: 1,
+            syntaxErrorCount: 10,
+            skippedCount: 2,
+            ignoredCount: 1,
+            escapedCount: 4,
+            timedOutCount: 2,
+            notTestedCount: 3,
+            totalMutantsCount: 6,
+            mutationScoreIndicator: 52.,
+            coverageRate: 42.,
+            coveredCodeMutationScoreIndicator: 74.,
+            expected: <<<'DISPLAY'
+
+
+                6 mutations were generated:
+                       3 mutants were killed by Test Framework
+                       2 mutants were caught by Static Analysis
+                       1 mutants were configured to be ignored
+                       3 mutants were not covered by tests
+                       4 covered mutants were not detected
+                       1 errors were encountered
+                      10 syntax errors were encountered
+                       2 time outs were encountered
+                       2 mutants required more time than configured
+
+                Metrics:
+                         Mutation Code Coverage: <low>42%</low>
+                         Covered Code MSI: <medium>74%</medium>
+
+                DISPLAY,
+        );
+
+        yield 'no metrics' => $emptyScenario->build();
+
+        yield 'no metrics with uncovered' => $emptyScenario
+            ->withUncovered(true)
+            ->withExpected(
+                <<<'DISPLAY'
+
+
+                    0 mutations were generated:
+                           0 mutants were killed by Test Framework
+
+                    Metrics:
+                             Mutation Score Indicator (MSI): <low>0%</low>
+                             Mutation Code Coverage: <low>0%</low>
+                             Covered Code MSI: <low>0%</low>
+
+                    DISPLAY,
+            )
+            ->build();
+
+        yield 'all metrics' => $completeScenario->build();
+
+        yield 'all metrics with uncovered' => $completeScenario
+            ->withUncovered(true)
+            ->withExpected(
+                <<<'DISPLAY'
+
+
+                    6 mutations were generated:
+                           3 mutants were killed by Test Framework
+                           2 mutants were caught by Static Analysis
+                           1 mutants were configured to be ignored
+                           3 mutants were not covered by tests
+                           4 covered mutants were not detected
+                           1 errors were encountered
+                          10 syntax errors were encountered
+                           2 time outs were encountered
+                           2 mutants required more time than configured
+
+                    Metrics:
+                             Mutation Score Indicator (MSI): <medium>52%</medium>
+                             Mutation Code Coverage: <low>42%</low>
+                             Covered Code MSI: <medium>74%</medium>
+
+                    DISPLAY,
+            )
+            ->build();
+
+        yield 'it marks all percentages as low if bellow the low threshold' => $emptyScenario
+            ->withUncovered(true)
+            ->withMutationScoreIndicator(49)
+            ->withCoverageRate(49)
+            ->withCoveredCodeMutationScoreIndicator(49)
+            ->withExpected(
+                <<<'DISPLAY'
+
+
+                    0 mutations were generated:
+                           0 mutants were killed by Test Framework
+
+                    Metrics:
+                             Mutation Score Indicator (MSI): <low>49%</low>
+                             Mutation Code Coverage: <low>49%</low>
+                             Covered Code MSI: <low>49%</low>
+
+                    DISPLAY,
+            )
+            ->build();
+
+        yield 'it marks all percentages as meidum if above the low threshold' => $emptyScenario
+            ->withUncovered(true)
+            ->withMutationScoreIndicator(50)
+            ->withCoverageRate(50)
+            ->withCoveredCodeMutationScoreIndicator(50)
+            ->withExpected(
+                <<<'DISPLAY'
+
+
+                    0 mutations were generated:
+                           0 mutants were killed by Test Framework
+
+                    Metrics:
+                             Mutation Score Indicator (MSI): <medium>50%</medium>
+                             Mutation Code Coverage: <medium>50%</medium>
+                             Covered Code MSI: <medium>50%</medium>
+
+                    DISPLAY,
+            )
+            ->build();
+
+        yield 'it marks all percentages as medium if bellow the high threshold' => $emptyScenario
+            ->withUncovered(true)
+            ->withMutationScoreIndicator(89)
+            ->withCoverageRate(89)
+            ->withCoveredCodeMutationScoreIndicator(89)
+            ->withExpected(
+                <<<'DISPLAY'
+
+
+                    0 mutations were generated:
+                           0 mutants were killed by Test Framework
+
+                    Metrics:
+                             Mutation Score Indicator (MSI): <medium>89%</medium>
+                             Mutation Code Coverage: <medium>89%</medium>
+                             Covered Code MSI: <medium>89%</medium>
+
+                    DISPLAY,
+            )
+            ->build();
+
+        yield 'it marks all percentages as high if above the high threshold' => $emptyScenario
+            ->withUncovered(true)
+            ->withMutationScoreIndicator(90)
+            ->withCoverageRate(90)
+            ->withCoveredCodeMutationScoreIndicator(90)
+            ->withExpected(
+                <<<'DISPLAY'
+
+
+                    0 mutations were generated:
+                           0 mutants were killed by Test Framework
+
+                    Metrics:
+                             Mutation Score Indicator (MSI): <high>90%</high>
+                             Mutation Code Coverage: <high>90%</high>
+                             Covered Code MSI: <high>90%</high>
+
+                    DISPLAY,
+            )
+            ->build();
+
+        yield 'it marks all percentages based on their respective values' => $emptyScenario
+            ->withUncovered(true)
+            ->withMutationScoreIndicator(40)
+            ->withCoverageRate(60)
+            ->withCoveredCodeMutationScoreIndicator(95)
+            ->withExpected(
+                <<<'DISPLAY'
+
+
+                    0 mutations were generated:
+                           0 mutants were killed by Test Framework
+
+                    Metrics:
+                             Mutation Score Indicator (MSI): <low>40%</low>
+                             Mutation Code Coverage: <medium>60%</medium>
+                             Covered Code MSI: <high>95%</high>
+
+                    DISPLAY,
+            )
+            ->build();
+
+        yield 'it rounds all percentages to the next lowest integer' => $emptyScenario
+            ->withUncovered(true)
+            ->withMutationScoreIndicator(40.55555555)
+            ->withCoverageRate(60.55555555)
+            ->withCoveredCodeMutationScoreIndicator(95.5555)
+            ->withExpected(
+                <<<'DISPLAY'
+
+
+                    0 mutations were generated:
+                           0 mutants were killed by Test Framework
+
+                    Metrics:
+                             Mutation Score Indicator (MSI): <low>40%</low>
+                             Mutation Code Coverage: <medium>60%</medium>
+                             Covered Code MSI: <high>95%</high>
+
+                    DISPLAY,
+            )
+            ->build();
+
+        yield 'it pads the counts values' => $emptyScenario
+            ->withTotalMutantsCount(10_000)
+            ->withKilledByTestsCount(3)
+            ->withKilledByIgnoredCount(2000)
+            ->withExpected(
+                <<<'DISPLAY'
+
+
+                    10000 mutations were generated:
+                           3 mutants were killed by Test Framework
+                        2000 mutants were configured to be ignored
+
+                    Metrics:
+                             Mutation Code Coverage: <low>0%</low>
+                             Covered Code MSI: <low>0%</low>
+
+                    DISPLAY,
+            )
+            ->build();
+    }
+
+    private function createReporter(
+        MetricsScenario $scenario,
+    ): Reporter {
+        return new ShowMetricsReporter(
+            $this->output,
+            $this->createMetricsCalculator($scenario),
+            $scenario->withUncovered,
+        );
+    }
+
+    private function createMetricsCalculator(MetricsScenario $scenario): MetricsCalculator
+    {
+        $metricsCalculatorMock = $this->createMock(MetricsCalculator::class);
+
+        $metricsCalculatorMock
+            ->method('getKilledByTestsCount')
+            ->willReturn($scenario->killedByTestsCount);
+        $metricsCalculatorMock
+            ->method('getKilledByStaticAnalysisCount')
+            ->willReturn($scenario->killedByStaticAnalysisCount);
+        $metricsCalculatorMock
+            ->method('getIgnoredCount')
+            ->willReturn($scenario->ignoredCount);
+        $metricsCalculatorMock
+            ->method('getNotTestedCount')
+            ->willReturn($scenario->notTestedCount);
+        $metricsCalculatorMock
+            ->method('getEscapedCount')
+            ->willReturn($scenario->escapedCount);
+        $metricsCalculatorMock
+            ->method('getErrorCount')
+            ->willReturn($scenario->errorCount);
+        $metricsCalculatorMock
+            ->method('getSyntaxErrorCount')
+            ->willReturn($scenario->syntaxErrorCount);
+        $metricsCalculatorMock
+            ->method('getTimedOutCount')
+            ->willReturn($scenario->timedOutCount);
+        $metricsCalculatorMock
+            ->method('getSkippedCount')
+            ->willReturn($scenario->skippedCount);
+        $metricsCalculatorMock
+            ->method('getTotalMutantsCount')
+            ->willReturn($scenario->totalMutantsCount);
+        $metricsCalculatorMock
+            ->method('getMutationScoreIndicator')
+            ->willReturn($scenario->mutationScoreIndicator);
+        $metricsCalculatorMock
+            ->method('getCoverageRate')
+            ->willReturn($scenario->coverageRate);
+        $metricsCalculatorMock
+            ->method('getCoveredCodeMutationScoreIndicator')
+            ->willReturn($scenario->coveredCodeMutationScoreIndicator);
+
+        return $metricsCalculatorMock;
+    }
+}


### PR DESCRIPTION
This PR is a follow up of https://github.com/infection/infection/pull/2959, to see the why & the goal, check it out.

## Description

This PR extracts `MutationTestingConsoleSubscriber::showMetrics()` into a dedicated `ShowMetricsReporter`.

Note that while porting the tests from `MutationTestingConsoleSubscriber`, it showed that the `treatTimeoutsAsEscaped` had no influence on the outcome of that output, hence I removed it from `MetricsScenario`.

## Related issues

- https://github.com/infection/infection/pull/2927
- https://github.com/infection/infection/issues/2866
