### PR TITLE
ci: Download Mago before executing it

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -81,7 +81,7 @@ jobs:
           composer install --no-interaction --prefer-dist --no-progress
 
       - name: Download Mago
-        shell: vendor/bin/mago --version
+        run: vendor/bin/mago --version
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        # Should use the latest supported PHP version
+        # Should use the oldest supported PHP version
         php-version: ['8.3']
 
     name: Autoreview on PHP ${{ matrix.php-version }}
@@ -79,6 +79,11 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Download Mago
+        shell: vendor/bin/mago --version
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run auto-review tests
         # Ensures we see all the errors


### PR DESCRIPTION
Currently in the CI we get:

<details>
<summary>Execution of Mago in the CI before</summary>

```
touch -c vendor/bin/mago
./vendor/bin/mago analyze
 1207/1227 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░]  98%Downloading mago 1.22.0 for x86_64-unknown-linux-gnu...

  0.0 / 9.2 MB (0%)
  0.0 / 9.2 MB (0%)
  0.0 / 9.2 MB (0%)
  0.0 / 9.2 MB (0%)
  0.0 / 9.2 MB (0%)
  0.0 / 9.2 MB (0%)
  0.0 / 9.2 MB (0%)
  0.0 / 9.2 MB (0%)
  0.0 / 9.2 MB (0%)
  0.0 / 9.2 MB (0%)
  0.0 / 9.2 MB (0%)
  0.0 / 9.2 MB (0%)
  0.1 / 9.2 MB (0%)
  0.1 / 9.2 MB (0%)
  0.1 / 9.2 MB (0%)
  0.1 / 9.2 MB (0%)
  0.1 / 9.2 MB (0%)
  0.1 / 9.2 MB (0%)
  0.1 / 9.2 MB (0%)
  0.1 / 9.2 MB (0%)
  0.1 / 9.2 MB (0%)
  0.1 / 9.2 MB (0%)
  0.1 / 9.2 MB (1%)
  0.1 / 9.2 MB (1%)
  0.1 / 9.2 MB (1%)
  0.1 / 9.2 MB (1%)
  0.1 / 9.2 MB (1%)
  0.1 / 9.2 MB (1%)
  0.1 / 9.2 MB (1%)
  0.1 / 9.2 MB (1%)
  0.1 / 9.2 MB (1%)
  0.1 / 9.2 MB (1%)
  0.1 / 9.2 MB (1%)
  0.1 / 9.2 MB (1%)
  0.2 / 9.2 MB (1%)
  0.2 / 9.2 MB (1%)
  0.2 / 9.2 MB (1%)
  0.2 / 9.2 MB (1%)
  0.2 / 9.2 MB (2%)
  0.2 / 9.2 MB (2%)
  0.2 / 9.2 MB (2%)
  0.2 / 9.2 MB (2%)
  0.2 / 9.2 MB (2%)
  0.2 / 9.2 MB (2%)
  0.2 / 9.2 MB (2%)
  0.2 / 9.2 MB (2%)
  0.3 / 9.2 MB (2%)
  0.3 / 9.2 MB (2%)
  0.3 / 9.2 MB (2%)
  0.3 / 9.2 MB (2%)
  0.3 / 9.2 MB (2%)
  8.9 / 9.2 MB (97%)
  8.9 / 9.2 MB (97%)
  8.9 / 9.2 MB (97%)
  8.9 / 9.2 MB (97%)
  8.9 / 9.2 MB (97%)
  9.0 / 9.2 MB (97%)
  9.0 / 9.2 MB (97%)
  9.0 / 9.2 MB (97%)
  9.0 / 9.2 MB (97%)
  9.0 / 9.2 MB (97%)
  9.0 / 9.2 MB (97%)
  9.0 / 9.2 MB (98%)
  9.0 / 9.2 MB (98%)
  9.0 / 9.2 MB (98%)
  9.0 / 9.2 MB (98%)
  9.2 / 9.2 MB (100%)
  9.2 / 9.2 MB (100%)
  9.2 / 9.2 MB (100%)
  9.2 / 9.2 MB (100%)
Downloaded.
 INFO Filtered out 6443 issues based on the baseline file.
 INFO No issues found.

```
</details>

Now the download is done in a separate step so the actual analysis is less polluted.
