### PR TITLE
build(mago): Configure which exceptions to not handle

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -7,18 +7,6 @@ message = "Property `$ci` is missing a type hint."
 count = 1
 
 [[issues]]
-file = "src/Command/BaseCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\BaseCommand::getApplication`.'
-count = 1
-
-[[issues]]
-file = "src/Command/BaseCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\BaseCommand::getIO`.'
-count = 1
-
-[[issues]]
 file = "src/Command/ConfigureCommand.php"
 code = "less-specific-nested-argument-type"
 message = 'Argument type mismatch for argument #2 of `Infection\Config\ValueProvider\ExcludeDirsProvider::get`: expected `array<array-key, string>`, but provided type `list<mixed>` is less specific.'
@@ -70,48 +58,6 @@ count = 1
 file = "src/Command/ConfigureCommand.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Command\ConfigureCommand::abort`.'
-count = 1
-
-[[issues]]
-file = "src/Command/ConfigureCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Command\ConfigureCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/ConfigureCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Command\ConfigureCommand::saveConfig`.'
-count = 1
-
-[[issues]]
-file = "src/Command/ConfigureCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Command\ConfigureCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/ConfigureCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Command\ConfigureCommand::saveConfig`.'
-count = 1
-
-[[issues]]
-file = "src/Command/ConfigureCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\ConfigureCommand::configure`.'
-count = 1
-
-[[issues]]
-file = "src/Command/ConfigureCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\ConfigureCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/ConfigureCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Command\ConfigureCommand::executeCommand`.'
 count = 1
 
 [[issues]]
@@ -177,55 +123,7 @@ count = 1
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\Command\Debug\DumpAstCommand::getFile`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Command\Debug\DumpAstCommand::getFile`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Debug\DumpAstCommand::configure`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Debug\DumpAstCommand::getChangedLinesRanges`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Debug\DumpAstCommand::getFile`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Debug\DumpAstCommand::shouldShowAttributes`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Command\Debug\DumpAstCommand::__construct`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\Debug\DumpAstCommand::getFile`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\Debug\DumpAstCommand::parseChangedLinesRange`.'
 count = 1
 
 [[issues]]
@@ -243,49 +141,7 @@ count = 1
 [[issues]]
 file = "src/Command/Debug/MockTeamCityCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\StreamException` in `Infection\Command\Debug\MockTeamCityCommand::getLinesFromStdin`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Debug\MockTeamCityCommand::configure`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Debug\MockTeamCityCommand::getLogFile`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Debug\MockTeamCityCommand::getTimeInMilliseconds`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Command\Debug\MockTeamCityCommand::__construct`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Command\Debug\MockTeamCityCommand::getLogLines`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\Debug\MockTeamCityCommand::getLogFile`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\Debug\MockTeamCityCommand::getTimeInMilliseconds`.'
 count = 1
 
 [[issues]]
@@ -349,36 +205,6 @@ message = "Redundant docblock type for variable `$definition`."
 count = 1
 
 [[issues]]
-file = "src/Command/DescribeCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\DescribeCommand::configure`.'
-count = 1
-
-[[issues]]
-file = "src/Command/DescribeCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\DescribeCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/DescribeCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Command\DescribeCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/DescribeCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\DescribeCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/GitBaseReferenceCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Command\Git\GitBaseReferenceCommand::__construct`.'
-count = 1
-
-[[issues]]
 file = "src/Command/Git/GitChangedFilesCommand.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Command\Git\GitChangedFilesCommand::executeCommand`.'
@@ -388,18 +214,6 @@ count = 1
 file = "src/Command/Git/GitChangedFilesCommand.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\Git\GitChangedFilesCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/GitChangedFilesCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Command\Git\GitChangedFilesCommand::__construct`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/GitChangedFilesCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\Git\GitChangedFilesCommand::executeCommand`.'
 count = 1
 
 [[issues]]
@@ -415,24 +229,6 @@ message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceF
 count = 1
 
 [[issues]]
-file = "src/Command/Git/GitChangedLinesCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Command\Git\GitChangedLinesCommand::__construct`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/GitChangedLinesCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\Git\GitChangedLinesCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/GitDefaultBaseCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Command\Git\GitDefaultBaseCommand::__construct`.'
-count = 1
-
-[[issues]]
 file = "src/Command/Git/Option/BaseOption.php"
 code = "invalid-return-statement"
 message = '''Invalid return type for function `infection\command\git\option\baseoption::addoption`: expected `('T.infection\command\git\option\baseoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
@@ -445,24 +241,6 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 1
 
 [[issues]]
-file = "src/Command/Git/Option/BaseOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Git\Option\BaseOption::addOption`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/Option/BaseOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Git\Option\BaseOption::get`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/Option/BaseOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\Git\Option\BaseOption::get`.'
-count = 1
-
-[[issues]]
 file = "src/Command/Git/Option/FilterOption.php"
 code = "invalid-return-statement"
 message = '''Invalid return type for function `infection\command\git\option\filteroption::addoption`: expected `('T.infection\command\git\option\filteroption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
@@ -472,24 +250,6 @@ count = 1
 file = "src/Command/Git/Option/FilterOption.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "src/Command/Git/Option/FilterOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Git\Option\FilterOption::addOption`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/Option/FilterOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Git\Option\FilterOption::get`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/Option/FilterOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\Git\Option\FilterOption::get`.'
 count = 1
 
 [[issues]]
@@ -507,12 +267,6 @@ count = 1
 [[issues]]
 file = "src/Command/InitialTest/InitialTestRunCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Command\InitialTest\InitialTestRunCommand::__construct`.'
-count = 1
-
-[[issues]]
-file = "src/Command/InitialTest/InitialTestRunCommand.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\process\runner\initialtestsfailed` in `Infection\Command\InitialTest\InitialTestRunCommand::executeCommand`.'
 count = 1
 
@@ -520,18 +274,6 @@ count = 1
 file = "src/Command/InitialTest/Option/InitialTestsPhpOptionsOption.php"
 code = "invalid-return-statement"
 message = '''Invalid return type for function `infection\command\initialtest\option\initialtestsphpoptionsoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
-count = 1
-
-[[issues]]
-file = "src/Command/InitialTest/Option/InitialTestsPhpOptionsOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\InitialTest\Option\InitialTestsPhpOptionsOption::addOption`.'
-count = 1
-
-[[issues]]
-file = "src/Command/InitialTest/Option/InitialTestsPhpOptionsOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\InitialTest\Option\InitialTestsPhpOptionsOption::get`.'
 count = 1
 
 [[issues]]
@@ -550,18 +292,6 @@ count = 1
 file = "src/Command/ListSourcesCommand.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\ListSourcesCommand::collectPaths`.'
-count = 1
-
-[[issues]]
-file = "src/Command/ListSourcesCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Command\ListSourcesCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/ListSourcesCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Command\ListSourcesCommand::__construct`.'
 count = 1
 
 [[issues]]
@@ -597,36 +327,6 @@ count = 1
 [[issues]]
 file = "src/Command/MakeCustomMutatorCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Command\MakeCustomMutatorCommand::createProjectFilesFromTemplates`.'
-count = 1
-
-[[issues]]
-file = "src/Command/MakeCustomMutatorCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Command\MakeCustomMutatorCommand::createProjectFilesFromTemplates`.'
-count = 1
-
-[[issues]]
-file = "src/Command/MakeCustomMutatorCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\MakeCustomMutatorCommand::configure`.'
-count = 1
-
-[[issues]]
-file = "src/Command/MakeCustomMutatorCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\MakeCustomMutatorCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/MakeCustomMutatorCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\MakeCustomMutatorCommand::interact`.'
-count = 1
-
-[[issues]]
-file = "src/Command/MakeCustomMutatorCommand.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Command\MakeCustomMutatorCommand::createProjectFilesFromTemplates`.'
 count = 1
 
@@ -634,18 +334,6 @@ count = 1
 file = "src/Command/Option/ConfigurationOption.php"
 code = "invalid-return-statement"
 message = '''Invalid return type for function `infection\command\option\configurationoption::addoption`: expected `('T.infection\command\option\configurationoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
-count = 1
-
-[[issues]]
-file = "src/Command/Option/ConfigurationOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\ConfigurationOption::addOption`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/ConfigurationOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\ConfigurationOption::get`.'
 count = 1
 
 [[issues]]
@@ -658,18 +346,6 @@ count = 1
 file = "src/Command/Option/DebugOption.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `infection\command\option\debugoption::get`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/DebugOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\DebugOption::addOption`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/DebugOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\DebugOption::get`.'
 count = 1
 
 [[issues]]
@@ -698,24 +374,6 @@ count = 1
 
 [[issues]]
 file = "src/Command/Option/MapSourceClassToTestOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Command\Option\MapSourceClassToTestOption::assertIsValid`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/MapSourceClassToTestOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\MapSourceClassToTestOption::addOption`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/MapSourceClassToTestOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\MapSourceClassToTestOption::get`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/MapSourceClassToTestOption.php"
 code = "unused-template-parameter"
 message = 'Template parameter `T` is never used in method `Infection\Command\Option\MapSourceClassToTestOption::addOption`.'
 count = 1
@@ -739,81 +397,9 @@ message = "Casting `mixed` to `bool`."
 count = 1
 
 [[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Command\Option\SourceFilterOptions::assertGitBaseHasRequiredFilter`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Command\Option\SourceFilterOptions::assertOnlyOneTypeOfFiltering`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Command\Option\SourceFilterOptions::assertOnlyOneTypeOfGitFiltering`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\SourceFilterOptions::addOption`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\SourceFilterOptions::getGitDiffBase`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\SourceFilterOptions::getGitDiffFilter`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\SourceFilterOptions::getGitFilter`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\SourceFilterOptions::getPlainFilter`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\Option\SourceFilterOptions::getGitDiffBase`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\Option\SourceFilterOptions::getGitDiffFilter`.'
-count = 1
-
-[[issues]]
 file = "src/Command/Option/TestFrameworkOption.php"
 code = "invalid-return-statement"
 message = '''Invalid return type for function `infection\command\option\testframeworkoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
-count = 1
-
-[[issues]]
-file = "src/Command/Option/TestFrameworkOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\TestFrameworkOption::addOption`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/TestFrameworkOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\TestFrameworkOption::get`.'
 count = 1
 
 [[issues]]
@@ -826,18 +412,6 @@ count = 1
 file = "src/Command/Option/TestFrameworkOptionsOption.php"
 code = "invalid-return-statement"
 message = '''Invalid return type for function `infection\command\option\testframeworkoptionsoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
-count = 1
-
-[[issues]]
-file = "src/Command/Option/TestFrameworkOptionsOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\TestFrameworkOptionsOption::addOption`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Option/TestFrameworkOptionsOption.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\Option\TestFrameworkOptionsOption::get`.'
 count = 1
 
 [[issues]]
@@ -939,55 +513,13 @@ count = 1
 [[issues]]
 file = "src/Command/RunCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Command\RunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Command\RunCommand::createContainer`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Command\RunCommand::runConfigurationCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\ExceptionInterface` in `Infection\Command\RunCommand::runConfigurationCommand`.'
 count = 1
 
 [[issues]]
 file = "src/Command/RunCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\RunCommand::configure`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\RunCommand::createContainer`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\RunCommand::runConfigurationCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Command\RunCommand::startUp`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ValueError` in `Infection\Command\RunCommand::getMutationAnalysisLoggerName`.'
 count = 1
 
 [[issues]]
@@ -1006,66 +538,6 @@ count = 4
 file = "src/Command/RunCommandHelper.php"
 code = "mixed-operand"
 message = "Casting `mixed` to `bool`."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommandHelper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Command\RunCommandHelper::getUseGitHubLogger`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommandHelper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\RunCommandHelper::getIgnoreMsiWithNoMutations`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommandHelper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\RunCommandHelper::getMaxTimeouts`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommandHelper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\RunCommandHelper::getNumberOfShownMutations`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommandHelper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\RunCommandHelper::getStringOption`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommandHelper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\RunCommandHelper::getThreadCount`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommandHelper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\RunCommandHelper::getTimeoutsAsEscaped`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommandHelper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Command\RunCommandHelper::getUseGitHubLogger`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommandHelper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\RunCommandHelper::getNumberOfShownMutations`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommandHelper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Command\RunCommandHelper::getThreadCount`.'
 count = 1
 
 [[issues]]
@@ -1123,12 +595,6 @@ message = "This member selector uses a non-literal string type (`string`); its s
 count = 1
 
 [[issues]]
-file = "src/Config/Guesser/SourceDirGuesser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\Config\Guesser\SourceDirGuesser::parsePsrSection`.'
-count = 1
-
-[[issues]]
 file = "src/Config/ValueProvider/ExcludeDirsProvider.php"
 code = "less-specific-nested-return-statement"
 message = '''Returned type `(closure(mixed): truthy-mixed)` is less specific than the declared return type `(closure(string): string)` for function `infection\config\valueprovider\excludedirsprovider::getvalidator` due to nested 'mixed'.'''
@@ -1156,18 +622,6 @@ count = 1
 file = "src/Config/ValueProvider/ExcludeDirsProvider.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "src/Config/ValueProvider/ExcludeDirsProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Config\ValueProvider\ExcludeDirsProvider::get`.'
-count = 1
-
-[[issues]]
-file = "src/Config/ValueProvider/ExcludeDirsProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Config\ValueProvider\ExcludeDirsProvider::get`.'
 count = 1
 
 [[issues]]
@@ -1221,12 +675,6 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/SourceDirsProvider.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\Config\ValueProvider\SourceDirsProvider::get`.'
-count = 1
-
-[[issues]]
-file = "src/Config/ValueProvider/SourceDirsProvider.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\RuntimeException` in `Infection\Config\ValueProvider\SourceDirsProvider::get`.'
 count = 1
 
@@ -1240,24 +688,6 @@ count = 1
 file = "src/Config/ValueProvider/TestFrameworkConfigPathProvider.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `infection\config\valueprovider\testframeworkconfigpathprovider::asktestframeworkconfiglocation`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Config/ValueProvider/TestFrameworkConfigPathProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Config\ValueProvider\TestFrameworkConfigPathProvider::get`.'
-count = 1
-
-[[issues]]
-file = "src/Config/ValueProvider/TestFrameworkConfigPathProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Config\ValueProvider\TestFrameworkConfigPathProvider::get`.'
-count = 1
-
-[[issues]]
-file = "src/Config/ValueProvider/TestFrameworkConfigPathProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Config\ValueProvider\TestFrameworkConfigPathProvider::askTestFrameworkConfigLocation`.'
 count = 1
 
 [[issues]]
@@ -1281,12 +711,6 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/TextLogFileProvider.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Config\ValueProvider\TextLogFileProvider::get`.'
-count = 1
-
-[[issues]]
-file = "src/Config/ValueProvider/TextLogFileProvider.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\RuntimeException` in `Infection\Config\ValueProvider\TextLogFileProvider::get`.'
 count = 1
 
@@ -1294,12 +718,6 @@ count = 1
 file = "src/Configuration/Configuration.php"
 code = "redundant-type-comparison"
 message = 'Redundant type assertion: `$mutators` of type `array<string, Infection\Mutator\Mutator<PhpParser\Node>>` is always not `iterable<mixed, Infection\Mutator\Mutator<PhpParser\Node>>`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/Configuration.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Configuration\Configuration::__construct`.'
 count = 1
 
 [[issues]]
@@ -1321,57 +739,9 @@ message = 'Potentially unhandled exception `UnexpectedValueException` in `Infect
 count = 1
 
 [[issues]]
-file = "src/Configuration/ConfigurationFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Configuration\ConfigurationFactory::retrieveIgnoreSourceCodeMutatorsMap`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/ConfigurationFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Configuration\ConfigurationFactory::retrieveThreadCount`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/Entry/StrykerConfig.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Configuration\Entry\StrykerConfig::forBadge`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/Entry/StrykerConfig.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Configuration\Entry\StrykerConfig::forFullReport`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/Entry/StrykerConfig.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Configuration\Entry\StrykerConfig::__construct`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/Entry/StrykerConfig.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Configuration\Entry\StrykerConfig::applicableForBranch`.'
-count = 1
-
-[[issues]]
 file = "src/Configuration/Schema/InvalidSchema.php"
 code = "redundant-type-comparison"
 message = "Redundant type assertion: `$errors` of type `array<array-key, string>` is always not `iterable<mixed, string>`."
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/InvalidSchema.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Configuration\Schema\InvalidSchema::create`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfiguration.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Configuration\Schema\SchemaConfiguration::__construct`.'
 count = 1
 
 [[issues]]
@@ -1501,24 +871,6 @@ message = 'Could not infer a precise return type for function `infection\configu
 count = 1
 
 [[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Configuration\Schema\SchemaConfigurationFactory::getStaticAnalysisTool`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Configuration\Schema\SchemaConfigurationFactory::getTestFramework`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Configuration\Schema\SchemaConfigurationFactory::getTimeout`.'
-count = 1
-
-[[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFile.php"
 code = "mixed-property-type-coercion"
 message = "A value with a less specific type `mixed` is being assigned to property `$$decodedContents` (null|stdClass)."
@@ -1528,12 +880,6 @@ count = 1
 file = "src/Configuration/Schema/SchemaConfigurationFile.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `infection\configuration\schema\schemaconfigurationfile::getdecodedcontents`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationFile.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Configuration\Schema\SchemaConfigurationFile::getDecodedContents`.'
 count = 1
 
 [[issues]]
@@ -1603,33 +949,9 @@ message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\
 count = 1
 
 [[issues]]
-file = "src/Console/Application.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Console\Application::getPrettyVersion`.'
-count = 1
-
-[[issues]]
-file = "src/Console/Application.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Console\Application::getDefaultCommands`.'
-count = 1
-
-[[issues]]
-file = "src/Console/Input/MsiParser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Console\Input\MsiParser::parse`.'
-count = 1
-
-[[issues]]
 file = "src/Console/LogVerbosity.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "src/Console/LogVerbosity.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Console\LogVerbosity::convertVerbosityLevel`.'
 count = 1
 
 [[issues]]
@@ -1676,996 +998,6 @@ count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getAdapterInstallationDecider`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getAdapterInstaller`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getCiDetector`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getCleanUpAfterMutationTestingFinishedSubscriberFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getComposerExecutableFinder`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getConfigurationFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getConfiguration`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getCoverageChecker`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getDiffColorizer`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getDiffSourceCodeMatcher`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getDiffer`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getEventDispatcher`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getFileMutationGenerator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getFileParser`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getFileReporterFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getFileStore`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getFileSystem`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getFilteringResultsCollectorFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getGit`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getIndexXmlCoverageLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getIndexXmlCoverageParser`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getInitialStaticAnalysisProcessFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getInitialStaticAnalysisRunner`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getInitialTestRunProcessFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getInitialTestsRunProcessFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getInitialTestsRunner`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getJUnitReportLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getJUnitTestExecutionInfoAdder`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getLineRangeCalculator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getLogger`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMaxTimeoutsChecker`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMemoryFormatter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMemoryLimiter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMetricsCalculator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMinMsiChecker`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMutantCodeFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMutantExecutionResultFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMutantFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMutantProcessContainerFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMutatedCodePrinter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMutationAnalysisLoggerFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMutationAnalysisLogger`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMutationGenerator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMutationTestingRunner`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMutatorFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getMutatorResolver`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getNodeDumper`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getNodeTraverserFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getOutput`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getParser`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getPhpUnitXmlCoverageTraceProvider`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getPrinter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getProcessRunner`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getProjectDir`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getReporter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getResultsCollector`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getRootsFileLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getRootsFileOrDirectoryLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getSchemaConfigurationFileLoader`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getSchemaConfigurationLoader`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getSchemaConfiguration`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getShellCommandLineExecutor`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getSourceCollector`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getSourceLineMatcher`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getStaticAnalysisConfigLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getStaticAnalysisToolAdapter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getStaticAnalysisToolExecutableFinder`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getStaticAnalysisToolFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getStopwatch`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getStrykerHtmlReportBuilder`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getStrykerLoggerFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getSubscriberRegisterer`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getTargetDetectionStatusesProvider`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getTestFrameworkAdapter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getTestFrameworkConfigLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getTestFrameworkExtraOptionsFilter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getTestFrameworkFinder`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getTimeFormatter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getTraceProvider`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getTracer`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Container\Container::getXmlCoverageParser`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getAdapterInstallationDecider`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getAdapterInstaller`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getCiDetector`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getCleanUpAfterMutationTestingFinishedSubscriberFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getComposerExecutableFinder`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getConfigurationFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getConfiguration`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getCoverageChecker`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getDiffColorizer`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getDiffSourceCodeMatcher`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getDiffer`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getEventDispatcher`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getFileMutationGenerator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getFileParser`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getFileReporterFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getFileStore`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getFileSystem`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getFilteringResultsCollectorFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getGit`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getIndexXmlCoverageLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getIndexXmlCoverageParser`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getInitialStaticAnalysisProcessFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getInitialStaticAnalysisRunner`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getInitialTestRunProcessFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getInitialTestsRunProcessFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getInitialTestsRunner`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getJUnitReportLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getJUnitTestExecutionInfoAdder`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getLineRangeCalculator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getLogger`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMaxTimeoutsChecker`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMemoryFormatter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMemoryLimiter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMetricsCalculator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMinMsiChecker`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMutantCodeFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMutantExecutionResultFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMutantFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMutantProcessContainerFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMutatedCodePrinter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMutationAnalysisLoggerFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMutationAnalysisLogger`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMutationGenerator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMutationTestingRunner`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMutatorFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getMutatorResolver`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getNodeDumper`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getNodeTraverserFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getOutput`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getParser`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getPhpUnitXmlCoverageTraceProvider`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getPrinter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getProcessRunner`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getProjectDir`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getReporter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getResultsCollector`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getRootsFileLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getRootsFileOrDirectoryLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getSchemaConfigurationFileLoader`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getSchemaConfigurationLoader`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getSchemaConfiguration`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getShellCommandLineExecutor`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getSourceCollector`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getSourceLineMatcher`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getStaticAnalysisConfigLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getStaticAnalysisToolAdapter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getStaticAnalysisToolExecutableFinder`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getStaticAnalysisToolFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getStopwatch`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getStrykerHtmlReportBuilder`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getStrykerLoggerFactory`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getSubscriberRegisterer`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getTargetDetectionStatusesProvider`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getTestFrameworkAdapter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getTestFrameworkConfigLocator`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getTestFrameworkExtraOptionsFilter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getTestFrameworkFinder`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getTimeFormatter`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getTraceProvider`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getTracer`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Container\Container::getXmlCoverageParser`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Container\Container::withValues`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
 code = "unused-parameter"
 message = "Parameter `$container` is never used."
 count = 1
@@ -2707,18 +1039,6 @@ message = "Type `iterable` in return type of `mutationsProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "src/Differ/ChangedLinesRange.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Differ\ChangedLinesRange::create`.'
-count = 1
-
-[[issues]]
-file = "src/Differ/ChangedLinesRange.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Differ\ChangedLinesRange::forRange`.'
-count = 1
-
-[[issues]]
 file = "src/Differ/DiffColorizer.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #1 of `array_filter`: expected `array<('K.array_filter() extends array-key), ('V.array_filter() extends mixed)>`, but found `mixed`."
@@ -2743,24 +1063,6 @@ message = "Reference created from a previously undefined variable `$matches`."
 count = 1
 
 [[issues]]
-file = "src/Differ/DiffColorizer.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Differ\DiffColorizer::isMultiLineDiff`.'
-count = 1
-
-[[issues]]
-file = "src/Differ/DiffColorizer.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Differ\DiffColorizer::colorize`.'
-count = 1
-
-[[issues]]
-file = "src/Differ/DiffSourceCodeMatcher.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Differ\DiffSourceCodeMatcher::matches`.'
-count = 1
-
-[[issues]]
 file = "src/Differ/Differ.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `infection\differ\differ::processtokens`: expected `array{0: string, 1: int(0)|int(1)|int(2)|int(3)|int(4)}`, but found `mixed`.'
@@ -2774,12 +1076,6 @@ count = 1
 
 [[issues]]
 file = "src/Differ/Differ.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Differ\Differ::processTokens`.'
-count = 1
-
-[[issues]]
-file = "src/Differ/Differ.php"
 code = "unused-parameter"
 message = "Parameter `$lcs` is never used."
 count = 1
@@ -2788,36 +1084,6 @@ count = 1
 file = "src/Differ/Tokens.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `infection\differ\tokens::computerange`: expected `array{0: int(0)|positive-int, 1: int(0)|positive-int}`, but found `list{non-negative-int, int}`.'
-count = 1
-
-[[issues]]
-file = "src/Differ/Tokens.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Differ\Tokens::computeRange`.'
-count = 1
-
-[[issues]]
-file = "src/Engine.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Engine::getFilteredExtraOptionsForMutant`.'
-count = 1
-
-[[issues]]
-file = "src/Engine.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\StringsException` in `Infection\Engine::getFilteredExtraOptionsForMutant`.'
-count = 1
-
-[[issues]]
-file = "src/Engine.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Engine::runInitialTestSuite`.'
-count = 1
-
-[[issues]]
-file = "src/Engine.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Engine::runInitialStaticAnalysis`.'
 count = 1
 
 [[issues]]
@@ -2887,39 +1153,9 @@ message = 'Potentially unhandled exception `ReflectionException` in `Infection\E
 count = 1
 
 [[issues]]
-file = "src/Event/EventDispatcher/SyncEventDispatcher.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ValueError` in `Infection\Event\EventDispatcher\SyncEventDispatcher::inferSubscribedEvents`.'
-count = 1
-
-[[issues]]
-file = "src/Event/EventDispatcher/SyncEventDispatcher.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Event\EventDispatcher\SyncEventDispatcher::inferSubscribedEvents`.'
-count = 1
-
-[[issues]]
 file = "src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriber::onMutationTestingWasFinished`.'
-count = 1
-
-[[issues]]
-file = "src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriber::onMutationTestingWasFinished`.'
-count = 1
-
-[[issues]]
-file = "src/Event/Subscriber/DispatchPcntlSignalSubscriber.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcntlException` in `Infection\Event\Subscriber\DispatchPcntlSignalSubscriber::onMutantProcessWasFinished`.'
-count = 1
-
-[[issues]]
-file = "src/Event/Subscriber/StopInfectionOnSigintSignalSubscriber.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcntlException` in `Infection\Event\Subscriber\StopInfectionOnSigintSignalSubscriber::onMutationTestingWasStarted`.'
 count = 1
 
 [[issues]]
@@ -2942,158 +1178,8 @@ count = 6
 
 [[issues]]
 file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::appendToFile`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::chgrp`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::chmod`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::chown`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::copy`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::createFinder`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::dumpFile`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::exists`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::hardlink`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::isAbsolutePath`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::isReadableDirectory`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::isReadableFile`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::isReadable`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::makePathRelative`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::mirror`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::mkdir`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::readFile`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::readlink`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::realPath`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::remove`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::rename`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::symlink`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::tempnam`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\FileSystem\FakeFileSystem::touch`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FakeFileSystem.php"
 code = "unused-parameter"
 message = "Parameter `$filename` is never used."
-count = 1
-
-[[issues]]
-file = "src/FileSystem/FileStore.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\FileSystem\FileStore::getContents`.'
 count = 1
 
 [[issues]]
@@ -3118,18 +1204,6 @@ count = 1
 file = "src/FileSystem/FileSystem.php"
 code = "unused-parameter"
 message = "Parameter `$type` is never used."
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/ConcreteComposerExecutableFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\FileSystem\Finder\ConcreteComposerExecutableFinder::find`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/ConcreteComposerExecutableFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\FileSystem\Finder\ConcreteComposerExecutableFinder::find`.'
 count = 1
 
 [[issues]]
@@ -3195,54 +1269,6 @@ count = 1
 [[issues]]
 file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder::addVendorBinToPath`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder::findStaticAnalysisExecutable`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder::findFromBatchFile`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder::find`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder::addVendorBinToPath`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder::findFromBatchFile`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder::addVendorBinToPath`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder::find`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\filesystem\finder\exception\finderexception` in `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder::findStaticAnalysisExecutable`.'
 count = 1
 
@@ -3291,54 +1317,6 @@ count = 1
 [[issues]]
 file = "src/FileSystem/Finder/TestFrameworkFinder.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\FileSystem\Finder\TestFrameworkFinder::addVendorBinToPath`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/TestFrameworkFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\FileSystem\Finder\TestFrameworkFinder::findTestFramework`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/TestFrameworkFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\FileSystem\Finder\TestFrameworkFinder::findFromBatchFile`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/TestFrameworkFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\FileSystem\Finder\TestFrameworkFinder::find`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/TestFrameworkFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\FileSystem\Finder\TestFrameworkFinder::addVendorBinToPath`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/TestFrameworkFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\FileSystem\Finder\TestFrameworkFinder::findFromBatchFile`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/TestFrameworkFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\FileSystem\Finder\TestFrameworkFinder::addVendorBinToPath`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/TestFrameworkFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\FileSystem\Finder\TestFrameworkFinder::find`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/TestFrameworkFinder.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\filesystem\finder\exception\finderexception` in `Infection\FileSystem\Finder\TestFrameworkFinder::findTestFramework`.'
 count = 1
 
@@ -3361,18 +1339,6 @@ message = "Redundant type assertion: `$roots` of type `array<array-key, string>`
 count = 2
 
 [[issues]]
-file = "src/FileSystem/Locator/FileNotFound.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\FileSystem\Locator\FileNotFound::fromFileName`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Locator/FileNotFound.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\FileSystem\Locator\FileNotFound::fromFiles`.'
-count = 1
-
-[[issues]]
 file = "src/FileSystem/Locator/FileOrDirectoryNotFound.php"
 code = "redundant-type-comparison"
 message = "Redundant type assertion: `$files` of type `array<array-key, string>` is always not `iterable<mixed, string>`."
@@ -3385,18 +1351,6 @@ message = "Redundant type assertion: `$roots` of type `array<array-key, string>`
 count = 2
 
 [[issues]]
-file = "src/FileSystem/Locator/FileOrDirectoryNotFound.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\FileSystem\Locator\FileOrDirectoryNotFound::fromFileName`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Locator/FileOrDirectoryNotFound.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\FileSystem\Locator\FileOrDirectoryNotFound::fromFiles`.'
-count = 1
-
-[[issues]]
 file = "src/FileSystem/Locator/RootsFileLocator.php"
 code = "redundant-type-comparison"
 message = "Redundant type assertion: `$roots` of type `array<array-key, string>` is always not `iterable<mixed, string>`."
@@ -3406,18 +1360,6 @@ count = 1
 file = "src/FileSystem/Locator/RootsFileLocator.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\FileSystem\Locator\RootsFileLocator::innerLocateOneOf`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Locator/RootsFileLocator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\FileSystem\Locator\RootsFileLocator::locate`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Locator/RootsFileLocator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\FileSystem\Locator\RootsFileLocator::__construct`.'
 count = 1
 
 [[issues]]
@@ -3433,39 +1375,9 @@ message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileNot
 count = 1
 
 [[issues]]
-file = "src/FileSystem/Locator/RootsFileOrDirectoryLocator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\FileSystem\Locator\RootsFileOrDirectoryLocator::locate`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Locator/RootsFileOrDirectoryLocator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\FileSystem\Locator\RootsFileOrDirectoryLocator::__construct`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/TmpDirProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\FileSystem\TmpDirProvider::providePath`.'
-count = 1
-
-[[issues]]
 file = "src/Framework/ClassName.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `infection\framework\classname::getshortclassname`: expected `non-empty-string`, but found `string`.'
-count = 1
-
-[[issues]]
-file = "src/Framework/ClassName.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Framework\ClassName::getCanonicalSourceClassNames`.'
-count = 1
-
-[[issues]]
-file = "src/Framework/ClassName.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Framework\ClassName::getCanonicalTestClassNames`.'
 count = 1
 
 [[issues]]
@@ -3507,24 +1419,6 @@ count = 1
 [[issues]]
 file = "src/Framework/Enum/EnumBucket.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Framework\Enum\EnumBucket::asserValueIsANativeEnum`.'
-count = 1
-
-[[issues]]
-file = "src/Framework/Enum/EnumBucket.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Framework\Enum\EnumBucket::assertIsEmpty`.'
-count = 1
-
-[[issues]]
-file = "src/Framework/Enum/EnumBucket.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Framework\Enum\EnumBucket::throwValueNotAvailable`.'
-count = 1
-
-[[issues]]
-file = "src/Framework/Enum/EnumBucket.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Framework\Enum\EnumBucket::throwValueNotAvailable`.'
 count = 1
 
@@ -3538,18 +1432,6 @@ count = 1
 file = "src/Framework/Str.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `infection\framework\str::findlastnonemptylineindex`: expected `non-negative-int`, but found `int`.'
-count = 1
-
-[[issues]]
-file = "src/Framework/Str.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\Framework\Str::findLastNonEmptyLineIndex`.'
-count = 1
-
-[[issues]]
-file = "src/Framework/Str.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\MbstringException` in `Infection\Framework\Str::convertToUtf8`.'
 count = 1
 
 [[issues]]
@@ -3603,24 +1485,6 @@ count = 2
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Git\CommandLineGit::diff`.'
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Git\CommandLineGit::parseChangedLinesRangeFromLine`.'
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Git\CommandLineGit::parseFilePathFromLine`.'
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\Git\CommandLineGit::diff`.'
 count = 1
 
@@ -3634,30 +1498,6 @@ count = 1
 file = "src/Git/CommandLineGit.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Git\CommandLineGit::diff`.'
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Git\CommandLineGit::getBaseReference`.'
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Git\CommandLineGit::parseChangedLinesRangeFromLine`.'
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Git\CommandLineGit::parseFilePathFromLine`.'
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Git\CommandLineGit::readSymbolicReference`.'
 count = 1
 
 [[issues]]
@@ -3676,12 +1516,6 @@ count = 1
 file = "src/Logger/Console/BasicConsoleLogger.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #2 of `webmozart\assert\assert::keyexists`: expected `int|string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/Console/BasicConsoleLogger.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Logger\Console\BasicConsoleLogger::log`.'
 count = 1
 
 [[issues]]
@@ -3709,75 +1543,9 @@ message = "Possible argument type mismatch for argument #2 of `strtr`: expected 
 count = 1
 
 [[issues]]
-file = "src/Logger/Console/ConsoleLogger.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Logger\Console\ConsoleLogger::log`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/ConsoleDotLogger.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Logger\MutationAnalysis\ConsoleDotLogger::finishEvaluation`.'
-count = 1
-
-[[issues]]
 file = "src/Logger/MutationAnalysis/TeamCity/TeamCity.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `infection\logger\mutationanalysis\teamcity\teamcity::escapevalue`: expected `non-empty-string`, but found `array<array-key, mixed>|string`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TeamCity.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Logger\MutationAnalysis\TeamCity\TeamCity::testStarted`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TeamCity.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Logger\MutationAnalysis\TeamCity\TeamCity::escapeValue`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TeamCityLoggerState.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\Logger\MutationAnalysis\TeamCity\TeamCityLoggerState::assertAllTestSuitesAreClosed`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TeamCityLoggerState.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\Logger\MutationAnalysis\TeamCity\TeamCityLoggerState::assertAllTestsAreFinished`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TeamCityLoggerState.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Logger\MutationAnalysis\TeamCity\TeamCityLoggerState::assertAllTestSuitesAreClosed`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TeamCityLoggerState.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Logger\MutationAnalysis\TeamCity\TeamCityLoggerState::assertAllTestsAreFinished`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TeamCityLoggerState.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Logger\MutationAnalysis\TeamCity\TeamCityLoggerState::closeTest`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TeamCityLoggerState.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Logger\MutationAnalysis\TeamCity\TeamCityLoggerState::getTestSuite`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TestSuite.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\InvalidArgumentException` in `Infection\Logger\MutationAnalysis\TeamCity\TestSuite::create`.'
 count = 1
 
 [[issues]]
@@ -3793,27 +1561,9 @@ message = 'Invalid argument type for argument #2 of `infection\metrics\filtering
 count = 1
 
 [[issues]]
-file = "src/Metrics/MetricsCalculator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Metrics\MetricsCalculator::collect`.'
-count = 1
-
-[[issues]]
 file = "src/Metrics/MinMsiChecker.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\metrics\minmsicheckfailed` in `Infection\Metrics\MinMsiChecker::checkMinMsi`.'
-count = 1
-
-[[issues]]
-file = "src/Metrics/ResultsCollector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Metrics\ResultsCollector::collect`.'
-count = 1
-
-[[issues]]
-file = "src/Metrics/SortableMutantExecutionResults.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\Metrics\SortableMutantExecutionResults::getSortedExecutionResults`.'
 count = 1
 
 [[issues]]
@@ -3865,12 +1615,6 @@ message = 'Potentially unhandled exception `RuntimeException` in `Infection\Muta
 count = 1
 
 [[issues]]
-file = "src/Mutant/MutantExecutionResult.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutant\MutantExecutionResult::__construct`.'
-count = 1
-
-[[issues]]
 file = "src/Mutant/TestFrameworkMutantExecutionResultFactory.php"
 code = "mixed-operand"
 message = "Right operand in `&&` operation has `mixed` type."
@@ -3880,24 +1624,6 @@ count = 1
 file = "src/Mutant/TestFrameworkMutantExecutionResultFactory.php"
 code = "possibly-null-operand"
 message = "Left operand in `>` comparison might be `null` (type `int|null`)."
-count = 1
-
-[[issues]]
-file = "src/Mutant/TestFrameworkMutantExecutionResultFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Mutant\TestFrameworkMutantExecutionResultFactory::createFromProcess`.'
-count = 1
-
-[[issues]]
-file = "src/Mutant/TestFrameworkMutantExecutionResultFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Mutant\TestFrameworkMutantExecutionResultFactory::retrieveProcessOutput`.'
-count = 1
-
-[[issues]]
-file = "src/Mutant/TestFrameworkMutantExecutionResultFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutant\TestFrameworkMutantExecutionResultFactory::retrieveProcessOutput`.'
 count = 1
 
 [[issues]]
@@ -3916,18 +1642,6 @@ count = 1
 file = "src/Mutation/FileMutationGenerator.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Mutation\FileMutationGenerator::generateMutations`.'
-count = 1
-
-[[issues]]
-file = "src/Mutation/FileMutationGenerator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutation\FileMutationGenerator::generate`.'
-count = 1
-
-[[issues]]
-file = "src/Mutation/Mutation.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutation\Mutation::__construct`.'
 count = 1
 
 [[issues]]
@@ -3961,33 +1675,15 @@ message = 'Redundant type assertion: `$mutators` of type `array<array-key, Infec
 count = 1
 
 [[issues]]
-file = "src/Mutation/MutationGenerator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutation\MutationGenerator::__construct`.'
-count = 1
-
-[[issues]]
 file = "src/Mutator/AllowedFunctionsConfig.php"
 code = "redundant-type-comparison"
 message = "Redundant type assertion: `$enabled` of type `bool` is always not `bool`."
 count = 1
 
 [[issues]]
-file = "src/Mutator/AllowedFunctionsConfig.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\AllowedFunctionsConfig::__construct`.'
-count = 1
-
-[[issues]]
 file = "src/Mutator/Boolean/ArrayItem.php"
 code = "redundant-docblock-type"
 message = "Redundant docblock type for variable `$value`."
-count = 1
-
-[[issues]]
-file = "src/Mutator/Boolean/InstanceOf_.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\Boolean\InstanceOf_::mutate`.'
 count = 1
 
 [[issues]]
@@ -4069,12 +1765,6 @@ message = "Redundant type assertion: `$enabled` of type `bool` is always not `bo
 count = 1
 
 [[issues]]
-file = "src/Mutator/Boolean/TrueValueConfig.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\Boolean\TrueValueConfig::__construct`.'
-count = 1
-
-[[issues]]
 file = "src/Mutator/Cast/AbstractCastMutator.php"
 code = "possibly-null-argument"
 message = 'Argument #1 of method `infection\phpparser\visitor\parentconnector::findparent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
@@ -4153,27 +1843,9 @@ message = 'Could not infer a precise return type for function `infection\mutator
 count = 1
 
 [[issues]]
-file = "src/Mutator/Extensions/MBString.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Error` in `Infection\Mutator\Extensions\MBString::getConvertCaseModeValue`.'
-count = 1
-
-[[issues]]
 file = "src/Mutator/Extensions/MBStringConfig.php"
 code = "incompatible-parameter-type"
 message = 'Parameter `$settings` of `Infection\Mutator\Extensions\MBStringConfig::__construct()` expects type `array<string, bool>` but parent `Infection\Mutator\MutatorConfig::__construct()` expects type `array<array-key, mixed>`'
-count = 1
-
-[[issues]]
-file = "src/Mutator/FunctionSignature/ProtectedVisibility.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\FunctionSignature\ProtectedVisibility::hasSameProtectedParentMethod`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/FunctionSignature/PublicVisibility.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\FunctionSignature\PublicVisibility::hasSamePublicParentMethod`.'
 count = 1
 
 [[issues]]
@@ -4189,21 +1861,9 @@ message = 'Invalid argument type for argument #2 of `Infection\Mutator\IgnoreCon
 count = 1
 
 [[issues]]
-file = "src/Mutator/IgnoreMutator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\Mutator\IgnoreMutator::getDefinition`.'
-count = 1
-
-[[issues]]
 file = "src/Mutator/InvalidMutator.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #1 of `array_keys`: expected `array<('K.array_keys() extends array-key), ('V.array_keys() extends mixed)>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "src/Mutator/InvalidMutator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\InvalidMutator::create`.'
 count = 1
 
 [[issues]]
@@ -4234,12 +1894,6 @@ count = 1
 file = "src/Mutator/MutatorFactory.php"
 code = "too-many-arguments"
 message = 'Class `Infection\Mutator\ConfigurableMutator` has no `__construct` method, but arguments were provided to `new`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\MutatorFactory::create`.'
 count = 1
 
 [[issues]]
@@ -4363,24 +2017,6 @@ message = "Invalid modification of by-reference parameter `$mutators`."
 count = 2
 
 [[issues]]
-file = "src/Mutator/MutatorResolver.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Mutator\MutatorResolver::registerFromName`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorResolver.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Mutator\MutatorResolver::registerFromProfile`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorResolver.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Mutator\MutatorResolver::resolve`.'
-count = 1
-
-[[issues]]
 file = "src/Mutator/NodeMutationGenerator.php"
 code = "less-specific-nested-argument-type"
 message = 'Argument type mismatch for argument #5 of `infection\mutation\mutation::__construct`: expected `array<string, float|int|string>`, but provided type `array<string, mixed>` is less specific.'
@@ -4437,19 +2073,7 @@ count = 1
 [[issues]]
 file = "src/Mutator/NodeMutationGenerator.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\NodeMutationGenerator::__construct`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/NodeMutationGenerator.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\mutator\invalidmutator` in `Infection\Mutator\NodeMutationGenerator::generateForMutator`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/NoopMutator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\Mutator\NoopMutator::getDefinition`.'
 count = 1
 
 [[issues]]
@@ -4492,24 +2116,6 @@ count = 1
 file = "src/Mutator/Operator/Finally_.php"
 code = "redundant-type-comparison"
 message = 'Redundant type assertion: `$parentNode` of type `PhpParser\Node\Stmt\TryCatch` is always not `PhpParser\Node\Stmt\TryCatch`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Operator/Finally_.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\Operator\Finally_::hasAtLeastOneCatchBlock`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Operator/SpreadAssignment.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\Operator\SpreadAssignment::canMutate`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Operator/SpreadAssignment.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\Operator\SpreadAssignment::mutate`.'
 count = 1
 
 [[issues]]
@@ -4561,18 +2167,6 @@ message = "Reference created from a previously undefined variable `$matches`."
 count = 2
 
 [[issues]]
-file = "src/Mutator/Regex/PregMatchRemoveCaret.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Mutator\Regex\PregMatchRemoveCaret::isProperRegexToMutate`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Regex/PregMatchRemoveCaret.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Mutator\Regex\PregMatchRemoveCaret::mutateRegex`.'
-count = 1
-
-[[issues]]
 file = "src/Mutator/Regex/PregMatchRemoveDollar.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #3 of `Safe\preg_match`: expected `array<array-key, string>|null`, but found `mixed`.'
@@ -4585,18 +2179,6 @@ message = "Reference created from a previously undefined variable `$matches`."
 count = 2
 
 [[issues]]
-file = "src/Mutator/Regex/PregMatchRemoveDollar.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Mutator\Regex\PregMatchRemoveDollar::isProperRegexToMutate`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Regex/PregMatchRemoveDollar.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Mutator\Regex\PregMatchRemoveDollar::mutateRegex`.'
-count = 1
-
-[[issues]]
 file = "src/Mutator/Regex/PregMatchRemoveFlags.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #3 of `Safe\preg_match`: expected `array<array-key, string>|null`, but found `mixed`.'
@@ -4607,18 +2189,6 @@ file = "src/Mutator/Regex/PregMatchRemoveFlags.php"
 code = "reference-to-undefined-variable"
 message = "Reference created from a previously undefined variable `$matches`."
 count = 2
-
-[[issues]]
-file = "src/Mutator/Regex/PregMatchRemoveFlags.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Mutator\Regex\PregMatchRemoveFlags::isProperRegexToMutate`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Regex/PregMatchRemoveFlags.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Mutator\Regex\PregMatchRemoveFlags::mutateRegex`.'
-count = 1
 
 [[issues]]
 file = "src/Mutator/Regex/PregQuote.php"
@@ -4636,12 +2206,6 @@ count = 1
 file = "src/Mutator/Removal/ArrayItemRemovalConfig.php"
 code = "redundant-type-comparison"
 message = "Redundant type assertion: `$this->limit` of type `int|int(2147483647)|int(9223372036854775807)` is always not `int`."
-count = 1
-
-[[issues]]
-file = "src/Mutator/Removal/ArrayItemRemovalConfig.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\Removal\ArrayItemRemovalConfig::__construct`.'
 count = 1
 
 [[issues]]
@@ -4819,12 +2383,6 @@ message = 'Could not infer a precise return type for function `infection\mutator
 count = 1
 
 [[issues]]
-file = "src/Mutator/Util/NameResolver.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Mutator\Util\NameResolver::resolveName`.'
-count = 1
-
-[[issues]]
 file = "src/PhpParser/FileParser.php"
 code = "possibly-false-argument"
 message = 'Argument #1 of method `infection\phpparser\unparsablefile::frominvalidfile` is possibly `false`, but parameter type `string` does not accept it.'
@@ -4837,21 +2395,9 @@ message = "Potential array in middle operand of string concatenation."
 count = 1
 
 [[issues]]
-file = "src/PhpParser/InfectionPrettyPrinter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\PhpParser\InfectionPrettyPrinter::pSingleQuotedString`.'
-count = 1
-
-[[issues]]
 file = "src/PhpParser/MutatedNode.php"
 code = "redundant-type-comparison"
 message = 'Redundant type assertion: `$value` of type `array<array-key, PhpParser\Node>` is always not `iterable<mixed, PhpParser\Node>`.'
-count = 1
-
-[[issues]]
-file = "src/PhpParser/MutatedNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\PhpParser\MutatedNode::__construct`.'
 count = 1
 
 [[issues]]
@@ -4953,25 +2499,7 @@ count = 1
 [[issues]]
 file = "src/PhpParser/NodeDumper/NodeDumper.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\PhpParser\NodeDumper\NodeDumper::dumpRecursive`.'
-count = 1
-
-[[issues]]
-file = "src/PhpParser/NodeDumper/NodeDumper.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\PhpParser\NodeDumper\NodeDumper::toColumn`.'
-count = 1
-
-[[issues]]
-file = "src/PhpParser/NodeDumper/NodeDumper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\PhpParser\NodeDumper\NodeDumper::dumpRecursive`.'
-count = 1
-
-[[issues]]
-file = "src/PhpParser/NodeDumper/NodeDumper.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\PhpParser\NodeDumper\NodeDumper::dump`.'
 count = 1
 
 [[issues]]
@@ -5041,12 +2569,6 @@ message = 'Could not infer a precise return type for function `infection\phppars
 count = 1
 
 [[issues]]
-file = "src/PhpParser/Visitor/ParentConnector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\PhpParser\Visitor\ParentConnector::getParent`.'
-count = 1
-
-[[issues]]
 file = "src/PhpParser/Visitor/ReflectionVisitor.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
@@ -5065,51 +2587,9 @@ message = 'Argument #1 of method `infection\phpparser\visitor\parentconnector::f
 count = 1
 
 [[issues]]
-file = "src/PhpParser/Visitor/ReflectionVisitor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\PhpParser\Visitor\ReflectionVisitor::findFunctionScope`.'
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/ReflectionVisitor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\PhpParser\Visitor\ReflectionVisitor::findReflectionClass`.'
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/ReflectionVisitor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\PhpParser\Visitor\ReflectionVisitor::getClassReflectionForNode`.'
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/ReflectionVisitor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\PhpParser\Visitor\ReflectionVisitor::getFunctionScope`.'
-count = 1
-
-[[issues]]
-file = "src/Process/DryRunProcess.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Process\DryRunProcess::fromProcess`.'
-count = 1
-
-[[issues]]
-file = "src/Process/Factory/InitialStaticAnalysisProcessFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Process\Factory\InitialStaticAnalysisProcessFactory::createProcess`.'
-count = 1
-
-[[issues]]
 file = "src/Process/Factory/InitialTestsRunProcessFactory.php"
 code = "ambiguous-instantiation-target"
 message = "Ambiguous instantiation: the expression used with `new` can resolve to multiple different classes."
-count = 1
-
-[[issues]]
-file = "src/Process/Factory/InitialTestsRunProcessFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Process\Factory\InitialTestsRunProcessFactory::createProcess`.'
 count = 1
 
 [[issues]]
@@ -5119,33 +2599,9 @@ message = 'Unsafe `new $class_name`: constructor of `Symfony\Component\Process\P
 count = 1
 
 [[issues]]
-file = "src/Process/Factory/MutantProcessContainerFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Process\Factory\MutantProcessContainerFactory::create`.'
-count = 1
-
-[[issues]]
 file = "src/Process/OriginalPhpProcess.php"
 code = "incompatible-parameter-type"
 message = 'Parameter `$env` of `Infection\Process\OriginalPhpProcess::start()` expects type `array<array-key, bool|string>|null` but parent `Symfony\Component\Process\Process::start()` expects type `array<array-key, mixed>`'
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/InitialStaticAnalysisRunFailed.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Process\Runner\InitialStaticAnalysisRunFailed::fromProcessAndAdapter`.'
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/InitialStaticAnalysisRunFailed.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Process\Runner\InitialStaticAnalysisRunFailed::fromProcessAndAdapter`.'
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/InitialStaticAnalysisRunner.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Process\Runner\InitialStaticAnalysisRunner::run`.'
 count = 1
 
 [[issues]]
@@ -5170,24 +2626,6 @@ count = 1
 file = "src/Process/Runner/InitialStaticAnalysisRunner.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\Process\Runner\InitialStaticAnalysisRunner::run`.'
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/InitialTestsFailed.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Process\Runner\InitialTestsFailed::fromProcessAndAdapter`.'
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/InitialTestsFailed.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Process\Runner\InitialTestsFailed::fromProcessAndAdapter`.'
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/InitialTestsRunner.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Process\Runner\InitialTestsRunner::run`.'
 count = 1
 
 [[issues]]
@@ -5229,12 +2667,6 @@ count = 3
 [[issues]]
 file = "src/Process/Runner/ParallelProcessRunner.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Process\Runner\ParallelProcessRunner::startProcess`.'
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/ParallelProcessRunner.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessStartFailedException` in `Infection\Process\Runner\ParallelProcessRunner::startProcess`.'
 count = 1
 
@@ -5242,18 +2674,6 @@ count = 1
 file = "src/Process/Runner/ParallelProcessRunner.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\Process\Runner\ParallelProcessRunner::startProcess`.'
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/ParallelProcessRunner.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Process\Runner\ParallelProcessRunner::run`.'
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/ProcessQueue.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Process\Runner\ProcessQueue::enqueueFrom`.'
 count = 1
 
 [[issues]]
@@ -5281,12 +2701,6 @@ message = 'Argument type mismatch for argument #1 of `infection\reporter\basetex
 count = 1
 
 [[issues]]
-file = "src/Reporter/FileReporter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Reporter\FileReporter::report`.'
-count = 1
-
-[[issues]]
 file = "src/Reporter/FileReporterFactory.php"
 code = "invalid-yield-key-type"
 message = "Invalid key type yielded; expected `string`, but found `null|string`."
@@ -5299,39 +2713,9 @@ message = 'Argument #2 of method `symfony\component\filesystem\path::makerelativ
 count = 1
 
 [[issues]]
-file = "src/Reporter/GitHubAnnotationsReporter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\ExecException` in `Infection\Reporter\GitHubAnnotationsReporter::__construct`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/GitHubAnnotationsReporter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\InvalidArgumentException` in `Infection\Reporter\GitHubAnnotationsReporter::getLines`.'
-count = 1
-
-[[issues]]
 file = "src/Reporter/GitLabCodeQualityReporter.php"
 code = "possibly-null-argument"
 message = 'Argument #2 of method `symfony\component\filesystem\path::makerelative` is possibly `null`, but parameter type `string` does not accept it.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/GitLabCodeQualityReporter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\ExecException` in `Infection\Reporter\GitLabCodeQualityReporter::__construct`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/GitLabCodeQualityReporter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\InvalidArgumentException` in `Infection\Reporter\GitLabCodeQualityReporter::getLines`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/HtmlFileReporter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Reporter\Html\HtmlFileReporter::getMutationTestingReport`.'
 count = 1
 
 [[issues]]
@@ -5407,66 +2791,6 @@ message = "Redundant type assertion: `$originalCode` of type `string` is always 
 count = 1
 
 [[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Reporter\Html\StrykerHtmlReportBuilder::retrieveFiles`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Reporter\Html\StrykerHtmlReportBuilder::getKilledBy`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Reporter\Html\StrykerHtmlReportBuilder::getTestsCompleted`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Reporter\Html\StrykerHtmlReportBuilder::retrieveReplacementFromDiff`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\InvalidArgumentException` in `Infection\Reporter\Html\StrykerHtmlReportBuilder::retrieveFiles`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Reporter\Html\StrykerHtmlReportBuilder::getFiles`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Reporter\Html\StrykerHtmlReportBuilder::getMutatorDescription`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Reporter\Html\StrykerHtmlReportBuilder::getTestsCompleted`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Reporter\Html\StrykerHtmlReportBuilder::retrieveFiles`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/Http/Response.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Reporter\Http\Response::__construct`.'
-count = 1
-
-[[issues]]
 file = "src/Reporter/Http/StrykerCurlClient.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `infection\reporter\http\response::__construct`: expected `int`, but found `mixed`.'
@@ -5476,12 +2800,6 @@ count = 1
 file = "src/Reporter/Http/StrykerCurlClient.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "src/Reporter/Http/StrykerCurlClient.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\CurlException` in `Infection\Reporter\Http\StrykerCurlClient::request`.'
 count = 1
 
 [[issues]]
@@ -5509,42 +2827,6 @@ message = "Invalid argument type for argument #2 of `sprintf`: expected `Stringa
 count = 2
 
 [[issues]]
-file = "src/Reporter/ShowMutationsReporter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\Reporter\ShowMutationsReporter::showMutations`.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/StrykerReporter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Reporter\StrykerReporter::report`.'
-count = 1
-
-[[issues]]
-file = "src/Resource/Memory/MemoryFormatter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Resource\Memory\MemoryFormatter::toHumanReadableString`.'
-count = 1
-
-[[issues]]
-file = "src/Resource/Memory/MemoryLimiterEnvironment.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Resource\Memory\MemoryLimiterEnvironment::hasMemoryLimitSet`.'
-count = 1
-
-[[issues]]
-file = "src/Resource/Time/Stopwatch.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Resource\Time\Stopwatch::start`.'
-count = 1
-
-[[issues]]
-file = "src/Resource/Time/Stopwatch.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Resource\Time\Stopwatch::stop`.'
-count = 1
-
-[[issues]]
 file = "src/Source/Collector/BasicSourceCollector.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `infection\source\collector\basicsourcecollector::makepathsabsolute`: expected `array<array-key, non-empty-string>`, but found `array<array-key, string>|list<string>`.'
@@ -5554,24 +2836,6 @@ count = 1
 file = "src/Source/Collector/BasicSourceCollector.php"
 code = "less-specific-nested-return-statement"
 message = '''Returned type `Infection\FileSystem\Finder\Iterator\RealPathFilterIterator<mixed, mixed>|Iterator<mixed, Symfony\Component\Finder\SplFileInfo>|Symfony\Component\Finder\Iterator\PathFilterIterator` is less specific than the declared return type `Iterator<mixed, Symfony\Component\Finder\SplFileInfo>` for function `infection\source\collector\basicsourcecollector::filter` due to nested 'mixed'.'''
-count = 1
-
-[[issues]]
-file = "src/Source/Collector/BasicSourceCollector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\Source\Collector\BasicSourceCollector::doCollect`.'
-count = 1
-
-[[issues]]
-file = "src/Source/Collector/BasicSourceCollector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\Source\Collector\BasicSourceCollector::createFinder`.'
-count = 1
-
-[[issues]]
-file = "src/Source/Collector/FakeSourceCollector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\Source\Collector\FakeSourceCollector::collect`.'
 count = 1
 
 [[issues]]
@@ -5595,12 +2859,6 @@ count = 1
 [[issues]]
 file = "src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator::locate`.'
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\filesystem\locator\fileordirectorynotfound` in `Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator::locate`.'
 count = 1
 
@@ -5608,12 +2866,6 @@ count = 1
 file = "src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::assertMinimumVersionSatisfied`.'
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::retrieveVersion`.'
 count = 1
 
 [[issues]]
@@ -5647,39 +2899,9 @@ message = "Left operand in `>` comparison might be `null` (type `int|null`)."
 count = 1
 
 [[issues]]
-file = "src/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory::createFromProcess`.'
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory::retrieveProcessOutput`.'
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory::retrieveProcessOutput`.'
-count = 1
-
-[[issues]]
 file = "src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory::buildMutationConfigFile`.'
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory::create`.'
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/StaticAnalysisToolFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\StaticAnalysis\StaticAnalysisToolFactory::create`.'
 count = 1
 
 [[issues]]
@@ -5704,12 +2926,6 @@ count = 1
 file = "src/TestFramework/AbstractTestFrameworkAdapter.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\AbstractTestFramework\InvalidVersion` in `Infection\TestFramework\AbstractTestFrameworkAdapter::getMutantCommandLine`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/AbstractTestFrameworkAdapter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\TestFramework\AbstractTestFrameworkAdapter::retrieveVersion`.'
 count = 1
 
 [[issues]]
@@ -5757,24 +2973,6 @@ count = 1
 [[issues]]
 file = "src/TestFramework/AdapterInstaller.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\TestFramework\AdapterInstaller::install`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/AdapterInstaller.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\InvalidArgumentException` in `Infection\TestFramework\AdapterInstaller::install`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/AdapterInstaller.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\TestFramework\AdapterInstaller::install`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/AdapterInstaller.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\TestFramework\AdapterInstaller::install`.'
 count = 1
 
@@ -5797,21 +2995,9 @@ message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\
 count = 1
 
 [[issues]]
-file = "src/TestFramework/AdapterInstaller.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\AdapterInstaller::install`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/CommandLineBuilder.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\filesystem\finder\exception\finderexception` in `Infection\TestFramework\CommandLineBuilder::findPhp`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Config/MutationConfigBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\Config\MutationConfigBuilder::getInterceptorNamespacePrefix`.'
 count = 1
 
 [[issues]]
@@ -5823,49 +3009,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/Config/TestFrameworkConfigLocator.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\TestFramework\Config\TestFrameworkConfigLocator::locate`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Config/TestFrameworkConfigLocator.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\filesystem\locator\fileordirectorynotfound` in `Infection\TestFramework\Config\TestFrameworkConfigLocator::locate`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/CoverageChecker.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\CoverageNotFound` in `Infection\TestFramework\Coverage\CoverageChecker::checkCoverageHasBeenGenerated`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/CoverageChecker.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\CoverageNotFound` in `Infection\TestFramework\Coverage\CoverageChecker::checkCoverageRequirements`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/CoverageChecker.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\CoverageNotFound` in `Infection\TestFramework\Coverage\CoverageChecker::checkIndexCoverageReport`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/CoverageChecker.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\CoverageNotFound` in `Infection\TestFramework\Coverage\CoverageChecker::checkJUnitReport`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/CoverageChecker.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\TestFramework\Coverage\CoverageChecker::isPcovIncludedInInitialTestPhpOptions`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/CoverageChecker.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\TestFramework\Coverage\CoverageChecker::isXdebugIncludedInInitialTestPhpOptions`.'
 count = 1
 
 [[issues]]
@@ -5965,18 +3109,6 @@ message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidX
 count = 1
 
 [[issues]]
-file = "src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider::testCaseMapGenerator`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider::getTestFileInfo`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/Coverage/Locator/BaseReportLocator.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\InvalidReportSource` in `Infection\TestFramework\Coverage\Locator\BaseReportLocator::lookup`.'
@@ -5996,26 +3128,8 @@ count = 1
 
 [[issues]]
 file = "src/TestFramework/Coverage/Locator/BaseReportLocator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\TestFramework\Coverage\Locator\BaseReportLocator::createIndexFinder`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/Locator/BaseReportLocator.php"
 code = "unused-parameter"
 message = "Parameter `$sourceDirectory` is never used."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/Locator/FakeLocator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\TestFramework\Coverage\Locator\FakeLocator::getDefaultLocation`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/Locator/FakeLocator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\TestFramework\Coverage\Locator\FakeLocator::locate`.'
 count = 1
 
 [[issues]]
@@ -6043,27 +3157,9 @@ message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidX
 count = 1
 
 [[issues]]
-file = "src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser::parseNodes`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php"
 code = "redundant-cast"
 message = "Redundant cast to `(string)`: the expression already has this type."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\TestFramework\Coverage\XmlReport\SourceFileInfoProvider::provideXPath`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\TestFramework\Coverage\XmlReport\SourceFileInfoProvider::retrieveSourceFileInfo`.'
 count = 1
 
 [[issues]]
@@ -6085,12 +3181,6 @@ message = "Redundant docblock type for variable `$methodRange`."
 count = 1
 
 [[issues]]
-file = "src/TestFramework/Coverage/XmlReport/TestLocator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\Coverage\XmlReport\TestLocator::getTestsForFunctionSignature`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php"
 code = "invalid-type-cast"
 message = "Non numeric string of type `string` implicitly cast to `float`."
@@ -6105,25 +3195,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\TestFramework\Coverage\XmlReport\XmlCoverageParser::parse`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\TestFramework\Coverage\XmlReport\XmlCoverageParser::parse`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\Coverage\XmlReport\XmlCoverageParser::collectCoveredLinesData`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\Coverage\XmlReport\XmlCoverageParser::collectMethodsCoverageData`.'
 count = 1
 
 [[issues]]
@@ -6148,18 +3220,6 @@ count = 5
 file = "src/TestFramework/Factory.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\TestFramework\Factory::getFilteredSourceFilesToMutate`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Factory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\TestFramework\Factory::create`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Factory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\Factory::create`.'
 count = 1
 
 [[issues]]
@@ -6205,24 +3265,6 @@ message = 'Potentially unhandled exception `Infection\AbstractTestFramework\Inva
 count = 1
 
 [[issues]]
-file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter::getMemoryUsed`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter::isSyntaxError`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter::testsPass`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
 code = "falsable-return-statement"
 message = "Function `38891935849420780:4202` is declared to return `string` but possibly returns 'false' (inferred as `false|string`)."
@@ -6247,18 +3289,6 @@ message = 'Possible argument type mismatch for argument #6 of `infection\testfra
 count = 1
 
 [[issues]]
-file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory::create`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory::create`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `infection\testframework\phpunit\commandline\filterbuilder::splitmethodnamefromproviderkey`: expected `array{0: string, 1: string}`, but found `non-empty-list<string>`.'
@@ -6268,18 +3298,6 @@ count = 1
 file = "src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder::build`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder::build`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder::__construct`.'
 count = 1
 
 [[issues]]
@@ -6298,24 +3316,6 @@ count = 2
 file = "src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder::getXPath`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder::build`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder::addTestSuiteWithFilteredTestFiles`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder::removeExistingTestSuiteNodes`.'
 count = 1
 
 [[issues]]
@@ -6351,42 +3351,6 @@ count = 4
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator::getErrorLevelName`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator::buildSchemaPath`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator::createNode`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator::removeAttribute`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator::removeCoverageChildNode`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator::removeExistingLoggers`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\testframework\phpunit\config\invalidphpunitconfiguration` in `Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator::validate`.'
 count = 1
 
@@ -6409,12 +3373,6 @@ message = "Cannot perform array access on possibly `null` value."
 count = 1
 
 [[issues]]
-file = "src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider::provide`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/TestFrameworkExtraOptionsFilter.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `infection\testframework\testframeworkextraoptionsfilter::filterformutantprocess`: expected `string`, but found `array<array-key, mixed>|array<array-key, string>|string`.'
@@ -6433,12 +3391,6 @@ message = "Redundant type assertion: `$actualExtraOptions` of type `array<array-
 count = 1
 
 [[issues]]
-file = "src/TestFramework/TestFrameworkExtraOptionsFilter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\TestFrameworkExtraOptionsFilter::filterForMutantProcess`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/TestFrameworkTypes.php"
 code = "mixed-array-access"
 message = "Unsafe array access on type `mixed`."
@@ -6454,12 +3406,6 @@ count = 2
 file = "src/TestFramework/TestFrameworkTypes.php"
 code = "possibly-static-access-on-interface"
 message = 'Potential static method call on interface `Infection\AbstractTestFramework\TestFrameworkAdapterFactory` via `class-string`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/TestFrameworkTypes.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\TestFrameworkTypes::getTypes`.'
 count = 1
 
 [[issues]]
@@ -6499,12 +3445,6 @@ message = 'Argument #1 of method `infection\phpparser\visitor\parentconnector::f
 count = 1
 
 [[issues]]
-file = "src/TestFramework/Tracing/Trace/NodeLineRangeData.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\Tracing\Trace\NodeLineRangeData::__construct`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/Tracing/TraceProviderAdapterTracer.php"
 code = "redundant-type-comparison"
 message = "Redundant type assertion: `$traceSourcePathname` of type `string` is always not `false`."
@@ -6541,24 +3481,6 @@ message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Loc
 count = 1
 
 [[issues]]
-file = "src/TestFramework/Tracing/TraceProviderAdapterTracer.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\TestFramework\Tracing\TraceProviderAdapterTracer::getTraceGenerator`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Tracing/TraceProviderAdapterTracer.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\Tracing\TraceProviderAdapterTracer::lookup`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Tracing/TraceProviderAdapterTracer.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\Tracing\TraceProviderAdapterTracer::tryToTrace`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/VersionParser.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `infection\testframework\versionparser::parse`: expected `string`, but found `null|string`.'
@@ -6574,18 +3496,6 @@ count = 1
 file = "src/TestFramework/VersionParser.php"
 code = "possibly-null-array-access"
 message = "Cannot perform array access on possibly `null` value."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/VersionParser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\TestFramework\VersionParser::parse`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/VersionParser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\VersionParser::parse`.'
 count = 1
 
 [[issues]]
@@ -6634,54 +3544,6 @@ count = 2
 file = "src/TestFramework/XML/SafeDOMXPath.php"
 code = "redundant-null-coalesce"
 message = "Redundant null coalesce: left-hand side can never be `null` or undefined."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/XML/SafeDOMXPath.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\TestFramework\XML\SafeDOMXPath::queryList`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/XML/SafeDOMXPath.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\XML\SafeDOMXPath::fromFile`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/XML/SafeDOMXPath.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\XML\SafeDOMXPath::fromString`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/XML/SafeDOMXPath.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\XML\SafeDOMXPath::getElement`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/XML/SafeDOMXPath.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\XML\SafeDOMXPath::queryAttribute`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/XML/SafeDOMXPath.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\XML\SafeDOMXPath::queryElement`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/XML/SafeDOMXPath.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\XML\SafeDOMXPath::queryList`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/XML/SafeDOMXPath.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\TestFramework\XML\SafeDOMXPath::registerNamespace`.'
 count = 1
 
 [[issues]]
@@ -6751,24 +3613,6 @@ message = "Redundant docblock type for variable `$expectedCodeSample`."
 count = 1
 
 [[issues]]
-file = "src/Testing/BaseMutatorTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Testing\BaseMutatorTestCase::assertMutatesInput`.'
-count = 1
-
-[[issues]]
-file = "src/Testing/BaseMutatorTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Testing\BaseMutatorTestCase::createMutator`.'
-count = 1
-
-[[issues]]
-file = "src/Testing/BaseMutatorTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Testing\BaseMutatorTestCase::getTestedMutatorClassName`.'
-count = 1
-
-[[issues]]
 file = "src/Testing/MutatorName.php"
 code = "less-specific-return-statement"
 message = 'Returned type `array-key` is less specific than the declared return type `string` for function `infection\testing\mutatorname::getname`.'
@@ -6778,12 +3622,6 @@ count = 1
 file = "src/Testing/MutatorName.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #1 of `array_flip`: expected `array<('K.array_flip() extends array-key), ('V.array_flip() extends array-key)>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "src/Testing/MutatorName.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Testing\MutatorName::getName`.'
 count = 1
 
 [[issues]]
@@ -7821,25 +4659,7 @@ count = 1
 [[issues]]
 file = "tests/benchmark/BlackfireInstrumentor.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\Benchmark\BlackfireInstrumentor::ensureResultInvariance`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/BlackfireInstrumentor.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Throwable` in `Infection\Benchmark\BlackfireInstrumentor::profileSample`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/BlackfireInstrumentor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Benchmark\BlackfireInstrumentor::check`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/DummyInstrumentor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `LogicException` in `Infection\Benchmark\DummyInstrumentor::ensureResultInvariance`.'
 count = 1
 
 [[issues]]
@@ -7861,21 +4681,9 @@ message = "A value with a less specific type `mixed` is being assigned to proper
 count = 1
 
 [[issues]]
-file = "tests/benchmark/MutationGenerator/MutationGeneratorBench.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Benchmark\MutationGenerator\MutationGeneratorBench::tearDown`.'
-count = 1
-
-[[issues]]
 file = "tests/benchmark/MutationGenerator/create-main.php"
 code = "possibly-false-argument"
 message = "The first value for `require_once` might be `false`."
-count = 1
-
-[[issues]]
-file = "tests/benchmark/MutationGenerator/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\Benchmark\MutationGenerator\collectSources`.'
 count = 1
 
 [[issues]]
@@ -7921,12 +4729,6 @@ message = "A value with a less specific type `mixed` is being assigned to proper
 count = 1
 
 [[issues]]
-file = "tests/benchmark/ParseGitDiff/GitParseDiffBench.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Benchmark\ParseGitDiff\GitParseDiffBench::tearDown`.'
-count = 1
-
-[[issues]]
 file = "tests/benchmark/ParseGitDiff/generator.php"
 code = "impossible-condition"
 message = "This condition (type `false`) will always evaluate to false."
@@ -7943,24 +4745,6 @@ file = "tests/benchmark/ParseGitDiff/generator.php"
 code = "redundant-comparison"
 message = "Redundant `===` comparison: left-hand side is never identical to right-hand side."
 count = 3
-
-[[issues]]
-file = "tests/benchmark/ParseGitDiff/generator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Benchmark\ParseGitDiff\Configuration::create`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/ParseGitDiff/generator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Benchmark\ParseGitDiff\Generator::generateDiffOutput`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/ParseGitDiff/generator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Benchmark\ParseGitDiff\Generator::generateFileSizes`.'
-count = 1
 
 [[issues]]
 file = "tests/benchmark/ParseGitDiff/generator.php"
@@ -8023,12 +4807,6 @@ message = "Redundant cast to `(float)`: the expression already has this type."
 count = 1
 
 [[issues]]
-file = "tests/benchmark/Tracing/TracingBench.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Benchmark\Tracing\TracingBench::tearDown`.'
-count = 1
-
-[[issues]]
 file = "tests/benchmark/Tracing/create-main.php"
 code = "less-specific-nested-return-statement"
 message = '''Returned type `array<array-key, mixed>` is less specific than the declared return type `array<array-key, SplFileInfo>` for function `infection\benchmark\tracing\takepercentageofsources` due to nested 'mixed'.'''
@@ -8062,24 +4840,6 @@ count = 1
 file = "tests/benchmark/Tracing/create-main.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Benchmark\Tracing\collectSources`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/Tracing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Benchmark\Tracing\collectSources`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/Tracing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Benchmark\Tracing\collectSources`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/Tracing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Benchmark\Tracing\collectSources`.'
 count = 1
 
 [[issues]]
@@ -8143,12 +4903,6 @@ message = 'Method `fail` does not exist on type `Infection\Tests\AutoReview\Buil
 count = 1
 
 [[issues]]
-file = "tests/phpunit/AutoReview/BuildConfigYmlTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\AutoReview\BuildConfigYmlTest::test_valid_yaml_has_key`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/ConcreteClassReflector.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
@@ -8158,12 +4912,6 @@ count = 1
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulationTest.php"
 code = "non-existent-method"
 message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\AutoReview\EnvVariableManipulation\EnvManipulationTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\AutoReview\EnvVariableManipulation\EnvManipulationTest::test_the_test_cases_manipulation_environment_variables_uses_the_backup_env_trait`.'
 count = 1
 
 [[issues]]
@@ -8242,24 +4990,6 @@ count = 1
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestedClassForEnvManipulations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestCaseForEnvManipulations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestedClassForEnvManipulations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestCaseForEnvManipulations`.'
 count = 1
 
 [[issues]]
@@ -8480,24 +5210,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::checkTestCaseForIoOperations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::checkTestedClassForIoOperations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::checkTestCaseForIoOperations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "yield-from-non-iterable"
 message = "Cannot `yield from` non-iterable type `null`."
 count = 1
@@ -8632,24 +5344,6 @@ count = 1
 file = "tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php"
 code = "possibly-undefined-variable"
 message = "Variable `$matches` might not have been defined on all execution paths leading to this point."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\AutoReview\IntegrationGroup\IoCodeDetector::retrieveSafeFileSystemFunctions`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Tests\AutoReview\IntegrationGroup\IoCodeDetector::retrieveSafeFileSystemFunctions`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\Tests\AutoReview\IntegrationGroup\IoCodeDetector::retrieveSafeFileSystemFunctions`.'
 count = 1
 
 [[issues]]
@@ -8788,12 +5482,6 @@ count = 1
 file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
 code = "mixed-property-type-coercion"
 message = "Mixed property type coercion"
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\SplException` in `Infection\Tests\AutoReview\Mutator\MutatorProvider::provideConfigurableMutatorClasses`.'
 count = 1
 
 [[issues]]
@@ -8965,24 +5653,6 @@ message = 'Potentially unhandled exception `ReflectionException` in `Infection\T
 count = 1
 
 [[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\SplException` in `Infection\Tests\AutoReview\Mutator\MutatorTest::test_configurable_mutators_declare_a_mutator_config`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\SplException` in `Infection\Tests\AutoReview\Mutator\MutatorTest::test_mutators_do_not_declare_public_methods`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\SplException` in `Infection\Tests\AutoReview\Mutator\MutatorTest::test_only_configurable_mutators_have_a_config`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/PhpDoc/PHPDocParser.php"
 code = "less-specific-nested-return-statement"
 message = '''Returned type `list<mixed>` is less specific than the declared return type `array<array-key, string>` for function `infection\tests\autoreview\phpdoc\phpdocparser::parse` due to nested 'mixed'.'''
@@ -9016,12 +5686,6 @@ count = 1
 file = "tests/phpunit/AutoReview/PhpDoc/PHPDocParser.php"
 code = "reference-to-undefined-variable"
 message = "Reference created from a previously undefined variable `$matches`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/PhpDoc/PHPDocParser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Tests\AutoReview\PhpDoc\PHPDocParser::parse`.'
 count = 1
 
 [[issues]]
@@ -9118,18 +5782,6 @@ count = 1
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider::provideSourceClasses`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider::provideTestClasses`.'
 count = 1
 
 [[issues]]
@@ -9281,12 +5933,6 @@ file = "tests/phpunit/BenchmarkSmokeTest.php"
 code = "non-existent-method"
 message = 'Method `marktestskipped` does not exist on type `Infection\Tests\BenchmarkSmokeTest`.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/BenchmarkSmokeTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Tests\BenchmarkSmokeTest::test_all_the_benchmarks_can_be_executed`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/BenchmarkSmokeTest.php"
@@ -9487,12 +6133,6 @@ message = 'Potentially unhandled exception `RuntimeException` in `Infection\Test
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Command\Debug\MockTeamCityCommandTest::createTeamCityLog`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Command/DescribeCommandTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\DescribeCommandTest`.'
@@ -9526,30 +6166,6 @@ count = 1
 file = "tests/phpunit/Command/DescribeCommandTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\DescribeCommandTest::test_it_errors_when_mutator_does_not_exist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\DescribeCommandTest::test_it_can_describe_a_mutator_when_asked_for_a_name`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\DescribeCommandTest::test_it_described_the_remedy`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\DescribeCommandTest::test_it_describes`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\DescribeCommandTest::test_it_errors_when_mutator_does_not_exist`.'
 count = 1
 
 [[issues]]
@@ -9592,108 +6208,6 @@ count = 4
 file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Command\Git\GitBaseReferenceCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_outputs_the_base_reference_with_provided_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_trims_the_base_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_outputs_the_base_reference_with_provided_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_rejects_blank_base_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_trims_the_base_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_outputs_the_base_reference_with_provided_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_trims_the_base_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_outputs_the_base_reference_with_provided_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_rejects_blank_base_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_trims_the_base_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_outputs_the_base_reference_with_provided_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_rejects_blank_base_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_trims_the_base_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_outputs_the_base_reference_with_provided_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_trims_the_base_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_outputs_the_base_reference_with_provided_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_trims_the_base_option`.'
 count = 1
 
 [[issues]]
@@ -9759,43 +6273,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\Git\GitChangedFilesCommandTest::test_it_outputs_changed_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\Git\GitChangedFilesCommandTest::test_it_outputs_changed_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\Git\GitChangedFilesCommandTest::test_it_outputs_changed_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\Git\GitChangedFilesCommandTest::test_it_outputs_changed_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitChangedFilesCommandTest::test_it_outputs_changed_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Command\Git\GitChangedFilesCommandTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Command\Git\GitChangedFilesCommandTest::tearDown`.'
 count = 1
 
 [[issues]]
@@ -9867,43 +6345,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::test_it_outputs_changed_lines`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::test_it_outputs_changed_lines`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::test_it_outputs_changed_lines`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::test_it_outputs_changed_lines`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::test_it_outputs_changed_lines`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::tearDown`.'
 count = 1
 
 [[issues]]
@@ -9940,30 +6382,6 @@ count = 1
 file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Command\Git\GitDefaultBaseCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\Git\GitDefaultBaseCommandTest::test_it_outputs_the_default_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\Git\GitDefaultBaseCommandTest::test_it_outputs_the_default_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\Git\GitDefaultBaseCommandTest::test_it_outputs_the_default_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\Git\GitDefaultBaseCommandTest::test_it_outputs_the_default_base`.'
 count = 1
 
 [[issues]]
@@ -10011,43 +6429,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::createCommandTester`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::createCommandTester`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::createCommandTester`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::createCommandTester`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::tearDown`.'
 count = 1
 
 [[issues]]
@@ -10084,24 +6466,6 @@ count = 1
 file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::test_it_lists_source_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::tearDown`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::test_it_lists_source_files`.'
 count = 1
 
 [[issues]]
@@ -10155,24 +6519,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::createFileSystemMock`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::createFileSystemMock`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::createFileSystemMock`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_create_custom_mutator_when_name_is_not_provided_at_command_call`.'
 count = 1
 
@@ -10204,48 +6550,6 @@ count = 1
 file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_uppercases_the_value_from_quetion_helper`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_create_custom_mutator_when_name_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_create_custom_mutator_when_name_is_not_provided_at_command_call`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_create_custom_mutator_when_name_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_trims_the_argument_value`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_trims_the_value_from_quetion_helper`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_uppercases_first_letter_of_argument_value`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_uppercases_the_value_from_quetion_helper`.'
 count = 1
 
 [[issues]]
@@ -10310,300 +6614,6 @@ count = 7
 
 [[issues]]
 file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_ignore_msi_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_max_timeouts`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_number_of_shown_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_string_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_timeouts_as_escaped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\RunCommandHelperTest::test_it_uses_github_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Command\RunCommandHelperTest::test_thread_count_from_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_ignore_msi_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_max_timeouts`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_number_of_shown_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_string_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_timeouts_as_escaped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_uses_github_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Command\RunCommandHelperTest::test_thread_count_from_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_ignore_msi_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_max_timeouts`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_number_of_shown_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_string_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_timeouts_as_escaped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_uses_github_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Command\RunCommandHelperTest::test_thread_count_from_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_ignore_msi_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_max_timeouts`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_number_of_shown_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_string_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_timeouts_as_escaped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_uses_github_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_thread_count_from_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_ignore_msi_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_max_timeouts`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_number_of_shown_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_string_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_timeouts_as_escaped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_uses_github_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_thread_count_from_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_ignore_msi_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_max_timeouts`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_number_of_shown_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_string_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_timeouts_as_escaped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_uses_github_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_thread_count_from_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_ignore_msi_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_max_timeouts`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_number_of_shown_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_string_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_returns_timeouts_as_escaped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_it_uses_github_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Command\RunCommandHelperTest::test_thread_count_from_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -10627,18 +6637,6 @@ message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tes
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_show_mutations_value_is_string_but_not_max`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\CommandNotFoundException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_threads_value_is_string_but_not_max`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Config/ConsoleHelperTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
@@ -10657,48 +6655,6 @@ message = 'Method `once` does not exist on type `Infection\Tests\Config\ConsoleH
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Config/ConsoleHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Config\ConsoleHelperTest::test_it_writes_to_section`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ConsoleHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Config\ConsoleHelperTest::test_it_writes_to_section`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ConsoleHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Config\ConsoleHelperTest::test_it_writes_to_section`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ConsoleHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Config\ConsoleHelperTest::test_it_writes_to_section`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ConsoleHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Config\ConsoleHelperTest::test_it_writes_to_section`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ConsoleHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Config\ConsoleHelperTest::test_it_writes_to_section`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ConsoleHelperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Config\ConsoleHelperTest::test_it_writes_to_section`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `providesJsonComposerAndLocations` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -10714,12 +6670,6 @@ count = 1
 file = "tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Config\Guesser\PhpUnitPathGuesserTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Config\Guesser\PhpUnitPathGuesserTest::test_it_guesses_correctly`.'
 count = 1
 
 [[issues]]
@@ -10750,54 +6700,6 @@ count = 1
 file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
 code = "non-existent-method"
 message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Config\Guesser\SourceDirGuesserTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Config\Guesser\SourceDirGuesserTest::test_it_parser_psr0`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Config\Guesser\SourceDirGuesserTest::test_it_parser_psr4`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Config\Guesser\SourceDirGuesserTest::test_it_returns_list_if_contains_array_of_paths_without_src`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Config\Guesser\SourceDirGuesserTest::test_it_returns_null_when_does_not_have_autoload`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Config\Guesser\SourceDirGuesserTest::test_it_returns_null_when_does_not_have_psr_autoload`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Config\Guesser\SourceDirGuesserTest::test_it_returns_only_src_if_contains_array_of_paths`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Config\Guesser\SourceDirGuesserTest::test_it_returns_only_src_if_several_are_in_psr_config`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Config\Guesser\SourceDirGuesserTest::test_it_throw_invalid_autoload_exception`.'
 count = 1
 
 [[issues]]
@@ -10840,36 +6742,6 @@ count = 1
 file = "tests/phpunit/Config/ValueProvider/BaseProviderTestCase.php"
 code = "reference-to-undefined-variable"
 message = "Reference created from a previously undefined variable `$output`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/BaseProviderTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\ExecException` in `Infection\Tests\Config\ValueProvider\BaseProviderTestCase::hasSttyAvailable`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/BaseProviderTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Config\ValueProvider\BaseProviderTestCase::createStreamOutput`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/BaseProviderTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Config\ValueProvider\BaseProviderTestCase::getInputStream`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/BaseProviderTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\InvalidArgumentException` in `Infection\Tests\Config\ValueProvider\BaseProviderTestCase::createStreamOutput`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/BaseProviderTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\Config\ValueProvider\BaseProviderTestCase::createStreamableInput`.'
 count = 1
 
 [[issues]]
@@ -10923,24 +6795,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest::test_passes_when_correct_dir_typed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest::test_returns_an_array_with_incremented_keys_started_from_zero`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest::tearDown`.'
 count = 1
 
@@ -10984,12 +6838,6 @@ count = 1
 file = "tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php"
 code = "non-existent-method"
 message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Config\ValueProvider\PCOVDirectoryProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Config\ValueProvider\PCOVDirectoryProviderTest::test_it_loads_current_value_from_environment`.'
 count = 1
 
 [[issues]]
@@ -11042,114 +6890,6 @@ count = 3
 
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_asks_question_if_no_config_is_found_in_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_returns_null_if_executable_is_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_validates_incorrect_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_asks_question_if_no_config_is_found_in_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_returns_null_if_executable_is_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_validates_incorrect_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_asks_question_if_no_config_is_found_in_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_returns_null_if_executable_is_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_validates_incorrect_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_asks_question_if_no_config_is_found_in_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_returns_null_if_executable_is_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_validates_incorrect_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_asks_question_if_no_config_is_found_in_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_returns_null_if_executable_is_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_validates_incorrect_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_asks_question_if_no_config_is_found_in_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_it_returns_null_if_executable_is_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest::test_validates_incorrect_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -11188,36 +6928,6 @@ count = 1
 file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
 code = "non-existent-method"
 message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Config\ValueProvider\SourceDirsProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Config\ValueProvider\SourceDirsProviderTest::test_it_fills_choices_with_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Config\ValueProvider\SourceDirsProviderTest::test_it_throws_exception_when_current_dir_is_selected_with_another_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Config\ValueProvider\SourceDirsProviderTest::test_it_uses_guesser_and_default_value`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Config\ValueProvider\SourceDirsProviderTest::test_it_uses_guesser_and_multiple_guessed_dirs`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Config\ValueProvider\SourceDirsProviderTest::test_it_uses_guesser_and_non_default_guessed_value`.'
 count = 1
 
 [[issues]]
@@ -11282,84 +6992,6 @@ count = 5
 
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_asks_question_if_no_config_is_found_in_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_automatically_guesses_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_calls_locator_in_the_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_validates_incorrect_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_asks_question_if_no_config_is_found_in_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_asks_question_if_no_config_is_found_in_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_automatically_guesses_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_calls_locator_in_the_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_validates_incorrect_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_asks_question_if_no_config_is_found_in_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_automatically_guesses_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_it_calls_locator_in_the_current_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest::test_validates_incorrect_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -11398,18 +7030,6 @@ count = 1
 file = "tests/phpunit/Configuration/ConfigurationBuilderTest.php"
 code = "non-existent-method"
 message = 'Method `assertequals` does not exist on type `Infection\Tests\Configuration\ConfigurationBuilderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryGit.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryGit::getChangedFileRelativePaths`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryGit.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryGit::getChangedLinesRangesByFileRelativePaths`.'
 count = 1
 
 [[issues]]
@@ -12043,12 +7663,6 @@ message = 'Too few arguments provided for method `infection\configuration\schema
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::test_it_can_create_a_config`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
@@ -12075,55 +7689,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest::test_it_create_a_configuration_from_a_file_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest::test_it_create_a_configuration_from_a_file_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest::test_it_create_a_configuration_from_a_file_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest::test_it_create_a_configuration_from_a_file_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest::test_it_create_a_configuration_from_a_file_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest::test_it_create_a_configuration_from_a_file_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest::test_it_create_a_configuration_from_a_file_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest::test_it_create_a_configuration_from_a_file_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest::test_it_create_a_configuration_from_a_file_path`.'
 count = 1
 
 [[issues]]
@@ -12225,48 +7791,6 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest::test_it_loads_the_located_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest::test_it_loads_the_located_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest::test_it_loads_the_located_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest::test_it_loads_the_located_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest::test_it_loads_the_located_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest::test_it_loads_the_located_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest::test_it_loads_the_located_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest::configurationPathsProvider`.'
 count = 1
 
@@ -12310,18 +7834,6 @@ count = 2
 file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Configuration\Schema\SchemaValidatorTest::createConfigWithContents`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Configuration\Schema\SchemaValidatorTest::createConfigWithContents`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\Configuration\Schema\SchemaValidatorTest::createConfigWithContents`.'
 count = 1
 
 [[issues]]
@@ -12477,66 +7989,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Console/E2ETest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Tests\Console\E2ETest::installComposerDeps`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Console\E2ETest::runOnE2EFixture`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Console\E2ETest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Console\E2ETest::tearDown`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\Console\E2ETest::test_it_runs_configure_command_if_no_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Console\E2ETest::runOnE2EFixture`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Console\E2ETest::test_it_runs_on_itself`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\Tests\Console\E2ETest::e2eTestSuiteDataProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\InvalidArgumentException` in `Infection\Tests\Console\E2ETest::installComposerDeps`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Tests\Console\E2ETest::installComposerDeps`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\Console\E2ETest::installComposerDeps`.'
 count = 1
 
@@ -12680,174 +8132,6 @@ count = 4
 
 [[issues]]
 file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesNotChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_int_version_to_string_version_of_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_to_normal_and_writes_notice_when_invalid_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesNotChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_int_version_to_string_version_of_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_to_normal_and_writes_notice_when_invalid_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Console\LogVerbosityTest::test_it_works_if_verbosity_is_valid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesNotChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesNotChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_int_version_to_string_version_of_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_to_normal_and_writes_notice_when_invalid_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::test_it_works_if_verbosity_is_valid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesNotChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_int_version_to_string_version_of_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_to_normal_and_writes_notice_when_invalid_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::test_it_works_if_verbosity_is_valid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesNotChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_int_version_to_string_version_of_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_to_normal_and_writes_notice_when_invalid_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::setInputExpectationsWhenItDoesNotChange`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_int_version_to_string_version_of_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Console\LogVerbosityTest::test_it_converts_to_normal_and_writes_notice_when_invalid_verbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -12868,30 +8152,6 @@ count = 1
 file = "tests/phpunit/Console/OutputFormatterStyleConfiguratorTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Console\OutputFormatterStyleConfiguratorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/OutputFormatterStyleConfiguratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Console\OutputFormatterStyleConfiguratorTest::test_it_adds_styles`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/OutputFormatterStyleConfiguratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Console\OutputFormatterStyleConfiguratorTest::test_it_adds_styles`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/OutputFormatterStyleConfiguratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Console\OutputFormatterStyleConfiguratorTest::test_it_adds_styles`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/OutputFormatterStyleConfiguratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Console\OutputFormatterStyleConfiguratorTest::test_it_adds_styles`.'
 count = 1
 
 [[issues]]
@@ -13018,24 +8278,6 @@ count = 1
 file = "tests/phpunit/Container/ContainerTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\Container\ContainerTest::test_it_can_build_lazy_source_file_data_factory_that_fails_on_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\Container\ContainerTest::test_it_can_build_lazy_source_file_data_factory_that_fails_on_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\ContainerExceptionInterface` in `Infection\Tests\Container\ContainerTest::test_it_can_be_instantiated_without_any_services`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Container\NotFoundExceptionInterface` in `Infection\Tests\Container\ContainerTest::test_it_can_be_instantiated_without_any_services`.'
 count = 1
 
 [[issues]]
@@ -13622,324 +8864,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
 code = "unused-parameter"
 message = "Parameter `$event` is never used."
 count = 6
@@ -13957,27 +8881,9 @@ message = 'Redundant type assertion: `$value` of type `Infection\Tests\EnvVariab
 count = 1
 
 [[issues]]
-file = "tests/phpunit/EnvVariableManipulation/BacksUpEnvironmentVariables.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\EnvVariableManipulation\BacksUpEnvironmentVariables::restoreEnvironmentVariables`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/EnvVariableManipulation/EnvBackup.php"
 code = "redundant-type-comparison"
 message = "Redundant type assertion: `$environmentVariables` of type `array<string, string>` is always not `iterable<mixed, string>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EnvVariableManipulation/EnvBackup.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\EnvVariableManipulation\EnvBackup::restore`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EnvVariableManipulation/EnvBackup.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\EnvVariableManipulation\EnvBackup::createSnapshot`.'
 count = 1
 
 [[issues]]
@@ -13991,12 +8897,6 @@ file = "tests/phpunit/EnvVariableManipulation/EnvBackupTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\EnvVariableManipulation\EnvBackupTest`.'
 count = 4
-
-[[issues]]
-file = "tests/phpunit/EnvVariableManipulation/EnvBackupTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\EnvVariableManipulation\EnvBackupTest::test_it_can_backup_and_restore_environment_variables`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Environment/BuildContextResolverTest.php"
@@ -14027,36 +8927,6 @@ file = "tests/phpunit/Environment/BuildContextResolverTest.php"
 code = "non-existent-method"
 message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Environment\BuildContextResolverTest`.'
 count = 5
-
-[[issues]]
-file = "tests/phpunit/Environment/BuildContextResolverTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Environment\BuildContextResolverTest::test_resolve_returns_build_context_when_ci_is_detected_and_build_is_not_for_pull_request`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/BuildContextResolverTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Environment\BuildContextResolverTest::test_resolve_throws_when_branch_name_is_empty`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/BuildContextResolverTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Environment\BuildContextResolverTest::test_resolve_throws_when_ci_is_in_pull_request_context`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/BuildContextResolverTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Environment\BuildContextResolverTest::test_resolve_throws_when_ci_is_maybe_in_pull_request_context`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/BuildContextResolverTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Environment\BuildContextResolverTest::test_resolve_throws_when_repository_name_is_empty`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Environment/BuildContextTest.php"
@@ -14318,24 +9188,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberFactoryTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberFactoryTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberFactoryTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -14350,24 +9202,6 @@ count = 1
 file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberTest.php"
 code = "non-existent-method"
 message = 'Method `exactly` does not exist on type `Infection\Tests\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberTest::test_it_execute_remove_on_mutation_testing_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberTest::test_it_execute_remove_on_mutation_testing_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberTest::test_it_execute_remove_on_mutation_testing_finished`.'
 count = 1
 
 [[issues]]
@@ -14387,78 +9221,6 @@ file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubsc
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest`.'
 count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_sub_step_was_completed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_sub_step_was_completed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_sub_step_was_completed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest::test_it_reacts_on_initial_static_analysis_was_finished`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
@@ -14483,78 +9245,6 @@ file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest`.'
 count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_suite_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_case_was_completed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_suite_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_suite_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_case_was_completed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_suite_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_suite_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_case_was_completed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_suite_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_suite_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_suite_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest::test_it_reacts_on_initial_test_suite_was_finished`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
@@ -14600,186 +9290,6 @@ count = 5
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutable_file_was_processed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_evaluation_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_process_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_testing_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_does_not_reacts_on_mutable_file_was_processed_if_no_mutation_is_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutable_file_was_processed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_evaluation_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_process_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_testing_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_testing_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_does_not_reacts_on_mutable_file_was_processed_if_no_mutation_is_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutable_file_was_processed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_evaluation_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_process_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_testing_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_testing_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_does_not_reacts_on_mutable_file_was_processed_if_no_mutation_is_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutable_file_was_processed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_evaluation_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_process_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_testing_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_testing_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutable_file_was_processed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_evaluation_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_process_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_testing_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutable_file_was_processed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_evaluation_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_process_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest::test_it_reacts_on_mutation_testing_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -14795,78 +9305,6 @@ file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.ph
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest`.'
 count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_mutation_generation_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_mutation_generation_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_mutation_generation_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_source_file_was_processed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_mutation_generation_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_mutation_generation_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_source_file_was_processed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_mutation_generation_was_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_mutation_generation_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_source_file_was_processed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_mutation_generation_was_started`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest::test_it_reacts_on_mutation_generation_was_started`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
@@ -14887,24 +9325,6 @@ message = 'Method `once` does not exist on type `Infection\Tests\Event\Subscribe
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationTestingResultsCollectorSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\MutationTestingResultsCollectorSubscriberTest::test_it_reacts_on_mutation_process_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationTestingResultsCollectorSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\MutationTestingResultsCollectorSubscriberTest::test_it_reacts_on_mutation_process_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationTestingResultsCollectorSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\MutationTestingResultsCollectorSubscriberTest::test_it_reacts_on_mutation_process_finished`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Event/Subscriber/ReportAfterMutationTestingFinishedSubscriberTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
@@ -14914,24 +9334,6 @@ count = 1
 file = "tests/phpunit/Event/Subscriber/ReportAfterMutationTestingFinishedSubscriberTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Event\Subscriber\ReportAfterMutationTestingFinishedSubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/ReportAfterMutationTestingFinishedSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Event\Subscriber\ReportAfterMutationTestingFinishedSubscriberTest::test_it_reacts_on_mutation_testing_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/ReportAfterMutationTestingFinishedSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Event\Subscriber\ReportAfterMutationTestingFinishedSubscriberTest::test_it_reacts_on_mutation_testing_finished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/ReportAfterMutationTestingFinishedSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Event\Subscriber\ReportAfterMutationTestingFinishedSubscriberTest::test_it_reacts_on_mutation_testing_finished`.'
 count = 1
 
 [[issues]]
@@ -14997,42 +9399,6 @@ count = 2
 [[issues]]
 file = "tests/phpunit/FileSystem/FileStoreTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\FileSystem\FileStoreTest::test_it_reads_file_contents_from_a_path_and_caches_it_until_a_new_file_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\FileSystem\FileStoreTest::test_it_reads_file_contents_from_spl_file_info_and_caches_it_until_a_new_file_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\FileSystem\FileStoreTest::test_it_reads_file_contents_from_a_path_and_caches_it_until_a_new_file_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\FileSystem\FileStoreTest::test_it_reads_file_contents_from_spl_file_info_and_caches_it_until_a_new_file_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\FileSystem\FileStoreTest::test_it_reads_file_contents_from_a_path_and_caches_it_until_a_new_file_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\FileSystem\FileStoreTest::test_it_reads_file_contents_from_spl_file_info_and_caches_it_until_a_new_file_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\FileStoreTest::test_it_reads_file_contents_from_a_path_and_caches_it_until_a_new_file_is_requested`.'
 count = 1
 
@@ -15046,24 +9412,6 @@ count = 1
 file = "tests/phpunit/FileSystem/FileStoreTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileSystemTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\FileSystem\FileSystemTestCase::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileSystemTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\FileSystem\FileSystemTestCase::tearDown`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileSystemTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\FileSystemTestCase::setUp`.'
 count = 1
 
 [[issues]]
@@ -15157,72 +9505,6 @@ message = 'Method `once` does not exist on type `Infection\Tests\FileSystem\Find
 count = 2
 
 [[issues]]
-file = "tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\FileSystem\Finder\MemoizedComposerExecutableFinderTest::test_it_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\FileSystem\Finder\MemoizedComposerExecutableFinderTest::test_it`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\FileSystem\Finder\MemoizedComposerExecutableFinderTest::test_it`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\FileSystem\Finder\MemoizedComposerExecutableFinderTest::test_it_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\FileSystem\Finder\MemoizedComposerExecutableFinderTest::test_it`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\FileSystem\Finder\MemoizedComposerExecutableFinderTest::test_it_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\FileSystem\Finder\MemoizedComposerExecutableFinderTest::test_it`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MockVendor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Finder\MockVendor::__construct`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MockVendor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Finder\MockVendor::setUpComposerBatchTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MockVendor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Finder\MockVendor::setUpPlatformTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MockVendor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Finder\MockVendor::setUpProjectBatchTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/FileSystem/Finder/MockVendor.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\Finder\MockVendor::__construct`.'
@@ -15303,36 +9585,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest::test_it_adds_vendor_bin_to_path_if_needed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest::test_it_finds_framework_executable`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest::test_it_finds_framework_script_from_bat`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest::test_invalid_custom_path_throws_exception`.'
 count = 1
 
@@ -15406,36 +9658,6 @@ count = 5
 file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
 code = "string-member-selector"
 message = "This member selector uses a non-literal string type (`string`); its specific value cannot be statically determined."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\DirException` in `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest::test_it_adds_vendor_bin_to_path_if_needed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest::test_it_finds_framework_executable`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest::test_it_finds_framework_script_from_bat`.'
 count = 1
 
 [[issues]]
@@ -15578,30 +9800,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest::invalidPathsProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest::multipleInvalidPathsProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest::multiplePathsProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest::pathsProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -15686,30 +9884,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest::invalidPathsProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest::multipleInvalidPathsProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest::multiplePathsProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest::pathsProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -15751,244 +9925,16 @@ message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::getFormatter`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::getVerbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::isDebug`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::isDecorated`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::isQuiet`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::isVerbose`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::isVeryVerbose`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::setDecorated`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::setFormatter`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::setVerbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::write`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony5.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony5::writeln`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
 code = "imprecise-type"
 message = "Type `iterable` in parameter `$messages` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::getFormatter`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::getVerbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::isDebug`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::isDecorated`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::isQuiet`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::isVerbose`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::isVeryVerbose`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::setDecorated`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::setFormatter`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::setVerbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::write`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony6::writeln`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
 code = "imprecise-type"
 message = "Type `iterable` in parameter `$messages` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::getFormatter`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::getVerbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::isDebug`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::isDecorated`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::isQuiet`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::isSilent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::isVerbose`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::isVeryVerbose`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::setDecorated`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::setFormatter`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::setVerbosity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::write`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Console\FakeOutputSymfony7::writeln`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/DummyCiDetector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\DummyCiDetector::fromEnvironment`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Fixtures/DummyCiDetector.php"
@@ -16006,24 +9952,6 @@ count = 1
 file = "tests/phpunit/Fixtures/Event/EventDispatcherCollector.php"
 code = "imprecise-type"
 message = "Type `array` in return type of `getEvents` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Event/EventDispatcherCollector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\Tests\Fixtures\Event\EventDispatcherCollector::addSubscriber`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Event/SubscriberCollectEventDispatcher.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher::dispatch`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Event/UnknownEventSubscriber.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Event\UnknownEventSubscriber::onUnknownEventSubscriber`.'
 count = 1
 
 [[issues]]
@@ -16057,24 +9985,6 @@ message = "Parameter `$event` is never used."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Fixtures/FakeCiDetector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\FakeCiDetector::detect`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/FakeCiDetector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\FakeCiDetector::fromEnvironment`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/FakeCiDetector.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\FakeCiDetector::isCiDetected`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Fixtures/Finder/MockRealPathFinder.php"
 code = "imprecise-type"
 message = "Type `array` in parameter `$filter` is imprecise, equivalent to `array<array-key, mixed>`."
@@ -16105,12 +10015,6 @@ message = 'Argument type mismatch for argument #2 of `symfony\component\finder\i
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRealPathFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\Tests\Fixtures\Finder\MockRealPathFinder::setFilter`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Fixtures/Finder/MockRelativePathFinder.php"
 code = "imprecise-type"
 message = "Type `array` in parameter `$filter` is imprecise, equivalent to `array<array-key, mixed>`."
@@ -16138,12 +10042,6 @@ count = 1
 file = "tests/phpunit/Fixtures/Finder/MockRelativePathFinder.php"
 code = "less-specific-nested-argument-type"
 message = 'Argument type mismatch for argument #2 of `symfony\component\finder\iterator\multiplepcrefilteriterator::__construct`: expected `array<array-key, string>`, but provided type `non-empty-array<array-key, mixed>` is less specific.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRelativePathFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\Tests\Fixtures\Finder\MockRelativePathFinder::setFilter`.'
 count = 1
 
 [[issues]]
@@ -16195,30 +10093,6 @@ message = "Parameter `$b` is never used."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Fixtures/Logger/FakeLogger.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Logger\FakeLogger::log`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Mutation/FakeNodeTraverser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Mutation\FakeNodeTraverser::addVisitor`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Mutation/FakeNodeTraverser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Mutation\FakeNodeTraverser::removeVisitor`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Mutation/FakeNodeTraverser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Mutation\FakeNodeTraverser::traverse`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Fixtures/Mutator/CustomMutator.php"
 code = "missing-template-parameter"
 message = 'Too few template arguments for `Infection\Mutator\Mutator`: expected 1, but found 0.'
@@ -16237,132 +10111,6 @@ message = 'Too few template arguments for `Infection\Mutator\Mutator`: expected 
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Fixtures/Mutator/FakeMutator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Mutator\FakeMutator::canMutate`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Mutator/FakeMutator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Mutator\FakeMutator::getDefinition`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Mutator/FakeMutator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Mutator\FakeMutator::getName`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Mutator/FakeMutator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\Mutator\FakeMutator::mutate`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getAttribute`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getAttributes`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getComments`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getDocComment`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getEndFilePos`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getEndLine`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getEndTokenPos`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getLine`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getStartFilePos`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getStartLine`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getStartTokenPos`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getSubNodeNames`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::getType`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::hasAttribute`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::setAttribute`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::setAttributes`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeNode.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeNode::setDocComment`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Fixtures/PhpParser/FakeVisitor.php"
 code = "docblock-type-mismatch"
 message = 'Docblock return type `PhpParser\Node|array<array-key, PhpParser\Node>|int` is incompatible with native return type `void`.'
@@ -16375,39 +10123,9 @@ message = 'Docblock return type `array<array-key, PhpParser\Node>` is incompatib
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeVisitor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeVisitor::afterTraverse`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeVisitor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeVisitor::beforeTraverse`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeVisitor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeVisitor::enterNode`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeVisitor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\PhpParser\FakeVisitor::leaveNode`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Fixtures/Process/DummyMutantProcess.php"
 code = "extend-final-class"
 message = 'Class `Infection\Tests\Fixtures\Process\DummyMutantProcess` cannot extend final class `Infection\Process\MutantProcess`'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Process/DummyMutantProcess.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\AssertionFailedError` in `Infection\Tests\Fixtures\Process\DummyMutantProcess::markAsTimedOut`.'
 count = 1
 
 [[issues]]
@@ -16423,27 +10141,9 @@ message = 'Class `Infection\Tests\Fixtures\Resource\Time\FakeTimeFormatter` cann
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Fixtures/TestFramework/Coverage/JUnit/FakeTestFileDataProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\TestFramework\Coverage\JUnit\FakeTestFileDataProvider::getTestFileInfo`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Fixtures/TestFramework/DummyTestFrameworkFactory.php"
 code = "imprecise-type"
 message = "Type `array` in parameter `$sourceDirectories` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/TestFramework/FakeAwareAdapter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\TestFramework\FakeAwareAdapter::getName`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/TestFramework/FakeAwareAdapter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Fixtures\TestFramework\FakeAwareAdapter::testsPass`.'
 count = 1
 
 [[issues]]
@@ -16778,108 +10478,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Git\CommandLineGitTest::test_it_falls_back_to_the_given_branch_when_no_merge_base_could_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Git\CommandLineGitTest::test_it_get_the_changed_lines_ranges_by_files_relative_paths`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_merge_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_relative_paths_of_the_changed_files_as_a_string`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Git\CommandLineGitTest::test_it_get_the_changed_lines_ranges_by_files_relative_paths`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_default_git_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_merge_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_relative_paths_of_the_changed_files_as_a_string`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Git\CommandLineGitTest::test_it_throws_no_code_to_mutate_exception_when_diff_is_empty`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Git\CommandLineGitTest::test_it_falls_back_to_the_given_branch_when_no_merge_base_could_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Git\CommandLineGitTest::test_it_get_the_changed_lines_ranges_by_files_relative_paths`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_merge_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_relative_paths_of_the_changed_files_as_a_string`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Git\CommandLineGitTest::test_it_falls_back_to_the_given_branch_when_no_merge_base_could_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Git\CommandLineGitTest::test_it_get_the_changed_lines_ranges_by_files_relative_paths`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_merge_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_relative_paths_of_the_changed_files_as_a_string`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -16901,30 +10499,6 @@ file = "tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Logger\ArtefactCollection\ConsoleNoProgressLoggerTest`.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleNoProgressLoggerTest::test_it_logs_on_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleNoProgressLoggerTest::test_it_logs_on_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleNoProgressLoggerTest::test_it_logs_on_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleNoProgressLoggerTest::test_it_logs_on_start`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php"
@@ -16955,138 +10529,6 @@ file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest`.'
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_does_not_output_the_initial_process_text_if_in_debug_mode_on_finish`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_sets_test_framework_version_as_unknown_in_case_of_exception_on_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_does_not_output_the_initial_process_text_if_in_debug_mode_on_finish`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_logs_the_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_outputs_the_initial_process_text_if_in_debug_mode_on_finish`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_sets_test_framework_version_as_unknown_in_case_of_exception_on_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_does_not_output_the_initial_process_text_if_in_debug_mode_on_finish`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_logs_the_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_outputs_the_initial_process_text_if_in_debug_mode_on_finish`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_sets_test_framework_version_as_unknown_in_case_of_exception_on_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_does_not_output_the_initial_process_text_if_in_debug_mode_on_finish`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_logs_the_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_outputs_the_initial_process_text_if_in_debug_mode_on_finish`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_sets_test_framework_version_as_unknown_in_case_of_exception_on_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_does_not_output_the_initial_process_text_if_in_debug_mode_on_finish`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_logs_the_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_outputs_the_initial_process_text_if_in_debug_mode_on_finish`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_sets_test_framework_version_as_unknown_in_case_of_exception_on_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_does_not_output_the_initial_process_text_if_in_debug_mode_on_finish`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_sets_test_framework_version_as_unknown_in_case_of_exception_on_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_does_not_output_the_initial_process_text_if_in_debug_mode_on_finish`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest::test_it_sets_test_framework_version_as_unknown_in_case_of_exception_on_start`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
@@ -17134,30 +10576,6 @@ count = 2
 file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `never` does not exist on type `Infection\Tests\Logger\ArtefactCollection\InitialStaticAnalysisExecution\InitialStaticAnalysisExecutionLoggerFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Logger\ArtefactCollection\InitialStaticAnalysisExecution\InitialStaticAnalysisExecutionLoggerFactoryTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Logger\ArtefactCollection\InitialStaticAnalysisExecution\InitialStaticAnalysisExecutionLoggerFactoryTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\InitialStaticAnalysisExecution\InitialStaticAnalysisExecutionLoggerFactoryTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\InitialStaticAnalysisExecution\InitialStaticAnalysisExecutionLoggerFactoryTest::setUp`.'
 count = 1
 
 [[issues]]
@@ -17210,30 +10628,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLoggerFactoryTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLoggerFactoryTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLoggerFactoryTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLoggerFactoryTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -17254,24 +10648,6 @@ count = 1
 file = "tests/phpunit/Logger/Console/BasicConsoleLoggerTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\Console\BasicConsoleLoggerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/BasicConsoleLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Log\InvalidArgumentException` in `Infection\Tests\Logger\Console\BasicConsoleLoggerTest::test_it_can_log_messages`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/BufferedOutputWithStdErrOutput.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Logger\Console\BufferedOutputWithStdErrOutput::section`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/BufferedOutputWithStdErrOutput.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Logger\Console\BufferedOutputWithStdErrOutput::setErrorOutput`.'
 count = 1
 
 [[issues]]
@@ -17311,48 +10687,6 @@ message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tes
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Logger/Console/ConsoleLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Log\InvalidArgumentException` in `Infection\Tests\Logger\Console\ConsoleLoggerTest::test_it_casts_the_context_values_into_strings`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/ConsoleLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Log\InvalidArgumentException` in `Infection\Tests\Logger\Console\ConsoleLoggerTest::test_it_interpolates_the_message_with_the_context`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/ConsoleLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Log\InvalidArgumentException` in `Infection\Tests\Logger\Console\ConsoleLoggerTest::test_it_throws_a_friendly_error_on_invalid_log_level`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/ConsoleLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Log\InvalidArgumentException` in `Infection\Tests\Logger\Console\ConsoleLoggerTest::test_it_uses_the_io_blocks_when_passing_the_block_context`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/ConsoleLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Psr\Log\InvalidArgumentException` in `Infection\Tests\Logger\Console\ConsoleLoggerTest::test_the_log_level_is_added_to_the_message`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/ConsoleLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Logger\Console\ConsoleLoggerTest::valueToCastProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/DummyLogger.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\Logger\DummyLogger::log`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `detectionStatusProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -17363,36 +10697,6 @@ file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\MutationAnalysis\ConsoleDotLoggerTest`.'
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/FakeMutationAnalysisLogger.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Logger\MutationAnalysis\FakeMutationAnalysisLogger::finishAnalysis`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/FakeMutationAnalysisLogger.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Logger\MutationAnalysis\FakeMutationAnalysisLogger::finishEvaluation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/FakeMutationAnalysisLogger.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Logger\MutationAnalysis\FakeMutationAnalysisLogger::finishMutationGenerationForFile`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/FakeMutationAnalysisLogger.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Logger\MutationAnalysis\FakeMutationAnalysisLogger::startAnalysis`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/FakeMutationAnalysisLogger.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Logger\MutationAnalysis\FakeMutationAnalysisLogger::startEvaluation`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/MutationAnalysisLoggerFactoryTest.php"
@@ -17413,12 +10717,6 @@ message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Log
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/MutationAnalysisLoggerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Logger\MutationAnalysis\MutationAnalysisLoggerFactoryTest::test_it_can_create_all_known_factories`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/NodeIdFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `assertnotsame` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\NodeIdFactoryTest`.'
@@ -17429,12 +10727,6 @@ file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/NodeIdFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\NodeIdFactoryTest`.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/RemoveInternalBlankLines.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\Logger\MutationAnalysis\TeamCity\RemoveInternalBlankLines::remove`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/RemoveInternalBlankLinesTest.php"
@@ -17564,48 +10856,6 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Logger/MutationGeneration/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Logger\MutationGeneration\ConsoleProgressBarLoggerTest::test_it_logs_the_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Logger\MutationGeneration\ConsoleProgressBarLoggerTest::test_it_logs_the_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Logger\MutationGeneration\ConsoleProgressBarLoggerTest::test_it_logs_the_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Logger\MutationGeneration\ConsoleProgressBarLoggerTest::test_it_logs_the_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Logger\MutationGeneration\ConsoleProgressBarLoggerTest::test_it_logs_the_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Logger\MutationGeneration\ConsoleProgressBarLoggerTest::test_it_logs_the_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleProgressBarLoggerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Logger\MutationGeneration\ConsoleProgressBarLoggerTest::test_it_logs_the_start`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleProgressBarLoggerTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -17633,12 +10883,6 @@ file = "tests/phpunit/Logger/MutationGeneration/MutationGenerationLoggerFactoryT
 code = "non-existent-method"
 message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Logger\MutationGeneration\MutationGenerationLoggerFactoryTest`.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/MutationGenerationLoggerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Logger\MutationGeneration\MutationGenerationLoggerFactoryTest::test_it_creates_a_progress_bar_logger_if_does_not_skip_the_progress_bar`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Metrics/CalculatorTest.php"
@@ -17713,78 +10957,6 @@ message = 'Argument #1 of method `infection\tests\metrics\createmutantexecutionr
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_filtering_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_non_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_non_filtering_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_filtering_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_non_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_non_filtering_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_filtering_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_non_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_non_filtering_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_filtering_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_non_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest::test_it_makes_non_filtering_collector`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
@@ -17800,60 +10972,6 @@ count = 2
 file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
 code = "non-existent-method"
 message = 'Method `never` does not exist on type `Infection\Tests\Metrics\FilteringResultsCollectorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\FilteringResultsCollectorTest::test_it_collects_everything_when_told_to`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\FilteringResultsCollectorTest::test_it_collects_nothing_by_default`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\FilteringResultsCollectorTest::test_it_does_not_collect_everything_when_told_to`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorTest::test_it_collects_everything_when_told_to`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorTest::test_it_collects_nothing_by_default`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorTest::test_it_does_not_collect_everything_when_told_to`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorTest::test_it_collects_everything_when_told_to`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorTest::test_it_collects_nothing_by_default`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\FilteringResultsCollectorTest::test_it_does_not_collect_everything_when_told_to`.'
 count = 1
 
 [[issues]]
@@ -18067,318 +11185,6 @@ message = 'Method `once` does not exist on type `Infection\Tests\Metrics\TargetD
 count = 14
 
 [[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_ignores_more_statuses_when_running_in_only_covered_mode_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_ignores_some_statuses_when_debugging_is_not_enabled_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_full_stryker_report_with_verbosity_none`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_full_stryker_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_html_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_debugging_is_enabled_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_debugging_log_is_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_per_mutator_report_is_expected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_certain_statuses_for_json_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_certain_statuses_including_not_covered_for_json_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_escaped_when_using_github_annotations_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_escaped_when_using_gitlab_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_nothing_for_stryker_badge_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_ignores_more_statuses_when_running_in_only_covered_mode_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_ignores_some_statuses_when_debugging_is_not_enabled_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_full_stryker_report_with_verbosity_none`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_full_stryker_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_html_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_debugging_is_enabled_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_debugging_log_is_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_per_mutator_report_is_expected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_certain_statuses_for_json_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_certain_statuses_including_not_covered_for_json_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_escaped_when_using_github_annotations_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_escaped_when_using_gitlab_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_nothing_for_stryker_badge_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_ignores_more_statuses_when_running_in_only_covered_mode_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_ignores_some_statuses_when_debugging_is_not_enabled_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_full_stryker_report_with_verbosity_none`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_full_stryker_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_html_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_debugging_is_enabled_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_debugging_log_is_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_per_mutator_report_is_expected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_certain_statuses_for_json_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_certain_statuses_including_not_covered_for_json_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_escaped_when_using_github_annotations_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_escaped_when_using_gitlab_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_nothing_for_stryker_badge_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_ignores_more_statuses_when_running_in_only_covered_mode_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_ignores_some_statuses_when_debugging_is_not_enabled_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_full_stryker_report_with_verbosity_none`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_full_stryker_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_for_html_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_debugging_is_enabled_for_text_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_debugging_log_is_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_all_statuses_when_per_mutator_report_is_expected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_certain_statuses_for_json_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_certain_statuses_including_not_covered_for_json_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_escaped_when_using_github_annotations_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_escaped_when_using_gitlab_logger`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::test_it_provides_nothing_for_stryker_badge_report`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/MockedContainer.php"
 code = "imprecise-type"
 message = "Type `array` in parameter `$values` is imprecise, equivalent to `array<array-key, mixed>`."
@@ -18427,18 +11233,6 @@ message = 'Method `fail` does not exist on type `Infection\Tests\Mutant\MutantAs
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutant/MutantAssertionsTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\ExpectationFailedException` in `Infection\Tests\Mutant\MutantAssertionsTest::test_it_can_compare_mutants`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `InvalidArgumentException` in `Infection\Tests\Mutant\MutantBuilder::materialize`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutant/MutantBuilderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutantBuilder` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -18458,12 +11252,6 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Mutant/MutantCodeFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\Mutant\MutantCodeFactoryTest::mutationProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantCodeFactoryTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -18478,12 +11266,6 @@ count = 1
 file = "tests/phpunit/Mutant/MutantCodePrinterTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutant\MutantCodePrinterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantCodePrinterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\Mutant\MutantCodePrinterTest::statementsProvider`.'
 count = 1
 
 [[issues]]
@@ -18511,12 +11293,6 @@ message = 'Method `fail` does not exist on type `Infection\Tests\Mutant\MutantEx
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutant/MutantExecutionResultAssertionsTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\ExpectationFailedException` in `Infection\Tests\Mutant\MutantExecutionResultAssertionsTest::test_it_can_compare_mutants`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutant/MutantExecutionResultBuilderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `executionResultProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -18539,72 +11315,6 @@ file = "tests/phpunit/Mutant/MutantFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Mutant\MutantFactoryTest`.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutant\MutantFactoryTest::test_it_creates_a_mutant_instance_from_the_given_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutant\MutantFactoryTest::test_it_creates_a_mutant_instance_from_the_given_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutant\MutantFactoryTest::test_it_printing_the_original_file_is_memoized`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutant\MutantFactoryTest::test_it_creates_a_mutant_instance_from_the_given_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutant\MutantFactoryTest::test_it_printing_the_original_file_is_memoized`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutant\MutantFactoryTest::test_it_creates_a_mutant_instance_from_the_given_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutant\MutantFactoryTest::test_it_printing_the_original_file_is_memoized`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutant\MutantFactoryTest::test_it_creates_a_mutant_instance_from_the_given_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutant\MutantFactoryTest::test_it_printing_the_original_file_is_memoized`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutant\MutantFactoryTest::test_it_creates_a_mutant_instance_from_the_given_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutant\MutantFactoryTest::test_it_creates_a_mutant_instance_from_the_given_mutation`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutant/MutantFactoryTest.php"
@@ -18665,204 +11375,6 @@ file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest`.'
 count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_a_killed_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_an_escaped_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_marks_mutant_as_killed_when_tests_pass_from_output_but_exit_code_is_non_zero`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_a_killed_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_an_escaped_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_a_non_covered_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_a_timed_out_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_an_errored_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_marks_mutant_as_killed_when_tests_pass_from_output_but_exit_code_is_non_zero`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_a_killed_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_an_escaped_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_a_non_covered_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_a_timed_out_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_an_errored_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_marks_mutant_as_killed_when_tests_pass_from_output_but_exit_code_is_non_zero`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_a_killed_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_an_escaped_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_a_non_covered_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_a_timed_out_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_an_errored_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_marks_mutant_as_killed_when_tests_pass_from_output_but_exit_code_is_non_zero`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_a_killed_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_an_escaped_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_a_non_covered_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_a_timed_out_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_an_errored_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_marks_mutant_as_killed_when_tests_pass_from_output_but_exit_code_is_non_zero`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_a_killed_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_an_escaped_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_marks_mutant_as_killed_when_tests_pass_from_output_but_exit_code_is_non_zero`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_a_killed_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_an_escaped_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest::test_it_marks_mutant_as_killed_when_tests_pass_from_output_but_exit_code_is_non_zero`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
@@ -19028,80 +11540,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_parses_the_source_file_and_yields_the_generated_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_parses_the_source_file_and_yields_the_generated_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_traverses_the_source_statements`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_parses_the_source_file_and_yields_the_generated_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_traverses_the_source_statements`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_parses_the_source_file_and_yields_the_generated_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_traverses_the_source_statements`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_parses_the_source_file_and_yields_the_generated_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_traverses_the_source_statements`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_parses_the_source_file_and_yields_the_generated_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_parses_the_source_file_and_yields_the_generated_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationAssertions.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\ExpectationFailedException` in `Infection\Tests\Mutation\MutationAssertions::assertStateIs`.'
 count = 1
 
 [[issues]]
@@ -19114,12 +11554,6 @@ count = 1
 file = "tests/phpunit/Mutation/MutationAssertionsTest.php"
 code = "non-existent-method"
 message = 'Method `fail` does not exist on type `Infection\Tests\Mutation\MutationAssertionsTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationAssertionsTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\ExpectationFailedException` in `Infection\Tests\Mutation\MutationAssertionsTest::test_it_can_compare_mutations`.'
 count = 1
 
 [[issues]]
@@ -19270,96 +11704,6 @@ count = 1
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
 count = 1
 
 [[issues]]
@@ -20191,12 +12535,6 @@ message = "Type `iterable` in return type of `mutationsProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\MiscException` in `Infection\Tests\Mutator\Extensions\MBStringTest::defineMissingMbCaseConstants`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -20297,168 +12635,6 @@ file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #2 of `infection\mutator\ignoremutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\ignoremutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_mutates_the_node_via_its_decorated_mutator`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can_and_no_reflection_class_could_be_found_for_the_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_can_and_a_reflection_class_could_be_found_for_the_node_and_the_node_is_ignored`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_mutates_the_node_via_its_decorated_mutator`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can_and_no_reflection_class_could_be_found_for_the_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_can_and_a_reflection_class_could_be_found_for_the_node_and_the_node_is_ignored`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can_and_no_reflection_class_could_be_found_for_the_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_can_and_a_reflection_class_could_be_found_for_the_node_and_the_node_is_ignored`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_mutates_the_node_via_its_decorated_mutator`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can_and_no_reflection_class_could_be_found_for_the_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_can_and_a_reflection_class_could_be_found_for_the_node_and_the_node_is_ignored`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_mutates_the_node_via_its_decorated_mutator`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can_and_no_reflection_class_could_be_found_for_the_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_can_and_a_reflection_class_could_be_found_for_the_node_and_the_node_is_ignored`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_mutates_the_node_via_its_decorated_mutator`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can_and_no_reflection_class_could_be_found_for_the_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_can_and_a_reflection_class_could_be_found_for_the_node_and_the_node_is_ignored`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_mutates_the_node_via_its_decorated_mutator`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can_and_no_reflection_class_could_be_found_for_the_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_can_and_a_reflection_class_could_be_found_for_the_node_and_the_node_is_ignored`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutator\IgnoreMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
@@ -20689,18 +12865,6 @@ message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/MutatorFixturesProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Mutator\MutatorFixturesProvider::getFixtureFileContent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFixturesProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\Mutator\MutatorFixturesProvider::getFixtureFileContent`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/MutatorParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutatorInputProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -20918,18 +13082,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\AssertionFailedError` in `Infection\Tests\Mutator\MutatorRobustnessTest::test_the_mutator_does_not_crash`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\Tests\Mutator\MutatorRobustnessTest::provideCodeSamples`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -20999,90 +13151,6 @@ file = "tests/phpunit/Mutator/NoopMutatorTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `infection\mutator\noopmutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\noopmutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
 count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_mutate_node_if_its_decorated_mutator_can`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Mutator\NoopMutatorTest::test_it_should_not_mutate_node_if_its_decorated_mutator_cannot`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/NoopMutatorTest.php"
@@ -21310,24 +13378,6 @@ count = 1
 file = "tests/phpunit/Mutator/ProfileListProvider.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutator\ProfileListProvider::implementedMutatorProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Mutator\ProfileListProvider::implementedMutatorProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\InvalidArgumentException` in `Infection\Tests\Mutator\ProfileListProvider::getMutatorClassNameFromPath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Finder\Exception\DirectoryNotFoundException` in `Infection\Tests\Mutator\ProfileListProvider::implementedMutatorProvider`.'
 count = 1
 
 [[issues]]
@@ -21963,12 +14013,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::mockNode`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::invokeMethod`.'
 count = 1
 
@@ -22036,48 +14080,6 @@ count = 1
 file = "tests/phpunit/PhpParser/FakeToken.php"
 code = "incompatible-parameter-type"
 message = 'Parameter `$kind` of `Infection\Tests\PhpParser\FakeToken::is()` expects type `array<array-key, int|string>|int|string` but parent `PhpToken::is()` expects type `array<array-key, mixed>|int|string`'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FakeToken.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\PhpParser\FakeToken::__toString`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FakeToken.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\PhpParser\FakeToken::getEndLine`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FakeToken.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\PhpParser\FakeToken::getEndPos`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FakeToken.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\PhpParser\FakeToken::getTokenName`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FakeToken.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\PhpParser\FakeToken::isIgnorable`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FakeToken.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\PhpParser\FakeToken::is`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FakeToken.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\PhpParser\FakeToken::tokenize`.'
 count = 1
 
 [[issues]]
@@ -22174,60 +14176,6 @@ count = 1
 file = "tests/phpunit/PhpParser/FileParserTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\PhpParser\FileParserTest::test_it_parses_the_given_file_only_once`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\PhpParser\FileParserTest::test_it_parses_the_given_file_only_once`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\PhpParser\FileParserTest::test_it_parses_the_given_file_only_once`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\PhpParser\FileParserTest::createFileInfo`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\PhpParser\FileParserTest::test_it_parses_the_given_file_only_once`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\PhpParser\FileParserTest::test_it_parses_the_given_file_only_once`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\PhpParser\FileParserTest::test_it_parses_the_given_file_only_once`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\PhpParser\FileParserTest::test_it_parses_the_given_file_only_once`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\PhpParser\FileParserTest::test_it_parses_the_given_file_only_once`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\PhpParser\FileParserTest::test_it_throws_upon_failure`.'
 count = 1
 
 [[issues]]
@@ -22471,12 +14419,6 @@ message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/BaseVisitorTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\PhpParser\Visitor\BaseVisitorTestCase::parseCode`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -22492,12 +14434,6 @@ count = 1
 file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\EnrichmentTraverse\EnrichmentTraverseIntegrationTest::test_it_creates_a_rich_ast`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\PhpParser\Visitor\EnrichmentTraverse\EnrichmentTraverseIntegrationTest::nodeProvider`.'
 count = 1
 
 [[issues]]
@@ -22873,12 +14809,6 @@ message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\Poten
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\PhpParser\Visitor\ReflectionVisitorTest::nodeProvider`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/SkipIgnoredNodesVisitor/SkipIgnoredNodesVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -23005,12 +14935,6 @@ message = 'Method `asserttrue` does not exist on type `Infection\Tests\Process\D
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Process/DryRunProcessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Tests\Process\DryRunProcessTest::test_it_presents_process_as_expected`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Process/Factory/InitialStaticAnalysisProcessFactoryTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `infection\process\factory\initialstaticanalysisprocessfactory::__construct`: expected `Infection\StaticAnalysis\StaticAnalysisToolAdapter`, but found `mixed`.'
@@ -23057,54 +14981,6 @@ file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `assertnull` does not exist on type `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest`.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest::test_it_creates_a_process_with_coverage_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest::test_it_creates_a_process_with_coverage`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest::test_it_creates_a_process_with_coverage_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest::test_it_creates_a_process_with_coverage`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest::test_it_creates_a_process_with_coverage_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest::test_it_creates_a_process_with_coverage`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest::test_it_creates_a_process_with_coverage_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest::test_it_creates_a_process_with_coverage`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
@@ -23155,30 +15031,6 @@ message = 'Method `isstring` does not exist on type `Infection\Tests\Process\Fac
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Factory\MutantProcessContainerFactoryTest::test_it_creates_a_process_with_timeout`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Factory\MutantProcessContainerFactoryTest::test_it_creates_a_process_with_timeout`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Factory\MutantProcessContainerFactoryTest::test_it_creates_a_process_with_timeout`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Factory\MutantProcessContainerFactoryTest::test_it_creates_a_process_with_timeout`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Process/MutantProcessContainerTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
@@ -23219,132 +15071,6 @@ file = "tests/phpunit/Process/MutantProcessContainerTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Process\MutantProcessContainerTest`.'
 count = 7
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_builds_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_next_mutant_process_after_building_it`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_true_when_there_is_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_builds_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_next_mutant_process_after_building_it`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_true_when_there_is_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_builds_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_next_mutant_process_after_building_it`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_true_when_there_is_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_builds_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_next_mutant_process_after_building_it`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_true_when_there_is_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_builds_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_next_mutant_process_after_building_it`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_true_when_there_is_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_builds_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_next_mutant_process_after_building_it`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_true_when_there_is_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_builds_next_process_to_kill_mutant`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_next_mutant_process_after_building_it`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\MutantProcessContainerTest::test_it_returns_true_when_there_is_next_process_to_kill_mutant`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/MutantProcessContainerTest.php"
@@ -23392,24 +15118,6 @@ count = 3
 file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
 code = "non-existent-method"
 message = 'Method `assertstringnotcontainsstring` does not exist on type `Infection\Tests\Process\OriginalPhpProcessTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Tests\Process\OriginalPhpProcessTest::test_it_extends_symfony_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Tests\Process\OriginalPhpProcessTest::test_it_injects_xdebug_env_vars`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Tests\Process\OriginalPhpProcessTest::test_it_takes_command_line`.'
 count = 1
 
 [[issues]]
@@ -23491,30 +15199,6 @@ message = 'Method `once` does not exist on type `Infection\Tests\Process\Runner\
 count = 3
 
 [[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunFailedTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\InitialStaticAnalysisRunFailedTest::test_log_initial_tests_do_not_pass`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunFailedTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\InitialStaticAnalysisRunFailedTest::test_log_initial_tests_do_not_pass`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunFailedTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\InitialStaticAnalysisRunFailedTest::test_log_initial_tests_do_not_pass`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunFailedTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\InitialStaticAnalysisRunFailedTest::test_log_initial_tests_do_not_pass`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
@@ -23530,18 +15214,6 @@ count = 1
 file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
 code = "non-existent-method"
 message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Process\Runner\InitialStaticAnalysisRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\InitialStaticAnalysisRunnerTest::test_it_creates_a_process_execute_it_and_dispatch_events_accordingly`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Tests\Process\Runner\InitialStaticAnalysisRunnerTest::createProcessForCode`.'
 count = 1
 
 [[issues]]
@@ -23567,30 +15239,6 @@ file = "tests/phpunit/Process/Runner/InitialTestsFailedTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Process\Runner\InitialTestsFailedTest`.'
 count = 6
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsFailedTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\InitialTestsFailedTest::test_log_initial_tests_do_not_pass`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsFailedTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\InitialTestsFailedTest::test_log_initial_tests_do_not_pass`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsFailedTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\InitialTestsFailedTest::test_log_initial_tests_do_not_pass`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsFailedTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\InitialTestsFailedTest::test_log_initial_tests_do_not_pass`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
@@ -23632,66 +15280,6 @@ count = 1
 file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
 code = "non-existent-method"
 message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Process\Runner\InitialTestsRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_creates_a_process_execute_it_and_dispatch_events_accordingly`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_stops_the_process_execution_on_the_first_error`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_creates_a_process_execute_it_and_dispatch_events_accordingly`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_stops_the_process_execution_on_the_first_error`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_creates_a_process_execute_it_and_dispatch_events_accordingly`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_stops_the_process_execution_on_the_first_error`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_creates_a_process_execute_it_and_dispatch_events_accordingly`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_stops_the_process_execution_on_the_first_error`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::createProcessForCode`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\LogicException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_stops_the_process_execution_on_the_first_error`.'
 count = 1
 
 [[issues]]
@@ -23860,360 +15448,6 @@ count = 1
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "non-existent-property"
 message = 'Property `$mutationCount` does not exist on class `Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_only_matched_by_id_mutants`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations_when_concurrent_execution_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_dispatches_events_even_when_no_mutations_is_given`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_code_is_ignored_by_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_mutants_are_not_matched_by_mutant_id`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_there_is_not_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_passes_through_iterables_when_concurrent_execution_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_container_to_finished_event`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_only_matched_by_id_mutants`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations_when_concurrent_execution_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_dispatches_events_even_when_no_mutations_is_given`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_code_is_ignored_by_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_mutants_are_not_matched_by_mutant_id`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_there_is_not_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_keeps_mutations_if_diff_matcher_does_not_match`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_passes_through_iterables_when_concurrent_execution_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_container_to_finished_event`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_only_matched_by_id_mutants`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_code_is_ignored_by_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_mutants_are_not_matched_by_mutant_id`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_keeps_mutations_if_diff_matcher_does_not_match`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_container_to_finished_event`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_only_matched_by_id_mutants`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations_when_concurrent_execution_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_dispatches_events_even_when_no_mutations_is_given`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_code_is_ignored_by_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_mutants_are_not_matched_by_mutant_id`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_there_is_not_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_keeps_mutations_if_diff_matcher_does_not_match`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_passes_through_iterables_when_concurrent_execution_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_container_to_finished_event`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_only_matched_by_id_mutants`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations_when_concurrent_execution_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_dispatches_events_even_when_no_mutations_is_given`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_code_is_ignored_by_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_mutants_are_not_matched_by_mutant_id`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_there_is_not_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_keeps_mutations_if_diff_matcher_does_not_match`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_passes_through_iterables_when_concurrent_execution_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_only_matched_by_id_mutants`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations_when_concurrent_execution_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_dispatches_events_even_when_no_mutations_is_given`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_code_is_ignored_by_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_mutants_are_not_matched_by_mutant_id`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_there_is_not_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_passes_through_iterables_when_concurrent_execution_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_only_matched_by_id_mutants`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations_when_concurrent_execution_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_applies_and_run_the_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_dispatches_events_even_when_no_mutations_is_given`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_code_is_ignored_by_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_mutants_are_not_matched_by_mutant_id`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_does_not_create_processes_when_there_is_not_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::test_it_passes_through_iterables_when_concurrent_execution_requested`.'
 count = 1
 
 [[issues]]
@@ -24393,390 +15627,6 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainerWithNextMutantProcess`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainer`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_decrement_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_increment_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_minus_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainerWithNextMutantProcess`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainer`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createTimeOutMutantProcessContainer`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_initial_enqueue_from_is_called_before_loop`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_it_does_nothing_when_no_process_is_given`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_mark_as_finished_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_mark_as_timed_out_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_decrement_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_increment_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_minus_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_while_loop_condition_with_while_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_while_loop_wait_call_with_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainerWithNextMutantProcess`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainer`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createTimeOutMutantProcessContainer`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_mark_as_finished_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_mark_as_timed_out_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_while_loop_condition_with_while_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_while_loop_wait_call_with_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainerWithNextMutantProcess`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainer`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createTimeOutMutantProcessContainer`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_initial_enqueue_from_is_called_before_loop`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_it_does_nothing_when_no_process_is_given`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_mark_as_finished_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_mark_as_timed_out_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_decrement_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_increment_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_minus_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_while_loop_condition_with_while_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_while_loop_wait_call_with_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainerWithNextMutantProcess`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainer`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createTimeOutMutantProcessContainer`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_initial_enqueue_from_is_called_before_loop`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_it_does_nothing_when_no_process_is_given`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_mark_as_finished_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_mark_as_timed_out_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_decrement_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_increment_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_minus_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_while_loop_condition_with_while_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_while_loop_wait_call_with_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainerWithNextMutantProcess`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainer`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_decrement_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_increment_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_minus_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainerWithNextMutantProcess`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::createMutantProcessContainer`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_decrement_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_increment_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_minus_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_has_processes_that_could_be_freed_greater_than_or_equal_to_behavior`.'
 count = 1
 
@@ -24881,210 +15731,6 @@ file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Process\Runner\ProcessQueueTest`.'
 count = 19
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_accepts_items_when_below_capacity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_advances_iterator`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_measures_time_correctly`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_respects_max_queue_depth_when_equal`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_respects_max_queue_depth_when_exceeded`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_time_calculation_uses_subtraction`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_default_max_depth_of_one`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_exhausted_iterator_returns_zero`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_valid_iterator_enqueues_item`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_accepts_items_when_below_capacity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_advances_iterator`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_measures_time_correctly`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_time_calculation_uses_subtraction`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_default_max_depth_of_one`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_exhausted_iterator_returns_zero`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_valid_iterator_enqueues_item`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_accepts_items_when_below_capacity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_advances_iterator`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_measures_time_correctly`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_respects_max_queue_depth_when_equal`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_respects_max_queue_depth_when_exceeded`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_time_calculation_uses_subtraction`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_default_max_depth_of_one`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_exhausted_iterator_returns_zero`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_valid_iterator_enqueues_item`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_accepts_items_when_below_capacity`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_advances_iterator`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_measures_time_correctly`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_respects_max_queue_depth_when_equal`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_respects_max_queue_depth_when_exceeded`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_time_calculation_uses_subtraction`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_default_max_depth_of_one`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_exhausted_iterator_returns_zero`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Process\Runner\ProcessQueueTest::test_enqueue_from_with_valid_iterator_enqueues_item`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
@@ -25273,18 +15919,6 @@ message = 'Potentially unhandled exception `ReflectionException` in `Infection\T
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Reflection/ContainerReflection.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ValueError` in `Infection\Tests\Reflection\ContainerReflection::__construct`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reflection/ContainerReflection.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\Reflection\ContainerReflection::__construct`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reflection/CoreClassReflectionTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Reflection\CoreClassReflectionTest`.'
@@ -25327,12 +15961,6 @@ message = "Type `iterable` in return type of `metricsProvider` is imprecise, equ
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Reporter/FakeReporter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\Reporter\FakeReporter::report`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/FederatedReporterTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
@@ -25343,24 +15971,6 @@ file = "tests/phpunit/Reporter/FederatedReporterTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Reporter\FederatedReporterTest`.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Reporter/FederatedReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\FederatedReporterTest::test_it_reports_with_all_the_registered_reporters`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FederatedReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\FederatedReporterTest::test_it_reports_with_all_the_registered_reporters`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FederatedReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\FederatedReporterTest::test_it_reports_with_all_the_registered_reporters`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
@@ -25465,78 +16075,6 @@ message = 'Method `once` does not exist on type `Infection\Tests\Reporter\FileRe
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Reporter\FileReporterTest::test_it_fails_if_cannot_write_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Reporter\FileReporterTest::test_it_reports_the_correct_lines_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\FileReporterTest::test_it_fails_if_cannot_write_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\FileReporterTest::test_it_reports_the_correct_lines_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\FileReporterTest::test_it_fails_if_cannot_write_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\FileReporterTest::test_it_reports_the_correct_lines_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\FileReporterTest::test_it_fails_if_cannot_write_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\FileReporterTest::test_it_reports_the_correct_lines_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Reporter\FileReporterTest::test_it_fails_if_cannot_write_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Reporter\FileReporterTest::test_it_reports_the_correct_lines_with_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Reporter\FileReporterTest::test_it_fails_if_cannot_write_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Reporter\FileReporterTest::test_it_reports_the_correct_lines_with_no_mutations`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/GitHubActionsLogTextFileReporterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `completeMetricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -25568,18 +16106,6 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Reporter\GitHubAnnotationsReporterTest::test_it_reports_correctly_with_ci_github_workspace`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Reporter\GitHubAnnotationsReporterTest::test_it_reports_correctly_with_custom_github_workspace`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -25607,30 +16133,6 @@ file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
 code = "non-existent-method"
 message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\Reporter\GitLabCodeQualityReporterTest`.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Reporter\GitLabCodeQualityReporterTest::test_it_reports_correctly_with_ci_project_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Reporter\GitLabCodeQualityReporterTest::test_it_reports_correctly_with_custom_project_dir`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Reporter\GitLabCodeQualityReporterTest::assertReportedContentIs`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\UrlException` in `Infection\Tests\Reporter\GitLabCodeQualityReporterTest::createNonUtf8CharactersCollector`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
@@ -25693,36 +16195,6 @@ message = 'Argument #2 of method `infection\mutant\mutantexecutionresult::__cons
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Reporter\Html\StrykerHtmlReportBuilderTest::initHtmlReportCollector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\Reporter\Html\StrykerHtmlReportBuilderTest::metricsProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Reporter\Html\StrykerHtmlReportBuilderTest::assertJsonDocumentMatchesSchema`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Reporter\Html\StrykerHtmlReportBuilderTest::test_it_reports_correctly_with_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\UrlException` in `Infection\Tests\Reporter\Html\StrykerHtmlReportBuilderTest::initHtmlReportCollector`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/Http/ResponseTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `valueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -25766,90 +16238,6 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_can_send_a_report_with_expected_response_status_code`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_issues_a_warning_when_the_report_could_not_be_sent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_can_send_a_report_with_expected_response_status_code`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_issues_a_warning_when_the_report_could_not_be_sent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_can_send_a_report_with_expected_response_status_code`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_issues_a_warning_when_the_report_could_not_be_sent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_can_send_a_report_with_expected_response_status_code`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_issues_a_warning_when_the_report_could_not_be_sent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_can_send_a_report_with_expected_response_status_code`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_issues_a_warning_when_the_report_could_not_be_sent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_can_send_a_report_with_expected_response_status_code`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_issues_a_warning_when_the_report_could_not_be_sent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_can_send_a_report_with_expected_response_status_code`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Reporter\Http\StrykerDashboardClientTest::test_it_issues_a_warning_when_the_report_could_not_be_sent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -25864,18 +16252,6 @@ count = 1
 file = "tests/phpunit/Reporter/JsonReporterTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\JsonReporterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/JsonReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Reporter\JsonReporterTest::assertReportedContentIs`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/JsonReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\UrlException` in `Infection\Tests\Reporter\JsonReporterTest::createNonUtf8CharactersCollector`.'
 count = 1
 
 [[issues]]
@@ -25906,12 +16282,6 @@ count = 13
 file = "tests/phpunit/Reporter/ShowMetricsReporter/ShowMetricsReporterTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\ShowMetricsReporter\ShowMetricsReporterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/ShowMetricsReporter/ShowMetricsReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Reporter\ShowMetricsReporter\ShowMetricsReporterTest::createMetricsCalculator`.'
 count = 1
 
 [[issues]]
@@ -26000,330 +16370,6 @@ count = 4
 
 [[issues]]
 file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key_for_full_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key_and_matching_branch_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_missing_our_api_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key_for_full_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key_and_matching_branch_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_branch_not_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_branch_not_from_config_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_branch_not_from_config`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_not_travis`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_pull_request`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_repo_slug_not_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key_for_full_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key_and_matching_branch_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_missing_our_api_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key_for_full_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key_and_matching_branch_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_branch_not_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_branch_not_from_config_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_branch_not_from_config`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_not_travis`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_pull_request`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_repo_slug_not_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_missing_our_api_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key_for_full_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key_and_matching_branch_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_branch_not_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_branch_not_from_config_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_branch_not_from_config`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_not_travis`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_it_is_pull_request`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_skips_logging_when_repo_slug_not_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key_for_full_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key_and_matching_branch_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key_for_full_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key_and_matching_branch_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_missing_our_api_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key_for_full_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_our_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key_and_matching_branch_regex`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Reporter\StrykerReporterTest::test_it_sends_report_when_everything_is_ok_with_stryker_key`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -26350,12 +16396,6 @@ count = 1
 file = "tests/phpunit/Reporter/SummaryJsonReporterTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\SummaryJsonReporterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/SummaryJsonReporterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\JsonException` in `Infection\Tests\Reporter\SummaryJsonReporterTest::assertReportedContentIs`.'
 count = 1
 
 [[issues]]
@@ -26386,42 +16426,6 @@ count = 1
 file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Resource\Listener\PerformanceLoggerSubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Resource\Listener\PerformanceLoggerSubscriberTest::test_it_reacts_on_application_execution_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Resource\Listener\PerformanceLoggerSubscriberTest::test_it_reacts_on_application_execution_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Resource\Listener\PerformanceLoggerSubscriberTest::test_it_reacts_on_application_execution_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Resource\Listener\PerformanceLoggerSubscriberTest::test_it_reacts_on_application_execution_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Resource\Listener\PerformanceLoggerSubscriberTest::test_it_reacts_on_application_execution_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Resource\Listener\PerformanceLoggerSubscriberTest::test_it_reacts_on_application_execution_events`.'
 count = 1
 
 [[issues]]
@@ -26498,24 +16502,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Resource\Memory\MemoryLimiterEnvironmentTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Resource\Memory\MemoryLimiterEnvironmentTest::tearDown`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\InfoException` in `Infection\Tests\Resource\Memory\MemoryLimiterEnvironmentTest::test_it_can_detect_if_a_memory_limit_is_set`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -26567,90 +16553,6 @@ file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\Resource\Memory\MemoryLimiterTest`.'
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::test_it_applies_memory_limit_if_possible`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::configureEnvironmentToBeCalledOnce`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::test_it_applies_memory_limit_if_possible`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::test_it_does_nothing_when_adapter_is_not_memory_limit_aware`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::configureEnvironmentToBeCalledOnce`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::test_it_applies_memory_limit_if_possible`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::configureEnvironmentToBeCalledOnce`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::test_it_applies_memory_limit_if_possible`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::test_it_does_nothing_when_adapter_is_not_memory_limit_aware`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::configureEnvironmentToBeCalledOnce`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::test_it_applies_memory_limit_if_possible`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::test_it_does_nothing_when_adapter_is_not_memory_limit_aware`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::test_it_applies_memory_limit_if_possible`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Resource\Memory\MemoryLimiterTest::test_it_applies_memory_limit_if_possible`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Resource/Time/StopwatchTest.php"
@@ -26822,30 +16724,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Source\Collector\CachedSourceCollectorTest::test_it_caches_the_collected_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Source\Collector\CachedSourceCollectorTest::test_it_caches_the_collected_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Source\Collector\CachedSourceCollectorTest::test_it_caches_the_collected_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Source\Collector\CachedSourceCollectorTest::test_it_caches_the_collected_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -26978,48 +16856,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest::createGitStub`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest::createGitStub`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest::createGitStub`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest::createGitStub`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest::createGitStub`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest::createGitStub`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest::createGitStub`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -27134,174 +16970,6 @@ count = 4
 
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_complex_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_single_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_complex_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_single_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_complex_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_single_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_complex_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_single_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_complex_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_single_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_complex_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_single_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_complex_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line_with_single_option`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest::test_it_builds_initial_run_command_line`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -27334,84 +17002,6 @@ count = 2
 file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_a_killed_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_an_escaped_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_an_errored_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_a_killed_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_an_escaped_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_a_time_out_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_an_errored_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_a_killed_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_an_escaped_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_an_errored_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_a_killed_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_crate_a_result_from_an_escaped_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest::test_it_can_create_a_result_from_an_errored_mutant_process`.'
 count = 1
 
 [[issues]]
@@ -27469,132 +17059,6 @@ message = 'Method `once` does not exist on type `Infection\Tests\StaticAnalysis\
 count = 6
 
 [[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_timeout`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_without_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_timeout`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_without_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_timeout`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_without_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_timeout`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_without_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_timeout`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_without_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_timeout`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_without_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_multiple_options`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_with_timeout`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest::test_it_creates_a_process_without_options`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #2 of `infection\staticanalysis\staticanalysistoolfactory::__construct`: expected `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder`, but found `mixed`.'
@@ -27647,18 +17111,6 @@ file = "tests/phpunit/TestFramework/AdapterInstallationDeciderTest.php"
 code = "non-existent-method"
 message = 'Method `asserttrue` does not exist on type `Infection\Tests\TestFramework\AdapterInstallationDeciderTest`.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/AdapterInstallationDeciderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\AdapterInstallationDeciderTest::test_it_should_install_when_user_answers_yes`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/AdapterInstallationDeciderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\StreamException` in `Infection\Tests\TestFramework\AdapterInstallationDeciderTest::test_it_should_install_when_user_answers_yes`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/AdapterInstallationDeciderTest.php"
@@ -27745,12 +17197,6 @@ message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Test
 count = 3
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\CoverageChecker\CoverageCheckerTest::test_it_does_not_pass_existence_check_if_junit_file_is_missing_with_junit_report_with_phpunit_test_framework_adapter`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/CoverageNotFoundTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\CoverageNotFoundTest`.'
@@ -27808,54 +17254,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
 count = 1
 
 [[issues]]
@@ -28208,96 +17606,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_adds_if_junit_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_adds_if_junit_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_add_if_junit_is_not_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_load_the_trace_tests_until_necessary`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_adds_if_junit_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_add_if_junit_is_not_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_load_the_trace_tests_until_necessary`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_adds_if_junit_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_add_if_junit_is_not_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_load_the_trace_tests_until_necessary`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_adds_if_junit_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_add_if_junit_is_not_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_load_the_trace_tests_until_necessary`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_adds_if_junit_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_adds_if_junit_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -28309,33 +17617,15 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionBDDProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\CodeceptionBDDProvider::infoProvider`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionCestProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionCestProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\CodeceptionCestProvider::infoProvider`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionUnitProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionUnitProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\CodeceptionUnitProvider::infoProvider`.'
 count = 1
 
 [[issues]]
@@ -28371,18 +17661,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::createJUnit`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::tearDown`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::setUp`.'
 count = 1
 
@@ -28405,21 +17683,9 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit09Provider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\PhpUnit09Provider::infoProvider`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit10Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit10Provider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\PhpUnit10Provider::infoProvider`.'
 count = 1
 
 [[issues]]
@@ -28429,21 +17695,9 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit11Provider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\PhpUnit11Provider::infoProvider`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit12Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit12Provider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\PhpUnit12Provider::infoProvider`.'
 count = 1
 
 [[issues]]
@@ -28468,48 +17722,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
 count = 1
 
 [[issues]]
@@ -28702,114 +17914,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_returns_the_default_path_if_it_exists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found_if_the_result_is_located_at_the_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found_if_the_result_is_located_at_the_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_returns_the_default_path_if_it_exists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found_if_the_result_is_located_at_the_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_returns_the_default_path_if_it_exists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found_if_the_result_is_located_at_the_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_returns_the_default_path_if_it_exists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found_if_the_result_is_located_at_the_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_returns_the_default_path_if_it_exists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found_if_the_result_is_located_at_the_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found_if_the_result_is_located_at_the_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found`.'
 count = 1
 
 [[issues]]
@@ -29211,24 +18315,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest::test_it_provides_file_information`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest::tearDown`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest::test_it_errors_when_no_lines_were_executed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest::setUp`.'
 count = 1
 
@@ -29329,60 +18415,6 @@ message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Loc
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/CodeceptionProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -29459,162 +18491,6 @@ file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/So
 code = "non-existent-method"
 message = 'Method `once` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest`.'
 count = 9
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_source_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_xml_file_contains_invalid_xml`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_xml_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\XmlReport\InvalidCoverage` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_provides_file_info_and_xpath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_source_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_provides_file_info_and_xpath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_source_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_xml_file_contains_invalid_xml`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_xml_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_provides_file_info_and_xpath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_source_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_xml_file_contains_invalid_xml`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_xml_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_provides_file_info_and_xpath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_source_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_xml_file_contains_invalid_xml`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_xml_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_provides_file_info_and_xpath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_source_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_xml_file_contains_invalid_xml`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_xml_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_provides_file_info_and_xpath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_source_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_provides_file_info_and_xpath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_errors_when_the_source_file_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest::test_it_provides_file_info_and_xpath`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
@@ -29918,174 +18794,6 @@ count = 12
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested_and_pcov_is_in_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_no_coverage_is_expected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\Exception` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_with_fast_path_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested_and_pcov_is_in_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_no_coverage_is_expected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_with_fast_path_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested_and_pcov_is_in_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_no_coverage_is_expected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_with_fast_path_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested_and_pcov_is_in_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_no_coverage_is_expected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_with_fast_path_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested_and_pcov_is_in_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_no_coverage_is_expected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_with_fast_path_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested_and_pcov_is_in_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_no_coverage_is_expected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameNotConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_with_fast_path_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested_and_pcov_is_in_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_when_no_coverage_is_expected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest::test_it_provides_initial_test_run_command_line_with_fast_path_when_coverage_report_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
@@ -30184,168 +18892,6 @@ count = 2
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::queryXpath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::createConfigBuilder`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_adds_execution_order_for_proper_phpunit_versions`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_adds_fail_on_risky_and_warning_for_proper_phpunit_versions`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_builds_and_dump_the_xml_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_creates_a_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_creates_coverage_filter_whitelist_node_if_does_not_exist_and_version_situation_is_uncertain`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_creates_coverage_filter_whitelist_node_if_does_not_exist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_creates_coverage_include_node_if_does_not_exist_for_10_0_version_of_phpunit`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_creates_source_include_node_if_does_not_exist_for_10_1_version_of_phpunit`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_deactivates_stderr_redirection`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_deactivates_the_colors`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_disables_caching`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_add_coverage_loggers_ever_for_latest_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_add_coverage_loggers_ever_for_legacy_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_create_coverage_filter_whitelist_node_if_already_exist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_create_coverage_include_node_if_already_exist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_create_legacy_coverage_filter_whitelist_node_for_10_0_version_of_phpunit`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_update_fail_on_risky_attributes_if_it_is_already_set`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_update_fail_on_warning_attributes_if_it_is_already_set`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_update_order_if_it_is_already_set`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_removes_original_loggers`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_removes_printer_class`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_replaces_bootstrap_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_replaces_coverage_filter_include_node_if_exists_but_filtered_source_files_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_replaces_relative_path_to_absolute_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_sets_stops_on_failure`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\SimplexmlException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_builds_and_dump_the_xml_configuration`.'
 count = 1
 
 [[issues]]
@@ -30454,144 +19000,6 @@ count = 1
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::queryXpath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\ExecException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::assertPHPSyntaxIsValid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::createConfigBuilder`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_interceptor_is_included`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_adds_fail_on_risky_and_warning_for_proper_phpunit_versions`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_builds_and_dump_the_xml_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_can_build_the_config_for_multiple_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_deactivates_the_colors`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_does_not_set_default_execution_order_for_phpunit_7_1`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_does_not_update_fail_on_risky_attributes_if_it_is_already_set`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_does_not_update_fail_on_warning_attributes_if_it_is_already_set`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_handles_root_test_suite`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_preserves_white_spaces_and_formatting`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_removes_default_test_suite`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_removes_original_loggers`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_removes_printer_class`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_custom_autoloader_when_attribute_is_absent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_custom_autoloader`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_default_execution_order_when_attribute_is_absent_for_phpunit_7_2`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_default_execution_order_when_attribute_is_present_for_phpunit_7_2`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_defects_execution_order_and_cache_result_when_attribute_is_present_for_phpunit_7_3`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_sorted_list_of_test_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_stops_on_failure`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\SimplexmlException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_builds_and_dump_the_xml_configuration`.'
 count = 1
 
 [[issues]]
@@ -30781,18 +19189,6 @@ message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFrame
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/TestFrameworkExtraOptionsFilterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\PcreException` in `Infection\Tests\TestFramework\TestFrameworkExtraOptionsFilterTest::test_it_skips_filter_for_mutant_process`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/TestFrameworkExtraOptionsFilterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\StringsException` in `Infection\Tests\TestFramework\TestFrameworkExtraOptionsFilterTest::test_it_skips_filter_for_mutant_process`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/TestFrameworkTypesTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\TestFrameworkTypesTest`.'
@@ -30895,36 +19291,6 @@ message = 'Method `assertequals` does not exist on type `Infection\Tests\TestFra
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/FakeTrace.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\TestFramework\Tracing\Trace\FakeTrace::getAllTestsForMutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/FakeTrace.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\TestFramework\Tracing\Trace\FakeTrace::getRealPath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/FakeTrace.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\TestFramework\Tracing\Trace\FakeTrace::getSourceFileInfo`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/FakeTrace.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\TestFramework\Tracing\Trace\FakeTrace::getTests`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/FakeTrace.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `infection\tests\unsupportedmethod` in `Infection\Tests\TestFramework\Tracing\Trace\FakeTrace::hasTests`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Trace/LineRangeCalculatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideCodeAndRangeCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -31021,12 +19387,6 @@ message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFrame
 count = 2
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/SyntheticTrace.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\Tests\TestFramework\Tracing\Trace\SyntheticTrace::getAllTestsForMutation`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Trace/TestLocationsNormalizer.php"
 code = "impossible-condition"
 message = "This condition (type `false`) will always evaluate to false."
@@ -31084,12 +19444,6 @@ count = 5
 file = "tests/phpunit/TestFramework/Tracing/Trace/TestLocationsTest.php"
 code = "possibly-undefined-variable"
 message = "Variable `$testsLocations` might not have been defined on all execution paths leading to this point."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/TraceAssertion.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\ExpectationFailedException` in `Infection\Tests\TestFramework\Tracing\Trace\TraceAssertion::assertEquals`.'
 count = 1
 
 [[issues]]
@@ -31180,66 +19534,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Tracing\Throwable\NoTraceFound` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_traverses_and_pauses_the_trace_generator_as_needed_and_caches_the_results`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_finds_traces_on_windows`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\InvalidArgumentException` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_traverses_and_pauses_the_trace_generator_as_needed_and_caches_the_results`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_can_trace_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_finds_traces_on_windows`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_handles_empty_trace_provider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\IncompatibleReturnValueException` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_traverses_and_pauses_the_trace_generator_as_needed_and_caches_the_results`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_finds_traces_on_windows`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_traverses_and_pauses_the_trace_generator_as_needed_and_caches_the_results`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_finds_traces_on_windows`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_traverses_and_pauses_the_trace_generator_as_needed_and_caches_the_results`.'
 count = 1
 
 [[issues]]
@@ -31681,24 +19975,6 @@ message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidX
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_be_created_for_an_xml_string_with_a_namespace_registered`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_be_created_for_an_xml_string_without_a_namespace`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Safe\Exceptions\FilesystemException` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_be_created_for_an_xml_string_with_a_namespace_registered_if_the_document_has_no_namespace`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Testing/BaseMutatorTestCaseIntegrationTest.php"
 code = "non-existent-method"
 message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Testing\BaseMutatorTestCaseIntegrationTest`.'
@@ -31731,12 +20007,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestingUtility/Console/Command/TestOptionCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\LogicException` in `Infection\Tests\TestingUtility\Console\Command\TestOptionCommand::__construct`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/Console/Command/TestOptionCommand.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\RuntimeException` in `Infection\Tests\TestingUtility\Console\Command\TestOptionCommand::bind`.'
 count = 1
 
@@ -31757,12 +20027,6 @@ file = "tests/phpunit/TestingUtility/FileSystem/MockSplFileInfoTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\TestingUtility\FileSystem\MockSplFileInfoTest`.'
 count = 11
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/NonRewindableIterator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\Tests\TestingUtility\Iterable\NonRewindableIterator::rewind`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/TestingUtility/Iterable/NonRewindableIteratorTest.php"
@@ -31813,18 +20077,6 @@ message = 'Method `assertsame` does not exist on type `Infection\Tests\TestingUt
 count = 13
 
 [[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/YieldOnceIterator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\Tests\TestingUtility\Iterable\YieldOnceIterator::current`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/YieldOnceIterator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `DomainException` in `Infection\Tests\TestingUtility\Iterable\YieldOnceIterator::key`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestingUtility/Iterable/YieldOnceIteratorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -31852,12 +20104,6 @@ count = 1
 file = "tests/phpunit/TestingUtility/PHPUnit/ExpectsThrowables.php"
 code = "non-existent-method"
 message = 'Method `fail` does not exist on type `Infection\Tests\TestingUtility\PHPUnit\ExpectsThrowables`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/PHPUnit/ExpectsThrowables.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Exception` in `Infection\Tests\TestingUtility\PHPUnit\ExpectsThrowables::expectToThrow`.'
 count = 1
 
 [[issues]]
@@ -31918,12 +20164,6 @@ count = 1
 file = "tests/phpunit/TestingUtility/PhpParser/Visitor/SkipNodesVisitor/SkipNodesVisitorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\TestingUtility\PhpParser\Visitor\SkipNodesVisitor\SkipNodesVisitorTest::test_it_skips_encountered_nodes`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/Process/TestPhpExecutableFinder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Webmozart\Assert\InvalidArgumentException` in `Infection\Tests\TestingUtility\Process\TestPhpExecutableFinder::lookup`.'
 count = 1
 
 [[issues]]

--- a/mago.toml
+++ b/mago.toml
@@ -39,6 +39,13 @@ analyze-dead-code = true
 memoize-properties = true
 allow-possibly-undefined-array-keys = true
 check-throws = true
+unchecked-exceptions = [
+    "LogicException",
+    "Error",
+    "PHPUnit\\Exception",
+    "Psr\\Container\\ContainerExceptionInterface",
+    "Safe\\Exceptions\\SafeExceptionInterface",
+]
 check-missing-override = false
 find-unused-parameters = true
 strict-list-index-checks = false


### PR DESCRIPTION
Mago offers the feature to check when exceptions are not handled. It is a nice feature which I've actually missed in PHPStan (or maybe we did not enable mode strict enough for it?).

However, there is a few exceptions that should not be handled, notably PHPUnit ones, `LogicException` and `Error`.

See https://mago.carthage.software/tools/analyzer/configuration-reference#exception-filtering.
