### PR TITLE
test: Leverage SafeDOMXPath

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -1171,12 +1171,6 @@ parameters:
 			path: ../tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
 
 		-
-			rawMessage: 'Method Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::queryXpath() should return DOMNodeList but returns DOMNodeList<DOMNameSpaceNode|DOMNode>|false.'
-			identifier: return.type
-			count: 1
-			path: ../tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
-
-		-
 			rawMessage: Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.
 			identifier: ternary.shortNotAllowed
 			count: 1
@@ -1191,12 +1185,6 @@ parameters:
 		-
 			rawMessage: 'Method Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::queryXpath() return type with generic class DOMNodeList does not specify its types: TNode'
 			identifier: missingType.generics
-			count: 1
-			path: ../tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
-
-		-
-			rawMessage: 'Method Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::queryXpath() should return DOMNodeList but returns DOMNodeList<DOMNameSpaceNode|DOMNode>|false.'
-			identifier: return.type
 			count: 1
 			path: ../tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
 

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -35,14 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpUnit\Config\Builder;
 
-use DOMDocument;
 use DOMNodeList;
-use DOMXPath;
 use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\InvalidPhpUnitConfiguration;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider;
+use Infection\TestFramework\SafeDOMXPath;
 use Infection\Tests\FileSystem\FileSystemTestCase;
 use InvalidArgumentException;
 use const PHP_EOL;
@@ -552,13 +551,9 @@ final class InitialConfigBuilderTest extends FileSystemTestCase
         ];
     }
 
-    // TODO: at this point it is better to use the SafeDOMXPath...
     private function queryXpath(string $xml, string $query): DOMNodeList
     {
-        $dom = new DOMDocument();
-        $dom->loadXML($xml);
-
-        return (new DOMXPath($dom))->query($query);
+        return SafeDOMXPath::fromString($xml)->queryList($query);
     }
 
     private function createConfigBuilderForPHPUnit93(): InitialConfigBuilder

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -36,17 +36,16 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\PhpUnit\Config\Builder;
 
 use function array_map;
-use DOMDocument;
 use DOMNameSpaceNode;
 use DOMNode;
 use DOMNodeList;
-use DOMXPath;
 use function escapeshellarg;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\StreamWrapper\IncludeInterceptor;
 use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator;
+use Infection\TestFramework\SafeDOMXPath;
 use Infection\TestFramework\Tracing\TestRunOrderResolver;
 use Infection\Tests\FileSystem\FileSystemTestCase;
 use function iterator_to_array;
@@ -769,13 +768,9 @@ final class MutationConfigBuilderTest extends FileSystemTestCase
         ];
     }
 
-    // TODO: at this point it is better to use the SafeDOMXPath...
     private function queryXpath(string $xml, string $query): DOMNodeList
     {
-        $dom = new DOMDocument();
-        $dom->loadXML($xml);
-
-        return (new DOMXPath($dom))->query($query);
+        return SafeDOMXPath::fromString($xml)->queryList($query);
     }
 
     private function createConfigBuilder(


### PR DESCRIPTION
This PR fixes the last TODOs I could find about preferring to use the `SafeDOMXPath` instead of the PHP native API for more type safety, removing the corresponding PHPStan baseline suppressions.
