### PR TITLE
feat(mago): Add support for mago static analysis 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,13 @@ cs: $(PHP_CS_FIXER)
 	LC_ALL=C sort -u .gitignore -o .gitignore
 	$(MAKE) check_trailing_whitespaces
 
+.PHONY: cs-docker
+cs-docker:	  	 	## Runs PHP-CS-Fixer in docker
+cs-docker: $(DOCKER_FILE_IMAGE) $(PHP_CS_FIXER)
+	$(DOCKER_RUN_82) $(PHP_CS_FIXER) fix -v --diff
+	LC_ALL=C sort -u .gitignore -o .gitignore
+	$(MAKE) check_trailing_whitespaces
+
 .PHONY: cs-check
 cs-check:		## Runs PHP-CS-Fixer in dry-run mode
 cs-check: $(PHP_CS_FIXER)

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -753,7 +753,7 @@ count = 1
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #13 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `array<string, mixed>`, but provided type `array<array-key, mixed>` is less specific.'
+message = 'Argument type mismatch for argument #14 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `array<string, mixed>`, but provided type `array<array-key, mixed>` is less specific.'
 count = 1
 
 [[issues]]
@@ -807,19 +807,25 @@ count = 1
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #11 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `bool|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #11 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `float|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #12 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `int|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #12 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `bool|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #19 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `int|null|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #13 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `int|null`, but found `mixed`.'
+count = 1
+
+[[issues]]
+file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #20 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `int|null|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -831,13 +837,7 @@ count = 1
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #8 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `bool|null`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #9 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `float|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #9 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `bool|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -7099,6 +7099,18 @@ message = 'Method `assertequals` does not exist on type `Infection\Tests\Configu
 count = 1
 
 [[issues]]
+file = "tests/phpunit/Configuration/Entry/MagoTest.php"
+code = "imprecise-type"
+message = "Type `iterable` in return type of `basePathProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/Entry/MagoTest.php"
+code = "non-existent-method"
+message = 'Method `assertequals` does not exist on type `Infection\Tests\Configuration\Entry\MagoTest`.'
+count = 2
+
+[[issues]]
 file = "tests/phpunit/Configuration/Entry/PhpStanTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `basePathProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -7209,13 +7221,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "invalid-argument"
-message = '''Invalid argument type for argument #1 of `array_values`: expected `array<('K.array_values() extends array-key), mixed>`, but found `array{'bootstrap': null, 'ignoreMsiWithNoMutations': null, 'initialTestsPhpOptions': null, 'logs': infection\configuration\entry\logs, 'maxTimeouts': null, 'minCoveredMsi': null, 'minMsi': null, 'mutators': array{}, 'path': string('/path/to/config'), 'phpStan': Infection\Configuration\Entry\PhpStan, 'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source, 'staticAnalysisTool': null, 'staticAnalysisToolOptions': null, 'testFramework': null, 'testFrameworkOptions': null, 'threadCount': null, 'timeout': null, 'timeoutsAsEscaped': null, 'tmpDir': null, ...<array<string, mixed>, mixed>}`.'''
+message = '''Invalid argument type for argument #1 of `array_values`: expected `array<('K.array_values() extends array-key), mixed>`, but found `array{'bootstrap': null, 'ignoreMsiWithNoMutations': null, 'initialTestsPhpOptions': null, 'logs': infection\configuration\entry\logs, 'mago': Infection\Configuration\Entry\Mago, 'maxTimeouts': null, 'minCoveredMsi': null, 'minMsi': null, 'mutators': array{}, 'path': string('/path/to/config'), 'phpStan': Infection\Configuration\Entry\PhpStan, 'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source, 'staticAnalysisTool': null, 'staticAnalysisToolOptions': null, 'testFramework': null, 'testFrameworkOptions': null, 'threadCount': null, 'timeout': null, 'timeoutsAsEscaped': null, 'tmpDir': null, ...<array<string, mixed>, mixed>}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "invalid-argument"
-message = "Invalid argument type for argument #2 of `array_merge`: expected `array<string('bootstrap')|string('ignoreMsiWithNoMutations')|string('initialTestsPhpOptions')|string('logs')|string('maxTimeouts')|string('minCoveredMsi')|string('minMsi')|string('mutators')|string('path')|string('phpStan')|string('phpunit')|string('source')|string('staticAnalysisTool')|string('staticAnalysisToolOptions')|string('testFramework')|string('testFrameworkOptions')|string('threadCount')|string('timeout')|string('timeoutsAsEscaped')|string('tmpDir'), mixed>`, but found `array<array<string, mixed>, mixed>`."
+message = "Invalid argument type for argument #2 of `array_merge`: expected `array<string('bootstrap')|string('ignoreMsiWithNoMutations')|string('initialTestsPhpOptions')|string('logs')|string('mago')|string('maxTimeouts')|string('minCoveredMsi')|string('minMsi')|string('mutators')|string('path')|string('phpStan')|string('phpunit')|string('source')|string('staticAnalysisTool')|string('staticAnalysisToolOptions')|string('testFramework')|string('testFrameworkOptions')|string('threadCount')|string('timeout')|string('timeoutsAsEscaped')|string('tmpDir'), mixed>`, but found `array<array<string, mixed>, mixed>`."
 count = 1
 
 [[issues]]
@@ -7313,6 +7325,12 @@ file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'logs': infection\configuration\entry\logs, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 2
+
+[[issues]]
+file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
+code = "possibly-invalid-argument"
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mago': Infection\Configuration\Entry\Mago, 'source': Infection\Configuration\Entry\Source}`.'''
+count = 3
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
@@ -17039,6 +17057,216 @@ file = "tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php"
 code = "non-existent-method"
 message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\StaticAnalysis\Config\StaticAnalysisConfigLocatorTest`.'
 count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterFactoryTest.php"
+code = "non-existent-method"
+message = 'Method `assertsame` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterFactoryTest`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "imprecise-type"
+message = "Type `iterable` in return type of `provideValidVersions` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `Infection\StaticAnalysis\Mago\Adapter\MagoAdapter::__construct`: expected `Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory`, but found `mixed`.'
+count = 6
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
+count = 4
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "non-existent-method"
+message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "non-existent-method"
+message = 'Method `assertsame` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
+count = 6
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "non-existent-method"
+message = 'Method `createstub` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
+count = 6
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "non-existent-method"
+message = 'Method `expectexception` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "non-existent-method"
+message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "non-existent-method"
+message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "non-existent-method"
+message = 'Method `once` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
+count = 4
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_accepts_valid_versions`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_rejects_invalid_versions`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_returns_version`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_returns_version`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_returns_version`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_returns_version`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "unused-method"
+message = "Method `setup()` is never used."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
+code = "deprecated-method"
+message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
+count = 5
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
+code = "missing-magic-method"
+message = "Call to documented magic method `method()` on a class that cannot handle it."
+count = 18
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
+count = 4
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
+code = "non-existent-method"
+message = 'Method `assertgreaterthan` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactoryTest`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
+code = "non-existent-method"
+message = 'Method `assertlessthan` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactoryTest`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
+code = "non-existent-method"
+message = 'Method `exactly` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactoryTest`.'
+count = 3
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
+code = "non-existent-method"
+message = 'Method `once` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactoryTest`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
+code = "unused-method"
+message = "Method `setup()` is never used."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
+code = "deprecated-method"
+message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
+count = 3
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `Infection\StaticAnalysis\Mago\Process\MagoMutantProcessFactory::__construct`: expected `Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory`, but found `mixed`.'
+count = 3
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
+count = 6
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
+code = "mixed-assignment"
+message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
+count = 3
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
+code = "non-existent-method"
+message = 'Method `assertfalse` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Process\MagoMutantProcessFactoryTest`.'
+count = 6
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
+code = "non-existent-method"
+message = 'Method `assertsame` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Process\MagoMutantProcessFactoryTest`.'
+count = 6
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
+code = "non-existent-method"
+message = 'Method `createstub` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Process\MagoMutantProcessFactoryTest`.'
+count = 3
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
+code = "non-existent-method"
+message = 'Method `never` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Process\MagoMutantProcessFactoryTest`.'
+count = 3
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
+code = "non-existent-method"
+message = 'Method `once` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Process\MagoMutantProcessFactoryTest`.'
+count = 3
 
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterFactoryTest.php"

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -152,6 +152,21 @@
                 }
             }
         },
+        "mago": {
+            "type": "object",
+            "description": "Mago additional settings.",
+            "additionalProperties": false,
+            "properties": {
+                "configDir": {
+                    "type": "string",
+                    "description": "Path to directory containing mago configuration file."
+                },
+                "customPath": {
+                    "type": "string",
+                    "description": "Custom path to mago executable."
+                }
+            }
+        },
         "ignoreMsiWithNoMutations": {
             "type": "boolean",
             "description": "Ignore MSI violations with zero mutations."

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -38,6 +38,7 @@ namespace Infection\Configuration;
 use function array_map;
 use function explode;
 use Infection\Configuration\Entry\Logs;
+use Infection\Configuration\Entry\Mago;
 use Infection\Configuration\Entry\PhpStan;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Entry\Source;
@@ -75,6 +76,7 @@ readonly class Configuration
         public string $tmpDir,
         public PhpUnit $phpUnit,
         public PhpStan $phpStan,
+        public Mago $mago,
         public array $mutators,
         public string $testFramework,
         public ?string $bootstrap,

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -43,6 +43,7 @@ use function dirname;
 use function file_exists;
 use function in_array;
 use Infection\Configuration\Entry\Logs;
+use Infection\Configuration\Entry\Mago;
 use Infection\Configuration\Entry\PhpStan;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Schema\SchemaConfiguration;
@@ -166,6 +167,7 @@ class ConfigurationFactory
             tmpDir: $namespacedTmpDir,
             phpUnit: $this->retrievePhpUnit($schema, $configDir),
             phpStan: $this->retrievePhpStan($schema, $configDir),
+            mago: $this->retrieveMago($schema, $configDir),
             mutators: $mutators,
             testFramework: $testFramework,
             bootstrap: $schema->bootstrap,
@@ -264,6 +266,11 @@ class ConfigurationFactory
     private function retrievePhpStan(SchemaConfiguration $schema, string $configDir): PhpStan
     {
         return $schema->phpStan->withAbsolutePaths($configDir);
+    }
+
+    private function retrieveMago(SchemaConfiguration $schema, string $configDir): Mago
+    {
+        return $schema->mago->withAbsolutePaths($configDir);
     }
 
     private static function retrieveCoverageBasePath(

--- a/src/Configuration/Entry/Mago.php
+++ b/src/Configuration/Entry/Mago.php
@@ -33,53 +33,41 @@
 
 declare(strict_types=1);
 
-namespace Infection\Configuration\Schema;
+namespace Infection\Configuration\Entry;
 
-use Infection\Configuration\Entry\Logs;
-use Infection\Configuration\Entry\Mago;
-use Infection\Configuration\Entry\PhpStan;
-use Infection\Configuration\Entry\PhpUnit;
-use Infection\Configuration\Entry\Source;
-use Infection\StaticAnalysis\StaticAnalysisToolTypes;
-use Infection\TestFramework\TestFrameworkTypes;
-use Webmozart\Assert\Assert;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @internal
  */
-final readonly class SchemaConfiguration
+final readonly class Mago
 {
-    /**
-     * @param non-empty-string $pathname
-     * @param array<string, mixed> $mutators
-     * @param TestFrameworkTypes::*|null $testFramework
-     * @param StaticAnalysisToolTypes::*|null $staticAnalysisTool
-     */
     public function __construct(
-        public string $pathname,
-        public ?float $timeout,
-        public Source $source,
-        public Logs $logs,
-        public ?string $tmpDir,
-        public PhpUnit $phpUnit,
-        public PhpStan $phpStan,
-        public Mago $mago,
-        public ?bool $ignoreMsiWithNoMutations,
-        public ?float $minMsi,
-        public ?float $minCoveredMsi,
-        public ?bool $timeoutsAsEscaped,
-        public ?int $maxTimeouts,
-        public array $mutators,
-        public ?string $testFramework,
-        public ?string $bootstrap,
-        public ?string $initialTestsPhpOptions,
-        public ?string $testFrameworkExtraOptions,
-        public ?string $staticAnalysisToolOptions,
-        public string|int|null $threads,
-        public ?string $staticAnalysisTool,
+        public ?string $configDir,
+        public ?string $customPath,
     ) {
-        Assert::nullOrGreaterThanEq($timeout, 0);
-        Assert::nullOrOneOf($testFramework, TestFrameworkTypes::getTypes());
-        Assert::nullOrOneOf($staticAnalysisTool, StaticAnalysisToolTypes::getTypes());
+    }
+
+    public function withAbsolutePaths(string $basePath): self
+    {
+        $configDir = $this->configDir;
+        $customPath = $this->customPath;
+
+        $newConfigDir = $configDir === null
+            ? $basePath
+            : self::makeAbsolute($configDir, $basePath);
+
+        $newCustomPath = $customPath === null
+            ? null
+            : self::makeAbsolute($customPath, $basePath);
+
+        return new self($newConfigDir, $newCustomPath);
+    }
+
+    private static function makeAbsolute(string $path, string $basePath): string
+    {
+        return Path::isAbsolute($path)
+            ? $path
+            : Path::join($basePath, $path);
     }
 }

--- a/src/Configuration/Schema/SchemaConfigurationFactory.php
+++ b/src/Configuration/Schema/SchemaConfigurationFactory.php
@@ -39,6 +39,7 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use Infection\Configuration\Entry\Logs;
+use Infection\Configuration\Entry\Mago;
 use Infection\Configuration\Entry\PhpStan;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Entry\Source;
@@ -59,6 +60,9 @@ class SchemaConfigurationFactory
      */
     public function create(string $pathname, stdClass $rawConfig): SchemaConfiguration
     {
+        /** @var stdClass $mago */
+        $mago = $rawConfig->mago ?? new stdClass();
+
         return new SchemaConfiguration(
             pathname: $pathname,
             timeout: self::getTimeout($rawConfig),
@@ -67,6 +71,7 @@ class SchemaConfigurationFactory
             tmpDir: self::normalizeString($rawConfig->tmpDir ?? null),
             phpUnit: self::createPhpUnit($rawConfig->phpUnit ?? new stdClass()),
             phpStan: self::createPhpStan($rawConfig->phpStan ?? new stdClass()),
+            mago: self::createMago($mago),
             ignoreMsiWithNoMutations: $rawConfig->ignoreMsiWithNoMutations ?? null,
             minMsi: $rawConfig->minMsi ?? null,
             minCoveredMsi: $rawConfig->minCoveredMsi ?? null,
@@ -182,6 +187,25 @@ class SchemaConfigurationFactory
         return new PhpStan(
             self::normalizeString($phpStan->configDir ?? null),
             self::normalizeString($phpStan->customPath ?? null),
+        );
+    }
+
+    private static function createMago(stdClass $mago): Mago
+    {
+        /**
+         * Based on the schema validation this is guaranteed to be a string if it exists
+         * @var string|null $customPath
+         */
+        $customPath = $mago->customPath ?? null;
+        /**
+         * Based on the schema validation this is guaranteed to be a string if it exists
+         * @var string|null $configDir
+         */
+        $configDir = $mago->configDir ?? null;
+
+        return new Mago(
+            self::normalizeString($configDir),
+            self::normalizeString($customPath),
         );
     }
 

--- a/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
+++ b/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
@@ -51,6 +51,9 @@ readonly class StaticAnalysisConfigLocator implements TestFrameworkConfigLocator
         'neon',
         'neon.dist',
         'dist.neon',
+        'toml',
+        'json',
+        'yaml',
     ];
 
     public function __construct(

--- a/src/StaticAnalysis/Mago/Adapter/MagoAdapter.php
+++ b/src/StaticAnalysis/Mago/Adapter/MagoAdapter.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\StaticAnalysis\Mago\Adapter;
+
+use function array_merge;
+use Infection\Process\Factory\LazyMutantProcessFactory;
+use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
+use Infection\StaticAnalysis\Mago\Process\MagoMutantProcessFactory;
+use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
+use Infection\TestFramework\CommandLineBuilder;
+use Infection\TestFramework\VersionParser;
+use RuntimeException;
+use Safe\Exceptions\PcreException;
+use function sprintf;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Exception\ProcessSignaledException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+use function version_compare;
+
+/**
+ * @internal
+ */
+final class MagoAdapter implements StaticAnalysisToolAdapter
+{
+    /**
+     * @param list<string> $staticAnalysisToolOptions
+     */
+    public function __construct(
+        private readonly MagoMutantExecutionResultFactory $mutantExecutionResultFactory,
+        private readonly string $staticAnalysisConfigPath,
+        private readonly string $staticAnalysisToolExecutable,
+        private readonly CommandLineBuilder $commandLineBuilder,
+        private readonly VersionParser $versionParser,
+        private readonly float $timeout,
+        private readonly array $staticAnalysisToolOptions,
+        private ?string $version = null,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'Mago';
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getInitialRunCommandLine(): array
+    {
+        $options = array_merge([
+            "--config=$this->staticAnalysisConfigPath",
+            'analyze',
+        ], $this->staticAnalysisToolOptions);
+
+        return $this->commandLineBuilder->build(
+            $this->staticAnalysisToolExecutable,
+            [],
+            $options,
+        );
+    }
+
+    public function createMutantProcessFactory(): LazyMutantProcessFactory
+    {
+        return new MagoMutantProcessFactory(
+            $this->mutantExecutionResultFactory,
+            $this->staticAnalysisToolExecutable,
+            $this->commandLineBuilder,
+            $this->timeout,
+            $this->staticAnalysisToolOptions,
+        );
+    }
+
+    /**
+     * @throws PcreException|ProcessTimedOutException|RuntimeException|ProcessSignaledException|ProcessFailedException
+     */
+    public function getVersion(): string
+    {
+        return $this->version ??= $this->retrieveVersion();
+    }
+
+    /**
+     * @throws RuntimeException|PcreException
+     */
+    public function assertMinimumVersionSatisfied(): void
+    {
+        $version = $this->getVersion();
+
+        if (version_compare($version, '1.23.0', '>=')) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'Infection requires Mago version >=1.23.0, but "%s" is installed.',
+            $version,
+        ));
+    }
+
+    /**
+     * @throws PcreException|ProcessTimedOutException|RuntimeException|ProcessSignaledException|ProcessFailedException
+     */
+    private function retrieveVersion(): string
+    {
+        $testFrameworkVersionExecutable = $this->commandLineBuilder->build(
+            $this->staticAnalysisToolExecutable,
+            [],
+            ['--version'],
+        );
+
+        $process = new Process($testFrameworkVersionExecutable);
+        $process->mustRun();
+
+        return $this->versionParser->parse($process->getOutput());
+    }
+}

--- a/src/StaticAnalysis/Mago/Adapter/MagoAdapterFactory.php
+++ b/src/StaticAnalysis/Mago/Adapter/MagoAdapterFactory.php
@@ -33,53 +33,37 @@
 
 declare(strict_types=1);
 
-namespace Infection\Configuration\Schema;
+namespace Infection\StaticAnalysis\Mago\Adapter;
 
-use Infection\Configuration\Entry\Logs;
-use Infection\Configuration\Entry\Mago;
-use Infection\Configuration\Entry\PhpStan;
-use Infection\Configuration\Entry\PhpUnit;
-use Infection\Configuration\Entry\Source;
-use Infection\StaticAnalysis\StaticAnalysisToolTypes;
-use Infection\TestFramework\TestFrameworkTypes;
-use Webmozart\Assert\Assert;
+use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
+use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
+use Infection\StaticAnalysis\StaticAnalysisToolAdapterFactory;
+use Infection\TestFramework\CommandLineBuilder;
+use Infection\TestFramework\VersionParser;
 
 /**
  * @internal
  */
-final readonly class SchemaConfiguration
+final class MagoAdapterFactory implements StaticAnalysisToolAdapterFactory
 {
     /**
-     * @param non-empty-string $pathname
-     * @param array<string, mixed> $mutators
-     * @param TestFrameworkTypes::*|null $testFramework
-     * @param StaticAnalysisToolTypes::*|null $staticAnalysisTool
+     * @param list<string> $staticAnalysisToolOptions
      */
-    public function __construct(
-        public string $pathname,
-        public ?float $timeout,
-        public Source $source,
-        public Logs $logs,
-        public ?string $tmpDir,
-        public PhpUnit $phpUnit,
-        public PhpStan $phpStan,
-        public Mago $mago,
-        public ?bool $ignoreMsiWithNoMutations,
-        public ?float $minMsi,
-        public ?float $minCoveredMsi,
-        public ?bool $timeoutsAsEscaped,
-        public ?int $maxTimeouts,
-        public array $mutators,
-        public ?string $testFramework,
-        public ?string $bootstrap,
-        public ?string $initialTestsPhpOptions,
-        public ?string $testFrameworkExtraOptions,
-        public ?string $staticAnalysisToolOptions,
-        public string|int|null $threads,
-        public ?string $staticAnalysisTool,
-    ) {
-        Assert::nullOrGreaterThanEq($timeout, 0);
-        Assert::nullOrOneOf($testFramework, TestFrameworkTypes::getTypes());
-        Assert::nullOrOneOf($staticAnalysisTool, StaticAnalysisToolTypes::getTypes());
+    public static function create(
+        string $staticAnalysisConfigPath,
+        string $staticAnalysisToolExecutable,
+        float $timeout,
+        string $tmpDir,
+        array $staticAnalysisToolOptions,
+    ): StaticAnalysisToolAdapter {
+        return new MagoAdapter(
+            new MagoMutantExecutionResultFactory(),
+            $staticAnalysisConfigPath,
+            $staticAnalysisToolExecutable,
+            new CommandLineBuilder(),
+            new VersionParser(),
+            $timeout,
+            $staticAnalysisToolOptions,
+        );
     }
 }

--- a/src/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactory.php
+++ b/src/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactory.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\StaticAnalysis\Mago\Mutant;
+
+use Infection\Mutant\DetectionStatus;
+use Infection\Mutant\MutantExecutionResult;
+use Infection\Mutant\MutantExecutionResultFactory;
+use Infection\Process\MutantProcess;
+use function sprintf;
+use Symfony\Component\Process\Process;
+use function trim;
+use Webmozart\Assert\Assert;
+
+/**
+ * @internal
+ * @final
+ */
+class MagoMutantExecutionResultFactory implements MutantExecutionResultFactory
+{
+    private const int PROCESS_MIN_ERROR_CODE = 100;
+
+    public function createFromProcess(MutantProcess $mutantProcess): MutantExecutionResult
+    {
+        $process = $mutantProcess->getProcess();
+        $mutant = $mutantProcess->getMutant();
+        $mutation = $mutant->getMutation();
+
+        return new MutantExecutionResult(
+            $process->getCommandLine(),
+            $this->retrieveProcessOutput($process),
+            $this->retrieveDetectionStatus($mutantProcess),
+            $mutant->getDiff(),
+            $mutation->getHash(),
+            $mutation->getMutatorClass(),
+            $mutation->getMutatorName(),
+            $mutation->getOriginalFilePath(),
+            $mutation->getOriginalStartingLine(),
+            $mutation->getOriginalEndingLine(),
+            $mutation->getOriginalStartFilePosition(),
+            $mutation->getOriginalEndFilePosition(),
+            $mutant->getPrettyPrintedOriginalCode(),
+            $mutant->getMutatedCode(),
+            $mutant->getTests(),
+            $mutantProcess->getFinishedAt() - $process->getStartTime(),
+        );
+    }
+
+    private function retrieveProcessOutput(Process $process): string
+    {
+        Assert::true(
+            $process->isTerminated(),
+            sprintf(
+                'Cannot retrieve a non-terminated process output. Got "%s"',
+                $process->getStatus(),
+            ),
+        );
+
+        return trim($process->getOutput() . "\n\n" . $process->getErrorOutput());
+    }
+
+    private function retrieveDetectionStatus(MutantProcess $mutantProcess): DetectionStatus
+    {
+        if ($mutantProcess->isTimedOut()) {
+            return DetectionStatus::TIMED_OUT;
+        }
+
+        $process = $mutantProcess->getProcess();
+
+        $exitCode = $process->getExitCode();
+
+        if ($exitCode !== null && $exitCode > self::PROCESS_MIN_ERROR_CODE) {
+            // See \Symfony\Component\Process\Process::$exitCodes
+            return DetectionStatus::ERROR;
+        }
+
+        if ($exitCode === 0) {
+            return DetectionStatus::ESCAPED;
+        }
+
+        return DetectionStatus::KILLED_BY_STATIC_ANALYSIS;
+    }
+}

--- a/src/StaticAnalysis/Mago/Process/MagoMutantProcessFactory.php
+++ b/src/StaticAnalysis/Mago/Process/MagoMutantProcessFactory.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\StaticAnalysis\Mago\Process;
+
+use function array_merge;
+use Infection\Mutant\Mutant;
+use Infection\Process\Factory\LazyMutantProcessFactory;
+use Infection\Process\MutantProcess;
+use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
+use Infection\TestFramework\CommandLineBuilder;
+use Symfony\Component\Process\Process;
+
+/**
+ * @internal
+ */
+final readonly class MagoMutantProcessFactory implements LazyMutantProcessFactory
+{
+    /**
+     * @param list<string> $staticAnalysisToolOptions
+     */
+    public function __construct(
+        private MagoMutantExecutionResultFactory $mutantExecutionResultFactory,
+        private string $staticAnalysisToolExecutable,
+        private CommandLineBuilder $commandLineBuilder,
+        private float $timeout,
+        private array $staticAnalysisToolOptions,
+    ) {
+    }
+
+    public function create(Mutant $mutant): MutantProcess
+    {
+        $process = new Process(
+            command: $this->getMutantCommandLine(
+                $mutant->getFilePath(),
+                $mutant->getMutation()->getOriginalFilePath(),
+            ),
+            timeout: $this->timeout,
+        );
+
+        return new MutantProcess(
+            $process,
+            $mutant,
+            $this->mutantExecutionResultFactory,
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getMutantCommandLine(
+        string $mutatedFilePath,
+        string $originalFilePath,
+    ): array {
+        $options = array_merge(
+            [
+                '--colors=never',
+                'analyze',
+                '--reporting-format=short',
+                '--substitute',
+                "$originalFilePath=$mutatedFilePath",
+            ],
+            $this->staticAnalysisToolOptions,
+        );
+
+        return $this->commandLineBuilder->build(
+            $this->staticAnalysisToolExecutable,
+            [],
+            $options,
+        );
+    }
+}

--- a/src/StaticAnalysis/StaticAnalysisToolFactory.php
+++ b/src/StaticAnalysis/StaticAnalysisToolFactory.php
@@ -39,6 +39,7 @@ use function implode;
 use Infection\Configuration\Configuration;
 use Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder;
 use Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator;
+use Infection\StaticAnalysis\Mago\Adapter\MagoAdapterFactory;
 use Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterFactory;
 use InvalidArgumentException;
 use function sprintf;
@@ -72,7 +73,22 @@ final readonly class StaticAnalysisToolFactory
             );
         }
 
-        $availableTestFrameworks = [StaticAnalysisToolTypes::PHPSTAN];
+        if ($adapterName === StaticAnalysisToolTypes::MAGO) {
+            $magoConfigPath = $this->staticAnalysisConfigLocator->locate(StaticAnalysisToolTypes::MAGO);
+
+            return MagoAdapterFactory::create(
+                $magoConfigPath,
+                $this->staticAnalysisToolExecutableFiner->find(
+                    StaticAnalysisToolTypes::MAGO,
+                    (string) $this->infectionConfig->mago->customPath,
+                ),
+                $timeout,
+                $this->infectionConfig->tmpDir,
+                $this->infectionConfig->getStaticAnalysisToolOptions(),
+            );
+        }
+
+        $availableTestFrameworks = [StaticAnalysisToolTypes::PHPSTAN, StaticAnalysisToolTypes::MAGO];
 
         throw new InvalidArgumentException(sprintf(
             'Invalid name of static analysis tool "%s". Available names are: %s',

--- a/tests/e2e/Mago_Integration/README.md
+++ b/tests/e2e/Mago_Integration/README.md
@@ -1,0 +1,1 @@
+This e2e ensures Infection work correctly with mago static analysis tool, integrated natively.

--- a/tests/e2e/Mago_Integration/composer.json
+++ b/tests/e2e/Mago_Integration/composer.json
@@ -1,0 +1,16 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.6.20",
+        "carthage-software/mago": "^1.23"
+    },
+    "autoload": {
+        "psr-4": {
+            "Mago_Integration\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Mago_Integration\\Test\\": "tests/"
+        }
+    }
+}

--- a/tests/e2e/Mago_Integration/expected-output.txt
+++ b/tests/e2e/Mago_Integration/expected-output.txt
@@ -1,0 +1,11 @@
+Total: 8
+
+Killed by Test Framework: 1
+Killed by Static Analysis: 3
+Errored: 0
+Syntax Errors: 0
+Escaped: 4
+Timed Out: 0
+Skipped: 0
+Ignored: 0
+Not Covered: 0

--- a/tests/e2e/Mago_Integration/infection.json5
+++ b/tests/e2e/Mago_Integration/infection.json5
@@ -1,0 +1,15 @@
+{
+    "$schema": "../../../resources/schema.json",
+    "timeout": 25,
+    "threads": 4,
+    "staticAnalysisTool": "mago",
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "infection.log"
+    },
+    "tmpDir": "."
+}

--- a/tests/e2e/Mago_Integration/mago.toml
+++ b/tests/e2e/Mago_Integration/mago.toml
@@ -1,0 +1,41 @@
+# Welcome to Mago!
+# For full documentation, see https://mago.carthage.software/tools/overview
+version = "1"
+php-version = "8.5.0"
+
+[source]
+workspace = "."
+paths = ["src/", "tests/"]
+includes = ["vendor"]
+excludes = []
+
+[source.glob]
+literal-separator = true
+
+[formatter]
+print-width = 120
+tab-width = 4
+use-tabs = false
+
+[linter]
+integrations = ["phpunit"]
+
+[linter.rules]
+ambiguous-function-call = { enabled = false }
+literal-named-argument = { enabled = false }
+halstead = { effort-threshold = 7000 }
+
+[analyzer]
+plugins = []
+find-unused-definitions = true
+find-unused-expressions = false
+analyze-dead-code = false
+memoize-properties = true
+allow-possibly-undefined-array-keys = true
+check-throws = false
+check-missing-override = false
+find-unused-parameters = false
+strict-list-index-checks = false
+no-boolean-literal-comparison = false
+check-missing-type-hints = false
+register-super-globals = true

--- a/tests/e2e/Mago_Integration/phpunit.xml
+++ b/tests/e2e/Mago_Integration/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/tests/e2e/Mago_Integration/src/SecondSourceClass.php
+++ b/tests/e2e/Mago_Integration/src/SecondSourceClass.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Mago_Integration;
+
+// This class exists only to check that mago re-analyzes only 1 of 2 classes for each Mutant
+class SecondSourceClass
+{
+
+}

--- a/tests/e2e/Mago_Integration/src/SourceClass.php
+++ b/tests/e2e/Mago_Integration/src/SourceClass.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Mago_Integration;
+
+class SourceClass
+{
+    /**
+     * @template T
+     * @param array<T> $values
+     * @return list<T>
+     */
+    public function makeAList(array $values): array
+    {
+        // some code to generate more mutations
+
+        $strings = ['1'];
+
+        $ints = array_map(function ($value): int {
+            return (int) $value;
+        }, $strings);
+
+        $nonEmptyArray = ['1'];
+
+        $nonEmptyArrayFromMethod = $this->returnNonEmptyArray();
+
+        $inlineNonEmpty = ['1'];
+
+        return array_values($values);
+    }
+
+    /**
+     * @return non-empty-array<int, string>
+     */
+    private function returnNonEmptyArray(): array
+    {
+        return ['test'];
+    }
+}

--- a/tests/e2e/Mago_Integration/tests/SourceClassTest.php
+++ b/tests/e2e/Mago_Integration/tests/SourceClassTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Mago_Integration\Test;
+
+use Mago_Integration\SourceClass;
+use PHPUnit\Framework\TestCase;
+use function array_key_first;
+
+class SourceClassTest extends TestCase
+{
+    public function test_hello()
+    {
+        $sourceClass = new SourceClass();
+
+        $list = $sourceClass->makeAList(['a' => 'b', 'c' => 'd']);
+
+        $this->assertCount(2, $list);
+
+        // try to kill to not run mago
+//        $this->assertSame(0, array_key_first($list));
+    }
+}

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -262,6 +262,7 @@ final class MakefileTest extends BaseMakefileTestCase
             [33mcompile:[0m	 	 Bundles Infection into a PHAR
             [33mcompile-docker:[0m	 	 Bundles Infection into a PHAR using docker
             [33mcs:[0m	  	 	 Runs PHP-CS-Fixer
+            [33mcs-docker:[0m	  	 	 Runs PHP-CS-Fixer in docker
             [33mcs-check:[0m		 Runs PHP-CS-Fixer in dry-run mode
             [33mprofile:[0m 	 	 Runs Blackfire
             [33mautoreview:[0m 	 	 Runs various checks (static analysis & AutoReview test suite)

--- a/tests/phpunit/Configuration/ConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/ConfigurationBuilder.php
@@ -40,6 +40,7 @@ use function array_values;
 use function implode;
 use Infection\Configuration\Configuration;
 use Infection\Configuration\Entry\Logs;
+use Infection\Configuration\Entry\Mago;
 use Infection\Configuration\Entry\PhpStan;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Entry\Source;
@@ -71,6 +72,7 @@ final class ConfigurationBuilder
         private string $tmpDir,
         private PhpUnit $phpUnit,
         private PhpStan $phpStan,
+        private Mago $mago,
         private array $mutators,
         private string $testFramework,
         private ?string $bootstrap,
@@ -113,6 +115,7 @@ final class ConfigurationBuilder
             tmpDir: $configuration->tmpDir,
             phpUnit: $configuration->phpUnit,
             phpStan: $configuration->phpStan,
+            mago: $configuration->mago,
             mutators: $configuration->mutators,
             testFramework: $configuration->testFramework,
             bootstrap: $configuration->bootstrap,
@@ -157,6 +160,7 @@ final class ConfigurationBuilder
             tmpDir: '/tmp/infection',
             phpUnit: new PhpUnit(null, null),
             phpStan: new PhpStan(null, null),
+            mago: new Mago(null, null),
             mutators: [],
             testFramework: TestFrameworkTypes::PHPUNIT,
             bootstrap: null,
@@ -216,6 +220,7 @@ final class ConfigurationBuilder
             tmpDir: '/tmp/infection-test',
             phpUnit: new PhpUnit('config/phpunit', 'bin/phpunit'),
             phpStan: new PhpStan('config/phpstan', 'bin/phpstan'),
+            mago: new Mago('config/mago', 'bin/mago'),
             mutators: [
                 'Fake' => new IgnoreMutator(
                     new IgnoreConfig([]),
@@ -342,6 +347,14 @@ final class ConfigurationBuilder
     {
         $clone = clone $this;
         $clone->phpStan = $phpStan;
+
+        return $clone;
+    }
+
+    public function withMago(Mago $mago): self
+    {
+        $clone = clone $this;
+        $clone->mago = $mago;
 
         return $clone;
     }
@@ -590,6 +603,7 @@ final class ConfigurationBuilder
             tmpDir: $this->tmpDir,
             phpUnit: $this->phpUnit,
             phpStan: $this->phpStan,
+            mago: $this->mago,
             mutators: $this->mutators,
             testFramework: $this->testFramework,
             bootstrap: $this->bootstrap,

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Configuration\ConfigurationFactory;
 use Infection\Configuration\Configuration;
 use Infection\Configuration\ConfigurationFactory;
 use Infection\Configuration\Entry\Logs;
+use Infection\Configuration\Entry\Mago;
 use Infection\Configuration\Entry\PhpStan;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Entry\Source;
@@ -119,6 +120,7 @@ final class ConfigurationFactoryTest extends TestCase
             tmpDir: '',
             phpUnit: new PhpUnit(null, null),
             phpStan: new PhpStan(null, null),
+            mago: new Mago(null, null),
             ignoreMsiWithNoMutations: null,
             minMsi: null,
             minCoveredMsi: null,
@@ -134,7 +136,7 @@ final class ConfigurationFactoryTest extends TestCase
             staticAnalysisTool: StaticAnalysisToolTypes::PHPSTAN,
         );
 
-        $this->expectExceptionMessage('Expected one of: "phpstan". Got: "non-supported-static-analysis-tool"');
+        $this->expectExceptionMessage('Expected one of: "phpstan", "mago". Got: "non-supported-static-analysis-tool"');
 
         $this
             ->createConfigurationFactory(
@@ -193,6 +195,7 @@ final class ConfigurationFactoryTest extends TestCase
             tmpDir: '',
             phpUnit: new PhpUnit(null, null),
             phpStan: new PhpStan(null, null),
+            mago: new Mago(null, null),
             ignoreMsiWithNoMutations: null,
             minMsi: null,
             minCoveredMsi: null,
@@ -253,6 +256,7 @@ final class ConfigurationFactoryTest extends TestCase
             tmpDir: sys_get_temp_dir() . '/infection',
             phpUnit: new PhpUnit('/path/to', null),
             phpStan: new PhpStan('/path/to', null),
+            mago: new Mago('/path/to', null),
             mutators: self::getDefaultMutators(),
             testFramework: TestFrameworkTypes::PHPUNIT,
             bootstrap: null,
@@ -1174,6 +1178,7 @@ final class ConfigurationFactoryTest extends TestCase
                     ->withTmpDir('config/tmp')
                     ->withPhpUnit(new PhpUnit('config/phpunit-dir', '/path/to/config/phpunit'))
                     ->withPhpStan(new PhpStan('config/phpstan-dir', '/path/to/bin/phpstan'))
+                    ->withMago(new Mago('config/mago-dir', '/path/to/bin/mago'))
                     ->withMutators(['@default' => true])
                     ->withTestFramework('phpunit')
                     ->withBootstrap(__DIR__ . '/../../Fixtures/Files/bootstrap/bootstrap.php')
@@ -1247,6 +1252,7 @@ final class ConfigurationFactoryTest extends TestCase
                     ->withTmpDir('/path/to/config/tmp/infection')
                     ->withPhpUnit(new PhpUnit('/path/to/config/phpunit-dir', '/path/to/config/phpunit'))
                     ->withPhpStan(new PhpStan('/path/to/config/phpstan-dir', '/path/to/bin/phpstan'))
+                    ->withMago(new Mago('/path/to/config/mago-dir', '/path/to/bin/mago'))
                     ->withMutators([
                         'TrueValue' => new TrueValue(new TrueValueConfig([])),
                     ])

--- a/tests/phpunit/Configuration/Entry/MagoTest.php
+++ b/tests/phpunit/Configuration/Entry/MagoTest.php
@@ -33,53 +33,64 @@
 
 declare(strict_types=1);
 
-namespace Infection\Configuration\Schema;
+namespace Infection\Tests\Configuration\Entry;
 
-use Infection\Configuration\Entry\Logs;
 use Infection\Configuration\Entry\Mago;
-use Infection\Configuration\Entry\PhpStan;
-use Infection\Configuration\Entry\PhpUnit;
-use Infection\Configuration\Entry\Source;
-use Infection\StaticAnalysis\StaticAnalysisToolTypes;
-use Infection\TestFramework\TestFrameworkTypes;
-use Webmozart\Assert\Assert;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 
-/**
- * @internal
- */
-final readonly class SchemaConfiguration
+#[CoversClass(Mago::class)]
+final class MagoTest extends TestCase
 {
-    /**
-     * @param non-empty-string $pathname
-     * @param array<string, mixed> $mutators
-     * @param TestFrameworkTypes::*|null $testFramework
-     * @param StaticAnalysisToolTypes::*|null $staticAnalysisTool
-     */
-    public function __construct(
-        public string $pathname,
-        public ?float $timeout,
-        public Source $source,
-        public Logs $logs,
-        public ?string $tmpDir,
-        public PhpUnit $phpUnit,
-        public PhpStan $phpStan,
-        public Mago $mago,
-        public ?bool $ignoreMsiWithNoMutations,
-        public ?float $minMsi,
-        public ?float $minCoveredMsi,
-        public ?bool $timeoutsAsEscaped,
-        public ?int $maxTimeouts,
-        public array $mutators,
-        public ?string $testFramework,
-        public ?string $bootstrap,
-        public ?string $initialTestsPhpOptions,
-        public ?string $testFrameworkExtraOptions,
-        public ?string $staticAnalysisToolOptions,
-        public string|int|null $threads,
-        public ?string $staticAnalysisTool,
-    ) {
-        Assert::nullOrGreaterThanEq($timeout, 0);
-        Assert::nullOrOneOf($testFramework, TestFrameworkTypes::getTypes());
-        Assert::nullOrOneOf($staticAnalysisTool, StaticAnalysisToolTypes::getTypes());
+    #[DataProvider('basePathProvider')]
+    public function test_it_can_create_a_new_instance_with_absolute_paths(
+        Mago $mago,
+        string $basePath,
+        Mago $expected,
+    ): void {
+        $originalMago = clone $mago;
+
+        $actual = $mago->withAbsolutePaths($basePath);
+
+        $this->assertEquals($expected, $actual);
+        // Sanity check
+        $this->assertEquals($originalMago, $mago);
+    }
+
+    public static function basePathProvider(): iterable
+    {
+        yield 'minimal' => [
+            new Mago(null, null),
+            '/path/to/project',
+            new Mago(
+                '/path/to/project',
+                null,
+            ),
+        ];
+
+        yield 'both paths are relative' => [
+            new Mago(
+                'devTools/mago',
+                'devTools/mago/bin/mago',
+            ),
+            '/path/to/project',
+            new Mago(
+                '/path/to/project/devTools/mago',
+                '/path/to/project/devTools/mago/bin/mago',
+            ),
+        ];
+
+        yield 'both paths are absolute' => [
+            new Mago(
+                '/path/to/another-project/devTools/mago',
+                '/path/to/another-project/devTools/mago/bin/mago',
+            ),
+            '/path/to/project',
+            new Mago(
+                '/path/to/another-project/devTools/mago',
+                '/path/to/another-project/devTools/mago/bin/mago',
+            ),
+        ];
     }
 }

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationBuilder.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Configuration\Schema;
 
 use Infection\Configuration\Entry\Logs;
+use Infection\Configuration\Entry\Mago;
 use Infection\Configuration\Entry\PhpStan;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Entry\Source;
@@ -60,6 +61,7 @@ final class SchemaConfigurationBuilder
         private ?string $tmpDir,
         private PhpUnit $phpUnit,
         private PhpStan $phpStan,
+        private Mago $mago,
         private ?bool $ignoreMsiWithNoMutations,
         private ?float $minMsi,
         private ?float $minCoveredMsi,
@@ -86,6 +88,7 @@ final class SchemaConfigurationBuilder
             tmpDir: $schema->tmpDir,
             phpUnit: $schema->phpUnit,
             phpStan: $schema->phpStan,
+            mago: $schema->mago,
             ignoreMsiWithNoMutations: $schema->ignoreMsiWithNoMutations,
             minMsi: $schema->minMsi,
             minCoveredMsi: $schema->minCoveredMsi,
@@ -112,6 +115,7 @@ final class SchemaConfigurationBuilder
             tmpDir: null,
             phpUnit: new PhpUnit(null, null),
             phpStan: new PhpStan(null, null),
+            mago: new Mago(null, null),
             ignoreMsiWithNoMutations: null,
             minMsi: null,
             minCoveredMsi: null,
@@ -149,6 +153,7 @@ final class SchemaConfigurationBuilder
             tmpDir: '/tmp/infection',
             phpUnit: new PhpUnit('/config/phpunit', '/custom/phpunit'),
             phpStan: new PhpStan('/config/phpstan', '/custom/phpstan'),
+            mago: new Mago('/config/mago', '/custom/mago'),
             ignoreMsiWithNoMutations: true,
             minMsi: 80.0,
             minCoveredMsi: 90.0,
@@ -220,6 +225,14 @@ final class SchemaConfigurationBuilder
     {
         $clone = clone $this;
         $clone->phpStan = $phpStan;
+
+        return $clone;
+    }
+
+    public function withMago(Mago $mago): self
+    {
+        $clone = clone $this;
+        $clone->mago = $mago;
 
         return $clone;
     }
@@ -347,6 +360,7 @@ final class SchemaConfigurationBuilder
             tmpDir: $this->tmpDir,
             phpUnit: $this->phpUnit,
             phpStan: $this->phpStan,
+            mago: $this->mago,
             ignoreMsiWithNoMutations: $this->ignoreMsiWithNoMutations,
             minMsi: $this->minMsi,
             minCoveredMsi: $this->minCoveredMsi,

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -43,6 +43,7 @@ use function array_merge;
 use function array_values;
 use function implode;
 use Infection\Configuration\Entry\Logs;
+use Infection\Configuration\Entry\Mago;
 use Infection\Configuration\Entry\PhpStan;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Entry\Source;
@@ -709,6 +710,61 @@ final class SchemaConfigurationFactoryTest extends TestCase
             self::createConfig([
                 'source' => new Source(['src'], []),
                 'tmpDir' => 'custom-tmp',
+            ]),
+        ];
+
+        yield '[mago] no property' => [
+            <<<'JSON'
+                {
+                    "source": {
+                        "directories": ["src"]
+                    },
+                    "mago": {}
+                }
+                JSON,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mago' => new Mago(null, null),
+            ]),
+        ];
+
+        yield '[mago][configDir] nominal' => [
+            <<<'JSON'
+                {
+                    "source": {
+                        "directories": ["src"]
+                    },
+                    "mago": {
+                        "configDir": "mago.toml"
+                    }
+                }
+                JSON,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mago' => new Mago(
+                    'mago.toml',
+                    null,
+                ),
+            ]),
+        ];
+
+        yield '[mago][customPath] nominal' => [
+            <<<'JSON'
+                {
+                    "source": {
+                        "directories": ["src"]
+                    },
+                    "mago": {
+                        "customPath": "path/to/mago"
+                    }
+                }
+                JSON,
+            self::createConfig([
+                'source' => new Source(['src'], []),
+                'mago' => new Mago(
+                    null,
+                    'path/to/mago',
+                ),
             ]),
         ];
 
@@ -2658,6 +2714,7 @@ final class SchemaConfigurationFactoryTest extends TestCase
             'tmpDir' => null,
             'phpunit' => new PhpUnit(null, null),
             'phpStan' => new PhpStan(null, null),
+            'mago' => new Mago(null, null),
             'ignoreMsiWithNoMutations' => null,
             'minMsi' => null,
             'minCoveredMsi' => null,

--- a/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterFactoryTest.php
@@ -33,56 +33,27 @@
 
 declare(strict_types=1);
 
-namespace Infection\StaticAnalysis;
+namespace Infection\Tests\StaticAnalysis\Mago\Adapter;
 
-use function count;
-use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
-use Infection\ExtensionInstaller\GeneratedExtensionsConfig;
-use function is_a;
-use Webmozart\Assert\Assert;
+use Infection\StaticAnalysis\Mago\Adapter\MagoAdapterFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
 
-/**
- * @internal
- */
-final class StaticAnalysisToolTypes
+#[Group('integration')]
+#[CoversClass(MagoAdapterFactory::class)]
+final class MagoAdapterFactoryTest extends TestCase
 {
-    public const string PHPSTAN = 'phpstan';
+    public function test_it_can_create_an_adapter(): void
+    {
+        $adapter = MagoAdapterFactory::create(
+            '/path/to/mago-config-path',
+            '/path/to/mago',
+            32.3,
+            '/tmp',
+            [],
+        );
 
-    public const string MAGO = 'mago';
-
-    /**
-     * @var string[]
-     */
-    private static array $defaultTypes = [
-        self::PHPSTAN,
-        self::MAGO,
-    ];
-
-    /**
-     * @param mixed[] $installedExtensions
-     *
-     * @return string[]
-     */
-    public static function getTypes(
-        array $installedExtensions = GeneratedExtensionsConfig::EXTENSIONS,
-    ): array {
-        $types = self::$defaultTypes;
-
-        // todo [phpstan-integration]
-        //        if (count($installedExtensions) > 0) {
-        //            foreach ($installedExtensions as $installedExtension) {
-        //                $factory = $installedExtension['extra']['class'];
-        //
-        //                Assert::classExists($factory);
-        //
-        //                if (!is_a($factory, TestFrameworkAdapterFactory::class, true)) {
-        //                    continue;
-        //                }
-        //
-        //                $types[] = $factory::getAdapterName();
-        //            }
-        //        }
-
-        return $types;
+        $this->assertSame('Mago', $adapter->getName());
     }
 }

--- a/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php
@@ -33,11 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\StaticAnalysis\PHPStan\Adapter;
+namespace Infection\Tests\StaticAnalysis\Mago\Adapter;
 
-use Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter;
-use Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory;
-use Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory;
+use Infection\StaticAnalysis\Mago\Adapter\MagoAdapter;
+use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
+use Infection\StaticAnalysis\Mago\Process\MagoMutantProcessFactory;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\VersionParser;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -47,13 +47,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use function sprintf;
-use Symfony\Component\Filesystem\Filesystem;
 
 #[Group('integration')]
-#[CoversClass(PHPStanAdapter::class)]
-final class PHPStanAdapterTest extends TestCase
+#[CoversClass(MagoAdapter::class)]
+final class MagoAdapterTest extends TestCase
 {
-    private PHPStanAdapter $adapter;
+    private MagoAdapter $adapter;
 
     private CommandLineBuilder&MockObject $commandLineBuilder;
 
@@ -61,15 +60,13 @@ final class PHPStanAdapterTest extends TestCase
     {
         $this->commandLineBuilder = $this->createMock(CommandLineBuilder::class);
 
-        $this->adapter = new PHPStanAdapter(
-            $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
-            '/path/to/phpstan-config-path',
-            '/path/to/phpstan',
+        $this->adapter = new MagoAdapter(
+            $this->createStub(MagoMutantExecutionResultFactory::class),
+            '/path/to/mago-config-path',
+            '/path/to/mago',
             $this->commandLineBuilder,
             new VersionParser(),
             31.0,
-            '/tmp',
             [],
             '9.0',
         );
@@ -77,7 +74,7 @@ final class PHPStanAdapterTest extends TestCase
 
     public function test_it_has_a_name(): void
     {
-        $this->assertSame('PHPStan', $this->adapter->getName());
+        $this->assertSame('Mago', $this->adapter->getName());
     }
 
     public function test_it_builds_initial_run_command_line(): void
@@ -85,119 +82,111 @@ final class PHPStanAdapterTest extends TestCase
         $this->commandLineBuilder
             ->expects($this->once())
             ->method('build')
-            ->with('/path/to/phpstan', [], ['--configuration=/path/to/phpstan-config-path'])
-            ->willReturn(['/usr/bin/php', '/path/to/phpstan', '--configuration=/path/to/phpstan-config-path'])
+            ->with('/path/to/mago', [], ['--config=/path/to/mago-config-path', 'analyze'])
+            ->willReturn(['/path/to/mago', '--config=/path/to/mago-config-path', 'analyze'])
         ;
 
         $this->assertSame([
-            '/usr/bin/php',
-            '/path/to/phpstan',
-            '--configuration=/path/to/phpstan-config-path',
+            '/path/to/mago',
+            '--config=/path/to/mago-config-path',
+            'analyze',
         ], $this->adapter->getInitialRunCommandLine());
     }
 
     public function test_it_builds_initial_run_command_line_with_single_option(): void
     {
-        $adapter = new PHPStanAdapter(
-            $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
-            '/path/to/phpstan-config-path',
-            '/path/to/phpstan',
+        $adapter = new MagoAdapter(
+            $this->createStub(MagoMutantExecutionResultFactory::class),
+            '/path/to/mago-config-path',
+            '/path/to/mago',
             $this->commandLineBuilder,
             new VersionParser(),
             31.0,
-            '/tmp',
-            ['--memory-limit=1G'],
+            ['--sort'],
             '9.0',
         );
 
         $this->commandLineBuilder
             ->expects($this->once())
             ->method('build')
-            ->with('/path/to/phpstan', [], [
-                '--configuration=/path/to/phpstan-config-path',
-                '--memory-limit=1G',
+            ->with('/path/to/mago', [], [
+                '--config=/path/to/mago-config-path',
+                'analyze',
+                '--sort',
             ])
-            ->willReturn(['/usr/bin/php', '/path/to/phpstan', '--configuration=/path/to/phpstan-config-path', '--memory-limit=1G'])
+            ->willReturn(['/path/to/mago', '--config=/path/to/mago-config-path', '--sort'])
         ;
 
         $this->assertSame([
-            '/usr/bin/php',
-            '/path/to/phpstan',
-            '--configuration=/path/to/phpstan-config-path',
-            '--memory-limit=1G',
+            '/path/to/mago',
+            '--config=/path/to/mago-config-path',
+            '--sort',
         ], $adapter->getInitialRunCommandLine());
     }
 
     public function test_it_builds_initial_run_command_line_with_multiple_options(): void
     {
-        $adapter = new PHPStanAdapter(
-            $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
-            '/path/to/phpstan-config-path',
-            '/path/to/phpstan',
+        $adapter = new MagoAdapter(
+            $this->createStub(MagoMutantExecutionResultFactory::class),
+            '/path/to/mago-config-path',
+            '/path/to/mago',
             $this->commandLineBuilder,
             new VersionParser(),
             31.0,
-            '/tmp',
-            ['--memory-limit=-1', '--no-progress'],
+            ['--no-progress'],
             '9.0',
         );
 
         $this->commandLineBuilder
             ->expects($this->once())
             ->method('build')
-            ->with('/path/to/phpstan', [], [
-                '--configuration=/path/to/phpstan-config-path',
-                '--memory-limit=-1',
+            ->with('/path/to/mago', [], [
+                '--config=/path/to/mago-config-path',
+                'analyze',
                 '--no-progress',
             ])
-            ->willReturn(['/usr/bin/php', '/path/to/phpstan', '--configuration=/path/to/phpstan-config-path', '--memory-limit=-1', '--no-progress'])
+            ->willReturn(['/path/to/mago', '--config=/path/to/mago-config-path', 'analyze', '--no-progress'])
         ;
 
         $this->assertSame([
-            '/usr/bin/php',
-            '/path/to/phpstan',
-            '--configuration=/path/to/phpstan-config-path',
-            '--memory-limit=-1',
+            '/path/to/mago',
+            '--config=/path/to/mago-config-path',
+            'analyze',
             '--no-progress',
         ], $adapter->getInitialRunCommandLine());
     }
 
     public function test_it_builds_initial_run_command_line_with_complex_options(): void
     {
-        $adapter = new PHPStanAdapter(
-            $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
-            '/path/to/phpstan-config-path',
-            '/path/to/phpstan',
+        $adapter = new MagoAdapter(
+            $this->createStub(MagoMutantExecutionResultFactory::class),
+            '/path/to/mago-config-path',
+            '/path/to/mago',
             $this->commandLineBuilder,
             new VersionParser(),
             31.0,
-            '/tmp',
-            ['--memory-limit=2G', '--level=max', '--no-progress'],
+            ['--no-stubs', '--baseline /path/to/baseline.toml'],
             '9.0',
         );
 
         $this->commandLineBuilder
             ->expects($this->once())
             ->method('build')
-            ->with('/path/to/phpstan', [], [
-                '--configuration=/path/to/phpstan-config-path',
-                '--memory-limit=2G',
-                '--level=max',
-                '--no-progress',
+            ->with('/path/to/mago', [], [
+                '--config=/path/to/mago-config-path',
+                'analyze',
+                '--no-stubs',
+                '--baseline /path/to/baseline.toml',
             ])
-            ->willReturn(['/usr/bin/php', '/path/to/phpstan', '--configuration=/path/to/phpstan-config-path', '--memory-limit=2G', '--level=max', '--no-progress'])
+            ->willReturn(['/path/to/mago', '--config=/path/to/mago-config-path', 'analyze', '--no-stubs', '--baseline /path/to/baseline.toml'])
         ;
 
         $this->assertSame([
-            '/usr/bin/php',
-            '/path/to/phpstan',
-            '--configuration=/path/to/phpstan-config-path',
-            '--memory-limit=2G',
-            '--level=max',
-            '--no-progress',
+            '/path/to/mago',
+            '--config=/path/to/mago-config-path',
+            'analyze',
+            '--no-stubs',
+            '--baseline /path/to/baseline.toml',
         ], $adapter->getInitialRunCommandLine());
     }
 
@@ -209,7 +198,7 @@ final class PHPStanAdapterTest extends TestCase
     public function test_it_creates_mutant_process_creator(): void
     {
         $this->assertInstanceOf(
-            PHPStanMutantProcessFactory::class,
+            MagoMutantProcessFactory::class,
             $this->adapter->createMutantProcessFactory(),
         );
     }
@@ -219,16 +208,14 @@ final class PHPStanAdapterTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        $adapter = new PHPStanAdapter(
-            $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
-            '/path/to/phpstan-config-path',
-            '/path/to/phpstan',
+        $adapter = new MagoAdapter(
+            $this->createStub(MagoMutantExecutionResultFactory::class),
+            '/path/to/mago-config-path',
+            '/path/to/mago',
             $this->commandLineBuilder,
             new VersionParser(),
             31.0,
-            '/tmp',
-            ['--memory-limit=-1'],
+            [],
             $version,
         );
 
@@ -239,22 +226,20 @@ final class PHPStanAdapterTest extends TestCase
     #[DataProvider('provideInvalidVersions')]
     public function test_it_rejects_invalid_versions(string $version): void
     {
-        $adapter = new PHPStanAdapter(
-            $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
-            '/path/to/phpstan-config-path',
-            '/path/to/phpstan',
+        $adapter = new MagoAdapter(
+            $this->createStub(MagoMutantExecutionResultFactory::class),
+            '/path/to/mago-config-path',
+            '/path/to/mago',
             $this->commandLineBuilder,
             new VersionParser(),
             31.0,
-            '/tmp',
             [],
             $version,
         );
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf(
-            'Infection requires PHPStan version >=1.12.27 or >=2.1.17, but "%s" is installed.',
+            'Infection requires Mago version >=1.23.0, but "%s" is installed.',
             $version,
         ));
 
@@ -263,27 +248,11 @@ final class PHPStanAdapterTest extends TestCase
 
     public static function provideValidVersions(): iterable
     {
-        yield 'major version 3' => ['3.0.0'];
+        yield 'major version 1 with valid minor' => ['1.23.0'];
 
-        yield 'major version 2 with valid patch' => ['2.1.17'];
+        yield 'major version 1 with valid patch' => ['1.23.1'];
 
-        yield 'major version 2 with higher minor' => ['2.2.0'];
-
-        yield 'major version 1 with valid patch' => ['1.12.27'];
-
-        yield 'major version 1 with valid patch 2' => ['1.12.28'];
-
-        yield 'major version 1 with higher minor' => ['1.13.0'];
-
-        yield 'dev version 1.12.x' => ['1.12.x-dev@asgar3'];
-
-        yield 'dev version 1.13.x' => ['1.13.x-dev@cfa0299'];
-
-        yield 'dev version 2.1.x' => ['2.1.x-dev@cfa0299'];
-
-        yield 'dev version 2.2.x' => ['2.2.x-dev@cfa0299'];
-
-        yield 'PHPStan-src dev' => ['dev-648dbd911cef28707338fe5c25875d50e7875391@648dbd9'];
+        yield 'major version 2' => ['2.0.0'];
     }
 
     /**
@@ -291,11 +260,7 @@ final class PHPStanAdapterTest extends TestCase
      */
     public static function provideInvalidVersions(): iterable
     {
-        yield 'major version 2 with too low minor' => ['2.0.17'];
-
-        yield 'major version 2 with too low patch' => ['2.1.1'];
-
-        yield 'major version 2 with too low minor and patch' => ['2.0.0'];
+        yield 'major version 1 with too low minor' => ['1.19.0'];
 
         yield 'major version 1 with too low patch' => ['1.12.26'];
 
@@ -304,7 +269,5 @@ final class PHPStanAdapterTest extends TestCase
         yield 'major version 0' => ['0.12.0'];
 
         yield 'dev version 1.0.x' => ['1.0.x-dev@cfa0299'];
-
-        yield 'dev version 2.0.x' => ['2.0.x-dev@cfa0299'];
     }
 }

--- a/tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php
@@ -1,0 +1,472 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\StaticAnalysis\Mago\Mutant;
+
+use Generator;
+use Infection\AbstractTestFramework\Coverage\TestLocation;
+use Infection\Mutant\DetectionStatus;
+use Infection\Mutation\Mutation;
+use Infection\Mutator\Loop\For_;
+use Infection\PhpParser\MutatedNode;
+use Infection\Process\MutantProcess;
+use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
+use Infection\Testing\MutatorName;
+use Infection\Tests\Mutant\MutantBuilder;
+use Infection\Tests\Mutant\MutantExecutionResultAssertions;
+use PhpParser\Node\Stmt\Nop;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+#[CoversClass(MagoMutantExecutionResultFactory::class)]
+final class MagoMutantExecutionResultFactoryTest extends TestCase
+{
+    use MutantExecutionResultAssertions;
+
+    private MagoMutantExecutionResultFactory $resultFactory;
+
+    protected function setUp(): void
+    {
+        $this->resultFactory = new MagoMutantExecutionResultFactory();
+    }
+
+    public function test_it_can_create_a_result_from_a_time_out_mutant_process(): void
+    {
+        $processMock = $this->createMock(Process::class);
+        $processMock
+            ->method('getCommandLine')
+            ->willReturn(
+                $processCommandLine = 'bin/mago --tmp-file="Source.h4sz.php" --instead-of="Source.php"',
+            )
+        ;
+        $processMock
+            ->method('isTerminated')
+            ->willReturn(true)
+        ;
+        $processMock
+            ->method('getOutput')
+            ->willReturn($processOutput = 'OK')
+        ;
+
+        $mutantProcess = new MutantProcess(
+            $processMock,
+            MutantBuilder::materialize(
+                '/path/to/mutant',
+                new Mutation(
+                    $originalFilePath = 'path/to/Foo.php',
+                    [],
+                    For_::class,
+                    $mutatorName = MutatorName::getName(For_::class),
+                    [
+                        'startLine' => $originalStartingLine = 10,
+                        'endLine' => 15,
+                        'startTokenPos' => 0,
+                        'endTokenPos' => 8,
+                        'startFilePos' => 2,
+                        'endFilePos' => 4,
+                    ],
+                    'Unknown',
+                    MutatedNode::wrap(new Nop()),
+                    0,
+                    [],
+                    [],
+                    '',
+                ),
+                'notCovered#0',
+                $mutantDiff = <<<'DIFF'
+                    --- Original
+                    +++ New
+                    @@ @@
+
+                    - echo 'original';
+                    + echo 'notCovered#0';
+
+                    DIFF,
+                '<?php $a = 1;',
+            ),
+            $this->resultFactory,
+        );
+
+        $mutantProcess->markAsTimedOut();
+
+        $this->assertResultStateIs(
+            $this->resultFactory->createFromProcess($mutantProcess),
+            $processCommandLine,
+            $processOutput,
+            DetectionStatus::TIMED_OUT,
+            $mutantDiff,
+            $mutatorName,
+            $originalFilePath,
+            $originalStartingLine,
+        );
+    }
+
+    public function test_it_can_create_a_result_from_an_errored_mutant_process(): void
+    {
+        $processMock = $this->createMock(Process::class);
+        $processMock
+            ->method('getCommandLine')
+            ->willReturn(
+                $processCommandLine = 'bin/mago --tmp-file="Source.h4sz.php" --instead-of="Source.php"',
+            )
+        ;
+        $processMock
+            ->method('isTerminated')
+            ->willReturn(true)
+        ;
+        $processMock
+            ->method('getOutput')
+            ->willReturn($processOutput = 'Fatal Error')
+        ;
+        $processMock
+            ->expects($this->once())
+            ->method('getExitCode')
+            ->willReturn(152)
+        ;
+
+        $mutantProcess = new MutantProcess(
+            $processMock,
+            MutantBuilder::materialize(
+                '/path/to/mutant',
+                new Mutation(
+                    $originalFilePath = 'path/to/Foo.php',
+                    [],
+                    For_::class,
+                    $mutatorName = MutatorName::getName(For_::class),
+                    [
+                        'startLine' => $originalStartingLine = 10,
+                        'endLine' => 15,
+                        'startTokenPos' => 0,
+                        'endTokenPos' => 8,
+                        'startFilePos' => 2,
+                        'endFilePos' => 4,
+                    ],
+                    'Unknown',
+                    MutatedNode::wrap(new Nop()),
+                    0,
+                    [
+                        new TestLocation(
+                            'FooTest::test_it_can_instantiate',
+                            '/path/to/acme/FooTest.php',
+                            0.01,
+                        ),
+                    ],
+                    [],
+                    '',
+                ),
+                'errored#0',
+                $mutantDiff = <<<'DIFF'
+                    --- Original
+                    +++ New
+                    @@ @@
+
+                    - echo 'original';
+                    + echo 'errored#0';
+
+                    DIFF,
+                '<?php $a = 1;',
+            ),
+            $this->resultFactory,
+        );
+
+        $this->assertResultStateIs(
+            $this->resultFactory->createFromProcess($mutantProcess),
+            $processCommandLine,
+            $processOutput,
+            DetectionStatus::ERROR,
+            $mutantDiff,
+            $mutatorName,
+            $originalFilePath,
+            $originalStartingLine,
+        );
+    }
+
+    public function test_it_can_crate_a_result_from_an_escaped_mutant_process(): void
+    {
+        $processMock = $this->createMock(Process::class);
+        $processMock
+            ->method('getCommandLine')
+            ->willReturn(
+                $processCommandLine = 'bin/mago --tmp-file="Source.h4sz.php" --instead-of="Source.php"',
+            )
+        ;
+        $processMock
+            ->method('isTerminated')
+            ->willReturn(true)
+        ;
+        $processMock
+            ->method('getOutput')
+            ->willReturn('OK')
+        ;
+        $processMock
+            ->method('getErrorOutput')
+            ->willReturn('empty')
+        ;
+        $processMock
+            ->expects($this->exactly(1))
+            ->method('getExitCode')
+            ->willReturn(0)
+        ;
+
+        $mutantProcess = new MutantProcess(
+            $processMock,
+            MutantBuilder::materialize(
+                '/path/to/mutant',
+                new Mutation(
+                    $originalFilePath = 'path/to/Foo.php',
+                    [],
+                    For_::class,
+                    $mutatorName = MutatorName::getName(For_::class),
+                    [
+                        'startLine' => $originalStartingLine = 10,
+                        'endLine' => 15,
+                        'startTokenPos' => 0,
+                        'endTokenPos' => 8,
+                        'startFilePos' => 2,
+                        'endFilePos' => 4,
+                    ],
+                    'Unknown',
+                    MutatedNode::wrap(new Nop()),
+                    0,
+                    [
+                        new TestLocation(
+                            'FooTest::test_it_can_instantiate',
+                            '/path/to/acme/FooTest.php',
+                            0.01,
+                        ),
+                    ],
+                    [],
+                    '',
+                ),
+                'escaped#0',
+                $mutantDiff = <<<'DIFF'
+                    --- Original
+                    +++ New
+                    @@ @@
+
+                    - echo 'original';
+                    + echo 'escaped#0';
+
+                    DIFF,
+                '<?php $a = 1;',
+            ),
+            $this->resultFactory,
+        );
+
+        $this->assertResultStateIs(
+            $this->resultFactory->createFromProcess($mutantProcess),
+            $processCommandLine,
+            "OK\n\nempty",
+            DetectionStatus::ESCAPED,
+            $mutantDiff,
+            $mutatorName,
+            $originalFilePath,
+            $originalStartingLine,
+        );
+    }
+
+    public function test_it_can_tell_time_has_passed(): void
+    {
+        $processMock = $this->createMock(Process::class);
+        $processMock
+            ->method('getCommandLine')
+            ->willReturn(
+                $processCommandLine = 'bin/mago --tmp-file="Source.h4sz.php" --instead-of="Source.php"',
+            )
+        ;
+        $processMock
+            ->method('isTerminated')
+            ->willReturn(true)
+        ;
+        // now at the time of creating the test, some time should have passed since now
+        $processMock
+            ->method('getStartTime')
+            ->willReturn(1776284617.597)
+        ;
+        $processMock
+            ->method('getOutput')
+            ->willReturn('OK')
+        ;
+        $processMock
+            ->method('getErrorOutput')
+            ->willReturn('empty')
+        ;
+        $processMock
+            ->expects($this->exactly(1))
+            ->method('getExitCode')
+            ->willReturn(0)
+        ;
+
+        $mutantProcess = new MutantProcess(
+            $processMock,
+            MutantBuilder::materialize(
+                '/path/to/mutant',
+                new Mutation(
+                    $originalFilePath = 'path/to/Foo.php',
+                    [],
+                    For_::class,
+                    $mutatorName = MutatorName::getName(For_::class),
+                    [
+                        'startLine' => $originalStartingLine = 10,
+                        'endLine' => 15,
+                        'startTokenPos' => 0,
+                        'endTokenPos' => 8,
+                        'startFilePos' => 2,
+                        'endFilePos' => 4,
+                    ],
+                    'Unknown',
+                    MutatedNode::wrap(new Nop()),
+                    0,
+                    [
+                        new TestLocation(
+                            'FooTest::test_it_can_instantiate',
+                            '/path/to/acme/FooTest.php',
+                            0.01,
+                        ),
+                    ],
+                    [],
+                    '',
+                ),
+                'escaped#0',
+                $mutantDiff = <<<'DIFF'
+                    --- Original
+                    +++ New
+                    @@ @@
+
+                    - echo 'original';
+                    + echo 'escaped#0';
+
+                    DIFF,
+                '<?php $a = 1;',
+            ),
+            $this->resultFactory,
+        );
+        $mutantProcess->markAsFinished();
+
+        $result = $this->resultFactory->createFromProcess($mutantProcess);
+        $this->assertGreaterThan(0, $result->getProcessRuntime());
+        $this->assertLessThan($mutantProcess->getFinishedAt(), $result->getProcessRuntime());
+    }
+
+    #[DataProvider('errorCodes')]
+    public function test_it_can_crate_a_result_from_a_killed_mutant_process(int $errorCode): void
+    {
+        $processMock = $this->createMock(Process::class);
+        $processMock
+            ->method('getCommandLine')
+            ->willReturn(
+                $processCommandLine = 'bin/mago --tmp-file="Source.h4sz.php" --instead-of="Source.php"',
+            )
+        ;
+        $processMock
+            ->method('isTerminated')
+            ->willReturn(true)
+        ;
+        $processMock
+            ->method('getOutput')
+            ->willReturn('failed')
+        ;
+        $processMock
+            ->expects($this->exactly(1))
+            ->method('getExitCode')
+            ->willReturn($errorCode)
+        ;
+
+        $mutantProcess = new MutantProcess(
+            $processMock,
+            MutantBuilder::materialize(
+                '/path/to/mutant',
+                new Mutation(
+                    $originalFilePath = 'path/to/Foo.php',
+                    [],
+                    For_::class,
+                    $mutatorName = MutatorName::getName(For_::class),
+                    [
+                        'startLine' => $originalStartingLine = 10,
+                        'endLine' => 15,
+                        'startTokenPos' => 0,
+                        'endTokenPos' => 8,
+                        'startFilePos' => 2,
+                        'endFilePos' => 4,
+                    ],
+                    'Unknown',
+                    MutatedNode::wrap(new Nop()),
+                    0,
+                    [
+                        new TestLocation(
+                            'FooTest::test_it_can_instantiate',
+                            '/path/to/acme/FooTest.php',
+                            0.01,
+                        ),
+                    ],
+                    [],
+                    '',
+                ),
+                'killed#0',
+                $mutantDiff = <<<'DIFF'
+                    --- Original
+                    +++ New
+                    @@ @@
+
+                    - echo 'original';
+                    + echo 'killed#0';
+
+                    DIFF,
+                '<?php $a = 1;',
+            ),
+            $this->resultFactory,
+        );
+
+        $this->assertResultStateIs(
+            $this->resultFactory->createFromProcess($mutantProcess),
+            $processCommandLine,
+            'failed',
+            DetectionStatus::KILLED_BY_STATIC_ANALYSIS,
+            $mutantDiff,
+            $mutatorName,
+            $originalFilePath,
+            $originalStartingLine,
+        );
+    }
+
+    public static function errorCodes(): Generator
+    {
+        yield 'standard error code' => [1];
+
+        yield 'minimum error code' => [100];
+    }
+}

--- a/tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\StaticAnalysis\Mago\Process;
+
+use Infection\AbstractTestFramework\Coverage\TestLocation;
+use Infection\Mutation\Mutation;
+use Infection\Mutator\Loop\For_;
+use Infection\PhpParser\MutatedNode;
+use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
+use Infection\StaticAnalysis\Mago\Process\MagoMutantProcessFactory;
+use Infection\TestFramework\CommandLineBuilder;
+use Infection\Testing\MutatorName;
+use Infection\Tests\Mutant\MutantBuilder;
+use PhpParser\Node\Stmt\Nop;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+#[Group('integration')]
+#[CoversClass(MagoMutantProcessFactory::class)]
+final class MagoMutantProcessFactoryTest extends TestCase
+{
+    public function test_it_creates_a_process_with_timeout(): void
+    {
+        $mutant = MutantBuilder::materialize(
+            $mutantFilePath = '/path/to/mutant',
+            new Mutation(
+                $originalFilePath = 'path/to/Foo.php',
+                [],
+                For_::class,
+                MutatorName::getName(For_::class),
+                [
+                    'startLine' => 10,
+                    'endLine' => 15,
+                    'startTokenPos' => 0,
+                    'endTokenPos' => 8,
+                    'startFilePos' => 2,
+                    'endFilePos' => 4,
+                ],
+                'Unknown',
+                MutatedNode::wrap(new Nop()),
+                0,
+                [
+                    new TestLocation(
+                        'FooTest::test_it_can_instantiate',
+                        '/path/to/acme/FooTest.php',
+                        0.01,
+                    ),
+                ],
+                [],
+                '',
+            ),
+            'killed#0',
+            <<<'DIFF'
+                --- Original
+                +++ New
+                @@ @@
+
+                - echo 'original';
+                + echo 'killed#0';
+
+                DIFF,
+            '<?php $a = 1;',
+        );
+
+        $phpStanMutantExecutionResultFactory = $this->createStub(MagoMutantExecutionResultFactory::class);
+        $commandLineBuilder = $this->createMock(CommandLineBuilder::class);
+        $commandLineBuilder
+            ->expects($this->once())
+            ->method('build')
+            ->with('/path/to/mago', [], [
+                '--colors=never',
+                'analyze',
+                '--reporting-format=short',
+                '--substitute',
+                "$originalFilePath=$mutantFilePath",
+            ])
+            ->willReturn(['/path/to/mago'])
+        ;
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->expects($this->never())
+            ->method('dumpFile');
+
+        $factory = new MagoMutantProcessFactory(
+            $phpStanMutantExecutionResultFactory,
+            '/path/to/mago',
+            $commandLineBuilder,
+            100.0,
+            [],
+        );
+
+        $mutantProcess = $factory->create($mutant);
+
+        $process = $mutantProcess->getProcess();
+
+        $this->assertSame(100.0, $process->getTimeout());
+        $this->assertFalse($process->isStarted());
+
+        $this->assertSame($mutant, $mutantProcess->getMutant());
+        $this->assertFalse($mutantProcess->isTimedOut());
+    }
+
+    public function test_it_creates_a_process_with_multiple_options(): void
+    {
+        $mutant = MutantBuilder::materialize(
+            $mutantFilePath = '/path/to/mutant',
+            new Mutation(
+                $originalFilePath = 'path/to/Foo.php',
+                [],
+                For_::class,
+                MutatorName::getName(For_::class),
+                [
+                    'startLine' => 10,
+                    'endLine' => 15,
+                    'startTokenPos' => 0,
+                    'endTokenPos' => 8,
+                    'startFilePos' => 2,
+                    'endFilePos' => 4,
+                ],
+                'Unknown',
+                MutatedNode::wrap(new Nop()),
+                0,
+                [
+                    new TestLocation(
+                        'FooTest::test_it_can_instantiate',
+                        '/path/to/acme/FooTest.php',
+                        0.01,
+                    ),
+                ],
+                [],
+                '',
+            ),
+            'killed#0',
+            <<<'DIFF'
+                --- Original
+                +++ New
+                @@ @@
+
+                - echo 'original';
+                + echo 'killed#0';
+
+                DIFF,
+            '<?php $a = 1;',
+        );
+
+        $phpStanMutantExecutionResultFactory = $this->createStub(MagoMutantExecutionResultFactory::class);
+        $commandLineBuilder = $this->createMock(CommandLineBuilder::class);
+        $commandLineBuilder
+            ->expects($this->once())
+            ->method('build')
+            ->with('/path/to/mago', [], [
+                '--colors=never',
+                'analyze',
+                '--reporting-format=short',
+                '--substitute',
+                "$originalFilePath=$mutantFilePath",
+                '--no-stubs',
+                '--baseline /path/to/baseline.toml',
+            ])
+            ->willReturn(['/path/to/mago'])
+        ;
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->expects($this->never())
+            ->method('dumpFile');
+
+        $factory = new MagoMutantProcessFactory(
+            $phpStanMutantExecutionResultFactory,
+            '/path/to/mago',
+            $commandLineBuilder,
+            100.0,
+            [
+                '--no-stubs',
+                '--baseline /path/to/baseline.toml',
+            ],
+        );
+
+        $mutantProcess = $factory->create($mutant);
+
+        $process = $mutantProcess->getProcess();
+
+        $this->assertSame(100.0, $process->getTimeout());
+        $this->assertFalse($process->isStarted());
+
+        $this->assertSame($mutant, $mutantProcess->getMutant());
+        $this->assertFalse($mutantProcess->isTimedOut());
+    }
+
+    public function test_it_creates_a_process_without_options(): void
+    {
+        $mutant = MutantBuilder::materialize(
+            $mutantFilePath = '/path/to/mutant',
+            new Mutation(
+                $originalFilePath = 'path/to/Foo.php',
+                [],
+                For_::class,
+                MutatorName::getName(For_::class),
+                [
+                    'startLine' => 10,
+                    'endLine' => 15,
+                    'startTokenPos' => 0,
+                    'endTokenPos' => 8,
+                    'startFilePos' => 2,
+                    'endFilePos' => 4,
+                ],
+                'Unknown',
+                MutatedNode::wrap(new Nop()),
+                0,
+                [
+                    new TestLocation(
+                        'FooTest::test_it_can_instantiate',
+                        '/path/to/acme/FooTest.php',
+                        0.01,
+                    ),
+                ],
+                [],
+                '',
+            ),
+            'killed#0',
+            <<<'DIFF'
+                --- Original
+                +++ New
+                @@ @@
+
+                - echo 'original';
+                + echo 'killed#0';
+
+                DIFF,
+            '<?php $a = 1;',
+        );
+
+        $phpStanMutantExecutionResultFactory = $this->createStub(MagoMutantExecutionResultFactory::class);
+        $commandLineBuilder = $this->createMock(CommandLineBuilder::class);
+        $commandLineBuilder
+            ->expects($this->once())
+            ->method('build')
+            ->with('/path/to/mago', [], [
+                '--colors=never',
+                'analyze',
+                '--reporting-format=short',
+                '--substitute',
+                "$originalFilePath=$mutantFilePath",
+            ])
+            ->willReturn(['/path/to/mago'])
+        ;
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->expects($this->never())
+            ->method('dumpFile');
+
+        $factory = new MagoMutantProcessFactory(
+            $phpStanMutantExecutionResultFactory,
+            '/path/to/mago',
+            $commandLineBuilder,
+            100.0,
+            [],
+        );
+
+        $mutantProcess = $factory->create($mutant);
+
+        $process = $mutantProcess->getProcess();
+
+        $this->assertSame(100.0, $process->getTimeout());
+        $this->assertFalse($process->isStarted());
+
+        $this->assertSame($mutant, $mutantProcess->getMutant());
+        $this->assertFalse($mutantProcess->isTimedOut());
+    }
+}

--- a/tests/phpunit/StaticAnalysis/StaticAnalysisToolTypesTest.php
+++ b/tests/phpunit/StaticAnalysis/StaticAnalysisToolTypesTest.php
@@ -49,6 +49,7 @@ final class StaticAnalysisToolTypesTest extends TestCase
         $this->assertSame(
             [
                 StaticAnalysisToolTypes::PHPSTAN,
+                StaticAnalysisToolTypes::MAGO,
             ],
             $types,
         );


### PR DESCRIPTION
## Description

This introduces mago as a second static analysis tool we can use to kill
mutants that aren't killed by tests. It works pretty much the same as
the phpstan analysis except it uses a different tool.

For now we require mago >=1.20.0 because that's the only version I've
tested this on. But we can probably lower that version number a bit if
someone askes for it.

## Changes

- Adds support for mago static analysis tool

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (provide link to PR: https://github.com/infection/site/pull/XXX)
- [x] CHANGELOG.md updated (if deprecations/breaking changes)
- [ ] Appropriate labels applied (e.g. `performance`, `feature`).


## Reviewer Notes

I only checked that things work in the e2e test but I'm not 100% convinced that everything works as you'd expect.

- ~Is the mago output shown anywhere when a mutant is(n't) killed by mago~ Yes this is useful output which is saved in the logs to see *why* a mutant was killed.
- ~Mago does have a method to "replace" an existing file with a new one but that relies on stdin. I now have it running on the mutated file without any config changes and without providing the original file, I'm not sure that this will work in larger code bases where more things depend on context from the full code base analysis. Could use some insights on this.~ It does as of 1.23.0

## Related issues

Fixes https://github.com/infection/infection/issues/2393
