### PR TITLE
perf(ast): Skip checking the other comments once ignore all is found

### DIFF
--- a/src/PhpParser/Visitor/IgnoreAllMutationsAnnotationReaderVisitor.php
+++ b/src/PhpParser/Visitor/IgnoreAllMutationsAnnotationReaderVisitor.php
@@ -63,6 +63,8 @@ final class IgnoreAllMutationsAnnotationReaderVisitor extends NodeVisitorAbstrac
             if (str_contains($comment->getText(), self::IGNORE_ALL_MUTATIONS_ANNOTATION)) {
                 $this->changingIgnorer->startIgnoring();
                 $this->ignoredNodes->offsetSet($node);
+
+                break;
             }
         }
 


### PR DESCRIPTION
Since we are not looking for anything else in the comments here, we can stop the traverse early.