### PR TITLE
build(mago): Align excludes with PHPStan

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -974,6 +974,12 @@ count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
+code = "non-existent-class"
+message = 'Class `Infection\FileSystem\DummyFileSystem` not found.'
+count = 1
+
+[[issues]]
+file = "src/Container/Container.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #2 of `dicontainer\container::inject`: expected `('T.infection\container\container::clonewithservice() extends object)`, but possibly received `('T.infection\container\container::clonewithservice() extends object)|(closure(infection\container\container): ('T.infection\container\container::clonewithservice() extends object))`.'''
 count = 1
@@ -1000,42 +1006,6 @@ count = 1
 file = "src/Container/Container.php"
 code = "unused-parameter"
 message = "Parameter `$container` is never used."
-count = 1
-
-[[issues]]
-file = "src/CustomMutator/templates/__Name__.php"
-code = "invalid-yield-value-type"
-message = 'Invalid value type yielded; expected `unknown-ref(App\Mutator\TODO)`, but found `PhpParser\Node`.'
-count = 1
-
-[[issues]]
-file = "src/CustomMutator/templates/__Name__.php"
-code = "missing-template-parameter"
-message = 'Too few template arguments for `Infection\Mutator\Mutator`: expected 1, but found 0.'
-count = 1
-
-[[issues]]
-file = "src/CustomMutator/templates/__Name__.php"
-code = "no-value"
-message = 'Argument #2 passed to method `infection\mutator\definition::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "src/CustomMutator/templates/__Name__.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `App\Mutator\TODO`.'
-count = 1
-
-[[issues]]
-file = "src/CustomMutator/templates/__Name__.php"
-code = "non-existent-class-like"
-message = 'Class, interface, enum, or trait `App\Mutator\MutatorCategory` not found.'
-count = 1
-
-[[issues]]
-file = "src/CustomMutator/templates/__Name__Test.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -1156,12 +1126,6 @@ count = 1
 file = "src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriber::onMutationTestingWasFinished`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/DummyFileSystem.php"
-code = "imprecise-type"
-message = "Type `iterable` in parameter `$files` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -6079,12 +6043,6 @@ message = 'Potentially unhandled exception `RuntimeException` in `Infection\Test
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Command/Debug/DumpAstCommand/EchoGreeter.php"
-code = "missing-return-statement"
-message = "Missing return statement in function 'greet'"
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidTimeValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -7027,6 +6985,18 @@ message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
+file = "tests/phpunit/Configuration/ConfigurationBuilder.php"
+code = "no-value"
+message = 'Argument #2 passed to method `infection\mutator\ignoremutator::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/ConfigurationBuilder.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Mutator\FakeMutator` not found.'
+count = 1
+
+[[issues]]
 file = "tests/phpunit/Configuration/ConfigurationBuilderTest.php"
 code = "non-existent-method"
 message = 'Method `assertequals` does not exist on type `Infection\Tests\Configuration\ConfigurationBuilderTest`.'
@@ -7036,6 +7006,24 @@ count = 1
 file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `valueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
+code = "no-value"
+message = 'Argument #5 passed to method `infection\configuration\configurationfactory::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\DummyCiDetector` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Mutator\CustomMutator` not found.'
 count = 1
 
 [[issues]]
@@ -8996,6 +8984,54 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
+code = "impossible-assignment"
+message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
+count = 2
+
+[[issues]]
+file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
+code = "invalid-property-access"
+message = "Attempting to access a property on a non-object type (`never`)."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
+code = "no-value"
+message = 'Argument #1 passed to method `Infection\Event\EventDispatcher\SyncEventDispatcher::addsubscriber` has type `never`, meaning it cannot produce a value.'
+count = 3
+
+[[issues]]
+file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
+code = "no-value"
+message = 'Argument #1 passed to method `Infection\Event\EventDispatcher\SyncEventDispatcher::dispatch` has type `never`, meaning it cannot produce a value.'
+count = 2
+
+[[issues]]
+file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\UnknownEventSubscriber` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\UserEventSubscriber` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\UserWasCreatedCounterSubscriber` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\UserWasCreated` not found.'
+count = 3
+
+[[issues]]
+file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Event\EventDispatcher\SyncEventDispatcherTest`.'
 count = 4
@@ -9124,7 +9160,7 @@ count = 1
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
 code = "impossible-assignment"
 message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
-count = 1
+count = 4
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
@@ -9135,14 +9171,38 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
 code = "no-value"
-message = 'Argument #1 passed to method `infection\tests\fixtures\event\ionullsubscriber::__construct` has type `never`, meaning it cannot produce a value.'
-count = 3
+message = 'Argument #1 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
+code = "no-value"
+message = 'Argument #2 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
+code = "no-value"
+message = 'Argument #3 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Console\FakeOutput` not found.'
 count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\DummySubscriberFactory` not found.'
+count = 2
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\IONullSubscriber` not found.'
+count = 3
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
@@ -9338,6 +9398,48 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
+code = "invalid-method-access"
+message = 'Attempting to access a method on a non-object type (`unknown-ref(Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher)`).'
+count = 4
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
+code = "no-value"
+message = 'Argument #1 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
+code = "no-value"
+message = 'Argument #2 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
+code = "no-value"
+message = 'Argument #3 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\DummySubscriberFactory` not found.'
+count = 3
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
+code = "non-existent-class-like"
+message = 'Cannot find class, interface, enum, or type alias `Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "non-existent-method"
 message = 'Method `assertcount` does not exist on type `Infection\Tests\Event\Subscriber\SubscriberRegistererTest`.'
 count = 3
@@ -9347,6 +9449,12 @@ file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Event\Subscriber\SubscriberRegistererTest`.'
 count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
+code = "possibly-invalid-argument"
+message = 'Possible argument type mismatch for argument #1 of `infection\event\subscriber\subscriberregisterer::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher)`.'
+count = 2
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
@@ -9922,228 +10030,6 @@ count = 1
 file = "tests/phpunit/FileSystem/TmpDirProviderTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony6.php"
-code = "imprecise-type"
-message = "Type `iterable` in parameter `$messages` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Console/FakeOutputSymfony7.php"
-code = "imprecise-type"
-message = "Type `iterable` in parameter `$messages` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Fixtures/DummyCiDetector.php"
-code = "unused-parameter"
-message = "Parameter `$environment` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Event/EventDispatcherCollector.php"
-code = "imprecise-type"
-message = "Type `array` in property `$events` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Event/EventDispatcherCollector.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `getEvents` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Event/UnknownEventSubscriber.php"
-code = "unused-parameter"
-message = "Parameter `$event` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Event/UserEventSubscriber.php"
-code = "missing-property-type"
-message = "Property `$count` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Event/UserEventSubscriber.php"
-code = "mixed-operand"
-message = "Cannot reliably increment a `mixed` operand."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Event/UserEventSubscriber.php"
-code = "unused-parameter"
-message = "Parameter `$event` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Event/UserWasCreatedCounterSubscriber.php"
-code = "unused-parameter"
-message = "Parameter `$event` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRealPathFinder.php"
-code = "imprecise-type"
-message = "Type `array` in parameter `$filter` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRealPathFinder.php"
-code = "imprecise-type"
-message = "Type `array` in parameter `$sourceDirectories` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRealPathFinder.php"
-code = "imprecise-type"
-message = "Type `array` in property `$filters` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRealPathFinder.php"
-code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #1 of `symfony\component\finder\finder::in`: expected `array<array-key, string>|string`, but provided type `array<array-key, mixed>` is less specific.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRealPathFinder.php"
-code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #2 of `symfony\component\finder\iterator\multiplepcrefilteriterator::__construct`: expected `array<array-key, string>`, but provided type `non-empty-array<array-key, mixed>` is less specific.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRelativePathFinder.php"
-code = "imprecise-type"
-message = "Type `array` in parameter `$filter` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRelativePathFinder.php"
-code = "imprecise-type"
-message = "Type `array` in parameter `$sourceDirectories` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRelativePathFinder.php"
-code = "imprecise-type"
-message = "Type `array` in property `$filters` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRelativePathFinder.php"
-code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #1 of `symfony\component\finder\finder::in`: expected `array<array-key, string>|string`, but provided type `array<array-key, mixed>` is less specific.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Finder/MockRelativePathFinder.php"
-code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #2 of `symfony\component\finder\iterator\multiplepcrefilteriterator::__construct`: expected `array<array-key, string>`, but provided type `non-empty-array<array-key, mixed>` is less specific.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/ForHtmlReport.php"
-code = "always-matching-switch-case"
-message = "This switch case will always match, making subsequent cases unreachable."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/ForHtmlReport.php"
-code = "redundant-comparison"
-message = "Redundant `!==` comparison: left-hand side is always not identical to right-hand side."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/ForHtmlReport.php"
-code = "redundant-condition"
-message = "This condition (type `true`) will always evaluate to true."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/ForHtmlReport.php"
-code = "unreachable-switch-default"
-message = "Unreachable default case"
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/ForHtmlReport.php"
-code = "unused-parameter"
-message = "Parameter `$a` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/ForHtmlReport.php"
-code = "unused-parameter"
-message = "Parameter `$keys` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/ForHtmlReport2.php"
-code = "unused-parameter"
-message = "Parameter `$a` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/ForHtmlReport2.php"
-code = "unused-parameter"
-message = "Parameter `$b` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Mutator/CustomMutator.php"
-code = "missing-template-parameter"
-message = 'Too few template arguments for `Infection\Mutator\Mutator`: expected 1, but found 0.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Mutator/CustomNameMutator.php"
-code = "missing-template-parameter"
-message = 'Too few template arguments for `Infection\Mutator\Mutator`: expected 1, but found 0.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Mutator/FakeMutator.php"
-code = "missing-template-parameter"
-message = 'Too few template arguments for `Infection\Mutator\Mutator`: expected 1, but found 0.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeVisitor.php"
-code = "docblock-type-mismatch"
-message = 'Docblock return type `PhpParser\Node|array<array-key, PhpParser\Node>|int` is incompatible with native return type `void`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Fixtures/PhpParser/FakeVisitor.php"
-code = "docblock-type-mismatch"
-message = 'Docblock return type `array<array-key, PhpParser\Node>` is incompatible with native return type `void`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Process/DummyMutantProcess.php"
-code = "extend-final-class"
-message = 'Class `Infection\Tests\Fixtures\Process\DummyMutantProcess` cannot extend final class `Infection\Process\MutantProcess`'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Resource/Memory/FakeMemoryFormatter.php"
-code = "extend-final-class"
-message = 'Class `Infection\Tests\Fixtures\Resource\Memory\FakeMemoryFormatter` cannot extend final class `Infection\Resource\Memory\MemoryFormatter`'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/Resource/Time/FakeTimeFormatter.php"
-code = "extend-final-class"
-message = 'Class `Infection\Tests\Fixtures\Resource\Time\FakeTimeFormatter` cannot extend final class `Infection\Resource\Time\TimeFormatter`'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Fixtures/TestFramework/DummyTestFrameworkFactory.php"
-code = "imprecise-type"
-message = "Type `array` in parameter `$sourceDirectories` is imprecise, equivalent to `array<array-key, mixed>`."
 count = 1
 
 [[issues]]
@@ -11468,6 +11354,18 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Mutator\FakeMutator` not found.'
+count = 4
+
+[[issues]]
+file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\PhpParser\FakeNode` not found.'
+count = 4
+
+[[issues]]
+file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
 code = "non-existent-method"
 message = 'Method `anything` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest`.'
 count = 1
@@ -11601,6 +11499,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "mixed-argument"
+message = "Cannot unpack argument of type `mixed` because it is not guaranteed to be iterable."
+count = 2
+
+[[issues]]
+file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
+code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 3
 
@@ -11618,9 +11522,27 @@ count = 4
 
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
+code = "no-value"
+message = 'Argument #2 passed to method `infection\mutator\ignoremutator::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Mutator\FakeMutator` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutation\MutationGeneratorTest`.'
 count = 1
+
+[[issues]]
+file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
+code = "non-existent-method"
+message = 'Method `create` does not exist on type `Infection\Tests\WithConsecutive`.'
+count = 2
 
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
@@ -12579,6 +12501,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
 code = "mixed-argument"
+message = "Cannot unpack argument of type `mixed` because it is not guaranteed to be iterable."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
+code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 8
 
@@ -12604,6 +12532,12 @@ count = 3
 file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
 code = "non-existent-method"
 message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\IgnoreMutatorTest`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
+code = "non-existent-method"
+message = 'Method `create` does not exist on type `Infection\Tests\WithConsecutive`.'
 count = 1
 
 [[issues]]
@@ -14330,6 +14264,18 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
+code = "no-value"
+message = 'Argument #1 passed to method `Infection\PhpParser\NodeTraverserFactory::createmutationtraverser` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\PhpParser\FakeVisitor` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\PhpParser\NodeTraverserFactoryTest`.'
 count = 1
@@ -14338,6 +14284,12 @@ count = 1
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\NodeTraverserFactoryTest`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
+code = "possibly-invalid-argument"
+message = '''Possible argument type mismatch for argument #2 of `Infection\Tests\PhpParser\NodeTraverserFactoryTest::asserttraverservisitorsare`: expected `list<class-string<PhpParser\NodeVisitor>>`, but possibly received `list{class-string('PhpParser\NodeVisitor\CloningVisitor'), class-string('Infection\Tests\Fixtures\PhpParser\FakeVisitor')}`.'''
 count = 1
 
 [[issues]]
@@ -14434,24 +14386,6 @@ count = 1
 file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\EnrichmentTraverse\EnrichmentTraverseIntegrationTest::test_it_creates_a_rich_ast`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/Fixtures/AbstractMethod.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/Fixtures/ConcreteClass.php"
-code = "invalid-callable"
-message = "Expression of type `nonnull` cannot be called as a function or method."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/Fixtures/TraitExample.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
 count = 1
 
 [[issues]]
@@ -14996,6 +14930,12 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
+code = "impossible-assignment"
+message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `timeoutDataProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
@@ -15005,6 +14945,12 @@ file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 2
+
+[[issues]]
+file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not found.'
+count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
@@ -15200,8 +15146,38 @@ count = 3
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
+code = "invalid-method-access"
+message = 'Attempting to access a method on a non-object type (`unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`).'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
+code = "mixed-argument"
+message = "Invalid argument type for argument #2 of `array_map`: expected `array<('K.array_map() extends array-key), object>`, but found `mixed`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
+code = "no-value"
+message = 'Argument #2 passed to method `infection\process\runner\initialstaticanalysisrunner::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
+code = "non-existent-class-like"
+message = 'Cannot find class, interface, enum, or type alias `Infection\Tests\Fixtures\Event\EventDispatcherCollector`.'
 count = 1
 
 [[issues]]
@@ -15242,9 +15218,57 @@ count = 6
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
+code = "invalid-method-access"
+message = 'Attempting to access a method on a non-object type (`unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`).'
+count = 2
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 2
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
+code = "mixed-argument"
+message = "Invalid argument type for argument #1 of `end`: expected `array<array-key, ('T.end() extends mixed)>|object`, but found `mixed`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
+code = "mixed-argument"
+message = "Invalid argument type for argument #2 of `array_map`: expected `array<('K.array_map() extends array-key), object>`, but found `mixed`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
+code = "mixed-array-access"
+message = "Unsafe array access on type `mixed`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
+code = "mixed-assignment"
+message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
+code = "no-value"
+message = 'Argument #2 passed to method `infection\process\runner\initialtestsrunner::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
+code = "non-existent-class-like"
+message = 'Cannot find class, interface, enum, or type alias `Infection\Tests\Fixtures\Event\EventDispatcherCollector`.'
+count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
@@ -15284,6 +15308,12 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
+code = "possibly-invalid-argument"
+message = "Possible argument type mismatch for argument #1 of `array_filter`: expected `array<array-key, mixed>`, but possibly received `array<array-key, mixed>|list<mixed>|object`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_stops_the_process_execution_on_the_first_error`.'
 count = 1
@@ -15302,21 +15332,21 @@ count = 11
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertaresameevents`: expected `array<array-key, Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationWasStarted|Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished|Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted>`, but provided type `array<array-key, mixed>` is less specific.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::asserthasevent`: expected `array<array-key, object>`, but provided type `array<array-key, mixed>` is less specific.'
-count = 1
+code = "invalid-method-access"
+message = 'Attempting to access a method on a non-object type (`unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`).'
+count = 10
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 8
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
+code = "mixed-argument"
+message = "Cannot unpack argument of type `mixed` because it is not guaranteed to be iterable."
+count = 11
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
@@ -15332,6 +15362,18 @@ count = 22
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertaresameevents`: expected `array<array-key, Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationWasStarted|Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished|Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted>`, but found `mixed`.'
+count = 7
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::asserthasevent`: expected `array<array-key, object>`, but found `mixed`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 6
@@ -15340,6 +15382,24 @@ count = 6
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `infection\tests\process\runner\mutationtestingrunnertest::someiterable`. Saw type `mixed`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
+code = "no-value"
+message = 'Argument #4 passed to method `infection\process\runner\mutationtestingrunner::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
+code = "non-existent-class-like"
+message = 'Cannot find class, interface, enum, or type alias `Infection\Tests\Fixtures\Event\EventDispatcherCollector`.'
 count = 1
 
 [[issues]]
@@ -15405,6 +15465,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "non-existent-method"
+message = 'Method `create` does not exist on type `Infection\Tests\WithConsecutive`.'
+count = 11
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
+code = "non-existent-method"
 message = 'Method `createstub` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
 count = 1
 
@@ -15452,6 +15518,12 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
+code = "possibly-invalid-argument"
+message = 'Possible argument type mismatch for argument #4 of `infection\process\runner\mutationtestingrunner::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`.'
+count = 6
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::invokeMethod`.'
 count = 1
@@ -15461,6 +15533,12 @@ file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
 count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
+code = "impossible-assignment"
+message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
+count = 2
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
@@ -15518,12 +15596,6 @@ count = 6
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `infection\tests\fixtures\process\dummymutantprocess::__construct`: expected `Infection\Mutant\TestFrameworkMutantExecutionResultFactory`, but found `mixed`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 2
@@ -15533,6 +15605,18 @@ file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "mixed-method-access"
 message = "Attempting to access a method on a non-object type (`mixed`)."
 count = 17
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
+code = "no-value"
+message = 'Argument #1 passed to method `infection\process\mutantprocesscontainer::__construct` has type `never`, meaning it cannot produce a value.'
+count = 5
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Process\DummyMutantProcess` not found.'
+count = 5
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
@@ -15980,6 +16064,42 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
+code = "no-value"
+message = 'Argument #2 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
+count = 7
+
+[[issues]]
+file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
+code = "no-value"
+message = 'Argument #3 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
+count = 7
+
+[[issues]]
+file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
+code = "no-value"
+message = 'Argument #4 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
+count = 7
+
+[[issues]]
+file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\FileSystem\DummyFileSystem` not found.'
+count = 7
+
+[[issues]]
+file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Logger\FakeLogger` not found.'
+count = 7
+
+[[issues]]
+file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Reporter\DummyLineMutationTestingResultsReporter` not found.'
+count = 7
+
+[[issues]]
+file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\FileLocationReporter\FileLocationReporterTest`.'
 count = 1
@@ -16022,6 +16142,18 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
+code = "no-value"
+message = 'Argument #7 passed to method `infection\reporter\filereporterfactory::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Logger\FakeLogger` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Reporter\FileReporterFactoryTest`.'
 count = 1
@@ -16055,6 +16187,18 @@ file = "tests/phpunit/Reporter/FileReporterTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 2
+
+[[issues]]
+file = "tests/phpunit/Reporter/FileReporterTest.php"
+code = "no-value"
+message = 'Argument #3 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
+count = 4
+
+[[issues]]
+file = "tests/phpunit/Reporter/FileReporterTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Reporter\DummyLineMutationTestingResultsReporter` not found.'
+count = 4
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterTest.php"
@@ -16328,6 +16472,30 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
+code = "no-value"
+message = 'Argument #3 passed to method `infection\reporter\strykerreporterfactory::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
+code = "no-value"
+message = 'Argument #4 passed to method `infection\reporter\strykerreporterfactory::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\FakeCiDetector` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Logger\FakeLogger` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Reporter\StrykerReporterFactoryTest`.'
 count = 2
@@ -16414,6 +16582,30 @@ count = 1
 file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
+code = "no-value"
+message = 'Argument #2 passed to method `infection\resource\listener\performanceloggersubscriber::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
+code = "no-value"
+message = 'Argument #3 passed to method `infection\resource\listener\performanceloggersubscriber::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Resource\Memory\FakeMemoryFormatter` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Resource\Time\FakeTimeFormatter` not found.'
 count = 1
 
 [[issues]]
@@ -16520,6 +16712,12 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
+code = "impossible-assignment"
+message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
+count = 2
+
+[[issues]]
+file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `memoryLimitProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
@@ -16535,6 +16733,18 @@ file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #2 of `Infection\Resource\Memory\MemoryLimiter::limitmemory`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
 count = 1
+
+[[issues]]
+file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
+code = "no-value"
+message = 'Argument #2 passed to method `Infection\Resource\Memory\MemoryLimiter::limitmemory` has type `never`, meaning it cannot produce a value.'
+count = 3
+
+[[issues]]
+file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\TestFramework\FakeAwareAdapter` not found.'
+count = 3
 
 [[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
@@ -19208,6 +19418,18 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
+code = "no-value"
+message = "Argument #2 passed to function `array_map` has type `never`, meaning it cannot produce a value."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
+code = "non-existent-class-like"
+message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\TestFramework\PhpUnit\Coverage\JUnitTimes` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
 code = "non-existent-method"
 message = 'Method `assertGreaterThan` does not exist on type `Infection\Tests\TestFramework\Tracing\TestLocationBucketSorterTest`.'
 count = 2
@@ -19612,6 +19834,12 @@ count = 8
 file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `infection\tests\testframework\tracing\tracer\tracerintegrationtest::createfilesystemstub`. Saw type `mixed`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\TestFramework\Coverage\JUnit\FakeTestFileDataProvider` not found.'
 count = 1
 
 [[issues]]
@@ -20177,51 +20405,3 @@ file = "tests/phpunit/UnsupportedMethodTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\UnsupportedMethodTest`.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/WithConsecutive.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `create` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/WithConsecutive.php"
-code = "invalid-iterator"
-message = "The expression provided to `foreach` is not iterable. It resolved to type `mixed`, which is not iterable."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/WithConsecutive.php"
-code = "invalid-return-tag"
-message = "Failed to resolve `@return` type string."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/WithConsecutive.php"
-code = "missing-parameter-type"
-message = "Parameter `$parameterGroups` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/WithConsecutive.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `count`: expected `Countable|array<array-key, mixed>`, but found `mixed`."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/WithConsecutive.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/WithConsecutive.php"
-code = "possibly-null-operand"
-message = "Right operand in `<` comparison might be `null` (type `non-negative-int|null`)."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/WithConsecutive.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\WithConsecutive::create`.'
-count = 1

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -33,7 +33,7 @@ count = 1
 [[issues]]
 file = "src/Command/ConfigureCommand.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\config\guesser\sourcedirguesser::__construct`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Config\Guesser\SourceDirGuesser::__construct`: expected `stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -75,25 +75,25 @@ count = 1
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
 code = "no-value"
-message = 'Argument #1 passed to method `infection\differ\changedlinesrange::create` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `Infection\Differ\ChangedLinesRange::create` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
 code = "no-value"
-message = 'Argument #1 passed to method `webmozart\assert\assert::natural` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `Webmozart\Assert\Assert::natural` has type `never`, meaning it cannot produce a value.'
 count = 2
 
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
 code = "no-value"
-message = 'Argument #2 passed to method `infection\differ\changedlinesrange::create` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Differ\ChangedLinesRange::create` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
 code = "possibly-false-argument"
-message = 'Argument #1 of method `infection\phpparser\visitor\labelmutationcandidatesvisitor::__construct` is possibly `false`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `Infection\PhpParser\Visitor\LabelMutationCandidatesVisitor::__construct` is possibly `false`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -153,6 +153,12 @@ count = 1
 [[issues]]
 file = "src/Command/DescribeCommand.php"
 code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `Infection\Mutator\MutatorResolver::isValidMutator`: expected `string`, but found `mixed`.'
+count = 1
+
+[[issues]]
+file = "src/Command/DescribeCommand.php"
+code = "mixed-argument"
 message = "Invalid argument type for argument #1 of `array_key_exists`: expected `bool|float|int|string`, but found `mixed`."
 count = 2
 
@@ -160,12 +166,6 @@ count = 2
 file = "src/Command/DescribeCommand.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #1 of `array_keys`: expected `array<('K.array_keys() extends array-key), ('V.array_keys() extends mixed)>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "src/Command/DescribeCommand.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\mutator\mutatorresolver::isvalidmutator`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -231,7 +231,7 @@ count = 1
 [[issues]]
 file = "src/Command/Git/Option/BaseOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `infection\command\git\option\baseoption::addoption`: expected `('T.infection\command\git\option\baseoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `Infection\Command\Git\Option\BaseOption::addOption`: expected `('T.infection\command\git\option\baseoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -243,7 +243,7 @@ count = 1
 [[issues]]
 file = "src/Command/Git/Option/FilterOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `infection\command\git\option\filteroption::addoption`: expected `('T.infection\command\git\option\filteroption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `Infection\Command\Git\Option\FilterOption::addOption`: expected `('T.infection\command\git\option\filteroption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -273,7 +273,7 @@ count = 1
 [[issues]]
 file = "src/Command/InitialTest/Option/InitialTestsPhpOptionsOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `infection\command\initialtest\option\initialtestsphpoptionsoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `Infection\Command\InitialTest\Option\InitialTestsPhpOptionsOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -285,7 +285,7 @@ count = 1
 [[issues]]
 file = "src/Command/ListSourcesCommand.php"
 code = "possibly-false-argument"
-message = 'Argument #1 of method `symfony\component\filesystem\path::makerelative` is possibly `false`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `Symfony\Component\Filesystem\Path::makeRelative` is possibly `false`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -303,7 +303,7 @@ count = 1
 [[issues]]
 file = "src/Command/MakeCustomMutatorCommand.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Command\MakeCustomMutatorCommand::mutatornameisempty`: expected `null|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Command\MakeCustomMutatorCommand::mutatorNameIsEmpty`: expected `null|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -333,19 +333,19 @@ count = 1
 [[issues]]
 file = "src/Command/Option/ConfigurationOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `infection\command\option\configurationoption::addoption`: expected `('T.infection\command\option\configurationoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `Infection\Command\Option\ConfigurationOption::addOption`: expected `('T.infection\command\option\configurationoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
 file = "src/Command/Option/DebugOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `infection\command\option\debugoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `Infection\Command\Option\DebugOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
 file = "src/Command/Option/DebugOption.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\command\option\debugoption::get`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Command\Option\DebugOption::get`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -357,13 +357,13 @@ count = 1
 [[issues]]
 file = "src/Command/Option/MapSourceClassToTestOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `infection\command\option\mapsourceclasstotestoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `Infection\Command\Option\MapSourceClassToTestOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
 file = "src/Command/Option/MapSourceClassToTestOption.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\command\option\mapsourceclasstotestoption::assertisvalid`: expected `string`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `Infection\Command\Option\MapSourceClassToTestOption::assertIsValid`: expected `string`, but found `nonnull`.'
 count = 1
 
 [[issues]]
@@ -381,7 +381,7 @@ count = 1
 [[issues]]
 file = "src/Command/Option/SourceFilterOptions.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `infection\command\option\sourcefilteroptions::addoption`: expected `('T.infection\command\option\sourcefilteroptions::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `Infection\Command\Option\SourceFilterOptions::addOption`: expected `('T.infection\command\option\sourcefilteroptions::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -399,7 +399,7 @@ count = 1
 [[issues]]
 file = "src/Command/Option/TestFrameworkOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `infection\command\option\testframeworkoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `Infection\Command\Option\TestFrameworkOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -411,7 +411,7 @@ count = 1
 [[issues]]
 file = "src/Command/Option/TestFrameworkOptionsOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `infection\command\option\testframeworkoptionsoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `Infection\Command\Option\TestFrameworkOptionsOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -423,7 +423,7 @@ count = 1
 [[issues]]
 file = "src/Command/RunCommand.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #37 of `Infection\Container\Container::withvalues`: expected `null|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #37 of `Infection\Container\Container::withValues`: expected `null|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -549,7 +549,7 @@ count = 2
 [[issues]]
 file = "src/Config/Guesser/PhpUnitPathGuesser.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #1 of `Infection\Config\Guesser\PhpUnitPathGuesser::getphpunitdir`: expected `array<string, string>`, but provided type `array<array-key, mixed>` is less specific.'
+message = 'Argument type mismatch for argument #1 of `Infection\Config\Guesser\PhpUnitPathGuesser::getPhpUnitDir`: expected `array<string, string>`, but provided type `array<array-key, mixed>` is less specific.'
 count = 2
 
 [[issues]]
@@ -573,7 +573,7 @@ count = 1
 [[issues]]
 file = "src/Config/Guesser/SourceDirGuesser.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #1 of `Infection\Config\Guesser\SourceDirGuesser::parsepath`: expected `array<array-key, string>|string`, but provided type `array<array-key, mixed>|string` is less specific.'
+message = 'Argument type mismatch for argument #1 of `Infection\Config\Guesser\SourceDirGuesser::parsePath`: expected `array<array-key, string>|string`, but provided type `array<array-key, mixed>|string` is less specific.'
 count = 1
 
 [[issues]]
@@ -597,13 +597,13 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/ExcludeDirsProvider.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(mixed): truthy-mixed)` is less specific than the declared return type `(closure(string): string)` for function `infection\config\valueprovider\excludedirsprovider::getvalidator` due to nested 'mixed'.'''
+message = '''Returned type `(closure(mixed): truthy-mixed)` is less specific than the declared return type `(closure(string): string)` for function `Infection\Config\ValueProvider\ExcludeDirsProvider::getValidator` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Config/ValueProvider/ExcludeDirsProvider.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `list<truthy-mixed>` is less specific than the declared return type `array<array-key, string>` for function `infection\config\valueprovider\excludedirsprovider::get` due to nested 'mixed'.'''
+message = '''Returned type `list<truthy-mixed>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Config\ValueProvider\ExcludeDirsProvider::get` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -669,7 +669,7 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/SourceDirsProvider.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\config\valueprovider\sourcedirsprovider::get`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Config\ValueProvider\SourceDirsProvider::get`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -681,13 +681,13 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/TestFrameworkConfigPathProvider.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\config\guesser\phpunitpathguesser::__construct`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Config\Guesser\PhpUnitPathGuesser::__construct`: expected `stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Config/ValueProvider/TestFrameworkConfigPathProvider.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\config\valueprovider\testframeworkconfigpathprovider::asktestframeworkconfiglocation`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Config\ValueProvider\TestFrameworkConfigPathProvider::askTestFrameworkConfigLocation`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -705,7 +705,7 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/TextLogFileProvider.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\config\valueprovider\textlogfileprovider::get`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Config\ValueProvider\TextLogFileProvider::get`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -729,7 +729,7 @@ count = 1
 [[issues]]
 file = "src/Configuration/ConfigurationFactory.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `array<string, list<mixed>>` is less specific than the declared return type `array<string, array<int, string>>` for function `infection\configuration\configurationfactory::retrieveignoresourcecodemutatorsmap` due to nested 'mixed'.'''
+message = '''Returned type `array<string, list<mixed>>` is less specific than the declared return type `array<string, array<int, string>>` for function `Infection\Configuration\ConfigurationFactory::retrieveIgnoreSourceCodeMutatorsMap` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -747,7 +747,7 @@ count = 1
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\configuration\schema\schemaconfigurationfactory::normalizestringarray`: expected `list<non-empty-string>`, but found `list<string>`.'
+message = 'Invalid return type for function `Infection\Configuration\Schema\SchemaConfigurationFactory::normalizeStringArray`: expected `list<non-empty-string>`, but found `list<string>`.'
 count = 1
 
 [[issues]]
@@ -759,91 +759,91 @@ count = 1
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #13 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `array<string, mixed>`, but provided type `array<array-key, mixed>` is less specific.'
+message = 'Argument type mismatch for argument #13 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `array<string, mixed>`, but provided type `array<array-key, mixed>` is less specific.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::createlogs`: expected `stdClass`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::createLogs`: expected `stdClass`, but found `nonnull`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::createphpstan`: expected `stdClass`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::createPhpStan`: expected `stdClass`, but found `nonnull`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::createphpunit`: expected `stdClass`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::createPhpUnit`: expected `stdClass`, but found `nonnull`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::createsource`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::createSource`: expected `stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::createstrykerconfig`: expected `null|stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::createStrykerConfig`: expected `null|stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::normalizestring`: expected `null|string`, but found `mixed`.'
-count = 18
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::normalizestringarray`: expected `array<array-key, string>`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::normalizeStringArray`: expected `array<array-key, string>`, but found `nonnull`.'
 count = 2
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #10 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `float|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::normalizeString`: expected `null|string`, but found `mixed`.'
+count = 18
+
+[[issues]]
+file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #10 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `float|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #11 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `bool|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #11 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `bool|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #12 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `int|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #12 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `int|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #19 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `int|null|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #19 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `int|null|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #8 of `infection\configuration\entry\logs::__construct`: expected `bool`, but found `nonnull`.'
+message = 'Invalid argument type for argument #8 of `Infection\Configuration\Entry\Logs::__construct`: expected `bool`, but found `nonnull`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #8 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `bool|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #8 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `bool|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #9 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `float|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #9 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `float|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -855,19 +855,19 @@ count = 3
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\configuration\schema\schemaconfigurationfactory::getstaticanalysistool`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Configuration\Schema\SchemaConfigurationFactory::getStaticAnalysisTool`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\configuration\schema\schemaconfigurationfactory::gettestframework`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Configuration\Schema\SchemaConfigurationFactory::getTestFramework`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\configuration\schema\schemaconfigurationfactory::gettimeout`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Configuration\Schema\SchemaConfigurationFactory::getTimeout`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -879,7 +879,7 @@ count = 1
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFile.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\configuration\schema\schemaconfigurationfile::getdecodedcontents`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Configuration\Schema\SchemaConfigurationFile::getDecodedContents`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -933,13 +933,13 @@ count = 1
 [[issues]]
 file = "src/Configuration/SourceFilter/PlainFilter.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\configuration\sourcefilter\plainfilter::parsevalues`: expected `array<array-key, non-empty-string>`, but found `array<non-negative-int, string>`.'
+message = 'Invalid return type for function `Infection\Configuration\SourceFilter\PlainFilter::parseValues`: expected `array<array-key, non-empty-string>`, but found `array<non-negative-int, string>`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/SourceFilter/PlainFilter.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\configuration\sourcefilter\plainfilter::tostring`: expected `non-empty-string`, but found `string`.'
+message = 'Invalid return type for function `Infection\Configuration\SourceFilter\PlainFilter::toString`: expected `non-empty-string`, but found `string`.'
 count = 1
 
 [[issues]]
@@ -969,7 +969,7 @@ count = 1
 [[issues]]
 file = "src/Container/Container.php"
 code = "less-specific-nested-argument-type"
-message = '''Argument type mismatch for argument #2 of `Infection\Container\Container::offsetset`: expected `(closure(Infection\Container\Container): ('T.infection\container\container::clonewithservice() extends object))`, but provided type `('T.infection\container\container::clonewithservice() extends Closure)|Closure` is less specific.'''
+message = '''Argument type mismatch for argument #2 of `Infection\Container\Container::offsetSet`: expected `(closure(Infection\Container\Container): ('T.infection\container\container::clonewithservice() extends object))`, but provided type `('T.infection\container\container::clonewithservice() extends Closure)|Closure` is less specific.'''
 count = 1
 
 [[issues]]
@@ -981,7 +981,7 @@ count = 1
 [[issues]]
 file = "src/Container/Container.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #2 of `dicontainer\container::inject`: expected `('T.infection\container\container::clonewithservice() extends object)`, but possibly received `('T.infection\container\container::clonewithservice() extends object)|(closure(infection\container\container): ('T.infection\container\container::clonewithservice() extends object))`.'''
+message = '''Possible argument type mismatch for argument #2 of `DIContainer\Container::inject`: expected `('T.infection\container\container::clonewithservice() extends object)`, but possibly received `('T.infection\container\container::clonewithservice() extends object)|(closure(infection\container\container): ('T.infection\container\container::clonewithservice() extends object))`.'''
 count = 1
 
 [[issues]]
@@ -1035,7 +1035,7 @@ count = 1
 [[issues]]
 file = "src/Differ/Differ.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\differ\differ::processtokens`: expected `array{0: string, 1: int(0)|int(1)|int(2)|int(3)|int(4)}`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Differ\Differ::processTokens`: expected `array{0: string, 1: int(0)|int(1)|int(2)|int(3)|int(4)}`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -1053,7 +1053,7 @@ count = 1
 [[issues]]
 file = "src/Differ/Tokens.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\differ\tokens::computerange`: expected `array{0: int(0)|positive-int, 1: int(0)|positive-int}`, but found `list{non-negative-int, int}`.'
+message = 'Invalid return type for function `Infection\Differ\Tokens::computeRange`: expected `array{0: int(0)|positive-int, 1: int(0)|positive-int}`, but found `list{non-negative-int, int}`.'
 count = 1
 
 [[issues]]
@@ -1149,7 +1149,7 @@ count = 1
 [[issues]]
 file = "src/FileSystem/FileSystem.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `symfony\component\filesystem\exception\ioexception::__construct`: expected `string`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `Symfony\Component\Filesystem\Exception\IOException::__construct`: expected `string`, but found `nonnull`.'
 count = 1
 
 [[issues]]
@@ -1161,7 +1161,7 @@ count = 1
 [[issues]]
 file = "src/FileSystem/FileSystem.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `symfony\component\filesystem\exception\ioexception::__construct`: expected `int`, but possibly received `int|string`.'
+message = 'Possible argument type mismatch for argument #2 of `Symfony\Component\Filesystem\Exception\IOException::__construct`: expected `int`, but possibly received `int|string`.'
 count = 1
 
 [[issues]]
@@ -1179,7 +1179,7 @@ count = 1
 [[issues]]
 file = "src/FileSystem/Finder/Iterator/RealPathFilterIterator.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `symfony\component\finder\iterator\multiplepcrefilteriterator::isaccepted`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Symfony\Component\Finder\Iterator\MultiplePcreFilterIterator::isAccepted`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -1341,7 +1341,7 @@ count = 1
 [[issues]]
 file = "src/Framework/ClassName.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\framework\classname::getshortclassname`: expected `non-empty-string`, but found `string`.'
+message = 'Invalid return type for function `Infection\Framework\ClassName::getShortClassName`: expected `non-empty-string`, but found `string`.'
 count = 1
 
 [[issues]]
@@ -1353,13 +1353,13 @@ count = 3
 [[issues]]
 file = "src/Framework/Enum/EnumBucket.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `infection\framework\enum\enumbucket::getcasesindexedbyname`: expected `array<string, ('E.infection\framework\enum\enumbucket::getcasesindexedbyname() extends BackedEnum)>`, but found `array<string, BackedEnum&static>`.'''
+message = '''Invalid return type for function `Infection\Framework\Enum\EnumBucket::getCasesIndexedByName`: expected `array<string, ('E.infection\framework\enum\enumbucket::getcasesindexedbyname() extends BackedEnum)>`, but found `array<string, BackedEnum&static>`.'''
 count = 1
 
 [[issues]]
 file = "src/Framework/Enum/EnumBucket.php"
 code = "mixed-argument"
-message = '''Invalid argument type for argument #1 of `infection\framework\enum\enumbucket::describecase`: expected `BackedEnum&'T.infection\framework\enum\enumbucket extends BackedEnum`, but found `mixed`.'''
+message = '''Invalid argument type for argument #1 of `Infection\Framework\Enum\EnumBucket::describeCase`: expected `BackedEnum&'T.infection\framework\enum\enumbucket extends BackedEnum`, but found `mixed`.'''
 count = 2
 
 [[issues]]
@@ -1389,31 +1389,31 @@ count = 1
 [[issues]]
 file = "src/Framework/Iterable/GeneratorFactory.php"
 code = "mixed-argument"
-message = '''Invalid argument type for argument #1 of `infection\framework\iterable\generatorfactory::fromiterable`: expected `iterable<('TKey.infection\framework\iterable\generatorfactory::fromiterable() extends mixed), ('TValue.infection\framework\iterable\generatorfactory::fromiterable() extends mixed)>`, but found `mixed`.'''
+message = '''Invalid argument type for argument #1 of `Infection\Framework\Iterable\GeneratorFactory::fromIterable`: expected `iterable<('TKey.infection\framework\iterable\generatorfactory::fromiterable() extends mixed), ('TValue.infection\framework\iterable\generatorfactory::fromiterable() extends mixed)>`, but found `mixed`.'''
 count = 1
 
 [[issues]]
 file = "src/Framework/Str.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\framework\str::findlastnonemptylineindex`: expected `non-negative-int`, but found `int`.'
+message = 'Invalid return type for function `Infection\Framework\Str::findLastNonEmptyLineIndex`: expected `non-negative-int`, but found `int`.'
 count = 1
 
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\git\commandlinegit::getchangedfilerelativepaths`: expected `non-empty-string`, but found `string`.'
+message = 'Invalid return type for function `Infection\Git\CommandLineGit::getChangedFileRelativePaths`: expected `non-empty-string`, but found `string`.'
 count = 1
 
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\git\commandlinegit::parsefilepathfromline`: expected `string`, but found `null|string`.'
+message = 'Invalid return type for function `Infection\Git\CommandLineGit::parseFilePathFromLine`: expected `string`, but found `null|string`.'
 count = 1
 
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `list<mixed>` is less specific than the declared return type `array<array-key, string>` for function `infection\git\commandlinegit::diff` due to nested 'mixed'.'''
+message = '''Returned type `list<mixed>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Git\CommandLineGit::diff` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -1425,7 +1425,7 @@ count = 2
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "nullable-return-statement"
-message = 'Function `infection\git\commandlinegit::parsefilepathfromline` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
+message = 'Function `Infection\Git\CommandLineGit::parseFilePathFromLine` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
 count = 1
 
 [[issues]]
@@ -1479,7 +1479,7 @@ count = 1
 [[issues]]
 file = "src/Logger/Console/BasicConsoleLogger.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `webmozart\assert\assert::keyexists`: expected `int|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Webmozart\Assert\Assert::keyExists`: expected `int|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -1509,7 +1509,7 @@ count = 1
 [[issues]]
 file = "src/Logger/MutationAnalysis/TeamCity/TeamCity.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\logger\mutationanalysis\teamcity\teamcity::escapevalue`: expected `non-empty-string`, but found `array<array-key, mixed>|string`.'
+message = 'Invalid return type for function `Infection\Logger\MutationAnalysis\TeamCity\TeamCity::escapeValue`: expected `non-empty-string`, but found `array<array-key, mixed>|string`.'
 count = 1
 
 [[issues]]
@@ -1521,7 +1521,7 @@ count = 1
 [[issues]]
 file = "src/Metrics/FilteringResultsCollectorFactory.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #2 of `infection\metrics\filteringresultscollector::__construct`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `non-empty-array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
+message = 'Invalid argument type for argument #2 of `Infection\Metrics\FilteringResultsCollector::__construct`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `non-empty-array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
 count = 1
 
 [[issues]]
@@ -1533,7 +1533,7 @@ count = 1
 [[issues]]
 file = "src/Metrics/TargetDetectionStatusesProvider.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Metrics\TargetDetectionStatusesProvider::findrequired`.'
+message = 'Call to deprecated method: `Infection\Metrics\TargetDetectionStatusesProvider::findRequired`.'
 count = 1
 
 [[issues]]
@@ -1545,7 +1545,7 @@ count = 1
 [[issues]]
 file = "src/Metrics/TargetDetectionStatusesProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\metrics\targetdetectionstatusesprovider::get`: expected `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`, but found `array<string, enum(Infection\Mutant\DetectionStatus)>`.'
+message = 'Invalid return type for function `Infection\Metrics\TargetDetectionStatusesProvider::get`: expected `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`, but found `array<string, enum(Infection\Mutant\DetectionStatus)>`.'
 count = 1
 
 [[issues]]
@@ -1563,13 +1563,13 @@ count = 1
 [[issues]]
 file = "src/Mutant/DetectionStatus.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\mutant\detectionstatus::getcasesexcluding`: expected `list<enum(Infection\Mutant\DetectionStatus)>`, but found `list<mixed>`.'
+message = 'Invalid return type for function `Infection\Mutant\DetectionStatus::getCasesExcluding`: expected `list<enum(Infection\Mutant\DetectionStatus)>`, but found `list<mixed>`.'
 count = 1
 
 [[issues]]
 file = "src/Mutant/DetectionStatus.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `infection\mutant\detectionstatus::getindexedcases`: expected `array<key-of<enum(infection\mutant\detectionstatus)>, enum(infection\mutant\detectionstatus)>`, but found `array{'ERROR': enum(Infection\Mutant\DetectionStatus), 'ESCAPED': enum(Infection\Mutant\DetectionStatus), 'IGNORED': enum(Infection\Mutant\DetectionStatus), 'KILLED_BY_STATIC_ANALYSIS': enum(Infection\Mutant\DetectionStatus), 'KILLED_BY_TESTS': enum(Infection\Mutant\DetectionStatus), 'NOT_COVERED': enum(Infection\Mutant\DetectionStatus), 'SKIPPED': enum(Infection\Mutant\DetectionStatus), 'SYNTAX_ERROR': enum(Infection\Mutant\DetectionStatus), 'TIMED_OUT': enum(Infection\Mutant\DetectionStatus)}`.'''
+message = '''Invalid return type for function `Infection\Mutant\DetectionStatus::getIndexedCases`: expected `array<key-of<enum(infection\mutant\detectionstatus)>, enum(infection\mutant\detectionstatus)>`, but found `array{'ERROR': enum(Infection\Mutant\DetectionStatus), 'ESCAPED': enum(Infection\Mutant\DetectionStatus), 'IGNORED': enum(Infection\Mutant\DetectionStatus), 'KILLED_BY_STATIC_ANALYSIS': enum(Infection\Mutant\DetectionStatus), 'KILLED_BY_TESTS': enum(Infection\Mutant\DetectionStatus), 'NOT_COVERED': enum(Infection\Mutant\DetectionStatus), 'SKIPPED': enum(Infection\Mutant\DetectionStatus), 'SYNTAX_ERROR': enum(Infection\Mutant\DetectionStatus), 'TIMED_OUT': enum(Infection\Mutant\DetectionStatus)}`.'''
 count = 1
 
 [[issues]]
@@ -1593,7 +1593,7 @@ count = 1
 [[issues]]
 file = "src/Mutation/FileMutationGenerator.php"
 code = "possibly-false-argument"
-message = 'Argument #2 of method `infection\mutator\nodemutationgenerator::__construct` is possibly `false`, but parameter type `string` does not accept it.'
+message = 'Argument #2 of method `Infection\Mutator\NodeMutationGenerator::__construct` is possibly `false`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -1611,13 +1611,13 @@ count = 1
 [[issues]]
 file = "src/Mutation/MutationAttributeKeys.php"
 code = "less-specific-argument"
-message = '''Argument type mismatch for argument #1 of `infection\mutation\mutationattributekeys::assertallattributesexist`: expected `array<string('endFilePos')|string('endLine')|string('endTokenPos')|string('startFilePos')|string('startLine')|string('startTokenPos'), mixed>`, but provided type `array<array-key, float|int|string>` is less specific.'''
+message = '''Argument type mismatch for argument #1 of `Infection\Mutation\MutationAttributeKeys::assertAllAttributesExist`: expected `array<string('endFilePos')|string('endLine')|string('endTokenPos')|string('startFilePos')|string('startLine')|string('startTokenPos'), mixed>`, but provided type `array<array-key, float|int|string>` is less specific.'''
 count = 1
 
 [[issues]]
 file = "src/Mutation/MutationAttributeKeys.php"
 code = "less-specific-return-statement"
-message = '''Returned type `array<array-key, float|int|string>` is less specific than the declared return type `array<string('endFilePos')|string('endLine')|string('endTokenPos')|string('startFilePos')|string('startLine')|string('startTokenPos'), float|int|string>` for function `infection\mutation\mutationattributekeys::pluck`.'''
+message = '''Returned type `array<array-key, float|int|string>` is less specific than the declared return type `array<string('endFilePos')|string('endLine')|string('endTokenPos')|string('startFilePos')|string('startLine')|string('startTokenPos'), float|int|string>` for function `Infection\Mutation\MutationAttributeKeys::pluck`.'''
 count = 1
 
 [[issues]]
@@ -1629,7 +1629,7 @@ count = 1
 [[issues]]
 file = "src/Mutation/MutationGenerator.php"
 code = "possibly-false-argument"
-message = 'Argument #1 of method `infection\event\events\mutationanalysis\mutationgeneration\mutablefilewasprocessed::__construct` is possibly `false`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `Infection\Event\Events\MutationAnalysis\MutationGeneration\MutableFileWasProcessed::__construct` is possibly `false`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -1653,13 +1653,13 @@ count = 1
 [[issues]]
 file = "src/Mutator/Boolean/LogicalAndAllSubExprNegation.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `non-empty-string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `non-empty-string`."
 count = 1
 
 [[issues]]
 file = "src/Mutator/Boolean/LogicalOr.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `non-empty-string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `non-empty-string`."
 count = 1
 
 [[issues]]
@@ -1731,37 +1731,37 @@ count = 1
 [[issues]]
 file = "src/Mutator/Cast/AbstractCastMutator.php"
 code = "possibly-null-argument"
-message = 'Argument #1 of method `infection\phpparser\visitor\parentconnector::findparent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
+message = 'Argument #1 of method `Infection\PhpParser\Visitor\ParentConnector::findParent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/BCMath.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr>)` for function `infection\mutator\extensions\bcmath::makecheckingminargsmapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr>)` for function `Infection\Mutator\Extensions\BCMath::makeCheckingMinArgsMapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/BCMath.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\BinaryOp>)` for function `infection\mutator\extensions\bcmath::makebinaryoperatormapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\BinaryOp>)` for function `Infection\Mutator\Extensions\BCMath::makeBinaryOperatorMapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/BCMath.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\BinaryOp\Mod>)` for function `infection\mutator\extensions\bcmath::makepowermodulomapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\BinaryOp\Mod>)` for function `Infection\Mutator\Extensions\BCMath::makePowerModuloMapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/BCMath.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\Cast\String_>)` for function `infection\mutator\extensions\bcmath::makecasttostringmapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\Cast\String_>)` for function `Infection\Mutator\Extensions\BCMath::makeCastToStringMapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/BCMath.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `infection\mutator\extensions\bcmath::makesquarerootsmapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `Infection\Mutator\Extensions\BCMath::makeSquareRootsMapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -1779,19 +1779,19 @@ count = 1
 [[issues]]
 file = "src/Mutator/Extensions/MBString.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): Generator<mixed, mixed, mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `infection\mutator\extensions\mbstring::makeconvertcasemapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): Generator<mixed, mixed, mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `Infection\Mutator\Extensions\MBString::makeConvertCaseMapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/MBString.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `infection\mutator\extensions\mbstring::makefunctionandremoveextraargsmapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `Infection\Mutator\Extensions\MBString::makeFunctionAndRemoveExtraArgsMapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/MBString.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `infection\mutator\extensions\mbstring::makefunctionmapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `Infection\Mutator\Extensions\MBString::makeFunctionMapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -1803,7 +1803,7 @@ count = 1
 [[issues]]
 file = "src/Mutator/Extensions/MBString.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\mutator\extensions\mbstring::getconvertcasemodevalue`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Mutator\Extensions\MBString::getConvertCaseModeValue`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -1821,7 +1821,7 @@ count = 1
 [[issues]]
 file = "src/Mutator/IgnoreMutator.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Mutator\IgnoreConfig::isignored`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Mutator\IgnoreConfig::isIgnored`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -1875,7 +1875,7 @@ count = 1
 [[issues]]
 file = "src/Mutator/MutatorParser.php"
 code = "less-specific-return-statement"
-message = 'Returned type `list<array-key>` is less specific than the declared return type `array<array-key, string>` for function `infection\mutator\mutatorparser::parse`.'
+message = 'Returned type `list<array-key>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Mutator\MutatorParser::parse`.'
 count = 1
 
 [[issues]]
@@ -1905,49 +1905,49 @@ count = 1
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\mutator\mutatorresolver::resolve`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but found `array<string, array<array-key, string>>`.'
+message = 'Invalid return type for function `Infection\Mutator\MutatorResolver::resolve`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but found `array<string, array<array-key, string>>`.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #3 of `infection\mutator\mutatorresolver::registerfromclass`: expected `array<string, array<string, string>>`, but provided type `array<string, array<array-key, string>>` is less specific.'
+message = 'Argument type mismatch for argument #3 of `Infection\Mutator\MutatorResolver::registerFromClass`: expected `array<string, array<string, string>>`, but provided type `array<string, array<array-key, string>>` is less specific.'
 count = 2
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #3 of `infection\mutator\mutatorresolver::registerfromname`: expected `array<string, array<string, string>>`, but provided type `array<string, array<array-key, string>>` is less specific.'
+message = 'Argument type mismatch for argument #3 of `Infection\Mutator\MutatorResolver::registerFromName`: expected `array<string, array<string, string>>`, but provided type `array<string, array<array-key, string>>` is less specific.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #2 of `infection\mutator\mutatorresolver::registerfromclass`: expected `array<string, array<array-key, string>>|bool`, but provided type `array<string, array<array-key, mixed>>|bool` is less specific.'
+message = 'Argument type mismatch for argument #2 of `Infection\Mutator\MutatorResolver::registerFromClass`: expected `array<string, array<array-key, string>>|bool`, but provided type `array<string, array<array-key, mixed>>|bool` is less specific.'
 count = 2
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #2 of `infection\mutator\mutatorresolver::registerfromclass`: expected `array<string, array<array-key, string>>|bool`, but provided type `array<string, mixed>|bool` is less specific.'
+message = 'Argument type mismatch for argument #2 of `Infection\Mutator\MutatorResolver::registerFromClass`: expected `array<string, array<array-key, string>>|bool`, but provided type `array<string, mixed>|bool` is less specific.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "less-specific-return-statement"
-message = 'Returned type `array<array-key, mixed>` is less specific than the declared return type `array<string, array<array-key, mixed>>|bool` for function `infection\mutator\mutatorresolver::resolvesettings`.'
+message = 'Returned type `array<array-key, mixed>` is less specific than the declared return type `array<string, array<array-key, mixed>>|bool` for function `Infection\Mutator\MutatorResolver::resolveSettings`.'
 count = 2
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `array_unique`: expected `array<('K.array_unique() extends array-key), ('V.array_unique() extends mixed)>`, but found `mixed`."
+message = 'Invalid argument type for argument #1 of `Infection\Mutator\MutatorResolver::registerFromClass`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\mutator\mutatorresolver::registerfromclass`: expected `string`, but found `mixed`.'
+message = "Invalid argument type for argument #1 of `array_unique`: expected `array<('K.array_unique() extends array-key), ('V.array_unique() extends mixed)>`, but found `mixed`."
 count = 1
 
 [[issues]]
@@ -1983,13 +1983,13 @@ count = 2
 [[issues]]
 file = "src/Mutator/NodeMutationGenerator.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #5 of `infection\mutation\mutation::__construct`: expected `array<string, float|int|string>`, but provided type `array<string, mixed>` is less specific.'
+message = 'Argument type mismatch for argument #5 of `Infection\Mutation\Mutation::__construct`: expected `array<string, float|int|string>`, but provided type `array<string, mixed>` is less specific.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/NodeMutationGenerator.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `iterable<mixed, Infection\AbstractTestFramework\Coverage\TestLocation>|list<mixed>` is less specific than the declared return type `array<array-key, Infection\AbstractTestFramework\Coverage\TestLocation>` for function `infection\mutator\nodemutationgenerator::getalltestsforcurrentnode` due to nested 'mixed'.'''
+message = '''Returned type `iterable<mixed, Infection\AbstractTestFramework\Coverage\TestLocation>|list<mixed>` is less specific than the declared return type `array<array-key, Infection\AbstractTestFramework\Coverage\TestLocation>` for function `Infection\Mutator\NodeMutationGenerator::getAllTestsForCurrentNode` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -2001,13 +2001,13 @@ count = 1
 [[issues]]
 file = "src/Mutator/NodeMutationGenerator.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\mutator\nodemutationgenerator::isinsidefunction`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Mutator\NodeMutationGenerator::isInsideFunction`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/NodeMutationGenerator.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\mutator\nodemutationgenerator::isonfunctionsignature`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Mutator\NodeMutationGenerator::isOnFunctionSignature`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -2061,7 +2061,7 @@ count = 2
 [[issues]]
 file = "src/Mutator/Operator/Concat.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `phpparser\node\expr\binaryop::__construct`: expected `PhpParser\Node\Expr`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `PhpParser\Node\Expr\BinaryOp::__construct`: expected `PhpParser\Node\Expr`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -2103,19 +2103,19 @@ count = 1
 [[issues]]
 file = "src/Mutator/Regex/AbstractPregMatch.php"
 code = "hidden-generator-return"
-message = 'The value returned by generator function `infection\mutator\regex\abstractpregmatch::mutate` may be inaccessible to callers.'
+message = 'The value returned by generator function `Infection\Mutator\Regex\AbstractPregMatch::mutate` may be inaccessible to callers.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/Regex/AbstractPregMatch.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Regex\AbstractPregMatch::getnewregexargument`: expected `PhpParser\Node\Arg`, but possibly received `PhpParser\Node\Arg|PhpParser\Node\VariadicPlaceholder`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Regex\AbstractPregMatch::getNewRegexArgument`: expected `PhpParser\Node\Arg`, but possibly received `PhpParser\Node\Arg|PhpParser\Node\VariadicPlaceholder`.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/Regex/PregMatchMatches.php"
 code = "hidden-generator-return"
-message = 'The value returned by generator function `infection\mutator\regex\pregmatchmatches::mutate` may be inaccessible to callers.'
+message = 'The value returned by generator function `Infection\Mutator\Regex\PregMatchMatches::mutate` may be inaccessible to callers.'
 count = 1
 
 [[issues]]
@@ -2157,7 +2157,7 @@ count = 2
 [[issues]]
 file = "src/Mutator/Regex/PregQuote.php"
 code = "hidden-generator-return"
-message = 'The value returned by generator function `infection\mutator\regex\pregquote::mutate` may be inaccessible to callers.'
+message = 'The value returned by generator function `Infection\Mutator\Regex\PregQuote::mutate` may be inaccessible to callers.'
 count = 1
 
 [[issues]]
@@ -2307,13 +2307,13 @@ count = 5
 [[issues]]
 file = "src/Mutator/Util/AbstractIdenticalComparison.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Util\AbstractIdenticalComparison::getclassconstantvalue`: expected `PhpParser\Node\Identifier`, but possibly received `PhpParser\Node\Expr|PhpParser\Node\Expr\Error|PhpParser\Node\Identifier`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Util\AbstractIdenticalComparison::getClassConstantValue`: expected `PhpParser\Node\Identifier`, but possibly received `PhpParser\Node\Expr|PhpParser\Node\Expr\Error|PhpParser\Node\Identifier`.'
 count = 2
 
 [[issues]]
 file = "src/Mutator/Util/AbstractIdenticalComparison.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Util\AbstractIdenticalComparison::getstaticmethodreturntype`: expected `PhpParser\Node\Identifier`, but possibly received `PhpParser\Node\Expr|PhpParser\Node\Identifier`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Util\AbstractIdenticalComparison::getStaticMethodReturnType`: expected `PhpParser\Node\Identifier`, but possibly received `PhpParser\Node\Expr|PhpParser\Node\Identifier`.'
 count = 1
 
 [[issues]]
@@ -2343,13 +2343,13 @@ count = 1
 [[issues]]
 file = "src/Mutator/Util/NameResolver.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\mutator\util\nameresolver::resolvename`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Mutator\Util\NameResolver::resolveName`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/FileParser.php"
 code = "possibly-false-argument"
-message = 'Argument #1 of method `infection\phpparser\unparsablefile::frominvalidfile` is possibly `false`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `Infection\PhpParser\UnparsableFile::fromInvalidFile` is possibly `false`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -2469,13 +2469,13 @@ count = 1
 [[issues]]
 file = "src/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\phpparser\visitor\addidtotraversednodesvisitor\addidtotraversednodesvisitor::getnodeid`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitor::getNodeId`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/FullyQualifiedClassNameManipulator.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\phpparser\visitor\fullyqualifiedclassnamemanipulator::getfqcn`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\FullyQualifiedClassNameManipulator::getFqcn`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -2487,13 +2487,13 @@ count = 1
 [[issues]]
 file = "src/PhpParser/Visitor/LabelMutationCandidatesVisitor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\phpparser\visitor\labelmutationcandidatesvisitor::isinsidefunction`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\LabelMutationCandidatesVisitor::isInsideFunction`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/LabelMutationCandidatesVisitor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\phpparser\visitor\labelmutationcandidatesvisitor::isonfunctionsignature`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\LabelMutationCandidatesVisitor::isOnFunctionSignature`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -2517,19 +2517,19 @@ count = 1
 [[issues]]
 file = "src/PhpParser/Visitor/LabelNodesAsEligibleVisitor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\phpparser\visitor\labelnodesaseligiblevisitor::iseligible`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\LabelNodesAsEligibleVisitor::isEligible`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/ParentConnector.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\phpparser\visitor\parentconnector::findparent`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\ParentConnector::findParent`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/ParentConnector.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\phpparser\visitor\parentconnector::getparent`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\ParentConnector::getParent`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -2541,13 +2541,13 @@ count = 4
 [[issues]]
 file = "src/PhpParser/Visitor/ReflectionVisitor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\phpparser\visitor\reflectionvisitor::isstricttypesenabled`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\ReflectionVisitor::isStrictTypesEnabled`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/ReflectionVisitor.php"
 code = "possibly-null-argument"
-message = 'Argument #1 of method `infection\phpparser\visitor\parentconnector::findparent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
+message = 'Argument #1 of method `Infection\PhpParser\Visitor\ParentConnector::findParent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
 count = 1
 
 [[issues]]
@@ -2625,7 +2625,7 @@ count = 1
 [[issues]]
 file = "src/Process/Runner/ParallelProcessRunner.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `Infection\Process\Runner\ProcessQueue::enqueuefrom`: expected `Iterator<mixed, Infection\Process\MutantProcessContainer>`, but possibly received `Generator<mixed, Infection\Process\MutantProcessContainer, mixed, mixed>`.'
+message = 'Possible argument type mismatch for argument #1 of `Infection\Process\Runner\ProcessQueue::enqueueFrom`: expected `Iterator<mixed, Infection\Process\MutantProcessContainer>`, but possibly received `Generator<mixed, Infection\Process\MutantProcessContainer, mixed, mixed>`.'
 count = 3
 
 [[issues]]
@@ -2661,7 +2661,7 @@ count = 1
 [[issues]]
 file = "src/Reporter/BaseTextFileReporter.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #1 of `infection\reporter\basetextfilereporter::getmutatorline`: expected `int`, but provided type `array-key` is less specific.'
+message = 'Argument type mismatch for argument #1 of `Infection\Reporter\BaseTextFileReporter::getMutatorLine`: expected `int`, but provided type `array-key` is less specific.'
 count = 1
 
 [[issues]]
@@ -2673,13 +2673,13 @@ count = 8
 [[issues]]
 file = "src/Reporter/GitHubAnnotationsReporter.php"
 code = "possibly-null-argument"
-message = 'Argument #2 of method `symfony\component\filesystem\path::makerelative` is possibly `null`, but parameter type `string` does not accept it.'
+message = 'Argument #2 of method `Symfony\Component\Filesystem\Path::makeRelative` is possibly `null`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
 file = "src/Reporter/GitLabCodeQualityReporter.php"
 code = "possibly-null-argument"
-message = 'Argument #2 of method `symfony\component\filesystem\path::makerelative` is possibly `null`, but parameter type `string` does not accept it.'
+message = 'Argument #2 of method `Symfony\Component\Filesystem\Path::makeRelative` is possibly `null`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -2757,7 +2757,7 @@ count = 1
 [[issues]]
 file = "src/Reporter/Http/StrykerCurlClient.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\reporter\http\response::__construct`: expected `int`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Reporter\Http\Response::__construct`: expected `int`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -2793,13 +2793,13 @@ count = 2
 [[issues]]
 file = "src/Source/Collector/BasicSourceCollector.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\source\collector\basicsourcecollector::makepathsabsolute`: expected `array<array-key, non-empty-string>`, but found `array<array-key, string>|list<string>`.'
+message = 'Invalid return type for function `Infection\Source\Collector\BasicSourceCollector::makePathsAbsolute`: expected `array<array-key, non-empty-string>`, but found `array<array-key, string>|list<string>`.'
 count = 1
 
 [[issues]]
 file = "src/Source/Collector/BasicSourceCollector.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `Infection\FileSystem\Finder\Iterator\RealPathFilterIterator<mixed, mixed>|Iterator<mixed, Symfony\Component\Finder\SplFileInfo>|Symfony\Component\Finder\Iterator\PathFilterIterator` is less specific than the declared return type `Iterator<mixed, Symfony\Component\Finder\SplFileInfo>` for function `infection\source\collector\basicsourcecollector::filter` due to nested 'mixed'.'''
+message = '''Returned type `Infection\FileSystem\Finder\Iterator\RealPathFilterIterator<mixed, mixed>|Iterator<mixed, Symfony\Component\Finder\SplFileInfo>|Symfony\Component\Finder\Iterator\PathFilterIterator` is less specific than the declared return type `Iterator<mixed, Symfony\Component\Finder\SplFileInfo>` for function `Infection\Source\Collector\BasicSourceCollector::filter` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -2817,7 +2817,7 @@ count = 1
 [[issues]]
 file = "src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `infection\filesystem\locator\fileordirectorynotfound::multiplefilesdonotexist`.'
+message = 'Call to deprecated method: `Infection\FileSystem\Locator\FileOrDirectoryNotFound::multipleFilesDoNotExist`.'
 count = 1
 
 [[issues]]
@@ -2919,7 +2919,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/AdapterInstallationDecider.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\testframework\adapterinstallationdecider::shouldbeinstalled`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\TestFramework\AdapterInstallationDecider::shouldBeInstalled`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -2931,7 +2931,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/AdapterInstaller.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Composer\Autoload\ClassLoader::setpsr4`: expected `list<string>|string`, but possibly received `array<array-key, string>`.'
+message = 'Possible argument type mismatch for argument #2 of `Composer\Autoload\ClassLoader::setPsr4`: expected `list<string>|string`, but possibly received `array<array-key, string>`.'
 count = 1
 
 [[issues]]
@@ -2967,7 +2967,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/Config/TestFrameworkConfigLocator.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `infection\filesystem\locator\fileordirectorynotfound::multiplefilesdonotexist`.'
+message = 'Call to deprecated method: `Infection\FileSystem\Locator\FileOrDirectoryNotFound::multipleFilesDoNotExist`.'
 count = 1
 
 [[issues]]
@@ -3153,7 +3153,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #2 of `infection\testframework\tracing\trace\testlocations::__construct`: expected `array<string, Infection\TestFramework\Tracing\Trace\SourceMethodLineRange>`, but provided type `array<array-key, Infection\TestFramework\Tracing\Trace\SourceMethodLineRange>` is less specific.'
+message = 'Argument type mismatch for argument #2 of `Infection\TestFramework\Tracing\Trace\TestLocations::__construct`: expected `array<string, Infection\TestFramework\Tracing\Trace\SourceMethodLineRange>`, but provided type `array<array-key, Infection\TestFramework\Tracing\Trace\SourceMethodLineRange>` is less specific.'
 count = 1
 
 [[issues]]
@@ -3249,13 +3249,13 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #6 of `infection\testframework\phpunit\config\builder\initialconfigbuilder::__construct`: expected `array<array-key, string>`, but possibly received `array<array-key, false|string>|list<false|string>`.'
+message = 'Possible argument type mismatch for argument #6 of `Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder::__construct`: expected `array<array-key, string>`, but possibly received `array<array-key, false|string>|list<false|string>`.'
 count = 1
 
 [[issues]]
 file = "src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\testframework\phpunit\commandline\filterbuilder::splitmethodnamefromproviderkey`: expected `array{0: string, 1: string}`, but found `non-empty-list<string>`.'
+message = 'Invalid return type for function `Infection\TestFramework\PhpUnit\CommandLine\FilterBuilder::splitMethodNameFromProviderKey`: expected `array{0: string, 1: string}`, but found `non-empty-list<string>`.'
 count = 1
 
 [[issues]]
@@ -3273,7 +3273,7 @@ count = 2
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php"
 code = "possibly-false-argument"
-message = "Argument #1 of method `domnode::appendchild` is possibly `false`, but parameter type `DOMNode` does not accept it."
+message = "Argument #1 of method `DOMNode::appendChild` is possibly `false`, but parameter type `DOMNode` does not accept it."
 count = 2
 
 [[issues]]
@@ -3291,7 +3291,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
 code = "falsable-return-statement"
-message = '''Function `infection\testframework\phpunit\config\xmlconfigurationmanipulator::createnode` is declared to return `DOMElement` but possibly returns 'false' (inferred as `DOMElement|false`).'''
+message = '''Function `Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator::createNode` is declared to return `DOMElement` but possibly returns 'false' (inferred as `DOMElement|false`).'''
 count = 1
 
 [[issues]]
@@ -3303,13 +3303,13 @@ count = 2
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\testframework\phpunit\config\xmlconfigurationmanipulator::createnode`: expected `DOMElement`, but found `DOMElement|false`.'
+message = 'Invalid return type for function `Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator::createNode`: expected `DOMElement`, but found `DOMElement|false`.'
 count = 1
 
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
 code = "possibly-false-argument"
-message = "Argument #1 of method `domnode::appendchild` is possibly `false`, but parameter type `DOMNode` does not accept it."
+message = "Argument #1 of method `DOMNode::appendChild` is possibly `false`, but parameter type `DOMNode` does not accept it."
 count = 4
 
 [[issues]]
@@ -3321,13 +3321,13 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\testframework\phpunit\config\xmlconfigurationversionprovider::provide`: expected `string`, but found `null|string`.'
+message = 'Invalid return type for function `Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider::provide`: expected `string`, but found `null|string`.'
 count = 1
 
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php"
 code = "nullable-return-statement"
-message = 'Function `infection\testframework\phpunit\config\xmlconfigurationversionprovider::provide` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
+message = 'Function `Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider::provide` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
 count = 1
 
 [[issues]]
@@ -3339,7 +3339,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/TestFrameworkExtraOptionsFilter.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\testframework\testframeworkextraoptionsfilter::filterformutantprocess`: expected `string`, but found `array<array-key, mixed>|array<array-key, string>|string`.'
+message = 'Invalid return type for function `Infection\TestFramework\TestFrameworkExtraOptionsFilter::filterForMutantProcess`: expected `string`, but found `array<array-key, mixed>|array<array-key, string>|string`.'
 count = 1
 
 [[issues]]
@@ -3393,19 +3393,19 @@ count = 1
 [[issues]]
 file = "src/TestFramework/Tracing/Trace/EmptyTrace.php"
 code = "falsable-return-statement"
-message = '''Function `infection\testframework\tracing\trace\emptytrace::getrealpath` is declared to return `string` but possibly returns 'false' (inferred as `false|string`).'''
+message = '''Function `Infection\TestFramework\Tracing\Trace\EmptyTrace::getRealPath` is declared to return `string` but possibly returns 'false' (inferred as `false|string`).'''
 count = 1
 
 [[issues]]
 file = "src/TestFramework/Tracing/Trace/EmptyTrace.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\testframework\tracing\trace\emptytrace::getrealpath`: expected `string`, but found `false|string`.'
+message = 'Invalid return type for function `Infection\TestFramework\Tracing\Trace\EmptyTrace::getRealPath`: expected `string`, but found `false|string`.'
 count = 1
 
 [[issues]]
 file = "src/TestFramework/Tracing/Trace/LineRangeCalculator.php"
 code = "possibly-null-argument"
-message = 'Argument #1 of method `infection\phpparser\visitor\parentconnector::findparent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
+message = 'Argument #1 of method `Infection\PhpParser\Visitor\ParentConnector::findParent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
 count = 1
 
 [[issues]]
@@ -3447,13 +3447,13 @@ count = 1
 [[issues]]
 file = "src/TestFramework/VersionParser.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\testframework\versionparser::parse`: expected `string`, but found `null|string`.'
+message = 'Invalid return type for function `Infection\TestFramework\VersionParser::parse`: expected `string`, but found `null|string`.'
 count = 1
 
 [[issues]]
 file = "src/TestFramework/VersionParser.php"
 code = "nullable-return-statement"
-message = 'Function `infection\testframework\versionparser::parse` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
+message = 'Function `Infection\TestFramework\VersionParser::parse` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
 count = 1
 
 [[issues]]
@@ -3483,7 +3483,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/XML/SafeDOMXPath.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\testframework\xml\safedomxpath::querycount`: expected `non-negative-int`, but found `int`.'
+message = 'Invalid return type for function `Infection\TestFramework\XML\SafeDOMXPath::queryCount`: expected `non-negative-int`, but found `int`.'
 count = 1
 
 [[issues]]
@@ -3567,7 +3567,7 @@ count = 2
 [[issues]]
 file = "src/Testing/BaseMutatorTestCase.php"
 code = "possibly-null-argument"
-message = 'Argument #3 of method `infection\mutator\nodemutationgenerator::__construct` is possibly `null`, but parameter type `array<array-key, PhpParser\Node>` does not accept it.'
+message = 'Argument #3 of method `Infection\Mutator\NodeMutationGenerator::__construct` is possibly `null`, but parameter type `array<array-key, PhpParser\Node>` does not accept it.'
 count = 1
 
 [[issues]]
@@ -3579,7 +3579,7 @@ count = 1
 [[issues]]
 file = "src/Testing/MutatorName.php"
 code = "less-specific-return-statement"
-message = 'Returned type `array-key` is less specific than the declared return type `string` for function `infection\testing\mutatorname::getname`.'
+message = 'Returned type `array-key` is less specific than the declared return type `string` for function `Infection\Testing\MutatorName::getName`.'
 count = 1
 
 [[issues]]
@@ -3747,7 +3747,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-function-call.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `arrayoneitem_functioncall\test::getcollection`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `ArrayOneItem_FunctionCall\Test::getCollection`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -3771,7 +3771,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-method-call.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `arrayoneitem_methodcall\test::getcollection`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `ArrayOneItem_MethodCall\Test::getCollection`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -3855,7 +3855,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-mutates-return-typehint-fqcn-allows-null.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `functioncall_returntypehintfqcnallowsnull\test::test`: expected `DateTime|null`, but found `non-negative-int`.'
+message = 'Invalid return type for function `FunctionCall_ReturnTypehintFqcnAllowsNull\Test::test`: expected `DateTime|null`, but found `non-negative-int`.'
 count = 1
 
 [[issues]]
@@ -3867,13 +3867,13 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-not-mutates-return-typehint-fqcn-does-not-allow-null.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `functioncall_returntypehintfqcndoesnotallownull\test::test`: expected `DateTime`, but found `non-negative-int`.'
+message = 'Invalid return type for function `FunctionCall_ReturnTypehintFqcnDoesNotAllowNull\Test::test`: expected `DateTime`, but found `non-negative-int`.'
 count = 1
 
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-not-mutates-with-not-nullable-typehint.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `functioncall_notmutateswithnotnullabletypehint\test::test`: expected `bool`, but found `non-negative-int`.'
+message = 'Invalid return type for function `FunctionCall_NotMutatesWithNotNullableTypehint\Test::test`: expected `bool`, but found `non-negative-int`.'
 count = 1
 
 [[issues]]
@@ -3897,7 +3897,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/NewObject/no-mutates-scalar-return-typehint-allows-null.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `newobject_scalarreturntypehintsallowsnull\test::test`: expected `int|null`, but found `stdClass`.'
+message = 'Invalid return type for function `NewObject_ScalarReturnTypehintsAllowsNull\Test::test`: expected `int|null`, but found `stdClass`.'
 count = 1
 
 [[issues]]
@@ -3921,7 +3921,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/NewObject/no-not-mutates-scalar-return-typehint-does-not-allow-null.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `newobject_scalarreturntypehintfqcndoesnotallownull\test::test`: expected `int`, but found `stdClass`.'
+message = 'Invalid return type for function `NewObject_ScalarReturnTypehintFqcnDoesNotAllowNull\Test::test`: expected `int`, but found `stdClass`.'
 count = 1
 
 [[issues]]
@@ -3975,7 +3975,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-enum.php"
 code = "invalid-return-statement"
-message = 'Cannot return a non-referenceable value from function `protectedvisibilityfinal\testenum::foo`.'
+message = 'Cannot return a non-referenceable value from function `ProtectedVisibilityFinal\TestEnum::foo`.'
 count = 1
 
 [[issues]]
@@ -4005,7 +4005,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final.php"
 code = "invalid-return-statement"
-message = 'Cannot return a non-referenceable value from function `protectedvisibilityfinal\test::foo`.'
+message = 'Cannot return a non-referenceable value from function `ProtectedVisibilityFinal\Test::foo`.'
 count = 1
 
 [[issues]]
@@ -4329,7 +4329,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-one-class.php"
 code = "invalid-return-statement"
-message = 'Cannot return a non-referenceable value from function `publicvisibilityoneclass\test::foo`.'
+message = 'Cannot return a non-referenceable value from function `PublicVisibilityOneClass\Test::foo`.'
 count = 1
 
 [[issues]]
@@ -4611,7 +4611,7 @@ count = 2
 [[issues]]
 file = "tests/benchmark/BlackfireInstrumentor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\benchmark\blackfireinstrumentor::profilesample`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Benchmark\BlackfireInstrumentor::profileSample`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -4665,7 +4665,7 @@ count = 1
 [[issues]]
 file = "tests/benchmark/MutationGenerator/profile.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\benchmark\instrumentorfactory::create`: expected `bool`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Benchmark\InstrumentorFactory::create`: expected `bool`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -4701,7 +4701,7 @@ count = 3
 [[issues]]
 file = "tests/benchmark/ParseGitDiff/generator.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\benchmark\parsegitdiff\generator::generatefilepath`: expected `non-empty-string`, but found `string`.'
+message = 'Invalid return type for function `Infection\Benchmark\ParseGitDiff\Generator::generateFilePath`: expected `non-empty-string`, but found `string`.'
 count = 1
 
 [[issues]]
@@ -4731,7 +4731,7 @@ count = 1
 [[issues]]
 file = "tests/benchmark/ParseGitDiff/profile.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\benchmark\instrumentorfactory::create`: expected `bool`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Benchmark\InstrumentorFactory::create`: expected `bool`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -4773,7 +4773,7 @@ count = 1
 [[issues]]
 file = "tests/benchmark/Tracing/create-main.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `array<array-key, mixed>` is less specific than the declared return type `array<array-key, SplFileInfo>` for function `infection\benchmark\tracing\takepercentageofsources` due to nested 'mixed'.'''
+message = '''Returned type `array<array-key, mixed>` is less specific than the declared return type `array<array-key, SplFileInfo>` for function `Infection\Benchmark\Tracing\takePercentageOfSources` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -4821,7 +4821,7 @@ count = 1
 [[issues]]
 file = "tests/benchmark/Tracing/profile.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\benchmark\instrumentorfactory::create`: expected `bool`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Benchmark\InstrumentorFactory::create`: expected `bool`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -4869,7 +4869,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ConcreteClassReflector.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -4893,13 +4893,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
 code = "falsable-return-statement"
-message = '''Function `infection\tests\autoreview\envvariablemanipulation\envtestcasesprovider::checktestcaseforenvmanipulations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
+message = '''Function `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestCaseForEnvManipulations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
 code = "falsable-return-statement"
-message = '''Function `infection\tests\autoreview\envvariablemanipulation\envtestcasesprovider::checktestedclassforenvmanipulations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
+message = '''Function `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestedClassForEnvManipulations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
 count = 1
 
 [[issues]]
@@ -4917,13 +4917,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\tests\autoreview\envvariablemanipulation\envtestcasesprovider::checktestcaseforenvmanipulations`: expected `null|string`, but found `false|string`.'
+message = 'Invalid return type for function `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestCaseForEnvManipulations`: expected `null|string`, but found `false|string`.'
 count = 2
 
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\tests\autoreview\envvariablemanipulation\envtestcasesprovider::checktestedclassforenvmanipulations`: expected `null|string`, but found `false|string`.'
+message = 'Invalid return type for function `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestedClassForEnvManipulations`: expected `null|string`, but found `false|string`.'
 count = 1
 
 [[issues]]
@@ -4935,7 +4935,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 2
 
 [[issues]]
@@ -4983,7 +4983,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProviderTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -5013,7 +5013,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/Event/SubscriberProvider.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 2
 
 [[issues]]
@@ -5031,7 +5031,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/Event/SubscriberTest.php"
 code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but found `mixed`."
+message = "Invalid argument type for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but found `mixed`."
 count = 1
 
 [[issues]]
@@ -5091,13 +5091,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "falsable-return-statement"
-message = '''Function `infection\tests\autoreview\integrationgroup\integrationgroupprovider::checktestcaseforiooperations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
+message = '''Function `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::checkTestCaseForIoOperations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
 count = 3
 
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "falsable-return-statement"
-message = '''Function `infection\tests\autoreview\integrationgroup\integrationgroupprovider::checktestedclassforiooperations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
+message = '''Function `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::checkTestedClassForIoOperations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
 count = 1
 
 [[issues]]
@@ -5121,13 +5121,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\tests\autoreview\integrationgroup\integrationgroupprovider::checktestcaseforiooperations`: expected `null|string`, but found `false|string`.'
+message = 'Invalid return type for function `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::checkTestCaseForIoOperations`: expected `null|string`, but found `false|string`.'
 count = 3
 
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\tests\autoreview\integrationgroup\integrationgroupprovider::checktestedclassforiooperations`: expected `null|string`, but found `false|string`.'
+message = 'Invalid return type for function `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::checkTestedClassForIoOperations`: expected `null|string`, but found `false|string`.'
 count = 1
 
 [[issues]]
@@ -5145,7 +5145,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 2
 
 [[issues]]
@@ -5229,7 +5229,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -5259,7 +5259,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -5283,7 +5283,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php"
 code = "less-specific-return-statement"
-message = 'Returned type `list<array-key>` is less specific than the declared return type `array<array-key, string>` for function `infection\tests\autoreview\integrationgroup\iocodedetector::retrievesafefilesystemfunctions`.'
+message = 'Returned type `list<array-key>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Tests\AutoReview\IntegrationGroup\IoCodeDetector::retrieveSafeFileSystemFunctions`.'
 count = 1
 
 [[issues]]
@@ -5421,13 +5421,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
 code = "less-specific-nested-argument-type"
-message = "Argument type mismatch for argument #1 of `array_column`: expected `array<array-key, array<int(1), ('V.array_column() extends mixed)>|object>|list<array<int(1), ('V.array_column() extends mixed)>|object>`, but provided type `array<array-key, mixed>` is less specific."
+message = 'Argument type mismatch for argument #1 of `Infection\Tests\AutoReview\ConcreteClassReflector::filterByConcreteClasses`: expected `array<array-key, string>`, but provided type `list<mixed>` is less specific.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #1 of `infection\tests\autoreview\concreteclassreflector::filterbyconcreteclasses`: expected `array<array-key, string>`, but provided type `list<mixed>` is less specific.'
+message = "Argument type mismatch for argument #1 of `array_column`: expected `array<array-key, array<int(1), ('V.array_column() extends mixed)>|object>|list<array<int(1), ('V.array_column() extends mixed)>|object>`, but provided type `array<array-key, mixed>` is less specific."
 count = 1
 
 [[issues]]
@@ -5469,7 +5469,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorProviderTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 2
 
 [[issues]]
@@ -5583,7 +5583,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 3
 
 [[issues]]
@@ -5619,7 +5619,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/PhpDoc/PHPDocParser.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `list<mixed>` is less specific than the declared return type `array<array-key, string>` for function `infection\tests\autoreview\phpdoc\phpdocparser::parse` due to nested 'mixed'.'''
+message = '''Returned type `list<mixed>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Tests\AutoReview\PhpDoc\PHPDocParser::parse` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -5733,7 +5733,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #1 of `infection\tests\autoreview\concreteclassreflector::filterbyconcreteclasses`: expected `array<array-key, string>`, but provided type `array<array-key, mixed>` is less specific.'
+message = 'Argument type mismatch for argument #1 of `Infection\Tests\AutoReview\ConcreteClassReflector::filterByConcreteClasses`: expected `array<array-key, string>`, but provided type `array<array-key, mixed>` is less specific.'
 count = 1
 
 [[issues]]
@@ -5745,7 +5745,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -5835,7 +5835,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 4
 
 [[issues]]
@@ -5943,7 +5943,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/CI/MemoizedCiDetectorTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\CI\ConfigurableEnv::setvariables`: expected `array<string, false|string>`, but possibly received `array{'TRAVIS': true}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\CI\ConfigurableEnv::setVariables`: expected `array<string, false|string>`, but possibly received `array{'TRAVIS': true}`.'''
 count = 1
 
 [[issues]]
@@ -6195,7 +6195,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Tests\Command\Git\GitChangedFilesCommandTest::createcommandtester`: expected `Infection\Git\Git`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Tests\Command\Git\GitChangedFilesCommandTest::createCommandTester`: expected `Infection\Git\Git`, but found `mixed`.'
 count = 2
 
 [[issues]]
@@ -6267,7 +6267,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Tests\Command\Git\GitChangedLinesCommandTest::createcommandtester`: expected `Infection\Git\Git`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Tests\Command\Git\GitChangedLinesCommandTest::createCommandTester`: expected `Infection\Git\Git`, but found `mixed`.'
 count = 2
 
 [[issues]]
@@ -6621,7 +6621,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\config\guesser\phpunitpathguesser::__construct`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Config\Guesser\PhpUnitPathGuesser::__construct`: expected `stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -6633,7 +6633,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\config\guesser\sourcedirguesser::__construct`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Config\Guesser\SourceDirGuesser::__construct`: expected `stdClass`, but found `mixed`.'
 count = 8
 
 [[issues]]
@@ -6711,7 +6711,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\config\valueprovider\excludedirsprovider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Config\ValueProvider\ExcludeDirsProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -6807,7 +6807,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `infection\config\valueprovider\phpunitcustomexecutablepathprovider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Config\ValueProvider\PhpUnitCustomExecutablePathProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -6861,7 +6861,7 @@ count = 5
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\config\valueprovider\sourcedirsprovider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Config\ValueProvider\SourceDirsProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -6957,7 +6957,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\config\valueprovider\textlogfileprovider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Config\ValueProvider\TextLogFileProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -6987,7 +6987,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/ConfigurationBuilder.php"
 code = "no-value"
-message = 'Argument #2 passed to method `infection\mutator\ignoremutator::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Mutator\IgnoreMutator::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -7011,7 +7011,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
 code = "no-value"
-message = 'Argument #5 passed to method `infection\configuration\configurationfactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #5 passed to method `Infection\Configuration\ConfigurationFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -7209,7 +7209,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::assertjsonisschemavalid`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::assertJsonIsSchemaValid`: expected `stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -7257,385 +7257,385 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': null, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': null, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': string('src/bootstrap.php'), 'initialTestsPhpOptions': string('-d zend_extension=xdebug.so'), 'logs': Infection\Configuration\Entry\Logs, 'mutators': array{'@arithmetic': true, '@boolean': true, '@cast': true, '@conditional_boundary': true, '@conditional_negotiation': true, '@default': true, '@function_signature': true, '@loop': true, '@number': true, '@operator': true, '@regex': true, '@removal': true, '@return_value': true, '@sort': true, 'ArrayItem': true, 'ArrayItemRemoval': object{ignore: list{string('file')}, settings: object{limit: int(10), remove: string('first')}}, 'ArrayOneItem': true, 'AssignCoalesce': true, 'Assignment': true, 'AssignmentEqual': true, 'BCMath': object{ignore: list{string('file')}, settings: object{bcadd: false, bccomp: false, bcdiv: false, bcmod: false, bcmul: false, bcpow: false, bcpowmod: false, bcsqrt: false, bcsub: false}}, 'BitwiseAnd': true, 'BitwiseNot': true, 'BitwiseOr': true, 'BitwiseXor': true, 'Break_': true, 'CastArray': true, 'CastBool': true, 'CastFloat': true, 'CastInt': true, 'CastObject': true, 'CastString': true, 'Coalesce': true, 'Continue_': true, 'Decrement': true, 'DecrementInteger': true, 'DivEqual': true, 'Division': true, 'Equal': true, 'EqualIdentical': true, 'Exponentiation': true, 'FalseValue': true, 'Finally_': true, 'FloatNegation': true, 'For_': true, 'Foreach_': true, 'FunctionCall': true, 'FunctionCallRemoval': true, 'GreaterThan': true, 'GreaterThanNegotiation': true, 'GreaterThanOrEqualTo': true, 'GreaterThanOrEqualToNegotiation': true, 'Identical': true, 'Increment': true, 'IncrementInteger': true, 'IntegerNegation': true, 'LessThan': true, 'LessThanNegotiation': true, 'LessThanOrEqualTo': true, 'LessThanOrEqualToNegotiation': true, 'LogicalAnd': true, 'LogicalLowerAnd': true, 'LogicalLowerOr': true, 'LogicalNot': true, 'LogicalOr': true, 'MBString': object{ignore: list{string('file')}, settings: object{mb_chr: false, mb_convert_case: false, mb_ord: false, mb_parse_str: false, mb_send_mail: false, mb_strcut: false, mb_stripos: false, mb_stristr: false, mb_strlen: false, mb_strpos: false, mb_strrchr: false, mb_strripos: false, mb_strrpos: false, mb_strstr: false, mb_strtolower: false, mb_strtoupper: false, mb_substr: false, mb_substr_count: false}}, 'MethodCallRemoval': true, 'Minus': true, 'MinusEqual': true, 'ModEqual': true, 'Modulus': true, 'MulEqual': true, 'Multiplication': true, 'NewObject': true, 'NotEqual': true, 'NotEqualNotIdentical': true, 'NotIdentical': true, 'NotIdenticalNotEqual': true, 'OneZeroFloat': true, 'Plus': true, 'PlusEqual': true, 'PowEqual': true, 'PregMatchMatches': true, 'PregQuote': true, 'ProtectedVisibility': true, 'PublicVisibility': true, 'RoundingFamily': true, 'ShiftLeft': true, 'ShiftRight': true, 'Spaceship': true, 'This': true, 'Throw_': true, 'TrueValue': object{ignore: list{string('fileA')}, settings: object{array_search: false, in_array: false}}, 'UnwrapArrayChangeKeyCase': true, 'UnwrapArrayChunk': true, 'UnwrapArrayColumn': true, 'UnwrapArrayCombine': true, 'UnwrapArrayDiff': true, 'UnwrapArrayDiffAssoc': true, 'UnwrapArrayDiffKey': true, 'UnwrapArrayDiffUassoc': true, 'UnwrapArrayDiffUkey': true, 'UnwrapArrayFilter': true, 'UnwrapArrayFlip': true, 'UnwrapArrayIntersect': true, 'UnwrapArrayIntersectAssoc': true, 'UnwrapArrayIntersectKey': true, 'UnwrapArrayIntersectUassoc': true, 'UnwrapArrayIntersectUkey': true, 'UnwrapArrayKeys': true, 'UnwrapArrayMap': true, 'UnwrapArrayMerge': true, 'UnwrapArrayMergeRecursive': true, 'UnwrapArrayPad': true, 'UnwrapArrayReduce': true, 'UnwrapArrayReplace': true, 'UnwrapArrayReplaceRecursive': true, 'UnwrapArrayReverse': true, 'UnwrapArraySlice': true, 'UnwrapArraySplice': true, 'UnwrapArrayUdiff': true, 'UnwrapArrayUdiffAssoc': true, 'UnwrapArrayUdiffUassoc': true, 'UnwrapArrayUintersect': true, 'UnwrapArrayUintersectAssoc': true, 'UnwrapArrayUintersectUassoc': true, 'UnwrapArrayUnique': true, 'UnwrapArrayValues': true, 'UnwrapLcFirst': true, 'UnwrapStrRepeat': true, 'UnwrapStrToLower': true, 'UnwrapStrToUpper': true, 'UnwrapTrim': true, 'UnwrapUcFirst': true, 'UnwrapUcWords': true, 'Yield_': true}, 'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source, 'testFramework': string('phpunit'), 'testFrameworkOptions': string('--debug'), 'timeout': int(5), 'tmpDir': string('custom-tmp')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': string('src/bootstrap.php'), 'initialTestsPhpOptions': string('-d zend_extension=xdebug.so'), 'logs': Infection\Configuration\Entry\Logs, 'mutators': array{'@arithmetic': true, '@boolean': true, '@cast': true, '@conditional_boundary': true, '@conditional_negotiation': true, '@default': true, '@function_signature': true, '@loop': true, '@number': true, '@operator': true, '@regex': true, '@removal': true, '@return_value': true, '@sort': true, 'ArrayItem': true, 'ArrayItemRemoval': object{ignore: list{string('file')}, settings: object{limit: int(10), remove: string('first')}}, 'ArrayOneItem': true, 'AssignCoalesce': true, 'Assignment': true, 'AssignmentEqual': true, 'BCMath': object{ignore: list{string('file')}, settings: object{bcadd: false, bccomp: false, bcdiv: false, bcmod: false, bcmul: false, bcpow: false, bcpowmod: false, bcsqrt: false, bcsub: false}}, 'BitwiseAnd': true, 'BitwiseNot': true, 'BitwiseOr': true, 'BitwiseXor': true, 'Break_': true, 'CastArray': true, 'CastBool': true, 'CastFloat': true, 'CastInt': true, 'CastObject': true, 'CastString': true, 'Coalesce': true, 'Continue_': true, 'Decrement': true, 'DecrementInteger': true, 'DivEqual': true, 'Division': true, 'Equal': true, 'EqualIdentical': true, 'Exponentiation': true, 'FalseValue': true, 'Finally_': true, 'FloatNegation': true, 'For_': true, 'Foreach_': true, 'FunctionCall': true, 'FunctionCallRemoval': true, 'GreaterThan': true, 'GreaterThanNegotiation': true, 'GreaterThanOrEqualTo': true, 'GreaterThanOrEqualToNegotiation': true, 'Identical': true, 'Increment': true, 'IncrementInteger': true, 'IntegerNegation': true, 'LessThan': true, 'LessThanNegotiation': true, 'LessThanOrEqualTo': true, 'LessThanOrEqualToNegotiation': true, 'LogicalAnd': true, 'LogicalLowerAnd': true, 'LogicalLowerOr': true, 'LogicalNot': true, 'LogicalOr': true, 'MBString': object{ignore: list{string('file')}, settings: object{mb_chr: false, mb_convert_case: false, mb_ord: false, mb_parse_str: false, mb_send_mail: false, mb_strcut: false, mb_stripos: false, mb_stristr: false, mb_strlen: false, mb_strpos: false, mb_strrchr: false, mb_strripos: false, mb_strrpos: false, mb_strstr: false, mb_strtolower: false, mb_strtoupper: false, mb_substr: false, mb_substr_count: false}}, 'MethodCallRemoval': true, 'Minus': true, 'MinusEqual': true, 'ModEqual': true, 'Modulus': true, 'MulEqual': true, 'Multiplication': true, 'NewObject': true, 'NotEqual': true, 'NotEqualNotIdentical': true, 'NotIdentical': true, 'NotIdenticalNotEqual': true, 'OneZeroFloat': true, 'Plus': true, 'PlusEqual': true, 'PowEqual': true, 'PregMatchMatches': true, 'PregQuote': true, 'ProtectedVisibility': true, 'PublicVisibility': true, 'RoundingFamily': true, 'ShiftLeft': true, 'ShiftRight': true, 'Spaceship': true, 'This': true, 'Throw_': true, 'TrueValue': object{ignore: list{string('fileA')}, settings: object{array_search: false, in_array: false}}, 'UnwrapArrayChangeKeyCase': true, 'UnwrapArrayChunk': true, 'UnwrapArrayColumn': true, 'UnwrapArrayCombine': true, 'UnwrapArrayDiff': true, 'UnwrapArrayDiffAssoc': true, 'UnwrapArrayDiffKey': true, 'UnwrapArrayDiffUassoc': true, 'UnwrapArrayDiffUkey': true, 'UnwrapArrayFilter': true, 'UnwrapArrayFlip': true, 'UnwrapArrayIntersect': true, 'UnwrapArrayIntersectAssoc': true, 'UnwrapArrayIntersectKey': true, 'UnwrapArrayIntersectUassoc': true, 'UnwrapArrayIntersectUkey': true, 'UnwrapArrayKeys': true, 'UnwrapArrayMap': true, 'UnwrapArrayMerge': true, 'UnwrapArrayMergeRecursive': true, 'UnwrapArrayPad': true, 'UnwrapArrayReduce': true, 'UnwrapArrayReplace': true, 'UnwrapArrayReplaceRecursive': true, 'UnwrapArrayReverse': true, 'UnwrapArraySlice': true, 'UnwrapArraySplice': true, 'UnwrapArrayUdiff': true, 'UnwrapArrayUdiffAssoc': true, 'UnwrapArrayUdiffUassoc': true, 'UnwrapArrayUintersect': true, 'UnwrapArrayUintersectAssoc': true, 'UnwrapArrayUintersectUassoc': true, 'UnwrapArrayUnique': true, 'UnwrapArrayValues': true, 'UnwrapLcFirst': true, 'UnwrapStrRepeat': true, 'UnwrapStrToLower': true, 'UnwrapStrToUpper': true, 'UnwrapTrim': true, 'UnwrapUcFirst': true, 'UnwrapUcWords': true, 'Yield_': true}, 'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source, 'testFramework': string('phpunit'), 'testFrameworkOptions': string('--debug'), 'timeout': int(5), 'tmpDir': string('custom-tmp')}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': string('src/bootstrap.php'), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': string('src/bootstrap.php'), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'ignoreMsiWithNoMutations': false, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'ignoreMsiWithNoMutations': false, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'ignoreMsiWithNoMutations': true, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'ignoreMsiWithNoMutations': true, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'initialTestsPhpOptions': null, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'initialTestsPhpOptions': null, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'initialTestsPhpOptions': string('-d zend_extension=xdebug.so'), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'initialTestsPhpOptions': string('-d zend_extension=xdebug.so'), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'logs': Infection\Configuration\Entry\Logs, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'logs': Infection\Configuration\Entry\Logs, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 14
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'logs': infection\configuration\entry\logs, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'logs': infection\configuration\entry\logs, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minCoveredMsi': float(3.14), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minCoveredMsi': float(3.14), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minCoveredMsi': float(32.0), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minCoveredMsi': float(32.0), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minMsi': float(3.14), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minMsi': float(3.14), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minMsi': float(32.0), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minMsi': float(32.0), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'@arithmetic': true, '@boolean': true, '@cast': true, '@conditional_boundary': true, '@conditional_negotiation': true, '@default': true, '@function_signature': true, '@loop': true, '@number': true, '@operator': true, '@regex': true, '@removal': true, '@return_value': true, '@sort': true}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'@arithmetic': true, '@boolean': true, '@cast': true, '@conditional_boundary': true, '@conditional_negotiation': true, '@default': true, '@function_signature': true, '@loop': true, '@number': true, '@operator': true, '@regex': true, '@removal': true, '@return_value': true, '@sort': true}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': false}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': false}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string('file')}, settings: object{limit: int(10), remove: string('first')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string('file')}, settings: object{limit: int(10), remove: string('first')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{settings: object{limit: int(10)}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{settings: object{limit: int(10)}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{settings: object{remove: string('first')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{settings: object{remove: string('first')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': true}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': true}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': false}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': false}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string('file')}, settings: object{bcadd: false, bccomp: false, bcdiv: false, bcmod: false, bcmul: false, bcpow: false, bcpowmod: false, bcsqrt: false, bcsub: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string('file')}, settings: object{bcadd: false, bccomp: false, bcdiv: false, bcmod: false, bcmul: false, bcpow: false, bcpowmod: false, bcsqrt: false, bcsub: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{settings: stdClass}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{settings: stdClass}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': true}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': true}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': false}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': false}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string('file')}, settings: object{mb_chr: false, mb_convert_case: false, mb_ord: false, mb_parse_str: false, mb_send_mail: false, mb_strcut: false, mb_stripos: false, mb_stristr: false, mb_strlen: false, mb_strpos: false, mb_strrchr: false, mb_strripos: false, mb_strrpos: false, mb_strstr: false, mb_strtolower: false, mb_strtoupper: false, mb_substr: false, mb_substr_count: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string('file')}, settings: object{mb_chr: false, mb_convert_case: false, mb_ord: false, mb_parse_str: false, mb_send_mail: false, mb_strcut: false, mb_stripos: false, mb_stristr: false, mb_strlen: false, mb_strpos: false, mb_strrchr: false, mb_strripos: false, mb_strrpos: false, mb_strstr: false, mb_strtolower: false, mb_strtoupper: false, mb_substr: false, mb_substr_count: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{settings: stdClass}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{settings: stdClass}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': true}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': true}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': false}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': false}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string('fileA')}, settings: object{array_search: false, in_array: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string('fileA')}, settings: object{array_search: false, in_array: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{settings: object{array_search: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{settings: object{array_search: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{settings: object{in_array: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{settings: object{in_array: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': true}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': true}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': array{}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': array{}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': list{string(' file '), string(' ')}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': list{string(' file '), string(' ')}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': list{string('A::B')}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': list{string('A::B')}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, false>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, false>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, object{ignore: list{string(' file '), string('')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, object{ignore: list{string(' file '), string('')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, object{ignore: list{string('fileA'), string('fileB')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, object{ignore: list{string('fileA'), string('fileB')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, true>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, true>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), false>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), false>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), object{ignore: list{string(' file '), string('')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), object{ignore: list{string(' file '), string('')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), object{ignore: list{string('fileA'), string('fileB')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), object{ignore: list{string('fileA'), string('fileB')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), true>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), true>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 5
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFramework': string('phpunit')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFramework': string('phpunit')}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFramework': string}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFramework': string}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFrameworkOptions': null}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFrameworkOptions': null}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFrameworkOptions': string('--debug')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFrameworkOptions': string('--debug')}`.'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'timeout': int(100)}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'timeout': int(100)}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'tmpDir': null}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'tmpDir': null}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'tmpDir': string('custom-tmp')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'tmpDir': string('custom-tmp')}`.'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source}`.'''
 count = 5
 
 [[issues]]
@@ -7647,7 +7647,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "too-few-arguments"
-message = 'Too few arguments provided for method `infection\configuration\schema\schemaconfiguration::__construct`.'
+message = 'Too few arguments provided for method `Infection\Configuration\Schema\SchemaConfiguration::__construct`.'
 count = 1
 
 [[issues]]
@@ -7887,25 +7887,25 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Console/E2ETest.php"
 code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `Composer\Autoload\ClassLoader::setPsr4`: expected `string`, but found `mixed`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/E2ETest.php"
+code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `Composer\Autoload\ClassLoader::set`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Console/E2ETest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Composer\Autoload\ClassLoader::setpsr4`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Composer\Autoload\ClassLoader::setPsr4`: expected `list<string>|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Console/E2ETest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #2 of `Composer\Autoload\ClassLoader::set`: expected `list<string>|string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Composer\Autoload\ClassLoader::setpsr4`: expected `list<string>|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -8145,7 +8145,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Container/Builder/IndexXmlCoverageParserBuilderTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\tests\container\builder\indexxmlcoverageparserbuildertest::getissourcefiltered`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Tests\Container\Builder\IndexXmlCoverageParserBuilderTest::getIsSourceFiltered`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -8343,31 +8343,31 @@ count = 96
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #10 of `infection\engine::__construct`: expected `Infection\Metrics\MaxTimeoutsChecker`, but found `mixed`.'
+message = 'Invalid argument type for argument #10 of `Infection\Engine::__construct`: expected `Infection\Metrics\MaxTimeoutsChecker`, but found `mixed`.'
 count = 3
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #11 of `infection\engine::__construct`: expected `Infection\Console\ConsoleOutput`, but found `mixed`.'
+message = 'Invalid argument type for argument #11 of `Infection\Engine::__construct`: expected `Infection\Console\ConsoleOutput`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #13 of `infection\engine::__construct`: expected `Infection\TestFramework\TestFrameworkExtraOptionsFilter`, but found `mixed`.'
+message = 'Invalid argument type for argument #13 of `Infection\Engine::__construct`: expected `Infection\TestFramework\TestFrameworkExtraOptionsFilter`, but found `mixed`.'
 count = 5
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #15 of `infection\engine::__construct`: expected `Infection\StaticAnalysis\StaticAnalysisToolAdapter|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #15 of `Infection\Engine::__construct`: expected `Infection\StaticAnalysis\StaticAnalysisToolAdapter|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `infection\engine::__construct`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Engine::__construct`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
 count = 5
 
 [[issues]]
@@ -8997,7 +8997,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
 code = "no-value"
-message = 'Argument #1 passed to method `Infection\Event\EventDispatcher\SyncEventDispatcher::addsubscriber` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `Infection\Event\EventDispatcher\SyncEventDispatcher::addSubscriber` has type `never`, meaning it cannot produce a value.'
 count = 3
 
 [[issues]]
@@ -9087,7 +9087,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Event/Events/MutationAnalysis/MutationEvaluation/MutantProcessWasFinishedTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\event\events\mutationanalysis\mutationevaluation\mutantprocesswasfinished::__construct`: expected `Infection\Mutant\MutantExecutionResult`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished::__construct`: expected `Infection\Mutant\MutantExecutionResult`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -9135,7 +9135,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Event/Events/MutationAnalysis/MutationTestingWasStartedTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `infection\event\events\mutationanalysis\mutationtestingwasstarted::__construct`: expected `Infection\Process\Runner\ProcessRunner`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted::__construct`: expected `Infection\Process\Runner\ProcessRunner`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -9171,19 +9171,19 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
 code = "no-value"
-message = 'Argument #1 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -9321,7 +9321,7 @@ count = 6
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `infection\event\events\mutationanalysis\mutationtestingwasstarted::__construct`: expected `Infection\Process\Runner\ProcessRunner`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted::__construct`: expected `Infection\Process\Runner\ProcessRunner`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -9405,19 +9405,19 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "no-value"
-message = 'Argument #1 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -9453,7 +9453,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `infection\event\subscriber\subscriberregisterer::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher)`.'
+message = 'Possible argument type mismatch for argument #1 of `Infection\Event\Subscriber\SubscriberRegisterer::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher)`.'
 count = 2
 
 [[issues]]
@@ -9465,7 +9465,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/FileSystem/FileStoreTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\FileSystem\FileStore::getcontents`: expected `SplFileInfo|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\FileSystem\FileStore::getContents`: expected `SplFileInfo|string`, but found `mixed`.'
 count = 4
 
 [[issues]]
@@ -9759,7 +9759,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `infection\filesystem\finder\testframeworkfinder::__construct`: expected `Infection\FileSystem\Finder\ComposerExecutableFinder`, but possibly received `PHPUnit\Framework\MockObject\MockObject`.'
+message = 'Possible argument type mismatch for argument #1 of `Infection\FileSystem\Finder\TestFrameworkFinder::__construct`: expected `Infection\FileSystem\Finder\ComposerExecutableFinder`, but possibly received `PHPUnit\Framework\MockObject\MockObject`.'
 count = 5
 
 [[issues]]
@@ -9801,7 +9801,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `infection\filesystem\locator\fileordirectorynotfound::multiplefilesdonotexist`.'
+message = 'Call to deprecated method: `Infection\FileSystem\Locator\FileOrDirectoryNotFound::multipleFilesDoNotExist`.'
 count = 1
 
 [[issues]]
@@ -10755,7 +10755,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Logger/MutationGeneration/MutationGenerationLoggerFactoryTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `infection\logger\mutationgeneration\mutationgenerationloggerfactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Logger\MutationGeneration\MutationGenerationLoggerFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -10839,7 +10839,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
 code = "possibly-null-argument"
-message = 'Argument #1 of method `infection\tests\metrics\createmutantexecutionresult::addmutantexecutionresult` is possibly `null`, but parameter type `Infection\Metrics\Collector` does not accept it.'
+message = 'Argument #1 of method `Infection\Tests\Metrics\CreateMutantExecutionResult::addMutantExecutionResult` is possibly `null`, but parameter type `Infection\Metrics\Collector` does not accept it.'
 count = 2
 
 [[issues]]
@@ -11013,26 +11013,26 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::assertprovides`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
-count = 4
+message = 'Invalid argument type for argument #2 of `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::assertProvidesExcluding`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
+count = 10
 
 [[issues]]
 file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::assertprovidesexcluding`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
-count = 10
+message = 'Invalid argument type for argument #2 of `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::assertProvides`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
+count = 4
+
+[[issues]]
+file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `Infection\Metrics\TargetDetectionStatusesProvider::__construct`: expected `Infection\Configuration\Entry\Logs`, but found `mixed`.'
+count = 3
 
 [[issues]]
 file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 16
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\metrics\targetdetectionstatusesprovider::__construct`: expected `Infection\Configuration\Entry\Logs`, but found `mixed`.'
-count = 3
 
 [[issues]]
 file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
@@ -11217,7 +11217,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `infection\tests\mutant\mutantbuilder::materialize`.'
+message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
 count = 6
 
 [[issues]]
@@ -11319,6 +11319,12 @@ count = 6
 [[issues]]
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
 code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `Infection\FileSystem\FileStore::__construct`: expected `Infection\FileSystem\FileSystem`, but found `mixed`.'
+count = 2
+
+[[issues]]
+file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
+code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
 count = 1
 
@@ -11331,13 +11337,7 @@ count = 10
 [[issues]]
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\filesystem\filestore::__construct`: expected `Infection\FileSystem\FileSystem`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #4 of `infection\mutation\filemutationgenerator::__construct`: expected `Infection\Source\Matcher\SourceLineMatcher`, but found `mixed`.'
+message = 'Invalid argument type for argument #4 of `Infection\Mutation\FileMutationGenerator::__construct`: expected `Infection\Source\Matcher\SourceLineMatcher`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -11475,7 +11475,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutation/MutationBuilder.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #6 of `infection\tests\mutation\mutationbuilder::__construct`: expected `array<string, float|int|string>`, but provided type `array<array-key, float|int|string>` is less specific.'
+message = 'Argument type mismatch for argument #6 of `Infection\Tests\Mutation\MutationBuilder::__construct`: expected `array<string, float|int|string>`, but provided type `array<array-key, float|int|string>` is less specific.'
 count = 1
 
 [[issues]]
@@ -11511,7 +11511,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `infection\mutation\mutationgenerator::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but found `mixed`.'
+message = 'Invalid argument type for argument #3 of `Infection\Mutation\MutationGenerator::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -11523,7 +11523,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `infection\mutator\ignoremutator::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Mutator\IgnoreMutator::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -11643,13 +11643,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutation/MutationTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #2 of `phpparser\node\stmt\namespace_::__construct`: expected `array<array-key, PhpParser\Node\Stmt>|null`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
+message = 'Invalid argument type for argument #2 of `PhpParser\Node\Stmt\Namespace_::__construct`: expected `array<array-key, PhpParser\Node\Stmt>|null`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
 count = 5
 
 [[issues]]
 file = "tests/phpunit/Mutation/MutationTest.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #5 of `infection\mutation\mutation::__construct`: expected `array<string, float|int|string>`, but provided type `array<array-key, float|int|string>` is less specific.'
+message = 'Argument type mismatch for argument #5 of `Infection\Mutation\Mutation::__construct`: expected `array<string, float|int|string>`, but provided type `array<array-key, float|int|string>` is less specific.'
 count = 1
 
 [[issues]]
@@ -11781,7 +11781,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/Arithmetic/PlusTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #1 of `phpparser\node\expr\array_::__construct`: expected `array<array-key, PhpParser\Node\ArrayItem>`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
+message = 'Invalid argument type for argument #1 of `PhpParser\Node\Expr\Array_::__construct`: expected `array<array-key, PhpParser\Node\ArrayItem>`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
 count = 2
 
 [[issues]]
@@ -11843,48 +11843,6 @@ file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
-code = "mixed-operand"
-message = "Left operand in `==` comparison has `mixed` type."
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
-code = "non-existent-constant"
-message = 'Undefined constant: `Infection\Tests\Mutator\Boolean\PHP`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
-code = "non-existent-constant"
-message = 'Undefined constant: `Infection\Tests\Mutator\Boolean\_MAJOR_VERSION`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
-code = "non-existent-constant"
-message = 'Undefined constant: `Infection\Tests\Mutator\Boolean\_SAPI`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
-code = "parse"
-message = "Parse error encountered during parsing"
-count = 42
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
-code = "unevaluated-code"
-message = "Unreachable code detected."
-count = 15
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
-code = "unused-statement"
-message = "Expression has no effect as a statement"
-count = 8
 
 [[issues]]
 file = "tests/phpunit/Mutator/Boolean/FalseValueTest.php"
@@ -12057,7 +12015,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Mutator/Boolean/TrueValueConfigTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\mutator\boolean\truevalueconfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Boolean\TrueValueConfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
 count = 1
 
 [[issues]]
@@ -12237,7 +12195,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/DefinitionTest.php"
 code = "possibly-null-argument"
-message = 'Argument #4 of method `infection\mutator\definition::__construct` is possibly `null`, but parameter type `string` does not accept it.'
+message = 'Argument #4 of method `Infection\Mutator\Definition::__construct` is possibly `null`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -12261,7 +12219,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Mutator/Extensions/BCMathConfigTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\mutator\extensions\bcmathconfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Extensions\BCMathConfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
 count = 1
 
 [[issues]]
@@ -12339,7 +12297,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Mutator/Extensions/MBStringConfigTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\mutator\extensions\mbstringconfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Extensions\MBStringConfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
 count = 1
 
 [[issues]]
@@ -12567,7 +12525,7 @@ count = 7
 [[issues]]
 file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #2 of `infection\mutator\ignoremutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\ignoremutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
+message = '''Possible argument type mismatch for argument #2 of `Infection\Mutator\IgnoreMutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\ignoremutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
 count = 4
 
 [[issues]]
@@ -12669,7 +12627,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #1 of `Infection\Tests\Mutator\MutatorFactoryTest::assertsamemutatorsbyclass`: expected `array<array-key, string>`, but provided type `list<mixed>` is less specific.'
+message = 'Argument type mismatch for argument #1 of `Infection\Tests\Mutator\MutatorFactoryTest::assertSameMutatorsByClass`: expected `array<array-key, string>`, but provided type `list<mixed>` is less specific.'
 count = 1
 
 [[issues]]
@@ -12783,7 +12741,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #3 of `Infection\Tests\Mutator\MutatorFactoryTest::createboolnode`: expected `Infection\Reflection\ClassReflection`, but possibly received `Infection\Reflection\ClassReflection|PHPUnit\Framework\MockObject\MockObject`.'
+message = 'Possible argument type mismatch for argument #3 of `Infection\Tests\Mutator\MutatorFactoryTest::createBoolNode`: expected `Infection\Reflection\ClassReflection`, but possibly received `Infection\Reflection\ClassReflection|PHPUnit\Framework\MockObject\MockObject`.'
 count = 1
 
 [[issues]]
@@ -12975,7 +12933,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\testing\mutatorname::getname`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Testing\MutatorName::getName`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -13083,7 +13041,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Mutator/NoopMutatorTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\mutator\noopmutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\noopmutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\NoopMutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\noopmutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
 count = 3
 
 [[issues]]
@@ -13275,7 +13233,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/ProfileListProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\tests\mutator\profilelistprovider::getprofiles`: expected `array<array-key, mixed>`, but found `array<string, array<array-key, string>>|null`.'
+message = 'Invalid return type for function `Infection\Tests\Mutator\ProfileListProvider::getProfiles`: expected `array<array-key, mixed>`, but found `array<string, array<array-key, string>>|null`.'
 count = 1
 
 [[issues]]
@@ -13293,13 +13251,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/ProfileListProvider.php"
 code = "nullable-return-statement"
-message = 'Function `infection\tests\mutator\profilelistprovider::getprofiles` is declared to return `array<array-key, mixed>` but possibly returns a nullable value (inferred as `array<string, array<array-key, string>>|null`).'
+message = 'Function `Infection\Tests\Mutator\ProfileListProvider::getProfiles` is declared to return `array<array-key, mixed>` but possibly returns a nullable value (inferred as `array<string, array<array-key, string>>|null`).'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/ProfileListProvider.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -13425,13 +13383,13 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\mutator\removal\arrayitemremovalconfig::__construct`: expected `array{'limit'?: int|null, 'remove'?: null|string}`, but possibly received `array<array-key, mixed>`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Removal\ArrayItemRemovalConfig::__construct`: expected `array{'limit'?: int|null, 'remove'?: null|string}`, but possibly received `array<array-key, mixed>`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `infection\mutator\removal\arrayitemremovalconfig::__construct`: expected `array{'limit'?: int|null, 'remove'?: null|string}`, but possibly received `array{'limit': string('foo')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Removal\ArrayItemRemovalConfig::__construct`: expected `array{'limit'?: int|null, 'remove'?: null|string}`, but possibly received `array{'limit': string('foo')}`.'''
 count = 1
 
 [[issues]]
@@ -13917,7 +13875,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\tests\mutator\util\abstractvaluetonullreturnvaluetest::mockfunction`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::mockFunction`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -14157,7 +14115,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperScenario.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #1 of `infection\tests\phpparser\nodedumper\nodedumper\nodedumperscenario::__construct`: expected `PhpParser\Node|list<PhpParser\Node>`, but found `string`.'
+message = 'Invalid argument type for argument #1 of `Infection\Tests\PhpParser\NodeDumper\NodeDumper\NodeDumperScenario::__construct`: expected `PhpParser\Node|list<PhpParser\Node>`, but found `string`.'
 count = 1
 
 [[issues]]
@@ -14205,7 +14163,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
 code = "invalid-argument"
-message = '''Invalid argument type for argument #1 of `infection\tests\phpparser\nodedumper\nodedumper\nodedumperscenario::fornode`: expected `PhpParser\Node|list<PhpParser\Node>`, but found `array{0: string('Foo'), 1: string('Bar'), 'Key': string('FooBar')}`.'''
+message = '''Invalid argument type for argument #1 of `Infection\Tests\PhpParser\NodeDumper\NodeDumper\NodeDumperScenario::forNode`: expected `PhpParser\Node|list<PhpParser\Node>`, but found `array{0: string('Foo'), 1: string('Bar'), 'Key': string('FooBar')}`.'''
 count = 1
 
 [[issues]]
@@ -14253,19 +14211,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\tests\phpparser\nodetraverserfactorytest::getvisitorclassnames`: expected `list<class-string<PhpParser\NodeVisitor>>`, but found `list<string>`.'
+message = 'Invalid return type for function `Infection\Tests\PhpParser\NodeTraverserFactoryTest::getVisitorClassNames`: expected `list<class-string<PhpParser\NodeVisitor>>`, but found `list<string>`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #1 of `infection\tests\phpparser\nodetraverserfactorytest::getvisitorclassnames`: expected `PhpParser\NodeTraverser`, but provided type `PhpParser\NodeTraverserInterface` is less specific.'
+message = 'Argument type mismatch for argument #1 of `Infection\Tests\PhpParser\NodeTraverserFactoryTest::getVisitorClassNames`: expected `PhpParser\NodeTraverser`, but provided type `PhpParser\NodeTraverserInterface` is less specific.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "no-value"
-message = 'Argument #1 passed to method `Infection\PhpParser\NodeTraverserFactory::createmutationtraverser` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `Infection\PhpParser\NodeTraverserFactory::createMutationTraverser` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -14289,7 +14247,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #2 of `Infection\Tests\PhpParser\NodeTraverserFactoryTest::asserttraverservisitorsare`: expected `list<class-string<PhpParser\NodeVisitor>>`, but possibly received `list{class-string('PhpParser\NodeVisitor\CloningVisitor'), class-string('Infection\Tests\Fixtures\PhpParser\FakeVisitor')}`.'''
+message = '''Possible argument type mismatch for argument #2 of `Infection\Tests\PhpParser\NodeTraverserFactoryTest::assertTraverserVisitorsAre`: expected `list<class-string<PhpParser\NodeVisitor>>`, but possibly received `list{class-string('PhpParser\NodeVisitor\CloningVisitor'), class-string('Infection\Tests\Fixtures\PhpParser\FakeVisitor')}`.'''
 count = 1
 
 [[issues]]
@@ -14439,7 +14397,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameManipulatorTest.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\tests\phpparser\visitor\fullyqualifiedclassnamemanipulatortest::getfqcns`: expected `array<int, PhpParser\Node\Name>`, but found `array<int, PhpParser\Node\Name|null>`.'
+message = 'Invalid return type for function `Infection\Tests\PhpParser\Visitor\FullyQualifiedClassNameManipulatorTest::getFqcns`: expected `array<int, PhpParser\Node\Name>`, but found `array<int, PhpParser\Node\Name|null>`.'
 count = 1
 
 [[issues]]
@@ -14565,7 +14523,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\tests\phpparser\visitor\marktraversednodesasvisitedvisitor\marktraversednodesasvisitedvisitortest::clonenodes`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Tests\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitorTest::cloneNodes`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -14679,13 +14637,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\phpparser\visitor\parentconnector::findparent`: expected `PhpParser\Node`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\PhpParser\Visitor\ParentConnector::findParent`: expected `PhpParser\Node`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\phpparser\visitor\parentconnector::getparent`: expected `PhpParser\Node`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\PhpParser\Visitor\ParentConnector::getParent`: expected `PhpParser\Node`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -14763,7 +14721,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCase.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `infection\tests\phpparser\visitor\visitortestcase\visitortestcase::parse`: expected `array<array-key, PhpParser\Node\Stmt>`, but found `array<array-key, PhpParser\Node\Stmt>|null`.'
+message = 'Invalid return type for function `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase::parse`: expected `array<array-key, PhpParser\Node\Stmt>`, but found `array<array-key, PhpParser\Node\Stmt>|null`.'
 count = 1
 
 [[issues]]
@@ -14787,7 +14745,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCase.php"
 code = "nullable-return-statement"
-message = 'Function `infection\tests\phpparser\visitor\visitortestcase\visitortestcase::parse` is declared to return `array<array-key, PhpParser\Node\Stmt>` but possibly returns a nullable value (inferred as `array<array-key, PhpParser\Node\Stmt>|null`).'
+message = 'Function `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase::parse` is declared to return `array<array-key, PhpParser\Node\Stmt>` but possibly returns a nullable value (inferred as `array<array-key, PhpParser\Node\Stmt>|null`).'
 count = 1
 
 [[issues]]
@@ -14871,7 +14829,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Process/Factory/InitialStaticAnalysisProcessFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\process\factory\initialstaticanalysisprocessfactory::__construct`: expected `Infection\StaticAnalysis\StaticAnalysisToolAdapter`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Process\Factory\InitialStaticAnalysisProcessFactory::__construct`: expected `Infection\StaticAnalysis\StaticAnalysisToolAdapter`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -14925,7 +14883,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `infection\tests\mutant\mutantbuilder::materialize`.'
+message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
 count = 1
 
 [[issues]]
@@ -15105,7 +15063,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/IndexedMutantProcessContainerTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `infection\process\runner\indexedmutantprocesscontainer::__construct`: expected `Infection\Process\MutantProcessContainer`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Process\Runner\IndexedMutantProcessContainer::__construct`: expected `Infection\Process\MutantProcessContainer`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -15165,7 +15123,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `infection\process\runner\initialstaticanalysisrunner::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Process\Runner\InitialStaticAnalysisRunner::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -15255,7 +15213,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `infection\process\runner\initialtestsrunner::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Process\Runner\InitialTestsRunner::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -15327,7 +15285,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `infection\tests\mutant\mutantbuilder::materialize`.'
+message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
 count = 11
 
 [[issues]]
@@ -15363,13 +15321,13 @@ count = 22
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertaresameevents`: expected `array<array-key, Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationWasStarted|Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished|Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted>`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertAreSameEvents`: expected `array<array-key, Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationWasStarted|Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished|Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted>`, but found `mixed`.'
 count = 7
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::asserthasevent`: expected `array<array-key, object>`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertHasEvent`: expected `array<array-key, object>`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -15381,13 +15339,13 @@ count = 6
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\tests\process\runner\mutationtestingrunnertest::someiterable`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Tests\Process\Runner\MutationTestingRunnerTest::someIterable`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "no-value"
-message = 'Argument #4 passed to method `infection\process\runner\mutationtestingrunner::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #4 passed to method `Infection\Process\Runner\MutationTestingRunner::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -15519,7 +15477,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #4 of `infection\process\runner\mutationtestingrunner::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`.'
+message = 'Possible argument type mismatch for argument #4 of `Infection\Process\Runner\MutationTestingRunner::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`.'
 count = 6
 
 [[issues]]
@@ -15591,7 +15549,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `infection\process\runner\indexedmutantprocesscontainer::__construct`: expected `Infection\Process\MutantProcessContainer`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Process\Runner\IndexedMutantProcessContainer::__construct`: expected `Infection\Process\MutantProcessContainer`, but found `mixed`.'
 count = 6
 
 [[issues]]
@@ -15609,7 +15567,7 @@ count = 17
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "no-value"
-message = 'Argument #1 passed to method `infection\process\mutantprocesscontainer::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `Infection\Process\MutantProcessContainer::__construct` has type `never`, meaning it cannot produce a value.'
 count = 5
 
 [[issues]]
@@ -15957,13 +15915,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reflection/ContainerReflection.php"
 code = "less-specific-nested-argument-type"
-message = '''Argument type mismatch for argument #1 of `infection\tests\reflection\containerreflection::handlecommonerrors`: expected `(callable(class-string<'T.infection\tests\reflection\containerreflection::createservice() extends object>): ('T.infection\tests\reflection\containerreflection::createservice() extends object)|null)`, but provided type `(closure(...mixed=): mixed)` is less specific.'''
+message = '''Argument type mismatch for argument #1 of `Infection\Tests\Reflection\ContainerReflection::handleCommonErrors`: expected `(callable(class-string<'T.infection\tests\reflection\containerreflection::createservice() extends object>): ('T.infection\tests\reflection\containerreflection::createservice() extends object)|null)`, but provided type `(closure(...mixed=): mixed)` is less specific.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Reflection/ContainerReflection.php"
 code = "less-specific-nested-argument-type"
-message = '''Argument type mismatch for argument #1 of `infection\tests\reflection\containerreflection::handlecommonerrors`: expected `(callable(class-string<'T.infection\tests\reflection\containerreflection::getservice() extends object>): ('T.infection\tests\reflection\containerreflection::getservice() extends object)|null)`, but provided type `(closure(...mixed=): mixed)` is less specific.'''
+message = '''Argument type mismatch for argument #1 of `Infection\Tests\Reflection\ContainerReflection::handleCommonErrors`: expected `(callable(class-string<'T.infection\tests\reflection\containerreflection::getservice() extends object>): ('T.infection\tests\reflection\containerreflection::getservice() extends object)|null)`, but provided type `(closure(...mixed=): mixed)` is less specific.'''
 count = 1
 
 [[issues]]
@@ -15981,7 +15939,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reflection/ContainerReflection.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\tests\reflection\containerreflection::getfactories`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Tests\Reflection\ContainerReflection::getFactories`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -16065,19 +16023,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
 count = 7
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
 count = 7
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
 code = "no-value"
-message = 'Argument #4 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #4 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
 count = 7
 
 [[issues]]
@@ -16125,7 +16083,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `infection\reporter\filereporterfactory::__construct`: expected `Symfony\Component\Filesystem\Filesystem`, but found `mixed`.'
+message = 'Invalid argument type for argument #3 of `Infection\Reporter\FileReporterFactory::__construct`: expected `Symfony\Component\Filesystem\Filesystem`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -16143,7 +16101,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
 code = "no-value"
-message = 'Argument #7 passed to method `infection\reporter\filereporterfactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #7 passed to method `Infection\Reporter\FileReporterFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -16191,7 +16149,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
 count = 4
 
 [[issues]]
@@ -16335,7 +16293,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
 code = "possibly-null-argument"
-message = 'Argument #2 of method `infection\mutant\mutantexecutionresult::__construct` is possibly `null`, but parameter type `string` does not accept it.'
+message = 'Argument #2 of method `Infection\Mutant\MutantExecutionResult::__construct` is possibly `null`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -16473,13 +16431,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `infection\reporter\strykerreporterfactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `Infection\Reporter\StrykerReporterFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
 code = "no-value"
-message = 'Argument #4 passed to method `infection\reporter\strykerreporterfactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #4 passed to method `Infection\Reporter\StrykerReporterFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -16587,13 +16545,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `infection\resource\listener\performanceloggersubscriber::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Resource\Listener\PerformanceLoggerSubscriber::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `infection\resource\listener\performanceloggersubscriber::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `Infection\Resource\Listener\PerformanceLoggerSubscriber::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -16683,7 +16641,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
 code = "too-few-arguments"
-message = "Too few arguments provided for method `ReflectionProperty::setvalue`."
+message = "Too few arguments provided for method `ReflectionProperty::setValue`."
 count = 2
 
 [[issues]]
@@ -16731,13 +16689,13 @@ count = 6
 [[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Resource\Memory\MemoryLimiter::limitmemory`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Resource\Memory\MemoryLimiter::limitMemory`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Resource\Memory\MemoryLimiter::limitmemory` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Resource\Memory\MemoryLimiter::limitMemory` has type `never`, meaning it cannot produce a value.'
 count = 3
 
 [[issues]]
@@ -16863,7 +16821,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #1 of `infection\tests\source\collector\basicsourcecollector\basicsourcecollectortest::normalizepaths`: expected `array<string, SplFileInfo>`, but provided type `array<array-key, SplFileInfo>` is less specific.'
+message = 'Argument type mismatch for argument #1 of `Infection\Tests\Source\Collector\BasicSourceCollector\BasicSourceCollectorTest::normalizePaths`: expected `array<string, SplFileInfo>`, but provided type `array<array-key, SplFileInfo>` is less specific.'
 count = 1
 
 [[issues]]
@@ -16887,7 +16845,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `infection\source\collector\basicsourcecollector::create`: expected `array<array-key, non-empty-string>`, but possibly received `list{string}`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\Source\Collector\BasicSourceCollector::create`: expected `array<array-key, non-empty-string>`, but possibly received `list{string}`.'
 count = 1
 
 [[issues]]
@@ -16977,7 +16935,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Source/Collector/SourceCollectorFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\source\collector\sourcecollectorfactory::__construct`: expected `Infection\Git\Git`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Source\Collector\SourceCollectorFactory::__construct`: expected `Infection\Git\Git`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -17121,19 +17079,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
 code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::__construct`: expected `Symfony\Component\Filesystem\Filesystem`, but found `mixed`.'
+count = 6
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
+code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 4
 
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\staticanalysis\phpstan\adapter\phpstanadapter::__construct`: expected `Symfony\Component\Filesystem\Filesystem`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `infection\staticanalysis\phpstan\adapter\phpstanadapter::__construct`: expected `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::__construct`: expected `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory`, but found `mixed`.'
 count = 6
 
 [[issues]]
@@ -17187,7 +17145,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `infection\tests\mutant\mutantbuilder::materialize`.'
+message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
 count = 4
 
 [[issues]]
@@ -17223,7 +17181,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `infection\tests\mutant\mutantbuilder::materialize`.'
+message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
 count = 3
 
 [[issues]]
@@ -17235,7 +17193,7 @@ count = 6
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `infection\staticanalysis\phpstan\process\phpstanmutantprocessfactory::__construct`: expected `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory::__construct`: expected `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory`, but found `mixed`.'
 count = 3
 
 [[issues]]
@@ -17271,13 +17229,13 @@ count = 6
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `infection\staticanalysis\staticanalysistoolfactory::__construct`: expected `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\StaticAnalysis\StaticAnalysisToolFactory::__construct`: expected `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `infection\staticanalysis\staticanalysistoolfactory::__construct`: expected `Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator`, but found `mixed`.'
+message = 'Invalid argument type for argument #3 of `Infection\StaticAnalysis\StaticAnalysisToolFactory::__construct`: expected `Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -18717,7 +18675,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\testframework\coverage\xmlreport\testlocator::__construct`: expected `Infection\TestFramework\Tracing\Trace\TestLocations`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\TestFramework\Coverage\XmlReport\TestLocator::__construct`: expected `Infection\TestFramework\Tracing\Trace\TestLocations`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -18741,7 +18699,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `infection\tests\testframework\tracing\trace\testlocationsnormalizer::normalize`: expected `array<array-key, Infection\AbstractTestFramework\Coverage\TestLocation|Infection\TestFramework\Tracing\Trace\TestLocations>`, but possibly received `iterable<mixed, Infection\AbstractTestFramework\Coverage\TestLocation>`.'
+message = 'Possible argument type mismatch for argument #1 of `Infection\Tests\TestFramework\Tracing\Trace\TestLocationsNormalizer::normalize`: expected `array<array-key, Infection\AbstractTestFramework\Coverage\TestLocation|Infection\TestFramework\Tracing\Trace\TestLocations>`, but possibly received `iterable<mixed, Infection\AbstractTestFramework\Coverage\TestLocation>`.'
 count = 2
 
 [[issues]]
@@ -18849,7 +18807,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\tests\testframework\coverage\xmlreport\xmlcoverageparser\xmlcoverageparsertest::createsourcefileinfoproviderstub`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\XmlCoverageParserTest::createSourceFileInfoProviderStub`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -18879,13 +18837,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/FactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `infection\testframework\factory::__construct`: expected `Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface`, but found `mixed`.'
+message = 'Invalid argument type for argument #3 of `Infection\TestFramework\Factory::__construct`: expected `Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface`, but found `mixed`.'
 count = 2
 
 [[issues]]
 file = "tests/phpunit/TestFramework/FactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #4 of `infection\testframework\factory::__construct`: expected `Infection\FileSystem\Finder\TestFrameworkFinder`, but found `mixed`.'
+message = 'Invalid argument type for argument #4 of `Infection\TestFramework\Factory::__construct`: expected `Infection\FileSystem\Finder\TestFrameworkFinder`, but found `mixed`.'
 count = 2
 
 [[issues]]
@@ -18957,13 +18915,13 @@ count = 15
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #5 of `infection\testframework\phpunit\adapter\phpunitadapter::__construct`: expected `Infection\TestFramework\Config\InitialConfigBuilder`, but found `mixed`.'
+message = 'Invalid argument type for argument #5 of `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter::__construct`: expected `Infection\TestFramework\Config\InitialConfigBuilder`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #6 of `infection\testframework\phpunit\adapter\phpunitadapter::__construct`: expected `Infection\TestFramework\Config\MutationConfigBuilder`, but found `mixed`.'
+message = 'Invalid argument type for argument #6 of `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter::__construct`: expected `Infection\TestFramework\Config\MutationConfigBuilder`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -19095,7 +19053,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
 code = "null-argument"
-message = 'Argument #1 of method `symfony\component\filesystem\path::normalize` is `null`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `Symfony\Component\Filesystem\Path::normalize` is `null`, but parameter type `string` does not accept it.'
 count = 2
 
 [[issues]]
@@ -19239,19 +19197,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
 code = "possibly-false-argument"
-message = 'Argument #1 of method `Infection\TestFramework\PhpUnit\Config\Path\PathReplacer::replaceinnode` is possibly `false`, but parameter type `DOMNameSpaceNode|DOMNode` does not accept it.'
+message = "Argument #1 of method `DOMNode::appendChild` is possibly `false`, but parameter type `DOMNode` does not accept it."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
 code = "possibly-false-argument"
-message = "Argument #1 of method `domnode::appendchild` is possibly `false`, but parameter type `DOMNode` does not accept it."
+message = 'Argument #1 of method `Infection\TestFramework\PhpUnit\Config\Path\PathReplacer::replaceInNode` is possibly `false`, but parameter type `DOMNameSpaceNode|DOMNode` does not accept it.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
 code = "possibly-null-argument"
-message = 'Argument #1 of method `symfony\component\filesystem\path::normalize` is possibly `null`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `Symfony\Component\Filesystem\Path::normalize` is possibly `null`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -19635,7 +19593,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Trace/TestLocationsNormalizer.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\tests\testframework\tracing\trace\testlocationsnormalizer::normalize`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Tests\TestFramework\Tracing\Trace\TestLocationsNormalizer::normalize`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -19695,7 +19653,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\tests\testframework\tracing\traceprovideradaptertracertest::createtracemock`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::createTraceMock`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -19815,7 +19773,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `infection\testframework\coverage\junit\junittestexecutioninfoadder::__construct`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder::__construct`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -19833,7 +19791,7 @@ count = 8
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `infection\tests\testframework\tracing\tracer\tracerintegrationtest::createfilesystemstub`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `Infection\Tests\TestFramework\Tracing\Tracer\TracerIntegrationTest::createFileSystemStub`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -19959,31 +19917,31 @@ count = 2
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::getelement`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::getElement`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryattribute`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryAttribute`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::querycount`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryCount`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryelement`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryElement`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::querylist`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryList`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
 count = 1
 
 [[issues]]

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -11499,12 +11499,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "mixed-argument"
-message = "Cannot unpack argument of type `mixed` because it is not guaranteed to be iterable."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 3
 
@@ -11537,12 +11531,6 @@ file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutation\MutationGeneratorTest`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `create` does not exist on type `Infection\Tests\WithConsecutive`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
@@ -12501,12 +12489,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
 code = "mixed-argument"
-message = "Cannot unpack argument of type `mixed` because it is not guaranteed to be iterable."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 8
 
@@ -12532,12 +12514,6 @@ count = 3
 file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
 code = "non-existent-method"
 message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\IgnoreMutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `create` does not exist on type `Infection\Tests\WithConsecutive`.'
 count = 1
 
 [[issues]]
@@ -15345,12 +15321,6 @@ count = 8
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "mixed-argument"
-message = "Cannot unpack argument of type `mixed` because it is not guaranteed to be iterable."
-count = 11
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
 count = 8
 
@@ -15461,12 +15431,6 @@ file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "non-existent-method"
 message = 'Method `callback` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `create` does not exist on type `Infection\Tests\WithConsecutive`.'
-count = 11
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
@@ -20405,3 +20369,51 @@ file = "tests/phpunit/UnsupportedMethodTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\UnsupportedMethodTest`.'
 count = 2
+
+[[issues]]
+file = "tests/phpunit/WithConsecutive.php"
+code = "imprecise-type"
+message = "Type `array` in return type of `create` is imprecise, equivalent to `array<array-key, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/WithConsecutive.php"
+code = "invalid-iterator"
+message = "The expression provided to `foreach` is not iterable. It resolved to type `mixed`, which is not iterable."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/WithConsecutive.php"
+code = "invalid-return-tag"
+message = "Failed to resolve `@return` type string."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/WithConsecutive.php"
+code = "missing-parameter-type"
+message = "Parameter `$parameterGroups` is missing a type hint."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/WithConsecutive.php"
+code = "mixed-argument"
+message = "Invalid argument type for argument #1 of `count`: expected `Countable|array<array-key, mixed>`, but found `mixed`."
+count = 2
+
+[[issues]]
+file = "tests/phpunit/WithConsecutive.php"
+code = "mixed-assignment"
+message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
+count = 2
+
+[[issues]]
+file = "tests/phpunit/WithConsecutive.php"
+code = "possibly-null-operand"
+message = "Right operand in `<` comparison might be `null` (type `non-negative-int|null`)."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/WithConsecutive.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\WithConsecutive::create`.'
+count = 1

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -33,7 +33,7 @@ count = 1
 [[issues]]
 file = "src/Command/ConfigureCommand.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Config\Guesser\SourceDirGuesser::__construct`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\config\guesser\sourcedirguesser::__construct`: expected `stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -75,25 +75,25 @@ count = 1
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
 code = "no-value"
-message = 'Argument #1 passed to method `Infection\Differ\ChangedLinesRange::create` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `infection\differ\changedlinesrange::create` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
 code = "no-value"
-message = 'Argument #1 passed to method `Webmozart\Assert\Assert::natural` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `webmozart\assert\assert::natural` has type `never`, meaning it cannot produce a value.'
 count = 2
 
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Differ\ChangedLinesRange::create` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `infection\differ\changedlinesrange::create` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
 code = "possibly-false-argument"
-message = 'Argument #1 of method `Infection\PhpParser\Visitor\LabelMutationCandidatesVisitor::__construct` is possibly `false`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `infection\phpparser\visitor\labelmutationcandidatesvisitor::__construct` is possibly `false`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -153,12 +153,6 @@ count = 1
 [[issues]]
 file = "src/Command/DescribeCommand.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Mutator\MutatorResolver::isValidMutator`: expected `string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Command/DescribeCommand.php"
-code = "mixed-argument"
 message = "Invalid argument type for argument #1 of `array_key_exists`: expected `bool|float|int|string`, but found `mixed`."
 count = 2
 
@@ -166,6 +160,12 @@ count = 2
 file = "src/Command/DescribeCommand.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #1 of `array_keys`: expected `array<('K.array_keys() extends array-key), ('V.array_keys() extends mixed)>`, but found `mixed`."
+count = 1
+
+[[issues]]
+file = "src/Command/DescribeCommand.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `infection\mutator\mutatorresolver::isvalidmutator`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -231,7 +231,7 @@ count = 1
 [[issues]]
 file = "src/Command/Git/Option/BaseOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Infection\Command\Git\Option\BaseOption::addOption`: expected `('T.infection\command\git\option\baseoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `infection\command\git\option\baseoption::addoption`: expected `('T.infection\command\git\option\baseoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -243,7 +243,7 @@ count = 1
 [[issues]]
 file = "src/Command/Git/Option/FilterOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Infection\Command\Git\Option\FilterOption::addOption`: expected `('T.infection\command\git\option\filteroption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `infection\command\git\option\filteroption::addoption`: expected `('T.infection\command\git\option\filteroption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -273,7 +273,7 @@ count = 1
 [[issues]]
 file = "src/Command/InitialTest/Option/InitialTestsPhpOptionsOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Infection\Command\InitialTest\Option\InitialTestsPhpOptionsOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `infection\command\initialtest\option\initialtestsphpoptionsoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -285,7 +285,7 @@ count = 1
 [[issues]]
 file = "src/Command/ListSourcesCommand.php"
 code = "possibly-false-argument"
-message = 'Argument #1 of method `Symfony\Component\Filesystem\Path::makeRelative` is possibly `false`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `symfony\component\filesystem\path::makerelative` is possibly `false`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -303,7 +303,7 @@ count = 1
 [[issues]]
 file = "src/Command/MakeCustomMutatorCommand.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Command\MakeCustomMutatorCommand::mutatorNameIsEmpty`: expected `null|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Command\MakeCustomMutatorCommand::mutatornameisempty`: expected `null|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -333,19 +333,19 @@ count = 1
 [[issues]]
 file = "src/Command/Option/ConfigurationOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Infection\Command\Option\ConfigurationOption::addOption`: expected `('T.infection\command\option\configurationoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `infection\command\option\configurationoption::addoption`: expected `('T.infection\command\option\configurationoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
 file = "src/Command/Option/DebugOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Infection\Command\Option\DebugOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `infection\command\option\debugoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
 file = "src/Command/Option/DebugOption.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Command\Option\DebugOption::get`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\command\option\debugoption::get`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -357,13 +357,13 @@ count = 1
 [[issues]]
 file = "src/Command/Option/MapSourceClassToTestOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Infection\Command\Option\MapSourceClassToTestOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `infection\command\option\mapsourceclasstotestoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
 file = "src/Command/Option/MapSourceClassToTestOption.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Command\Option\MapSourceClassToTestOption::assertIsValid`: expected `string`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `infection\command\option\mapsourceclasstotestoption::assertisvalid`: expected `string`, but found `nonnull`.'
 count = 1
 
 [[issues]]
@@ -381,7 +381,7 @@ count = 1
 [[issues]]
 file = "src/Command/Option/SourceFilterOptions.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Infection\Command\Option\SourceFilterOptions::addOption`: expected `('T.infection\command\option\sourcefilteroptions::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `infection\command\option\sourcefilteroptions::addoption`: expected `('T.infection\command\option\sourcefilteroptions::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -399,7 +399,7 @@ count = 1
 [[issues]]
 file = "src/Command/Option/TestFrameworkOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Infection\Command\Option\TestFrameworkOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `infection\command\option\testframeworkoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -411,7 +411,7 @@ count = 1
 [[issues]]
 file = "src/Command/Option/TestFrameworkOptionsOption.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Infection\Command\Option\TestFrameworkOptionsOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
+message = '''Invalid return type for function `infection\command\option\testframeworkoptionsoption::addoption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
 count = 1
 
 [[issues]]
@@ -423,7 +423,7 @@ count = 1
 [[issues]]
 file = "src/Command/RunCommand.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #37 of `Infection\Container\Container::withValues`: expected `null|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #37 of `Infection\Container\Container::withvalues`: expected `null|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -549,7 +549,7 @@ count = 2
 [[issues]]
 file = "src/Config/Guesser/PhpUnitPathGuesser.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #1 of `Infection\Config\Guesser\PhpUnitPathGuesser::getPhpUnitDir`: expected `array<string, string>`, but provided type `array<array-key, mixed>` is less specific.'
+message = 'Argument type mismatch for argument #1 of `Infection\Config\Guesser\PhpUnitPathGuesser::getphpunitdir`: expected `array<string, string>`, but provided type `array<array-key, mixed>` is less specific.'
 count = 2
 
 [[issues]]
@@ -573,7 +573,7 @@ count = 1
 [[issues]]
 file = "src/Config/Guesser/SourceDirGuesser.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #1 of `Infection\Config\Guesser\SourceDirGuesser::parsePath`: expected `array<array-key, string>|string`, but provided type `array<array-key, mixed>|string` is less specific.'
+message = 'Argument type mismatch for argument #1 of `Infection\Config\Guesser\SourceDirGuesser::parsepath`: expected `array<array-key, string>|string`, but provided type `array<array-key, mixed>|string` is less specific.'
 count = 1
 
 [[issues]]
@@ -597,13 +597,13 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/ExcludeDirsProvider.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(mixed): truthy-mixed)` is less specific than the declared return type `(closure(string): string)` for function `Infection\Config\ValueProvider\ExcludeDirsProvider::getValidator` due to nested 'mixed'.'''
+message = '''Returned type `(closure(mixed): truthy-mixed)` is less specific than the declared return type `(closure(string): string)` for function `infection\config\valueprovider\excludedirsprovider::getvalidator` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Config/ValueProvider/ExcludeDirsProvider.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `list<truthy-mixed>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Config\ValueProvider\ExcludeDirsProvider::get` due to nested 'mixed'.'''
+message = '''Returned type `list<truthy-mixed>` is less specific than the declared return type `array<array-key, string>` for function `infection\config\valueprovider\excludedirsprovider::get` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -669,7 +669,7 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/SourceDirsProvider.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Config\ValueProvider\SourceDirsProvider::get`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\config\valueprovider\sourcedirsprovider::get`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -681,13 +681,13 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/TestFrameworkConfigPathProvider.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Config\Guesser\PhpUnitPathGuesser::__construct`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\config\guesser\phpunitpathguesser::__construct`: expected `stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Config/ValueProvider/TestFrameworkConfigPathProvider.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Config\ValueProvider\TestFrameworkConfigPathProvider::askTestFrameworkConfigLocation`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\config\valueprovider\testframeworkconfigpathprovider::asktestframeworkconfiglocation`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -705,7 +705,7 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/TextLogFileProvider.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Config\ValueProvider\TextLogFileProvider::get`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\config\valueprovider\textlogfileprovider::get`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -729,7 +729,7 @@ count = 1
 [[issues]]
 file = "src/Configuration/ConfigurationFactory.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `array<string, list<mixed>>` is less specific than the declared return type `array<string, array<int, string>>` for function `Infection\Configuration\ConfigurationFactory::retrieveIgnoreSourceCodeMutatorsMap` due to nested 'mixed'.'''
+message = '''Returned type `array<string, list<mixed>>` is less specific than the declared return type `array<string, array<int, string>>` for function `infection\configuration\configurationfactory::retrieveignoresourcecodemutatorsmap` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -747,7 +747,7 @@ count = 1
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Configuration\Schema\SchemaConfigurationFactory::normalizeStringArray`: expected `list<non-empty-string>`, but found `list<string>`.'
+message = 'Invalid return type for function `infection\configuration\schema\schemaconfigurationfactory::normalizestringarray`: expected `list<non-empty-string>`, but found `list<string>`.'
 count = 1
 
 [[issues]]
@@ -759,91 +759,91 @@ count = 1
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #13 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `array<string, mixed>`, but provided type `array<array-key, mixed>` is less specific.'
+message = 'Argument type mismatch for argument #13 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `array<string, mixed>`, but provided type `array<array-key, mixed>` is less specific.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::createLogs`: expected `stdClass`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::createlogs`: expected `stdClass`, but found `nonnull`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::createPhpStan`: expected `stdClass`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::createphpstan`: expected `stdClass`, but found `nonnull`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::createPhpUnit`: expected `stdClass`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::createphpunit`: expected `stdClass`, but found `nonnull`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::createSource`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::createsource`: expected `stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::createStrykerConfig`: expected `null|stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::createstrykerconfig`: expected `null|stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::normalizeStringArray`: expected `array<array-key, string>`, but found `nonnull`.'
-count = 2
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Configuration\Schema\SchemaConfigurationFactory::normalizeString`: expected `null|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::normalizestring`: expected `null|string`, but found `mixed`.'
 count = 18
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #10 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `float|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\configuration\schema\schemaconfigurationfactory::normalizestringarray`: expected `array<array-key, string>`, but found `nonnull`.'
+count = 2
+
+[[issues]]
+file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #10 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `float|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #11 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `bool|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #11 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `bool|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #12 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `int|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #12 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `int|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #19 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `int|null|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #19 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `int|null|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #8 of `Infection\Configuration\Entry\Logs::__construct`: expected `bool`, but found `nonnull`.'
+message = 'Invalid argument type for argument #8 of `infection\configuration\entry\logs::__construct`: expected `bool`, but found `nonnull`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #8 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `bool|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #8 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `bool|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #9 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `float|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #9 of `infection\configuration\schema\schemaconfiguration::__construct`: expected `float|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -855,19 +855,19 @@ count = 3
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Configuration\Schema\SchemaConfigurationFactory::getStaticAnalysisTool`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\configuration\schema\schemaconfigurationfactory::getstaticanalysistool`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Configuration\Schema\SchemaConfigurationFactory::getTestFramework`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\configuration\schema\schemaconfigurationfactory::gettestframework`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Configuration\Schema\SchemaConfigurationFactory::getTimeout`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\configuration\schema\schemaconfigurationfactory::gettimeout`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -879,7 +879,7 @@ count = 1
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFile.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Configuration\Schema\SchemaConfigurationFile::getDecodedContents`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\configuration\schema\schemaconfigurationfile::getdecodedcontents`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -933,13 +933,13 @@ count = 1
 [[issues]]
 file = "src/Configuration/SourceFilter/PlainFilter.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Configuration\SourceFilter\PlainFilter::parseValues`: expected `array<array-key, non-empty-string>`, but found `array<non-negative-int, string>`.'
+message = 'Invalid return type for function `infection\configuration\sourcefilter\plainfilter::parsevalues`: expected `array<array-key, non-empty-string>`, but found `array<non-negative-int, string>`.'
 count = 1
 
 [[issues]]
 file = "src/Configuration/SourceFilter/PlainFilter.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Configuration\SourceFilter\PlainFilter::toString`: expected `non-empty-string`, but found `string`.'
+message = 'Invalid return type for function `infection\configuration\sourcefilter\plainfilter::tostring`: expected `non-empty-string`, but found `string`.'
 count = 1
 
 [[issues]]
@@ -969,7 +969,7 @@ count = 1
 [[issues]]
 file = "src/Container/Container.php"
 code = "less-specific-nested-argument-type"
-message = '''Argument type mismatch for argument #2 of `Infection\Container\Container::offsetSet`: expected `(closure(Infection\Container\Container): ('T.infection\container\container::clonewithservice() extends object))`, but provided type `('T.infection\container\container::clonewithservice() extends Closure)|Closure` is less specific.'''
+message = '''Argument type mismatch for argument #2 of `Infection\Container\Container::offsetset`: expected `(closure(Infection\Container\Container): ('T.infection\container\container::clonewithservice() extends object))`, but provided type `('T.infection\container\container::clonewithservice() extends Closure)|Closure` is less specific.'''
 count = 1
 
 [[issues]]
@@ -981,7 +981,7 @@ count = 1
 [[issues]]
 file = "src/Container/Container.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #2 of `DIContainer\Container::inject`: expected `('T.infection\container\container::clonewithservice() extends object)`, but possibly received `('T.infection\container\container::clonewithservice() extends object)|(closure(infection\container\container): ('T.infection\container\container::clonewithservice() extends object))`.'''
+message = '''Possible argument type mismatch for argument #2 of `dicontainer\container::inject`: expected `('T.infection\container\container::clonewithservice() extends object)`, but possibly received `('T.infection\container\container::clonewithservice() extends object)|(closure(infection\container\container): ('T.infection\container\container::clonewithservice() extends object))`.'''
 count = 1
 
 [[issues]]
@@ -1035,7 +1035,7 @@ count = 1
 [[issues]]
 file = "src/Differ/Differ.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Differ\Differ::processTokens`: expected `array{0: string, 1: int(0)|int(1)|int(2)|int(3)|int(4)}`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\differ\differ::processtokens`: expected `array{0: string, 1: int(0)|int(1)|int(2)|int(3)|int(4)}`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -1053,7 +1053,7 @@ count = 1
 [[issues]]
 file = "src/Differ/Tokens.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Differ\Tokens::computeRange`: expected `array{0: int(0)|positive-int, 1: int(0)|positive-int}`, but found `list{non-negative-int, int}`.'
+message = 'Invalid return type for function `infection\differ\tokens::computerange`: expected `array{0: int(0)|positive-int, 1: int(0)|positive-int}`, but found `list{non-negative-int, int}`.'
 count = 1
 
 [[issues]]
@@ -1149,7 +1149,7 @@ count = 1
 [[issues]]
 file = "src/FileSystem/FileSystem.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Symfony\Component\Filesystem\Exception\IOException::__construct`: expected `string`, but found `nonnull`.'
+message = 'Invalid argument type for argument #1 of `symfony\component\filesystem\exception\ioexception::__construct`: expected `string`, but found `nonnull`.'
 count = 1
 
 [[issues]]
@@ -1161,7 +1161,7 @@ count = 1
 [[issues]]
 file = "src/FileSystem/FileSystem.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Symfony\Component\Filesystem\Exception\IOException::__construct`: expected `int`, but possibly received `int|string`.'
+message = 'Possible argument type mismatch for argument #2 of `symfony\component\filesystem\exception\ioexception::__construct`: expected `int`, but possibly received `int|string`.'
 count = 1
 
 [[issues]]
@@ -1179,7 +1179,7 @@ count = 1
 [[issues]]
 file = "src/FileSystem/Finder/Iterator/RealPathFilterIterator.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Symfony\Component\Finder\Iterator\MultiplePcreFilterIterator::isAccepted`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `symfony\component\finder\iterator\multiplepcrefilteriterator::isaccepted`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -1341,7 +1341,7 @@ count = 1
 [[issues]]
 file = "src/Framework/ClassName.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Framework\ClassName::getShortClassName`: expected `non-empty-string`, but found `string`.'
+message = 'Invalid return type for function `infection\framework\classname::getshortclassname`: expected `non-empty-string`, but found `string`.'
 count = 1
 
 [[issues]]
@@ -1353,13 +1353,13 @@ count = 3
 [[issues]]
 file = "src/Framework/Enum/EnumBucket.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Infection\Framework\Enum\EnumBucket::getCasesIndexedByName`: expected `array<string, ('E.infection\framework\enum\enumbucket::getcasesindexedbyname() extends BackedEnum)>`, but found `array<string, BackedEnum&static>`.'''
+message = '''Invalid return type for function `infection\framework\enum\enumbucket::getcasesindexedbyname`: expected `array<string, ('E.infection\framework\enum\enumbucket::getcasesindexedbyname() extends BackedEnum)>`, but found `array<string, BackedEnum&static>`.'''
 count = 1
 
 [[issues]]
 file = "src/Framework/Enum/EnumBucket.php"
 code = "mixed-argument"
-message = '''Invalid argument type for argument #1 of `Infection\Framework\Enum\EnumBucket::describeCase`: expected `BackedEnum&'T.infection\framework\enum\enumbucket extends BackedEnum`, but found `mixed`.'''
+message = '''Invalid argument type for argument #1 of `infection\framework\enum\enumbucket::describecase`: expected `BackedEnum&'T.infection\framework\enum\enumbucket extends BackedEnum`, but found `mixed`.'''
 count = 2
 
 [[issues]]
@@ -1389,31 +1389,31 @@ count = 1
 [[issues]]
 file = "src/Framework/Iterable/GeneratorFactory.php"
 code = "mixed-argument"
-message = '''Invalid argument type for argument #1 of `Infection\Framework\Iterable\GeneratorFactory::fromIterable`: expected `iterable<('TKey.infection\framework\iterable\generatorfactory::fromiterable() extends mixed), ('TValue.infection\framework\iterable\generatorfactory::fromiterable() extends mixed)>`, but found `mixed`.'''
+message = '''Invalid argument type for argument #1 of `infection\framework\iterable\generatorfactory::fromiterable`: expected `iterable<('TKey.infection\framework\iterable\generatorfactory::fromiterable() extends mixed), ('TValue.infection\framework\iterable\generatorfactory::fromiterable() extends mixed)>`, but found `mixed`.'''
 count = 1
 
 [[issues]]
 file = "src/Framework/Str.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Framework\Str::findLastNonEmptyLineIndex`: expected `non-negative-int`, but found `int`.'
+message = 'Invalid return type for function `infection\framework\str::findlastnonemptylineindex`: expected `non-negative-int`, but found `int`.'
 count = 1
 
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Git\CommandLineGit::getChangedFileRelativePaths`: expected `non-empty-string`, but found `string`.'
+message = 'Invalid return type for function `infection\git\commandlinegit::getchangedfilerelativepaths`: expected `non-empty-string`, but found `string`.'
 count = 1
 
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Git\CommandLineGit::parseFilePathFromLine`: expected `string`, but found `null|string`.'
+message = 'Invalid return type for function `infection\git\commandlinegit::parsefilepathfromline`: expected `string`, but found `null|string`.'
 count = 1
 
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `list<mixed>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Git\CommandLineGit::diff` due to nested 'mixed'.'''
+message = '''Returned type `list<mixed>` is less specific than the declared return type `array<array-key, string>` for function `infection\git\commandlinegit::diff` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -1425,7 +1425,7 @@ count = 2
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "nullable-return-statement"
-message = 'Function `Infection\Git\CommandLineGit::parseFilePathFromLine` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
+message = 'Function `infection\git\commandlinegit::parsefilepathfromline` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
 count = 1
 
 [[issues]]
@@ -1479,7 +1479,7 @@ count = 1
 [[issues]]
 file = "src/Logger/Console/BasicConsoleLogger.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Webmozart\Assert\Assert::keyExists`: expected `int|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `webmozart\assert\assert::keyexists`: expected `int|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -1509,7 +1509,7 @@ count = 1
 [[issues]]
 file = "src/Logger/MutationAnalysis/TeamCity/TeamCity.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Logger\MutationAnalysis\TeamCity\TeamCity::escapeValue`: expected `non-empty-string`, but found `array<array-key, mixed>|string`.'
+message = 'Invalid return type for function `infection\logger\mutationanalysis\teamcity\teamcity::escapevalue`: expected `non-empty-string`, but found `array<array-key, mixed>|string`.'
 count = 1
 
 [[issues]]
@@ -1521,7 +1521,7 @@ count = 1
 [[issues]]
 file = "src/Metrics/FilteringResultsCollectorFactory.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Metrics\FilteringResultsCollector::__construct`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `non-empty-array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
+message = 'Invalid argument type for argument #2 of `infection\metrics\filteringresultscollector::__construct`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `non-empty-array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
 count = 1
 
 [[issues]]
@@ -1533,7 +1533,7 @@ count = 1
 [[issues]]
 file = "src/Metrics/TargetDetectionStatusesProvider.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Metrics\TargetDetectionStatusesProvider::findRequired`.'
+message = 'Call to deprecated method: `Infection\Metrics\TargetDetectionStatusesProvider::findrequired`.'
 count = 1
 
 [[issues]]
@@ -1545,7 +1545,7 @@ count = 1
 [[issues]]
 file = "src/Metrics/TargetDetectionStatusesProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Metrics\TargetDetectionStatusesProvider::get`: expected `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`, but found `array<string, enum(Infection\Mutant\DetectionStatus)>`.'
+message = 'Invalid return type for function `infection\metrics\targetdetectionstatusesprovider::get`: expected `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`, but found `array<string, enum(Infection\Mutant\DetectionStatus)>`.'
 count = 1
 
 [[issues]]
@@ -1563,13 +1563,13 @@ count = 1
 [[issues]]
 file = "src/Mutant/DetectionStatus.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Mutant\DetectionStatus::getCasesExcluding`: expected `list<enum(Infection\Mutant\DetectionStatus)>`, but found `list<mixed>`.'
+message = 'Invalid return type for function `infection\mutant\detectionstatus::getcasesexcluding`: expected `list<enum(Infection\Mutant\DetectionStatus)>`, but found `list<mixed>`.'
 count = 1
 
 [[issues]]
 file = "src/Mutant/DetectionStatus.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Infection\Mutant\DetectionStatus::getIndexedCases`: expected `array<key-of<enum(infection\mutant\detectionstatus)>, enum(infection\mutant\detectionstatus)>`, but found `array{'ERROR': enum(Infection\Mutant\DetectionStatus), 'ESCAPED': enum(Infection\Mutant\DetectionStatus), 'IGNORED': enum(Infection\Mutant\DetectionStatus), 'KILLED_BY_STATIC_ANALYSIS': enum(Infection\Mutant\DetectionStatus), 'KILLED_BY_TESTS': enum(Infection\Mutant\DetectionStatus), 'NOT_COVERED': enum(Infection\Mutant\DetectionStatus), 'SKIPPED': enum(Infection\Mutant\DetectionStatus), 'SYNTAX_ERROR': enum(Infection\Mutant\DetectionStatus), 'TIMED_OUT': enum(Infection\Mutant\DetectionStatus)}`.'''
+message = '''Invalid return type for function `infection\mutant\detectionstatus::getindexedcases`: expected `array<key-of<enum(infection\mutant\detectionstatus)>, enum(infection\mutant\detectionstatus)>`, but found `array{'ERROR': enum(Infection\Mutant\DetectionStatus), 'ESCAPED': enum(Infection\Mutant\DetectionStatus), 'IGNORED': enum(Infection\Mutant\DetectionStatus), 'KILLED_BY_STATIC_ANALYSIS': enum(Infection\Mutant\DetectionStatus), 'KILLED_BY_TESTS': enum(Infection\Mutant\DetectionStatus), 'NOT_COVERED': enum(Infection\Mutant\DetectionStatus), 'SKIPPED': enum(Infection\Mutant\DetectionStatus), 'SYNTAX_ERROR': enum(Infection\Mutant\DetectionStatus), 'TIMED_OUT': enum(Infection\Mutant\DetectionStatus)}`.'''
 count = 1
 
 [[issues]]
@@ -1593,7 +1593,7 @@ count = 1
 [[issues]]
 file = "src/Mutation/FileMutationGenerator.php"
 code = "possibly-false-argument"
-message = 'Argument #2 of method `Infection\Mutator\NodeMutationGenerator::__construct` is possibly `false`, but parameter type `string` does not accept it.'
+message = 'Argument #2 of method `infection\mutator\nodemutationgenerator::__construct` is possibly `false`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -1611,13 +1611,13 @@ count = 1
 [[issues]]
 file = "src/Mutation/MutationAttributeKeys.php"
 code = "less-specific-argument"
-message = '''Argument type mismatch for argument #1 of `Infection\Mutation\MutationAttributeKeys::assertAllAttributesExist`: expected `array<string('endFilePos')|string('endLine')|string('endTokenPos')|string('startFilePos')|string('startLine')|string('startTokenPos'), mixed>`, but provided type `array<array-key, float|int|string>` is less specific.'''
+message = '''Argument type mismatch for argument #1 of `infection\mutation\mutationattributekeys::assertallattributesexist`: expected `array<string('endFilePos')|string('endLine')|string('endTokenPos')|string('startFilePos')|string('startLine')|string('startTokenPos'), mixed>`, but provided type `array<array-key, float|int|string>` is less specific.'''
 count = 1
 
 [[issues]]
 file = "src/Mutation/MutationAttributeKeys.php"
 code = "less-specific-return-statement"
-message = '''Returned type `array<array-key, float|int|string>` is less specific than the declared return type `array<string('endFilePos')|string('endLine')|string('endTokenPos')|string('startFilePos')|string('startLine')|string('startTokenPos'), float|int|string>` for function `Infection\Mutation\MutationAttributeKeys::pluck`.'''
+message = '''Returned type `array<array-key, float|int|string>` is less specific than the declared return type `array<string('endFilePos')|string('endLine')|string('endTokenPos')|string('startFilePos')|string('startLine')|string('startTokenPos'), float|int|string>` for function `infection\mutation\mutationattributekeys::pluck`.'''
 count = 1
 
 [[issues]]
@@ -1629,7 +1629,7 @@ count = 1
 [[issues]]
 file = "src/Mutation/MutationGenerator.php"
 code = "possibly-false-argument"
-message = 'Argument #1 of method `Infection\Event\Events\MutationAnalysis\MutationGeneration\MutableFileWasProcessed::__construct` is possibly `false`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `infection\event\events\mutationanalysis\mutationgeneration\mutablefilewasprocessed::__construct` is possibly `false`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -1653,13 +1653,13 @@ count = 1
 [[issues]]
 file = "src/Mutator/Boolean/LogicalAndAllSubExprNegation.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `non-empty-string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `non-empty-string`."
 count = 1
 
 [[issues]]
 file = "src/Mutator/Boolean/LogicalOr.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `non-empty-string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `non-empty-string`."
 count = 1
 
 [[issues]]
@@ -1731,37 +1731,37 @@ count = 1
 [[issues]]
 file = "src/Mutator/Cast/AbstractCastMutator.php"
 code = "possibly-null-argument"
-message = 'Argument #1 of method `Infection\PhpParser\Visitor\ParentConnector::findParent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
+message = 'Argument #1 of method `infection\phpparser\visitor\parentconnector::findparent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/BCMath.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr>)` for function `Infection\Mutator\Extensions\BCMath::makeCheckingMinArgsMapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr>)` for function `infection\mutator\extensions\bcmath::makecheckingminargsmapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/BCMath.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\BinaryOp>)` for function `Infection\Mutator\Extensions\BCMath::makeBinaryOperatorMapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\BinaryOp>)` for function `infection\mutator\extensions\bcmath::makebinaryoperatormapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/BCMath.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\BinaryOp\Mod>)` for function `Infection\Mutator\Extensions\BCMath::makePowerModuloMapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\BinaryOp\Mod>)` for function `infection\mutator\extensions\bcmath::makepowermodulomapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/BCMath.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\Cast\String_>)` for function `Infection\Mutator\Extensions\BCMath::makeCastToStringMapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\Cast\String_>)` for function `infection\mutator\extensions\bcmath::makecasttostringmapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/BCMath.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `Infection\Mutator\Extensions\BCMath::makeSquareRootsMapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `infection\mutator\extensions\bcmath::makesquarerootsmapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -1779,19 +1779,19 @@ count = 1
 [[issues]]
 file = "src/Mutator/Extensions/MBString.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): Generator<mixed, mixed, mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `Infection\Mutator\Extensions\MBString::makeConvertCaseMapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): Generator<mixed, mixed, mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `infection\mutator\extensions\mbstring::makeconvertcasemapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/MBString.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `Infection\Mutator\Extensions\MBString::makeFunctionAndRemoveExtraArgsMapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `infection\mutator\extensions\mbstring::makefunctionandremoveextraargsmapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
 file = "src/Mutator/Extensions/MBString.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `Infection\Mutator\Extensions\MBString::makeFunctionMapper` due to nested 'mixed'.'''
+message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `infection\mutator\extensions\mbstring::makefunctionmapper` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -1803,7 +1803,7 @@ count = 1
 [[issues]]
 file = "src/Mutator/Extensions/MBString.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Mutator\Extensions\MBString::getConvertCaseModeValue`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\mutator\extensions\mbstring::getconvertcasemodevalue`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -1821,7 +1821,7 @@ count = 1
 [[issues]]
 file = "src/Mutator/IgnoreMutator.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Mutator\IgnoreConfig::isIgnored`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Mutator\IgnoreConfig::isignored`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -1875,7 +1875,7 @@ count = 1
 [[issues]]
 file = "src/Mutator/MutatorParser.php"
 code = "less-specific-return-statement"
-message = 'Returned type `list<array-key>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Mutator\MutatorParser::parse`.'
+message = 'Returned type `list<array-key>` is less specific than the declared return type `array<array-key, string>` for function `infection\mutator\mutatorparser::parse`.'
 count = 1
 
 [[issues]]
@@ -1905,49 +1905,49 @@ count = 1
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Mutator\MutatorResolver::resolve`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but found `array<string, array<array-key, string>>`.'
+message = 'Invalid return type for function `infection\mutator\mutatorresolver::resolve`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but found `array<string, array<array-key, string>>`.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #3 of `Infection\Mutator\MutatorResolver::registerFromClass`: expected `array<string, array<string, string>>`, but provided type `array<string, array<array-key, string>>` is less specific.'
+message = 'Argument type mismatch for argument #3 of `infection\mutator\mutatorresolver::registerfromclass`: expected `array<string, array<string, string>>`, but provided type `array<string, array<array-key, string>>` is less specific.'
 count = 2
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #3 of `Infection\Mutator\MutatorResolver::registerFromName`: expected `array<string, array<string, string>>`, but provided type `array<string, array<array-key, string>>` is less specific.'
+message = 'Argument type mismatch for argument #3 of `infection\mutator\mutatorresolver::registerfromname`: expected `array<string, array<string, string>>`, but provided type `array<string, array<array-key, string>>` is less specific.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #2 of `Infection\Mutator\MutatorResolver::registerFromClass`: expected `array<string, array<array-key, string>>|bool`, but provided type `array<string, array<array-key, mixed>>|bool` is less specific.'
+message = 'Argument type mismatch for argument #2 of `infection\mutator\mutatorresolver::registerfromclass`: expected `array<string, array<array-key, string>>|bool`, but provided type `array<string, array<array-key, mixed>>|bool` is less specific.'
 count = 2
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #2 of `Infection\Mutator\MutatorResolver::registerFromClass`: expected `array<string, array<array-key, string>>|bool`, but provided type `array<string, mixed>|bool` is less specific.'
+message = 'Argument type mismatch for argument #2 of `infection\mutator\mutatorresolver::registerfromclass`: expected `array<string, array<array-key, string>>|bool`, but provided type `array<string, mixed>|bool` is less specific.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "less-specific-return-statement"
-message = 'Returned type `array<array-key, mixed>` is less specific than the declared return type `array<string, array<array-key, mixed>>|bool` for function `Infection\Mutator\MutatorResolver::resolveSettings`.'
+message = 'Returned type `array<array-key, mixed>` is less specific than the declared return type `array<string, array<array-key, mixed>>|bool` for function `infection\mutator\mutatorresolver::resolvesettings`.'
 count = 2
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Mutator\MutatorResolver::registerFromClass`: expected `string`, but found `mixed`.'
+message = "Invalid argument type for argument #1 of `array_unique`: expected `array<('K.array_unique() extends array-key), ('V.array_unique() extends mixed)>`, but found `mixed`."
 count = 1
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
 code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `array_unique`: expected `array<('K.array_unique() extends array-key), ('V.array_unique() extends mixed)>`, but found `mixed`."
+message = 'Invalid argument type for argument #1 of `infection\mutator\mutatorresolver::registerfromclass`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -1983,13 +1983,13 @@ count = 2
 [[issues]]
 file = "src/Mutator/NodeMutationGenerator.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #5 of `Infection\Mutation\Mutation::__construct`: expected `array<string, float|int|string>`, but provided type `array<string, mixed>` is less specific.'
+message = 'Argument type mismatch for argument #5 of `infection\mutation\mutation::__construct`: expected `array<string, float|int|string>`, but provided type `array<string, mixed>` is less specific.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/NodeMutationGenerator.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `iterable<mixed, Infection\AbstractTestFramework\Coverage\TestLocation>|list<mixed>` is less specific than the declared return type `array<array-key, Infection\AbstractTestFramework\Coverage\TestLocation>` for function `Infection\Mutator\NodeMutationGenerator::getAllTestsForCurrentNode` due to nested 'mixed'.'''
+message = '''Returned type `iterable<mixed, Infection\AbstractTestFramework\Coverage\TestLocation>|list<mixed>` is less specific than the declared return type `array<array-key, Infection\AbstractTestFramework\Coverage\TestLocation>` for function `infection\mutator\nodemutationgenerator::getalltestsforcurrentnode` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -2001,13 +2001,13 @@ count = 1
 [[issues]]
 file = "src/Mutator/NodeMutationGenerator.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Mutator\NodeMutationGenerator::isInsideFunction`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\mutator\nodemutationgenerator::isinsidefunction`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/NodeMutationGenerator.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Mutator\NodeMutationGenerator::isOnFunctionSignature`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\mutator\nodemutationgenerator::isonfunctionsignature`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -2061,7 +2061,7 @@ count = 2
 [[issues]]
 file = "src/Mutator/Operator/Concat.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `PhpParser\Node\Expr\BinaryOp::__construct`: expected `PhpParser\Node\Expr`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `phpparser\node\expr\binaryop::__construct`: expected `PhpParser\Node\Expr`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -2103,19 +2103,19 @@ count = 1
 [[issues]]
 file = "src/Mutator/Regex/AbstractPregMatch.php"
 code = "hidden-generator-return"
-message = 'The value returned by generator function `Infection\Mutator\Regex\AbstractPregMatch::mutate` may be inaccessible to callers.'
+message = 'The value returned by generator function `infection\mutator\regex\abstractpregmatch::mutate` may be inaccessible to callers.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/Regex/AbstractPregMatch.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Regex\AbstractPregMatch::getNewRegexArgument`: expected `PhpParser\Node\Arg`, but possibly received `PhpParser\Node\Arg|PhpParser\Node\VariadicPlaceholder`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Regex\AbstractPregMatch::getnewregexargument`: expected `PhpParser\Node\Arg`, but possibly received `PhpParser\Node\Arg|PhpParser\Node\VariadicPlaceholder`.'
 count = 1
 
 [[issues]]
 file = "src/Mutator/Regex/PregMatchMatches.php"
 code = "hidden-generator-return"
-message = 'The value returned by generator function `Infection\Mutator\Regex\PregMatchMatches::mutate` may be inaccessible to callers.'
+message = 'The value returned by generator function `infection\mutator\regex\pregmatchmatches::mutate` may be inaccessible to callers.'
 count = 1
 
 [[issues]]
@@ -2157,7 +2157,7 @@ count = 2
 [[issues]]
 file = "src/Mutator/Regex/PregQuote.php"
 code = "hidden-generator-return"
-message = 'The value returned by generator function `Infection\Mutator\Regex\PregQuote::mutate` may be inaccessible to callers.'
+message = 'The value returned by generator function `infection\mutator\regex\pregquote::mutate` may be inaccessible to callers.'
 count = 1
 
 [[issues]]
@@ -2307,13 +2307,13 @@ count = 5
 [[issues]]
 file = "src/Mutator/Util/AbstractIdenticalComparison.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Util\AbstractIdenticalComparison::getClassConstantValue`: expected `PhpParser\Node\Identifier`, but possibly received `PhpParser\Node\Expr|PhpParser\Node\Expr\Error|PhpParser\Node\Identifier`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Util\AbstractIdenticalComparison::getclassconstantvalue`: expected `PhpParser\Node\Identifier`, but possibly received `PhpParser\Node\Expr|PhpParser\Node\Expr\Error|PhpParser\Node\Identifier`.'
 count = 2
 
 [[issues]]
 file = "src/Mutator/Util/AbstractIdenticalComparison.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Util\AbstractIdenticalComparison::getStaticMethodReturnType`: expected `PhpParser\Node\Identifier`, but possibly received `PhpParser\Node\Expr|PhpParser\Node\Identifier`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\Mutator\Util\AbstractIdenticalComparison::getstaticmethodreturntype`: expected `PhpParser\Node\Identifier`, but possibly received `PhpParser\Node\Expr|PhpParser\Node\Identifier`.'
 count = 1
 
 [[issues]]
@@ -2343,13 +2343,13 @@ count = 1
 [[issues]]
 file = "src/Mutator/Util/NameResolver.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Mutator\Util\NameResolver::resolveName`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\mutator\util\nameresolver::resolvename`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/FileParser.php"
 code = "possibly-false-argument"
-message = 'Argument #1 of method `Infection\PhpParser\UnparsableFile::fromInvalidFile` is possibly `false`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `infection\phpparser\unparsablefile::frominvalidfile` is possibly `false`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -2469,13 +2469,13 @@ count = 1
 [[issues]]
 file = "src/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitor::getNodeId`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\phpparser\visitor\addidtotraversednodesvisitor\addidtotraversednodesvisitor::getnodeid`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/FullyQualifiedClassNameManipulator.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\FullyQualifiedClassNameManipulator::getFqcn`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\phpparser\visitor\fullyqualifiedclassnamemanipulator::getfqcn`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -2487,13 +2487,13 @@ count = 1
 [[issues]]
 file = "src/PhpParser/Visitor/LabelMutationCandidatesVisitor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\LabelMutationCandidatesVisitor::isInsideFunction`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\phpparser\visitor\labelmutationcandidatesvisitor::isinsidefunction`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/LabelMutationCandidatesVisitor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\LabelMutationCandidatesVisitor::isOnFunctionSignature`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\phpparser\visitor\labelmutationcandidatesvisitor::isonfunctionsignature`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -2517,19 +2517,19 @@ count = 1
 [[issues]]
 file = "src/PhpParser/Visitor/LabelNodesAsEligibleVisitor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\LabelNodesAsEligibleVisitor::isEligible`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\phpparser\visitor\labelnodesaseligiblevisitor::iseligible`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/ParentConnector.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\ParentConnector::findParent`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\phpparser\visitor\parentconnector::findparent`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/ParentConnector.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\ParentConnector::getParent`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\phpparser\visitor\parentconnector::getparent`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -2541,13 +2541,13 @@ count = 4
 [[issues]]
 file = "src/PhpParser/Visitor/ReflectionVisitor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\ReflectionVisitor::isStrictTypesEnabled`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\phpparser\visitor\reflectionvisitor::isstricttypesenabled`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/ReflectionVisitor.php"
 code = "possibly-null-argument"
-message = 'Argument #1 of method `Infection\PhpParser\Visitor\ParentConnector::findParent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
+message = 'Argument #1 of method `infection\phpparser\visitor\parentconnector::findparent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
 count = 1
 
 [[issues]]
@@ -2625,7 +2625,7 @@ count = 1
 [[issues]]
 file = "src/Process/Runner/ParallelProcessRunner.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `Infection\Process\Runner\ProcessQueue::enqueueFrom`: expected `Iterator<mixed, Infection\Process\MutantProcessContainer>`, but possibly received `Generator<mixed, Infection\Process\MutantProcessContainer, mixed, mixed>`.'
+message = 'Possible argument type mismatch for argument #1 of `Infection\Process\Runner\ProcessQueue::enqueuefrom`: expected `Iterator<mixed, Infection\Process\MutantProcessContainer>`, but possibly received `Generator<mixed, Infection\Process\MutantProcessContainer, mixed, mixed>`.'
 count = 3
 
 [[issues]]
@@ -2661,7 +2661,7 @@ count = 1
 [[issues]]
 file = "src/Reporter/BaseTextFileReporter.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #1 of `Infection\Reporter\BaseTextFileReporter::getMutatorLine`: expected `int`, but provided type `array-key` is less specific.'
+message = 'Argument type mismatch for argument #1 of `infection\reporter\basetextfilereporter::getmutatorline`: expected `int`, but provided type `array-key` is less specific.'
 count = 1
 
 [[issues]]
@@ -2673,13 +2673,13 @@ count = 8
 [[issues]]
 file = "src/Reporter/GitHubAnnotationsReporter.php"
 code = "possibly-null-argument"
-message = 'Argument #2 of method `Symfony\Component\Filesystem\Path::makeRelative` is possibly `null`, but parameter type `string` does not accept it.'
+message = 'Argument #2 of method `symfony\component\filesystem\path::makerelative` is possibly `null`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
 file = "src/Reporter/GitLabCodeQualityReporter.php"
 code = "possibly-null-argument"
-message = 'Argument #2 of method `Symfony\Component\Filesystem\Path::makeRelative` is possibly `null`, but parameter type `string` does not accept it.'
+message = 'Argument #2 of method `symfony\component\filesystem\path::makerelative` is possibly `null`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -2757,7 +2757,7 @@ count = 1
 [[issues]]
 file = "src/Reporter/Http/StrykerCurlClient.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Reporter\Http\Response::__construct`: expected `int`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\reporter\http\response::__construct`: expected `int`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -2793,13 +2793,13 @@ count = 2
 [[issues]]
 file = "src/Source/Collector/BasicSourceCollector.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Source\Collector\BasicSourceCollector::makePathsAbsolute`: expected `array<array-key, non-empty-string>`, but found `array<array-key, string>|list<string>`.'
+message = 'Invalid return type for function `infection\source\collector\basicsourcecollector::makepathsabsolute`: expected `array<array-key, non-empty-string>`, but found `array<array-key, string>|list<string>`.'
 count = 1
 
 [[issues]]
 file = "src/Source/Collector/BasicSourceCollector.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `Infection\FileSystem\Finder\Iterator\RealPathFilterIterator<mixed, mixed>|Iterator<mixed, Symfony\Component\Finder\SplFileInfo>|Symfony\Component\Finder\Iterator\PathFilterIterator` is less specific than the declared return type `Iterator<mixed, Symfony\Component\Finder\SplFileInfo>` for function `Infection\Source\Collector\BasicSourceCollector::filter` due to nested 'mixed'.'''
+message = '''Returned type `Infection\FileSystem\Finder\Iterator\RealPathFilterIterator<mixed, mixed>|Iterator<mixed, Symfony\Component\Finder\SplFileInfo>|Symfony\Component\Finder\Iterator\PathFilterIterator` is less specific than the declared return type `Iterator<mixed, Symfony\Component\Finder\SplFileInfo>` for function `infection\source\collector\basicsourcecollector::filter` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -2817,7 +2817,7 @@ count = 1
 [[issues]]
 file = "src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\FileSystem\Locator\FileOrDirectoryNotFound::multipleFilesDoNotExist`.'
+message = 'Call to deprecated method: `infection\filesystem\locator\fileordirectorynotfound::multiplefilesdonotexist`.'
 count = 1
 
 [[issues]]
@@ -2919,7 +2919,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/AdapterInstallationDecider.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\TestFramework\AdapterInstallationDecider::shouldBeInstalled`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\testframework\adapterinstallationdecider::shouldbeinstalled`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -2931,7 +2931,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/AdapterInstaller.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Composer\Autoload\ClassLoader::setPsr4`: expected `list<string>|string`, but possibly received `array<array-key, string>`.'
+message = 'Possible argument type mismatch for argument #2 of `Composer\Autoload\ClassLoader::setpsr4`: expected `list<string>|string`, but possibly received `array<array-key, string>`.'
 count = 1
 
 [[issues]]
@@ -2967,7 +2967,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/Config/TestFrameworkConfigLocator.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\FileSystem\Locator\FileOrDirectoryNotFound::multipleFilesDoNotExist`.'
+message = 'Call to deprecated method: `infection\filesystem\locator\fileordirectorynotfound::multiplefilesdonotexist`.'
 count = 1
 
 [[issues]]
@@ -3153,7 +3153,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #2 of `Infection\TestFramework\Tracing\Trace\TestLocations::__construct`: expected `array<string, Infection\TestFramework\Tracing\Trace\SourceMethodLineRange>`, but provided type `array<array-key, Infection\TestFramework\Tracing\Trace\SourceMethodLineRange>` is less specific.'
+message = 'Argument type mismatch for argument #2 of `infection\testframework\tracing\trace\testlocations::__construct`: expected `array<string, Infection\TestFramework\Tracing\Trace\SourceMethodLineRange>`, but provided type `array<array-key, Infection\TestFramework\Tracing\Trace\SourceMethodLineRange>` is less specific.'
 count = 1
 
 [[issues]]
@@ -3249,13 +3249,13 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #6 of `Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder::__construct`: expected `array<array-key, string>`, but possibly received `array<array-key, false|string>|list<false|string>`.'
+message = 'Possible argument type mismatch for argument #6 of `infection\testframework\phpunit\config\builder\initialconfigbuilder::__construct`: expected `array<array-key, string>`, but possibly received `array<array-key, false|string>|list<false|string>`.'
 count = 1
 
 [[issues]]
 file = "src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\TestFramework\PhpUnit\CommandLine\FilterBuilder::splitMethodNameFromProviderKey`: expected `array{0: string, 1: string}`, but found `non-empty-list<string>`.'
+message = 'Invalid return type for function `infection\testframework\phpunit\commandline\filterbuilder::splitmethodnamefromproviderkey`: expected `array{0: string, 1: string}`, but found `non-empty-list<string>`.'
 count = 1
 
 [[issues]]
@@ -3273,7 +3273,7 @@ count = 2
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php"
 code = "possibly-false-argument"
-message = "Argument #1 of method `DOMNode::appendChild` is possibly `false`, but parameter type `DOMNode` does not accept it."
+message = "Argument #1 of method `domnode::appendchild` is possibly `false`, but parameter type `DOMNode` does not accept it."
 count = 2
 
 [[issues]]
@@ -3291,7 +3291,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
 code = "falsable-return-statement"
-message = '''Function `Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator::createNode` is declared to return `DOMElement` but possibly returns 'false' (inferred as `DOMElement|false`).'''
+message = '''Function `infection\testframework\phpunit\config\xmlconfigurationmanipulator::createnode` is declared to return `DOMElement` but possibly returns 'false' (inferred as `DOMElement|false`).'''
 count = 1
 
 [[issues]]
@@ -3303,13 +3303,13 @@ count = 2
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\TestFramework\PhpUnit\Config\XmlConfigurationManipulator::createNode`: expected `DOMElement`, but found `DOMElement|false`.'
+message = 'Invalid return type for function `infection\testframework\phpunit\config\xmlconfigurationmanipulator::createnode`: expected `DOMElement`, but found `DOMElement|false`.'
 count = 1
 
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php"
 code = "possibly-false-argument"
-message = "Argument #1 of method `DOMNode::appendChild` is possibly `false`, but parameter type `DOMNode` does not accept it."
+message = "Argument #1 of method `domnode::appendchild` is possibly `false`, but parameter type `DOMNode` does not accept it."
 count = 4
 
 [[issues]]
@@ -3321,13 +3321,13 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider::provide`: expected `string`, but found `null|string`.'
+message = 'Invalid return type for function `infection\testframework\phpunit\config\xmlconfigurationversionprovider::provide`: expected `string`, but found `null|string`.'
 count = 1
 
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php"
 code = "nullable-return-statement"
-message = 'Function `Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider::provide` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
+message = 'Function `infection\testframework\phpunit\config\xmlconfigurationversionprovider::provide` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
 count = 1
 
 [[issues]]
@@ -3339,7 +3339,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/TestFrameworkExtraOptionsFilter.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\TestFramework\TestFrameworkExtraOptionsFilter::filterForMutantProcess`: expected `string`, but found `array<array-key, mixed>|array<array-key, string>|string`.'
+message = 'Invalid return type for function `infection\testframework\testframeworkextraoptionsfilter::filterformutantprocess`: expected `string`, but found `array<array-key, mixed>|array<array-key, string>|string`.'
 count = 1
 
 [[issues]]
@@ -3393,19 +3393,19 @@ count = 1
 [[issues]]
 file = "src/TestFramework/Tracing/Trace/EmptyTrace.php"
 code = "falsable-return-statement"
-message = '''Function `Infection\TestFramework\Tracing\Trace\EmptyTrace::getRealPath` is declared to return `string` but possibly returns 'false' (inferred as `false|string`).'''
+message = '''Function `infection\testframework\tracing\trace\emptytrace::getrealpath` is declared to return `string` but possibly returns 'false' (inferred as `false|string`).'''
 count = 1
 
 [[issues]]
 file = "src/TestFramework/Tracing/Trace/EmptyTrace.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\TestFramework\Tracing\Trace\EmptyTrace::getRealPath`: expected `string`, but found `false|string`.'
+message = 'Invalid return type for function `infection\testframework\tracing\trace\emptytrace::getrealpath`: expected `string`, but found `false|string`.'
 count = 1
 
 [[issues]]
 file = "src/TestFramework/Tracing/Trace/LineRangeCalculator.php"
 code = "possibly-null-argument"
-message = 'Argument #1 of method `Infection\PhpParser\Visitor\ParentConnector::findParent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
+message = 'Argument #1 of method `infection\phpparser\visitor\parentconnector::findparent` is possibly `null`, but parameter type `PhpParser\Node` does not accept it.'
 count = 1
 
 [[issues]]
@@ -3447,13 +3447,13 @@ count = 1
 [[issues]]
 file = "src/TestFramework/VersionParser.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\TestFramework\VersionParser::parse`: expected `string`, but found `null|string`.'
+message = 'Invalid return type for function `infection\testframework\versionparser::parse`: expected `string`, but found `null|string`.'
 count = 1
 
 [[issues]]
 file = "src/TestFramework/VersionParser.php"
 code = "nullable-return-statement"
-message = 'Function `Infection\TestFramework\VersionParser::parse` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
+message = 'Function `infection\testframework\versionparser::parse` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
 count = 1
 
 [[issues]]
@@ -3483,7 +3483,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/XML/SafeDOMXPath.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\TestFramework\XML\SafeDOMXPath::queryCount`: expected `non-negative-int`, but found `int`.'
+message = 'Invalid return type for function `infection\testframework\xml\safedomxpath::querycount`: expected `non-negative-int`, but found `int`.'
 count = 1
 
 [[issues]]
@@ -3567,7 +3567,7 @@ count = 2
 [[issues]]
 file = "src/Testing/BaseMutatorTestCase.php"
 code = "possibly-null-argument"
-message = 'Argument #3 of method `Infection\Mutator\NodeMutationGenerator::__construct` is possibly `null`, but parameter type `array<array-key, PhpParser\Node>` does not accept it.'
+message = 'Argument #3 of method `infection\mutator\nodemutationgenerator::__construct` is possibly `null`, but parameter type `array<array-key, PhpParser\Node>` does not accept it.'
 count = 1
 
 [[issues]]
@@ -3579,7 +3579,7 @@ count = 1
 [[issues]]
 file = "src/Testing/MutatorName.php"
 code = "less-specific-return-statement"
-message = 'Returned type `array-key` is less specific than the declared return type `string` for function `Infection\Testing\MutatorName::getName`.'
+message = 'Returned type `array-key` is less specific than the declared return type `string` for function `infection\testing\mutatorname::getname`.'
 count = 1
 
 [[issues]]
@@ -3747,7 +3747,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-function-call.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `ArrayOneItem_FunctionCall\Test::getCollection`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `arrayoneitem_functioncall\test::getcollection`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -3771,7 +3771,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-method-call.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `ArrayOneItem_MethodCall\Test::getCollection`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `arrayoneitem_methodcall\test::getcollection`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -3855,7 +3855,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-mutates-return-typehint-fqcn-allows-null.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `FunctionCall_ReturnTypehintFqcnAllowsNull\Test::test`: expected `DateTime|null`, but found `non-negative-int`.'
+message = 'Invalid return type for function `functioncall_returntypehintfqcnallowsnull\test::test`: expected `DateTime|null`, but found `non-negative-int`.'
 count = 1
 
 [[issues]]
@@ -3867,13 +3867,13 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-not-mutates-return-typehint-fqcn-does-not-allow-null.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `FunctionCall_ReturnTypehintFqcnDoesNotAllowNull\Test::test`: expected `DateTime`, but found `non-negative-int`.'
+message = 'Invalid return type for function `functioncall_returntypehintfqcndoesnotallownull\test::test`: expected `DateTime`, but found `non-negative-int`.'
 count = 1
 
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-not-mutates-with-not-nullable-typehint.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `FunctionCall_NotMutatesWithNotNullableTypehint\Test::test`: expected `bool`, but found `non-negative-int`.'
+message = 'Invalid return type for function `functioncall_notmutateswithnotnullabletypehint\test::test`: expected `bool`, but found `non-negative-int`.'
 count = 1
 
 [[issues]]
@@ -3897,7 +3897,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/NewObject/no-mutates-scalar-return-typehint-allows-null.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `NewObject_ScalarReturnTypehintsAllowsNull\Test::test`: expected `int|null`, but found `stdClass`.'
+message = 'Invalid return type for function `newobject_scalarreturntypehintsallowsnull\test::test`: expected `int|null`, but found `stdClass`.'
 count = 1
 
 [[issues]]
@@ -3921,7 +3921,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/NewObject/no-not-mutates-scalar-return-typehint-does-not-allow-null.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `NewObject_ScalarReturnTypehintFqcnDoesNotAllowNull\Test::test`: expected `int`, but found `stdClass`.'
+message = 'Invalid return type for function `newobject_scalarreturntypehintfqcndoesnotallownull\test::test`: expected `int`, but found `stdClass`.'
 count = 1
 
 [[issues]]
@@ -3975,7 +3975,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-enum.php"
 code = "invalid-return-statement"
-message = 'Cannot return a non-referenceable value from function `ProtectedVisibilityFinal\TestEnum::foo`.'
+message = 'Cannot return a non-referenceable value from function `protectedvisibilityfinal\testenum::foo`.'
 count = 1
 
 [[issues]]
@@ -4005,7 +4005,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final.php"
 code = "invalid-return-statement"
-message = 'Cannot return a non-referenceable value from function `ProtectedVisibilityFinal\Test::foo`.'
+message = 'Cannot return a non-referenceable value from function `protectedvisibilityfinal\test::foo`.'
 count = 1
 
 [[issues]]
@@ -4329,7 +4329,7 @@ count = 1
 [[issues]]
 file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-one-class.php"
 code = "invalid-return-statement"
-message = 'Cannot return a non-referenceable value from function `PublicVisibilityOneClass\Test::foo`.'
+message = 'Cannot return a non-referenceable value from function `publicvisibilityoneclass\test::foo`.'
 count = 1
 
 [[issues]]
@@ -4611,7 +4611,7 @@ count = 2
 [[issues]]
 file = "tests/benchmark/BlackfireInstrumentor.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Benchmark\BlackfireInstrumentor::profileSample`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\benchmark\blackfireinstrumentor::profilesample`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -4665,7 +4665,7 @@ count = 1
 [[issues]]
 file = "tests/benchmark/MutationGenerator/profile.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Benchmark\InstrumentorFactory::create`: expected `bool`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\benchmark\instrumentorfactory::create`: expected `bool`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -4701,7 +4701,7 @@ count = 3
 [[issues]]
 file = "tests/benchmark/ParseGitDiff/generator.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Benchmark\ParseGitDiff\Generator::generateFilePath`: expected `non-empty-string`, but found `string`.'
+message = 'Invalid return type for function `infection\benchmark\parsegitdiff\generator::generatefilepath`: expected `non-empty-string`, but found `string`.'
 count = 1
 
 [[issues]]
@@ -4731,7 +4731,7 @@ count = 1
 [[issues]]
 file = "tests/benchmark/ParseGitDiff/profile.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Benchmark\InstrumentorFactory::create`: expected `bool`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\benchmark\instrumentorfactory::create`: expected `bool`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -4773,7 +4773,7 @@ count = 1
 [[issues]]
 file = "tests/benchmark/Tracing/create-main.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `array<array-key, mixed>` is less specific than the declared return type `array<array-key, SplFileInfo>` for function `Infection\Benchmark\Tracing\takePercentageOfSources` due to nested 'mixed'.'''
+message = '''Returned type `array<array-key, mixed>` is less specific than the declared return type `array<array-key, SplFileInfo>` for function `infection\benchmark\tracing\takepercentageofsources` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -4821,7 +4821,7 @@ count = 1
 [[issues]]
 file = "tests/benchmark/Tracing/profile.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Benchmark\InstrumentorFactory::create`: expected `bool`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\benchmark\instrumentorfactory::create`: expected `bool`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -4869,7 +4869,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ConcreteClassReflector.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -4893,13 +4893,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
 code = "falsable-return-statement"
-message = '''Function `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestCaseForEnvManipulations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
+message = '''Function `infection\tests\autoreview\envvariablemanipulation\envtestcasesprovider::checktestcaseforenvmanipulations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
 code = "falsable-return-statement"
-message = '''Function `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestedClassForEnvManipulations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
+message = '''Function `infection\tests\autoreview\envvariablemanipulation\envtestcasesprovider::checktestedclassforenvmanipulations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
 count = 1
 
 [[issues]]
@@ -4917,13 +4917,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestCaseForEnvManipulations`: expected `null|string`, but found `false|string`.'
+message = 'Invalid return type for function `infection\tests\autoreview\envvariablemanipulation\envtestcasesprovider::checktestcaseforenvmanipulations`: expected `null|string`, but found `false|string`.'
 count = 2
 
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestedClassForEnvManipulations`: expected `null|string`, but found `false|string`.'
+message = 'Invalid return type for function `infection\tests\autoreview\envvariablemanipulation\envtestcasesprovider::checktestedclassforenvmanipulations`: expected `null|string`, but found `false|string`.'
 count = 1
 
 [[issues]]
@@ -4935,7 +4935,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 2
 
 [[issues]]
@@ -4983,7 +4983,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProviderTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -5013,7 +5013,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/Event/SubscriberProvider.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 2
 
 [[issues]]
@@ -5031,7 +5031,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/Event/SubscriberTest.php"
 code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but found `mixed`."
+message = "Invalid argument type for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but found `mixed`."
 count = 1
 
 [[issues]]
@@ -5091,13 +5091,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "falsable-return-statement"
-message = '''Function `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::checkTestCaseForIoOperations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
+message = '''Function `infection\tests\autoreview\integrationgroup\integrationgroupprovider::checktestcaseforiooperations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
 count = 3
 
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "falsable-return-statement"
-message = '''Function `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::checkTestedClassForIoOperations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
+message = '''Function `infection\tests\autoreview\integrationgroup\integrationgroupprovider::checktestedclassforiooperations` is declared to return `null|string` but possibly returns 'false' (inferred as `false|string`).'''
 count = 1
 
 [[issues]]
@@ -5121,13 +5121,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::checkTestCaseForIoOperations`: expected `null|string`, but found `false|string`.'
+message = 'Invalid return type for function `infection\tests\autoreview\integrationgroup\integrationgroupprovider::checktestcaseforiooperations`: expected `null|string`, but found `false|string`.'
 count = 3
 
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProvider::checkTestedClassForIoOperations`: expected `null|string`, but found `false|string`.'
+message = 'Invalid return type for function `infection\tests\autoreview\integrationgroup\integrationgroupprovider::checktestedclassforiooperations`: expected `null|string`, but found `false|string`.'
 count = 1
 
 [[issues]]
@@ -5145,7 +5145,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 2
 
 [[issues]]
@@ -5229,7 +5229,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -5259,7 +5259,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -5283,7 +5283,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php"
 code = "less-specific-return-statement"
-message = 'Returned type `list<array-key>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Tests\AutoReview\IntegrationGroup\IoCodeDetector::retrieveSafeFileSystemFunctions`.'
+message = 'Returned type `list<array-key>` is less specific than the declared return type `array<array-key, string>` for function `infection\tests\autoreview\integrationgroup\iocodedetector::retrievesafefilesystemfunctions`.'
 count = 1
 
 [[issues]]
@@ -5421,13 +5421,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #1 of `Infection\Tests\AutoReview\ConcreteClassReflector::filterByConcreteClasses`: expected `array<array-key, string>`, but provided type `list<mixed>` is less specific.'
+message = "Argument type mismatch for argument #1 of `array_column`: expected `array<array-key, array<int(1), ('V.array_column() extends mixed)>|object>|list<array<int(1), ('V.array_column() extends mixed)>|object>`, but provided type `array<array-key, mixed>` is less specific."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
 code = "less-specific-nested-argument-type"
-message = "Argument type mismatch for argument #1 of `array_column`: expected `array<array-key, array<int(1), ('V.array_column() extends mixed)>|object>|list<array<int(1), ('V.array_column() extends mixed)>|object>`, but provided type `array<array-key, mixed>` is less specific."
+message = 'Argument type mismatch for argument #1 of `infection\tests\autoreview\concreteclassreflector::filterbyconcreteclasses`: expected `array<array-key, string>`, but provided type `list<mixed>` is less specific.'
 count = 1
 
 [[issues]]
@@ -5469,7 +5469,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorProviderTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 2
 
 [[issues]]
@@ -5583,7 +5583,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 3
 
 [[issues]]
@@ -5619,7 +5619,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/PhpDoc/PHPDocParser.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `list<mixed>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Tests\AutoReview\PhpDoc\PHPDocParser::parse` due to nested 'mixed'.'''
+message = '''Returned type `list<mixed>` is less specific than the declared return type `array<array-key, string>` for function `infection\tests\autoreview\phpdoc\phpdocparser::parse` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -5733,7 +5733,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #1 of `Infection\Tests\AutoReview\ConcreteClassReflector::filterByConcreteClasses`: expected `array<array-key, string>`, but provided type `array<array-key, mixed>` is less specific.'
+message = 'Argument type mismatch for argument #1 of `infection\tests\autoreview\concreteclassreflector::filterbyconcreteclasses`: expected `array<array-key, string>`, but provided type `array<array-key, mixed>` is less specific.'
 count = 1
 
 [[issues]]
@@ -5745,7 +5745,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -5835,7 +5835,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 4
 
 [[issues]]
@@ -5943,7 +5943,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/CI/MemoizedCiDetectorTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\CI\ConfigurableEnv::setVariables`: expected `array<string, false|string>`, but possibly received `array{'TRAVIS': true}`.'''
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\CI\ConfigurableEnv::setvariables`: expected `array<string, false|string>`, but possibly received `array{'TRAVIS': true}`.'''
 count = 1
 
 [[issues]]
@@ -6195,7 +6195,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Tests\Command\Git\GitChangedFilesCommandTest::createCommandTester`: expected `Infection\Git\Git`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Tests\Command\Git\GitChangedFilesCommandTest::createcommandtester`: expected `Infection\Git\Git`, but found `mixed`.'
 count = 2
 
 [[issues]]
@@ -6267,7 +6267,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Tests\Command\Git\GitChangedLinesCommandTest::createCommandTester`: expected `Infection\Git\Git`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Tests\Command\Git\GitChangedLinesCommandTest::createcommandtester`: expected `Infection\Git\Git`, but found `mixed`.'
 count = 2
 
 [[issues]]
@@ -6621,7 +6621,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Config\Guesser\PhpUnitPathGuesser::__construct`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\config\guesser\phpunitpathguesser::__construct`: expected `stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -6633,7 +6633,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Config\Guesser\SourceDirGuesser::__construct`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\config\guesser\sourcedirguesser::__construct`: expected `stdClass`, but found `mixed`.'
 count = 8
 
 [[issues]]
@@ -6711,7 +6711,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Config\ValueProvider\ExcludeDirsProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\config\valueprovider\excludedirsprovider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -6807,7 +6807,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Config\ValueProvider\PhpUnitCustomExecutablePathProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `infection\config\valueprovider\phpunitcustomexecutablepathprovider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -6861,7 +6861,7 @@ count = 5
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Config\ValueProvider\SourceDirsProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\config\valueprovider\sourcedirsprovider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -6957,7 +6957,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Config\ValueProvider\TextLogFileProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\config\valueprovider\textlogfileprovider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -6987,7 +6987,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/ConfigurationBuilder.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Mutator\IgnoreMutator::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `infection\mutator\ignoremutator::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -7011,7 +7011,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
 code = "no-value"
-message = 'Argument #5 passed to method `Infection\Configuration\ConfigurationFactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #5 passed to method `infection\configuration\configurationfactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -7209,7 +7209,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::assertJsonIsSchemaValid`: expected `stdClass`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::assertjsonisschemavalid`: expected `stdClass`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -7257,385 +7257,385 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': null, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': null, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': string('src/bootstrap.php'), 'initialTestsPhpOptions': string('-d zend_extension=xdebug.so'), 'logs': Infection\Configuration\Entry\Logs, 'mutators': array{'@arithmetic': true, '@boolean': true, '@cast': true, '@conditional_boundary': true, '@conditional_negotiation': true, '@default': true, '@function_signature': true, '@loop': true, '@number': true, '@operator': true, '@regex': true, '@removal': true, '@return_value': true, '@sort': true, 'ArrayItem': true, 'ArrayItemRemoval': object{ignore: list{string('file')}, settings: object{limit: int(10), remove: string('first')}}, 'ArrayOneItem': true, 'AssignCoalesce': true, 'Assignment': true, 'AssignmentEqual': true, 'BCMath': object{ignore: list{string('file')}, settings: object{bcadd: false, bccomp: false, bcdiv: false, bcmod: false, bcmul: false, bcpow: false, bcpowmod: false, bcsqrt: false, bcsub: false}}, 'BitwiseAnd': true, 'BitwiseNot': true, 'BitwiseOr': true, 'BitwiseXor': true, 'Break_': true, 'CastArray': true, 'CastBool': true, 'CastFloat': true, 'CastInt': true, 'CastObject': true, 'CastString': true, 'Coalesce': true, 'Continue_': true, 'Decrement': true, 'DecrementInteger': true, 'DivEqual': true, 'Division': true, 'Equal': true, 'EqualIdentical': true, 'Exponentiation': true, 'FalseValue': true, 'Finally_': true, 'FloatNegation': true, 'For_': true, 'Foreach_': true, 'FunctionCall': true, 'FunctionCallRemoval': true, 'GreaterThan': true, 'GreaterThanNegotiation': true, 'GreaterThanOrEqualTo': true, 'GreaterThanOrEqualToNegotiation': true, 'Identical': true, 'Increment': true, 'IncrementInteger': true, 'IntegerNegation': true, 'LessThan': true, 'LessThanNegotiation': true, 'LessThanOrEqualTo': true, 'LessThanOrEqualToNegotiation': true, 'LogicalAnd': true, 'LogicalLowerAnd': true, 'LogicalLowerOr': true, 'LogicalNot': true, 'LogicalOr': true, 'MBString': object{ignore: list{string('file')}, settings: object{mb_chr: false, mb_convert_case: false, mb_ord: false, mb_parse_str: false, mb_send_mail: false, mb_strcut: false, mb_stripos: false, mb_stristr: false, mb_strlen: false, mb_strpos: false, mb_strrchr: false, mb_strripos: false, mb_strrpos: false, mb_strstr: false, mb_strtolower: false, mb_strtoupper: false, mb_substr: false, mb_substr_count: false}}, 'MethodCallRemoval': true, 'Minus': true, 'MinusEqual': true, 'ModEqual': true, 'Modulus': true, 'MulEqual': true, 'Multiplication': true, 'NewObject': true, 'NotEqual': true, 'NotEqualNotIdentical': true, 'NotIdentical': true, 'NotIdenticalNotEqual': true, 'OneZeroFloat': true, 'Plus': true, 'PlusEqual': true, 'PowEqual': true, 'PregMatchMatches': true, 'PregQuote': true, 'ProtectedVisibility': true, 'PublicVisibility': true, 'RoundingFamily': true, 'ShiftLeft': true, 'ShiftRight': true, 'Spaceship': true, 'This': true, 'Throw_': true, 'TrueValue': object{ignore: list{string('fileA')}, settings: object{array_search: false, in_array: false}}, 'UnwrapArrayChangeKeyCase': true, 'UnwrapArrayChunk': true, 'UnwrapArrayColumn': true, 'UnwrapArrayCombine': true, 'UnwrapArrayDiff': true, 'UnwrapArrayDiffAssoc': true, 'UnwrapArrayDiffKey': true, 'UnwrapArrayDiffUassoc': true, 'UnwrapArrayDiffUkey': true, 'UnwrapArrayFilter': true, 'UnwrapArrayFlip': true, 'UnwrapArrayIntersect': true, 'UnwrapArrayIntersectAssoc': true, 'UnwrapArrayIntersectKey': true, 'UnwrapArrayIntersectUassoc': true, 'UnwrapArrayIntersectUkey': true, 'UnwrapArrayKeys': true, 'UnwrapArrayMap': true, 'UnwrapArrayMerge': true, 'UnwrapArrayMergeRecursive': true, 'UnwrapArrayPad': true, 'UnwrapArrayReduce': true, 'UnwrapArrayReplace': true, 'UnwrapArrayReplaceRecursive': true, 'UnwrapArrayReverse': true, 'UnwrapArraySlice': true, 'UnwrapArraySplice': true, 'UnwrapArrayUdiff': true, 'UnwrapArrayUdiffAssoc': true, 'UnwrapArrayUdiffUassoc': true, 'UnwrapArrayUintersect': true, 'UnwrapArrayUintersectAssoc': true, 'UnwrapArrayUintersectUassoc': true, 'UnwrapArrayUnique': true, 'UnwrapArrayValues': true, 'UnwrapLcFirst': true, 'UnwrapStrRepeat': true, 'UnwrapStrToLower': true, 'UnwrapStrToUpper': true, 'UnwrapTrim': true, 'UnwrapUcFirst': true, 'UnwrapUcWords': true, 'Yield_': true}, 'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source, 'testFramework': string('phpunit'), 'testFrameworkOptions': string('--debug'), 'timeout': int(5), 'tmpDir': string('custom-tmp')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': string('src/bootstrap.php'), 'initialTestsPhpOptions': string('-d zend_extension=xdebug.so'), 'logs': Infection\Configuration\Entry\Logs, 'mutators': array{'@arithmetic': true, '@boolean': true, '@cast': true, '@conditional_boundary': true, '@conditional_negotiation': true, '@default': true, '@function_signature': true, '@loop': true, '@number': true, '@operator': true, '@regex': true, '@removal': true, '@return_value': true, '@sort': true, 'ArrayItem': true, 'ArrayItemRemoval': object{ignore: list{string('file')}, settings: object{limit: int(10), remove: string('first')}}, 'ArrayOneItem': true, 'AssignCoalesce': true, 'Assignment': true, 'AssignmentEqual': true, 'BCMath': object{ignore: list{string('file')}, settings: object{bcadd: false, bccomp: false, bcdiv: false, bcmod: false, bcmul: false, bcpow: false, bcpowmod: false, bcsqrt: false, bcsub: false}}, 'BitwiseAnd': true, 'BitwiseNot': true, 'BitwiseOr': true, 'BitwiseXor': true, 'Break_': true, 'CastArray': true, 'CastBool': true, 'CastFloat': true, 'CastInt': true, 'CastObject': true, 'CastString': true, 'Coalesce': true, 'Continue_': true, 'Decrement': true, 'DecrementInteger': true, 'DivEqual': true, 'Division': true, 'Equal': true, 'EqualIdentical': true, 'Exponentiation': true, 'FalseValue': true, 'Finally_': true, 'FloatNegation': true, 'For_': true, 'Foreach_': true, 'FunctionCall': true, 'FunctionCallRemoval': true, 'GreaterThan': true, 'GreaterThanNegotiation': true, 'GreaterThanOrEqualTo': true, 'GreaterThanOrEqualToNegotiation': true, 'Identical': true, 'Increment': true, 'IncrementInteger': true, 'IntegerNegation': true, 'LessThan': true, 'LessThanNegotiation': true, 'LessThanOrEqualTo': true, 'LessThanOrEqualToNegotiation': true, 'LogicalAnd': true, 'LogicalLowerAnd': true, 'LogicalLowerOr': true, 'LogicalNot': true, 'LogicalOr': true, 'MBString': object{ignore: list{string('file')}, settings: object{mb_chr: false, mb_convert_case: false, mb_ord: false, mb_parse_str: false, mb_send_mail: false, mb_strcut: false, mb_stripos: false, mb_stristr: false, mb_strlen: false, mb_strpos: false, mb_strrchr: false, mb_strripos: false, mb_strrpos: false, mb_strstr: false, mb_strtolower: false, mb_strtoupper: false, mb_substr: false, mb_substr_count: false}}, 'MethodCallRemoval': true, 'Minus': true, 'MinusEqual': true, 'ModEqual': true, 'Modulus': true, 'MulEqual': true, 'Multiplication': true, 'NewObject': true, 'NotEqual': true, 'NotEqualNotIdentical': true, 'NotIdentical': true, 'NotIdenticalNotEqual': true, 'OneZeroFloat': true, 'Plus': true, 'PlusEqual': true, 'PowEqual': true, 'PregMatchMatches': true, 'PregQuote': true, 'ProtectedVisibility': true, 'PublicVisibility': true, 'RoundingFamily': true, 'ShiftLeft': true, 'ShiftRight': true, 'Spaceship': true, 'This': true, 'Throw_': true, 'TrueValue': object{ignore: list{string('fileA')}, settings: object{array_search: false, in_array: false}}, 'UnwrapArrayChangeKeyCase': true, 'UnwrapArrayChunk': true, 'UnwrapArrayColumn': true, 'UnwrapArrayCombine': true, 'UnwrapArrayDiff': true, 'UnwrapArrayDiffAssoc': true, 'UnwrapArrayDiffKey': true, 'UnwrapArrayDiffUassoc': true, 'UnwrapArrayDiffUkey': true, 'UnwrapArrayFilter': true, 'UnwrapArrayFlip': true, 'UnwrapArrayIntersect': true, 'UnwrapArrayIntersectAssoc': true, 'UnwrapArrayIntersectKey': true, 'UnwrapArrayIntersectUassoc': true, 'UnwrapArrayIntersectUkey': true, 'UnwrapArrayKeys': true, 'UnwrapArrayMap': true, 'UnwrapArrayMerge': true, 'UnwrapArrayMergeRecursive': true, 'UnwrapArrayPad': true, 'UnwrapArrayReduce': true, 'UnwrapArrayReplace': true, 'UnwrapArrayReplaceRecursive': true, 'UnwrapArrayReverse': true, 'UnwrapArraySlice': true, 'UnwrapArraySplice': true, 'UnwrapArrayUdiff': true, 'UnwrapArrayUdiffAssoc': true, 'UnwrapArrayUdiffUassoc': true, 'UnwrapArrayUintersect': true, 'UnwrapArrayUintersectAssoc': true, 'UnwrapArrayUintersectUassoc': true, 'UnwrapArrayUnique': true, 'UnwrapArrayValues': true, 'UnwrapLcFirst': true, 'UnwrapStrRepeat': true, 'UnwrapStrToLower': true, 'UnwrapStrToUpper': true, 'UnwrapTrim': true, 'UnwrapUcFirst': true, 'UnwrapUcWords': true, 'Yield_': true}, 'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source, 'testFramework': string('phpunit'), 'testFrameworkOptions': string('--debug'), 'timeout': int(5), 'tmpDir': string('custom-tmp')}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': string('src/bootstrap.php'), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'bootstrap': string('src/bootstrap.php'), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'ignoreMsiWithNoMutations': false, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'ignoreMsiWithNoMutations': false, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'ignoreMsiWithNoMutations': true, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'ignoreMsiWithNoMutations': true, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'initialTestsPhpOptions': null, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'initialTestsPhpOptions': null, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'initialTestsPhpOptions': string('-d zend_extension=xdebug.so'), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'initialTestsPhpOptions': string('-d zend_extension=xdebug.so'), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'logs': Infection\Configuration\Entry\Logs, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'logs': Infection\Configuration\Entry\Logs, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 14
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'logs': infection\configuration\entry\logs, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'logs': infection\configuration\entry\logs, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minCoveredMsi': float(3.14), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minCoveredMsi': float(3.14), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minCoveredMsi': float(32.0), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minCoveredMsi': float(32.0), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minMsi': float(3.14), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minMsi': float(3.14), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minMsi': float(32.0), 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'minMsi': float(32.0), 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'@arithmetic': true, '@boolean': true, '@cast': true, '@conditional_boundary': true, '@conditional_negotiation': true, '@default': true, '@function_signature': true, '@loop': true, '@number': true, '@operator': true, '@regex': true, '@removal': true, '@return_value': true, '@sort': true}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'@arithmetic': true, '@boolean': true, '@cast': true, '@conditional_boundary': true, '@conditional_negotiation': true, '@default': true, '@function_signature': true, '@loop': true, '@number': true, '@operator': true, '@regex': true, '@removal': true, '@return_value': true, '@sort': true}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': false}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': false}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string('file')}, settings: object{limit: int(10), remove: string('first')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string('file')}, settings: object{limit: int(10), remove: string('first')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{settings: object{limit: int(10)}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{settings: object{limit: int(10)}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{settings: object{remove: string('first')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': object{settings: object{remove: string('first')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': true}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'ArrayItemRemoval': true}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': false}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': false}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string('file')}, settings: object{bcadd: false, bccomp: false, bcdiv: false, bcmod: false, bcmul: false, bcpow: false, bcpowmod: false, bcsqrt: false, bcsub: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string('file')}, settings: object{bcadd: false, bccomp: false, bcdiv: false, bcmod: false, bcmul: false, bcpow: false, bcpowmod: false, bcsqrt: false, bcsub: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{settings: stdClass}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': object{settings: stdClass}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': true}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'BCMath': true}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': false}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': false}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string('file')}, settings: object{mb_chr: false, mb_convert_case: false, mb_ord: false, mb_parse_str: false, mb_send_mail: false, mb_strcut: false, mb_stripos: false, mb_stristr: false, mb_strlen: false, mb_strpos: false, mb_strrchr: false, mb_strripos: false, mb_strrpos: false, mb_strstr: false, mb_strtolower: false, mb_strtoupper: false, mb_substr: false, mb_substr_count: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string('file')}, settings: object{mb_chr: false, mb_convert_case: false, mb_ord: false, mb_parse_str: false, mb_send_mail: false, mb_strcut: false, mb_stripos: false, mb_stristr: false, mb_strlen: false, mb_strpos: false, mb_strrchr: false, mb_strripos: false, mb_strrpos: false, mb_strstr: false, mb_strtolower: false, mb_strtoupper: false, mb_substr: false, mb_substr_count: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{settings: stdClass}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': object{settings: stdClass}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': true}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'MBString': true}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': false}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': false}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string(' file '), string('')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string('fileA'), string('fileB')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string('fileA')}, settings: object{array_search: false, in_array: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignore: list{string('fileA')}, settings: object{array_search: false, in_array: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{ignoreSourceCodeByRegex: list{string('.*test.*')}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{settings: object{array_search: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{settings: object{array_search: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{settings: object{in_array: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': object{settings: object{in_array: false}}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': true}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'TrueValue': true}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': array{}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': array{}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': list{string(' file '), string(' ')}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': list{string(' file '), string(' ')}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': list{string('A::B')}}, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': array{'global-ignore': list{string('A::B')}}, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, false>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, false>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, object{ignore: list{string(' file '), string('')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, object{ignore: list{string(' file '), string('')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, object{ignore: list{string('fileA'), string('fileB')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, object{ignore: list{string('fileA'), string('fileB')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, true>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, true>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), false>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), false>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), object{ignore: list{string(' file '), string('')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), object{ignore: list{string(' file '), string('')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), object{ignore: list{string('fileA'), string('fileB')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), object{ignore: list{string('fileA'), string('fileB')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), true>, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), true>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 5
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFramework': string('phpunit')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFramework': string('phpunit')}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFramework': string}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFramework': string}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFrameworkOptions': null}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFrameworkOptions': null}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFrameworkOptions': string('--debug')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'testFrameworkOptions': string('--debug')}`.'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'timeout': int(100)}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'timeout': int(100)}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'tmpDir': null}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'tmpDir': null}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'tmpDir': string('custom-tmp')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source, 'tmpDir': string('custom-tmp')}`.'''
 count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\tests\configuration\schema\schemaconfigurationfactorytest::createconfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'source': Infection\Configuration\Entry\Source}`.'''
 count = 5
 
 [[issues]]
@@ -7647,7 +7647,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "too-few-arguments"
-message = 'Too few arguments provided for method `Infection\Configuration\Schema\SchemaConfiguration::__construct`.'
+message = 'Too few arguments provided for method `infection\configuration\schema\schemaconfiguration::__construct`.'
 count = 1
 
 [[issues]]
@@ -7887,25 +7887,25 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Console/E2ETest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Composer\Autoload\ClassLoader::setPsr4`: expected `string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `Composer\Autoload\ClassLoader::set`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Console/E2ETest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Composer\Autoload\ClassLoader::setPsr4`: expected `list<string>|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Composer\Autoload\ClassLoader::setpsr4`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Console/E2ETest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #2 of `Composer\Autoload\ClassLoader::set`: expected `list<string>|string`, but found `mixed`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/E2ETest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #2 of `Composer\Autoload\ClassLoader::setpsr4`: expected `list<string>|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -8145,7 +8145,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Container/Builder/IndexXmlCoverageParserBuilderTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\Container\Builder\IndexXmlCoverageParserBuilderTest::getIsSourceFiltered`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\tests\container\builder\indexxmlcoverageparserbuildertest::getissourcefiltered`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -8343,31 +8343,31 @@ count = 96
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #10 of `Infection\Engine::__construct`: expected `Infection\Metrics\MaxTimeoutsChecker`, but found `mixed`.'
+message = 'Invalid argument type for argument #10 of `infection\engine::__construct`: expected `Infection\Metrics\MaxTimeoutsChecker`, but found `mixed`.'
 count = 3
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #11 of `Infection\Engine::__construct`: expected `Infection\Console\ConsoleOutput`, but found `mixed`.'
+message = 'Invalid argument type for argument #11 of `infection\engine::__construct`: expected `Infection\Console\ConsoleOutput`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #13 of `Infection\Engine::__construct`: expected `Infection\TestFramework\TestFrameworkExtraOptionsFilter`, but found `mixed`.'
+message = 'Invalid argument type for argument #13 of `infection\engine::__construct`: expected `Infection\TestFramework\TestFrameworkExtraOptionsFilter`, but found `mixed`.'
 count = 5
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #15 of `Infection\Engine::__construct`: expected `Infection\StaticAnalysis\StaticAnalysisToolAdapter|null`, but found `mixed`.'
+message = 'Invalid argument type for argument #15 of `infection\engine::__construct`: expected `Infection\StaticAnalysis\StaticAnalysisToolAdapter|null`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Engine::__construct`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `infection\engine::__construct`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
 count = 5
 
 [[issues]]
@@ -8997,7 +8997,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
 code = "no-value"
-message = 'Argument #1 passed to method `Infection\Event\EventDispatcher\SyncEventDispatcher::addSubscriber` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `Infection\Event\EventDispatcher\SyncEventDispatcher::addsubscriber` has type `never`, meaning it cannot produce a value.'
 count = 3
 
 [[issues]]
@@ -9087,7 +9087,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Event/Events/MutationAnalysis/MutationEvaluation/MutantProcessWasFinishedTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished::__construct`: expected `Infection\Mutant\MutantExecutionResult`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\event\events\mutationanalysis\mutationevaluation\mutantprocesswasfinished::__construct`: expected `Infection\Mutant\MutantExecutionResult`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -9135,7 +9135,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Event/Events/MutationAnalysis/MutationTestingWasStartedTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted::__construct`: expected `Infection\Process\Runner\ProcessRunner`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `infection\event\events\mutationanalysis\mutationtestingwasstarted::__construct`: expected `Infection\Process\Runner\ProcessRunner`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -9171,19 +9171,19 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
 code = "no-value"
-message = 'Argument #1 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -9321,7 +9321,7 @@ count = 6
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted::__construct`: expected `Infection\Process\Runner\ProcessRunner`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `infection\event\events\mutationanalysis\mutationtestingwasstarted::__construct`: expected `Infection\Process\Runner\ProcessRunner`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -9405,19 +9405,19 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "no-value"
-message = 'Argument #1 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `infection\event\subscriber\chainsubscriberfactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -9453,7 +9453,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `Infection\Event\Subscriber\SubscriberRegisterer::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher)`.'
+message = 'Possible argument type mismatch for argument #1 of `infection\event\subscriber\subscriberregisterer::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher)`.'
 count = 2
 
 [[issues]]
@@ -9465,7 +9465,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/FileSystem/FileStoreTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\FileSystem\FileStore::getContents`: expected `SplFileInfo|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `Infection\FileSystem\FileStore::getcontents`: expected `SplFileInfo|string`, but found `mixed`.'
 count = 4
 
 [[issues]]
@@ -9759,7 +9759,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `Infection\FileSystem\Finder\TestFrameworkFinder::__construct`: expected `Infection\FileSystem\Finder\ComposerExecutableFinder`, but possibly received `PHPUnit\Framework\MockObject\MockObject`.'
+message = 'Possible argument type mismatch for argument #1 of `infection\filesystem\finder\testframeworkfinder::__construct`: expected `Infection\FileSystem\Finder\ComposerExecutableFinder`, but possibly received `PHPUnit\Framework\MockObject\MockObject`.'
 count = 5
 
 [[issues]]
@@ -9801,7 +9801,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\FileSystem\Locator\FileOrDirectoryNotFound::multipleFilesDoNotExist`.'
+message = 'Call to deprecated method: `infection\filesystem\locator\fileordirectorynotfound::multiplefilesdonotexist`.'
 count = 1
 
 [[issues]]
@@ -10755,7 +10755,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Logger/MutationGeneration/MutationGenerationLoggerFactoryTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Logger\MutationGeneration\MutationGenerationLoggerFactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `infection\logger\mutationgeneration\mutationgenerationloggerfactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -10839,7 +10839,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
 code = "possibly-null-argument"
-message = 'Argument #1 of method `Infection\Tests\Metrics\CreateMutantExecutionResult::addMutantExecutionResult` is possibly `null`, but parameter type `Infection\Metrics\Collector` does not accept it.'
+message = 'Argument #1 of method `infection\tests\metrics\createmutantexecutionresult::addmutantexecutionresult` is possibly `null`, but parameter type `Infection\Metrics\Collector` does not accept it.'
 count = 2
 
 [[issues]]
@@ -11013,26 +11013,26 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::assertProvidesExcluding`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
-count = 10
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "invalid-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::assertProvides`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
+message = 'Invalid argument type for argument #2 of `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::assertprovides`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
 count = 4
 
 [[issues]]
 file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Metrics\TargetDetectionStatusesProvider::__construct`: expected `Infection\Configuration\Entry\Logs`, but found `mixed`.'
-count = 3
+code = "invalid-argument"
+message = 'Invalid argument type for argument #2 of `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::assertprovidesexcluding`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
+count = 10
 
 [[issues]]
 file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 16
+
+[[issues]]
+file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #1 of `infection\metrics\targetdetectionstatusesprovider::__construct`: expected `Infection\Configuration\Entry\Logs`, but found `mixed`.'
+count = 3
 
 [[issues]]
 file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
@@ -11217,7 +11217,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
+message = 'Call to deprecated method: `infection\tests\mutant\mutantbuilder::materialize`.'
 count = 6
 
 [[issues]]
@@ -11319,12 +11319,6 @@ count = 6
 [[issues]]
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\FileSystem\FileStore::__construct`: expected `Infection\FileSystem\FileSystem`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
 count = 1
 
@@ -11337,7 +11331,13 @@ count = 10
 [[issues]]
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #4 of `Infection\Mutation\FileMutationGenerator::__construct`: expected `Infection\Source\Matcher\SourceLineMatcher`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\filesystem\filestore::__construct`: expected `Infection\FileSystem\FileSystem`, but found `mixed`.'
+count = 2
+
+[[issues]]
+file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #4 of `infection\mutation\filemutationgenerator::__construct`: expected `Infection\Source\Matcher\SourceLineMatcher`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -11475,7 +11475,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutation/MutationBuilder.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #6 of `Infection\Tests\Mutation\MutationBuilder::__construct`: expected `array<string, float|int|string>`, but provided type `array<array-key, float|int|string>` is less specific.'
+message = 'Argument type mismatch for argument #6 of `infection\tests\mutation\mutationbuilder::__construct`: expected `array<string, float|int|string>`, but provided type `array<array-key, float|int|string>` is less specific.'
 count = 1
 
 [[issues]]
@@ -11511,7 +11511,7 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `Infection\Mutation\MutationGenerator::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but found `mixed`.'
+message = 'Invalid argument type for argument #3 of `infection\mutation\mutationgenerator::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -11523,7 +11523,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Mutator\IgnoreMutator::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `infection\mutator\ignoremutator::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -11643,13 +11643,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutation/MutationTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #2 of `PhpParser\Node\Stmt\Namespace_::__construct`: expected `array<array-key, PhpParser\Node\Stmt>|null`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
+message = 'Invalid argument type for argument #2 of `phpparser\node\stmt\namespace_::__construct`: expected `array<array-key, PhpParser\Node\Stmt>|null`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
 count = 5
 
 [[issues]]
 file = "tests/phpunit/Mutation/MutationTest.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #5 of `Infection\Mutation\Mutation::__construct`: expected `array<string, float|int|string>`, but provided type `array<array-key, float|int|string>` is less specific.'
+message = 'Argument type mismatch for argument #5 of `infection\mutation\mutation::__construct`: expected `array<string, float|int|string>`, but provided type `array<array-key, float|int|string>` is less specific.'
 count = 1
 
 [[issues]]
@@ -11781,7 +11781,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/Arithmetic/PlusTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #1 of `PhpParser\Node\Expr\Array_::__construct`: expected `array<array-key, PhpParser\Node\ArrayItem>`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
+message = 'Invalid argument type for argument #1 of `phpparser\node\expr\array_::__construct`: expected `array<array-key, PhpParser\Node\ArrayItem>`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
 count = 2
 
 [[issues]]
@@ -11843,6 +11843,48 @@ file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
+
+[[issues]]
+file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
+code = "mixed-operand"
+message = "Left operand in `==` comparison has `mixed` type."
+count = 3
+
+[[issues]]
+file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
+code = "non-existent-constant"
+message = 'Undefined constant: `Infection\Tests\Mutator\Boolean\PHP`.'
+count = 4
+
+[[issues]]
+file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
+code = "non-existent-constant"
+message = 'Undefined constant: `Infection\Tests\Mutator\Boolean\_MAJOR_VERSION`.'
+count = 3
+
+[[issues]]
+file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
+code = "non-existent-constant"
+message = 'Undefined constant: `Infection\Tests\Mutator\Boolean\_SAPI`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
+code = "parse"
+message = "Parse error encountered during parsing"
+count = 42
+
+[[issues]]
+file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
+code = "unevaluated-code"
+message = "Unreachable code detected."
+count = 15
+
+[[issues]]
+file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
+code = "unused-statement"
+message = "Expression has no effect as a statement"
+count = 8
 
 [[issues]]
 file = "tests/phpunit/Mutator/Boolean/FalseValueTest.php"
@@ -12015,7 +12057,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Mutator/Boolean/TrueValueConfigTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Boolean\TrueValueConfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\mutator\boolean\truevalueconfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
 count = 1
 
 [[issues]]
@@ -12195,7 +12237,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/DefinitionTest.php"
 code = "possibly-null-argument"
-message = 'Argument #4 of method `Infection\Mutator\Definition::__construct` is possibly `null`, but parameter type `string` does not accept it.'
+message = 'Argument #4 of method `infection\mutator\definition::__construct` is possibly `null`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -12219,7 +12261,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Mutator/Extensions/BCMathConfigTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Extensions\BCMathConfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\mutator\extensions\bcmathconfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
 count = 1
 
 [[issues]]
@@ -12297,7 +12339,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Mutator/Extensions/MBStringConfigTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Extensions\MBStringConfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\mutator\extensions\mbstringconfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
 count = 1
 
 [[issues]]
@@ -12525,7 +12567,7 @@ count = 7
 [[issues]]
 file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #2 of `Infection\Mutator\IgnoreMutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\ignoremutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
+message = '''Possible argument type mismatch for argument #2 of `infection\mutator\ignoremutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\ignoremutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
 count = 4
 
 [[issues]]
@@ -12627,7 +12669,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
 code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #1 of `Infection\Tests\Mutator\MutatorFactoryTest::assertSameMutatorsByClass`: expected `array<array-key, string>`, but provided type `list<mixed>` is less specific.'
+message = 'Argument type mismatch for argument #1 of `Infection\Tests\Mutator\MutatorFactoryTest::assertsamemutatorsbyclass`: expected `array<array-key, string>`, but provided type `list<mixed>` is less specific.'
 count = 1
 
 [[issues]]
@@ -12741,7 +12783,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #3 of `Infection\Tests\Mutator\MutatorFactoryTest::createBoolNode`: expected `Infection\Reflection\ClassReflection`, but possibly received `Infection\Reflection\ClassReflection|PHPUnit\Framework\MockObject\MockObject`.'
+message = 'Possible argument type mismatch for argument #3 of `Infection\Tests\Mutator\MutatorFactoryTest::createboolnode`: expected `Infection\Reflection\ClassReflection`, but possibly received `Infection\Reflection\ClassReflection|PHPUnit\Framework\MockObject\MockObject`.'
 count = 1
 
 [[issues]]
@@ -12933,7 +12975,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Testing\MutatorName::getName`: expected `string`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\testing\mutatorname::getname`: expected `string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -13041,7 +13083,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Mutator/NoopMutatorTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\NoopMutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\noopmutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\mutator\noopmutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\noopmutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
 count = 3
 
 [[issues]]
@@ -13233,7 +13275,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/ProfileListProvider.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Tests\Mutator\ProfileListProvider::getProfiles`: expected `array<array-key, mixed>`, but found `array<string, array<array-key, string>>|null`.'
+message = 'Invalid return type for function `infection\tests\mutator\profilelistprovider::getprofiles`: expected `array<array-key, mixed>`, but found `array<string, array<array-key, string>>|null`.'
 count = 1
 
 [[issues]]
@@ -13251,13 +13293,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/ProfileListProvider.php"
 code = "nullable-return-statement"
-message = 'Function `Infection\Tests\Mutator\ProfileListProvider::getProfiles` is declared to return `array<array-key, mixed>` but possibly returns a nullable value (inferred as `array<string, array<array-key, string>>|null`).'
+message = 'Function `infection\tests\mutator\profilelistprovider::getprofiles` is declared to return `array<array-key, mixed>` but possibly returns a nullable value (inferred as `array<string, array<array-key, string>>|null`).'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/ProfileListProvider.php"
 code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
+message = "Possible argument type mismatch for argument #1 of `reflectionclass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -13383,13 +13425,13 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Removal\ArrayItemRemovalConfig::__construct`: expected `array{'limit'?: int|null, 'remove'?: null|string}`, but possibly received `array<array-key, mixed>`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\mutator\removal\arrayitemremovalconfig::__construct`: expected `array{'limit'?: int|null, 'remove'?: null|string}`, but possibly received `array<array-key, mixed>`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Removal\ArrayItemRemovalConfig::__construct`: expected `array{'limit'?: int|null, 'remove'?: null|string}`, but possibly received `array{'limit': string('foo')}`.'''
+message = '''Possible argument type mismatch for argument #1 of `infection\mutator\removal\arrayitemremovalconfig::__construct`: expected `array{'limit'?: int|null, 'remove'?: null|string}`, but possibly received `array{'limit': string('foo')}`.'''
 count = 1
 
 [[issues]]
@@ -13875,7 +13917,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::mockFunction`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\tests\mutator\util\abstractvaluetonullreturnvaluetest::mockfunction`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -14115,7 +14157,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperScenario.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Tests\PhpParser\NodeDumper\NodeDumper\NodeDumperScenario::__construct`: expected `PhpParser\Node|list<PhpParser\Node>`, but found `string`.'
+message = 'Invalid argument type for argument #1 of `infection\tests\phpparser\nodedumper\nodedumper\nodedumperscenario::__construct`: expected `PhpParser\Node|list<PhpParser\Node>`, but found `string`.'
 count = 1
 
 [[issues]]
@@ -14163,7 +14205,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
 code = "invalid-argument"
-message = '''Invalid argument type for argument #1 of `Infection\Tests\PhpParser\NodeDumper\NodeDumper\NodeDumperScenario::forNode`: expected `PhpParser\Node|list<PhpParser\Node>`, but found `array{0: string('Foo'), 1: string('Bar'), 'Key': string('FooBar')}`.'''
+message = '''Invalid argument type for argument #1 of `infection\tests\phpparser\nodedumper\nodedumper\nodedumperscenario::fornode`: expected `PhpParser\Node|list<PhpParser\Node>`, but found `array{0: string('Foo'), 1: string('Bar'), 'Key': string('FooBar')}`.'''
 count = 1
 
 [[issues]]
@@ -14211,19 +14253,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Tests\PhpParser\NodeTraverserFactoryTest::getVisitorClassNames`: expected `list<class-string<PhpParser\NodeVisitor>>`, but found `list<string>`.'
+message = 'Invalid return type for function `infection\tests\phpparser\nodetraverserfactorytest::getvisitorclassnames`: expected `list<class-string<PhpParser\NodeVisitor>>`, but found `list<string>`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #1 of `Infection\Tests\PhpParser\NodeTraverserFactoryTest::getVisitorClassNames`: expected `PhpParser\NodeTraverser`, but provided type `PhpParser\NodeTraverserInterface` is less specific.'
+message = 'Argument type mismatch for argument #1 of `infection\tests\phpparser\nodetraverserfactorytest::getvisitorclassnames`: expected `PhpParser\NodeTraverser`, but provided type `PhpParser\NodeTraverserInterface` is less specific.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "no-value"
-message = 'Argument #1 passed to method `Infection\PhpParser\NodeTraverserFactory::createMutationTraverser` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `Infection\PhpParser\NodeTraverserFactory::createmutationtraverser` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -14247,7 +14289,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #2 of `Infection\Tests\PhpParser\NodeTraverserFactoryTest::assertTraverserVisitorsAre`: expected `list<class-string<PhpParser\NodeVisitor>>`, but possibly received `list{class-string('PhpParser\NodeVisitor\CloningVisitor'), class-string('Infection\Tests\Fixtures\PhpParser\FakeVisitor')}`.'''
+message = '''Possible argument type mismatch for argument #2 of `Infection\Tests\PhpParser\NodeTraverserFactoryTest::asserttraverservisitorsare`: expected `list<class-string<PhpParser\NodeVisitor>>`, but possibly received `list{class-string('PhpParser\NodeVisitor\CloningVisitor'), class-string('Infection\Tests\Fixtures\PhpParser\FakeVisitor')}`.'''
 count = 1
 
 [[issues]]
@@ -14397,7 +14439,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameManipulatorTest.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Tests\PhpParser\Visitor\FullyQualifiedClassNameManipulatorTest::getFqcns`: expected `array<int, PhpParser\Node\Name>`, but found `array<int, PhpParser\Node\Name|null>`.'
+message = 'Invalid return type for function `infection\tests\phpparser\visitor\fullyqualifiedclassnamemanipulatortest::getfqcns`: expected `array<int, PhpParser\Node\Name>`, but found `array<int, PhpParser\Node\Name|null>`.'
 count = 1
 
 [[issues]]
@@ -14523,7 +14565,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitorTest::cloneNodes`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\tests\phpparser\visitor\marktraversednodesasvisitedvisitor\marktraversednodesasvisitedvisitortest::clonenodes`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -14637,13 +14679,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\PhpParser\Visitor\ParentConnector::findParent`: expected `PhpParser\Node`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\phpparser\visitor\parentconnector::findparent`: expected `PhpParser\Node`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\PhpParser\Visitor\ParentConnector::getParent`: expected `PhpParser\Node`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\phpparser\visitor\parentconnector::getparent`: expected `PhpParser\Node`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -14721,7 +14763,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCase.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase::parse`: expected `array<array-key, PhpParser\Node\Stmt>`, but found `array<array-key, PhpParser\Node\Stmt>|null`.'
+message = 'Invalid return type for function `infection\tests\phpparser\visitor\visitortestcase\visitortestcase::parse`: expected `array<array-key, PhpParser\Node\Stmt>`, but found `array<array-key, PhpParser\Node\Stmt>|null`.'
 count = 1
 
 [[issues]]
@@ -14745,7 +14787,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCase.php"
 code = "nullable-return-statement"
-message = 'Function `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase::parse` is declared to return `array<array-key, PhpParser\Node\Stmt>` but possibly returns a nullable value (inferred as `array<array-key, PhpParser\Node\Stmt>|null`).'
+message = 'Function `infection\tests\phpparser\visitor\visitortestcase\visitortestcase::parse` is declared to return `array<array-key, PhpParser\Node\Stmt>` but possibly returns a nullable value (inferred as `array<array-key, PhpParser\Node\Stmt>|null`).'
 count = 1
 
 [[issues]]
@@ -14829,7 +14871,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Process/Factory/InitialStaticAnalysisProcessFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Process\Factory\InitialStaticAnalysisProcessFactory::__construct`: expected `Infection\StaticAnalysis\StaticAnalysisToolAdapter`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\process\factory\initialstaticanalysisprocessfactory::__construct`: expected `Infection\StaticAnalysis\StaticAnalysisToolAdapter`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -14883,7 +14925,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
+message = 'Call to deprecated method: `infection\tests\mutant\mutantbuilder::materialize`.'
 count = 1
 
 [[issues]]
@@ -15063,7 +15105,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/IndexedMutantProcessContainerTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Process\Runner\IndexedMutantProcessContainer::__construct`: expected `Infection\Process\MutantProcessContainer`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `infection\process\runner\indexedmutantprocesscontainer::__construct`: expected `Infection\Process\MutantProcessContainer`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -15123,7 +15165,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Process\Runner\InitialStaticAnalysisRunner::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `infection\process\runner\initialstaticanalysisrunner::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -15213,7 +15255,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Process\Runner\InitialTestsRunner::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `infection\process\runner\initialtestsrunner::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -15285,7 +15327,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
+message = 'Call to deprecated method: `infection\tests\mutant\mutantbuilder::materialize`.'
 count = 11
 
 [[issues]]
@@ -15321,13 +15363,13 @@ count = 22
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertAreSameEvents`: expected `array<array-key, Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationWasStarted|Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished|Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted>`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertaresameevents`: expected `array<array-key, Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationWasStarted|Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished|Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted>`, but found `mixed`.'
 count = 7
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertHasEvent`: expected `array<array-key, object>`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::asserthasevent`: expected `array<array-key, object>`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -15339,13 +15381,13 @@ count = 6
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\Process\Runner\MutationTestingRunnerTest::someIterable`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\tests\process\runner\mutationtestingrunnertest::someiterable`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "no-value"
-message = 'Argument #4 passed to method `Infection\Process\Runner\MutationTestingRunner::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #4 passed to method `infection\process\runner\mutationtestingrunner::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -15477,7 +15519,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #4 of `Infection\Process\Runner\MutationTestingRunner::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`.'
+message = 'Possible argument type mismatch for argument #4 of `infection\process\runner\mutationtestingrunner::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`.'
 count = 6
 
 [[issues]]
@@ -15549,7 +15591,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Process\Runner\IndexedMutantProcessContainer::__construct`: expected `Infection\Process\MutantProcessContainer`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `infection\process\runner\indexedmutantprocesscontainer::__construct`: expected `Infection\Process\MutantProcessContainer`, but found `mixed`.'
 count = 6
 
 [[issues]]
@@ -15567,7 +15609,7 @@ count = 17
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "no-value"
-message = 'Argument #1 passed to method `Infection\Process\MutantProcessContainer::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #1 passed to method `infection\process\mutantprocesscontainer::__construct` has type `never`, meaning it cannot produce a value.'
 count = 5
 
 [[issues]]
@@ -15915,13 +15957,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reflection/ContainerReflection.php"
 code = "less-specific-nested-argument-type"
-message = '''Argument type mismatch for argument #1 of `Infection\Tests\Reflection\ContainerReflection::handleCommonErrors`: expected `(callable(class-string<'T.infection\tests\reflection\containerreflection::createservice() extends object>): ('T.infection\tests\reflection\containerreflection::createservice() extends object)|null)`, but provided type `(closure(...mixed=): mixed)` is less specific.'''
+message = '''Argument type mismatch for argument #1 of `infection\tests\reflection\containerreflection::handlecommonerrors`: expected `(callable(class-string<'T.infection\tests\reflection\containerreflection::createservice() extends object>): ('T.infection\tests\reflection\containerreflection::createservice() extends object)|null)`, but provided type `(closure(...mixed=): mixed)` is less specific.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Reflection/ContainerReflection.php"
 code = "less-specific-nested-argument-type"
-message = '''Argument type mismatch for argument #1 of `Infection\Tests\Reflection\ContainerReflection::handleCommonErrors`: expected `(callable(class-string<'T.infection\tests\reflection\containerreflection::getservice() extends object>): ('T.infection\tests\reflection\containerreflection::getservice() extends object)|null)`, but provided type `(closure(...mixed=): mixed)` is less specific.'''
+message = '''Argument type mismatch for argument #1 of `infection\tests\reflection\containerreflection::handlecommonerrors`: expected `(callable(class-string<'T.infection\tests\reflection\containerreflection::getservice() extends object>): ('T.infection\tests\reflection\containerreflection::getservice() extends object)|null)`, but provided type `(closure(...mixed=): mixed)` is less specific.'''
 count = 1
 
 [[issues]]
@@ -15939,7 +15981,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reflection/ContainerReflection.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\Reflection\ContainerReflection::getFactories`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\tests\reflection\containerreflection::getfactories`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -16023,19 +16065,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
 count = 7
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
 count = 7
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
 code = "no-value"
-message = 'Argument #4 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #4 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
 count = 7
 
 [[issues]]
@@ -16083,7 +16125,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `Infection\Reporter\FileReporterFactory::__construct`: expected `Symfony\Component\Filesystem\Filesystem`, but found `mixed`.'
+message = 'Invalid argument type for argument #3 of `infection\reporter\filereporterfactory::__construct`: expected `Symfony\Component\Filesystem\Filesystem`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -16101,7 +16143,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
 code = "no-value"
-message = 'Argument #7 passed to method `Infection\Reporter\FileReporterFactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #7 passed to method `infection\reporter\filereporterfactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -16149,7 +16191,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `infection\reporter\filereporter::__construct` has type `never`, meaning it cannot produce a value.'
 count = 4
 
 [[issues]]
@@ -16293,7 +16335,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
 code = "possibly-null-argument"
-message = 'Argument #2 of method `Infection\Mutant\MutantExecutionResult::__construct` is possibly `null`, but parameter type `string` does not accept it.'
+message = 'Argument #2 of method `infection\mutant\mutantexecutionresult::__construct` is possibly `null`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -16431,13 +16473,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `Infection\Reporter\StrykerReporterFactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `infection\reporter\strykerreporterfactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
 code = "no-value"
-message = 'Argument #4 passed to method `Infection\Reporter\StrykerReporterFactory::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #4 passed to method `infection\reporter\strykerreporterfactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -16545,13 +16587,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Resource\Listener\PerformanceLoggerSubscriber::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `infection\resource\listener\performanceloggersubscriber::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
 code = "no-value"
-message = 'Argument #3 passed to method `Infection\Resource\Listener\PerformanceLoggerSubscriber::__construct` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #3 passed to method `infection\resource\listener\performanceloggersubscriber::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
@@ -16641,7 +16683,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
 code = "too-few-arguments"
-message = "Too few arguments provided for method `ReflectionProperty::setValue`."
+message = "Too few arguments provided for method `ReflectionProperty::setvalue`."
 count = 2
 
 [[issues]]
@@ -16689,13 +16731,13 @@ count = 6
 [[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Resource\Memory\MemoryLimiter::limitMemory`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Resource\Memory\MemoryLimiter::limitmemory`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Resource\Memory\MemoryLimiter::limitMemory` has type `never`, meaning it cannot produce a value.'
+message = 'Argument #2 passed to method `Infection\Resource\Memory\MemoryLimiter::limitmemory` has type `never`, meaning it cannot produce a value.'
 count = 3
 
 [[issues]]
@@ -16821,7 +16863,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
 code = "less-specific-argument"
-message = 'Argument type mismatch for argument #1 of `Infection\Tests\Source\Collector\BasicSourceCollector\BasicSourceCollectorTest::normalizePaths`: expected `array<string, SplFileInfo>`, but provided type `array<array-key, SplFileInfo>` is less specific.'
+message = 'Argument type mismatch for argument #1 of `infection\tests\source\collector\basicsourcecollector\basicsourcecollectortest::normalizepaths`: expected `array<string, SplFileInfo>`, but provided type `array<array-key, SplFileInfo>` is less specific.'
 count = 1
 
 [[issues]]
@@ -16845,7 +16887,7 @@ count = 2
 [[issues]]
 file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\Source\Collector\BasicSourceCollector::create`: expected `array<array-key, non-empty-string>`, but possibly received `list{string}`.'
+message = 'Possible argument type mismatch for argument #2 of `infection\source\collector\basicsourcecollector::create`: expected `array<array-key, non-empty-string>`, but possibly received `list{string}`.'
 count = 1
 
 [[issues]]
@@ -16935,7 +16977,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Source/Collector/SourceCollectorFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Source\Collector\SourceCollectorFactory::__construct`: expected `Infection\Git\Git`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\source\collector\sourcecollectorfactory::__construct`: expected `Infection\Git\Git`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -17079,19 +17121,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::__construct`: expected `Symfony\Component\Filesystem\Filesystem`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 4
 
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::__construct`: expected `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\staticanalysis\phpstan\adapter\phpstanadapter::__construct`: expected `Symfony\Component\Filesystem\Filesystem`, but found `mixed`.'
+count = 6
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #2 of `infection\staticanalysis\phpstan\adapter\phpstanadapter::__construct`: expected `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory`, but found `mixed`.'
 count = 6
 
 [[issues]]
@@ -17145,7 +17187,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
+message = 'Call to deprecated method: `infection\tests\mutant\mutantbuilder::materialize`.'
 count = 4
 
 [[issues]]
@@ -17181,7 +17223,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
 code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
+message = 'Call to deprecated method: `infection\tests\mutant\mutantbuilder::materialize`.'
 count = 3
 
 [[issues]]
@@ -17193,7 +17235,7 @@ count = 6
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory::__construct`: expected `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `infection\staticanalysis\phpstan\process\phpstanmutantprocessfactory::__construct`: expected `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory`, but found `mixed`.'
 count = 3
 
 [[issues]]
@@ -17229,13 +17271,13 @@ count = 6
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\StaticAnalysis\StaticAnalysisToolFactory::__construct`: expected `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `infection\staticanalysis\staticanalysistoolfactory::__construct`: expected `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `Infection\StaticAnalysis\StaticAnalysisToolFactory::__construct`: expected `Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator`, but found `mixed`.'
+message = 'Invalid argument type for argument #3 of `infection\staticanalysis\staticanalysistoolfactory::__construct`: expected `Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -18675,7 +18717,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\TestFramework\Coverage\XmlReport\TestLocator::__construct`: expected `Infection\TestFramework\Tracing\Trace\TestLocations`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\testframework\coverage\xmlreport\testlocator::__construct`: expected `Infection\TestFramework\Tracing\Trace\TestLocations`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -18699,7 +18741,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `Infection\Tests\TestFramework\Tracing\Trace\TestLocationsNormalizer::normalize`: expected `array<array-key, Infection\AbstractTestFramework\Coverage\TestLocation|Infection\TestFramework\Tracing\Trace\TestLocations>`, but possibly received `iterable<mixed, Infection\AbstractTestFramework\Coverage\TestLocation>`.'
+message = 'Possible argument type mismatch for argument #1 of `infection\tests\testframework\tracing\trace\testlocationsnormalizer::normalize`: expected `array<array-key, Infection\AbstractTestFramework\Coverage\TestLocation|Infection\TestFramework\Tracing\Trace\TestLocations>`, but possibly received `iterable<mixed, Infection\AbstractTestFramework\Coverage\TestLocation>`.'
 count = 2
 
 [[issues]]
@@ -18807,7 +18849,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\XmlCoverageParserTest::createSourceFileInfoProviderStub`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\tests\testframework\coverage\xmlreport\xmlcoverageparser\xmlcoverageparsertest::createsourcefileinfoproviderstub`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -18837,13 +18879,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/FactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `Infection\TestFramework\Factory::__construct`: expected `Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface`, but found `mixed`.'
+message = 'Invalid argument type for argument #3 of `infection\testframework\factory::__construct`: expected `Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface`, but found `mixed`.'
 count = 2
 
 [[issues]]
 file = "tests/phpunit/TestFramework/FactoryTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #4 of `Infection\TestFramework\Factory::__construct`: expected `Infection\FileSystem\Finder\TestFrameworkFinder`, but found `mixed`.'
+message = 'Invalid argument type for argument #4 of `infection\testframework\factory::__construct`: expected `Infection\FileSystem\Finder\TestFrameworkFinder`, but found `mixed`.'
 count = 2
 
 [[issues]]
@@ -18915,13 +18957,13 @@ count = 15
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #5 of `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter::__construct`: expected `Infection\TestFramework\Config\InitialConfigBuilder`, but found `mixed`.'
+message = 'Invalid argument type for argument #5 of `infection\testframework\phpunit\adapter\phpunitadapter::__construct`: expected `Infection\TestFramework\Config\InitialConfigBuilder`, but found `mixed`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #6 of `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter::__construct`: expected `Infection\TestFramework\Config\MutationConfigBuilder`, but found `mixed`.'
+message = 'Invalid argument type for argument #6 of `infection\testframework\phpunit\adapter\phpunitadapter::__construct`: expected `Infection\TestFramework\Config\MutationConfigBuilder`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -19053,7 +19095,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
 code = "null-argument"
-message = 'Argument #1 of method `Symfony\Component\Filesystem\Path::normalize` is `null`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `symfony\component\filesystem\path::normalize` is `null`, but parameter type `string` does not accept it.'
 count = 2
 
 [[issues]]
@@ -19197,19 +19239,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
 code = "possibly-false-argument"
-message = "Argument #1 of method `DOMNode::appendChild` is possibly `false`, but parameter type `DOMNode` does not accept it."
+message = 'Argument #1 of method `Infection\TestFramework\PhpUnit\Config\Path\PathReplacer::replaceinnode` is possibly `false`, but parameter type `DOMNameSpaceNode|DOMNode` does not accept it.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
 code = "possibly-false-argument"
-message = 'Argument #1 of method `Infection\TestFramework\PhpUnit\Config\Path\PathReplacer::replaceInNode` is possibly `false`, but parameter type `DOMNameSpaceNode|DOMNode` does not accept it.'
+message = "Argument #1 of method `domnode::appendchild` is possibly `false`, but parameter type `DOMNode` does not accept it."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
 code = "possibly-null-argument"
-message = 'Argument #1 of method `Symfony\Component\Filesystem\Path::normalize` is possibly `null`, but parameter type `string` does not accept it.'
+message = 'Argument #1 of method `symfony\component\filesystem\path::normalize` is possibly `null`, but parameter type `string` does not accept it.'
 count = 1
 
 [[issues]]
@@ -19593,7 +19635,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Trace/TestLocationsNormalizer.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\TestFramework\Tracing\Trace\TestLocationsNormalizer::normalize`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\tests\testframework\tracing\trace\testlocationsnormalizer::normalize`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -19653,7 +19695,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::createTraceMock`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\tests\testframework\tracing\traceprovideradaptertracertest::createtracemock`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -19773,7 +19815,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder::__construct`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `infection\testframework\coverage\junit\junittestexecutioninfoadder::__construct`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -19791,7 +19833,7 @@ count = 8
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
 code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\TestFramework\Tracing\Tracer\TracerIntegrationTest::createFileSystemStub`. Saw type `mixed`.'
+message = 'Could not infer a precise return type for function `infection\tests\testframework\tracing\tracer\tracerintegrationtest::createfilesystemstub`. Saw type `mixed`.'
 count = 1
 
 [[issues]]
@@ -19917,31 +19959,31 @@ count = 2
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::getElement`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::getelement`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryAttribute`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryattribute`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryCount`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::querycount`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryElement`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryelement`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryList`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
+message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::querylist`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
 count = 1
 
 [[issues]]

--- a/mago.toml
+++ b/mago.toml
@@ -24,7 +24,6 @@ excludes = [
     "tests/phpunit/Command/Debug/DumpAstCommand/EchoGreeter.php",
     "tests/phpunit/Mutation/FileMutationGenerator/Fixtures",
     "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/Fixtures",
-    "tests/phpunit/WithConsecutive.php",
 ]
 
 [source.glob]

--- a/mago.toml
+++ b/mago.toml
@@ -13,9 +13,18 @@ paths = [
 ]
 includes = ["vendor"]
 excludes = [
+    "src/FileSystem/DummyFileSystem.php",
+    "src/CustomMutator/templates",
     "tests/benchmark/MutationGenerator/sources",
     "tests/benchmark/Tracing/benchmark-source",
-    "tests/benchmark/Tracing/coverage"
+    "tests/benchmark/Tracing/coverage",
+    "tests/benchmark/Tracing/sources",
+    "tests/phpunit/Fixtures",
+    "tests/phpunit/Command/Debug/DumpAstCommand/Greeter.php",
+    "tests/phpunit/Command/Debug/DumpAstCommand/EchoGreeter.php",
+    "tests/phpunit/Mutation/FileMutationGenerator/Fixtures",
+    "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/Fixtures",
+    "tests/phpunit/WithConsecutive.php",
 ]
 
 [source.glob]


### PR DESCRIPTION

## Description

Mago was analyzing paths that PHPStan and `devTools/check_trailing_whitespaces.sh` have always excluded: vendored Psalm sources under `tests/benchmark/Tracing/sources`, test fixtures, template stubs, and the `DummyFileSystem` placeholder. These files are not meant to pass static analysis and were only silent because of baseline entries. Also, polluted the baseline.

## Changes

Mirror the existing PHPStan exclude list in mago.toml so the three tools agree on what is "analysis surface" versus fixture/vendored material.

## Related issues

#3049