### PR TITLE
test: Improve the feedback when MutatorRobustnessTest fails

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -1033,6 +1033,12 @@ parameters:
 			path: ../tests/phpunit/Mutator/MutatorRobustnessTest.php
 
 		-
+			rawMessage: 'Class PHPUnit\Framework\AssertionFailedError constructor invoked with named argument $code, but it''s not allowed because of @no-named-arguments.'
+			identifier: argument.named
+			count: 1
+			path: ../tests/phpunit/Mutator/MutatorRobustnessTest.php
+
+		-
 			rawMessage: 'Class PHPUnit\Framework\AssertionFailedError constructor invoked with named argument $previous, but it''s not allowed because of @no-named-arguments.'
 			identifier: argument.named
 			count: 1

--- a/tests/phpunit/Mutator/MutatorRobustnessTest.php
+++ b/tests/phpunit/Mutator/MutatorRobustnessTest.php
@@ -59,6 +59,8 @@ use Throwable;
 #[CoversNothing]
 final class MutatorRobustnessTest extends TestCase
 {
+    private const FIXTURES_DIR = __DIR__ . '/../../autoloaded/mutator-code-samples';
+
     /**
      * @var array<string, SplFileInfo>|null
      */
@@ -80,19 +82,21 @@ final class MutatorRobustnessTest extends TestCase
      */
     #[DataProvider('mutatorWithCodeCaseProvider')]
     public function test_the_mutator_does_not_crash(
-        SplFileInfo $filePath,
+        SplFileInfo $fileInfo,
         Mutator $mutator,
     ): void {
         $this->expectNotToPerformAssertions();
+
         try {
-            $this->mutatesCode($filePath, $mutator);
+            $this->mutatesCode($fileInfo, $mutator);
         } catch (Throwable $throwable) {
             throw new AssertionFailedError(
                 sprintf(
                     'The mutator "%s" could not parse the file "%s".',
                     $mutator->getName(),
-                    $filePath,
+                    $fileInfo->getRealPath(),
                 ),
+                code: $throwable->getCode(),
                 previous: $throwable,
             );
         }
@@ -126,7 +130,7 @@ final class MutatorRobustnessTest extends TestCase
         }
 
         $finder = Finder::create()
-            ->in(__DIR__ . '/../../autoloaded/mutator-code-samples')
+            ->in(self::FIXTURES_DIR)
             ->name('*.php')
             ->files()
         ;


### PR DESCRIPTION
A few weeks ago I hit an annoying case where I had to step in with Xdebug to figure out what the failure was with `MutatorRobustnessTest` because:

- I had no idea which file was failing and where it was located.
- The exception message was incomplete: I could not figure out what was throwing from where.

This PR addresses the feedback provided by `MutatorRobustnessTest` upon failure. The key elements:

- The offending file path is given, not just the file name.
- Instead of having a failure message an exception is thrown which means we benefit from the regular reporting of exceptions by PHPUnit: message + stack trace.
- Leveraging the previous point, we can pass the original exception as the previous of the exception thrown, giving all the necessary information.

Output before:

```
F

Time: 00:00.040, Memory: 20.00 MB

There was 1 failure:

1) Infection\Tests\Mutator\MutatorRobustnessTest::test_the_mutator_does_not_crash_during_parsing with data set "[Infection\Mutator\Removal\FunctionCallRemoval] ReturnTypes.php" ('ReturnTypes.php', '<?php\n\nnamespace Infection\...}\n}\n', Infection\Mutator\Removal\FunctionCallRemoval Object (...))
The mutator "FunctionCallRemoval" could not parse the file "ReturnTypes.php": Undefined constant "Infection\CodeSamples\rrayObject".

/path/to/infection/tests/phpunit/Mutator/MutatorRobustnessTest.php:75
```

After:

```
.F

Time: 00:00.053, Memory: 20.00 MB

There was 1 failure:

1) Infection\Tests\Mutator\MutatorRobustnessTest::test_the_mutator_does_not_crash with data set "[Infection\Mutator\Unwrap\UnwrapArrayValues] ReturnTypes.php" ('/Users/tfidry/Project/Humbug/...es.php', '<?php\n\nnamespace Infection\...}\n}\n', Infection\Mutator\Unwrap\UnwrapArrayValues Object ())
The mutator "UnwrapArrayValues" could not parse the file "/path/to/infection/tests/autoloaded/mutator-code-samples/ReturnTypes.php".

/path/to/infection/tests/phpunit/Mutator/MutatorRobustnessTest.php:76

Caused by
Error: Undefined constant "Infection\CodeSamples\rrayObject"

/path/to/infection/tests/autoloaded/mutator-code-samples/ReturnTypes.php:5
/path/to/infection/src/Reflection/CoreClassReflection.php:56
/path/to/infection/src/PhpParser/Visitor/ReflectionVisitor.php:242
/path/to/infection/src/PhpParser/Visitor/ReflectionVisitor.php:103
/path/to/infection/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:196
/path/to/infection/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:98
/path/to/infection/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:227
/path/to/infection/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:76
/path/to/infection/tests/phpunit/Mutator/MutatorRobustnessTest.php:142
/path/to/infection/tests/phpunit/Mutator/MutatorRobustnessTest.php:74
```
