### PR TITLE
[DCD] Upgrade shipmonk/dead-code-detector to 0.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^11.5.27",
         "rector/rector": "^2.2.4",
-        "shipmonk/dead-code-detector": "^0.14.0",
+        "shipmonk/dead-code-detector": "^0.15",
         "shipmonk/name-collision-detector": "^2.1",
         "sidz/phpstan-rules": "^0.5.1",
         "symfony/yaml": "^6.4 || ^7.0 || ^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f606029f3902519afd99f15da6cc5cb",
+    "content-hash": "0548bf305724f0c7ffe38a7fb5d8e5a0",
     "packages": [
         {
             "name": "colinodell/json5",
@@ -5028,16 +5028,16 @@
         },
         {
             "name": "shipmonk/dead-code-detector",
-            "version": "0.14.1",
+            "version": "0.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/dead-code-detector.git",
-                "reference": "4fdc912b25b1e169041f534a517126a1090bb2f4"
+                "reference": "568f84ea3cb5e195ff6724b2a226dfb04dd3898e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/dead-code-detector/zipball/4fdc912b25b1e169041f534a517126a1090bb2f4",
-                "reference": "4fdc912b25b1e169041f534a517126a1090bb2f4",
+                "url": "https://api.github.com/repos/shipmonk-rnd/dead-code-detector/zipball/568f84ea3cb5e195ff6724b2a226dfb04dd3898e",
+                "reference": "568f84ea3cb5e195ff6724b2a226dfb04dd3898e",
                 "shasum": ""
             },
             "require": {
@@ -5045,6 +5045,7 @@
                 "phpstan/phpstan": "^2.1.23"
             },
             "require-dev": {
+                "behat/behat": "^3.14",
                 "composer-runtime-api": "^2.0",
                 "composer/semver": "^3.4",
                 "doctrine/orm": "^2.19 || ^3.0",
@@ -5052,6 +5053,7 @@
                 "ergebnis/composer-normalize": "^2.48.1",
                 "nette/application": "^3.1",
                 "nette/component-model": "^3.0",
+                "nette/tester": "^2.4",
                 "nette/utils": "^3.0 || ^4.0",
                 "nikic/php-parser": "^5.4.0",
                 "phpbench/phpbench": "^1.2",
@@ -5064,12 +5066,13 @@
                 "shipmonk/composer-dependency-analyser": "^1.8.2",
                 "shipmonk/coverage-guard": "^1.0.0",
                 "shipmonk/name-collision-detector": "^2.1.1",
-                "shipmonk/phpstan-dev": "^0.1.1",
+                "shipmonk/phpstan-dev": "^0.1.6",
                 "shipmonk/phpstan-rules": "^4.1.0",
                 "symfony/contracts": "^2.5 || ^3.0 || ^4.0",
                 "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ^8.0",
                 "symfony/doctrine-bridge": "^5.4 || ^6.0 || ^7.0 || ^8.0",
                 "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0 || ^8.0",
                 "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0 || ^8.0",
                 "symfony/routing": "^5.4 || ^6.0 || ^7.0 || ^8.0",
                 "symfony/validator": "^5.4 || ^6.0 || ^7.0 || ^8.0",
@@ -5101,9 +5104,9 @@
             ],
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/dead-code-detector/issues",
-                "source": "https://github.com/shipmonk-rnd/dead-code-detector/tree/0.14.1"
+                "source": "https://github.com/shipmonk-rnd/dead-code-detector/tree/0.15.0"
             },
-            "time": "2025-12-18T11:03:53+00:00"
+            "time": "2026-03-04T15:38:17+00:00"
         },
         {
             "name": "shipmonk/name-collision-detector",

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -109,6 +109,11 @@ parameters:
             identifier: shipmonk.deadMethod
             path: ../tests/phpunit/**/*Builder.php
 
+        # Test enum fixtures have cases that exist as test data, not all are used
+        -
+            identifier: shipmonk.deadEnumCase
+            path: ../tests/*
+
         # PHPStan is (understandably) a bit confused at class-names of classes that do not exist.
         -
             identifier: argument.type

--- a/tests/phpunit/TestFramework/Tracing/Trace/SyntheticTrace.php
+++ b/tests/phpunit/TestFramework/Tracing/Trace/SyntheticTrace.php
@@ -51,7 +51,6 @@ final readonly class SyntheticTrace implements Trace
     public function __construct(
         public SplFileInfo $sourceFileInfo,
         public string $realPath,
-        public string $relativePathname,
         public bool $hasTest,
         public TestLocations $tests,
     ) {

--- a/tests/phpunit/TestFramework/Tracing/TracerIntegrationTest.php
+++ b/tests/phpunit/TestFramework/Tracing/TracerIntegrationTest.php
@@ -191,7 +191,6 @@ final class TracerIntegrationTest extends TestCase
             new SyntheticTrace(
                 sourceFileInfo: MockSplFileInfo::create(self::FIXTURE_DIR . '/src/DemoCounterService.php'),
                 realPath: realpath($canonicalDemoCounterServicePathname),
-                relativePathname: $canonicalDemoCounterServicePathname,
                 hasTest: true,
                 tests: new TestLocations(
                     [
@@ -488,7 +487,6 @@ final class TracerIntegrationTest extends TestCase
             new SyntheticTrace(
                 sourceFileInfo: MockSplFileInfo::create(self::FIXTURE_DIR . '/src/DemoCounterService.php'),
                 realPath: realpath($canonicalDemoCounterServicePathname),
-                relativePathname: $canonicalDemoCounterServicePathname,
                 hasTest: true,
                 tests: new TestLocations(
                     [


### PR DESCRIPTION
## Description

Updates [Dead Code Detector to latest version](https://github.com/shipmonk-rnd/dead-code-detector/releases/tag/0.15.0) - I'm using your repository in E2E there, so green CI would nice for me :)

## Changes

- Enable detection of dead enum cases and dead properties (never read, never written) in addition to the already enabled dead methods and constants.
- Remove genuinely unused `SyntheticTrace::$relativePathname` property discovered by the new checks.

