### PR TITLE
refactor(ast): Simplify the NodeTraverser instantiation

### DIFF
--- a/src/PhpParser/NodeTraverserFactory.php
+++ b/src/PhpParser/NodeTraverserFactory.php
@@ -65,23 +65,21 @@ class NodeTraverserFactory
             new AbstractMethodIgnorer(),
         ];
 
-        $traverser = new NodeTraverser(new NodeVisitor\CloningVisitor());
-
-        $traverser->addVisitor(new IgnoreAllMutationsAnnotationReaderVisitor($changingIgnorer, new SplObjectStorage()));
-        $traverser->addVisitor(new NonMutableNodesIgnorerVisitor($nodeIgnorers));
-        $traverser->addVisitor(NameResolverFactory::create());
-        $traverser->addVisitor(new ParentConnectingVisitor());
-        $traverser->addVisitor(new ReflectionVisitor());
-        $traverser->addVisitor($mutationVisitor);
-
-        return $traverser;
+        return new NodeTraverser(
+            new NodeVisitor\CloningVisitor(),
+            new IgnoreAllMutationsAnnotationReaderVisitor($changingIgnorer, new SplObjectStorage()),
+            new NonMutableNodesIgnorerVisitor($nodeIgnorers),
+            NameResolverFactory::create(),
+            new ParentConnectingVisitor(),
+            new ReflectionVisitor(),
+            $mutationVisitor,
+        );
     }
 
     public function createPreTraverser(): NodeTraverserInterface
     {
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor(new NextConnectingVisitor());
-
-        return $traverser;
+        return new NodeTraverser(
+            new NextConnectingVisitor(),
+        );
     }
 }


### PR DESCRIPTION
Since https://github.com/nikic/PHP-Parser/commit/c48ee36f546c1157fe6c12ba324b71d2d31acffb, available as of `nikic/php-parser` 5.0, we can pass the visitors to the `NodeTraverser` constructor directly.

Since we require `^5.6.2`, we can safely use this.