### PR TITLE
refactor(tracing): Adjust the API of JUnitTestCaseSorter

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -427,12 +427,6 @@ parameters:
 			path: ../src/TestFramework/Tracing/TestRunOrderResolver.php
 
 		-
-			rawMessage: 'Unable to resolve the template type TMapKey in call to method Pipeline\Standard<mixed,Infection\AbstractTestFramework\Coverage\TestLocation>::map()'
-			identifier: argument.templateType
-			count: 1
-			path: ../src/TestFramework/Tracing/TestRunOrderResolver.php
-
-		-
 			rawMessage: 'Method Infection\Testing\BaseMutatorTestCase::createMutator() has parameter $settings with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -388,21 +388,6 @@ parameters:
 			path: ../src/TestFramework/Coverage/CoverageChecker.php
 
 		-
-			rawMessage: Do not use magic number in arithmetic operations. Move to constant with a suitable name.
-			count: 1
-			path: ../src/TestFramework/Coverage/JUnit/TestLocationBucketSorter.php
-
-		-
-			rawMessage: Do not use magic number in bitwise operations. Move to constant with a suitable name.
-			count: 3
-			path: ../src/TestFramework/Coverage/JUnit/TestLocationBucketSorter.php
-
-		-
-			rawMessage: Do not use magic number in comparison operations. Move to constant with a suitable name.
-			count: 1
-			path: ../src/TestFramework/Coverage/JUnit/TestLocationBucketSorter.php
-
-		-
 			rawMessage: 'Call to function array_filter() requires parameter #2 to be passed to avoid loose comparison semantics.'
 			identifier: arrayFilter.strict
 			count: 1
@@ -419,6 +404,33 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
+
+		-
+			rawMessage: Do not use magic number in arithmetic operations. Move to constant with a suitable name.
+			count: 1
+			path: ../src/TestFramework/Tracing/TestLocationBucketSorter.php
+
+		-
+			rawMessage: Do not use magic number in bitwise operations. Move to constant with a suitable name.
+			count: 3
+			path: ../src/TestFramework/Tracing/TestLocationBucketSorter.php
+
+		-
+			rawMessage: Do not use magic number in comparison operations. Move to constant with a suitable name.
+			count: 1
+			path: ../src/TestFramework/Tracing/TestLocationBucketSorter.php
+
+		-
+			rawMessage: 'Generator expects value type string, string|null given.'
+			identifier: generator.valueType
+			count: 1
+			path: ../src/TestFramework/Tracing/TestRunOrderResolver.php
+
+		-
+			rawMessage: 'Unable to resolve the template type TMapKey in call to method Pipeline\Standard<mixed,Infection\AbstractTestFramework\Coverage\TestLocation>::map()'
+			identifier: argument.templateType
+			count: 1
+			path: ../src/TestFramework/Tracing/TestRunOrderResolver.php
 
 		-
 			rawMessage: 'Method Infection\Testing\BaseMutatorTestCase::createMutator() has parameter $settings with no value type specified in iterable type array.'
@@ -1225,42 +1237,6 @@ parameters:
 			path: ../tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php
 
 		-
-			rawMessage: 'Call to internal method PHPUnit\Framework\TestCase::addToAssertionCount() from outside its root namespace PHPUnit.'
-			identifier: method.internal
-			count: 1
-			path: ../tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTest.php
-
-		-
-			rawMessage: 'Method Infection\Tests\TestFramework\Coverage\JUnit\TestLocationBucketSorterTest::quicksort() has parameter $uniqueTestLocations with no type specified.'
-			identifier: missingType.parameter
-			count: 1
-			path: ../tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTest.php
-
-		-
-			rawMessage: 'Method Infection\Tests\TestFramework\Coverage\JUnit\TestLocationBucketSorterTest::test_it_sorts_correctly() has parameter $uniqueTestLocations with generic class ArrayIterator but does not specify its types: TKey, TValue'
-			identifier: missingType.generics
-			count: 1
-			path: ../tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTest.php
-
-		-
-			rawMessage: 'Method Infection\Tests\TestFramework\Coverage\JUnit\TestLocationBucketSorterTest::test_it_sorts_faster_than_quicksort() has parameter $uniqueTestLocations with generic class ArrayIterator but does not specify its types: TKey, TValue'
-			identifier: missingType.generics
-			count: 1
-			path: ../tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTest.php
-
-		-
-			rawMessage: 'Method Infection\Tests\TestFramework\Coverage\JUnit\TestLocationBucketSorterTest::test_quicksort_sorts_correctly() has parameter $uniqueTestLocations with generic class ArrayIterator but does not specify its types: TKey, TValue'
-			identifier: missingType.generics
-			count: 1
-			path: ../tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTest.php
-
-		-
-			rawMessage: 'Only numeric types are allowed in /, float|null given on the right side.'
-			identifier: div.rightNonNumeric
-			count: 1
-			path: ../tests/phpunit/TestFramework/Coverage/JUnit/TestLocationBucketSorterTest.php
-
-		-
 			rawMessage: 'Method Infection\Tests\TestFramework\Coverage\XmlReport\TestLocatorTest::getTestsLocations() return type has no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1337,6 +1313,12 @@ parameters:
 			identifier: property.notFound
 			count: 2
 			path: ../tests/phpunit/TestFramework/SafeDOMXPath/SafeDOMXPathTest.php
+
+		-
+			rawMessage: 'Only numeric types are allowed in /, float|null given on the right side.'
+			identifier: div.rightNonNumeric
+			count: 1
+			path: ../tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php
 
 		-
 			rawMessage: Access to an undefined property PhpParser\NodeVisitor::$range.

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -40,13 +40,13 @@ use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
 use Infection\Config\ValueProvider\PCOVDirectoryProvider;
 use Infection\TestFramework\CommandLineBuilder;
-use Infection\TestFramework\Coverage\JUnit\JUnitTestCaseSorter;
 use Infection\TestFramework\PhpUnit\CommandLine\ArgumentsAndOptionsBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider;
+use Infection\TestFramework\Tracing\TestRunOrderResolver;
 use Infection\TestFramework\VersionParser;
 use function Safe\file_get_contents;
 use SplFileInfo;
@@ -108,7 +108,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
                 $testFrameworkConfigContent,
                 $configManipulator,
                 $projectDir,
-                new JUnitTestCaseSorter(),
+                new TestRunOrderResolver(),
             ),
             new ArgumentsAndOptionsBuilder(
                 $executeOnlyCoveringTestCases,

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -62,7 +62,7 @@ class MutationConfigBuilder extends ConfigBuilder
         private readonly string $originalXmlConfigContent,
         private readonly XmlConfigurationManipulator $configManipulator,
         private readonly string $projectDir,
-        private readonly TestRunOrderResolver $jUnitTestCaseSorter,
+        private readonly TestRunOrderResolver $testRunOrderResolver,
     ) {
     }
 
@@ -235,7 +235,7 @@ class MutationConfigBuilder extends ConfigBuilder
         $testSuite = $xPath->document->createElement('testsuite');
         $testSuite->setAttribute('name', 'Infection testsuite with filtered tests');
 
-        $orderedTestFilePaths = $this->jUnitTestCaseSorter->getOrderedTestFilePaths($tests);
+        $orderedTestFilePaths = $this->testRunOrderResolver->resolve($tests);
 
         foreach ($orderedTestFilePaths as $testFilePath) {
             $fileElement = $xPath->document->createElement('file', $testFilePath);

--- a/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
@@ -41,9 +41,9 @@ use DOMNodeList;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\StreamWrapper\IncludeInterceptor;
 use Infection\TestFramework\Config\MutationConfigBuilder as ConfigBuilder;
-use Infection\TestFramework\Coverage\JUnit\JUnitTestCaseSorter;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator;
 use Infection\TestFramework\SafeDOMXPath;
+use Infection\TestFramework\Tracing\TestRunOrderResolver;
 use function Safe\file_put_contents;
 use function sprintf;
 use Webmozart\Assert\Assert;
@@ -62,7 +62,7 @@ class MutationConfigBuilder extends ConfigBuilder
         private readonly string $originalXmlConfigContent,
         private readonly XmlConfigurationManipulator $configManipulator,
         private readonly string $projectDir,
-        private readonly JUnitTestCaseSorter $jUnitTestCaseSorter,
+        private readonly TestRunOrderResolver $jUnitTestCaseSorter,
     ) {
     }
 
@@ -235,12 +235,12 @@ class MutationConfigBuilder extends ConfigBuilder
         $testSuite = $xPath->document->createElement('testsuite');
         $testSuite->setAttribute('name', 'Infection testsuite with filtered tests');
 
-        $uniqueTestFilePaths = $this->jUnitTestCaseSorter->getUniqueSortedFileNames($tests);
+        $orderedTestFilePaths = $this->jUnitTestCaseSorter->getOrderedTestFilePaths($tests);
 
-        foreach ($uniqueTestFilePaths as $testFilePath) {
-            $file = $xPath->document->createElement('file', $testFilePath);
+        foreach ($orderedTestFilePaths as $testFilePath) {
+            $fileElement = $xPath->document->createElement('file', $testFilePath);
 
-            $testSuite->appendChild($file);
+            $testSuite->appendChild($fileElement);
         }
 
         Assert::isInstanceOf($nodeToAppendTestSuite, DOMNode::class);

--- a/src/TestFramework/Tracing/TestLocationBucketSorter.php
+++ b/src/TestFramework/Tracing/TestLocationBucketSorter.php
@@ -42,7 +42,7 @@ use function ksort;
 /**
  * @internal
  */
-final class TestLocationBucketSorter
+final readonly class TestLocationBucketSorter
 {
     use CannotBeInstantiated;
 

--- a/src/TestFramework/Tracing/TestLocationBucketSorter.php
+++ b/src/TestFramework/Tracing/TestLocationBucketSorter.php
@@ -33,9 +33,10 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\Coverage\JUnit;
+namespace Infection\TestFramework\Tracing;
 
 use Infection\AbstractTestFramework\Coverage\TestLocation;
+use Infection\CannotBeInstantiated;
 use function ksort;
 
 /**
@@ -43,6 +44,8 @@ use function ksort;
  */
 final class TestLocationBucketSorter
 {
+    use CannotBeInstantiated;
+
     /**
      * Pre-sort first buckets, optimistically assuming that most projects
      * won't have tests longer than a second.
@@ -57,10 +60,6 @@ final class TestLocationBucketSorter
         6 => [],
         7 => [],
     ];
-
-    private function __construct()
-    {
-    }
 
     /**
      * Sorts tests to run the fastest first. Exposed for benchmarking purposes.

--- a/src/TestFramework/Tracing/TestRunOrderResolver.php
+++ b/src/TestFramework/Tracing/TestRunOrderResolver.php
@@ -124,7 +124,7 @@ final readonly class TestRunOrderResolver
     private static function sortedLocationsGenerator(iterable $sortedTestLocations): iterable
     {
         return yield from take($sortedTestLocations)
-            ->map(static fn (TestLocation $testLocation) => $testLocation->getFilePath())
+            ->map(static fn (TestLocation $testLocation): ?string => $testLocation->getFilePath())
             ->stream();
     }
 

--- a/src/TestFramework/Tracing/TestRunOrderResolver.php
+++ b/src/TestFramework/Tracing/TestRunOrderResolver.php
@@ -38,7 +38,6 @@ namespace Infection\TestFramework\Tracing;
 use function count;
 use function current;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
-use function Pipeline\take;
 use function usort;
 
 /**
@@ -123,9 +122,16 @@ final readonly class TestRunOrderResolver
      */
     private static function sortedLocationsGenerator(iterable $sortedTestLocations): iterable
     {
-        return yield from take($sortedTestLocations)
-            ->map(static fn (TestLocation $testLocation): ?string => $testLocation->getFilePath())
-            ->stream();
+        foreach ($sortedTestLocations as $testLocation) {
+            // Note that there is a type issue here: $filePath is a string|null,
+            // but we expect strings.
+            // It is because in practice this code is used on completed TestLocation
+            // objects for which there is always a file type.
+            // Since this is a hotpath no assertion is being added here.
+            $filePath = $testLocation->getFilePath();
+
+            yield $filePath;
+        }
     }
 
     /**

--- a/src/TestFramework/Tracing/TestRunOrderResolver.php
+++ b/src/TestFramework/Tracing/TestRunOrderResolver.php
@@ -33,17 +33,21 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\Coverage\JUnit;
+namespace Infection\TestFramework\Tracing;
 
+use function array_map;
 use function count;
 use function current;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use function usort;
 
 /**
+ * Resolves the order in which test files should be run against a mutant,
+ * prioritizing the fastest tests first
+ *
  * @internal
  */
-final class JUnitTestCaseSorter
+final class TestRunOrderResolver
 {
     /**
      * Expected average number of buckets. Exposed for testing purposes.
@@ -59,11 +63,13 @@ final class JUnitTestCaseSorter
     public const USE_BUCKET_SORT_AFTER = 15;
 
     /**
+     * Returns unique test file paths ordered by execution time (fastest first).
+     *
      * @param TestLocation[] $tests
      *
-     * @return iterable<string>
+     * @return string[]
      */
-    public function getUniqueSortedFileNames(array $tests): iterable
+    public function getOrderedTestFilePaths(array $tests): array
     {
         $uniqueTestLocations = $this->uniqueByTestFile($tests);
 
@@ -113,16 +119,14 @@ final class JUnitTestCaseSorter
     /**
      * @param iterable<TestLocation> $sortedTestLocations
      *
-     * @return iterable<string>
+     * @return array<string>
      */
-    private static function sortedLocationsGenerator(iterable $sortedTestLocations): iterable
+    private static function sortedLocationsGenerator(iterable $sortedTestLocations): array
     {
-        foreach ($sortedTestLocations as $testLocation) {
-            /** @var string $filePath */
-            $filePath = $testLocation->getFilePath();
-
-            yield $filePath;
-        }
+        return array_map(
+            static fn (TestLocation $testLocation): string => $testLocation->getFilePath(),
+            $sortedTestLocations,
+        );
     }
 
     /**

--- a/src/TestFramework/Tracing/TestRunOrderResolver.php
+++ b/src/TestFramework/Tracing/TestRunOrderResolver.php
@@ -119,6 +119,8 @@ final readonly class TestRunOrderResolver
      * @param iterable<TestLocation> $sortedTestLocations
      *
      * @return iterable<string>
+     *
+     * @psalm-suppress InvalidReturnType
      */
     private static function sortedLocationsGenerator(iterable $sortedTestLocations): iterable
     {

--- a/src/TestFramework/Tracing/TestRunOrderResolver.php
+++ b/src/TestFramework/Tracing/TestRunOrderResolver.php
@@ -35,10 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Tracing;
 
-use function array_map;
 use function count;
 use function current;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
+use function Pipeline\take;
 use function usort;
 
 /**
@@ -47,7 +47,7 @@ use function usort;
  *
  * @internal
  */
-final class TestRunOrderResolver
+final readonly class TestRunOrderResolver
 {
     /**
      * Expected average number of buckets. Exposed for testing purposes.
@@ -67,9 +67,9 @@ final class TestRunOrderResolver
      *
      * @param TestLocation[] $tests
      *
-     * @return string[]
+     * @return iterable<string>
      */
-    public function getOrderedTestFilePaths(array $tests): array
+    public function resolve(array $tests): iterable
     {
         $uniqueTestLocations = $this->uniqueByTestFile($tests);
 
@@ -119,14 +119,13 @@ final class TestRunOrderResolver
     /**
      * @param iterable<TestLocation> $sortedTestLocations
      *
-     * @return array<string>
+     * @return iterable<string>
      */
-    private static function sortedLocationsGenerator(iterable $sortedTestLocations): array
+    private static function sortedLocationsGenerator(iterable $sortedTestLocations): iterable
     {
-        return array_map(
-            static fn (TestLocation $testLocation): string => $testLocation->getFilePath(),
-            $sortedTestLocations,
-        );
+        return yield from take($sortedTestLocations)
+            ->map(static fn (TestLocation $testLocation) => $testLocation->getFilePath())
+            ->stream();
     }
 
     /**

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -44,10 +44,10 @@ use DOMXPath;
 use function escapeshellarg;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\StreamWrapper\IncludeInterceptor;
-use Infection\TestFramework\Coverage\JUnit\JUnitTestCaseSorter;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator;
+use Infection\TestFramework\Tracing\TestRunOrderResolver;
 use Infection\Tests\FileSystem\FileSystemTestCase;
 use function iterator_to_array;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -790,7 +790,7 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
             file_get_contents($phpunitXmlPath),
             new XmlConfigurationManipulator($replacer, ''),
             'project/dir',
-            new JUnitTestCaseSorter(),
+            new TestRunOrderResolver(),
         );
     }
 

--- a/tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php
+++ b/tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php
@@ -33,7 +33,7 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework\Coverage\JUnit;
+namespace Infection\Tests\TestFramework\Tracing;
 
 use function abs;
 use function array_map;
@@ -42,11 +42,10 @@ use function array_slice;
 use ArrayIterator;
 use function extension_loaded;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
-use Infection\TestFramework\Coverage\JUnit\JUnitTestCaseSorter;
-use Infection\TestFramework\Coverage\JUnit\TestLocationBucketSorter;
+use Infection\TestFramework\Tracing\TestLocationBucketSorter;
+use Infection\TestFramework\Tracing\TestRunOrderResolver;
 use Infection\Tests\Fixtures\TestFramework\PhpUnit\Coverage\JUnitTimes;
 use function iterator_to_array;
-use function log;
 use function microtime;
 use const PHP_SAPI;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -206,7 +205,7 @@ final class TestLocationBucketSorterTest extends TestCase
             JUnitTimes::JUNIT_TIMES,
         );
 
-        yield 'Ten times the minimal amount of locations' => [new ArrayIterator(array_slice($locations, 0, JUnitTestCaseSorter::USE_BUCKET_SORT_AFTER * 10))];
+        yield 'Ten times the minimal amount of locations' => [new ArrayIterator(array_slice($locations, 0, TestRunOrderResolver::USE_BUCKET_SORT_AFTER * 10))];
 
         yield 'All locations' => [new ArrayIterator($locations)];
     }

--- a/tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php
+++ b/tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php
@@ -115,7 +115,7 @@ final class TestLocationBucketSorterTest extends TestCase
     }
 
     /**
-     * @param ArrayIterator<TestLocation> $uniqueTestLocations
+     * @param ArrayIterator<array-key, TestLocation> $uniqueTestLocations
      */
     #[DataProvider('locationsArrayProvider')]
     public function test_it_sorts_correctly(ArrayIterator $uniqueTestLocations): void
@@ -136,7 +136,7 @@ final class TestLocationBucketSorterTest extends TestCase
     /**
      * Sanity check
      *
-     * @param ArrayIterator<TestLocation> $uniqueTestLocations
+     * @param ArrayIterator<array-key, TestLocation> $uniqueTestLocations
      */
     #[DataProvider('locationsArrayProvider')]
     public function test_quicksort_sorts_correctly(ArrayIterator $uniqueTestLocations): void
@@ -152,7 +152,7 @@ final class TestLocationBucketSorterTest extends TestCase
     }
 
     /**
-     * @param ArrayIterator<TestLocation> $uniqueTestLocations
+     * @param ArrayIterator<array-key, TestLocation> $uniqueTestLocations
      */
     #[DataProvider('locationsArrayProvider')]
     public function test_it_sorts_faster_than_quicksort(ArrayIterator $uniqueTestLocations): void
@@ -165,7 +165,7 @@ final class TestLocationBucketSorterTest extends TestCase
 
         if (self::areConstraintsOrderValid($uniqueTestLocations)) {
             // Ignore silently as to not pollute to the log.
-            $this->addToAssertionCount(1);
+            $this->expectNotToPerformAssertions();
 
             return;
         }
@@ -226,6 +226,9 @@ final class TestLocationBucketSorterTest extends TestCase
         return abs($a - $b) / (abs($a) + abs($b));
     }
 
+    /**
+     * @param TestLocation[] $uniqueTestLocations
+     */
     private static function quicksort(&$uniqueTestLocations): void
     {
         usort(

--- a/tests/phpunit/TestFramework/Tracing/TestLocationSorterTest.php
+++ b/tests/phpunit/TestFramework/Tracing/TestLocationSorterTest.php
@@ -33,85 +33,86 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\TestFramework\Coverage\JUnit;
+namespace Infection\Tests\TestFramework\Tracing;
 
 use Infection\AbstractTestFramework\Coverage\TestLocation;
-use Infection\TestFramework\Coverage\JUnit\JUnitTestCaseSorter;
-use function iterator_to_array;
+use Infection\TestFramework\Tracing\TestRunOrderResolver;
 use function log;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(JUnitTestCaseSorter::class)]
-final class JUnitTestCaseSorterTest extends TestCase
+#[CoversClass(TestRunOrderResolver::class)]
+final class TestLocationSorterTest extends TestCase
 {
-    public function test_it_returns_first_file_name_if_there_is_only_one(): void
-    {
-        $coverageTestCases = [
-            new TestLocation(
-                'testMethod1',
-                '/path/to/test-file-1',
-                0.000234,
-            ),
-        ];
+    /**
+     * @param TestLocation[] $testLocations
+     * @param string[] $expected
+     */
+    #[DataProvider('scenarioProvider')]
+    public function test_it_returns_first_file_name_if_there_is_only_one(
+        array $testLocations,
+        array $expected,
+    ): void {
+        $resolver = new TestRunOrderResolver();
 
-        $sorter = new JUnitTestCaseSorter();
+        $actual = $resolver->getOrderedTestFilePaths($testLocations);
 
-        $uniqueSortedFileNames = $sorter->getUniqueSortedFileNames($coverageTestCases);
-
-        $this->assertSame(['/path/to/test-file-1'], $uniqueSortedFileNames);
+        $this->assertSame($expected, $actual);
     }
 
-    public function test_it_returns_unique_and_sorted_by_time_test_cases(): void
+    public static function scenarioProvider(): iterable
     {
-        $coverageTestCases = [
-            new TestLocation(
-                'testMethod1',
-                '/path/to/test-file-1',
-                0.500234,
-            ),
-            new TestLocation(
-                'testMethod2',
-                '/path/to/test-file-2',
-                0.900221,
-            ),
-            new TestLocation(
-                'testMethod3_1',
-                '/path/to/test-file-3',
-                0.000022,
-            ),
-            new TestLocation(
-                'testMethod3_2',
-                '/path/to/test-file-4',
-                0.210022,
-            ),
+        yield [
+            [
+                new TestLocation(
+                    'testMethod1',
+                    '/path/to/test-file-1',
+                    0.000234,
+                ),
+            ],
+            ['/path/to/test-file-1'],
         ];
 
-        $sorter = new JUnitTestCaseSorter();
-
-        $uniqueSortedFileNames = iterator_to_array(
-            $sorter->getUniqueSortedFileNames($coverageTestCases),
-            false,
-        );
-
-        $this->assertSame(
+        yield [
+            [
+                new TestLocation(
+                    'testMethod1',
+                    '/path/to/test-file-1',
+                    0.500234,
+                ),
+                new TestLocation(
+                    'testMethod2',
+                    '/path/to/test-file-2',
+                    0.900221,
+                ),
+                new TestLocation(
+                    'testMethod3_1',
+                    '/path/to/test-file-3',
+                    0.000022,
+                ),
+                new TestLocation(
+                    'testMethod3_2',
+                    '/path/to/test-file-4',
+                    0.210022,
+                ),
+            ],
             [
                 '/path/to/test-file-3',
                 '/path/to/test-file-4',
                 '/path/to/test-file-1',
                 '/path/to/test-file-2',
             ],
-            $uniqueSortedFileNames,
-        );
+        ];
     }
 
     public function test_it_has_correct_constants_for_bucket_sort(): void
     {
         $this->assertLessThan(
             // Quicksort's average O(n log n)
-            JUnitTestCaseSorter::USE_BUCKET_SORT_AFTER * log(JUnitTestCaseSorter::USE_BUCKET_SORT_AFTER),
+            TestRunOrderResolver::USE_BUCKET_SORT_AFTER * log(TestRunOrderResolver::USE_BUCKET_SORT_AFTER),
             // Bucket Sort's average O(n + k)
-            JUnitTestCaseSorter::USE_BUCKET_SORT_AFTER + JUnitTestCaseSorter::BUCKETS_COUNT,
+            TestRunOrderResolver::USE_BUCKET_SORT_AFTER + TestRunOrderResolver::BUCKETS_COUNT,
         );
     }
 }

--- a/tests/phpunit/TestFramework/Tracing/TestRunOrderResolverTest.php
+++ b/tests/phpunit/TestFramework/Tracing/TestRunOrderResolverTest.php
@@ -41,22 +41,23 @@ use function log;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use function Pipeline\take;
 
 #[CoversClass(TestRunOrderResolver::class)]
-final class TestLocationSorterTest extends TestCase
+final class TestRunOrderResolverTest extends TestCase
 {
     /**
      * @param TestLocation[] $testLocations
      * @param string[] $expected
      */
     #[DataProvider('scenarioProvider')]
-    public function test_it_returns_first_file_name_if_there_is_only_one(
+    public function test_it_resolves_the_unique_test_locations_ordered_from_fastest_to_slowest(
         array $testLocations,
         array $expected,
     ): void {
         $resolver = new TestRunOrderResolver();
 
-        $actual = $resolver->getOrderedTestFilePaths($testLocations);
+        $actual = take($resolver->resolve($testLocations))->toList();
 
         $this->assertSame($expected, $actual);
     }


### PR DESCRIPTION
## Description

Whilst resuming work on https://github.com/infection/infection/pull/2543 (recently unblocked by https://github.com/infection/infection/pull/2815), I investigated the remaining usages of the JUnit services that were left untouched at the time.

`JUnitTestCaseSorter` accumulates several naming, location, and documentation issues. I would like to address them separately from #2543 to keep that PR focused. The problems are not bugs – the behaviour is correct, but the naming has drifted far enough from what the service actually does that it warrants a dedicated clean-up.

`JUnitTestCaseTimeAdder` is an internal utility of `JUnitTestCaseSorter` and suffers from the same issues.


## Changes

This PR:

- Renames `JUnitTestCaseSorter` to `TestRunOrderResolver`. The rationale:
  - The service has no dependency on JUnit. The fact that its input may originate from a JUnit report is an implementation detail irrelevant to its API and behaviour.
  - It operates on `TestLocation` objects, not test cases.
  - "Sort/Sorter" implies an in-place re-ordering of the input. This service _extracts_ an ordered, deduplicated list — the output differs in both shape and content from the input.
- Since the service has no relationship with JUnit, it was moved out of that namespace. Co-locating it with `TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder` (the sole consumer) was considered, but that class may itself be restructured (see https://github.com/infection/infection/issues/2863). Placing it alongside `TestLocation` is not possible either, as that class lives in the separate `infection/abstract-testframework-adapter` package. Given that the service is directly related to trace information, it was placed in the `Trace` namespace instead.