### PR TITLE
refactor(event): Extract MutationTestingConsoleSubscriber advisory message to a reporter

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -113,6 +113,7 @@ use Infection\Process\Runner\MutationTestingRunner;
 use Infection\Process\Runner\ParallelProcessRunner;
 use Infection\Process\Runner\ProcessRunner;
 use Infection\Process\ShellCommandLineExecutor;
+use Infection\Reporter\AdvisoryReporter;
 use Infection\Reporter\FederatedReporter;
 use Infection\Reporter\FileLocationReporter;
 use Infection\Reporter\FileReporterFactory;
@@ -438,7 +439,6 @@ final class Container extends DIContainer
                 $config = $container->getConfiguration();
 
                 return new MutationTestingConsoleLoggerSubscriber(
-                    $output,
                     $container->getMutationAnalysisLogger(),
                     new ShowMutationsReporter(
                         $output,
@@ -458,6 +458,7 @@ final class Container extends DIContainer
                         $output,
                         $config->numberOfShownMutations,
                     ),
+                    new AdvisoryReporter($output),
                 );
             },
             PerformanceLoggerSubscriber::class => static fn (self $container): PerformanceLoggerSubscriber => new PerformanceLoggerSubscriber(

--- a/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingConsoleLoggerSubscriber.php
@@ -49,7 +49,6 @@ use Infection\Event\Events\MutationAnalysis\MutationTestingWasStartedSubscriber;
 use Infection\Framework\Iterable\IterableCounter;
 use Infection\Logger\MutationAnalysis\MutationAnalysisLogger;
 use Infection\Reporter\Reporter;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * TODO: should be renamed
@@ -63,11 +62,11 @@ final class MutationTestingConsoleLoggerSubscriber implements MutableFileWasProc
     private int $mutationCount = 0;
 
     public function __construct(
-        private readonly OutputInterface $output,
         private readonly MutationAnalysisLogger $logger,
         private readonly Reporter $showMutationsReporter,
         private readonly Reporter $showMetricsReporter,
         private readonly Reporter $reporter,
+        private readonly Reporter $advisoryReporter,
     ) {
     }
 
@@ -107,7 +106,6 @@ final class MutationTestingConsoleLoggerSubscriber implements MutableFileWasProc
         $this->showMutationsReporter->report();
         $this->showMetricsReporter->report();
         $this->reporter->report();
-
-        $this->output->writeln(['', 'Please note that some mutants will inevitably be harmless (i.e. false positives).']);
+        $this->advisoryReporter->report();
     }
 }

--- a/src/Reporter/AdvisoryReporter.php
+++ b/src/Reporter/AdvisoryReporter.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Reporter;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+final readonly class AdvisoryReporter implements Reporter
+{
+    public function __construct(
+        private OutputInterface $output,
+    ) {
+    }
+
+    public function report(): void
+    {
+        $this->output->writeln(['', 'Please note that some mutants will inevitably be harmless (i.e. false positives).']);
+    }
+}

--- a/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingConsoleLoggerSubscriberTest.php
@@ -49,8 +49,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 
 #[Group('integration')]
 #[CoversClass(MutationTestingConsoleLoggerSubscriber::class)]
@@ -71,8 +69,8 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
 
         $dispatcher = new SyncEventDispatcher();
         $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
-            $this->createStub(OutputInterface::class),
             $this->logger,
+            new NullReporter(),
             new NullReporter(),
             new NullReporter(),
             new NullReporter(),
@@ -91,8 +89,8 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
 
         $dispatcher = new SyncEventDispatcher();
         $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
-            $this->createStub(OutputInterface::class),
             $this->logger,
+            new NullReporter(),
             new NullReporter(),
             new NullReporter(),
             new NullReporter(),
@@ -113,8 +111,8 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
 
         $dispatcher = new SyncEventDispatcher();
         $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
-            $this->createStub(OutputInterface::class),
             $this->logger,
+            new NullReporter(),
             new NullReporter(),
             new NullReporter(),
             new NullReporter(),
@@ -140,12 +138,17 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
             ->expects($this->once())
             ->method('report');
 
+        $advisoryReporterMock = $this->createMock(Reporter::class);
+        $advisoryReporterMock
+            ->expects($this->once())
+            ->method('report');
+
         $subscriber = new MutationTestingConsoleLoggerSubscriber(
-            new NullOutput(),
             $this->logger,
             $showMutationsReporterMock,
             $showMetricsReporterMock,
             $reporterMock,
+            $advisoryReporterMock,
         );
 
         $subscriber->onMutationTestingWasFinished(
@@ -161,8 +164,8 @@ final class MutationTestingConsoleLoggerSubscriberTest extends TestCase
 
         $dispatcher = new SyncEventDispatcher();
         $dispatcher->addSubscriber(new MutationTestingConsoleLoggerSubscriber(
-            $this->createStub(OutputInterface::class),
             $this->logger,
+            new NullReporter(),
             new NullReporter(),
             new NullReporter(),
             new NullReporter(),

--- a/tests/phpunit/Reporter/AdvisoryReporterTest.php
+++ b/tests/phpunit/Reporter/AdvisoryReporterTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Reporter;
+
+use Infection\Framework\Str;
+use Infection\Reporter\AdvisoryReporter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+#[CoversClass(AdvisoryReporter::class)]
+final class AdvisoryReporterTest extends TestCase
+{
+    public function test_it_shows_an_advisory_message(): void
+    {
+        $output = new BufferedOutput();
+
+        $expected = <<<'DISPLAY'
+
+            Please note that some mutants will inevitably be harmless (i.e. false positives).
+
+            DISPLAY;
+
+        $reporter = new AdvisoryReporter($output);
+        $reporter->report();
+
+        $actual = Str::toUnixLineEndings($output->fetch());
+
+        $this->assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
## Description

This PR extracts the advisory message written by `MutationTestingConsoleSubscriber` to a `AdvisoryReporter`.

I'm not too happy with the name & location, but maybe we can move it to a place where it makes more sense afterwards.

## Related issues

- https://github.com/infection/infection/pull/2937
- https://github.com/infection/infection/pull/2959
- https://github.com/infection/infection/pull/2967
- https://github.com/infection/infection/pull/2968