### PR TITLE
build: Permit insecure PHPUnit 9.x-11.x in E2E tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,12 @@
         "allow-plugins": {
             "phpstan/extension-installer": true,
             "infection/extension-installer": true
+        },
+        "audit": {
+            "ignore": {
+                "PKSA-5jz8-6tcw-pbk4": "PHPUnit argument injection - no fix in 11.x line",
+                "PKSA-z3gr-8qht-p93v": "PHPUnit security advisory - no fix in 11.x line"
+            }
         }
     },
     "autoload": {

--- a/tests/e2e/Adapter_Installer/composer.json
+++ b/tests/e2e/Adapter_Installer/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Adapter_Installer\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Composer_Xdebug_Handler_Version_1/composer.json
+++ b/tests/e2e/Composer_Xdebug_Handler_Version_1/composer.json
@@ -14,5 +14,10 @@
     },
     "require": {
         "composer/xdebug-handler": "^1"
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Config_Bootstrap/composer.json
+++ b/tests/e2e/Config_Bootstrap/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "ConfigBoostrap\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Configure/composer.json
+++ b/tests/e2e/Configure/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Namespace_\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Custom_Mutator/composer.json
+++ b/tests/e2e/Custom_Mutator/composer.json
@@ -18,6 +18,9 @@
     "config": {
         "allow-plugins": {
             "infection/extension-installer": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     }
 }

--- a/tests/e2e/Custom_tmp_dir/composer.json
+++ b/tests/e2e/Custom_tmp_dir/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "TmpNamespace_\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Empty_Path/composer.json
+++ b/tests/e2e/Empty_Path/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "EmptyPass\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Example_Test/composer.json
+++ b/tests/e2e/Example_Test/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "ExampleTest\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Exception_Code/composer.json
+++ b/tests/e2e/Exception_Code/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "ExceptionCode\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Exclude_By_Folder/composer.json
+++ b/tests/e2e/Exclude_By_Folder/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Exclude_By_Folder\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Exclude_Mutations_By_Regex/composer.json
+++ b/tests/e2e/Exclude_Mutations_By_Regex/composer.json
@@ -14,5 +14,10 @@
     },
     "require": {
         "webmozart/assert": "^1.9"
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Exclude_by_file_name/composer.json
+++ b/tests/e2e/Exclude_by_file_name/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Exclude_by_file_name\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Exec_Path/composer.json
+++ b/tests/e2e/Exec_Path/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "ExecPath\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Github1735/composer.json
+++ b/tests/e2e/Github1735/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Github1735\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Ignore_All_Mutations/composer.json
+++ b/tests/e2e/Ignore_All_Mutations/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Ignore_All_Mutations\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Ignore_MSI_Zero_Mutations/composer.json
+++ b/tests/e2e/Ignore_MSI_Zero_Mutations/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "NamespaceIgnore_\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Ignore_no_source_file/composer.json
+++ b/tests/e2e/Ignore_no_source_file/composer.json
@@ -13,6 +13,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Initial_Configuration/composer.json
+++ b/tests/e2e/Initial_Configuration/composer.json
@@ -11,5 +11,10 @@
         "psr-0": {
             "Initial_Configuration": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Memory_Limit/composer.json
+++ b/tests/e2e/Memory_Limit/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "MemoryLimit\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Min_MSI/composer.json
+++ b/tests/e2e/Min_MSI/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Min_MSI\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Multiline_Statement/composer.json
+++ b/tests/e2e/Multiline_Statement/composer.json
@@ -12,5 +12,10 @@
         "psr-4": {
             "MultilineStatement\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Output_Stream/composer.json
+++ b/tests/e2e/Output_Stream/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "OutputStream\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PCOV_Directory/composer.json
+++ b/tests/e2e/PCOV_Directory/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "PCOV_Directory\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PCOV_PHPUnit8/composer.json
+++ b/tests/e2e/PCOV_PHPUnit8/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "PCOV_PHPUnit8\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PHPStan_Custom_Executable_Path/composer.json
+++ b/tests/e2e/PHPStan_Custom_Executable_Path/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "PHPStan_Custom_Executable_Path\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PHPStan_Integration/composer.json
+++ b/tests/e2e/PHPStan_Integration/composer.json
@@ -12,5 +12,10 @@
         "psr-4": {
             "PHPStan_Integration\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PHPUnit_09-3/composer.json
+++ b/tests/e2e/PHPUnit_09-3/composer.json
@@ -15,5 +15,10 @@
         "psr-4": {
             "Infection\\E2ETests\\PHPUnit_09_3\\Tests\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PHPUnit_10-1/composer.json
+++ b/tests/e2e/PHPUnit_10-1/composer.json
@@ -17,6 +17,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PHPUnit_11/composer.json
+++ b/tests/e2e/PHPUnit_11/composer.json
@@ -17,6 +17,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PHPUnit_12-0/composer.json
+++ b/tests/e2e/PHPUnit_12-0/composer.json
@@ -24,7 +24,8 @@
         "audit": {
             "ignore": {
                 "CVE-2026-24765": "Testing PHPUnit 12.0 compatibility"
-            }
+            },
+            "block-insecure": false
         }
     }
 }

--- a/tests/e2e/PHPUnit_12-5/composer.json
+++ b/tests/e2e/PHPUnit_12-5/composer.json
@@ -17,6 +17,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PHPUnit_Custom_Config_Dir/composer.json
+++ b/tests/e2e/PHPUnit_Custom_Config_Dir/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "PhpUnitCustomConfigDir\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PHPUnit_Hidden_Dependency/composer.json
+++ b/tests/e2e/PHPUnit_Hidden_Dependency/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "PHPUnit_Hidden_Dependency\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PHPUnit_XSD_Validation/composer.json
+++ b/tests/e2e/PHPUnit_XSD_Validation/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "PHPUnit_XSD_Validation\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PSR_0_Autoloader/composer.json
+++ b/tests/e2e/PSR_0_Autoloader/composer.json
@@ -11,5 +11,10 @@
         "psr-0": {
             "PSR_0_Autoloader\\Tests": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/PhpUnit_Depends_Order/composer.json
+++ b/tests/e2e/PhpUnit_Depends_Order/composer.json
@@ -11,5 +11,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6.20"
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Phpunit_Bat_Wrapper/composer.json
+++ b/tests/e2e/Phpunit_Bat_Wrapper/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "PhpUnitBatWrapper\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Profiles_Ignore_Combination/composer.json
+++ b/tests/e2e/Profiles_Ignore_Combination/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "ProfileIgnoreCombination\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Provide_Existing_Coverage/composer.json
+++ b/tests/e2e/Provide_Existing_Coverage/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "ProvideExistingCoverage\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Save_PHPUnit_Bootstrap_File/composer.json
+++ b/tests/e2e/Save_PHPUnit_Bootstrap_File/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "SavePhpUnitBoostrapFile\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Skip_Initial_Tests/composer.json
+++ b/tests/e2e/Skip_Initial_Tests/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "ProvideExistingCoverage\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Source_Directories_Config/composer.json
+++ b/tests/e2e/Source_Directories_Config/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Source_Directories_Config\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Stream_Wrapper_Execution/composer.json
+++ b/tests/e2e/Stream_Wrapper_Execution/composer.json
@@ -12,5 +12,10 @@
         "psr-4": {
             "Stream_Wrapper_Execution\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/StyleTag/composer.json
+++ b/tests/e2e/StyleTag/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "StyleTag\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Syntax_Error_PHPUnit/composer.json
+++ b/tests/e2e/Syntax_Error_PHPUnit/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Syntax_Error_PHPUnit\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Test_Framework_Options_Config/composer.json
+++ b/tests/e2e/Test_Framework_Options_Config/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Test_Framework_Options_Config\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Test_PHP_Options_Config/composer.json
+++ b/tests/e2e/Test_PHP_Options_Config/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Test_PHP_Options_Config\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/TimeoutSkipped/composer.json
+++ b/tests/e2e/TimeoutSkipped/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "TimeoutSkipped\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Variables_Order_EGPCS/composer.json
+++ b/tests/e2e/Variables_Order_EGPCS/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "Variables_Order_EGPCS\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/e2e/Without_Git/composer.json
+++ b/tests/e2e/Without_Git/composer.json
@@ -18,6 +18,9 @@
     "config": {
         "allow-plugins": {
             "infection/extension-installer": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     }
 }

--- a/tests/e2e/YieldValue/composer.json
+++ b/tests/e2e/YieldValue/composer.json
@@ -11,5 +11,10 @@
         "psr-4": {
             "YieldValue\\Test\\": "tests/"
         }
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }


### PR DESCRIPTION
## Description

Looking at this build error:

>    - Root composer.json requires phpunit/phpunit ^9.6.20, found phpunit/phpunit[9.6.20, ..., 9.6.34] but these were not loaded, because they are affected by security advisories ("PKSA-5jz8-6tcw-pbk4", "PKSA-z3gr-8qht-p93v"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
441

The advisory is [PKSA-5jz8-6tcw-pbk4](https://github.com/advisories/GHSA-qrr6-mg7r-m243), affected versions >=13.0.0,<=13.1.5|<=12.5.21. That covers every 9.x, 10.x, 11.x, and 12.x up to 12.5.21 - so no 9.x fix exists. Only 12.5.22+ / 13.1.6+ are safe. 

> pull request from an untrusted contributor that modifies phpunit.xml to include a newline-containing INI value, executed by a CI system that runs PHPUnit against the PR without isolation ... inject arbitrary additional directives into the child's configuration, including auto_prepend_file

There are proposed workarounds, but we still need to permit installing these versions. So let's do just that.

I also had to modify the main composer.json - review my comments below.

## Changes

- Adds `audit.block-insecure = false` for the affected E2E tests.

```
for d in $(git grep phpunit/phpunit tests/e2e | grep -F composer.json  | cut -f1 -d: | xargs -I{} dirname {}); do (cd $d; composer config audit.block-insecure false); done
```

## Checklist

- [x] Appropriate labels applied (e.g. `performance`, `feature`).
