### PR TITLE
Variant 1: Fix incorrectly style tag for non-canonical regexes with tripple `\\\`

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -108,6 +108,7 @@ use Infection\Mutation\MutationGenerator;
 use Infection\Mutator\MutatorFactory;
 use Infection\Mutator\MutatorResolver;
 use Infection\PhpParser\FileParser;
+use Infection\PhpParser\InfectionPrettyPrinter;
 use Infection\PhpParser\NodeDumper\NodeDumper;
 use Infection\PhpParser\NodeTraverserFactory;
 use Infection\Process\Factory\InitialStaticAnalysisProcessFactory;
@@ -170,7 +171,6 @@ use OndraM\CiDetector\CiDetector;
 use function php_ini_loaded_file;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
-use PhpParser\PrettyPrinter\Standard;
 use PhpParser\PrettyPrinterAbstract;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -332,7 +332,7 @@ final class Container extends DIContainer
                 new JUnitTestFileDataProvider($container->getJUnitReportLocator()),
             ),
             Parser::class => static fn (): Parser => (new ParserFactory())->createForHostVersion(),
-            PrettyPrinterAbstract::class => static fn (): Standard => new Standard(),
+            PrettyPrinterAbstract::class => static fn (): InfectionPrettyPrinter => new InfectionPrettyPrinter(),
             MetricsCalculator::class => static fn (self $container): MetricsCalculator => new MetricsCalculator(
                 $container->getConfiguration()->msiPrecision,
                 $container->getConfiguration()->timeoutsAsEscaped,

--- a/src/PhpParser/InfectionPrettyPrinter.php
+++ b/src/PhpParser/InfectionPrettyPrinter.php
@@ -33,48 +33,27 @@
 
 declare(strict_types=1);
 
-namespace Infection\Testing;
+namespace Infection\PhpParser;
 
-use Infection\Container\Container;
-use Infection\Mutant\MutantCodePrinter;
-use Infection\PhpParser\InfectionPrettyPrinter;
-use Infection\Tests\AutoReview\PhpDoc\PHPDocParser;
-use PhpParser\NodeDumper;
+use PhpParser\PrettyPrinter\Standard;
+use function Safe\preg_replace;
 
 /**
- * Singleton for the container and a few services (used for tests). The goal is to avoid
- * instantiating multiple times stateless services across the tests to reduce the memory footprint
- * and remove some redundant code.
- *
  * @internal
  */
-final class SingletonContainer
+final class InfectionPrettyPrinter extends Standard
 {
-    private static ?Container $container = null;
-
-    private static ?NodeDumper $dumper = null;
-
-    private static ?MutantCodePrinter $printer = null;
-
-    private static ?PHPDocParser $phpDocParser = null;
-
-    public static function getContainer(): Container
+    /**
+     * Prints a single-quoted string using minimal escaping.
+     *
+     * PHP-Parser's default regex also escapes a backslash when it is preceded by
+     * another backslash (the (?<=\\)\\ alternative), to avoid producing odd-looking
+     * three-backslash sequences. That extra rule changes non-canonical but valid
+     * source like '\\\|' (3 backslashes) to '\\\\|' (4 backslashes), making mutation
+     * diffs noisier than necessary. Dropping that rule keeps the original encoding.
+     */
+    protected function pSingleQuotedString(string $string): string
     {
-        return self::$container ??= Container::create();
-    }
-
-    public static function getNodeDumper(): NodeDumper
-    {
-        return self::$dumper ??= new NodeDumper();
-    }
-
-    public static function getPrinter(): MutantCodePrinter
-    {
-        return self::$printer ??= new MutantCodePrinter(new InfectionPrettyPrinter());
-    }
-
-    public static function getPHPDocParser(): PHPDocParser
-    {
-        return self::$phpDocParser ??= new PHPDocParser();
+        return '\'' . preg_replace('/\'|\\\\(?=[\'\\\\]|$)/', '\\\\$0', $string) . '\'';
     }
 }

--- a/tests/e2e/StyleTag/README.md
+++ b/tests/e2e/StyleTag/README.md
@@ -1,0 +1,11 @@
+# StyleTag e2e test
+
+* https://github.com/infection/infection/issues/2977
+
+## Summary
+When `PregMatchRemoveFlags` mutates a regex containing backslashes (e.g. `\|`, `\)`, `\w`),
+the diff colorizer could produce a Symfony Console style tag (like `<diff-del-inline>`)
+immediately preceded by a `\` from the PHP source. Symfony Console interprets `\<tag>` as an
+escaped literal `<tag>`, skipping the opening tag but still processing the closing tag, which
+causes "Incorrectly nested style tag found."
+

--- a/tests/e2e/StyleTag/composer.json
+++ b/tests/e2e/StyleTag/composer.json
@@ -1,0 +1,15 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.6.20"
+    },
+    "autoload": {
+        "psr-4": {
+            "StyleTag\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "StyleTag\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/e2e/StyleTag/expected-output.txt
+++ b/tests/e2e/StyleTag/expected-output.txt
@@ -1,0 +1,11 @@
+Total: 2
+
+Killed by Test Framework: 0
+Killed by Static Analysis: 0
+Errored: 0
+Syntax Errors: 0
+Escaped: 2
+Timed Out: 0
+Skipped: 0
+Ignored: 0
+Not Covered: 0

--- a/tests/e2e/StyleTag/infection.json5
+++ b/tests/e2e/StyleTag/infection.json5
@@ -1,0 +1,16 @@
+{
+    "$schema": "../../../resources/schema.json",
+    "timeout": 25,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "mutators": {
+        "PregMatchRemoveFlags": true
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/StyleTag/phpunit.xml
+++ b/tests/e2e/StyleTag/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/tests/e2e/StyleTag/src/SourceClass.php
+++ b/tests/e2e/StyleTag/src/SourceClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace StyleTag;
+
+class SourceClass
+{
+    public function hello(): string
+    {
+        preg_match('/(?:.*controller\\\|.*controllers\\\)([\w\\\]+)controller$/iU', '', $m);
+
+        return 'hello';
+    }
+}

--- a/tests/e2e/StyleTag/tests/SourceClassTest.php
+++ b/tests/e2e/StyleTag/tests/SourceClassTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace StyleTag\Test;
+
+use StyleTag\SourceClass;
+use PHPUnit\Framework\TestCase;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+        $this->assertSame('hello', $sourceClass->hello());
+    }
+}

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -80,6 +80,7 @@ use Infection\Mutator\Definition;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
 use Infection\Mutator\NodeMutationGenerator;
+use Infection\PhpParser\InfectionPrettyPrinter;
 use Infection\PhpParser\Visitor\NameResolverFactory;
 use Infection\Process\Runner\IndexedMutantProcessContainer;
 use Infection\Reporter\Http\StrykerCurlClient;
@@ -175,6 +176,7 @@ final class ProjectCodeProvider
         Tokens::class,
         TooManyReportsFound::class,
         XdebugHandler::class,
+        InfectionPrettyPrinter::class,
     ];
 
     /**

--- a/tests/phpunit/Mutator/Regex/PregMatchRemoveFlagsTest.php
+++ b/tests/phpunit/Mutator/Regex/PregMatchRemoveFlagsTest.php
@@ -130,6 +130,27 @@ final class PregMatchRemoveFlagsTest extends BaseMutatorTestCase
             ],
         ];
 
+        // https://github.com/infection/infection/issues/2977
+        yield 'It preserves non-canonical backslash encoding in the regex body when only flags change' => [
+            self::wrapCodeInMethod(
+                <<<'PHP'
+                    preg_match('/(?:.*controller\\\|.*controllers\\\)([\w\\\]+)controller$/iU', '', $m);
+                    PHP,
+            ),
+            [
+                self::wrapCodeInMethod(
+                    <<<'PHP'
+                        preg_match('/(?:.*controller\\\|.*controllers\\\)([\w\\\]+)controller$/U', '', $m);
+                        PHP,
+                ),
+                self::wrapCodeInMethod(
+                    <<<'PHP'
+                        preg_match('/(?:.*controller\\\|.*controllers\\\)([\w\\\]+)controller$/i', '', $m);
+                        PHP,
+                ),
+            ],
+        ];
+
         yield 'It does not mutate regular expression with an encapsed variable' => [
             self::wrapCodeInMethod(
                 <<<'PHP'


### PR DESCRIPTION
This is the 1st variant to fix https://github.com/infection/infection/issues/2977

See detailed explanation here https://github.com/infection/infection/issues/2977#issuecomment-4105923221

Diff is perfectly correct with this solution:

<img width="736" height="202" alt="image" src="https://github.com/user-attachments/assets/98b3aca4-a109-4fb3-965f-129b3e88dee1" />

This solution

- has ideal diff
- but overrides PHP-Parser method for canonical backslashes, so we need to maintain it (it's one liner but still)


2nd alternative solution is here: https://github.com/infection/infection/pull/3023