### PR TITLE
refactor: Add types to constants

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -32,18 +32,6 @@ count = 1
 
 [[issues]]
 file = "src/Command/ConfigureCommand.php"
-code = "missing-constant-type"
-message = "Class constant `NONINTERACTIVE_MODE_ERROR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/ConfigureCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_TEST_FRAMEWORK` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/ConfigureCommand.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `Infection\Config\Guesser\SourceDirGuesser::__construct`: expected `stdClass`, but found `mixed`.'
 count = 1
@@ -83,30 +71,6 @@ file = "src/Command/Debug/DumpAstCommand.php"
 code = "impossible-assignment"
 message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
 count = 2
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "missing-constant-type"
-message = "Class constant `CHANGED_LINES_PARTS_COUNT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "missing-constant-type"
-message = "Class constant `CHANGED_LINES_RANGES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "missing-constant-type"
-message = "Class constant `FILE_PATH_ARGUMENT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "missing-constant-type"
-message = "Class constant `SHOW_ATTRIBUTES` is missing a type hint."
-count = 1
 
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
@@ -170,30 +134,6 @@ count = 1
 
 [[issues]]
 file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_TIME_IN_MILLISECONDS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "missing-constant-type"
-message = "Class constant `LOG_FILE_PATH_ARGUMENT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "missing-constant-type"
-message = "Class constant `MILLISECONDS_IN_MICROSECONDS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "missing-constant-type"
-message = "Class constant `TIME_IN_MICRO_SECONDS_OPTION` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #3 of `sprintf`: expected `Stringable|null|scalar`, but found `mixed`."
 count = 1
@@ -226,18 +166,6 @@ count = 1
 file = "src/Command/DescribeCommand.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #1 of `array_key_exists`: expected `bool|float|int|string`, but found `mixed`."
-count = 2
-
-[[issues]]
-file = "src/Command/DescribeCommand.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `array_keys`: expected `array<('K.array_keys() extends array-key), ('V.array_keys() extends mixed)>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "src/Command/DescribeCommand.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #2 of `array_key_exists`: expected `array<array-key, mixed>`, but found `mixed`."
 count = 2
 
 [[issues]]
@@ -302,12 +230,6 @@ count = 1
 
 [[issues]]
 file = "src/Command/Git/Option/BaseOption.php"
-code = "missing-constant-type"
-message = "Class constant `NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Git/Option/BaseOption.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 1
@@ -316,12 +238,6 @@ count = 1
 file = "src/Command/Git/Option/FilterOption.php"
 code = "invalid-return-statement"
 message = '''Invalid return type for function `Infection\Command\Git\Option\FilterOption::addOption`: expected `('T.infection\command\git\option\filteroption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
-count = 1
-
-[[issues]]
-file = "src/Command/Git/Option/FilterOption.php"
-code = "missing-constant-type"
-message = "Class constant `NAME` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -356,12 +272,6 @@ count = 1
 
 [[issues]]
 file = "src/Command/InitialTest/Option/InitialTestsPhpOptionsOption.php"
-code = "missing-constant-type"
-message = "Class constant `NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/InitialTest/Option/InitialTestsPhpOptionsOption.php"
 code = "unused-template-parameter"
 message = 'Template parameter `T` is never used in method `Infection\Command\InitialTest\Option\InitialTestsPhpOptionsOption::addOption`.'
 count = 1
@@ -381,13 +291,7 @@ count = 1
 [[issues]]
 file = "src/Command/MakeCustomMutatorCommand.php"
 code = "invalid-return-statement"
-message = "Invalid return type for function `12472592161311982528:3960`: expected `string`, but found `null|string`."
-count = 1
-
-[[issues]]
-file = "src/Command/MakeCustomMutatorCommand.php"
-code = "missing-constant-type"
-message = "Class constant `MUTATOR_NAME_ARGUMENT` is missing a type hint."
+message = "Invalid return type for function `12472592161311982528:3967`: expected `string`, but found `null|string`."
 count = 1
 
 [[issues]]
@@ -405,7 +309,7 @@ count = 2
 [[issues]]
 file = "src/Command/MakeCustomMutatorCommand.php"
 code = "nullable-return-statement"
-message = "Function `12472592161311982528:3960` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`)."
+message = "Function `12472592161311982528:3967` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`)."
 count = 1
 
 [[issues]]
@@ -427,21 +331,9 @@ message = '''Invalid return type for function `Infection\Command\Option\Configur
 count = 1
 
 [[issues]]
-file = "src/Command/Option/ConfigurationOption.php"
-code = "missing-constant-type"
-message = "Class constant `NAME` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Command/Option/DebugOption.php"
 code = "invalid-return-statement"
 message = '''Invalid return type for function `Infection\Command\Option\DebugOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
-count = 1
-
-[[issues]]
-file = "src/Command/Option/DebugOption.php"
-code = "missing-constant-type"
-message = "Class constant `NAME` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -460,12 +352,6 @@ count = 1
 file = "src/Command/Option/MapSourceClassToTestOption.php"
 code = "invalid-return-statement"
 message = '''Invalid return type for function `Infection\Command\Option\MapSourceClassToTestOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
-count = 1
-
-[[issues]]
-file = "src/Command/Option/MapSourceClassToTestOption.php"
-code = "missing-constant-type"
-message = "Class constant `NAME` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -494,30 +380,6 @@ count = 1
 
 [[issues]]
 file = "src/Command/Option/SourceFilterOptions.php"
-code = "missing-constant-type"
-message = "Class constant `GIT_DIFF_BASE_NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "missing-constant-type"
-message = "Class constant `GIT_DIFF_FILTER_NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "missing-constant-type"
-message = "Class constant `GIT_DIFF_LINES_NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
-code = "missing-constant-type"
-message = "Class constant `PLAIN_FILTER_NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Option/SourceFilterOptions.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 2
@@ -536,12 +398,6 @@ count = 1
 
 [[issues]]
 file = "src/Command/Option/TestFrameworkOption.php"
-code = "missing-constant-type"
-message = "Class constant `NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Option/TestFrameworkOption.php"
 code = "unused-template-parameter"
 message = 'Template parameter `T` is never used in method `Infection\Command\Option\TestFrameworkOption::addOption`.'
 count = 1
@@ -554,188 +410,8 @@ count = 1
 
 [[issues]]
 file = "src/Command/Option/TestFrameworkOptionsOption.php"
-code = "missing-constant-type"
-message = "Class constant `NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/Option/TestFrameworkOptionsOption.php"
 code = "unused-template-parameter"
 message = 'Template parameter `T` is never used in method `Infection\Command\Option\TestFrameworkOptionsOption::addOption`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_COVERAGE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_DRY_RUN` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_EXECUTE_ONLY_COVERING_TEST_CASES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_FORCE_PROGRESS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_FORMATTER` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_IGNORE_MSI_WITH_NO_MUTATIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_LOGGER_GITHUB` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_LOGGER_GITLAB` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_LOGGER_HTML` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_LOGGER_PROJECT_ROOT_DIRECTORY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_LOGGER_SUMMARY_JSON` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_LOGGER_TEXT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_LOG_VERBOSITY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_MAX_TIMEOUTS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_MIN_COVERED_MSI` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_MIN_MSI` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_MUTANT_ID` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_MUTATORS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_NO_PROGRESS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_SHOW_MUTATIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_SKIP_INITIAL_TESTS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_STATIC_ANALYSIS_TOOL_OPTIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_STATIC_ANALYSIS_TOOL` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_TEAMCITY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_THREADS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_USE_NOOP_MUTATORS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_VALUE_NOT_PROVIDED` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_WITH_TIMEOUTS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "missing-constant-type"
-message = "Class constant `OPTION_WITH_UNCOVERED` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -872,12 +548,6 @@ count = 2
 
 [[issues]]
 file = "src/Config/Guesser/PhpUnitPathGuesser.php"
-code = "missing-constant-type"
-message = "Class constant `CURRENT_DIR_PATH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Config/Guesser/PhpUnitPathGuesser.php"
 code = "mixed-assignment"
 message = "Assigning `nonnull` type to a variable may lead to unexpected behavior."
 count = 1
@@ -928,12 +598,6 @@ count = 1
 file = "src/Config/ValueProvider/ExcludeDirsProvider.php"
 code = "less-specific-nested-return-statement"
 message = '''Returned type `list<truthy-mixed>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Config\ValueProvider\ExcludeDirsProvider::get` due to nested 'mixed'.'''
-count = 1
-
-[[issues]]
-file = "src/Config/ValueProvider/ExcludeDirsProvider.php"
-code = "missing-constant-type"
-message = "Class constant `EXCLUDED_ROOT_DIRS` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -1046,12 +710,6 @@ count = 1
 
 [[issues]]
 file = "src/Configuration/Configuration.php"
-code = "missing-constant-type"
-message = "Class constant `LOG_VERBOSITY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Configuration/Configuration.php"
 code = "redundant-type-comparison"
 message = 'Redundant type assertion: `$mutators` of type `array<string, Infection\Mutator\Mutator<PhpParser\Node>>` is always not `iterable<mixed, Infection\Mutator\Mutator<PhpParser\Node>>`.'
 count = 1
@@ -1066,12 +724,6 @@ count = 1
 file = "src/Configuration/ConfigurationFactory.php"
 code = "less-specific-nested-return-statement"
 message = '''Returned type `array<string, list<mixed>>` is less specific than the declared return type `array<string, array<int, string>>` for function `Infection\Configuration\ConfigurationFactory::retrieveIgnoreSourceCodeMutatorsMap` due to nested 'mixed'.'''
-count = 1
-
-[[issues]]
-file = "src/Configuration/ConfigurationFactory.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_TIMEOUT` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -1238,36 +890,6 @@ count = 1
 
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationLoader.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_DIST_JSON5_CONFIG_FILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationLoader.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_DIST_JSON_CONFIG_FILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationLoader.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_JSON5_CONFIG_FILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationLoader.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_JSON_CONFIG_FILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationLoader.php"
-code = "missing-constant-type"
-message = "Class constant `POSSIBLE_DEFAULT_CONFIG_FILE_NAMES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaConfigurationLoader.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileNotFound` in `Infection\Configuration\Schema\SchemaConfigurationLoader::loadConfiguration`.'
 count = 1
@@ -1276,12 +898,6 @@ count = 1
 file = "src/Configuration/Schema/SchemaConfigurationLoader.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Configuration\Schema\SchemaConfigurationLoader::loadConfiguration`.'
-count = 1
-
-[[issues]]
-file = "src/Configuration/Schema/SchemaValidator.php"
-code = "missing-constant-type"
-message = "Class constant `SCHEMA_FILE` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -1322,104 +938,14 @@ count = 1
 
 [[issues]]
 file = "src/Console/Application.php"
-code = "missing-constant-type"
-message = "Class constant `LOGO` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/Application.php"
-code = "missing-constant-type"
-message = "Class constant `NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/Application.php"
-code = "missing-constant-type"
-message = "Class constant `PACKAGE_NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/Application.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Console\Application::getPrettyVersion`.'
-count = 1
-
-[[issues]]
-file = "src/Console/ConsoleOutput.php"
-code = "missing-constant-type"
-message = "Class constant `MIN_MSI_CAN_GET_INCREASED_NOTICE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/ConsoleOutput.php"
-code = "missing-constant-type"
-message = "Class constant `RUNNING_WITH_DEBUGGER_NOTE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/Input/MsiParser.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_PRECISION` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/Input/MsiParser.php"
-code = "missing-constant-type"
-message = "Class constant `EXPLODE_PARTS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/LogVerbosity.php"
-code = "missing-constant-type"
-message = "Class constant `ALLOWED_OPTIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/LogVerbosity.php"
-code = "missing-constant-type"
-message = "Class constant `DEBUG_INTEGER` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/LogVerbosity.php"
-code = "missing-constant-type"
-message = "Class constant `DEBUG` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/LogVerbosity.php"
-code = "missing-constant-type"
-message = "Class constant `NONE_INTEGER` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/LogVerbosity.php"
-code = "missing-constant-type"
-message = "Class constant `NONE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/LogVerbosity.php"
-code = "missing-constant-type"
-message = "Class constant `NORMAL_INTEGER` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Console/LogVerbosity.php"
-code = "missing-constant-type"
-message = "Class constant `NORMAL` is missing a type hint."
 count = 1
 
 [[issues]]
 file = "src/Console/LogVerbosity.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "src/Console/XdebugHandler.php"
-code = "missing-constant-type"
-message = "Class constant `PREFIX` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -1443,223 +969,7 @@ count = 1
 [[issues]]
 file = "src/Container/Container.php"
 code = "missing-constant-type"
-message = "Class constant `DEFAULT_CONFIG_FILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_DEBUG` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_DRY_RUN` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_EXISTING_COVERAGE_PATH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_FILTER` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_FORCE_PROGRESS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
 message = "Class constant `DEFAULT_FORMATTER_NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_GITLAB_LOGGER_PATH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_GIT_DIFF_BASE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_GIT_DIFF_FILTER` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_HTML_LOGGER_PATH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_IGNORE_MSI_WITH_NO_MUTATIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_INITIAL_TESTS_PHP_OPTIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_LOGGER_PROJECT_ROOT_DIRECTORY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_LOG_VERBOSITY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_MAP_SOURCE_CLASS_TO_TEST_STRATEGY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_MAX_TIMEOUTS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_MIN_COVERED_MSI` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_MIN_MSI` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_MSI_PRECISION` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_MUTANT_ID` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_MUTATORS_INPUT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_NO_PROGRESS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_SHOW_MUTATIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_SKIP_INITIAL_TESTS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_STATIC_ANALYSIS_TOOL_OPTIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_STATIC_ANALYSIS_TOOL` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_SUMMARY_JSON_LOGGER_PATH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_TEST_FRAMEWORK_EXTRA_OPTIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_TEST_FRAMEWORK` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_TEXT_LOGGER_PATH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_THREAD_COUNT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_TIMEOUTS_AS_ESCAPED` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_USE_GITHUB_LOGGER` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_USE_NOOP_MUTATORS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_WITH_UNCOVERED` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -1723,12 +1033,6 @@ message = "Reference created from a previously undefined variable `$matches`."
 count = 1
 
 [[issues]]
-file = "src/Differ/DiffSourceCodeMatcher.php"
-code = "missing-constant-type"
-message = "Class constant `POSSIBLE_DELIMITERS` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Differ/Differ.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `Infection\Differ\Differ::processTokens`: expected `array{0: string, 1: int(0)|int(1)|int(2)|int(3)|int(4)}`, but found `mixed`.'
@@ -1750,12 +1054,6 @@ count = 1
 file = "src/Differ/Tokens.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `Infection\Differ\Tokens::computeRange`: expected `array{0: int(0)|positive-int, 1: int(0)|positive-int}`, but found `list{non-negative-int, int}`.'
-count = 1
-
-[[issues]]
-file = "src/Differ/Tokens.php"
-code = "missing-constant-type"
-message = "Class constant `CONTEXT_LINES` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -1822,12 +1120,6 @@ count = 1
 file = "src/Event/EventDispatcher/SyncEventDispatcher.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Event\EventDispatcher\SyncEventDispatcher::inferSubscribedEvents`.'
-count = 1
-
-[[issues]]
-file = "src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php"
-code = "missing-constant-type"
-message = "Class constant `PHPUNIT_RESULT_CACHE_PATTERN` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -1904,12 +1196,6 @@ count = 1
 
 [[issues]]
 file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
-code = "missing-constant-type"
-message = "Class constant `BAT_EXTENSION_LENGTH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #3 of `Safe\preg_match`: expected `array<array-key, string>|null`, but found `mixed`.'
 count = 1
@@ -1954,12 +1240,6 @@ count = 1
 file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\filesystem\finder\exception\finderexception` in `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder::shouldUseCustomPath`.'
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/TestFrameworkFinder.php"
-code = "missing-constant-type"
-message = "Class constant `BAT_EXTENSION_LENGTH` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -2077,12 +1357,6 @@ message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileNot
 count = 1
 
 [[issues]]
-file = "src/FileSystem/TmpDirProvider.php"
-code = "missing-constant-type"
-message = "Class constant `BASE_DIR_NAME` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Framework/ClassName.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `Infection\Framework\ClassName::getShortClassName`: expected `non-empty-string`, but found `string`.'
@@ -2137,27 +1411,9 @@ message = '''Invalid argument type for argument #1 of `Infection\Framework\Itera
 count = 1
 
 [[issues]]
-file = "src/Framework/Iterable/IterableCounter.php"
-code = "missing-constant-type"
-message = "Class constant `UNKNOWN_COUNT` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Framework/Str.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `Infection\Framework\Str::findLastNonEmptyLineIndex`: expected `non-negative-int`, but found `int`.'
-count = 1
-
-[[issues]]
-file = "src/Framework/Str.php"
-code = "missing-constant-type"
-message = "Class constant `SYSTEM_LINE_ENDINGS_REPLACEMENT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Framework/Str.php"
-code = "missing-constant-type"
-message = "Class constant `UNIX_LINE_ENDINGS_REPLACEMENT` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -2176,36 +1432,6 @@ count = 1
 file = "src/Git/CommandLineGit.php"
 code = "less-specific-nested-return-statement"
 message = '''Returned type `list<mixed>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Git\CommandLineGit::diff` due to nested 'mixed'.'''
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_SYMBOLIC_REFERENCE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "missing-constant-type"
-message = "Class constant `DIFF_LINE_PATH_KEY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "missing-constant-type"
-message = "Class constant `DIFF_LINE_RANGE_KEY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "missing-constant-type"
-message = "Class constant `DIFF_LINE_RANGE_REGEX` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "missing-constant-type"
-message = "Class constant `DIFF_LINE_REGEX` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -2282,30 +1508,6 @@ count = 1
 
 [[issues]]
 file = "src/Logger/Console/BasicConsoleLogger.php"
-code = "missing-constant-type"
-message = "Class constant `ERROR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/Console/BasicConsoleLogger.php"
-code = "missing-constant-type"
-message = "Class constant `FORMAT_LEVEL_MAP` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/Console/BasicConsoleLogger.php"
-code = "missing-constant-type"
-message = "Class constant `INFO` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/Console/BasicConsoleLogger.php"
-code = "missing-constant-type"
-message = "Class constant `VERBOSITY_LEVEL_MAP` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/Console/BasicConsoleLogger.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #2 of `Webmozart\Assert\Assert::keyExists`: expected `int|string`, but found `mixed`.'
 count = 1
@@ -2324,36 +1526,6 @@ count = 1
 
 [[issues]]
 file = "src/Logger/Console/ConsoleLogger.php"
-code = "missing-constant-type"
-message = "Class constant `ERROR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/Console/ConsoleLogger.php"
-code = "missing-constant-type"
-message = "Class constant `FORMAT_LEVEL_MAP` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/Console/ConsoleLogger.php"
-code = "missing-constant-type"
-message = "Class constant `INFO` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/Console/ConsoleLogger.php"
-code = "missing-constant-type"
-message = "Class constant `IO_MAP` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/Console/ConsoleLogger.php"
-code = "missing-constant-type"
-message = "Class constant `VERBOSITY_LEVEL_MAP` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/Console/ConsoleLogger.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 1
@@ -2365,39 +1537,9 @@ message = "Possible argument type mismatch for argument #2 of `strtr`: expected 
 count = 1
 
 [[issues]]
-file = "src/Logger/MutationAnalysis/ConsoleDotLogger.php"
-code = "missing-constant-type"
-message = "Class constant `DOTS_PER_ROW` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Logger/MutationAnalysis/TeamCity/TeamCity.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `Infection\Logger\MutationAnalysis\TeamCity\TeamCity::escapeValue`: expected `non-empty-string`, but found `array<array-key, mixed>|string`.'
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TeamCity.php"
-code = "missing-constant-type"
-message = "Class constant `CHARACTERS_TO_ESCAPE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TeamCity.php"
-code = "missing-constant-type"
-message = "Class constant `ESCAPED_CHARACTERS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/TeamCity.php"
-code = "missing-constant-type"
-message = "Class constant `UNICODE_CHARACTER_REGEX` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Logger/MutationAnalysis/TeamCity/Test.php"
-code = "missing-constant-type"
-message = "Class constant `MILLISECONDS_PER_SECOND` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -2410,12 +1552,6 @@ count = 1
 file = "src/Metrics/FilteringResultsCollectorFactory.php"
 code = "invalid-argument"
 message = 'Invalid argument type for argument #2 of `Infection\Metrics\FilteringResultsCollector::__construct`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `non-empty-array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
-count = 1
-
-[[issues]]
-file = "src/Metrics/MinMsiChecker.php"
-code = "missing-constant-type"
-message = "Class constant `VALUE_OVER_REQUIRED_TOLERANCE` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -2470,12 +1606,6 @@ count = 1
 file = "src/Mutant/MutantExecutionResult.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Mutant\MutantExecutionResult::toColumn`.'
-count = 1
-
-[[issues]]
-file = "src/Mutant/TestFrameworkMutantExecutionResultFactory.php"
-code = "missing-constant-type"
-message = "Class constant `PROCESS_MIN_ERROR_CODE` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -2542,12 +1672,6 @@ count = 1
 file = "src/Mutator/AllowedFunctionsConfig.php"
 code = "redundant-type-comparison"
 message = "Redundant type assertion: `$enabled` of type `bool` is always not `bool`."
-count = 1
-
-[[issues]]
-file = "src/Mutator/Arithmetic/RoundingFamily.php"
-code = "missing-constant-type"
-message = "Class constant `MUTATORS_MAP` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -2630,12 +1754,6 @@ count = 1
 
 [[issues]]
 file = "src/Mutator/Boolean/TrueValueConfig.php"
-code = "missing-constant-type"
-message = "Class constant `KNOWN_FUNCTIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/Boolean/TrueValueConfig.php"
 code = "redundant-type-comparison"
 message = "Redundant type assertion: `$enabled` of type `bool` is always not `bool`."
 count = 1
@@ -2689,12 +1807,6 @@ message = 'Parameter `$settings` of `Infection\Mutator\Extensions\BCMathConfig::
 count = 1
 
 [[issues]]
-file = "src/Mutator/Extensions/BCMathConfig.php"
-code = "missing-constant-type"
-message = "Class constant `KNOWN_FUNCTIONS` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Mutator/Extensions/MBString.php"
 code = "less-specific-nested-return-statement"
 message = '''Returned type `(closure(PhpParser\Node\Expr\FuncCall): Generator<mixed, mixed, mixed, mixed>)` is less specific than the declared return type `(closure(PhpParser\Node\Expr\FuncCall): iterable<mixed, PhpParser\Node\Expr\FuncCall>)` for function `Infection\Mutator\Extensions\MBString::makeConvertCaseMapper` due to nested 'mixed'.'''
@@ -2731,12 +1843,6 @@ message = 'Parameter `$settings` of `Infection\Mutator\Extensions\MBStringConfig
 count = 1
 
 [[issues]]
-file = "src/Mutator/Extensions/MBStringConfig.php"
-code = "missing-constant-type"
-message = "Class constant `KNOWN_FUNCTIONS` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Mutator/IgnoreConfig.php"
 code = "property-type-coercion"
 message = "A value of a less specific type `non-empty-array<string, array-key>` is being assigned to property `$$hashtable` (array<string, int>)."
@@ -2746,18 +1852,6 @@ count = 1
 file = "src/Mutator/IgnoreMutator.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #2 of `Infection\Mutator\IgnoreConfig::isIgnored`: expected `string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/InvalidMutator.php"
-code = "missing-constant-type"
-message = "Class constant `GITHUB_BUG_LINK` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/InvalidMutator.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `array_keys`: expected `array<('K.array_keys() extends array-key), ('V.array_keys() extends mixed)>`, but found `mixed`."
 count = 1
 
 [[issues]]
@@ -2800,24 +1894,6 @@ count = 1
 file = "src/Mutator/MutatorFactory.php"
 code = "unsafe-instantiation"
 message = 'Potentially unsafe instantiation: `class-string<Infection\Mutator\ConfigurableMutator>` may contain the interface `Infection\Mutator\ConfigurableMutator` itself, which cannot be instantiated.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorParser.php"
-code = "less-specific-return-statement"
-message = 'Returned type `list<array-key>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Mutator\MutatorParser::parse`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorParser.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #2 of `array_key_exists`: expected `array<array-key, mixed>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorParser.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #2 of `array_search`: expected `array<('K.array_search() extends array-key), string>`, but found `mixed`."
 count = 1
 
 [[issues]]
@@ -2870,50 +1946,8 @@ count = 2
 
 [[issues]]
 file = "src/Mutator/MutatorResolver.php"
-code = "missing-constant-type"
-message = "Class constant `GLOBAL_IGNORE_SETTING` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorResolver.php"
-code = "missing-constant-type"
-message = "Class constant `GLOBAL_IGNORE_SOURCE_CODE_BY_REGEX_SETTING` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorResolver.php"
-code = "missing-constant-type"
-message = "Class constant `IGNORE_SETTING` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorResolver.php"
-code = "missing-constant-type"
-message = "Class constant `IGNORE_SOURCE_CODE_BY_REGEX_SETTING` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorResolver.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Mutator\MutatorResolver::registerFromClass`: expected `string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorResolver.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #1 of `array_unique`: expected `array<('K.array_unique() extends array-key), ('V.array_unique() extends mixed)>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "src/Mutator/MutatorResolver.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #2 of `array_key_exists`: expected `array<array-key, mixed>`, but found `mixed`."
-count = 2
-
-[[issues]]
-file = "src/Mutator/MutatorResolver.php"
-code = "mixed-array-access"
-message = "Unsafe array access on type `mixed`."
 count = 1
 
 [[issues]]
@@ -3001,21 +2035,9 @@ message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no lon
 count = 1
 
 [[issues]]
-file = "src/Mutator/Number/DecrementInteger.php"
-code = "missing-constant-type"
-message = "Class constant `NON_NEGATIVE_INT_RETURNING_FUNCTIONS` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Mutator/Number/IncrementInteger.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Number/IncrementInteger.php"
-code = "missing-constant-type"
-message = "Class constant `FUNCTIONS_RETURNING_MAX_INTEGER` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -3067,132 +2089,6 @@ message = 'Class `PhpParser\Node\Expr\ArrayItem` is deprecated and should no lon
 count = 1
 
 [[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `ALL_MUTATORS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `ALL_PROFILES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `ARITHMETIC_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `BOOLEAN_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `CAST_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `CONDITIONAL_BOUNDARY_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `CONDITIONAL_NEGOTIATION_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `EQUAL_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `EXTENSIONS_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `FUNCTION_SIGNATURE_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `IDENTICAL_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `LOOP_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `NULLIFY_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `NUMBER_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `OPERATOR_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `REGEX_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `REMOVAL_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `RETURN_VALUE_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `SORT_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/ProfileList.php"
-code = "missing-constant-type"
-message = "Class constant `UNWRAP_PROFILE` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Mutator/Regex/AbstractPregMatch.php"
 code = "hidden-generator-return"
 message = 'The value returned by generator function `Infection\Mutator\Regex\AbstractPregMatch::mutate` may be inaccessible to callers.'
@@ -3211,18 +2107,6 @@ message = 'The value returned by generator function `Infection\Mutator\Regex\Pre
 count = 1
 
 [[issues]]
-file = "src/Mutator/Regex/PregMatchMatches.php"
-code = "missing-constant-type"
-message = "Class constant `MIN_ARGS_TO_MUTATE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/Regex/PregMatchRemoveCaret.php"
-code = "missing-constant-type"
-message = "Class constant `ANALYSE_REGEX` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Mutator/Regex/PregMatchRemoveCaret.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #3 of `Safe\preg_match`: expected `array<array-key, string>|null`, but found `mixed`.'
@@ -3236,12 +2120,6 @@ count = 2
 
 [[issues]]
 file = "src/Mutator/Regex/PregMatchRemoveDollar.php"
-code = "missing-constant-type"
-message = "Class constant `ANALYSE_REGEX` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/Regex/PregMatchRemoveDollar.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #3 of `Safe\preg_match`: expected `array<array-key, string>|null`, but found `mixed`.'
 count = 2
@@ -3251,12 +2129,6 @@ file = "src/Mutator/Regex/PregMatchRemoveDollar.php"
 code = "reference-to-undefined-variable"
 message = "Reference created from a previously undefined variable `$matches`."
 count = 2
-
-[[issues]]
-file = "src/Mutator/Regex/PregMatchRemoveFlags.php"
-code = "missing-constant-type"
-message = "Class constant `ANALYSE_REGEX` is missing a type hint."
-count = 1
 
 [[issues]]
 file = "src/Mutator/Regex/PregMatchRemoveFlags.php"
@@ -3284,20 +2156,8 @@ count = 1
 
 [[issues]]
 file = "src/Mutator/Removal/ArrayItemRemovalConfig.php"
-code = "missing-constant-type"
-message = "Class constant `REMOVE_VALUES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/Removal/ArrayItemRemovalConfig.php"
 code = "redundant-type-comparison"
 message = "Redundant type assertion: `$this->limit` of type `int|int(2147483647)|int(9223372036854775807)` is always not `int`."
-count = 1
-
-[[issues]]
-file = "src/Mutator/Removal/CatchBlockRemoval.php"
-code = "missing-constant-type"
-message = "Class constant `MIN_CATCH_COUNT_TO_MUTATE` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -3398,12 +2258,6 @@ count = 1
 
 [[issues]]
 file = "src/Mutator/Unwrap/UnwrapArrayUintersectUassoc.php"
-code = "missing-constant-type"
-message = "Class constant `NON_MUTABLE_ARGS_COUNT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/Unwrap/UnwrapArrayUintersectUassoc.php"
 code = "yield-from-invalid-value-type"
 message = "Invalid value type from `yield from`: current generator expects to yield `int`, but the inner iterable yields `array-key`."
 count = 1
@@ -3418,12 +2272,6 @@ count = 1
 file = "src/Mutator/Util/AbstractAllSubExprNegation.php"
 code = "incompatible-parameter-type"
 message = '''Parameter `$node` of `Infection\Mutator\Util\AbstractAllSubExprNegation::mutate()` expects type `PhpParser\Node\Expr` but parent `Infection\Mutator\Mutator::mutate()` expects type `('TNode.infection\mutator\util\abstractallsubexprnegation extends PhpParser\Node)`'''
-count = 1
-
-[[issues]]
-file = "src/Mutator/Util/AbstractAllSubExprNegation.php"
-code = "missing-constant-type"
-message = "Class constant `BOOLEANS` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -3484,18 +2332,6 @@ count = 1
 file = "src/Mutator/Util/NameResolver.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `Infection\Mutator\Util\NameResolver::resolveName`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Util/ReturnTypeHelper.php"
-code = "missing-constant-type"
-message = "Class constant `NULL` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Mutator/Util/ReturnTypeHelper.php"
-code = "missing-constant-type"
-message = "Class constant `VOID` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -3626,32 +2462,8 @@ count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `NODE_ID_ATTRIBUTE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitor.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitor::getNodeId`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/ExcludeIgnoredNodesVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `IGNORE_ALL_MUTATIONS_ANNOTATION` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/FullyQualifiedClassNameManipulator.php"
-code = "missing-constant-type"
-message = "Class constant `RESOLVED_NAMESPACE_NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/FullyQualifiedClassNameManipulator.php"
-code = "missing-constant-type"
-message = "Class constant `RESOLVED_NAME` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -3664,12 +2476,6 @@ count = 1
 file = "src/PhpParser/Visitor/FullyQualifiedClassNameManipulator.php"
 code = "non-existent-property"
 message = 'Property `$namespacedName` does not exist on interface `PhpParser\Node`.'
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/LabelMutationCandidatesVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `MUTATION_CANDIDATE` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -3704,32 +2510,8 @@ count = 1
 
 [[issues]]
 file = "src/PhpParser/Visitor/LabelNodesAsEligibleVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `ELIGIBLE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/LabelNodesAsEligibleVisitor.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\LabelNodesAsEligibleVisitor::isEligible`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `VISITED_ATTRIBUTE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/NextConnectingVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `NEXT_ATTRIBUTE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/ParentConnector.php"
-code = "missing-constant-type"
-message = "Class constant `PARENT_ATTRIBUTE` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -3742,42 +2524,6 @@ count = 1
 file = "src/PhpParser/Visitor/ParentConnector.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `Infection\PhpParser\Visitor\ParentConnector::getParent`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/ReflectionVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `FUNCTION_NAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/ReflectionVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `FUNCTION_SCOPE_KEY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/ReflectionVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `IS_INSIDE_FUNCTION_KEY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/ReflectionVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `IS_ON_FUNCTION_SIGNATURE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/ReflectionVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `REFLECTION_CLASS_KEY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/PhpParser/Visitor/ReflectionVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `STRICT_TYPES_KEY` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -3799,12 +2545,6 @@ message = 'Argument #1 of method `Infection\PhpParser\Visitor\ParentConnector::f
 count = 1
 
 [[issues]]
-file = "src/Process/DryRunProcess.php"
-code = "missing-constant-type"
-message = "Class constant `PASSING_TEST_OUTPUT` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Process/Factory/InitialTestsRunProcessFactory.php"
 code = "ambiguous-instantiation-target"
 message = "Ambiguous instantiation: the expression used with `new` can resolve to multiple different classes."
@@ -3814,18 +2554,6 @@ count = 1
 file = "src/Process/Factory/InitialTestsRunProcessFactory.php"
 code = "unsafe-instantiation"
 message = 'Unsafe `new $class_name`: constructor of `Symfony\Component\Process\Process` is not final and its signature might change in child classes, potentially leading to runtime errors.'
-count = 1
-
-[[issues]]
-file = "src/Process/Factory/MutantProcessContainerFactory.php"
-code = "missing-constant-type"
-message = "Class constant `TEST_FRAMEWORK_BOOTSTRAP_THRESHOLD` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Process/Factory/MutantProcessContainerFactory.php"
-code = "missing-constant-type"
-message = "Class constant `TIMEOUT_FACTOR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -3890,12 +2618,6 @@ count = 1
 
 [[issues]]
 file = "src/Process/Runner/ParallelProcessRunner.php"
-code = "missing-constant-type"
-message = "Class constant `POLL_WAIT_IN_MS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/ParallelProcessRunner.php"
 code = "possibly-invalid-argument"
 message = 'Possible argument type mismatch for argument #1 of `Infection\Process\Runner\ProcessQueue::enqueueFrom`: expected `Iterator<mixed, Infection\Process\MutantProcessContainer>`, but possibly received `Generator<mixed, Infection\Process\MutantProcessContainer, mixed, mixed>`.'
 count = 3
@@ -3910,18 +2632,6 @@ count = 1
 file = "src/Process/Runner/ParallelProcessRunner.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\Process\Runner\ParallelProcessRunner::startProcess`.'
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/ProcessQueue.php"
-code = "missing-constant-type"
-message = "Class constant `MINIMAL_DEPTH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Process/Runner/ProcessQueue.php"
-code = "missing-constant-type"
-message = "Class constant `NANO_SECONDS_IN_MILLI_SECOND` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -3943,33 +2653,9 @@ message = 'Potentially unhandled exception `ReflectionException` in `Infection\R
 count = 1
 
 [[issues]]
-file = "src/Reflection/Visibility.php"
-code = "missing-constant-type"
-message = "Class constant `PROTECTED` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Reflection/Visibility.php"
-code = "missing-constant-type"
-message = "Class constant `PUBLIC` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Reporter/BaseTextFileReporter.php"
 code = "less-specific-argument"
 message = 'Argument type mismatch for argument #1 of `Infection\Reporter\BaseTextFileReporter::getMutatorLine`: expected `int`, but provided type `array-key` is less specific.'
-count = 1
-
-[[issues]]
-file = "src/Reporter/FileLocationReporter.php"
-code = "missing-constant-type"
-message = "Class constant `PAD_LENGTH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Reporter/FileReporter.php"
-code = "missing-constant-type"
-message = "Class constant `ALLOWED_PHP_STREAMS` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -3977,12 +2663,6 @@ file = "src/Reporter/FileReporterFactory.php"
 code = "invalid-yield-key-type"
 message = "Invalid key type yielded; expected `string`, but found `null|string`."
 count = 8
-
-[[issues]]
-file = "src/Reporter/GitHubAnnotationsReporter.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_OUTPUT` is missing a type hint."
-count = 1
 
 [[issues]]
 file = "src/Reporter/GitHubAnnotationsReporter.php"
@@ -4006,24 +2686,6 @@ count = 1
 file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
 code = "imprecise-type"
 message = "Type `array` in return type of `retrieveMutants` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "missing-constant-type"
-message = "Class constant `DETECTION_STATUS_MAP` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "missing-constant-type"
-message = "Class constant `DIFF_HEADERS_LINES_COUNT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Reporter/Html/StrykerHtmlReportBuilder.php"
-code = "missing-constant-type"
-message = "Class constant `PLUS_LENGTH` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -4087,30 +2749,6 @@ message = "Redundant type assertion: `$originalCode` of type `string` is always 
 count = 1
 
 [[issues]]
-file = "src/Reporter/Http/Response.php"
-code = "missing-constant-type"
-message = "Class constant `HTTP_CREATED` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Reporter/Http/Response.php"
-code = "missing-constant-type"
-message = "Class constant `HTTP_MAX_ERROR_CODE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Reporter/Http/Response.php"
-code = "missing-constant-type"
-message = "Class constant `HTTP_OK` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Reporter/Http/StrykerCurlClient.php"
-code = "missing-constant-type"
-message = "Class constant `STRYKER_DASHBOARD_API_BASE_URL` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/Reporter/Http/StrykerCurlClient.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `Infection\Reporter\Http\Response::__construct`: expected `int`, but found `mixed`.'
@@ -4120,30 +2758,6 @@ count = 1
 file = "src/Reporter/Http/StrykerCurlClient.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "src/Reporter/PerMutatorReporter.php"
-code = "missing-constant-type"
-message = "Class constant `ROUND_PRECISION` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Reporter/ShowMetricsReporter.php"
-code = "missing-constant-type"
-message = "Class constant `LOW_QUALITY_THRESHOLD` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Reporter/ShowMetricsReporter.php"
-code = "missing-constant-type"
-message = "Class constant `MEDIUM_QUALITY_THRESHOLD` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Reporter/ShowMetricsReporter.php"
-code = "missing-constant-type"
-message = "Class constant `PAD_LENGTH` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -4169,30 +2783,6 @@ file = "src/Reporter/ShowMutationsReporter.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #2 of `sprintf`: expected `Stringable|null|scalar`, but found `mixed`."
 count = 2
-
-[[issues]]
-file = "src/Resource/Memory/MemoryFormatter.php"
-code = "missing-constant-type"
-message = "Class constant `BYTES_IN_KB` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Resource/Memory/MemoryFormatter.php"
-code = "missing-constant-type"
-message = "Class constant `DECIMALS_TO_SHOW` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Resource/Memory/MemoryFormatter.php"
-code = "missing-constant-type"
-message = "Class constant `UNITS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Resource/Time/TimeFormatter.php"
-code = "missing-constant-type"
-message = "Class constant `TIME_HORIZONS` is missing a type hint."
-count = 1
 
 [[issues]]
 file = "src/Source/Collector/BasicSourceCollector.php"
@@ -4226,26 +2816,8 @@ count = 1
 
 [[issues]]
 file = "src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_EXTENSIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\filesystem\locator\fileordirectorynotfound` in `Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator::locate`.'
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php"
-code = "missing-constant-type"
-message = "Class constant `VERSION_1` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php"
-code = "missing-constant-type"
-message = "Class constant `VERSION_2` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -4280,12 +2852,6 @@ count = 1
 
 [[issues]]
 file = "src/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactory.php"
-code = "missing-constant-type"
-message = "Class constant `PROCESS_MIN_ERROR_CODE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactory.php"
 code = "possibly-null-operand"
 message = "Left operand in `>` comparison might be `null` (type `int|null`)."
 count = 1
@@ -4294,12 +2860,6 @@ count = 1
 file = "src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory::buildMutationConfigFile`.'
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/StaticAnalysisToolTypes.php"
-code = "missing-constant-type"
-message = "Class constant `PHPSTAN` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -4352,12 +2912,6 @@ count = 1
 
 [[issues]]
 file = "src/TestFramework/AdapterInstallationDecider.php"
-code = "missing-constant-type"
-message = "Class constant `ADAPTER_NAME_TO_CLASS_MAP` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/AdapterInstallationDecider.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `Infection\TestFramework\AdapterInstallationDecider::shouldBeInstalled`. Saw type `mixed`.'
 count = 1
@@ -4366,18 +2920,6 @@ count = 1
 file = "src/TestFramework/AdapterInstallationDecider.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\RuntimeException` in `Infection\TestFramework\AdapterInstallationDecider::shouldBeInstalled`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/AdapterInstaller.php"
-code = "missing-constant-type"
-message = "Class constant `OFFICIAL_ADAPTERS_MAP` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/AdapterInstaller.php"
-code = "missing-constant-type"
-message = "Class constant `TIMEOUT` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -4412,12 +2954,6 @@ count = 1
 
 [[issues]]
 file = "src/TestFramework/CommandLineBuilder.php"
-code = "missing-constant-type"
-message = "Class constant `BAT_EXTENSION_LENGTH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/CommandLineBuilder.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\filesystem\finder\exception\finderexception` in `Infection\TestFramework\CommandLineBuilder::findPhp`.'
 count = 1
@@ -4430,26 +2966,8 @@ count = 1
 
 [[issues]]
 file = "src/TestFramework/Config/TestFrameworkConfigLocator.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_EXTENSIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Config/TestFrameworkConfigLocator.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `infection\filesystem\locator\fileordirectorynotfound` in `Infection\TestFramework\Config\TestFrameworkConfigLocator::locate`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/CoverageChecker.php"
-code = "missing-constant-type"
-message = "Class constant `CODECEPTION` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/CoverageChecker.php"
-code = "missing-constant-type"
-message = "Class constant `PHPUNIT` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -4471,27 +2989,9 @@ message = 'Parameter #1 of `Infection\TestFramework\Coverage\JUnit\JUnitReportLo
 count = 1
 
 [[issues]]
-file = "src/TestFramework/Coverage/JUnit/JUnitReportLocator.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_JUNIT_FILENAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/JUnit/JUnitReportLocator.php"
-code = "missing-constant-type"
-message = "Class constant `JUNIT_FILENAME_REGEX` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/TestFramework/Coverage/JUnit/JUnitTestCaseTimeAdder.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `array_sum`: expected `array<array-key, float|int>`, but possibly received `array<array-key, float|null>`."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php"
-code = "missing-constant-type"
-message = "Class constant `MAX_EXPLODE_PARTS` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -4609,18 +3109,6 @@ message = 'Parameter #1 of `Infection\TestFramework\Coverage\XmlReport\IndexXmlC
 count = 1
 
 [[issues]]
-file = "src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_INDEX_RELATIVE_PATHNAME` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php"
-code = "missing-constant-type"
-message = "Class constant `INDEX_FILENAME_REGEX` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser::parse`.'
@@ -4693,21 +3181,9 @@ message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceF
 count = 1
 
 [[issues]]
-file = "src/TestFramework/MapSourceClassToTestStrategy.php"
-code = "missing-constant-type"
-message = "Class constant `SIMPLE` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php"
 code = "invalid-type-cast"
 message = "Non numeric string of type `string` implicitly cast to `float`."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php"
-code = "missing-constant-type"
-message = "Class constant `COVERAGE_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -4774,42 +3250,6 @@ count = 1
 file = "src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `Infection\TestFramework\PhpUnit\CommandLine\FilterBuilder::splitMethodNameFromProviderKey`: expected `array{0: string, 1: string}`, but found `non-empty-list<string>`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php"
-code = "missing-constant-type"
-message = "Class constant `BAILOUT_OPTIMIZATION_LEVEL` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php"
-code = "missing-constant-type"
-message = "Class constant `DROP_DATA_PROVIDER_KEY_OPTIMIZATION_LEVEL` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php"
-code = "missing-constant-type"
-message = "Class constant `DROP_TEST_CASE_OPTIMIZATION_LEVEL` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php"
-code = "missing-constant-type"
-message = "Class constant `MAX_EXPLODE_PARTS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php"
-code = "missing-constant-type"
-message = "Class constant `NO_OPTIMIZATION_LEVEL` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php"
-code = "missing-constant-type"
-message = "Class constant `PCRE_LIMIT` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -4904,18 +3344,6 @@ count = 1
 
 [[issues]]
 file = "src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php"
-code = "missing-constant-type"
-message = "Class constant `LAST_LEGACY_VERSION` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php"
-code = "missing-constant-type"
-message = "Class constant `NEXT_MAINSTREAM_VERSION` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php"
 code = "nullable-return-statement"
 message = 'Function `Infection\TestFramework\PhpUnit\Config\XmlConfigurationVersionProvider::provide` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
 count = 1
@@ -4946,24 +3374,6 @@ count = 1
 
 [[issues]]
 file = "src/TestFramework/TestFrameworkTypes.php"
-code = "missing-constant-type"
-message = "Class constant `CODECEPTION` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/TestFrameworkTypes.php"
-code = "missing-constant-type"
-message = "Class constant `PHPSPEC` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/TestFrameworkTypes.php"
-code = "missing-constant-type"
-message = "Class constant `PHPUNIT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/TestFrameworkTypes.php"
 code = "mixed-array-access"
 message = "Unsafe array access on type `mixed`."
 count = 2
@@ -4981,27 +3391,9 @@ message = 'Potential static method call on interface `Infection\AbstractTestFram
 count = 1
 
 [[issues]]
-file = "src/TestFramework/Tracing/TestLocationBucketSorter.php"
-code = "missing-constant-type"
-message = "Class constant `INIT_BUCKETS` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "src/TestFramework/Tracing/TestRunOrderResolver.php"
 code = "invalid-yield-value-type"
 message = "Invalid value type yielded; expected `string`, but found `null|string`."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Tracing/TestRunOrderResolver.php"
-code = "missing-constant-type"
-message = "Class constant `BUCKETS_COUNT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Tracing/TestRunOrderResolver.php"
-code = "missing-constant-type"
-message = "Class constant `USE_BUCKET_SORT_AFTER` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -5078,12 +3470,6 @@ count = 1
 
 [[issues]]
 file = "src/TestFramework/VersionParser.php"
-code = "missing-constant-type"
-message = "Class constant `VERSION_REGEX` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/VersionParser.php"
 code = "nullable-return-statement"
 message = 'Function `Infection\TestFramework\VersionParser::parse` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`).'
 count = 1
@@ -5156,12 +3542,6 @@ count = 1
 
 [[issues]]
 file = "src/Testing/BaseMutatorTestCase.php"
-code = "missing-constant-type"
-message = "Class constant `WRAPPED_CODE_METHOD_BODY_INDENT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "src/Testing/BaseMutatorTestCase.php"
 code = "non-existent-method"
 message = 'Method `assertcount` does not exist on type `Infection\Testing\BaseMutatorTestCase`.'
 count = 1
@@ -5212,18 +3592,6 @@ count = 1
 file = "src/Testing/BaseMutatorTestCase.php"
 code = "redundant-docblock-type"
 message = "Redundant docblock type for variable `$expectedCodeSample`."
-count = 1
-
-[[issues]]
-file = "src/Testing/MutatorName.php"
-code = "less-specific-return-statement"
-message = 'Returned type `array-key` is less specific than the declared return type `string` for function `Infection\Testing\MutatorName::getName`.'
-count = 1
-
-[[issues]]
-file = "src/Testing/MutatorName.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `array_flip`: expected `array<('K.array_flip() extends array-key), ('V.array_flip() extends array-key)>`, but found `mixed`."
 count = 1
 
 [[issues]]
@@ -6523,12 +4891,6 @@ message = 'Method `assertstringcontainsstring` does not exist on type `Infection
 count = 1
 
 [[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulatorCodeDetector.php"
-code = "missing-constant-type"
-message = "Class constant `FUNCTIONS` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulatorCodeDetectorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `codeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -6788,12 +5150,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
-code = "missing-constant-type"
-message = "Class constant `KNOWN_INTEGRATIONAL_TESTS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php"
 code = "possibly-false-argument"
 message = 'Argument #1 of function `Safe\file_get_contents` is possibly `false`, but parameter type `string` does not accept it.'
 count = 3
@@ -6944,18 +5300,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php"
-code = "missing-constant-type"
-message = "Class constant `ARBITRARY_STATEMENTS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php"
-code = "missing-constant-type"
-message = "Class constant `NATIVE_FUNCTIONS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #3 of `Safe\preg_match_all`: expected `array<array-key, mixed>|null`, but found `mixed`.'
 count = 1
@@ -7000,12 +5344,6 @@ count = 1
 file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `subTargetProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
-code = "missing-constant-type"
-message = "Class constant `MAKEFILE_PATH` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -7156,12 +5494,6 @@ count = 1
 file = "tests/phpunit/AutoReview/Mutator/MutatorProviderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\Mutator\MutatorProviderTest::test_configurable_mutator_class_provider_is_valid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "missing-constant-type"
-message = "Class constant `KNOWN_MUTATOR_PUBLIC_METHODS` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -7418,30 +5750,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
-code = "missing-constant-type"
-message = "Class constant `CONCRETE_CLASSES_WITH_TESTS_IN_DIFFERENT_LOCATION` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
-code = "missing-constant-type"
-message = "Class constant `EXTENSION_POINTS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
-code = "missing-constant-type"
-message = "Class constant `NON_FINAL_EXTENSION_CLASSES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
-code = "missing-constant-type"
-message = "Class constant `NON_TESTED_CONCRETE_CLASSES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "mixed-property-type-coercion"
 message = "Mixed property type coercion"
 count = 1
@@ -7576,12 +5884,6 @@ count = 1
 file = "tests/phpunit/BenchmarkSmokeTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideBenchmarks` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/BenchmarkSmokeTest.php"
-code = "missing-constant-type"
-message = "Class constant `BENCHMARK_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -7760,12 +6062,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
-code = "missing-constant-type"
-message = "Class constant `LOG_EXAMPLE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
 code = "non-existent-method"
 message = 'Method `assertcount` does not exist on type `Infection\Tests\Command\Debug\MockTeamCityCommandTest`.'
 count = 1
@@ -7904,24 +6200,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "missing-constant-type"
-message = "Class constant `REFERENCE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "missing-constant-type"
-message = "Class constant `SOURCE_DIRECTORIES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 3
@@ -7990,24 +6268,6 @@ count = 1
 file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `commandExecutionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "missing-constant-type"
-message = "Class constant `REFERENCE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "missing-constant-type"
-message = "Class constant `SOURCE_DIRECTORIES` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -8120,12 +6380,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 8
@@ -8170,12 +6424,6 @@ count = 1
 file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `inputProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -8564,12 +6812,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "missing-constant-type"
-message = "Class constant `VALID_PHPUNIT_EXECUTABLE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 3
@@ -8780,12 +7022,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "missing-constant-type"
-message = "Class constant `GIT_DEFAULT_BASE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
 code = "no-value"
 message = 'Argument #5 passed to method `Infection\Configuration\ConfigurationFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
@@ -8984,26 +7220,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
-code = "missing-constant-type"
-message = "Class constant `PROFILES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
-code = "missing-constant-type"
-message = "Class constant `SCHEMA_FILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::assertJsonIsSchemaValid`: expected `stdClass`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `array_diff_key`: expected `array<('K.array_diff_key() extends array-key), ('V.array_diff_key() extends mixed)>`, but found `mixed`."
 count = 1
 
 [[issues]]
@@ -9327,30 +7545,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, false>, 'source': Infection\Configuration\Entry\Source}`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
-code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, stdClass&object{ignore: list{string(' file '), string('')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
-code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, stdClass&object{ignore: list{string('fileA'), string('fileB')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
-code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<array-key, true>, 'source': Infection\Configuration\Entry\Source}`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
-code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), false>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
@@ -9370,6 +7564,30 @@ count = 1
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string('@arithmetic')|string('@boolean')|string('@cast')|string('@conditional_boundary')|string('@conditional_negotiation')|string('@default')|string('@function_signature')|string('@loop')|string('@number')|string('@operator')|string('@regex')|string('@removal')|string('@return_value')|string('@sort'), true>, 'source': Infection\Configuration\Entry\Source}`.'''
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
+code = "possibly-invalid-argument"
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string, false>, 'source': Infection\Configuration\Entry\Source}`.'''
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
+code = "possibly-invalid-argument"
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string, stdClass&object{ignore: list{string(' file '), string('')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
+code = "possibly-invalid-argument"
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string, stdClass&object{ignore: list{string('fileA'), string('fileB')}}>, 'source': Infection\Configuration\Entry\Source}`.'''
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
+code = "possibly-invalid-argument"
+message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest::createConfig`: expected `array<array<string, mixed>, mixed>`, but possibly received `array{'mutators': non-empty-array<string, true>, 'source': Infection\Configuration\Entry\Source}`.'''
 count = 1
 
 [[issues]]
@@ -9478,12 +7696,6 @@ count = 1
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidConfigContentsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -9677,30 +7889,6 @@ file = "tests/phpunit/Console/E2ETest.php"
 code = "invalid-iterator"
 message = "The expression provided to `foreach` is not iterable. It resolved to type `mixed`, which is not iterable."
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "missing-constant-type"
-message = "Class constant `EXCLUDED_GROUP` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "missing-constant-type"
-message = "Class constant `EXPECT_ERROR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "missing-constant-type"
-message = "Class constant `EXPECT_SUCCESS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "missing-constant-type"
-message = "Class constant `MAX_FAILING_COMPOSER_INSTALL` is missing a type hint."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Console/E2ETest.php"
@@ -11432,18 +9620,6 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/MockVendor.php"
-code = "missing-constant-type"
-message = "Class constant `PACKAGE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MockVendor.php"
-code = "missing-constant-type"
-message = "Class constant `VENDOR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MockVendor.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\Finder\MockVendor::__construct`.'
 count = 1
@@ -11744,12 +9920,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
 code = "non-existent-method"
 message = 'Method `assertnull` does not exist on type `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest`.'
 count = 2
@@ -11830,12 +10000,6 @@ count = 1
 file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `pathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -12113,18 +10277,6 @@ file = "tests/phpunit/Framework/StrTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Framework\StrTest`.'
 count = 6
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "missing-constant-type"
-message = "Class constant `BAD_COMMIT_REFERENCE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "missing-constant-type"
-message = "Class constant `COMMIT_REFERENCE` is missing a type hint."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
@@ -12490,12 +10642,6 @@ count = 1
 file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `detectionStatusProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
-code = "missing-constant-type"
-message = "Class constant `ANY_PRIME_NUMBER` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -13052,18 +11198,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutant/MutantCodeFactoryTest.php"
-code = "missing-constant-type"
-message = "Class constant `PHP_TO_BE_MUTATED_CODE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantCodeFactoryTest.php"
-code = "missing-constant-type"
-message = "Class constant `PHP_UNTOUCHED_CODE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantCodeFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutant\MutantCodeFactoryTest`.'
 count = 2
@@ -13198,12 +11332,6 @@ count = 3
 file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -14090,18 +12218,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/DefinitionTest.php"
-code = "missing-constant-type"
-message = "Class constant `MUTATORS_WITHOUT_REMEDIES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/DefinitionTest.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `array_fill_keys`: expected `array<array-key, ('K.array_fill_keys() extends array-key)>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/DefinitionTest.php"
 code = "non-existent-method"
 message = 'Method `assertInstanceOf` does not exist on type `Infection\Tests\Mutator\DefinitionTest`.'
 count = 1
@@ -14121,7 +12237,7 @@ count = 4
 [[issues]]
 file = "tests/phpunit/Mutator/DefinitionTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `Infection\Mutator\MutatorFactory::create`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but possibly received `array<array-key, array{}>`.'
+message = 'Possible argument type mismatch for argument #1 of `Infection\Mutator\MutatorFactory::create`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but possibly received `array<class-string, array{}>`.'
 count = 1
 
 [[issues]]
@@ -14492,12 +12608,6 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorCategoryTest.php"
-code = "missing-constant-type"
-message = "Class constant `ALL_CONSTANT_KEY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorCategoryTest.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #1 of `array_unique`: expected `array<('K.array_unique() extends array-key), ('V.array_unique() extends mixed)>`, but found `mixed`."
 count = 1
@@ -14552,26 +12662,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "less-specific-nested-argument-type"
-message = 'Argument type mismatch for argument #1 of `Infection\Tests\Mutator\MutatorFactoryTest::assertSameMutatorsByClass`: expected `array<array-key, string>`, but provided type `list<mixed>` is less specific.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `array_fill_keys`: expected `array<array-key, ('K.array_fill_keys() extends array-key)>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `array_values`: expected `array<('K.array_values() extends array-key), ('V.array_values() extends mixed)>`, but found `mixed`."
 count = 1
 
 [[issues]]
@@ -14643,7 +12735,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `Infection\Mutator\MutatorFactory::create`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but possibly received `array<array-key, array{}>`.'
+message = 'Possible argument type mismatch for argument #1 of `Infection\Mutator\MutatorFactory::create`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but possibly received `array<class-string, array{}>`.'
 count = 1
 
 [[issues]]
@@ -14680,12 +12772,6 @@ count = 1
 file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
 code = "unused-method"
 message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFixturesProvider.php"
-code = "missing-constant-type"
-message = "Class constant `MUTATOR_FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -14852,42 +12938,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "invalid-array-element-key"
-message = "Invalid array key type."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "invalid-iterator"
-message = "The expression provided to `foreach` is not iterable. It resolved to type `mixed`, which is not iterable."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Testing\MutatorName::getName`: expected `string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #2 of `sprintf`: expected `Stringable|null|scalar`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
 code = "non-existent-method"
 message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\Mutator\MutatorRobustnessTest`.'
 count = 1
@@ -14895,7 +12945,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
 code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `Infection\Mutator\MutatorFactory::create`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but possibly received `non-empty-array<array-key, array{}>`.'
+message = 'Possible argument type mismatch for argument #1 of `Infection\Mutator\MutatorFactory::create`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but possibly received `non-empty-array<class-string, array{}>`.'
 count = 1
 
 [[issues]]
@@ -16274,12 +14324,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\EnrichmentTraverse\EnrichmentTraverseIntegrationTest`.'
 count = 1
@@ -16501,18 +14545,6 @@ message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\Poten
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/StopAtSkippedArgVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `SKIP_ATTRIBUTE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MutationCollectorVisitorTest.php"
-code = "missing-constant-type"
-message = "Class constant `CODE` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/MutationCollectorVisitorTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
@@ -16642,12 +14674,6 @@ count = 1
 file = "tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -17258,12 +15284,6 @@ count = 10
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "missing-constant-type"
-message = "Class constant `TIMEOUT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 8
@@ -17474,12 +15494,6 @@ count = 5
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "missing-constant-type"
-message = "Class constant `SIMULATED_TIME_MICROSECONDS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 3
@@ -17499,7 +15513,7 @@ count = 34
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `class@anonymous:14053425703945415052-24611:25389::__construct`: expected `Infection\Mutant\TestFrameworkMutantExecutionResultFactory`, but found `mixed`.'
+message = 'Invalid argument type for argument #1 of `class@anonymous:14053425703945415052-24615:25393::__construct`: expected `Infection\Mutant\TestFrameworkMutantExecutionResultFactory`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -17668,12 +15682,6 @@ count = 1
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_minus_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "missing-constant-type"
-message = "Class constant `SIMULATED_TIME_MICROSECONDS` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -18110,12 +16118,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "missing-constant-type"
-message = "Class constant `LOG_FILE_PATH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 2
@@ -18236,12 +16238,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
-code = "missing-constant-type"
-message = "Class constant `SCHEMA_FILE` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #2 of `sprintf`: expected `Stringable|null|scalar`, but found `mixed`."
 count = 1
@@ -18298,12 +16294,6 @@ count = 1
 file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideResponseStatusCodes` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "missing-constant-type"
-message = "Class constant `API_KEY` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -18812,12 +16802,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_ROOT` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
 code = "non-existent-method"
 message = 'Method `assertSame` does not exist on type `Infection\Tests\Source\Collector\BasicSourceCollector\BasicSourceCollectorTest`.'
 count = 1
@@ -19280,18 +17264,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/CommandLineBuilderTest.php"
-code = "missing-constant-type"
-message = "Class constant `PHP_EXTRA_ARGS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/CommandLineBuilderTest.php"
-code = "missing-constant-type"
-message = "Class constant `TEST_FRAMEWORK_ARGS` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/CommandLineBuilderTest.php"
 code = "non-existent-method"
 message = 'Method `assertcontains` does not exist on type `Infection\Tests\TestFramework\CommandLineBuilderTest`.'
 count = 6
@@ -19318,18 +17290,6 @@ count = 2
 file = "tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php"
 code = "non-existent-method"
 message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\TestFramework\Config\TestFrameworkConfigLocatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php"
-code = "missing-constant-type"
-message = "Class constant `COVERAGE_DIR_PATH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php"
-code = "missing-constant-type"
-message = "Class constant `JUNIT_PATH` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -19456,12 +17416,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `reportPathnameProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "missing-constant-type"
-message = "Class constant `TEST_DEFAULT_JUNIT` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -19807,33 +17761,15 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionBDDProvider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionCestProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionCestProvider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionUnitProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionUnitProvider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -19891,21 +17827,9 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit09Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit10Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit10Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -19915,21 +17839,9 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit11Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit12Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit12Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -20173,12 +18085,6 @@ message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Excepti
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/DemoReportLocator.php"
-code = "missing-constant-type"
-message = "Class constant `FILENAME_REGEX` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/Locator/FixedLocatorTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\Locator\FixedLocatorTest`.'
@@ -20242,12 +18148,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `reportPathnameProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "missing-constant-type"
-message = "Class constant `TEST_DEFAULT_RELATIVE_PATHNAME` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -20516,18 +18416,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "missing-constant-type"
-message = "Class constant `GENERAL_FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
 code = "non-existent-method"
 message = 'Method `assertequals` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest`.'
 count = 1
@@ -20677,21 +18565,9 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/CodeceptionProvider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpSpecProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpSpecProvider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -20701,21 +18577,9 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit09Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit10Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit10Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -20725,33 +18589,15 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit11Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit125Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit125Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit12Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit12Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -20840,12 +18686,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/CodeceptionProvider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/CodeceptionProvider.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\CodeceptionProvider::infoProvider`.'
 count = 1
@@ -20854,12 +18694,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpSpecProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpSpecProvider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -20876,12 +18710,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit09Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit09Provider.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\PhpUnit09Provider::infoProvider`.'
 count = 1
@@ -20890,12 +18718,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit10Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit10Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -20912,12 +18734,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit11Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit11Provider.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\PhpUnit11Provider::infoProvider`.'
 count = 1
@@ -20930,12 +18746,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit120Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit120Provider.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\PhpUnit120Provider::infoProvider`.'
 count = 1
@@ -20944,12 +18754,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit125Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit125Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -21179,18 +18983,6 @@ file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderT
 code = "invalid-property-access"
 message = "Attempting to access a property on a non-object type (`never`)."
 count = 9
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "missing-constant-type"
-message = "Class constant `TMP_DIR` is missing a type hint."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
@@ -21447,37 +19239,7 @@ count = 11
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
 code = "invalid-return-statement"
-message = "Invalid return type for function `1015983213910025095:19931`: expected `string`, but found `null|string`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "missing-constant-type"
-message = "Class constant `HASH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "missing-constant-type"
-message = "Class constant `MUTATED_FILE_PATH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "missing-constant-type"
-message = "Class constant `ORIGINAL_FILE_PATH` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "missing-constant-type"
-message = "Class constant `TMP_DIR` is missing a type hint."
+message = "Invalid return type for function `1015983213910025095:19966`: expected `string`, but found `null|string`."
 count = 1
 
 [[issues]]
@@ -21531,7 +19293,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
 code = "nullable-return-statement"
-message = "Function `1015983213910025095:19931` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`)."
+message = "Function `1015983213910025095:19966` is declared to return `string` but possibly returns a nullable value (inferred as `null|string`)."
 count = 1
 
 [[issues]]
@@ -21874,12 +19636,6 @@ count = 2
 file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `locationsArrayProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
-code = "missing-constant-type"
-message = "Class constant `EPSILON` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -22243,21 +19999,9 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/CodeceptionProvider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpSpecProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpSpecProvider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -22267,21 +20011,9 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit09Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit10Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit10Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -22291,33 +20023,15 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit11Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit120Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit120Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit125Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit125Provider.php"
-code = "missing-constant-type"
-message = "Class constant `FIXTURES_DIR` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -22414,12 +20128,6 @@ count = 1
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `validXmlFileProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "missing-constant-type"
-message = "Class constant `BOOKSTORE_XML` is missing a type hint."
 count = 1
 
 [[issues]]
@@ -22807,18 +20515,6 @@ message = "Possibly using `null` as an array index to access element."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/TrackableIterator.php"
-code = "missing-constant-type"
-message = "Class constant `EMPTY_KEY` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/TrackableIterator.php"
-code = "missing-constant-type"
-message = "Class constant `EMPTY_VALUE` is missing a type hint."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestingUtility/Iterable/TrackableIteratorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -22906,12 +20602,6 @@ count = 1
 file = "tests/phpunit/TestingUtility/PhpParser/Visitor/KeepOnlyDesiredAttributesVisitor/KeepOnlyDesiredAttributesVisitorTest.php"
 code = "non-existent-method"
 message = 'Method `assertsame` does not exist on type `Infection\Tests\TestingUtility\PhpParser\Visitor\KeepOnlyDesiredAttributesVisitor\KeepOnlyDesiredAttributesVisitorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/PhpParser/Visitor/SkipNodesVisitor/SkipNodesVisitor.php"
-code = "missing-constant-type"
-message = "Class constant `DEFAULT_STOP_TRAVERSE_TYPE` is missing a type hint."
 count = 1
 
 [[issues]]

--- a/rector.php
+++ b/rector.php
@@ -55,6 +55,7 @@ use Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector;
 use Rector\Php73\Rector\String_\SensitiveHereNowDocRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AddInstanceofAssertForNullableInstanceRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\DataProviderArrayItemsNewLinedRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCompareOnCountableWithMethodToAssertCountRector;
@@ -101,6 +102,7 @@ return RectorConfig::configure()
         typeDeclarations: true,
     )
     ->withRules([
+        AddTypeToConstRector::class,
         AddParamArrayDocblockFromAssignsParamToParamReferenceRector::class,
         AddParamArrayDocblockFromDataProviderRector::class,
         AddReturnDocblockForArrayDimAssignedObjectRector::class,

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -74,10 +74,9 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class ConfigureCommand extends BaseCommand
 {
-    public const NONINTERACTIVE_MODE_ERROR = 'Infection config generator requires an interactive mode.';
+    public const string NONINTERACTIVE_MODE_ERROR = 'Infection config generator requires an interactive mode.';
 
-    /** @var string */
-    private const OPTION_TEST_FRAMEWORK = 'test-framework';
+    private const string OPTION_TEST_FRAMEWORK = 'test-framework';
 
     protected function configure(): void
     {

--- a/src/Command/Debug/DumpAstCommand.php
+++ b/src/Command/Debug/DumpAstCommand.php
@@ -67,13 +67,13 @@ use Webmozart\Assert\Assert;
  */
 final class DumpAstCommand extends BaseCommand
 {
-    private const FILE_PATH_ARGUMENT = 'file';
+    private const string FILE_PATH_ARGUMENT = 'file';
 
-    private const SHOW_ATTRIBUTES = 'show-attributes';
+    private const string SHOW_ATTRIBUTES = 'show-attributes';
 
-    private const CHANGED_LINES_RANGES = 'changed-lines-ranges';
+    private const string CHANGED_LINES_RANGES = 'changed-lines-ranges';
 
-    private const CHANGED_LINES_PARTS_COUNT = 2;
+    private const int CHANGED_LINES_PARTS_COUNT = 2;
 
     public function __construct(
         private readonly FileSystem $fileSystem,

--- a/src/Command/Debug/MockTeamCityCommand.php
+++ b/src/Command/Debug/MockTeamCityCommand.php
@@ -58,13 +58,13 @@ use Webmozart\Assert\Assert;
  */
 final class MockTeamCityCommand extends BaseCommand
 {
-    private const MILLISECONDS_IN_MICROSECONDS = 1000;
+    private const int MILLISECONDS_IN_MICROSECONDS = 1000;
 
-    private const LOG_FILE_PATH_ARGUMENT = 'log';
+    private const string LOG_FILE_PATH_ARGUMENT = 'log';
 
-    private const TIME_IN_MICRO_SECONDS_OPTION = 'time';
+    private const string TIME_IN_MICRO_SECONDS_OPTION = 'time';
 
-    private const DEFAULT_TIME_IN_MILLISECONDS = 500;  // 0.5s
+    private const int DEFAULT_TIME_IN_MILLISECONDS = 500;  // 0.5s
 
     private readonly Closure $sleep;
 

--- a/src/Command/Git/Option/BaseOption.php
+++ b/src/Command/Git/Option/BaseOption.php
@@ -50,7 +50,7 @@ final class BaseOption
 {
     use CannotBeInstantiated;
 
-    public const NAME = 'base';
+    public const string NAME = 'base';
 
     /**
      * @template T of Command

--- a/src/Command/Git/Option/FilterOption.php
+++ b/src/Command/Git/Option/FilterOption.php
@@ -51,7 +51,7 @@ final class FilterOption
 {
     use CannotBeInstantiated;
 
-    public const NAME = 'filter';
+    public const string NAME = 'filter';
 
     /**
      * @template T of Command

--- a/src/Command/InitialTest/Option/InitialTestsPhpOptionsOption.php
+++ b/src/Command/InitialTest/Option/InitialTestsPhpOptionsOption.php
@@ -51,7 +51,7 @@ final class InitialTestsPhpOptionsOption implements CommandOption
 {
     use CannotBeInstantiated;
 
-    public const NAME = 'initial-tests-php-options';
+    public const string NAME = 'initial-tests-php-options';
 
     /**
      * @template T of Command

--- a/src/Command/MakeCustomMutatorCommand.php
+++ b/src/Command/MakeCustomMutatorCommand.php
@@ -54,7 +54,7 @@ use function ucfirst;
  */
 final class MakeCustomMutatorCommand extends BaseCommand
 {
-    private const MUTATOR_NAME_ARGUMENT = 'Mutator name';
+    private const string MUTATOR_NAME_ARGUMENT = 'Mutator name';
 
     protected function configure(): void
     {

--- a/src/Command/Option/ConfigurationOption.php
+++ b/src/Command/Option/ConfigurationOption.php
@@ -49,7 +49,7 @@ final class ConfigurationOption
 {
     use CannotBeInstantiated;
 
-    public const NAME = 'configuration';
+    public const string NAME = 'configuration';
 
     /**
      * @template T of Command

--- a/src/Command/Option/DebugOption.php
+++ b/src/Command/Option/DebugOption.php
@@ -48,7 +48,7 @@ final class DebugOption implements CommandOption
 {
     use CannotBeInstantiated;
 
-    public const NAME = 'debug';
+    public const string NAME = 'debug';
 
     /**
      * @template T of Command

--- a/src/Command/Option/MapSourceClassToTestOption.php
+++ b/src/Command/Option/MapSourceClassToTestOption.php
@@ -51,7 +51,7 @@ final class MapSourceClassToTestOption implements CommandOption
 {
     use CannotBeInstantiated;
 
-    public const NAME = 'map-source-class-to-test';
+    public const string NAME = 'map-source-class-to-test';
 
     /**
      * @template T of Command

--- a/src/Command/Option/SourceFilterOptions.php
+++ b/src/Command/Option/SourceFilterOptions.php
@@ -56,13 +56,13 @@ final class SourceFilterOptions
 {
     use CannotBeInstantiated;
 
-    public const PLAIN_FILTER_NAME = 'filter';
+    public const string PLAIN_FILTER_NAME = 'filter';
 
-    private const GIT_DIFF_FILTER_NAME = 'git-diff-filter';
+    private const string GIT_DIFF_FILTER_NAME = 'git-diff-filter';
 
-    private const GIT_DIFF_LINES_NAME = 'git-diff-lines';
+    private const string GIT_DIFF_LINES_NAME = 'git-diff-lines';
 
-    private const GIT_DIFF_BASE_NAME = 'git-diff-base';
+    private const string GIT_DIFF_BASE_NAME = 'git-diff-base';
 
     /**
      * @template T of Command

--- a/src/Command/Option/TestFrameworkOption.php
+++ b/src/Command/Option/TestFrameworkOption.php
@@ -52,7 +52,7 @@ final class TestFrameworkOption implements CommandOption
 {
     use CannotBeInstantiated;
 
-    public const NAME = 'test-framework';
+    public const string NAME = 'test-framework';
 
     /**
      * @template T of Command

--- a/src/Command/Option/TestFrameworkOptionsOption.php
+++ b/src/Command/Option/TestFrameworkOptionsOption.php
@@ -49,7 +49,7 @@ final class TestFrameworkOptionsOption implements CommandOption
 {
     use CannotBeInstantiated;
 
-    public const NAME = 'test-framework-options';
+    public const string NAME = 'test-framework-options';
 
     /**
      * @template T of Command

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -76,86 +76,67 @@ use Symfony\Component\Console\Input\InputOption;
  */
 final class RunCommand extends BaseCommand
 {
-    /** @var string */
-    public const OPTION_THREADS = 'threads';
+    public const string OPTION_THREADS = 'threads';
 
-    /** @var string */
-    public const OPTION_LOGGER_GITHUB = 'logger-github';
+    public const string OPTION_LOGGER_GITHUB = 'logger-github';
 
-    /** @var string */
-    public const OPTION_SHOW_MUTATIONS = 'show-mutations';
+    public const string OPTION_SHOW_MUTATIONS = 'show-mutations';
 
-    /** @var string */
-    public const OPTION_IGNORE_MSI_WITH_NO_MUTATIONS = 'ignore-msi-with-no-mutations';
+    public const string OPTION_IGNORE_MSI_WITH_NO_MUTATIONS = 'ignore-msi-with-no-mutations';
 
     /**
      * Sentinel value for VALUE_OPTIONAL options to distinguish "not provided" from "provided
      * without value"
      */
-    public const OPTION_VALUE_NOT_PROVIDED = false;
+    public const bool OPTION_VALUE_NOT_PROVIDED = false;
 
-    public const OPTION_LOGGER_SUMMARY_JSON = 'logger-summary-json';
+    public const string OPTION_LOGGER_SUMMARY_JSON = 'logger-summary-json';
 
-    /** @var string */
-    public const OPTION_WITH_TIMEOUTS = 'with-timeouts';
+    public const string OPTION_WITH_TIMEOUTS = 'with-timeouts';
 
-    /** @var string */
-    public const OPTION_MAX_TIMEOUTS = 'max-timeouts';
+    public const string OPTION_MAX_TIMEOUTS = 'max-timeouts';
 
-    private const OPTION_STATIC_ANALYSIS_TOOL = 'static-analysis-tool';
+    private const string OPTION_STATIC_ANALYSIS_TOOL = 'static-analysis-tool';
 
-    /** @var string */
-    private const OPTION_STATIC_ANALYSIS_TOOL_OPTIONS = 'static-analysis-tool-options';
+    private const string OPTION_STATIC_ANALYSIS_TOOL_OPTIONS = 'static-analysis-tool-options';
 
-    /** @var string */
-    private const OPTION_WITH_UNCOVERED = 'with-uncovered';
+    private const string OPTION_WITH_UNCOVERED = 'with-uncovered';
 
-    /** @var string */
-    private const OPTION_NO_PROGRESS = 'no-progress';
+    private const string OPTION_NO_PROGRESS = 'no-progress';
 
-    /** @var string */
-    private const OPTION_FORCE_PROGRESS = 'force-progress';
+    private const string OPTION_FORCE_PROGRESS = 'force-progress';
 
-    /** @var string */
-    private const OPTION_COVERAGE = 'coverage';
+    private const string OPTION_COVERAGE = 'coverage';
 
-    /** @var string */
-    private const OPTION_MUTATORS = 'mutators';
+    private const string OPTION_MUTATORS = 'mutators';
 
-    /** @var string */
-    private const OPTION_FORMATTER = 'formatter';
+    private const string OPTION_FORMATTER = 'formatter';
 
-    /** @var string */
-    private const OPTION_LOGGER_GITLAB = 'logger-gitlab';
+    private const string OPTION_LOGGER_GITLAB = 'logger-gitlab';
 
-    private const OPTION_LOGGER_PROJECT_ROOT_DIRECTORY = 'logger-project-root-directory';
+    private const string OPTION_LOGGER_PROJECT_ROOT_DIRECTORY = 'logger-project-root-directory';
 
-    private const OPTION_LOGGER_HTML = 'logger-html';
+    private const string OPTION_LOGGER_HTML = 'logger-html';
 
-    private const OPTION_LOGGER_TEXT = 'logger-text';
+    private const string OPTION_LOGGER_TEXT = 'logger-text';
 
-    private const OPTION_USE_NOOP_MUTATORS = 'noop';
+    private const string OPTION_USE_NOOP_MUTATORS = 'noop';
 
-    private const OPTION_EXECUTE_ONLY_COVERING_TEST_CASES = 'only-covering-test-cases';
+    private const string OPTION_EXECUTE_ONLY_COVERING_TEST_CASES = 'only-covering-test-cases';
 
-    /** @var string */
-    private const OPTION_MIN_MSI = 'min-msi';
+    private const string OPTION_MIN_MSI = 'min-msi';
 
-    /** @var string */
-    private const OPTION_MIN_COVERED_MSI = 'min-covered-msi';
+    private const string OPTION_MIN_COVERED_MSI = 'min-covered-msi';
 
-    /** @var string */
-    private const OPTION_LOG_VERBOSITY = 'log-verbosity';
+    private const string OPTION_LOG_VERBOSITY = 'log-verbosity';
 
-    /** @var string */
-    private const OPTION_SKIP_INITIAL_TESTS = 'skip-initial-tests';
+    private const string OPTION_SKIP_INITIAL_TESTS = 'skip-initial-tests';
 
-    /** @var string */
-    private const OPTION_DRY_RUN = 'dry-run';
+    private const string OPTION_DRY_RUN = 'dry-run';
 
-    private const OPTION_MUTANT_ID = 'id';
+    private const string OPTION_MUTANT_ID = 'id';
 
-    private const OPTION_TEAMCITY = 'teamcity';
+    private const string OPTION_TEAMCITY = 'teamcity';
 
     protected function configure(): void
     {

--- a/src/Config/Guesser/PhpUnitPathGuesser.php
+++ b/src/Config/Guesser/PhpUnitPathGuesser.php
@@ -44,7 +44,7 @@ use function trim;
  */
 final readonly class PhpUnitPathGuesser
 {
-    private const CURRENT_DIR_PATH = '.';
+    private const string CURRENT_DIR_PATH = '.';
 
     public function __construct(
         private stdClass $composerJsonContent,

--- a/src/Config/ValueProvider/ExcludeDirsProvider.php
+++ b/src/Config/ValueProvider/ExcludeDirsProvider.php
@@ -58,7 +58,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final readonly class ExcludeDirsProvider
 {
-    public const EXCLUDED_ROOT_DIRS = ['vendor', 'tests', 'test'];
+    public const array EXCLUDED_ROOT_DIRS = ['vendor', 'tests', 'test'];
 
     public function __construct(
         private ConsoleHelper $consoleHelper,

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -55,7 +55,7 @@ use Webmozart\Assert\Assert;
  */
 readonly class Configuration
 {
-    private const LOG_VERBOSITY = [
+    private const array LOG_VERBOSITY = [
         'all',
         'none',
         'default',

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -82,7 +82,7 @@ class ConfigurationFactory
     /**
      * Default allowed timeout (on a test basis) in seconds
      */
-    private const DEFAULT_TIMEOUT = 10;
+    private const int DEFAULT_TIMEOUT = 10;
 
     public function __construct(
         private readonly TmpDirProvider $tmpDirProvider,

--- a/src/Configuration/Schema/SchemaConfigurationLoader.php
+++ b/src/Configuration/Schema/SchemaConfigurationLoader.php
@@ -42,20 +42,20 @@ use Infection\FileSystem\Locator\Locator;
  */
 final readonly class SchemaConfigurationLoader
 {
-    public const POSSIBLE_DEFAULT_CONFIG_FILE_NAMES = [
+    public const array POSSIBLE_DEFAULT_CONFIG_FILE_NAMES = [
         self::DEFAULT_JSON5_CONFIG_FILE,
         self::DEFAULT_JSON_CONFIG_FILE,
         self::DEFAULT_DIST_JSON5_CONFIG_FILE,
         self::DEFAULT_DIST_JSON_CONFIG_FILE,
     ];
 
-    public const DEFAULT_JSON5_CONFIG_FILE = 'infection.json5';
+    public const string DEFAULT_JSON5_CONFIG_FILE = 'infection.json5';
 
-    private const DEFAULT_DIST_JSON5_CONFIG_FILE = 'infection.json5.dist';
+    private const string DEFAULT_DIST_JSON5_CONFIG_FILE = 'infection.json5.dist';
 
-    private const DEFAULT_DIST_JSON_CONFIG_FILE = 'infection.json.dist';
+    private const string DEFAULT_DIST_JSON_CONFIG_FILE = 'infection.json.dist';
 
-    private const DEFAULT_JSON_CONFIG_FILE = 'infection.json';
+    private const string DEFAULT_JSON_CONFIG_FILE = 'infection.json';
 
     public function __construct(
         private Locator $locator,

--- a/src/Configuration/Schema/SchemaValidator.php
+++ b/src/Configuration/Schema/SchemaValidator.php
@@ -46,7 +46,7 @@ use function str_contains;
  */
 class SchemaValidator
 {
-    private const SCHEMA_FILE = __DIR__ . '/../../../resources/schema.json';
+    private const string SCHEMA_FILE = __DIR__ . '/../../../resources/schema.json';
 
     /**
      * @throws InvalidSchema

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -65,11 +65,11 @@ use function trim;
  */
 final class Application extends BaseApplication
 {
-    public const PACKAGE_NAME = 'infection/infection';
+    public const string PACKAGE_NAME = 'infection/infection';
 
-    private const NAME = 'Infection - PHP Mutation Testing Framework';
+    private const string NAME = 'Infection - PHP Mutation Testing Framework';
 
-    private const LOGO = '
+    private const string LOGO = '
     ____      ____          __  _
    /  _/___  / __/__  _____/ /_(_)___  ____
    / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -46,9 +46,9 @@ use function sprintf;
  */
 class ConsoleOutput
 {
-    private const RUNNING_WITH_DEBUGGER_NOTE = 'You are running Infection with %s enabled.';
+    private const string RUNNING_WITH_DEBUGGER_NOTE = 'You are running Infection with %s enabled.';
 
-    private const MIN_MSI_CAN_GET_INCREASED_NOTICE = 'The %s is %s%% percentage points over the required %s. Consider increasing the required %s percentage the next time you run Infection.';
+    private const string MIN_MSI_CAN_GET_INCREASED_NOTICE = 'The %s is %s%% percentage points over the required %s. Consider increasing the required %s percentage the next time you run Infection.';
 
     public function __construct(
         private readonly LoggerInterface $logger,

--- a/src/Console/Input/MsiParser.php
+++ b/src/Console/Input/MsiParser.php
@@ -53,9 +53,9 @@ final class MsiParser
 {
     use CannotBeInstantiated;
 
-    public const DEFAULT_PRECISION = 2;
+    public const int DEFAULT_PRECISION = 2;
 
-    private const EXPLODE_PARTS = 2;
+    private const int EXPLODE_PARTS = 2;
 
     public static function detectPrecision(?string ...$values): int
     {

--- a/src/Console/LogVerbosity.php
+++ b/src/Console/LogVerbosity.php
@@ -47,31 +47,31 @@ final class LogVerbosity
 {
     use CannotBeInstantiated;
 
-    public const DEBUG = 'all';
+    public const string DEBUG = 'all';
 
-    public const NORMAL = 'default';
+    public const string NORMAL = 'default';
 
-    public const NONE = 'none';
-
-    /**
-     * @deprecated
-     */
-    public const DEBUG_INTEGER = 1;
+    public const string NONE = 'none';
 
     /**
      * @deprecated
      */
-    public const NORMAL_INTEGER = 2;
+    public const int DEBUG_INTEGER = 1;
 
     /**
      * @deprecated
      */
-    public const NONE_INTEGER = 3;
+    public const int NORMAL_INTEGER = 2;
+
+    /**
+     * @deprecated
+     */
+    public const int NONE_INTEGER = 3;
 
     /**
      * @var array<int, string>
      */
-    public const ALLOWED_OPTIONS = [
+    public const array ALLOWED_OPTIONS = [
         self::DEBUG_INTEGER => self::DEBUG,
         self::NORMAL_INTEGER => self::NORMAL,
         self::NONE_INTEGER => self::NONE,

--- a/src/Console/XdebugHandler.php
+++ b/src/Console/XdebugHandler.php
@@ -46,7 +46,7 @@ final class XdebugHandler
 {
     use CannotBeInstantiated;
 
-    private const PREFIX = 'INFECTION';
+    private const string PREFIX = 'INFECTION';
 
     public static function check(LoggerInterface $logger): void
     {

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -185,79 +185,79 @@ use Webmozart\Assert\Assert;
  */
 final class Container extends DIContainer
 {
-    public const DEFAULT_CONFIG_FILE = null;
+    public const null DEFAULT_CONFIG_FILE = null;
 
-    public const DEFAULT_MUTATORS_INPUT = '';
+    public const string DEFAULT_MUTATORS_INPUT = '';
 
-    public const DEFAULT_SHOW_MUTATIONS = 20;
+    public const int DEFAULT_SHOW_MUTATIONS = 20;
 
-    public const DEFAULT_LOG_VERBOSITY = LogVerbosity::NORMAL;
+    public const string DEFAULT_LOG_VERBOSITY = LogVerbosity::NORMAL;
 
-    public const DEFAULT_DEBUG = false;
+    public const bool DEFAULT_DEBUG = false;
 
-    public const DEFAULT_WITH_UNCOVERED = false;
+    public const bool DEFAULT_WITH_UNCOVERED = false;
 
     public const DEFAULT_FORMATTER_NAME = MutationAnalysisLoggerName::DOT;
 
-    public const DEFAULT_MUTANT_ID = null;
+    public const null DEFAULT_MUTANT_ID = null;
 
-    public const DEFAULT_GIT_DIFF_FILTER = null;
+    public const null DEFAULT_GIT_DIFF_FILTER = null;
 
-    public const DEFAULT_GIT_DIFF_BASE = null;
+    public const null DEFAULT_GIT_DIFF_BASE = null;
 
-    public const DEFAULT_USE_GITHUB_LOGGER = null;
+    public const null DEFAULT_USE_GITHUB_LOGGER = null;
 
-    public const DEFAULT_GITLAB_LOGGER_PATH = null;
+    public const null DEFAULT_GITLAB_LOGGER_PATH = null;
 
-    public const DEFAULT_LOGGER_PROJECT_ROOT_DIRECTORY = null;
+    public const null DEFAULT_LOGGER_PROJECT_ROOT_DIRECTORY = null;
 
-    public const DEFAULT_HTML_LOGGER_PATH = null;
+    public const null DEFAULT_HTML_LOGGER_PATH = null;
 
-    public const DEFAULT_TEXT_LOGGER_PATH = null;
+    public const null DEFAULT_TEXT_LOGGER_PATH = null;
 
-    public const DEFAULT_SUMMARY_JSON_LOGGER_PATH = null;
+    public const null DEFAULT_SUMMARY_JSON_LOGGER_PATH = null;
 
-    public const DEFAULT_USE_NOOP_MUTATORS = false;
+    public const bool DEFAULT_USE_NOOP_MUTATORS = false;
 
-    public const DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES = false;
+    public const bool DEFAULT_EXECUTE_ONLY_COVERING_TEST_CASES = false;
 
-    public const DEFAULT_NO_PROGRESS = false;
+    public const bool DEFAULT_NO_PROGRESS = false;
 
-    public const DEFAULT_FORCE_PROGRESS = false;
+    public const bool DEFAULT_FORCE_PROGRESS = false;
 
-    public const DEFAULT_EXISTING_COVERAGE_PATH = null;
+    public const null DEFAULT_EXISTING_COVERAGE_PATH = null;
 
-    public const DEFAULT_INITIAL_TESTS_PHP_OPTIONS = null;
+    public const null DEFAULT_INITIAL_TESTS_PHP_OPTIONS = null;
 
-    public const DEFAULT_SKIP_INITIAL_TESTS = false;
+    public const bool DEFAULT_SKIP_INITIAL_TESTS = false;
 
-    public const DEFAULT_IGNORE_MSI_WITH_NO_MUTATIONS = false;
+    public const bool DEFAULT_IGNORE_MSI_WITH_NO_MUTATIONS = false;
 
-    public const DEFAULT_MIN_MSI = null;
+    public const null DEFAULT_MIN_MSI = null;
 
-    public const DEFAULT_MIN_COVERED_MSI = null;
+    public const null DEFAULT_MIN_COVERED_MSI = null;
 
-    public const DEFAULT_TIMEOUTS_AS_ESCAPED = false;
+    public const bool DEFAULT_TIMEOUTS_AS_ESCAPED = false;
 
-    public const DEFAULT_MAX_TIMEOUTS = null;
+    public const null DEFAULT_MAX_TIMEOUTS = null;
 
-    public const DEFAULT_MSI_PRECISION = MsiParser::DEFAULT_PRECISION;
+    public const int DEFAULT_MSI_PRECISION = MsiParser::DEFAULT_PRECISION;
 
-    public const DEFAULT_TEST_FRAMEWORK = null;
+    public const null DEFAULT_TEST_FRAMEWORK = null;
 
-    public const DEFAULT_STATIC_ANALYSIS_TOOL = null;
+    public const null DEFAULT_STATIC_ANALYSIS_TOOL = null;
 
-    public const DEFAULT_TEST_FRAMEWORK_EXTRA_OPTIONS = null;
+    public const null DEFAULT_TEST_FRAMEWORK_EXTRA_OPTIONS = null;
 
-    public const DEFAULT_STATIC_ANALYSIS_TOOL_OPTIONS = null;
+    public const null DEFAULT_STATIC_ANALYSIS_TOOL_OPTIONS = null;
 
-    public const DEFAULT_FILTER = null;
+    public const null DEFAULT_FILTER = null;
 
-    public const DEFAULT_THREAD_COUNT = null;
+    public const null DEFAULT_THREAD_COUNT = null;
 
-    public const DEFAULT_DRY_RUN = false;
+    public const bool DEFAULT_DRY_RUN = false;
 
-    public const DEFAULT_MAP_SOURCE_CLASS_TO_TEST_STRATEGY = null;
+    public const null DEFAULT_MAP_SOURCE_CLASS_TO_TEST_STRATEGY = null;
 
     public static function create(): self
     {

--- a/src/Differ/DiffSourceCodeMatcher.php
+++ b/src/Differ/DiffSourceCodeMatcher.php
@@ -44,7 +44,7 @@ use function str_contains;
  */
 class DiffSourceCodeMatcher
 {
-    private const POSSIBLE_DELIMITERS = [
+    private const array POSSIBLE_DELIMITERS = [
         '#', '%', ':', ';', '=', '?', '@', '^', '~',
     ];
 

--- a/src/Differ/Tokens.php
+++ b/src/Differ/Tokens.php
@@ -53,7 +53,7 @@ use Webmozart\Assert\Assert;
  */
 final class Tokens
 {
-    private const CONTEXT_LINES = 3;
+    private const int CONTEXT_LINES = 3;
 
     private int $lastIndex = -1;
 

--- a/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php
+++ b/src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php
@@ -45,7 +45,7 @@ use Symfony\Component\Finder\Finder;
  */
 final readonly class CleanUpAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
 {
-    private const PHPUNIT_RESULT_CACHE_PATTERN = '/\.phpunit\.result\.cache\.(.*)/';
+    private const string PHPUNIT_RESULT_CACHE_PATTERN = '/\.phpunit\.result\.cache\.(.*)/';
 
     public function __construct(
         private Filesystem $filesystem,

--- a/src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php
+++ b/src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php
@@ -61,7 +61,7 @@ use Webmozart\Assert\Assert;
  */
 class StaticAnalysisToolExecutableFinder
 {
-    private const BAT_EXTENSION_LENGTH = 4;
+    private const int BAT_EXTENSION_LENGTH = 4;
 
     /**
      * @var array<string, string>

--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -61,7 +61,7 @@ use Webmozart\Assert\Assert;
  */
 class TestFrameworkFinder
 {
-    private const BAT_EXTENSION_LENGTH = 4;
+    private const int BAT_EXTENSION_LENGTH = 4;
 
     /**
      * @var array<string, string>

--- a/src/FileSystem/TmpDirProvider.php
+++ b/src/FileSystem/TmpDirProvider.php
@@ -46,7 +46,7 @@ use Webmozart\Assert\Assert;
  */
 final class TmpDirProvider
 {
-    private const BASE_DIR_NAME = 'infection';
+    private const string BASE_DIR_NAME = 'infection';
 
     /**
      * Provides a Infection namespaced temporary directory path.

--- a/src/Framework/Iterable/IterableCounter.php
+++ b/src/Framework/Iterable/IterableCounter.php
@@ -48,7 +48,7 @@ final class IterableCounter
     use CannotBeInstantiated;
 
     // Follows the Symfony ProgressBar convention: 0 indicates an unknown number of steps.
-    public const UNKNOWN_COUNT = 0;
+    public const int UNKNOWN_COUNT = 0;
 
     /**
      * @param iterable<mixed> $subjects

--- a/src/Framework/Str.php
+++ b/src/Framework/Str.php
@@ -53,13 +53,13 @@ final class Str
 {
     use CannotBeInstantiated;
 
-    private const SYSTEM_LINE_ENDINGS_REPLACEMENT = [
+    private const array SYSTEM_LINE_ENDINGS_REPLACEMENT = [
         "\r\n" => PHP_EOL,
         "\n" => PHP_EOL,
         "\r" => PHP_EOL,
     ];
 
-    private const UNIX_LINE_ENDINGS_REPLACEMENT = [
+    private const array UNIX_LINE_ENDINGS_REPLACEMENT = [
         "\r\n" => "\n",
         "\r" => "\n",
     ];

--- a/src/Git/CommandLineGit.php
+++ b/src/Git/CommandLineGit.php
@@ -62,15 +62,15 @@ use Webmozart\Assert\Assert;
 final readonly class CommandLineGit implements Git
 {
     // https://github.com/infection/infection/issues/2611
-    private const DEFAULT_SYMBOLIC_REFERENCE = 'refs/remotes/origin/HEAD';
+    private const string DEFAULT_SYMBOLIC_REFERENCE = 'refs/remotes/origin/HEAD';
 
-    private const DIFF_LINE_REGEX = '/diff.*a\/.*\sb\/(?<filePath>.*)/';
+    private const string DIFF_LINE_REGEX = '/diff.*a\/.*\sb\/(?<filePath>.*)/';
 
-    private const DIFF_LINE_PATH_KEY = 'filePath';
+    private const string DIFF_LINE_PATH_KEY = 'filePath';
 
-    private const DIFF_LINE_RANGE_REGEX = '/\s\+(?<range>.*)\s@/';
+    private const string DIFF_LINE_RANGE_REGEX = '/\s\+(?<range>.*)\s@/';
 
-    private const DIFF_LINE_RANGE_KEY = 'range';
+    private const string DIFF_LINE_RANGE_KEY = 'range';
 
     public function __construct(
         private ShellCommandLineExecutor $shellCommandLineExecutor,

--- a/src/Logger/Console/BasicConsoleLogger.php
+++ b/src/Logger/Console/BasicConsoleLogger.php
@@ -52,11 +52,11 @@ use Webmozart\Assert\Assert;
  */
 final class BasicConsoleLogger extends AbstractLogger implements LoggerInterface
 {
-    private const INFO = 'info';
+    private const string INFO = 'info';
 
-    private const ERROR = 'error';
+    private const string ERROR = 'error';
 
-    private const VERBOSITY_LEVEL_MAP = [
+    private const array VERBOSITY_LEVEL_MAP = [
         LogLevel::EMERGENCY => OutputInterface::VERBOSITY_NORMAL,
         LogLevel::ALERT => OutputInterface::VERBOSITY_NORMAL,
         LogLevel::CRITICAL => OutputInterface::VERBOSITY_NORMAL,
@@ -67,7 +67,7 @@ final class BasicConsoleLogger extends AbstractLogger implements LoggerInterface
         LogLevel::DEBUG => OutputInterface::VERBOSITY_DEBUG,
     ];
 
-    private const FORMAT_LEVEL_MAP = [
+    private const array FORMAT_LEVEL_MAP = [
         LogLevel::EMERGENCY => self::ERROR,
         LogLevel::ALERT => self::ERROR,
         LogLevel::CRITICAL => self::ERROR,

--- a/src/Logger/Console/ConsoleLogger.php
+++ b/src/Logger/Console/ConsoleLogger.php
@@ -56,11 +56,11 @@ use Webmozart\Assert\Assert;
  */
 final class ConsoleLogger extends AbstractLogger
 {
-    private const INFO = 'info';
+    private const string INFO = 'info';
 
-    private const ERROR = 'error';
+    private const string ERROR = 'error';
 
-    private const VERBOSITY_LEVEL_MAP = [
+    private const array VERBOSITY_LEVEL_MAP = [
         LogLevel::EMERGENCY => OutputInterface::VERBOSITY_NORMAL,
         LogLevel::ALERT => OutputInterface::VERBOSITY_NORMAL,
         LogLevel::CRITICAL => OutputInterface::VERBOSITY_NORMAL,
@@ -71,7 +71,7 @@ final class ConsoleLogger extends AbstractLogger
         LogLevel::DEBUG => OutputInterface::VERBOSITY_DEBUG,
     ];
 
-    private const FORMAT_LEVEL_MAP = [
+    private const array FORMAT_LEVEL_MAP = [
         LogLevel::EMERGENCY => self::ERROR,
         LogLevel::ALERT => self::ERROR,
         LogLevel::CRITICAL => self::ERROR,
@@ -82,7 +82,7 @@ final class ConsoleLogger extends AbstractLogger
         LogLevel::DEBUG => self::INFO,
     ];
 
-    private const IO_MAP = [
+    private const array IO_MAP = [
         LogLevel::ERROR => 'error',
         LogLevel::WARNING => 'warning',
         LogLevel::NOTICE => 'note',

--- a/src/Logger/MutationAnalysis/ConsoleDotLogger.php
+++ b/src/Logger/MutationAnalysis/ConsoleDotLogger.php
@@ -50,7 +50,7 @@ use Webmozart\Assert\Assert;
  */
 final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
 {
-    private const DOTS_PER_ROW = 50;
+    private const int DOTS_PER_ROW = 50;
 
     private ?int $mutationCount = null;
 

--- a/src/Logger/MutationAnalysis/TeamCity/TeamCity.php
+++ b/src/Logger/MutationAnalysis/TeamCity/TeamCity.php
@@ -61,11 +61,11 @@ use function str_replace;
 final readonly class TeamCity
 {
     // `|` must be escaped FIRST to avoid double-escaping.
-    private const CHARACTERS_TO_ESCAPE = ['|', "'", "\n", "\r", '[', ']'];
+    private const array CHARACTERS_TO_ESCAPE = ['|', "'", "\n", "\r", '[', ']'];
 
-    private const ESCAPED_CHARACTERS = ['||', "|'", '|n', '|r', '|[', '|]'];
+    private const array ESCAPED_CHARACTERS = ['||', "|'", '|n', '|r', '|[', '|]'];
 
-    private const UNICODE_CHARACTER_REGEX = '/\\\\u(?<hexadecimalDigits>[0-9A-Fa-f]{4})/';
+    private const string UNICODE_CHARACTER_REGEX = '/\\\\u(?<hexadecimalDigits>[0-9A-Fa-f]{4})/';
 
     public function __construct(
         private bool $timeoutsAsEscaped,

--- a/src/Logger/MutationAnalysis/TeamCity/Test.php
+++ b/src/Logger/MutationAnalysis/TeamCity/Test.php
@@ -47,7 +47,7 @@ use function sprintf;
  */
 final readonly class Test
 {
-    private const MILLISECONDS_PER_SECOND = 1000;
+    private const int MILLISECONDS_PER_SECOND = 1000;
 
     public function __construct(
         public string $id,

--- a/src/Metrics/MinMsiChecker.php
+++ b/src/Metrics/MinMsiChecker.php
@@ -43,7 +43,7 @@ use Infection\Console\ConsoleOutput;
  */
 class MinMsiChecker
 {
-    private const VALUE_OVER_REQUIRED_TOLERANCE = 2;
+    private const int VALUE_OVER_REQUIRED_TOLERANCE = 2;
 
     public function __construct(
         private readonly bool $ignoreMsiWithNoMutations,

--- a/src/Mutant/TestFrameworkMutantExecutionResultFactory.php
+++ b/src/Mutant/TestFrameworkMutantExecutionResultFactory.php
@@ -48,7 +48,7 @@ use Webmozart\Assert\Assert;
  */
 class TestFrameworkMutantExecutionResultFactory implements MutantExecutionResultFactory
 {
-    private const PROCESS_MIN_ERROR_CODE = 100;
+    private const int PROCESS_MIN_ERROR_CODE = 100;
 
     public function __construct(
         private readonly TestFrameworkAdapter $testFrameworkAdapter,

--- a/src/Mutator/Arithmetic/RoundingFamily.php
+++ b/src/Mutator/Arithmetic/RoundingFamily.php
@@ -53,7 +53,7 @@ final class RoundingFamily implements Mutator
 {
     use GetMutatorName;
 
-    private const MUTATORS_MAP = [
+    private const array MUTATORS_MAP = [
         'floor',
         'ceil',
         'round',

--- a/src/Mutator/Boolean/TrueValueConfig.php
+++ b/src/Mutator/Boolean/TrueValueConfig.php
@@ -44,7 +44,7 @@ use Webmozart\Assert\Assert;
  */
 final class TrueValueConfig implements MutatorConfig
 {
-    private const KNOWN_FUNCTIONS = [
+    private const array KNOWN_FUNCTIONS = [
         'array_search',
         'in_array',
     ];

--- a/src/Mutator/Extensions/BCMathConfig.php
+++ b/src/Mutator/Extensions/BCMathConfig.php
@@ -43,7 +43,7 @@ use Infection\Mutator\MutatorConfig;
  */
 final class BCMathConfig extends AllowedFunctionsConfig implements MutatorConfig
 {
-    private const KNOWN_FUNCTIONS = [
+    private const array KNOWN_FUNCTIONS = [
         'bcadd',
         'bccomp',
         'bcdiv',

--- a/src/Mutator/Extensions/MBStringConfig.php
+++ b/src/Mutator/Extensions/MBStringConfig.php
@@ -43,7 +43,7 @@ use Infection\Mutator\MutatorConfig;
  */
 final class MBStringConfig extends AllowedFunctionsConfig implements MutatorConfig
 {
-    private const KNOWN_FUNCTIONS = [
+    private const array KNOWN_FUNCTIONS = [
         'mb_chr',
         'mb_ord',
         'mb_parse_str',

--- a/src/Mutator/InvalidMutator.php
+++ b/src/Mutator/InvalidMutator.php
@@ -46,7 +46,7 @@ use Webmozart\Assert\Assert;
  */
 final class InvalidMutator extends RuntimeException
 {
-    private const GITHUB_BUG_LINK = 'https://github.com/infection/infection/issues/new?template=Bug_report.md';
+    private const string GITHUB_BUG_LINK = 'https://github.com/infection/infection/issues/new?template=Bug_report.md';
 
     public static function create(string $filePath, string $mutatorName, Throwable $previous): self
     {

--- a/src/Mutator/MutatorResolver.php
+++ b/src/Mutator/MutatorResolver.php
@@ -52,13 +52,13 @@ use stdClass;
  */
 final class MutatorResolver
 {
-    private const IGNORE_SETTING = 'ignore';
+    private const string IGNORE_SETTING = 'ignore';
 
-    private const IGNORE_SOURCE_CODE_BY_REGEX_SETTING = 'ignoreSourceCodeByRegex';
+    private const string IGNORE_SOURCE_CODE_BY_REGEX_SETTING = 'ignoreSourceCodeByRegex';
 
-    private const GLOBAL_IGNORE_SETTING = 'global-ignore';
+    private const string GLOBAL_IGNORE_SETTING = 'global-ignore';
 
-    private const GLOBAL_IGNORE_SOURCE_CODE_BY_REGEX_SETTING = 'global-ignoreSourceCodeByRegex';
+    private const string GLOBAL_IGNORE_SOURCE_CODE_BY_REGEX_SETTING = 'global-ignoreSourceCodeByRegex';
 
     /**
      * Resolves the given hashmap of enabled, disabled or configured mutators

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -54,7 +54,7 @@ final class DecrementInteger extends AbstractNumberMutator
 {
     use GetMutatorName;
 
-    public const NON_NEGATIVE_INT_RETURNING_FUNCTIONS = [
+    public const array NON_NEGATIVE_INT_RETURNING_FUNCTIONS = [
         'count',
         'iterator_count',
         'grapheme_strlen',

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -52,7 +52,7 @@ final class IncrementInteger extends AbstractNumberMutator
 {
     use GetMutatorName;
 
-    private const FUNCTIONS_RETURNING_MAX_INTEGER = [
+    private const array FUNCTIONS_RETURNING_MAX_INTEGER = [
         'preg_match' => 1,
     ];
 

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -45,6 +45,9 @@ final class ProfileList
 {
     use CannotBeInstantiated;
 
+    /**
+     * @var array<string, list<class-string>|list<string>>
+     */
     public const array ALL_PROFILES = [
         '@arithmetic' => self::ARITHMETIC_PROFILE,
         '@boolean' => self::BOOLEAN_PROFILE,
@@ -289,6 +292,9 @@ final class ProfileList
         Extensions\MBString::class,
     ];
 
+    /**
+     * @var list<string>
+     */
     public const array DEFAULT_PROFILE = [
         '@arithmetic',
         '@boolean',
@@ -307,6 +313,9 @@ final class ProfileList
         '@unwrap',
     ];
 
+    /**
+     * @var array<string, class-string>
+     */
     public const array ALL_MUTATORS = [
         // Arithmetic
         'Assignment' => Arithmetic\Assignment::class,

--- a/src/Mutator/ProfileList.php
+++ b/src/Mutator/ProfileList.php
@@ -45,7 +45,7 @@ final class ProfileList
 {
     use CannotBeInstantiated;
 
-    public const ALL_PROFILES = [
+    public const array ALL_PROFILES = [
         '@arithmetic' => self::ARITHMETIC_PROFILE,
         '@boolean' => self::BOOLEAN_PROFILE,
         '@cast' => self::CAST_PROFILE,
@@ -67,7 +67,7 @@ final class ProfileList
         '@unwrap' => self::UNWRAP_PROFILE,
     ];
 
-    public const ARITHMETIC_PROFILE = [
+    public const array ARITHMETIC_PROFILE = [
         Arithmetic\Assignment::class,
         Arithmetic\AssignmentEqual::class,
         Arithmetic\BitwiseAnd::class,
@@ -93,7 +93,7 @@ final class ProfileList
         Arithmetic\ShiftRight::class,
     ];
 
-    public const BOOLEAN_PROFILE = [
+    public const array BOOLEAN_PROFILE = [
         Boolean\ArrayAll::class,
         Boolean\ArrayAny::class,
         Boolean\ArrayItem::class,
@@ -117,14 +117,14 @@ final class ProfileList
         Boolean\Yield_::class,
     ];
 
-    public const CONDITIONAL_BOUNDARY_PROFILE = [
+    public const array CONDITIONAL_BOUNDARY_PROFILE = [
         ConditionalBoundary\GreaterThan::class,
         ConditionalBoundary\GreaterThanOrEqualTo::class,
         ConditionalBoundary\LessThan::class,
         ConditionalBoundary\LessThanOrEqualTo::class,
     ];
 
-    public const CONDITIONAL_NEGOTIATION_PROFILE = [
+    public const array CONDITIONAL_NEGOTIATION_PROFILE = [
         ConditionalNegotiation\Equal::class,
         ConditionalNegotiation\GreaterThanNegotiation::class,
         ConditionalNegotiation\GreaterThanOrEqualToNegotiation::class,
@@ -135,34 +135,34 @@ final class ProfileList
         ConditionalNegotiation\NotIdentical::class,
     ];
 
-    public const EQUAL_PROFILE = [
+    public const array EQUAL_PROFILE = [
         Boolean\NotIdenticalNotEqual::class,
     ];
 
-    public const FUNCTION_SIGNATURE_PROFILE = [
+    public const array FUNCTION_SIGNATURE_PROFILE = [
         FunctionSignature\ProtectedVisibility::class,
         FunctionSignature\PublicVisibility::class,
     ];
 
-    public const IDENTICAL_PROFILE = [
+    public const array IDENTICAL_PROFILE = [
         Boolean\EqualIdentical::class,
         Boolean\NotEqualNotIdentical::class,
     ];
 
-    public const NULLIFY_PROFILE = [
+    public const array NULLIFY_PROFILE = [
         Nullify\ArrayFind::class,
         Nullify\ArrayFindKey::class,
         Nullify\ArrayFirst::class,
         Nullify\ArrayLast::class,
     ];
 
-    public const NUMBER_PROFILE = [
+    public const array NUMBER_PROFILE = [
         Number\DecrementInteger::class,
         Number\IncrementInteger::class,
         Number\OneZeroFloat::class,
     ];
 
-    public const OPERATOR_PROFILE = [
+    public const array OPERATOR_PROFILE = [
         Operator\AssignCoalesce::class,
         Operator\Break_::class,
         Operator\Catch_::class,
@@ -181,7 +181,7 @@ final class ProfileList
         Operator\Throw_::class,
     ];
 
-    public const REGEX_PROFILE = [
+    public const array REGEX_PROFILE = [
         Regex\PregMatchMatches::class,
         Regex\PregMatchRemoveCaret::class,
         Regex\PregMatchRemoveDollar::class,
@@ -189,7 +189,7 @@ final class ProfileList
         Regex\PregQuote::class,
     ];
 
-    public const REMOVAL_PROFILE = [
+    public const array REMOVAL_PROFILE = [
         Removal\ArrayItemRemoval::class,
         Removal\CatchBlockRemoval::class,
         Removal\CloneRemoval::class,
@@ -201,7 +201,7 @@ final class ProfileList
         Removal\SharedCaseRemoval::class,
     ];
 
-    public const RETURN_VALUE_PROFILE = [
+    public const array RETURN_VALUE_PROFILE = [
         ReturnValue\ArrayOneItem::class,
         ReturnValue\FloatNegation::class,
         ReturnValue\FunctionCall::class,
@@ -211,18 +211,18 @@ final class ProfileList
         ReturnValue\YieldValue::class,
     ];
 
-    public const SORT_PROFILE = [
+    public const array SORT_PROFILE = [
         Sort\Spaceship::class,
     ];
 
-    public const LOOP_PROFILE = [
+    public const array LOOP_PROFILE = [
         Loop\DoWhile::class,
         Loop\For_::class,
         Loop\Foreach_::class,
         Loop\While_::class,
     ];
 
-    public const CAST_PROFILE = [
+    public const array CAST_PROFILE = [
         Cast\CastArray::class,
         Cast\CastBool::class,
         Cast\CastFloat::class,
@@ -231,7 +231,7 @@ final class ProfileList
         Cast\CastString::class,
     ];
 
-    public const UNWRAP_PROFILE = [
+    public const array UNWRAP_PROFILE = [
         Unwrap\UnwrapArrayChangeKeyCase::class,
         Unwrap\UnwrapArrayChunk::class,
         Unwrap\UnwrapArrayColumn::class,
@@ -284,12 +284,12 @@ final class ProfileList
         Unwrap\UnwrapUcWords::class,
     ];
 
-    public const EXTENSIONS_PROFILE = [
+    public const array EXTENSIONS_PROFILE = [
         Extensions\BCMath::class,
         Extensions\MBString::class,
     ];
 
-    public const DEFAULT_PROFILE = [
+    public const array DEFAULT_PROFILE = [
         '@arithmetic',
         '@boolean',
         '@cast',
@@ -307,7 +307,7 @@ final class ProfileList
         '@unwrap',
     ];
 
-    public const ALL_MUTATORS = [
+    public const array ALL_MUTATORS = [
         // Arithmetic
         'Assignment' => Arithmetic\Assignment::class,
         'AssignmentEqual' => Arithmetic\AssignmentEqual::class,

--- a/src/Mutator/Regex/PregMatchMatches.php
+++ b/src/Mutator/Regex/PregMatchMatches.php
@@ -51,7 +51,7 @@ final class PregMatchMatches implements Mutator
 {
     use GetMutatorName;
 
-    private const MIN_ARGS_TO_MUTATE = 3;
+    private const int MIN_ARGS_TO_MUTATE = 3;
 
     public static function getDefinition(): Definition
     {

--- a/src/Mutator/Regex/PregMatchRemoveCaret.php
+++ b/src/Mutator/Regex/PregMatchRemoveCaret.php
@@ -45,7 +45,7 @@ use function Safe\preg_match;
  */
 final class PregMatchRemoveCaret extends AbstractPregMatch
 {
-    public const ANALYSE_REGEX = '/^([^\w\s\\\\])([\^]?)([^\^]*)\1([gmixXsuUAJD]*)$/';
+    public const string ANALYSE_REGEX = '/^([^\w\s\\\\])([\^]?)([^\^]*)\1([gmixXsuUAJD]*)$/';
 
     public static function getDefinition(): Definition
     {

--- a/src/Mutator/Regex/PregMatchRemoveDollar.php
+++ b/src/Mutator/Regex/PregMatchRemoveDollar.php
@@ -45,7 +45,7 @@ use function Safe\preg_match;
  */
 final class PregMatchRemoveDollar extends AbstractPregMatch
 {
-    public const ANALYSE_REGEX = '/^([^\w\s\\\\])([^$]*)([$]?)\1([gmixXsuUAJD]*)$/';
+    public const string ANALYSE_REGEX = '/^([^\w\s\\\\])([^$]*)([$]?)\1([gmixXsuUAJD]*)$/';
 
     public static function getDefinition(): Definition
     {

--- a/src/Mutator/Regex/PregMatchRemoveFlags.php
+++ b/src/Mutator/Regex/PregMatchRemoveFlags.php
@@ -47,7 +47,7 @@ use function str_split;
  */
 final class PregMatchRemoveFlags extends AbstractPregMatch
 {
-    public const ANALYSE_REGEX = '/^([^\w\s\\\\])(.*)([^\w\s\\\\])([gmixXsuUAJD]*)$/';
+    public const string ANALYSE_REGEX = '/^([^\w\s\\\\])(.*)([^\w\s\\\\])([gmixXsuUAJD]*)$/';
 
     public static function getDefinition(): Definition
     {

--- a/src/Mutator/Removal/ArrayItemRemovalConfig.php
+++ b/src/Mutator/Removal/ArrayItemRemovalConfig.php
@@ -44,7 +44,7 @@ use Webmozart\Assert\Assert;
  */
 final readonly class ArrayItemRemovalConfig implements MutatorConfig
 {
-    private const REMOVE_VALUES = [
+    private const array REMOVE_VALUES = [
         'first',
         'last',
         'all',

--- a/src/Mutator/Removal/CatchBlockRemoval.php
+++ b/src/Mutator/Removal/CatchBlockRemoval.php
@@ -52,7 +52,7 @@ final class CatchBlockRemoval implements Mutator
 {
     use GetMutatorName;
 
-    private const MIN_CATCH_COUNT_TO_MUTATE = 2;
+    private const int MIN_CATCH_COUNT_TO_MUTATE = 2;
 
     public static function getDefinition(): Definition
     {

--- a/src/Mutator/Unwrap/UnwrapArrayUintersectUassoc.php
+++ b/src/Mutator/Unwrap/UnwrapArrayUintersectUassoc.php
@@ -47,7 +47,7 @@ use PhpParser\Node;
  */
 final class UnwrapArrayUintersectUassoc extends AbstractFunctionUnwrapMutator
 {
-    private const NON_MUTABLE_ARGS_COUNT = 2;
+    private const int NON_MUTABLE_ARGS_COUNT = 2;
 
     public static function getDefinition(): Definition
     {

--- a/src/Mutator/Util/AbstractAllSubExprNegation.php
+++ b/src/Mutator/Util/AbstractAllSubExprNegation.php
@@ -52,7 +52,7 @@ abstract class AbstractAllSubExprNegation implements Mutator
 {
     use GetMutatorName;
 
-    private const BOOLEANS = ['true', 'false'];
+    private const array BOOLEANS = ['true', 'false'];
 
     /**
      * @psalm-mutation-free

--- a/src/Mutator/Util/ReturnTypeHelper.php
+++ b/src/Mutator/Util/ReturnTypeHelper.php
@@ -46,9 +46,9 @@ use PhpParser\Node\Name;
  */
 final readonly class ReturnTypeHelper
 {
-    private const VOID = 'void';
+    private const string VOID = 'void';
 
-    private const NULL = 'null';
+    private const string NULL = 'null';
 
     private Identifier|Name|ComplexType|null $returnType;
 

--- a/src/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitor.php
+++ b/src/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitor.php
@@ -49,7 +49,7 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class AddIdToTraversedNodesVisitor extends NodeVisitorAbstract
 {
-    public const NODE_ID_ATTRIBUTE = 'nodeId';
+    public const string NODE_ID_ATTRIBUTE = 'nodeId';
 
     /**
      * @var array<positive-int|0, Node>

--- a/src/PhpParser/Visitor/ExcludeIgnoredNodesVisitor.php
+++ b/src/PhpParser/Visitor/ExcludeIgnoredNodesVisitor.php
@@ -45,7 +45,7 @@ use function str_contains;
  */
 final class ExcludeIgnoredNodesVisitor extends NodeVisitorAbstract
 {
-    private const IGNORE_ALL_MUTATIONS_ANNOTATION = '@infection-ignore-all';
+    private const string IGNORE_ALL_MUTATIONS_ANNOTATION = '@infection-ignore-all';
 
     private ?Node $excludedStartNode = null;
 

--- a/src/PhpParser/Visitor/FullyQualifiedClassNameManipulator.php
+++ b/src/PhpParser/Visitor/FullyQualifiedClassNameManipulator.php
@@ -45,9 +45,9 @@ final class FullyQualifiedClassNameManipulator
 {
     use CannotBeInstantiated;
 
-    public const RESOLVED_NAME = 'resolvedName';
+    public const string RESOLVED_NAME = 'resolvedName';
 
-    public const RESOLVED_NAMESPACE_NAME = 'namespacedName';
+    public const string RESOLVED_NAMESPACE_NAME = 'namespacedName';
 
     public static function getFqcn(Node $node): ?Node\Name
     {

--- a/src/PhpParser/Visitor/LabelMutationCandidatesVisitor.php
+++ b/src/PhpParser/Visitor/LabelMutationCandidatesVisitor.php
@@ -55,7 +55,7 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class LabelMutationCandidatesVisitor extends NodeVisitorAbstract
 {
-    public const MUTATION_CANDIDATE = 'mutationCandidate';
+    public const string MUTATION_CANDIDATE = 'mutationCandidate';
 
     public function __construct(
         private readonly string $filePath,

--- a/src/PhpParser/Visitor/LabelNodesAsEligibleVisitor.php
+++ b/src/PhpParser/Visitor/LabelNodesAsEligibleVisitor.php
@@ -47,7 +47,7 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class LabelNodesAsEligibleVisitor extends NodeVisitorAbstract
 {
-    public const ELIGIBLE = 'eligible';
+    public const string ELIGIBLE = 'eligible';
 
     public static function isEligible(Node $node): bool
     {

--- a/src/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor.php
+++ b/src/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor.php
@@ -47,7 +47,7 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class MarkTraversedNodesAsVisitedVisitor extends NodeVisitorAbstract
 {
-    public const VISITED_ATTRIBUTE = 'visited';
+    public const string VISITED_ATTRIBUTE = 'visited';
 
     public static function wasVisited(Node $node): bool
     {

--- a/src/PhpParser/Visitor/NextConnectingVisitor.php
+++ b/src/PhpParser/Visitor/NextConnectingVisitor.php
@@ -48,7 +48,7 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class NextConnectingVisitor extends NodeVisitorAbstract
 {
-    public const NEXT_ATTRIBUTE = 'next';
+    public const string NEXT_ATTRIBUTE = 'next';
 
     private ?Node $previous = null;
 

--- a/src/PhpParser/Visitor/ParentConnector.php
+++ b/src/PhpParser/Visitor/ParentConnector.php
@@ -46,7 +46,7 @@ final class ParentConnector
 {
     use CannotBeInstantiated;
 
-    private const PARENT_ATTRIBUTE = 'parent';
+    private const string PARENT_ATTRIBUTE = 'parent';
 
     public static function setParent(Node $node, ?Node $parent): void
     {

--- a/src/PhpParser/Visitor/ReflectionVisitor.php
+++ b/src/PhpParser/Visitor/ReflectionVisitor.php
@@ -52,17 +52,17 @@ use Webmozart\Assert\Assert;
  */
 final class ReflectionVisitor extends NodeVisitorAbstract
 {
-    public const STRICT_TYPES_KEY = 'isStrictTypes';
+    public const string STRICT_TYPES_KEY = 'isStrictTypes';
 
-    public const REFLECTION_CLASS_KEY = 'reflectionClass';
+    public const string REFLECTION_CLASS_KEY = 'reflectionClass';
 
-    public const IS_INSIDE_FUNCTION_KEY = 'isInsideFunction';
+    public const string IS_INSIDE_FUNCTION_KEY = 'isInsideFunction';
 
-    public const IS_ON_FUNCTION_SIGNATURE = 'isOnFunctionSignature';
+    public const string IS_ON_FUNCTION_SIGNATURE = 'isOnFunctionSignature';
 
-    public const FUNCTION_SCOPE_KEY = 'functionScope';
+    public const string FUNCTION_SCOPE_KEY = 'functionScope';
 
-    public const FUNCTION_NAME = 'functionName';
+    public const string FUNCTION_NAME = 'functionName';
 
     /** @var array<int, Node> */
     private array $functionScopeStack = [];

--- a/src/Process/DryRunProcess.php
+++ b/src/Process/DryRunProcess.php
@@ -52,7 +52,7 @@ final class DryRunProcess extends Process
      * Output that TestFrameworkAdapter::testsPass() recognizes as passing tests.
      * The pattern "OK (" triggers testsPass() to return true, causing ESCAPED status.
      */
-    public const PASSING_TEST_OUTPUT = 'OK (0 tests, 0 assertions)';
+    public const string PASSING_TEST_OUTPUT = 'OK (0 tests, 0 assertions)';
 
     public static function fromProcess(Process $process): self
     {

--- a/src/Process/Factory/MutantProcessContainerFactory.php
+++ b/src/Process/Factory/MutantProcessContainerFactory.php
@@ -51,9 +51,9 @@ use Symfony\Component\Process\Process;
  */
 class MutantProcessContainerFactory
 {
-    private const TIMEOUT_FACTOR = 5;
+    private const int TIMEOUT_FACTOR = 5;
 
-    private const TEST_FRAMEWORK_BOOTSTRAP_THRESHOLD = 5;
+    private const int TEST_FRAMEWORK_BOOTSTRAP_THRESHOLD = 5;
 
     public function __construct(
         private readonly TestFrameworkAdapter $testFrameworkAdapter,

--- a/src/Process/Runner/ParallelProcessRunner.php
+++ b/src/Process/Runner/ParallelProcessRunner.php
@@ -54,7 +54,7 @@ use Webmozart\Assert\Assert;
  */
 class ParallelProcessRunner implements ProcessRunner
 {
-    private const POLL_WAIT_IN_MS = 1000;
+    private const int POLL_WAIT_IN_MS = 1000;
 
     /**
      * @var array<int, IndexedMutantProcessContainer>

--- a/src/Process/Runner/ProcessQueue.php
+++ b/src/Process/Runner/ProcessQueue.php
@@ -48,9 +48,9 @@ use Webmozart\Assert\Assert;
  */
 class ProcessQueue
 {
-    private const MINIMAL_DEPTH = 1;
+    private const int MINIMAL_DEPTH = 1;
 
-    private const NANO_SECONDS_IN_MILLI_SECOND = 1_000_000;
+    private const int NANO_SECONDS_IN_MILLI_SECOND = 1_000_000;
 
     /**
      * @var SplQueue<MutantProcessContainer>

--- a/src/Reflection/Visibility.php
+++ b/src/Reflection/Visibility.php
@@ -40,9 +40,9 @@ namespace Infection\Reflection;
  */
 final readonly class Visibility
 {
-    public const PUBLIC = 'public';
+    public const string PUBLIC = 'public';
 
-    public const PROTECTED = 'protected';
+    public const string PROTECTED = 'protected';
 
     private function __construct(
         private string $variant,

--- a/src/Reporter/FileLocationReporter.php
+++ b/src/Reporter/FileLocationReporter.php
@@ -48,7 +48,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final readonly class FileLocationReporter implements Reporter
 {
-    private const PAD_LENGTH = 8;
+    private const int PAD_LENGTH = 8;
 
     public function __construct(
         private Reporter $decoratedReporter,

--- a/src/Reporter/FileReporter.php
+++ b/src/Reporter/FileReporter.php
@@ -50,7 +50,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final readonly class FileReporter implements Reporter
 {
-    public const ALLOWED_PHP_STREAMS = ['php://stdout', 'php://stderr'];
+    public const array ALLOWED_PHP_STREAMS = ['php://stdout', 'php://stderr'];
 
     public function __construct(
         private string $filePath,

--- a/src/Reporter/GitHubAnnotationsReporter.php
+++ b/src/Reporter/GitHubAnnotationsReporter.php
@@ -47,7 +47,7 @@ use function trim;
  */
 final class GitHubAnnotationsReporter implements LineMutationTestingResultsReporter
 {
-    public const DEFAULT_OUTPUT = 'php://stdout';
+    public const string DEFAULT_OUTPUT = 'php://stdout';
 
     public function __construct(
         private readonly ResultsCollector $resultsCollector,

--- a/src/Reporter/Html/StrykerHtmlReportBuilder.php
+++ b/src/Reporter/Html/StrykerHtmlReportBuilder.php
@@ -79,7 +79,7 @@ use Webmozart\Assert\Assert;
  */
 final readonly class StrykerHtmlReportBuilder
 {
-    private const DETECTION_STATUS_MAP = [
+    private const array DETECTION_STATUS_MAP = [
         DetectionStatus::KILLED_BY_TESTS->value => 'Killed',
         DetectionStatus::KILLED_BY_STATIC_ANALYSIS->value => 'Killed',
         DetectionStatus::ESCAPED->value => 'Survived',
@@ -91,9 +91,9 @@ final readonly class StrykerHtmlReportBuilder
         DetectionStatus::SKIPPED->value => 'Ignored',
     ];
 
-    private const PLUS_LENGTH = 1;
+    private const int PLUS_LENGTH = 1;
 
-    private const DIFF_HEADERS_LINES_COUNT = 1;
+    private const int DIFF_HEADERS_LINES_COUNT = 1;
 
     public function __construct(
         private MetricsCalculator $metricsCalculator,

--- a/src/Reporter/Http/Response.php
+++ b/src/Reporter/Http/Response.php
@@ -42,11 +42,11 @@ use Webmozart\Assert\Assert;
  */
 final readonly class Response
 {
-    public const HTTP_OK = 200;
+    public const int HTTP_OK = 200;
 
-    public const HTTP_CREATED = 201;
+    public const int HTTP_CREATED = 201;
 
-    public const HTTP_MAX_ERROR_CODE = 599;
+    public const int HTTP_MAX_ERROR_CODE = 599;
 
     public function __construct(
         public int $statusCode,

--- a/src/Reporter/Http/StrykerCurlClient.php
+++ b/src/Reporter/Http/StrykerCurlClient.php
@@ -59,7 +59,7 @@ use function sprintf;
  */
 class StrykerCurlClient
 {
-    private const STRYKER_DASHBOARD_API_BASE_URL = 'https://dashboard.stryker-mutator.io/api/reports';
+    private const string STRYKER_DASHBOARD_API_BASE_URL = 'https://dashboard.stryker-mutator.io/api/reports';
 
     public function request(
         string $repositorySlug,

--- a/src/Reporter/PerMutatorReporter.php
+++ b/src/Reporter/PerMutatorReporter.php
@@ -57,7 +57,7 @@ use function strlen;
  */
 final readonly class PerMutatorReporter implements LineMutationTestingResultsReporter
 {
-    private const ROUND_PRECISION = 2;
+    private const int ROUND_PRECISION = 2;
 
     public function __construct(
         private MetricsCalculator $metricsCalculator,

--- a/src/Reporter/ShowMetricsReporter.php
+++ b/src/Reporter/ShowMetricsReporter.php
@@ -47,11 +47,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final readonly class ShowMetricsReporter implements Reporter
 {
-    private const PAD_LENGTH = 8;
+    private const int PAD_LENGTH = 8;
 
-    private const LOW_QUALITY_THRESHOLD = 50;
+    private const int LOW_QUALITY_THRESHOLD = 50;
 
-    private const MEDIUM_QUALITY_THRESHOLD = 90;
+    private const int MEDIUM_QUALITY_THRESHOLD = 90;
 
     public function __construct(
         private OutputInterface $output,

--- a/src/Resource/Memory/MemoryFormatter.php
+++ b/src/Resource/Memory/MemoryFormatter.php
@@ -47,11 +47,11 @@ use Webmozart\Assert\Assert;
  */
 class MemoryFormatter
 {
-    private const BYTES_IN_KB = 1024;
+    private const int BYTES_IN_KB = 1024;
 
-    private const DECIMALS_TO_SHOW = 2;
+    private const int DECIMALS_TO_SHOW = 2;
 
-    private const UNITS = [
+    private const array UNITS = [
         'B',
         'KB',
         'MB',

--- a/src/Resource/Time/TimeFormatter.php
+++ b/src/Resource/Time/TimeFormatter.php
@@ -43,7 +43,7 @@ use function trim;
  */
 class TimeFormatter
 {
-    private const TIME_HORIZONS = [
+    private const array TIME_HORIZONS = [
         'h' => 3600,
         'm' => 60,
         's' => 1,

--- a/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
+++ b/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
@@ -47,7 +47,7 @@ use function sprintf;
  */
 readonly class StaticAnalysisConfigLocator implements TestFrameworkConfigLocatorInterface
 {
-    private const DEFAULT_EXTENSIONS = [
+    private const array DEFAULT_EXTENSIONS = [
         'neon',
         'neon.dist',
         'dist.neon',

--- a/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
+++ b/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
@@ -55,9 +55,9 @@ use function version_compare;
  */
 final class PHPStanAdapter implements StaticAnalysisToolAdapter
 {
-    private const VERSION_1 = 1;
+    private const int VERSION_1 = 1;
 
-    private const VERSION_2 = 2;
+    private const int VERSION_2 = 2;
 
     /**
      * @param list<string> $staticAnalysisToolOptions

--- a/src/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactory.php
+++ b/src/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactory.php
@@ -50,7 +50,7 @@ use Webmozart\Assert\Assert;
  */
 class PHPStanMutantExecutionResultFactory implements MutantExecutionResultFactory
 {
-    private const PROCESS_MIN_ERROR_CODE = 100;
+    private const int PROCESS_MIN_ERROR_CODE = 100;
 
     public function createFromProcess(MutantProcess $mutantProcess): MutantExecutionResult
     {

--- a/src/StaticAnalysis/StaticAnalysisToolTypes.php
+++ b/src/StaticAnalysis/StaticAnalysisToolTypes.php
@@ -46,7 +46,7 @@ use Webmozart\Assert\Assert;
  */
 final class StaticAnalysisToolTypes
 {
-    public const PHPSTAN = 'phpstan';
+    public const string PHPSTAN = 'phpstan';
 
     /**
      * @var string[]

--- a/src/TestFramework/AdapterInstallationDecider.php
+++ b/src/TestFramework/AdapterInstallationDecider.php
@@ -47,7 +47,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 final readonly class AdapterInstallationDecider
 {
-    private const ADAPTER_NAME_TO_CLASS_MAP = [
+    private const array ADAPTER_NAME_TO_CLASS_MAP = [
         TestFrameworkTypes::CODECEPTION => 'Infection\TestFramework\Codeception\CodeceptionAdapter',
         TestFrameworkTypes::PHPSPEC => 'Infection\TestFramework\PhpSpec\PhpSpecAdapter',
     ];

--- a/src/TestFramework/AdapterInstaller.php
+++ b/src/TestFramework/AdapterInstaller.php
@@ -45,13 +45,13 @@ use Webmozart\Assert\Assert;
  */
 final readonly class AdapterInstaller
 {
-    public const OFFICIAL_ADAPTERS_MAP = [
+    public const array OFFICIAL_ADAPTERS_MAP = [
         TestFrameworkTypes::CODECEPTION => 'infection/codeception-adapter',
         TestFrameworkTypes::PHPSPEC => 'infection/phpspec-adapter',
     ];
 
     // 2 minutes
-    private const TIMEOUT = 120.0;
+    private const float TIMEOUT = 120.0;
 
     public function __construct(
         private ComposerExecutableFinder $composerExecutableFinder,

--- a/src/TestFramework/CommandLineBuilder.php
+++ b/src/TestFramework/CommandLineBuilder.php
@@ -50,7 +50,7 @@ use Symfony\Component\Process\PhpExecutableFinder;
  */
 class CommandLineBuilder
 {
-    private const BAT_EXTENSION_LENGTH = 4;
+    private const int BAT_EXTENSION_LENGTH = 4;
 
     /** @var string[]|null */
     private ?array $cachedPhpCmdLine = null;

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -45,7 +45,7 @@ use function sprintf;
  */
 final readonly class TestFrameworkConfigLocator implements TestFrameworkConfigLocatorInterface
 {
-    private const DEFAULT_EXTENSIONS = [
+    private const array DEFAULT_EXTENSIONS = [
         'xml',
         'yml',
         'xml.dist',

--- a/src/TestFramework/Coverage/CoverageChecker.php
+++ b/src/TestFramework/Coverage/CoverageChecker.php
@@ -54,9 +54,9 @@ use function strtolower;
  */
 class CoverageChecker
 {
-    private const PHPUNIT = 'phpunit';
+    private const string PHPUNIT = 'phpunit';
 
-    private const CODECEPTION = 'codeception';
+    private const string CODECEPTION = 'codeception';
 
     private readonly string $frameworkAdapterName;
 

--- a/src/TestFramework/Coverage/JUnit/JUnitReportLocator.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitReportLocator.php
@@ -52,9 +52,9 @@ use Symfony\Component\Finder\Finder;
  */
 final class JUnitReportLocator extends BaseReportLocator implements ReportLocator
 {
-    public const JUNIT_FILENAME_REGEX = '/^(.+\.)?junit\.xml$/i';
+    public const string JUNIT_FILENAME_REGEX = '/^(.+\.)?junit\.xml$/i';
 
-    private const DEFAULT_JUNIT_FILENAME = 'junit.xml';
+    private const string DEFAULT_JUNIT_FILENAME = 'junit.xml';
 
     public static function create(
         FileSystem $filesystem,

--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -51,7 +51,7 @@ use function Later\lazy;
  */
 class JUnitTestExecutionInfoAdder
 {
-    private const MAX_EXPLODE_PARTS = 2;
+    private const int MAX_EXPLODE_PARTS = 2;
 
     public function __construct(
         private readonly TestFrameworkAdapter $adapter,

--- a/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php
+++ b/src/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocator.php
@@ -52,9 +52,9 @@ use Symfony\Component\Finder\Finder;
  */
 final class IndexXmlCoverageLocator extends BaseReportLocator implements ReportLocator
 {
-    public const INDEX_FILENAME_REGEX = '/^index\.xml$/i';
+    public const string INDEX_FILENAME_REGEX = '/^index\.xml$/i';
 
-    private const DEFAULT_INDEX_RELATIVE_PATHNAME = 'coverage-xml/index.xml';
+    private const string DEFAULT_INDEX_RELATIVE_PATHNAME = 'coverage-xml/index.xml';
 
     public static function create(
         FileSystem $filesystem,

--- a/src/TestFramework/MapSourceClassToTestStrategy.php
+++ b/src/TestFramework/MapSourceClassToTestStrategy.php
@@ -40,7 +40,7 @@ namespace Infection\TestFramework;
  */
 final class MapSourceClassToTestStrategy
 {
-    public const SIMPLE = 'simple';
+    public const string SIMPLE = 'simple';
 
     /**
      * @return list<string>

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -57,7 +57,7 @@ use function version_compare;
  */
 class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements MemoryUsageAware, ProvidesInitialRunOnlyOptions, SyntaxErrorAware
 {
-    final public const COVERAGE_DIR = 'coverage-xml';
+    final public const string COVERAGE_DIR = 'coverage-xml';
 
     public function __construct(
         string $testFrameworkExecutable,

--- a/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
@@ -51,18 +51,18 @@ use function version_compare;
  */
 final class FilterBuilder
 {
-    private const MAX_EXPLODE_PARTS = 2;
+    private const int MAX_EXPLODE_PARTS = 2;
 
     // The real limit is likely higher, but it is better to be safe than sorry.
-    private const PCRE_LIMIT = 30_000;
+    private const int PCRE_LIMIT = 30_000;
 
-    private const NO_OPTIMIZATION_LEVEL = 0;
+    private const int NO_OPTIMIZATION_LEVEL = 0;
 
-    private const DROP_DATA_PROVIDER_KEY_OPTIMIZATION_LEVEL = 1;
+    private const int DROP_DATA_PROVIDER_KEY_OPTIMIZATION_LEVEL = 1;
 
-    private const DROP_TEST_CASE_OPTIMIZATION_LEVEL = 2;
+    private const int DROP_TEST_CASE_OPTIMIZATION_LEVEL = 2;
 
-    private const BAILOUT_OPTIMIZATION_LEVEL = 3;
+    private const int BAILOUT_OPTIMIZATION_LEVEL = 3;
 
     /**
      * @param non-empty-array<TestLocation> $tests

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php
@@ -43,9 +43,9 @@ use function Safe\preg_match;
  */
 final class XmlConfigurationVersionProvider
 {
-    private const LAST_LEGACY_VERSION = '9.2';
+    private const string LAST_LEGACY_VERSION = '9.2';
 
-    private const NEXT_MAINSTREAM_VERSION = '9.3';
+    private const string NEXT_MAINSTREAM_VERSION = '9.3';
 
     public function provide(SafeDOMXPath $xPath): string
     {

--- a/src/TestFramework/TestFrameworkTypes.php
+++ b/src/TestFramework/TestFrameworkTypes.php
@@ -45,11 +45,11 @@ use Webmozart\Assert\Assert;
  */
 final class TestFrameworkTypes
 {
-    public const PHPUNIT = 'phpunit';
+    public const string PHPUNIT = 'phpunit';
 
-    public const PHPSPEC = 'phpspec';
+    public const string PHPSPEC = 'phpspec';
 
-    public const CODECEPTION = 'codeception';
+    public const string CODECEPTION = 'codeception';
 
     /**
      * @var string[]

--- a/src/TestFramework/Tracing/TestLocationBucketSorter.php
+++ b/src/TestFramework/Tracing/TestLocationBucketSorter.php
@@ -50,7 +50,7 @@ final readonly class TestLocationBucketSorter
      * Pre-sort first buckets, optimistically assuming that most projects
      * won't have tests longer than a second.
      */
-    private const INIT_BUCKETS = [
+    private const array INIT_BUCKETS = [
         0 => [],
         1 => [],
         2 => [],

--- a/src/TestFramework/Tracing/TestRunOrderResolver.php
+++ b/src/TestFramework/Tracing/TestRunOrderResolver.php
@@ -50,16 +50,14 @@ final readonly class TestRunOrderResolver
 {
     /**
      * Expected average number of buckets. Exposed for testing purposes.
-     *
-     * @var int
      */
-    public const BUCKETS_COUNT = 25;
+    public const int BUCKETS_COUNT = 25;
 
     /**
      * For 25 buckets QS becomes theoretically less efficient on average at and after 15 elements.
      * Exposed for testing purposes.
      */
-    public const USE_BUCKET_SORT_AFTER = 15;
+    public const int USE_BUCKET_SORT_AFTER = 15;
 
     /**
      * Returns unique test file paths ordered by execution time (fastest first).

--- a/src/TestFramework/VersionParser.php
+++ b/src/TestFramework/VersionParser.php
@@ -45,7 +45,7 @@ use Webmozart\Assert\Assert;
  */
 final class VersionParser
 {
-    private const VERSION_REGEX = '/(?<version>\d+\.\d+\.?\w*|dev)(?<prerelease>-[0-9a-zA-Z.]+)?(?<build>[\+|@][0-9a-zA-Z.]+)?/';
+    private const string VERSION_REGEX = '/(?<version>\d+\.\d+\.?\w*|dev)(?<prerelease>-[0-9a-zA-Z.]+)?(?<build>[\+|@][0-9a-zA-Z.]+)?/';
 
     public function parse(string $content): string
     {

--- a/src/Testing/BaseMutatorTestCase.php
+++ b/src/Testing/BaseMutatorTestCase.php
@@ -64,7 +64,7 @@ use Webmozart\Assert\Assert;
 
 abstract class BaseMutatorTestCase extends TestCase
 {
-    private const WRAPPED_CODE_METHOD_BODY_INDENT = '        ';
+    private const string WRAPPED_CODE_METHOD_BODY_INDENT = '        ';
 
     protected Mutator $mutator;
 

--- a/tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulatorCodeDetector.php
+++ b/tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulatorCodeDetector.php
@@ -43,7 +43,7 @@ final class EnvManipulatorCodeDetector
 {
     use CannotBeInstantiated;
 
-    private const FUNCTIONS = [
+    private const array FUNCTIONS = [
         'putenv',
         'Safe\putenv',
     ];

--- a/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProvider.php
@@ -55,7 +55,7 @@ final class IntegrationGroupProvider
      *
      * A better solution would be to find all tests that do not have corresponding class.
      */
-    private const KNOWN_INTEGRATIONAL_TESTS = [
+    private const array KNOWN_INTEGRATIONAL_TESTS = [
         E2ETest::class,
     ];
 

--- a/tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php
@@ -49,7 +49,7 @@ final class IoCodeDetector
     use CannotBeInstantiated;
 
     // See https://www.php.net/manual/en/ref.filesystem.php
-    private const NATIVE_FUNCTIONS = [
+    private const array NATIVE_FUNCTIONS = [
         'basename',
         'chgrp',
         'chmod',
@@ -133,7 +133,7 @@ final class IoCodeDetector
         'unlink',
     ];
 
-    private const ARBITRARY_STATEMENTS = [
+    private const array ARBITRARY_STATEMENTS = [
         'use Symfony\Component\Filesystem\Filesystem;',
     ];
 

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -58,7 +58,7 @@ use function substr_count;
 #[CoversNothing]
 final class MakefileTest extends BaseMakefileTestCase
 {
-    private const MAKEFILE_PATH = __DIR__ . '/../../../../Makefile';
+    private const string MAKEFILE_PATH = __DIR__ . '/../../../../Makefile';
 
     public function test_the_default_goal_is_the_help_command(): void
     {

--- a/tests/phpunit/AutoReview/Mutator/MutatorTest.php
+++ b/tests/phpunit/AutoReview/Mutator/MutatorTest.php
@@ -64,7 +64,7 @@ use function sprintf;
 #[CoversNothing]
 final class MutatorTest extends TestCase
 {
-    private const KNOWN_MUTATOR_PUBLIC_METHODS = [
+    private const array KNOWN_MUTATOR_PUBLIC_METHODS = [
         'getDefinition',
         'getName',
         'mutate',

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -128,7 +128,7 @@ final class ProjectCodeProvider
      * This array contains all classes that don't have tests yet, due to legacy
      * reasons. This list should never be added to, only removed from.
      */
-    public const NON_TESTED_CONCRETE_CLASSES = [
+    public const array NON_TESTED_CONCRETE_CLASSES = [
         AdapterInstaller::class,
         Application::class,
         BaseMutatorTestCase::class,
@@ -184,7 +184,7 @@ final class ProjectCodeProvider
      * does not follow the pattern "Acme\Service\Foo" -> "Acme\Tests\FooTest".
      * For example, test cases that are in a child directory.
      */
-    public const CONCRETE_CLASSES_WITH_TESTS_IN_DIFFERENT_LOCATION = [
+    public const array CONCRETE_CLASSES_WITH_TESTS_IN_DIFFERENT_LOCATION = [
         FilterBuilder::class,
     ];
 
@@ -192,7 +192,7 @@ final class ProjectCodeProvider
      * This array contains all classes that are not extension points, but not final due to legacy
      * reasons. This list should never be added to, only removed from.
      */
-    public const NON_FINAL_EXTENSION_CLASSES = [
+    public const array NON_FINAL_EXTENSION_CLASSES = [
         ConsoleHelper::class,
         FileSystem::class,
         MetricsCalculator::class,
@@ -206,7 +206,7 @@ final class ProjectCodeProvider
     /**
      * This array contains all classes that can be extended by our users.
      */
-    public const EXTENSION_POINTS = [
+    public const array EXTENSION_POINTS = [
         BaseMutatorTestCase::class,
         Definition::class,
         Mutator::class,

--- a/tests/phpunit/BenchmarkSmokeTest.php
+++ b/tests/phpunit/BenchmarkSmokeTest.php
@@ -54,7 +54,7 @@ use Symfony\Component\Process\Process;
 #[CoversNothing]
 final class BenchmarkSmokeTest extends TestCase
 {
-    private const BENCHMARK_DIR = __DIR__ . '/../benchmark';
+    private const string BENCHMARK_DIR = __DIR__ . '/../benchmark';
 
     /**
      * @param non-empty-list<string> $command

--- a/tests/phpunit/Command/Debug/MockTeamCityCommandTest.php
+++ b/tests/phpunit/Command/Debug/MockTeamCityCommandTest.php
@@ -55,7 +55,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(MockTeamCityCommand::class)]
 final class MockTeamCityCommandTest extends FileSystemTestCase
 {
-    private const LOG_EXAMPLE = <<<'TEAMCITY'
+    private const string LOG_EXAMPLE = <<<'TEAMCITY'
         ##teamcity[testSuiteStarted name='MySuite']
         ##teamcity[testStarted name='testExample']
         ##teamcity[testFinished name='testExample' duration='100']

--- a/tests/phpunit/Command/Git/GitChangedFilesCommandTest.php
+++ b/tests/phpunit/Command/Git/GitChangedFilesCommandTest.php
@@ -56,11 +56,11 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(GitChangedFilesCommand::class)]
 final class GitChangedFilesCommandTest extends TestCase
 {
-    private const REFERENCE = 'xyz1234';
+    private const string REFERENCE = 'xyz1234';
 
-    private const FIXTURES_DIR = __DIR__ . '/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/Fixtures';
 
-    private const SOURCE_DIRECTORIES = ['src', 'lib'];
+    private const array SOURCE_DIRECTORIES = ['src', 'lib'];
 
     private string $cwd = '';
 

--- a/tests/phpunit/Command/Git/GitChangedLinesCommandTest.php
+++ b/tests/phpunit/Command/Git/GitChangedLinesCommandTest.php
@@ -57,11 +57,11 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(GitChangedLinesCommand::class)]
 final class GitChangedLinesCommandTest extends TestCase
 {
-    private const REFERENCE = 'xyz1234';
+    private const string REFERENCE = 'xyz1234';
 
-    private const FIXTURES_DIR = __DIR__ . '/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/Fixtures';
 
-    private const SOURCE_DIRECTORIES = ['src', 'lib'];
+    private const array SOURCE_DIRECTORIES = ['src', 'lib'];
 
     private string $cwd = '';
 

--- a/tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php
+++ b/tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php
@@ -57,7 +57,7 @@ use Symfony\Component\Process\Process;
 #[CoversClass(InitialTestRunCommand::class)]
 final class InitialTestRunCommandTest extends TestCase
 {
-    private const FIXTURES_DIR = __DIR__ . '/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/Fixtures';
 
     private string $cwd = '';
 

--- a/tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php
+++ b/tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php
@@ -50,7 +50,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(ListSourcesCommand::class)]
 final class ListSourcesCommandTest extends TestCase
 {
-    private const FIXTURES_DIR = __DIR__ . '/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/Fixtures';
 
     private string $cwd;
 

--- a/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
@@ -52,7 +52,7 @@ use Symfony\Component\Filesystem\Path;
 #[CoversClass(PhpUnitCustomExecutablePathProvider::class)]
 final class PhpUnitCustomExecutablePathProviderTest extends BaseProviderTestCase
 {
-    private const VALID_PHPUNIT_EXECUTABLE = __DIR__ . '/../../../../vendor/bin/phpunit';
+    private const string VALID_PHPUNIT_EXECUTABLE = __DIR__ . '/../../../../vendor/bin/phpunit';
 
     private MockObject&TestFrameworkFinder $finderMock;
 

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -77,7 +77,7 @@ use function sys_get_temp_dir;
 #[CoversClass(ConfigurationFactory::class)]
 final class ConfigurationFactoryTest extends TestCase
 {
-    private const GIT_DEFAULT_BASE = 'test/default';
+    private const string GIT_DEFAULT_BASE = 'test/default';
 
     /**
      * @var array<string, Mutator>|null

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -67,9 +67,9 @@ use stdClass;
 #[CoversClass(SchemaConfigurationFactory::class)]
 final class SchemaConfigurationFactoryTest extends TestCase
 {
-    private const SCHEMA_FILE = 'file://' . __DIR__ . '/../../../../resources/schema.json';
+    private const string SCHEMA_FILE = 'file://' . __DIR__ . '/../../../../resources/schema.json';
 
-    private const PROFILES = [
+    private const array PROFILES = [
         '@arithmetic',
         '@boolean',
         '@cast',

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php
@@ -50,7 +50,7 @@ use function sprintf;
 #[CoversClass(SchemaConfigurationFile::class)]
 final class SchemaConfigurationFileTest extends TestCase
 {
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures/Configuration';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures/Configuration';
 
     public function test_it_can_be_instantiated(): void
     {

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -83,13 +83,13 @@ final class E2ETest extends TestCase
     /**
      * This group must be excluded from E2E testing to avoid endless recursive testing loop situation.
      */
-    private const EXCLUDED_GROUP = 'integration';
+    private const string EXCLUDED_GROUP = 'integration';
 
-    private const MAX_FAILING_COMPOSER_INSTALL = 5;
+    private const int MAX_FAILING_COMPOSER_INSTALL = 5;
 
-    private const EXPECT_ERROR = 1;
+    private const int EXPECT_ERROR = 1;
 
-    private const EXPECT_SUCCESS = 0;
+    private const int EXPECT_SUCCESS = 0;
 
     private string $cwd;
 

--- a/tests/phpunit/FileSystem/Finder/MockVendor.php
+++ b/tests/phpunit/FileSystem/Finder/MockVendor.php
@@ -44,9 +44,9 @@ use Symfony\Component\Filesystem\Filesystem;
 
 final readonly class MockVendor
 {
-    public const VENDOR = 'phptester';
+    public const string VENDOR = 'phptester';
 
-    public const PACKAGE = 'awesome-php-tester';
+    public const string PACKAGE = 'awesome-php-tester';
 
     private string $packageScript;
 

--- a/tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php
+++ b/tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php
@@ -55,7 +55,7 @@ use Symfony\Component\Filesystem\Path;
 #[CoversClass(RootsFileLocator::class)]
 final class RootsFileLocatorTest extends TestCase
 {
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures/Locator';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures/Locator';
 
     private Filesystem $filesystem;
 

--- a/tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php
+++ b/tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php
@@ -52,7 +52,7 @@ use Symfony\Component\Filesystem\Path;
 #[CoversClass(RootsFileOrDirectoryLocator::class)]
 final class RootsFileOrDirectoryLocatorTest extends TestCase
 {
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures/Locator';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures/Locator';
 
     private Filesystem $filesystem;
 

--- a/tests/phpunit/Fixtures/TestFramework/PhpUnit/Coverage/JUnitTimes.php
+++ b/tests/phpunit/Fixtures/TestFramework/PhpUnit/Coverage/JUnitTimes.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Fixtures\TestFramework\PhpUnit\Coverage;
 
 final class JUnitTimes
 {
-    public const JUNIT_TIMES = [
+    public const array JUNIT_TIMES = [
         670.332214,
         0.219290,
         0.007056,

--- a/tests/phpunit/Git/CommandLineGitIntegrationTest.php
+++ b/tests/phpunit/Git/CommandLineGitIntegrationTest.php
@@ -64,9 +64,9 @@ final class CommandLineGitIntegrationTest extends TestCase
     // - tests/phpunit/Git/CommandLineGitIntegrationTest.php
     // - tests/phpunit/Git/CommandLineGitTest.php
     // - tests/phpunit/Process/ShellCommandLineExecutorTest.php
-    private const COMMIT_REFERENCE = '40d08afda22d5fe6d0d87ffb95fd609dcb01992a';
+    private const string COMMIT_REFERENCE = '40d08afda22d5fe6d0d87ffb95fd609dcb01992a';
 
-    private const BAD_COMMIT_REFERENCE = '40d08afda22d5fe6d0d87ffb95fd609dcb01992a40d08afda22d5fe6d0d87ffb95fd609dcb01992a';
+    private const string BAD_COMMIT_REFERENCE = '40d08afda22d5fe6d0d87ffb95fd609dcb01992a40d08afda22d5fe6d0d87ffb95fd609dcb01992a';
 
     private static bool $commitReferenceExists;
 

--- a/tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php
@@ -52,7 +52,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 #[CoversClass(ConsoleDotLogger::class)]
 final class ConsoleDotLoggerTest extends TestCase
 {
-    private const ANY_PRIME_NUMBER = 127;
+    private const int ANY_PRIME_NUMBER = 127;
 
     public function test_begins_by_displaying_a_legend(): void
     {

--- a/tests/phpunit/Mutant/MutantCodeFactoryTest.php
+++ b/tests/phpunit/Mutant/MutantCodeFactoryTest.php
@@ -51,13 +51,13 @@ use Webmozart\Assert\Assert;
 #[CoversClass(MutantCodeFactory::class)]
 final class MutantCodeFactoryTest extends TestCase
 {
-    private const PHP_TO_BE_MUTATED_CODE = <<<'PHP_WRAP'
+    private const string PHP_TO_BE_MUTATED_CODE = <<<'PHP_WRAP'
         <?php
 
         $a = PHP_INT_MAX - 33;
         PHP_WRAP;
 
-    private const PHP_UNTOUCHED_CODE = <<<'PHP_WRAP'
+    private const string PHP_UNTOUCHED_CODE = <<<'PHP_WRAP'
         <?php
 
         namespace PHPStan_Integration;

--- a/tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php
+++ b/tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php
@@ -53,7 +53,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(FileMutationGenerator::class)]
 final class FileMutationGeneratorIntegrationTest extends TestCase
 {
-    private const FIXTURES_DIR = __DIR__ . '/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/Fixtures';
 
     public function test_it_generates_mutations_for_a_given_file(): void
     {

--- a/tests/phpunit/Mutator/DefinitionTest.php
+++ b/tests/phpunit/Mutator/DefinitionTest.php
@@ -52,7 +52,7 @@ use function sprintf;
 final class DefinitionTest extends TestCase
 {
     // TODO: address those
-    private const MUTATORS_WITHOUT_REMEDIES = [
+    private const array MUTATORS_WITHOUT_REMEDIES = [
         'Assignment',
         'AssignmentEqual',
         'BitwiseAnd',

--- a/tests/phpunit/Mutator/MutatorCategoryTest.php
+++ b/tests/phpunit/Mutator/MutatorCategoryTest.php
@@ -48,7 +48,7 @@ use function sprintf;
 #[CoversClass(MutatorCategory::class)]
 final class MutatorCategoryTest extends TestCase
 {
-    private const ALL_CONSTANT_KEY = 'ALL';
+    private const string ALL_CONSTANT_KEY = 'ALL';
 
     public function test_it_cannot_be_instantiated(): void
     {

--- a/tests/phpunit/Mutator/MutatorFixturesProvider.php
+++ b/tests/phpunit/Mutator/MutatorFixturesProvider.php
@@ -50,7 +50,7 @@ final class MutatorFixturesProvider
 {
     use CannotBeInstantiated;
 
-    private const MUTATOR_FIXTURES_DIR = __DIR__ . '/../../autoloaded/mutator-fixtures';
+    private const string MUTATOR_FIXTURES_DIR = __DIR__ . '/../../autoloaded/mutator-fixtures';
 
     /**
      * @var array<string, string>

--- a/tests/phpunit/Mutator/MutatorRobustnessTest.php
+++ b/tests/phpunit/Mutator/MutatorRobustnessTest.php
@@ -59,7 +59,7 @@ use Throwable;
 #[CoversNothing]
 final class MutatorRobustnessTest extends TestCase
 {
-    private const FIXTURES_DIR = __DIR__ . '/../../autoloaded/mutator-code-samples';
+    private const string FIXTURES_DIR = __DIR__ . '/../../autoloaded/mutator-code-samples';
 
     /**
      * @var array<string, SplFileInfo>|null

--- a/tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php
+++ b/tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php
@@ -53,7 +53,7 @@ use function Safe\file_get_contents;
 #[CoversNothing]
 final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
 {
-    private const FIXTURES_DIR = __DIR__ . '/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/Fixtures';
 
     /**
      * @param list<ChangedLinesRange>|null $changedLinesRange

--- a/tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/StopAtSkippedArgVisitor.php
+++ b/tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/StopAtSkippedArgVisitor.php
@@ -40,7 +40,7 @@ use PhpParser\NodeVisitorAbstract;
 
 final class StopAtSkippedArgVisitor extends NodeVisitorAbstract
 {
-    public const SKIP_ATTRIBUTE = 'skip';
+    public const string SKIP_ATTRIBUTE = 'skip';
 
     public static function markNodeAsSkipped(Node $node): Node
     {

--- a/tests/phpunit/PhpParser/Visitor/MutationCollectorVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/MutationCollectorVisitorTest.php
@@ -46,7 +46,7 @@ use PHPUnit\Framework\Attributes\Group;
 #[CoversClass(MutationCollectorVisitor::class)]
 final class MutationCollectorVisitorTest extends BaseVisitorTestCase
 {
-    private const CODE = <<<'PHP'
+    private const string CODE = <<<'PHP'
         <?php
 
         class Foo {}

--- a/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php
@@ -50,7 +50,7 @@ use function Safe\file_get_contents;
 #[CoversClass(ReflectionVisitor::class)]
 final class ReflectionVisitorTest extends VisitorTestCase
 {
-    private const FIXTURES_DIR = __DIR__ . '/../../../autoloaded/mutator-fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../../autoloaded/mutator-fixtures';
 
     /**
      * @param list<string>|null $desiredAttributes

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -75,7 +75,7 @@ use Symfony\Component\Filesystem\Filesystem;
 #[CoversClass(MutationTestingRunner::class)]
 final class MutationTestingRunnerTest extends TestCase
 {
-    private const TIMEOUT = 100.0;
+    private const float TIMEOUT = 100.0;
 
     private MockObject&MutantProcessContainerFactory $processFactoryMock;
 

--- a/tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php
+++ b/tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php
@@ -61,7 +61,7 @@ use Symfony\Component\Process\Process;
 #[CoversClass(ParallelProcessRunner::class)]
 final class ParallelProcessRunnerTest extends TestCase
 {
-    private const SIMULATED_TIME_MICROSECONDS = 1_000;
+    private const int SIMULATED_TIME_MICROSECONDS = 1_000;
 
     public function test_it_does_nothing_when_no_process_is_given(): void
     {

--- a/tests/phpunit/Process/Runner/ProcessQueueTest.php
+++ b/tests/phpunit/Process/Runner/ProcessQueueTest.php
@@ -45,7 +45,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ProcessQueue::class)]
 final class ProcessQueueTest extends TestCase
 {
-    private const SIMULATED_TIME_MICROSECONDS = 1_000_000;
+    private const int SIMULATED_TIME_MICROSECONDS = 1_000_000;
 
     public function test_new_queue_is_empty(): void
     {

--- a/tests/phpunit/Reporter/FileReporterTest.php
+++ b/tests/phpunit/Reporter/FileReporterTest.php
@@ -51,7 +51,7 @@ use Symfony\Component\Filesystem\Filesystem;
 #[CoversClass(FileReporter::class)]
 final class FileReporterTest extends FileSystemTestCase
 {
-    private const LOG_FILE_PATH = '/path/to/text.log';
+    private const string LOG_FILE_PATH = '/path/to/text.log';
 
     private MockObject&Filesystem $fileSystemMock;
 

--- a/tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php
+++ b/tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php
@@ -68,7 +68,7 @@ use function sprintf;
 #[CoversClass(StrykerHtmlReportBuilder::class)]
 final class StrykerHtmlReportBuilderTest extends TestCase
 {
-    private const SCHEMA_FILE = 'file://' . __DIR__ . '/../../../../resources/mutation-testing-report-schema.json';
+    private const string SCHEMA_FILE = 'file://' . __DIR__ . '/../../../../resources/mutation-testing-report-schema.json';
 
     /**
      * @param array<string, array<string, mixed>|string> $expectedReport

--- a/tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php
+++ b/tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php
@@ -49,7 +49,7 @@ use Psr\Log\LogLevel;
 #[CoversClass(StrykerDashboardClient::class)]
 final class StrykerDashboardClientTest extends TestCase
 {
-    private const API_KEY = '0e137d38-7611-4157-897b-54791cc1ef97';
+    private const string API_KEY = '0e137d38-7611-4157-897b-54791cc1ef97';
 
     private MockObject&StrykerCurlClient $clientMock;
 

--- a/tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php
+++ b/tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php
@@ -55,7 +55,7 @@ use Symfony\Component\Finder\SplFileInfo as FinderSplFileInfo;
 #[CoversClass(BasicSourceCollector::class)]
 final class BasicSourceCollectorTest extends FileSystemTestCase
 {
-    private const FIXTURES_ROOT = __DIR__ . '/Fixtures';
+    private const string FIXTURES_ROOT = __DIR__ . '/Fixtures';
 
     private Filesystem $filesystem;
 

--- a/tests/phpunit/TestFramework/CommandLineBuilderTest.php
+++ b/tests/phpunit/TestFramework/CommandLineBuilderTest.php
@@ -44,9 +44,9 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CommandLineBuilder::class)]
 final class CommandLineBuilderTest extends TestCase
 {
-    private const PHP_EXTRA_ARGS = ['-d zend_extension=xdebug.so'];
+    private const array PHP_EXTRA_ARGS = ['-d zend_extension=xdebug.so'];
 
-    private const TEST_FRAMEWORK_ARGS = ['--filter XYZ', '--exclude-group=integration'];
+    private const array TEST_FRAMEWORK_ARGS = ['--filter XYZ', '--exclude-group=integration'];
 
     private CommandLineBuilder $commandLineBuilder;
 

--- a/tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php
+++ b/tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php
@@ -65,9 +65,9 @@ use Symfony\Component\Filesystem\Path;
 #[CoversClass(CoverageChecker::class)]
 final class CoverageCheckerTest extends TestCase
 {
-    private const COVERAGE_DIR_PATH = __DIR__ . '/Fixtures';
+    private const string COVERAGE_DIR_PATH = __DIR__ . '/Fixtures';
 
-    private const JUNIT_PATH = __DIR__ . '/Fixtures/junit.xml';
+    private const string JUNIT_PATH = __DIR__ . '/Fixtures/junit.xml';
 
     public function test_it_needs_coverage_to_be_provided_if_initial_tests_are_skipped_without_junit_report(): void
     {

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php
@@ -58,7 +58,7 @@ final class JUnitReportLocatorTest extends FileSystemTestCase
     // Must not match the default pattern we are looking for. This allows us
     // to distinguish the case when the locator is looking for the default
     // location provided and when it is looking for the file.
-    private const TEST_DEFAULT_JUNIT = 'test-junit.xml';
+    private const string TEST_DEFAULT_JUNIT = 'test-junit.xml';
 
     private FileSystem $fileSystem;
 

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionBDDProvider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionBDDProvider.php
@@ -46,7 +46,7 @@ final class CodeceptionBDDProvider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionCestProvider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionCestProvider.php
@@ -45,7 +45,7 @@ final class CodeceptionCestProvider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionUnitProvider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionUnitProvider.php
@@ -45,7 +45,7 @@ final class CodeceptionUnitProvider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit09Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit09Provider.php
@@ -45,7 +45,7 @@ final readonly class PhpUnit09Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit10Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit10Provider.php
@@ -45,7 +45,7 @@ final class PhpUnit10Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit11Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit11Provider.php
@@ -45,7 +45,7 @@ final class PhpUnit11Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit12Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit12Provider.php
@@ -45,7 +45,7 @@ final class PhpUnit12Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/DemoReportLocator.php
+++ b/tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/DemoReportLocator.php
@@ -43,7 +43,7 @@ use Symfony\Component\Finder\Finder;
  */
 final class DemoReportLocator extends BaseReportLocator
 {
-    public const FILENAME_REGEX = '/^.+\.demo$/';
+    public const string FILENAME_REGEX = '/^.+\.demo$/';
 
     protected function configureFinder(Finder $finder): void
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php
@@ -57,7 +57,7 @@ use Symfony\Component\Filesystem\Path;
 #[CoversClass(IndexXmlCoverageLocator::class)]
 final class IndexXmlCoverageLocatorTest extends FileSystemTestCase
 {
-    private const TEST_DEFAULT_RELATIVE_PATHNAME = 'coverage-xml/non-standard/test-index.xml';
+    private const string TEST_DEFAULT_RELATIVE_PATHNAME = 'coverage-xml/non-standard/test-index.xml';
 
     private FileSystem $fileSystem;
 

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php
@@ -61,9 +61,9 @@ final class IndexXmlCoverageParserTest extends TestCase
 {
     use ExpectsThrowables;
 
-    private const GENERAL_FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string GENERAL_FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
-    private const FIXTURES_DIR = __DIR__ . '/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/Fixtures';
 
     private string $generatedIndexXmlPath;
 

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/CodeceptionProvider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/CodeceptionProvider.php
@@ -43,7 +43,7 @@ final class CodeceptionProvider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpSpecProvider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpSpecProvider.php
@@ -43,7 +43,7 @@ final class PhpSpecProvider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit09Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit09Provider.php
@@ -43,7 +43,7 @@ final readonly class PhpUnit09Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit10Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit10Provider.php
@@ -43,7 +43,7 @@ final class PhpUnit10Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit11Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit11Provider.php
@@ -43,7 +43,7 @@ final class PhpUnit11Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit125Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit125Provider.php
@@ -43,7 +43,7 @@ final class PhpUnit125Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit12Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit12Provider.php
@@ -43,7 +43,7 @@ final class PhpUnit12Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/CodeceptionProvider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/CodeceptionProvider.php
@@ -46,7 +46,7 @@ final class CodeceptionProvider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpSpecProvider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpSpecProvider.php
@@ -46,7 +46,7 @@ final class PhpSpecProvider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit09Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit09Provider.php
@@ -46,7 +46,7 @@ final readonly class PhpUnit09Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit10Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit10Provider.php
@@ -46,7 +46,7 @@ final class PhpUnit10Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit11Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit11Provider.php
@@ -46,7 +46,7 @@ final class PhpUnit11Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit120Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit120Provider.php
@@ -46,7 +46,7 @@ final class PhpUnit120Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit125Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit125Provider.php
@@ -46,7 +46,7 @@ final class PhpUnit125Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -59,9 +59,9 @@ use Symfony\Component\Filesystem\Path;
 #[CoversClass(InitialConfigBuilder::class)]
 final class InitialConfigBuilderTest extends TestCase
 {
-    private const FIXTURES = __DIR__ . '/Fixtures';
+    private const string FIXTURES = __DIR__ . '/Fixtures';
 
-    private const TMP_DIR = '/tmp/infection';
+    private const string TMP_DIR = '/tmp/infection';
 
     private string $projectPath;
 

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php
@@ -64,15 +64,15 @@ use Symfony\Component\Filesystem\Path;
 #[CoversClass(MutationConfigBuilder::class)]
 final class MutationConfigBuilderTest extends TestCase
 {
-    public const HASH = 'a1b2c3';
+    public const string HASH = 'a1b2c3';
 
-    private const FIXTURES = __DIR__ . '/Fixtures';
+    private const string FIXTURES = __DIR__ . '/Fixtures';
 
-    private const TMP_DIR = '/tmp/infection';
+    private const string TMP_DIR = '/tmp/infection';
 
-    private const ORIGINAL_FILE_PATH = '/original/file/path';
+    private const string ORIGINAL_FILE_PATH = '/original/file/path';
 
-    private const MUTATED_FILE_PATH = '/mutated/file/path';
+    private const string MUTATED_FILE_PATH = '/mutated/file/path';
 
     private string $projectPath;
 

--- a/tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php
+++ b/tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php
@@ -63,10 +63,8 @@ final class TestLocationBucketSorterTest extends TestCase
 {
     /**
      * Used for floating point comparisons.
-     *
-     * @var float
      */
-    private const EPSILON = 0.0001;
+    private const float EPSILON = 0.0001;
 
     public function test_it_sorts(): void
     {

--- a/tests/phpunit/TestFramework/Tracing/Tracer/CodeceptionProvider.php
+++ b/tests/phpunit/TestFramework/Tracing/Tracer/CodeceptionProvider.php
@@ -46,7 +46,7 @@ final class CodeceptionProvider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Tracing/Tracer/PhpSpecProvider.php
+++ b/tests/phpunit/TestFramework/Tracing/Tracer/PhpSpecProvider.php
@@ -46,7 +46,7 @@ final class PhpSpecProvider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit09Provider.php
+++ b/tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit09Provider.php
@@ -46,7 +46,7 @@ final readonly class PhpUnit09Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit10Provider.php
+++ b/tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit10Provider.php
@@ -46,7 +46,7 @@ final class PhpUnit10Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit11Provider.php
+++ b/tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit11Provider.php
@@ -46,7 +46,7 @@ final class PhpUnit11Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit120Provider.php
+++ b/tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit120Provider.php
@@ -46,7 +46,7 @@ final class PhpUnit120Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit125Provider.php
+++ b/tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit125Provider.php
@@ -46,7 +46,7 @@ final class PhpUnit125Provider
 {
     use CannotBeInstantiated;
 
-    private const FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
+    private const string FIXTURES_DIR = __DIR__ . '/../../Coverage/Fixtures';
 
     public static function infoProvider(): iterable
     {

--- a/tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php
+++ b/tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php
@@ -53,7 +53,7 @@ use Symfony\Component\Filesystem\Path;
 #[CoversClass(SafeDOMXPath::class)]
 final class SafeDOMXPathTest extends TestCase
 {
-    private const BOOKSTORE_XML = <<<'XML'
+    private const string BOOKSTORE_XML = <<<'XML'
         <?xml version="1.0" encoding="UTF-8"?>
         <bookstore>
           <book category="cooking">

--- a/tests/phpunit/TestingUtility/Iterable/TrackableIterator.php
+++ b/tests/phpunit/TestingUtility/Iterable/TrackableIterator.php
@@ -57,11 +57,11 @@ final class TrackableIterator implements Iterator
 {
     // Value representing the absence of a yielded key. We cannot use `null` as it is a result
     // that may be returned by `::key()`.
-    public const EMPTY_KEY = '__θθae5181162f0f0a5daacf223fee61d13d142e276807525867a836d3d6968854a0';
+    public const string EMPTY_KEY = '__θθae5181162f0f0a5daacf223fee61d13d142e276807525867a836d3d6968854a0';
 
     // Value representing the absence of a yielded value. We cannot use `null` as it is a result
     // that may be returned by `::value()`.
-    public const EMPTY_VALUE = '__θθfb31e5bcd01897b407311d26f33b78be5b4604f9199fe6e72240c5aee1a2ee44';
+    public const string EMPTY_VALUE = '__θθfb31e5bcd01897b407311d26f33b78be5b4604f9199fe6e72240c5aee1a2ee44';
 
     private bool $yieldedAnyValue = false;
 

--- a/tests/phpunit/TestingUtility/PhpParser/Visitor/SkipNodesVisitor/SkipNodesVisitor.php
+++ b/tests/phpunit/TestingUtility/PhpParser/Visitor/SkipNodesVisitor/SkipNodesVisitor.php
@@ -46,7 +46,7 @@ use PhpParser\NodeVisitorAbstract;
  */
 final class SkipNodesVisitor extends NodeVisitorAbstract
 {
-    public const DEFAULT_STOP_TRAVERSE_TYPE = self::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+    public const int DEFAULT_STOP_TRAVERSE_TYPE = self::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
 
     /**
      * @param list<int> $nodeIds


### PR DESCRIPTION
Now that #3068 has been merged, we can add types to constants. This PR achieves this using the `AddTypeToConstRector` rector rule, but it will later be enabled automatically by using the PHP 8.3 preset instead of PHP 8.2.