### PR TITLE
fix(testing): Ensure BaseMutatorTestCase handles custom mutator names

### DIFF
--- a/src/Testing/BaseMutatorTestCase.php
+++ b/src/Testing/BaseMutatorTestCase.php
@@ -35,8 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Testing;
 
-use function array_flip;
-use function array_key_exists;
 use function array_map;
 use function array_shift;
 use function count;
@@ -47,7 +45,6 @@ use Infection\Framework\Str;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\NodeMutationGenerator;
-use Infection\Mutator\ProfileList;
 use Infection\PhpParser\NodeTraverserFactory;
 use Infection\PhpParser\Visitor\MutationCollectorVisitor;
 use Infection\PhpParser\Visitor\MutatorVisitor;
@@ -152,15 +149,16 @@ abstract class BaseMutatorTestCase extends TestCase
     {
         $mutatorClassName = $this->getTestedMutatorClassName();
 
-        $isBuiltinMutator = array_key_exists($mutatorClassName, array_flip(ProfileList::ALL_MUTATORS));
-        $mutatorName = $isBuiltinMutator ? MutatorName::getName($mutatorClassName) : $mutatorClassName;
-
-        return SingletonContainer::getContainer()
+        $mutators = SingletonContainer::getContainer()
             ->getMutatorFactory()
             ->create([
                 $mutatorClassName => ['settings' => $settings],
-            ], false)[$mutatorName]
-        ;
+            ], false);
+
+        $mutator = array_shift($mutators);
+        Assert::isInstanceOf($mutator, Mutator::class);
+
+        return $mutator;
     }
 
     protected function getTestedMutatorClassName(): string

--- a/tests/phpunit/Fixtures/Mutator/CustomNameMutator.php
+++ b/tests/phpunit/Fixtures/Mutator/CustomNameMutator.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Fixtures\Mutator;
+
+use Infection\Mutator\Definition;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\MutatorCategory;
+use PhpParser\Node;
+
+final class CustomNameMutator implements Mutator
+{
+    public static function getDefinition(): Definition
+    {
+        return new Definition('Custom Name Mutator Description', MutatorCategory::ORTHOGONAL_REPLACEMENT, null, 'diff');
+    }
+
+    public function getName(): string
+    {
+        return 'CustomNameMutator';
+    }
+
+    public function canMutate(Node $node): bool
+    {
+        return false;
+    }
+
+    public function mutate(Node $node): iterable
+    {
+        yield $node;
+    }
+}

--- a/tests/phpunit/Testing/BaseMutatorTestCaseIntegrationTest.php
+++ b/tests/phpunit/Testing/BaseMutatorTestCaseIntegrationTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Testing;
+
+use Infection\Testing\BaseMutatorTestCase;
+use Infection\Tests\Fixtures\Mutator\CustomNameMutator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('integration')]
+#[CoversClass(BaseMutatorTestCase::class)]
+final class BaseMutatorTestCaseIntegrationTest extends BaseMutatorTestCase
+{
+    public function test_it_can_create_mutator_with_custom_name(): void
+    {
+        $mutator = $this->createMutator();
+
+        $this->assertInstanceOf(CustomNameMutator::class, $mutator);
+        $this->assertSame('CustomNameMutator', $mutator->getName());
+    }
+
+    protected function getTestedMutatorClassName(): string
+    {
+        return CustomNameMutator::class;
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes a bug in `BaseMutatorTestCase::createMutator()` where it was incorrectly using the mutator's FQCN as a lookup key for the MutatorFactory output, while MutatorFactory results are keyed by the mutator name (returned by `getName()`).

## Changes
- Fixes `BaseMutatorTestCase::createMutator()` to retrieve the first (and only) element from the `MutatorFactory::create()` result.
- Since `createMutator()` always requests exactly one mutator class, the resulting array will contain exactly one element, making the lookup by name unnecessary and error-prone for custom mutators.
- Adds tests/phpunit/Fixtures/Mutator/CustomNameMutator.php as a test fixture.
- Adds tests/phpunit/Testing/MutatorTestCaseIntegrationTest.php to ensure BaseMutatorTestCase correctly handles mutators with custom names.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated - N/A
- [ ] CHANGELOG.md updated - N/A
- [ ] Appropriate labels applied

## Related issues

#2990