### PR TITLE
build(mago): Exclude Rector and PHPStan from Mago's analysis

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -3542,56 +3542,20 @@ count = 1
 
 [[issues]]
 file = "src/Testing/BaseMutatorTestCase.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Testing\BaseMutatorTestCase`.'
-count = 1
-
-[[issues]]
-file = "src/Testing/BaseMutatorTestCase.php"
-code = "non-existent-method"
-message = 'Method `assertnotnull` does not exist on type `Infection\Testing\BaseMutatorTestCase`.'
-count = 1
-
-[[issues]]
-file = "src/Testing/BaseMutatorTestCase.php"
-code = "non-existent-method"
-message = 'Method `assertnotsame` does not exist on type `Infection\Testing\BaseMutatorTestCase`.'
-count = 1
-
-[[issues]]
-file = "src/Testing/BaseMutatorTestCase.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Testing\BaseMutatorTestCase`.'
-count = 1
-
-[[issues]]
-file = "src/Testing/BaseMutatorTestCase.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Testing\BaseMutatorTestCase`.'
-count = 3
-
-[[issues]]
-file = "src/Testing/BaseMutatorTestCase.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\MutatorFactory::create`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but possibly received `non-empty-array<string, array{'settings': array<array-key, mixed>}>`.'''
 count = 1
 
 [[issues]]
 file = "src/Testing/BaseMutatorTestCase.php"
-code = "possibly-null-argument"
-message = 'Argument #1 of method `PhpParser\NodeTraverserInterface::traverse` is possibly `null`, but parameter type `array<array-key, PhpParser\Node>` does not accept it.'
-count = 2
-
-[[issues]]
-file = "src/Testing/BaseMutatorTestCase.php"
-code = "possibly-null-argument"
-message = 'Argument #3 of method `Infection\Mutator\NodeMutationGenerator::__construct` is possibly `null`, but parameter type `array<array-key, PhpParser\Node>` does not accept it.'
+code = "redundant-docblock-type"
+message = "Redundant docblock type for variable `$expectedCodeSample`."
 count = 1
 
 [[issues]]
 file = "src/Testing/BaseMutatorTestCase.php"
-code = "redundant-docblock-type"
-message = "Redundant docblock type for variable `$expectedCodeSample`."
+code = "redundant-type-comparison"
+message = "Redundant type assertion: `$expectedCodeSample` of type `string` is always not `string`."
 count = 1
 
 [[issues]]
@@ -4867,39 +4831,15 @@ message = "Type `iterable` in return type of `providesYamlFilesForTesting` is im
 count = 1
 
 [[issues]]
-file = "tests/phpunit/AutoReview/BuildConfigYmlTest.php"
-code = "non-existent-method"
-message = 'Method `assertfileexists` does not exist on type `Infection\Tests\AutoReview\BuildConfigYmlTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/BuildConfigYmlTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\AutoReview\BuildConfigYmlTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/ConcreteClassReflector.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulationTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\AutoReview\EnvVariableManipulation\EnvManipulationTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulatorCodeDetectorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `codeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulatorCodeDetectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\AutoReview\EnvVariableManipulation\EnvManipulatorCodeDetectorTest`.'
 count = 1
 
 [[issues]]
@@ -4970,36 +4910,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertfileexists` does not exist on type `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProviderTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProviderTest.php"
-code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProviderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProviderTest::test_env_test_case_classes_provider_is_valid`.'
 count = 1
@@ -5035,57 +4945,9 @@ message = "Cannot `yield from` non-iterable type `null`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/AutoReview/Event/SubscriberProviderTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\AutoReview\Event\SubscriberProviderTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/Event/SubscriberTest.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Event/SubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\AutoReview\Event\SubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Event/SubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotnull` does not exist on type `Infection\Tests\AutoReview\Event\SubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Event/SubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\AutoReview\Event\SubscriberTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Event/SubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\AutoReview\Event\SubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Event/SubscriberTest.php"
-code = "non-existent-method"
-message = "Method `getname` does not exist on type `ReflectionIntersectionType`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Event/SubscriberTest.php"
-code = "non-existent-method"
-message = "Method `getname` does not exist on type `ReflectionUnionType`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Event/SubscriberTest.php"
-code = "possible-method-access-on-null"
-message = "Attempting to call a method on `null`."
+code = "possibly-invalid-argument"
+message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 1
 
 [[issues]]
@@ -5204,68 +5066,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertfileexists` does not exist on type `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php"
-code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupProviderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupProviderTest::test_io_test_case_classes_provider_is_valid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupTest.php"
-code = "missing-return-statement"
-message = "Missing return statement in function 'failwithintegrationgroupmessage'"
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IntegrationGroupTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\AutoReview\IntegrationGroup\IntegrationGroupTest`.'
 count = 1
 
 [[issues]]
@@ -5329,12 +5131,6 @@ message = "Type `iterable` in return type of `codeProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\AutoReview\IntegrationGroup\IoCodeDetectorTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `rootTestTargetProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -5351,42 +5147,6 @@ file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 2
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
-code = "non-existent-method"
-message = 'Method `addtoassertioncount` does not exist on type `Infection\Tests\AutoReview\Makefile\MakefileTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontains` does not exist on type `Infection\Tests\AutoReview\Makefile\MakefileTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
-code = "non-existent-method"
-message = 'Method `assertequalscanonicalizing` does not exist on type `Infection\Tests\AutoReview\Makefile\MakefileTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotcontains` does not exist on type `Infection\Tests\AutoReview\Makefile\MakefileTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\AutoReview\Makefile\MakefileTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\AutoReview\Makefile\MakefileTest`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
@@ -5468,18 +5228,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\AutoReview\Mutator\MutatorProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorProviderTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\AutoReview\Mutator\MutatorProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorProviderTest.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
 count = 2
@@ -5525,72 +5273,6 @@ file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 2
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontains` does not exist on type `Infection\Tests\AutoReview\Mutator\MutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\AutoReview\Mutator\MutatorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\AutoReview\Mutator\MutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\AutoReview\Mutator\MutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotnull` does not exist on type `Infection\Tests\AutoReview\Mutator\MutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\AutoReview\Mutator\MutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\AutoReview\Mutator\MutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\AutoReview\Mutator\MutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "non-existent-method"
-message = "Method `getname` does not exist on type `ReflectionIntersectionType`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "non-existent-method"
-message = "Method `getname` does not exist on type `ReflectionUnionType`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "possible-method-access-on-null"
-message = "Attempting to call a method on `null`."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
@@ -5671,21 +5353,9 @@ message = "Type `iterable` in return type of `phpDocProvider` is imprecise, equi
 count = 1
 
 [[issues]]
-file = "tests/phpunit/AutoReview/PhpDoc/PHPDocParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\AutoReview\PhpDoc\PHPDocParserTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/DocBlockParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `docBlocksProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/DocBlockParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\AutoReview\ProjectCode\DocBlockParserTest`.'
 count = 1
 
 [[issues]]
@@ -5779,72 +5449,6 @@ message = "Cannot `yield from` non-iterable type `null`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\AutoReview\ProjectCode\ProjectCodeProviderTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "non-existent-method"
-message = 'Method `assertfileexists` does not exist on type `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotnull` does not exist on type `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringnotcontainsstring` does not exist on type `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
@@ -5888,30 +5492,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/BenchmarkSmokeTest.php"
-code = "non-existent-method"
-message = 'Method `assertfileexists` does not exist on type `Infection\Tests\BenchmarkSmokeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/BenchmarkSmokeTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\BenchmarkSmokeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/BenchmarkSmokeTest.php"
-code = "non-existent-method"
-message = 'Method `marktestincomplete` does not exist on type `Infection\Tests\BenchmarkSmokeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/BenchmarkSmokeTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\BenchmarkSmokeTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/BenchmarkSmokeTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\BenchmarkSmokeTest::test_all_the_benchmarks_can_be_executed`.'
 count = 1
@@ -5936,50 +5516,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/CI/MemoizedCiDetectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\CI\MemoizedCiDetectorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/CI/MemoizedCiDetectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\CI\MemoizedCiDetectorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/CI/MemoizedCiDetectorTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\CI\MemoizedCiDetectorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/CI/MemoizedCiDetectorTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\CI\ConfigurableEnv::setVariables`: expected `array<string, false|string>`, but possibly received `array{'TRAVIS': true}`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/CI/NullCiDetectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\CI\NullCiDetectorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/CI/NullCiDetectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\CI\NullCiDetectorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/CI/NullCiDetectorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\CI\NullCiDetectorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/CI/NullCiDetectorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\CI\NullCiDetectorTest`.'
 count = 1
 
 [[issues]]
@@ -5992,18 +5530,6 @@ count = 1
 file = "tests/phpunit/Command/CommandOptionTestCase.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/CommandOptionTestCase.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\CommandOptionTestCase`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/CommandOptionTestCase.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\Command\CommandOptionTestCase`.'
 count = 1
 
 [[issues]]
@@ -6032,24 +5558,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\Debug\DumpAstCommand\DumpAstCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Command\Debug\DumpAstCommand\DumpAstCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Command\Debug\DumpAstCommand\DumpAstCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Debug\DumpAstCommand\DumpAstCommandTest::test_it_outputs_the_ast_of_a_file`.'
 count = 1
@@ -6058,30 +5566,6 @@ count = 1
 file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidTimeValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\Command\Debug\MockTeamCityCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\Debug\MockTeamCityCommandTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Command\Debug\MockTeamCityCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Command\Debug\MockTeamCityCommandTest`.'
 count = 1
 
 [[issues]]
@@ -6101,18 +5585,6 @@ file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Debug\MockTeamCityCommandTest::test_it_reads_log_from_stdin_when_no_file_provided`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\DescribeCommandTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\Command\DescribeCommandTest`.'
-count = 5
 
 [[issues]]
 file = "tests/phpunit/Command/DescribeCommandTest.php"
@@ -6146,50 +5618,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\Git\GitBaseReferenceCommandTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Command\Git\GitBaseReferenceCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Command\Git\GitBaseReferenceCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Command\Git\GitBaseReferenceCommandTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Command\Git\GitBaseReferenceCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_outputs_the_base_reference_with_provided_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -6203,42 +5633,6 @@ file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 3
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Tests\Command\Git\GitChangedFilesCommandTest::createCommandTester`: expected `Infection\Git\Git`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\Git\GitChangedFilesCommandTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Command\Git\GitChangedFilesCommandTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Command\Git\GitChangedFilesCommandTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Command\Git\GitChangedFilesCommandTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
@@ -6247,24 +5641,6 @@ message = 'Potentially unhandled exception `RuntimeException` in `Infection\Test
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unused-property"
-message = "Property `$cwd` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `commandExecutionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -6278,92 +5654,14 @@ count = 3
 
 [[issues]]
 file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Tests\Command\Git\GitChangedLinesCommandTest::createCommandTester`: expected `Infection\Git\Git`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\Git\GitChangedLinesCommandTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Command\Git\GitChangedLinesCommandTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Command\Git\GitChangedLinesCommandTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Command\Git\GitChangedLinesCommandTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::test_it_outputs_changed_lines`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "unused-property"
-message = "Property `$cwd` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\Git\GitDefaultBaseCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Command\Git\GitDefaultBaseCommandTest`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitDefaultBaseCommandTest::test_it_outputs_the_default_base`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -6386,38 +5684,8 @@ count = 8
 
 [[issues]]
 file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "unused-property"
-message = "Property `$cwd` is never used."
 count = 1
 
 [[issues]]
@@ -6428,56 +5696,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::test_it_lists_source_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "unused-property"
-message = "Property `$cwd` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\MakeCustomMutatorCommandTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\Command\MakeCustomMutatorCommandTest`.'
-count = 18
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Command\MakeCustomMutatorCommandTest`.'
 count = 1
 
 [[issues]]
@@ -6565,66 +5785,6 @@ message = "Type `iterable` in return type of `providesUsesGitHubLogger` is impre
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\RunCommandHelperTest`.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Command\RunCommandHelperTest`.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Command\RunCommandTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Command\RunCommandTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Command\RunCommandTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Config/ConsoleHelperTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Config/ConsoleHelperTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Config\ConsoleHelperTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Config/ConsoleHelperTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Config\ConsoleHelperTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `providesJsonComposerAndLocations` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -6637,40 +5797,10 @@ message = 'Invalid argument type for argument #1 of `Infection\Config\Guesser\Ph
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Config\Guesser\PhpUnitPathGuesserTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `Infection\Config\Guesser\SourceDirGuesser::__construct`: expected `stdClass`, but found `mixed`.'
 count = 8
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\Config\Guesser\SourceDirGuesserTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Config\Guesser\SourceDirGuesserTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Config\Guesser\SourceDirGuesserTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/SourceDirGuesserTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Config\Guesser\SourceDirGuesserTest`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/BaseProviderTestCase.php"
@@ -6722,42 +5852,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Config\ValueProvider\ExcludeDirsProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontains` does not exist on type `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Random\RandomException` in `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest::setUp`.'
 count = 1
@@ -6769,232 +5863,10 @@ message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Excepti
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "unused-property"
-message = "Property `$fileSystem` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Config\ValueProvider\PCOVDirectoryProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Config\ValueProvider\PCOVDirectoryProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Config\ValueProvider\PCOVDirectoryProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Config\ValueProvider\PCOVDirectoryProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Config\ValueProvider\PhpUnitCustomExecutablePathProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Config\ValueProvider\PhpUnitCustomExecutablePathProviderTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 5
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Config\ValueProvider\SourceDirsProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Config\ValueProvider\SourceDirsProviderTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Config\ValueProvider\SourceDirsProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Config\ValueProvider\SourceDirsProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Config\ValueProvider\SourceDirsProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/SourceDirsProviderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertdirectoryexists` does not exist on type `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "non-existent-method"
-message = 'Method `throwexception` does not exist on type `Infection\Tests\Config\ValueProvider\TestFrameworkConfigPathProviderTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Config\ValueProvider\TextLogFileProvider::__construct`: expected `Infection\Config\ConsoleHelper`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\Config\ValueProvider\TextLogFileProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Config\ValueProvider\TextLogFileProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Config\ValueProvider\TextLogFileProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/TextLogFileProviderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/ConfigurationBuilder.php"
@@ -7006,12 +5878,6 @@ count = 1
 file = "tests/phpunit/Configuration/ConfigurationBuilder.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Mutator\FakeMutator` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Configuration\ConfigurationBuilderTest`.'
 count = 1
 
 [[issues]]
@@ -7036,18 +5902,6 @@ count = 1
 file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Mutator\CustomMutator` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryTest`.'
 count = 1
 
 [[issues]]
@@ -7081,34 +5935,16 @@ message = "Type `iterable` in return type of `staticAnalysisToolOptionsProvider`
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Configuration/ConfigurationTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Configuration\ConfigurationTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Configuration/Entry/LogsBuilderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `logsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Configuration/Entry/LogsBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Configuration\Entry\LogsBuilderTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Configuration/Entry/MagoTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `basePathProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Entry/MagoTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Configuration\Entry\MagoTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Entry/PhpStanTest.php"
@@ -7117,45 +5953,15 @@ message = "Type `iterable` in return type of `basePathProvider` is imprecise, eq
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Configuration/Entry/PhpStanTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Configuration\Entry\PhpStanTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/Configuration/Entry/PhpUnitTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `basePathProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Entry/PhpUnitTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Configuration\Entry\PhpUnitTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Entry/StrykerConfigTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `branch_names_to_be_matched` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Entry/StrykerConfigTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotnull` does not exist on type `Infection\Tests\Configuration\Entry\StrykerConfigTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Entry/StrykerConfigTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Configuration\Entry\StrykerConfigTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Configuration/Entry/StrykerConfigTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Configuration\Entry\StrykerConfigTest`.'
 count = 1
 
 [[issues]]
@@ -7165,45 +5971,15 @@ message = "Type `iterable` in return type of `jsonErrorProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Configuration/Schema/InvalidFileTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\Configuration\Schema\InvalidFileTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/InvalidFileTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Configuration\Schema\InvalidFileTest`.'
-count = 9
-
-[[issues]]
 file = "tests/phpunit/Configuration/Schema/InvalidSchemaTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `configWithErrorsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Configuration/Schema/InvalidSchemaTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\Configuration\Schema\InvalidSchemaTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/InvalidSchemaTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Configuration\Schema\InvalidSchemaTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationBuilderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `configurationProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationBuilderTest`.'
 count = 1
 
 [[issues]]
@@ -7259,18 +6035,6 @@ file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationFactoryTest`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
@@ -7676,38 +6440,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "non-existent-method"
-message = 'Method `assertSame` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest::test_it_create_a_configuration_from_a_file_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -7718,39 +6452,9 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationFileTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotnull` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationFileTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationFileTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationFileTest`.'
-count = 8
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationFileTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
 code = "possible-method-access-on-null"
 message = "Attempting to call a method on `null`."
-count = 6
+count = 3
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
@@ -7784,32 +6488,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest::configurationPathsProvider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -7823,24 +6503,6 @@ file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Configuration\Schema\SchemaValidatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\Configuration\Schema\SchemaValidatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Configuration\Schema\SchemaValidatorTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
@@ -7858,36 +6520,6 @@ count = 1
 file = "tests/phpunit/Configuration/SourceFilter/PlainFilterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `valueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/SourceFilter/PlainFilterTest.php"
-code = "non-existent-method"
-message = 'Method `assertequalscanonicalizing` does not exist on type `Infection\Tests\Configuration\SourceFilter\PlainFilterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/SourceFilter/PlainFilterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Configuration\SourceFilter\PlainFilterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ConsoleOutputTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Console\ConsoleOutputTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Console/ConsoleOutputTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Console\ConsoleOutputTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ConsoleOutputTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -7940,54 +6572,6 @@ count = 9
 
 [[issues]]
 file = "tests/phpunit/Console/E2ETest.php"
-code = "non-existent-method"
-message = 'Method `assertdirectoryexists` does not exist on type `Infection\Tests\Console\E2ETest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "non-existent-method"
-message = 'Method `assertmatchesregularexpression` does not exist on type `Infection\Tests\Console\E2ETest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "non-existent-method"
-message = 'Method `assertnotempty` does not exist on type `Infection\Tests\Console\E2ETest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Console\E2ETest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\Console\E2ETest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "non-existent-method"
-message = 'Method `assertstringequalsfile` does not exist on type `Infection\Tests\Console\E2ETest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "non-existent-method"
-message = 'Method `marktestincomplete` does not exist on type `Infection\Tests\Console\E2ETest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Console\E2ETest`.'
-count = 9
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Exception` in `Infection\Tests\Console\E2ETest::runInfection`.'
 count = 1
@@ -8023,54 +6607,6 @@ message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unused-property"
-message = "Property `$cwd` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/IOTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\Console\IOTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Console/IOTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Console\IOTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/IOTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Console\IOTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/IOTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Console\IOTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Console/IOTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Console\IOTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Console/Input/MsiParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -8089,99 +6625,15 @@ message = "Type `iterable` in return type of `validValueProvider` is imprecise, 
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Console/Input/MsiParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Console\Input\MsiParserTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Console/Input/MsiParserTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Console\Input\MsiParserTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/Input/MsiParserTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Console\Input\MsiParserTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Console/LogVerbosityTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `convertedLogVerbosityProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\Console\LogVerbosityTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Console\LogVerbosityTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Console\LogVerbosityTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/OutputFormatterStyleConfiguratorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Console/OutputFormatterStyleConfiguratorTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Console\OutputFormatterStyleConfiguratorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/OutputFormatterStyleConfiguratorTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Console\OutputFormatterStyleConfiguratorTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Container/Builder/IndexXmlCoverageParserBuilderTest.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `Infection\Tests\Container\Builder\IndexXmlCoverageParserBuilderTest::getIsSourceFiltered`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/Builder/IndexXmlCoverageParserBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Container\Builder\IndexXmlCoverageParserBuilderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/Builder/IndexXmlCoverageParserBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Container\Builder\IndexXmlCoverageParserBuilderTest`.'
 count = 1
 
 [[issues]]
@@ -8212,48 +6664,6 @@ count = 1
 file = "tests/phpunit/Container/ContainerTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Container\ContainerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Container\ContainerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\Container\ContainerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Container\ContainerTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Container\ContainerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\Container\ContainerTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Container\ContainerTest`.'
 count = 1
 
 [[issues]]
@@ -8299,160 +6709,10 @@ message = "Type `iterable` in return type of `rangeProvider` is imprecise, equiv
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Differ/ChangedLinesRangeTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Differ\ChangedLinesRangeTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Differ/ChangedLinesRangeTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Differ\ChangedLinesRangeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Differ/ChangedLinesRangeTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Differ\ChangedLinesRangeTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Differ/DiffColorizerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Differ\DiffColorizerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Differ/DiffSourceCodeMatcherTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Differ\DiffSourceCodeMatcherTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Differ/DiffSourceCodeMatcherTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Differ/DifferTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `diffProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Differ/DifferTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Differ\DifferTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Differ/DifferTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 18
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 96
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #10 of `Infection\Engine::__construct`: expected `Infection\Metrics\MaxTimeoutsChecker`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #11 of `Infection\Engine::__construct`: expected `Infection\Console\ConsoleOutput`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #13 of `Infection\Engine::__construct`: expected `Infection\TestFramework\TestFrameworkExtraOptionsFilter`, but found `mixed`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #15 of `Infection\Engine::__construct`: expected `Infection\StaticAnalysis\StaticAnalysisToolAdapter|null`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Engine::__construct`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 15
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\EngineTest`.'
-count = 18
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\EngineTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "non-existent-method"
-message = 'Method `atleastonce` does not exist on type `Infection\Tests\EngineTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "non-existent-method"
-message = 'Method `callback` does not exist on type `Infection\Tests\EngineTest`.'
-count = 12
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\EngineTest`.'
-count = 15
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\EngineTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\EngineTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\EngineTest`.'
-count = 22
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\EngineTest`.'
-count = 70
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
@@ -8899,18 +7159,6 @@ message = "Redundant type assertion: `$environmentVariables` of type `array<stri
 count = 1
 
 [[issues]]
-file = "tests/phpunit/EnvVariableManipulation/EnvBackupTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\EnvVariableManipulation\EnvBackupTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EnvVariableManipulation/EnvBackupTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\EnvVariableManipulation\EnvBackupTest`.'
-count = 4
-
-[[issues]]
 file = "tests/phpunit/Environment/BuildContextResolverTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideBlankOrEmptyString` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -8921,54 +7169,6 @@ file = "tests/phpunit/Environment/BuildContextResolverTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 17
-
-[[issues]]
-file = "tests/phpunit/Environment/BuildContextResolverTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Environment\BuildContextResolverTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Environment/BuildContextResolverTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Environment\BuildContextResolverTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Environment/BuildContextResolverTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Environment\BuildContextResolverTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Environment/BuildContextTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Environment\BuildContextTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Environment/CouldNotResolveBuildContextTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Environment\CouldNotResolveBuildContextTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/CouldNotResolveStrykerApiKeyTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Environment\CouldNotResolveStrykerApiKeyTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/StrykerApiKeyResolverTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Environment\StrykerApiKeyResolverTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Environment/StrykerApiKeyResolverTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Environment\StrykerApiKeyResolverTest`.'
-count = 3
 
 [[issues]]
 file = "tests/phpunit/Environment/StrykerApiKeyResolverTest.php"
@@ -9014,6 +7214,12 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$userSubscriber->count` of type `null` can never be `int(0)`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
 code = "invalid-property-access"
 message = "Attempting to access a property on a non-object type (`never`)."
 count = 1
@@ -9029,6 +7235,12 @@ file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
 code = "no-value"
 message = 'Argument #1 passed to method `Infection\Event\EventDispatcher\SyncEventDispatcher::dispatch` has type `never`, meaning it cannot produce a value.'
 count = 2
+
+[[issues]]
+file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
+code = "no-value"
+message = 'Argument #2 passed to method `PHPUnit\Framework\Assert::assertSame` has type `never`, meaning it cannot produce a value.'
+count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
@@ -9053,132 +7265,6 @@ file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Event\UserWasCreated` not found.'
 count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Event\EventDispatcher\SyncEventDispatcherTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Event/Events/Application/ApplicationExecutionWasFinishedTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Event\Events\Application\ApplicationExecutionWasFinishedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/Application/ApplicationExecutionWasStartedTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Event\Events\Application\ApplicationExecutionWasStartedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/ArtefactCollection/InitialStaticAnalysis/InitialStaticAnalysisRunWasFinishedTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Event\Events\ArtefactCollection\InitialStaticAnalysis\InitialStaticAnalysisRunWasFinishedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/ArtefactCollection/InitialStaticAnalysis/InitialStaticAnalysisRunWasStartedTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Event\Events\ArtefactCollection\InitialStaticAnalysis\InitialStaticAnalysisRunWasStartedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/ArtefactCollection/InitialStaticAnalysis/InitialStaticAnalysisSubStepWasCompletedTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Event\Events\ArtefactCollection\InitialStaticAnalysis\InitialStaticAnalysisSubStepWasCompletedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/ArtefactCollection/InitialTestExecution/InitialTestCaseWasCompletedTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Event\Events\ArtefactCollection\InitialTestExecution\InitialTestCaseWasCompletedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/ArtefactCollection/InitialTestExecution/InitialTestSuiteWasFinishedTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Event\Events\ArtefactCollection\InitialTestExecution\InitialTestSuiteWasFinishedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/ArtefactCollection/InitialTestExecution/InitialTestSuiteWasStartedTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Event\Events\ArtefactCollection\InitialTestExecution\InitialTestSuiteWasStartedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationEvaluation/MutantProcessWasFinishedTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished::__construct`: expected `Infection\Mutant\MutantExecutionResult`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationEvaluation/MutantProcessWasFinishedTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationEvaluation/MutantProcessWasFinishedTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinishedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationEvaluation/MutantProcessWasFinishedTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinishedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationGeneration/MutableFileWasProcessedTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Event\Events\MutationAnalysis\MutationGeneration\MutableFileWasProcessedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationGeneration/MutationGenerationWasFinishedTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Event\Events\MutationAnalysis\MutationGeneration\MutationGenerationWasFinishedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationGeneration/MutationGenerationWasStartedTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Event\Events\MutationAnalysis\MutationGeneration\MutationGenerationWasStartedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationTestingWasFinishedTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Event\Events\MutationAnalysis\MutationTestingWasFinishedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationTestingWasStartedTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted::__construct`: expected `Infection\Process\Runner\ProcessRunner`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationTestingWasStartedTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationTestingWasStartedTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Event\Events\MutationAnalysis\MutationTestingWasStartedTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Event/Events/MutationAnalysis/MutationTestingWasStartedTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Event\Events\MutationAnalysis\MutationTestingWasStartedTest`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
@@ -9229,202 +7315,16 @@ message = 'Class `Infection\Tests\Fixtures\Event\IONullSubscriber` not found.'
 count = 3
 
 [[issues]]
-file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\Event\Subscriber\ChainSubscriberFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Event\Subscriber\ChainSubscriberFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `identicalto` does not exist on type `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Event\Subscriber\InitialStaticAnalysisExecutionLoggerSubscriberTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialStaticAnalysisExecutionLoggerSubscriberTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `identicalto` does not exist on type `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Event\Subscriber\InitialTestsExecutionLoggerSubscriberTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/InitialTestsExecutionLoggerSubscriberTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted::__construct`: expected `Infection\Process\Runner\ProcessRunner`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `identicalto` does not exist on type `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Event\Subscriber\MutationAnalysisLoggerSubscriberTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Event\Subscriber\MutationGenerationLoggerSubscriberTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationTestingResultsCollectorSubscriberTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/MutationTestingResultsCollectorSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Event\Subscriber\MutationTestingResultsCollectorSubscriberTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/ReportAfterMutationTestingFinishedSubscriberTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/ReportAfterMutationTestingFinishedSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Event\Subscriber\ReportAfterMutationTestingFinishedSubscriberTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "invalid-method-access"
 message = 'Attempting to access a method on a non-object type (`unknown-ref(Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher)`).'
 count = 4
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #2 of `PHPUnit\Framework\Assert::assertCount`: expected `Countable|iterable<mixed, mixed>`, but found `mixed`.'
+count = 3
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
@@ -9464,68 +7364,14 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\Event\Subscriber\SubscriberRegistererTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Event\Subscriber\SubscriberRegistererTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "possibly-invalid-argument"
 message = 'Possible argument type mismatch for argument #1 of `Infection\Event\Subscriber\SubscriberRegisterer::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher)`.'
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\FileSystem\FileStore::getContents`: expected `SplFileInfo|string`, but found `mixed`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "mixed-method-access"
-message = "Attempting to access a method on a non-object type (`mixed`)."
-count = 4
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\FileSystem\FileStoreTest`.'
-count = 8
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\FileSystem\FileStoreTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\FileSystem\FileStoreTest`.'
+code = "missing-magic-method"
+message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 2
 
 [[issues]]
@@ -9541,12 +7387,6 @@ message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Excepti
 count = 1
 
 [[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/FileSystem/FileSystemTestCase.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\FileSystemTestCase::setUp`.'
@@ -9559,18 +7399,6 @@ message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Excepti
 count = 1
 
 [[issues]]
-file = "tests/phpunit/FileSystem/Finder/Exception/FinderExceptionTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\FileSystem\Finder\Exception\FinderExceptionTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/Exception/FinderExceptionTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\FileSystem\Finder\Exception\FinderExceptionTest`.'
-count = 5
-
-[[issues]]
 file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
 code = "ambiguous-object-method-access"
 message = "Cannot statically verify method call on a generic `object` type."
@@ -9580,6 +7408,12 @@ count = 1
 file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `providesFinders` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #2 of `PHPUnit\Framework\Assert::assertCount`: expected `Countable|iterable<mixed, mixed>`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -9596,45 +7430,9 @@ count = 4
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\FileSystem\Finder\Iterator\RealPathFilterIteratorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\FileSystem\Finder\Iterator\RealPathFilterIteratorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\FileSystem\Finder\MemoizedComposerExecutableFinderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\FileSystem\Finder\MemoizedComposerExecutableFinderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\FileSystem\Finder\MemoizedComposerExecutableFinderTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/MockVendor.php"
@@ -9658,42 +7456,6 @@ count = 1
 file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "non-existent-method"
-message = 'Method `assertgreaterthan` does not exist on type `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotsame` does not exist on type `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest`.'
 count = 1
 
 [[issues]]
@@ -9734,42 +7496,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "non-existent-method"
-message = 'Method `assertgreaterthan` does not exist on type `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotsame` does not exist on type `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
 code = "possibly-false-argument"
 message = "Argument #1 of function `strlen` is possibly `false`, but parameter type `string` does not accept it."
 count = 2
@@ -9800,36 +7526,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\FileSystem\InMemoryFileSystemTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\FileSystem\InMemoryFileSystemTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\FileSystem\InMemoryFileSystemTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\FileSystem\InMemoryFileSystemTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\FileSystem\InMemoryFileSystemTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\InMemoryFileSystemTest::test_it_can_dump_and_read_a_file`.'
 count = 1
@@ -9853,12 +7549,6 @@ message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Excepti
 count = 1
 
 [[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/FileSystem/Locator/FileNotFoundTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `multipleNonExistentPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -9869,18 +7559,6 @@ file = "tests/phpunit/FileSystem/Locator/FileNotFoundTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nonExistentPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/FileNotFoundTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\FileSystem\Locator\FileNotFoundTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/FileNotFoundTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\FileSystem\Locator\FileNotFoundTest`.'
-count = 4
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php"
@@ -9899,18 +7577,6 @@ file = "tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nonExistentPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\FileSystem\Locator\FileOrDirectoryNotFoundTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\FileSystem\Locator\FileOrDirectoryNotFoundTest`.'
-count = 6
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
@@ -9935,24 +7601,6 @@ file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `pathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
@@ -9991,12 +7639,6 @@ message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrD
 count = 1
 
 [[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -10019,24 +7661,6 @@ file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `pathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
@@ -10075,18 +7699,6 @@ message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrD
 count = 1
 
 [[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/ProjectDirProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertisstring` does not exist on type `Infection\Tests\FileSystem\ProjectDirProviderTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/FileSystem/TmpDirProviderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidTmpDirProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -10096,24 +7708,6 @@ count = 1
 file = "tests/phpunit/FileSystem/TmpDirProviderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `tmpDirProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/TmpDirProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\FileSystem\TmpDirProviderTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/FileSystem/TmpDirProviderTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\FileSystem\TmpDirProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/TmpDirProviderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -10147,18 +7741,6 @@ message = "Type `iterable` in return type of `sourceClassNamesProvider` is impre
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Framework/ClassNameTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Framework\ClassNameTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Framework/ClassNameTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\Framework\ClassNameTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/Framework/Enum/EnumBucket/EnumBucketTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `enumProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -10184,30 +7766,6 @@ count = 3
 
 [[issues]]
 file = "tests/phpunit/Framework/Enum/EnumBucket/EnumBucketTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Framework\Enum\EnumBucket\EnumBucketTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/Enum/EnumBucket/EnumBucketTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Framework\Enum\EnumBucket\EnumBucketTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Framework/Enum/EnumBucket/EnumBucketTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Framework\Enum\EnumBucket\EnumBucketTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Framework/Enum/EnumBucket/EnumBucketTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\Framework\Enum\EnumBucket\EnumBucketTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Framework/Enum/EnumBucket/EnumBucketTest.php"
 code = "template-constraint-violation"
 message = "Argument type mismatch for template `T`."
 count = 3
@@ -10219,46 +7777,10 @@ message = "Type `iterable` in return type of `separatorProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Framework/Enum/ImplodableEnum/ImplodableEnumTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Framework\Enum\ImplodableEnum\ImplodableEnumTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/Framework/Iterable/GeneratorFactory/GeneratorFactoryTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `iterableProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/Iterable/GeneratorFactory/GeneratorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Framework\Iterable\GeneratorFactory\GeneratorFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/Iterable/GeneratorFactory/GeneratorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Framework\Iterable\GeneratorFactory\GeneratorFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/Iterable/IterableCounterTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Framework\Iterable\IterableCounterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/Iterable/IterableCounterTest.php"
-code = "non-existent-method"
-message = 'Method `assertisarray` does not exist on type `Infection\Tests\Framework\Iterable\IterableCounterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/Iterable/IterableCounterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Framework\Iterable\IterableCounterTest`.'
-count = 5
 
 [[issues]]
 file = "tests/phpunit/Framework/StrTest.php"
@@ -10288,60 +7810,6 @@ count = 1
 file = "tests/phpunit/Framework/StrTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `utf8StringConversionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/StrTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Framework\StrTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `assertarrayhaskey` does not exist on type `Infection\Tests\Git\CommandLineGitIntegrationTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `assertarraynothaskey` does not exist on type `Infection\Tests\Git\CommandLineGitIntegrationTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontains` does not exist on type `Infection\Tests\Git\CommandLineGitIntegrationTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotsame` does not exist on type `Infection\Tests\Git\CommandLineGitIntegrationTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Git\CommandLineGitIntegrationTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Git\CommandLineGitIntegrationTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `markTestSkipped` does not exist on type `Infection\Tests\Git\CommandLineGitIntegrationTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Git\CommandLineGitIntegrationTest`.'
 count = 1
 
 [[issues]]
@@ -10387,12 +7855,6 @@ message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Git/CommandLineGitTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `defaultGitBaseProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -10409,24 +7871,6 @@ file = "tests/phpunit/Git/CommandLineGitTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 7
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Git\CommandLineGitTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Git\CommandLineGitTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Git\CommandLineGitTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Git/CommandLineGitTest.php"
@@ -10447,64 +7891,10 @@ message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceF
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\ArtefactCollection\ConsoleNoProgressLoggerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Logger\ArtefactCollection\ConsoleNoProgressLoggerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 5
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Logger\ArtefactCollection\ConsoleProgressBarLoggerTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
@@ -10519,42 +7909,6 @@ message = "Call to documented magic method `method()` on a class that cannot han
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\Logger\ArtefactCollection\InitialStaticAnalysisExecution\InitialStaticAnalysisExecutionLoggerFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Logger\ArtefactCollection\InitialStaticAnalysisExecution\InitialStaticAnalysisExecutionLoggerFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Logger\ArtefactCollection\InitialStaticAnalysisExecution\InitialStaticAnalysisExecutionLoggerFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `debugProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -10564,42 +7918,6 @@ count = 1
 file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLoggerFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLoggerFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLoggerFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -10612,12 +7930,6 @@ count = 1
 file = "tests/phpunit/Logger/Console/BasicConsoleLoggerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideLogsInNormalVerbosity` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/BasicConsoleLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\Console\BasicConsoleLoggerTest`.'
 count = 1
 
 [[issues]]
@@ -10639,34 +7951,10 @@ message = "Parameter `$value` is missing a type hint."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Logger/Console/ConsoleLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\Console\ConsoleLoggerTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/ConsoleLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Logger\Console\ConsoleLoggerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/ConsoleLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Logger\Console\ConsoleLoggerTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `detectionStatusProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\MutationAnalysis\ConsoleDotLoggerTest`.'
-count = 4
 
 [[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/MutationAnalysisLoggerFactoryTest.php"
@@ -10682,21 +7970,9 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/MutationAnalysisLoggerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Logger\MutationAnalysis\MutationAnalysisLoggerFactoryTest`.'
+code = "possibly-invalid-argument"
+message = '''Possible argument type mismatch for argument #1 of `PHPUnit\Framework\Assert::assertInstanceOf`: expected `class-string<'ExpectedType.phpunit\framework\assert::assertinstanceof() extends object>`, but possibly received `string`.'''
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/NodeIdFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotsame` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\NodeIdFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/NodeIdFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\NodeIdFactoryTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/RemoveInternalBlankLinesTest.php"
@@ -10705,45 +7981,9 @@ message = "Type `iterable` in return type of `linesProvider` is imprecise, equiv
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/RemoveInternalBlankLinesTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\RemoveInternalBlankLinesTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerStateTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\TeamCityLoggerStateTest`.'
-count = 6
-
-[[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `executionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `assertCount` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\TeamCityLoggerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\TeamCityLoggerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\TeamCityLoggerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -10765,69 +8005,15 @@ message = "Type `iterable` in return type of `startedProvider` is imprecise, equ
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\TeamCityTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TestSuiteTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `suiteProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TestSuiteTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\TestSuiteTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TestTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `caseProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TestTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Logger\MutationAnalysis\TeamCity\TestTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleNoProgressLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Logger\MutationGeneration\ConsoleNoProgressLoggerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleNoProgressLoggerTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleProgressBarLoggerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleProgressBarLoggerTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Logger\MutationGeneration\ConsoleProgressBarLoggerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/ConsoleProgressBarLoggerTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -10849,12 +8035,6 @@ message = 'Class `Infection\Tests\Fixtures\Console\FakeOutput` not found.'
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Logger/MutationGeneration/MutationGenerationLoggerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Logger\MutationGeneration\MutationGenerationLoggerFactoryTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/Metrics/CalculatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `metricsCalculatorProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -10867,96 +8047,6 @@ message = "Type `iterable` in return type of `metricsProvider` is imprecise, equ
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Metrics/CalculatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Metrics\CalculatorTest`.'
-count = 9
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Metrics\FilteringResultsCollectorFactory::create`: expected `Infection\Metrics\Collector`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Metrics\FilteringResultsCollectorFactoryTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorFactoryTest.php"
-code = "possibly-null-argument"
-message = 'Argument #1 of method `Infection\Tests\Metrics\CreateMutantExecutionResult::addMutantExecutionResult` is possibly `null`, but parameter type `Infection\Metrics\Collector` does not accept it.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Metrics\FilteringResultsCollectorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/FilteringResultsCollectorTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Metrics\FilteringResultsCollectorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MaxTimeoutCountReachedTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Metrics\MaxTimeoutCountReachedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MaxTimeoutCountReachedTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Metrics\MaxTimeoutCountReachedTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/Metrics/MaxTimeoutsCheckerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `exceptionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -10966,18 +8056,6 @@ count = 1
 file = "tests/phpunit/Metrics/MaxTimeoutsCheckerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `noExceptionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MaxTimeoutsCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\Metrics\MaxTimeoutsCheckerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MaxTimeoutsCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\Metrics\MaxTimeoutsCheckerTest`.'
 count = 1
 
 [[issues]]
@@ -11000,38 +8078,8 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Metrics/MetricsCalculatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Metrics\MetricsCalculatorTest`.'
-count = 27
-
-[[issues]]
-file = "tests/phpunit/Metrics/MetricsCalculatorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Metrics\MetricsCalculatorTest::test_calculator_is_memoized`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MinMsiCheckFailedTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Metrics\MinMsiCheckFailedTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/MinMsiCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Metrics\MinMsiCheckerTest`.'
-count = 10
-
-[[issues]]
-file = "tests/phpunit/Metrics/MinMsiCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Metrics\MinMsiCheckerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/MinMsiCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Metrics\MinMsiCheckerTest`.'
 count = 1
 
 [[issues]]
@@ -11071,28 +8119,10 @@ message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed`
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Metrics/MinMsiCheckerTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/ResultsCollectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Metrics\ResultsCollectorTest`.'
-count = 14
-
-[[issues]]
 file = "tests/phpunit/Metrics/SortableMutantExecutionResultsTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `resultsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/SortableMutantExecutionResultsTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Metrics\SortableMutantExecutionResultsTest`.'
-count = 3
 
 [[issues]]
 file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
@@ -11105,54 +8135,6 @@ file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
 code = "invalid-argument"
 message = 'Invalid argument type for argument #2 of `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest::assertProvides`: expected `array<array-key, enum(Infection\Mutant\DetectionStatus)>`, but found `array<key-of<enum(Infection\Mutant\DetectionStatus)>, enum(Infection\Mutant\DetectionStatus)>`.'
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Metrics\TargetDetectionStatusesProvider::__construct`: expected `Infection\Configuration\Entry\Logs`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 16
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertequalscanonicalizing` does not exist on type `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/TargetDetectionStatusesProviderTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Metrics\TargetDetectionStatusesProviderTest`.'
-count = 14
 
 [[issues]]
 file = "tests/phpunit/MockedContainer.php"
@@ -11173,33 +8155,9 @@ message = "Type `iterable` in return type of `detectionStatusProvider` is imprec
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutant/DetectionStatusTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutant\DetectionStatusTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantAssertions.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Mutant\MutantAssertions`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantAssertions.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutant\MutantAssertions`.'
-count = 4
-
-[[issues]]
 file = "tests/phpunit/Mutant/MutantAssertionsTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutantProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantAssertionsTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Mutant\MutantAssertionsTest`.'
 count = 1
 
 [[issues]]
@@ -11215,40 +8173,10 @@ message = "Type `iterable` in return type of `mutationProvider` is imprecise, eq
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutant/MutantCodeFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutant\MutantCodeFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantCodeFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutant/MutantCodePrinterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `statementsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantCodePrinterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutant\MutantCodePrinterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantCodePrinterTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantExecutionResultAssertions.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutant\MutantExecutionResultAssertions`.'
-count = 7
 
 [[issues]]
 file = "tests/phpunit/Mutant/MutantExecutionResultAssertionsTest.php"
@@ -11257,39 +8185,9 @@ message = "Type `iterable` in return type of `mutantExecutionResultProvider` is 
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutant/MutantExecutionResultAssertionsTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Mutant\MutantExecutionResultAssertionsTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutant/MutantExecutionResultBuilderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `executionResultProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `atleastonce` does not exist on type `Infection\Tests\Mutant\MutantFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Mutant\MutantFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -11311,69 +8209,9 @@ message = "Call to documented magic method `method()` on a class that cannot han
 count = 18
 
 [[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 10
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Mutant\TestFrameworkMutantExecutionResultFactoryTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `assertarrayhaskey` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorIntegrationTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontainsonlyinstancesof` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorIntegrationTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorIntegrationTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorIntegrationTest`.'
+code = "redundant-type-comparison"
+message = 'Redundant type assertion: `$mutations` of type `list<Infection\Mutation\Mutation>` is always not `iterable<mixed, Infection\Mutation\Mutation>`.'
 count = 1
 
 [[issues]]
@@ -11398,43 +8236,7 @@ count = 1
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\FileSystem\FileStore::__construct`: expected `Infection\FileSystem\FileSystem`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 10
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #4 of `Infection\Mutation\FileMutationGenerator::__construct`: expected `Infection\Source\Matcher\SourceLineMatcher`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "mixed-method-access"
-message = "Attempting to access a method on a non-object type (`mixed`)."
-count = 2
+count = 7
 
 [[issues]]
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
@@ -11447,54 +8249,6 @@ file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.p
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\PhpParser\FakeNode` not found.'
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `assertTrue` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest`.'
-count = 6
 
 [[issues]]
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
@@ -11521,39 +8275,15 @@ message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceF
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutation/MutationAssertionsTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutation/MutationAssertionsTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Mutation\MutationAssertionsTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutation/MutationAttributeKeysTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `attributesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationAttributeKeysTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutation\MutationAttributeKeysTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationAttributeKeysTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\Mutation\MutationAttributeKeysTest`.'
 count = 1
 
 [[issues]]
@@ -11575,30 +8305,6 @@ message = "Type `iterable` in return type of `mutationProvider` is imprecise, eq
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutation/MutationBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutation\MutationBuilderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `Infection\Mutation\MutationGenerator::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 4
-
-[[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "no-value"
 message = 'Argument #2 passed to method `Infection\Mutator\IgnoreMutator::__construct` has type `never`, meaning it cannot produce a value.'
@@ -11609,24 +8315,6 @@ file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Mutator\FakeMutator` not found.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutation\MutationGeneratorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Mutation\MutationGeneratorTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Mutation\MutationGeneratorTest`.'
-count = 3
 
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
@@ -11723,12 +8411,6 @@ file = "tests/phpunit/Mutation/MutationTest.php"
 code = "less-specific-argument"
 message = 'Argument type mismatch for argument #5 of `Infection\Mutation\Mutation::__construct`: expected `array<string, float|int|string>`, but provided type `array<array-key, float|int|string>` is less specific.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutation\MutationTest`.'
-count = 14
 
 [[issues]]
 file = "tests/phpunit/Mutator/Arithmetic/AssignmentEqualTest.php"
@@ -11857,18 +8539,6 @@ message = 'Invalid argument type for argument #1 of `PhpParser\Node\Expr\Array_:
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/PlusTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\Arithmetic\PlusTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/PlusTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\Arithmetic\PlusTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/Arithmetic/PowEqualTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -11923,18 +8593,6 @@ message = "Type `iterable` in return type of `mutationsProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/Boolean/FalseValueTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\Boolean\FalseValueTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/FalseValueTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\Boolean\FalseValueTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/Boolean/InstanceOf_Test.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -11980,18 +8638,6 @@ count = 1
 file = "tests/phpunit/Mutator/Boolean/LogicalNotTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalNotTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\Boolean\LogicalNotTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalNotTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\Boolean\LogicalNotTest`.'
 count = 1
 
 [[issues]]
@@ -12074,18 +8720,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/Boolean/TrueValueConfigTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\Boolean\TrueValueConfigTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/TrueValueConfigTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Mutator\Boolean\TrueValueConfigTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/TrueValueConfigTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Boolean\TrueValueConfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
 count = 1
@@ -12094,18 +8728,6 @@ count = 1
 file = "tests/phpunit/Mutator/Boolean/TrueValueTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/TrueValueTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\Boolean\TrueValueTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/TrueValueTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\Boolean\TrueValueTest`.'
 count = 1
 
 [[issues]]
@@ -12236,24 +8858,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/DefinitionTest.php"
-code = "non-existent-method"
-message = 'Method `assertInstanceOf` does not exist on type `Infection\Tests\Mutator\DefinitionTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/DefinitionTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotnull` does not exist on type `Infection\Tests\Mutator\DefinitionTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/DefinitionTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\DefinitionTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutator/DefinitionTest.php"
 code = "possibly-invalid-argument"
 message = 'Possible argument type mismatch for argument #1 of `Infection\Mutator\MutatorFactory::create`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but possibly received `array<class-string, array{}>`.'
 count = 1
@@ -12269,18 +8873,6 @@ file = "tests/phpunit/Mutator/Extensions/BCMathConfigTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `settingsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/BCMathConfigTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\Extensions\BCMathConfigTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/BCMathConfigTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Mutator\Extensions\BCMathConfigTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Mutator/Extensions/BCMathConfigTest.php"
@@ -12347,18 +8939,6 @@ file = "tests/phpunit/Mutator/Extensions/MBStringConfigTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `settingsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringConfigTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\Extensions\MBStringConfigTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringConfigTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Mutator\Extensions\MBStringConfigTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Mutator/Extensions/MBStringConfigTest.php"
@@ -12511,88 +9091,10 @@ message = "Type `iterable` in return type of `nonIgnoredValuesProvider` is impre
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/IgnoreConfigTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\IgnoreConfigTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreConfigTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\IgnoreConfigTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 8
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\IgnoreMutatorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\IgnoreMutatorTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\IgnoreMutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Mutator\IgnoreMutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Mutator\IgnoreMutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Mutator\IgnoreMutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Mutator\IgnoreMutatorTest`.'
-count = 7
-
-[[issues]]
 file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #2 of `Infection\Mutator\IgnoreMutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\ignoremutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/InvalidMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\InvalidMutatorTest`.'
-count = 3
 
 [[issues]]
 file = "tests/phpunit/Mutator/Loop/DoWhileTest.php"
@@ -12650,24 +9152,6 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorCategoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\MutatorCategoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorCategoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\MutatorCategoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorCategoryTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\MutatorCategoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorCategoryTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutator\MutatorCategoryTest::test_it_cannot_be_instantiated`.'
 count = 1
@@ -12676,12 +9160,6 @@ count = 1
 file = "tests/phpunit/Mutator/MutatorCategoryTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutator\MutatorCategoryTest::test_it_lists_all_its_exposed_constants`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -12704,50 +9182,14 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontainsonlyinstancesof` does not exist on type `Infection\Tests\Mutator\MutatorFactoryTest`.'
+code = "no-value"
+message = 'Argument #2 passed to method `Infection\Tests\Mutator\MutatorFactoryTest::assertSameMutatorsByClass` has type `never`, meaning it cannot produce a value.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\Mutator\MutatorFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\MutatorFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Mutator\MutatorFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\MutatorFactoryTest`.'
-count = 5
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
 code = "non-existent-method"
 message = 'Method `expects` does not exist on type `Infection\Reflection\ClassReflection`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Mutator\MutatorFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Mutator\MutatorFactoryTest`.'
 count = 1
 
 [[issues]]
@@ -12787,12 +9229,6 @@ message = 'Potentially unhandled exception `ReflectionException` in `Infection\T
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/MutatorParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutatorInputProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -12800,20 +9236,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\MutatorParserTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorParserTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `UnexpectedValueException` in `Infection\Tests\Mutator\MutatorParserTest::test_it_can_parse_the_provided_input`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorParserTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -12845,48 +9269,6 @@ file = "tests/phpunit/Mutator/MutatorResolverTest.php"
 code = "invalid-array-index"
 message = '''Invalid index type `class-string('Infection\Mutator\Boolean\ArrayAll')|class-string('Infection\Mutator\Boolean\ArrayAny')|class-string('Infection\Mutator\Boolean\ArrayItem')|class-string('Infection\Mutator\Boolean\FalseValue')|class-string('Infection\Mutator\Boolean\InstanceOf_')|class-string('Infection\Mutator\Boolean\LogicalAnd')|class-string('Infection\Mutator\Boolean\LogicalAndAllSubExprNegation')|class-string('Infection\Mutator\Boolean\LogicalAndNegation')|class-string('Infection\Mutator\Boolean\LogicalAndSingleSubExprNegation')|class-string('Infection\Mutator\Boolean\LogicalLowerAnd')|class-string('Infection\Mutator\Boolean\LogicalLowerOr')|class-string('Infection\Mutator\Boolean\LogicalNot')|class-string('Infection\Mutator\Boolean\LogicalOr')|class-string('Infection\Mutator\Boolean\LogicalOrAllSubExprNegation')|class-string('Infection\Mutator\Boolean\LogicalOrNegation')|class-string('Infection\Mutator\Boolean\LogicalOrSingleSubExprNegation')|class-string('Infection\Mutator\Boolean\TrueValue')|class-string('Infection\Mutator\Boolean\Yield_')` used for array access on `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`.'''
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorResolverTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontains` does not exist on type `Infection\Tests\Mutator\MutatorResolverTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorResolverTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\Mutator\MutatorResolverTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorResolverTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\MutatorResolverTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorResolverTest.php"
-code = "non-existent-method"
-message = 'Method `assertisarray` does not exist on type `Infection\Tests\Mutator\MutatorResolverTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorResolverTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\MutatorResolverTest`.'
-count = 21
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorResolverTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\MutatorResolverTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorResolverTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Mutator\MutatorResolverTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorResolverTest.php"
@@ -12944,20 +9326,14 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorResolverTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
+code = "redundant-type-comparison"
+message = "Redundant type assertion: `$settings` of type `array<array-key, mixed>` is always not `array<array-key, mixed>`."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutatorWithCodeCaseProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\Mutator\MutatorRobustnessTest`.'
 count = 1
 
 [[issues]]
@@ -12979,82 +9355,16 @@ message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceF
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/NodeAttributesTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/NodeAttributesTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\NodeAttributesTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "mixed-property-type-coercion"
-message = 'A value with a less specific type `mixed` is being assigned to property `$$nodeStub` (PHPUnit\Framework\MockObject\Stub&PhpParser\Node).'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\NoopMutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\NoopMutatorTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\NoopMutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Mutator\NoopMutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Mutator\NoopMutatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Mutator\NoopMutatorTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/Mutator/NoopMutatorTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\NoopMutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\noopmutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
 count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/NoopMutatorTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/Nullify/ArrayFindKeyTest.php"
@@ -13159,21 +9469,9 @@ message = "Type `iterable` in return type of `mutationsProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/Operator/NullSafeMethodCallTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Mutator\Operator\NullSafeMethodCallTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/Operator/NullSafePropertyCallTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/NullSafePropertyCallTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Mutator\Operator\NullSafePropertyCallTest`.'
 count = 1
 
 [[issues]]
@@ -13279,24 +9577,6 @@ message = 'Potentially unhandled exception `ReflectionException` in `Infection\T
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/ProfileListProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertfileexists` does not exist on type `Infection\Tests\Mutator\ProfileListProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotsame` does not exist on type `Infection\Tests\Mutator\ProfileListProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProviderTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\ProfileListProviderTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/Mutator/ProfileListTest.php"
 code = "imprecise-type"
 message = "Type `array` in parameter `$profileOrMutators` is imprecise, equivalent to `array<array-key, mixed>`."
@@ -13312,24 +9592,6 @@ count = 1
 file = "tests/phpunit/Mutator/ProfileListTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListTest.php"
-code = "non-existent-method"
-message = 'Method `assertarrayhaskey` does not exist on type `Infection\Tests\Mutator\ProfileListTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\ProfileListTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\ProfileListTest`.'
 count = 1
 
 [[issues]]
@@ -13373,18 +9635,6 @@ file = "tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `settingsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\Removal\ArrayItemRemovalConfigTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Mutator\Removal\ArrayItemRemovalConfigTest`.'
-count = 3
 
 [[issues]]
 file = "tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php"
@@ -13483,18 +9733,6 @@ message = "Type `iterable` in return type of `mutationsProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\Mutator\ReturnValue\FunctionCallTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\ReturnValue\FunctionCallTest`.'
-count = 3
-
-[[issues]]
 file = "tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
@@ -13507,21 +9745,9 @@ message = "Type `iterable` in return type of `mutationsProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\ReturnValue\IntegerNegationTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/ReturnValue/NewObjectTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/NewObjectTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Mutator\ReturnValue\NewObjectTest`.'
 count = 1
 
 [[issues]]
@@ -13540,12 +9766,6 @@ count = 1
 file = "tests/phpunit/Mutator/Sort/SpaceshipTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Sort/SpaceshipTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\Sort\SpaceshipTest`.'
 count = 1
 
 [[issues]]
@@ -13858,78 +10078,12 @@ count = 1
 file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
-code = "mixed-method-access"
-message = "Attempting to access a method on a non-object type (`mixed`)."
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
-code = "mixed-property-type-coercion"
-message = 'A value with a less specific type `mixed` is being assigned to property `$$testSubjectStub` (PHPUnit\Framework\MockObject\Stub&Infection\Mutator\Util\AbstractValueToNullReturnValue).'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
-code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::mockFunction`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
-code = "non-existent-method"
-message = 'Method `getmockbuilder` does not exist on type `Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest`.'
-count = 1
+count = 2
 
 [[issues]]
 file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::invokeMethod`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/NameResolverTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Mutator\Util\NameResolverTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/NameResolverTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\Util\NameResolverTest`.'
 count = 1
 
 [[issues]]
@@ -13951,30 +10105,6 @@ message = "Type `iterable` in return type of `voidReturnTypeProvider` is impreci
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/Util/ReturnTypeHelperTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Mutator\Util\ReturnTypeHelperTest`.'
-count = 8
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/ReturnTypeHelperTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Mutator\Util\ReturnTypeHelperTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/ReturnTypeHelperTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Mutator\Util\ReturnTypeHelperTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/MutatorNameTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\MutatorNameTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/FakeToken.php"
 code = "incompatible-parameter-type"
 message = 'Parameter `$kind` of `Infection\Tests\PhpParser\FakeToken::is()` expects type `array<array-key, int|string>|int|string` but parent `PhpToken::is()` expects type `array<array-key, mixed>|int|string`'
@@ -13984,12 +10114,6 @@ count = 1
 file = "tests/phpunit/PhpParser/FakeTokenTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `methodProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FakeTokenTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\PhpParser\FakeTokenTest`.'
 count = 1
 
 [[issues]]
@@ -14024,45 +10148,15 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontainsonlyinstancesof` does not exist on type `Infection\Tests\PhpParser\FileParserTest`.'
+code = "redundant-type-comparison"
+message = "Redundant type assertion: `$fileRealPath` of type `non-empty-string` is always not `false`."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\PhpParser\FileParserTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotfalse` does not exist on type `Infection\Tests\PhpParser\FileParserTest`.'
+code = "redundant-type-comparison"
+message = 'Redundant type assertion: `$statements` of type `array<array-key, PhpParser\Node\Stmt>` is always not `iterable<mixed, PhpParser\Node>`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\FileParserTest`.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\PhpParser\FileParserTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\PhpParser\FileParserTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/PhpParser/FileParserTest.php"
@@ -14083,12 +10177,6 @@ message = 'Potentially unhandled exception `Throwable` in `Infection\Tests\PhpPa
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/MutatedNodeTest.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
@@ -14104,12 +10192,6 @@ count = 1
 file = "tests/phpunit/PhpParser/MutatedNodeTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/MutatedNodeTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\MutatedNodeTest`.'
 count = 1
 
 [[issues]]
@@ -14180,50 +10262,14 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotnull` does not exist on type `Infection\Tests\PhpParser\NodeDumper\NodeDumper\NodeDumperTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\NodeDumper\NodeDumper\NodeDumperTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\PhpParser\NodeDumper\NodeDumper\NodeDumperTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
-code = "possibly-null-argument"
-message = 'Argument #1 of method `Infection\PhpParser\NodeDumper\NodeDumper::dump` is possibly `null`, but parameter type `PhpParser\Node|array<array-key, PhpParser\Node>` does not accept it.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\NodeDumper\NodeDumper\NodeDumperTest::test_dump_nodes`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeDumper/PotentialCircularDependencyDetectedTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\NodeDumper\PotentialCircularDependencyDetectedTest`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `Infection\Tests\PhpParser\NodeTraverserFactoryTest::getVisitorClassNames`: expected `list<class-string<PhpParser\NodeVisitor>>`, but found `list<string>`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
-code = "less-specific-argument"
-message = 'Argument type mismatch for argument #1 of `Infection\Tests\PhpParser\NodeTraverserFactoryTest::getVisitorClassNames`: expected `PhpParser\NodeTraverser`, but provided type `PhpParser\NodeTraverserInterface` is less specific.'
 count = 1
 
 [[issues]]
@@ -14240,18 +10286,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\PhpParser\NodeTraverserFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\NodeTraverserFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #2 of `Infection\Tests\PhpParser\NodeTraverserFactoryTest::assertTraverserVisitorsAre`: expected `list<class-string<PhpParser\NodeVisitor>>`, but possibly received `list{class-string('PhpParser\NodeVisitor\CloningVisitor'), class-string('Infection\Tests\Fixtures\PhpParser\FakeVisitor')}`.'''
 count = 1
@@ -14263,58 +10297,10 @@ message = 'Potentially unhandled exception `ReflectionException` in `Infection\T
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/UnparsableFileTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\UnparsableFileTest`.'
-count = 3
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 6
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
-code = "mixed-property-access"
-message = "Attempting to access a property on a non-object type (`mixed`)."
-count = 4
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitorTest`.'
-count = 8
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitorTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
-code = "non-existent-property"
-message = 'Property `$expr` does not exist on class `PhpParser\Node\Stmt`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
@@ -14329,21 +10315,9 @@ message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\Poten
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/SequenceTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\AddIdToTraversedNodesVisitor\SequenceTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\EnrichmentTraverse\EnrichmentTraverseIntegrationTest`.'
 count = 1
 
 [[issues]]
@@ -14360,12 +10334,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/ExcludeIgnoredNodesVisitor/ExcludeIgnoredNodesVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\ExcludeIgnoredNodesVisitor\ExcludeIgnoredNodesVisitorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeIgnoredNodesVisitor/ExcludeIgnoredNodesVisitorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\ExcludeIgnoredNodesVisitor\ExcludeIgnoredNodesVisitorTest::test_it_marks_nodes_with_the_ignore_all_comment_as_ignored`.'
 count = 1
@@ -14378,18 +10346,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/ExcludeIgnoredNodesVisitor/MarkAllButIneligibleNodesAsVisitedVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertCount` does not exist on type `Infection\Tests\PhpParser\Visitor\ExcludeIgnoredNodesVisitor\MarkAllButIneligibleNodesAsVisitedVisitorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeIgnoredNodesVisitor/MarkAllButIneligibleNodesAsVisitedVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\ExcludeIgnoredNodesVisitor\MarkAllButIneligibleNodesAsVisitedVisitorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeIgnoredNodesVisitor/MarkAllButIneligibleNodesAsVisitedVisitorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\ExcludeIgnoredNodesVisitor\MarkAllButIneligibleNodesAsVisitedVisitorTest::test_it_labels_visited_nodes_as_visited_and_eligible_nodes_as_mutation_candidates`.'
 count = 1
@@ -14398,42 +10354,6 @@ count = 1
 file = "tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameManipulatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameManipulatorTest.php"
-code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Tests\PhpParser\Visitor\FullyQualifiedClassNameManipulatorTest::getFqcns`: expected `array<int, PhpParser\Node\Name>`, but found `array<int, PhpParser\Node\Name|null>`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertarrayhaskey` does not exist on type `Infection\Tests\PhpParser\Visitor\FullyQualifiedClassNameManipulatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\PhpParser\Visitor\FullyQualifiedClassNameManipulatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotnull` does not exist on type `Infection\Tests\PhpParser\Visitor\FullyQualifiedClassNameManipulatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\FullyQualifiedClassNameManipulatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameManipulatorTest.php"
-code = "possible-method-access-on-null"
-message = "Attempting to call a method on `null`."
 count = 1
 
 [[issues]]
@@ -14456,12 +10376,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/IgnoreNode/AbstractMethodIgnorerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\IgnoreNode\AbstractMethodIgnorerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/IgnoreNode/AbstractMethodIgnorerTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\IgnoreNode\AbstractMethodIgnorerTest::test_it_ignores_abstract_methods`.'
 count = 1
@@ -14470,12 +10384,6 @@ count = 1
 file = "tests/phpunit/PhpParser/Visitor/IgnoreNode/InterfaceIgnorerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/IgnoreNode/InterfaceIgnorerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\IgnoreNode\InterfaceIgnorerTest`.'
 count = 1
 
 [[issues]]
@@ -14492,12 +10400,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/LabelMutationCandidatesVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\LabelMutationCandidatesVisitorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/LabelMutationCandidatesVisitorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\LabelMutationCandidatesVisitorTest::test_it_labels_visited_nodes_as_visited_and_eligible_nodes_as_mutation_candidates`.'
 count = 1
@@ -14510,50 +10412,14 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/LabelNodesAsEligibleVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\LabelNodesAsEligibleVisitorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/LabelNodesAsEligibleVisitorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\LabelNodesAsEligibleVisitorTest::test_it_labels_visited_nodes_as_eligible`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php"
-code = "mixed-array-access"
-message = "Unsafe array access on type `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `Infection\Tests\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitorTest::cloneNodes`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php"
-code = "non-existent-property"
-message = 'Property `$stmts` does not exist on class `PhpParser\Node\Stmt`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php"
-code = "possibly-null-property-access"
-message = "Attempting to access a property on a possibly `null` value."
 count = 1
 
 [[issues]]
@@ -14569,63 +10435,15 @@ message = "Call to documented magic method `method()` on a class that cannot han
 count = 2
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MutationCollectorVisitorTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 10
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MutationCollectorVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\MutationCollectorVisitorTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MutationCollectorVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\PhpParser\Visitor\MutationCollectorVisitorTest`.'
-count = 10
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `providesMutationCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\MutatorVisitorTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/NextConnectingVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/NextConnectingVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\PhpParser\Visitor\NextConnectingVisitorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/NextConnectingVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\PhpParser\Visitor\NextConnectingVisitorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/NextConnectingVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\NextConnectingVisitorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/NextConnectingVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\PhpParser\Visitor\NextConnectingVisitorTest`.'
 count = 1
 
 [[issues]]
@@ -14642,48 +10460,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\PhpParser\Visitor\ParentConnector::findParent`: expected `PhpParser\Node`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\PhpParser\Visitor\ParentConnector::getParent`: expected `PhpParser\Node`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\PhpParser\Visitor\ParentConnectorTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\PhpParser\Visitor\ParentConnectorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\ParentConnectorTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
-code = "non-existent-property"
-message = 'Property `$name` does not exist on class `PhpParser\Node\Stmt`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\ParentConnectorTest::test_it_annotates_the_parent_nodes`.'
 count = 1
@@ -14692,12 +10468,6 @@ count = 1
 file = "tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\ReflectionVisitorTest`.'
 count = 1
 
 [[issues]]
@@ -14714,20 +10484,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/SkipIgnoredNodesVisitor/SkipIgnoredNodesVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\SkipIgnoredNodesVisitor\SkipIgnoredNodesVisitorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/SkipIgnoredNodesVisitor/SkipIgnoredNodesVisitorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\SkipIgnoredNodesVisitor\SkipIgnoredNodesVisitorTest::test_it_annotates_the_next_nodes`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCase.php"
-code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase::parse`: expected `array<array-key, PhpParser\Node\Stmt>`, but found `array<array-key, PhpParser\Node\Stmt>|null`.'
 count = 1
 
 [[issues]]
@@ -14743,18 +10501,6 @@ message = 'Argument type mismatch for argument #1 of `PhpParser\NodeTraverser::t
 count = 2
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCase.php"
-code = "non-existent-method"
-message = 'Method `assertnotnull` does not exist on type `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCase.php"
-code = "nullable-return-statement"
-message = 'Function `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase::parse` is declared to return `array<array-key, PhpParser\Node\Stmt>` but possibly returns a nullable value (inferred as `array<array-key, PhpParser\Node\Stmt>|null`).'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php"
 code = "invalid-method-access"
 message = 'Cannot access protected method `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase::setup`.'
@@ -14762,92 +10508,14 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCaseTest`.'
+code = "redundant-type-comparison"
+message = "Redundant type assertion: `$id` of type `non-negative-int` is always not `int`."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCaseTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php"
-code = "non-existent-method"
-message = 'Method `assertgreaterthanorequal` does not exist on type `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCaseTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCaseTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php"
-code = "non-existent-method"
-message = 'Method `assertisarray` does not exist on type `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCaseTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php"
-code = "non-existent-method"
-message = 'Method `assertisint` does not exist on type `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCaseTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotempty` does not exist on type `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCaseTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCaseTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php"
-code = "too-many-arguments"
-message = 'Class `Infection\Tests\PhpParser\Visitor\VisitorTestCase\ConcreteVisitorTestCase` has no `__construct` method, but arguments were provided to `new`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/DryRunProcessTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\DryRunProcessTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Process/DryRunProcessTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Process\DryRunProcessTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialStaticAnalysisProcessFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Process\Factory\InitialStaticAnalysisProcessFactory::__construct`: expected `Infection\StaticAnalysis\StaticAnalysisToolAdapter`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialStaticAnalysisProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\Process\Factory\InitialStaticAnalysisProcessFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialStaticAnalysisProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Process\Factory\InitialStaticAnalysisProcessFactoryTest`.'
+code = "redundant-type-comparison"
+message = 'Redundant type assertion: `$nodesById` of type `array<int(0)|positive-int, PhpParser\Node>` is always not `array<array-key, mixed>`.'
 count = 1
 
 [[issues]]
@@ -14855,36 +10523,6 @@ file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontains` does not exist on type `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotinstanceof` does not exist on type `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\Process\Factory\InitialTestsRunProcessFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
@@ -14917,120 +10555,6 @@ message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not f
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontains` does not exist on type `Infection\Tests\Process\Factory\MutantProcessContainerFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Process\Factory\MutantProcessContainerFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\Factory\MutantProcessContainerFactoryTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `isstring` does not exist on type `Infection\Tests\Process\Factory\MutantProcessContainerFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Process\MutantProcessContainerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\MutantProcessContainerTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Process\MutantProcessContainerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Process\MutantProcessContainerTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Process\MutantProcessContainerTest`.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessContainerTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessTest.php"
-code = "mixed-property-type-coercion"
-message = 'A value with a less specific type `mixed` is being assigned to property `$$processStub` (PHPUnit\Framework\MockObject\Stub&Symfony\Component\Process\Process).'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\MutantProcessTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Process\MutantProcessTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/MutantProcessTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Process\OriginalPhpProcessTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\Process\OriginalPhpProcessTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringnotcontainsstring` does not exist on type `Infection\Tests\Process\OriginalPhpProcessTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\Tests\Process\OriginalPhpProcessTest::test_it_injects_xdebug_env_vars`.'
@@ -15059,54 +10583,6 @@ file = "tests/phpunit/Process/Runner/DryProcessRunnerTest.php"
 code = "less-specific-nested-argument-type"
 message = 'Argument type mismatch for argument #1 of `Infection\Process\Runner\DryProcessRunner::run`: expected `iterable<mixed, Infection\Process\MutantProcessContainer>`, but provided type `iterable<mixed, mixed>` is less specific.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/DryProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Process\Runner\DryProcessRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/IndexedMutantProcessContainerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Process\Runner\IndexedMutantProcessContainer::__construct`: expected `Infection\Process\MutantProcessContainer`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/IndexedMutantProcessContainerTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/IndexedMutantProcessContainerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\Runner\IndexedMutantProcessContainerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/IndexedMutantProcessContainerTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Process\Runner\IndexedMutantProcessContainerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunFailedTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunFailedTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\Runner\InitialStaticAnalysisRunFailedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunFailedTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Process\Runner\InitialStaticAnalysisRunFailedTest`.'
-count = 3
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
@@ -15143,42 +10619,6 @@ file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
 code = "non-existent-class-like"
 message = 'Cannot find class, interface, enum, or type alias `Infection\Tests\Fixtures\Event\EventDispatcherCollector`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\Runner\InitialStaticAnalysisRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Process\Runner\InitialStaticAnalysisRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsFailedTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsFailedTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\Runner\InitialTestsFailedTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsFailedTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Process\Runner\InitialTestsFailedTest`.'
-count = 6
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
@@ -15236,42 +10676,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertgreaterthanorequal` does not exist on type `Infection\Tests\Process\Runner\InitialTestsRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Process\Runner\InitialTestsRunnerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertlessthanorequal` does not exist on type `Infection\Tests\Process\Runner\InitialTestsRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\Runner\InitialTestsRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `marktestincomplete` does not exist on type `Infection\Tests\Process\Runner\InitialTestsRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Process\Runner\InitialTestsRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `array_filter`: expected `array<array-key, mixed>`, but possibly received `array<array-key, mixed>|list<mixed>|object`."
 count = 1
@@ -15280,12 +10684,6 @@ count = 1
 file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_stops_the_process_execution_on_the_first_error`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -15302,21 +10700,15 @@ count = 10
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
+code = "less-specific-nested-argument-type"
+message = 'Argument type mismatch for argument #1 of `PHPUnit\Framework\Assert::callback`: expected `(callable(iterable<mixed, mixed>): bool)`, but provided type `(closure(iterable<mixed, mixed>): mixed)` is less specific.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 8
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 8
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 22
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
@@ -15332,15 +10724,15 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 6
+code = "mixed-argument"
+message = 'Invalid argument type for argument #2 of `PHPUnit\Framework\Assert::assertCount`: expected `Countable|iterable<mixed, mixed>`, but found `mixed`.'
+count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\Process\Runner\MutationTestingRunnerTest::someIterable`. Saw type `mixed`.'
-count = 1
+code = "mixed-assignment"
+message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
+count = 5
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
@@ -15359,96 +10751,6 @@ file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "non-existent-class-like"
 message = 'Cannot find class, interface, enum, or type alias `Infection\Tests\Fixtures\Event\EventDispatcherCollector`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 8
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertarrayhaskey` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontains` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertgreaterthan` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `callback` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 8
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Process\Runner\MutationTestingRunnerTest`.'
-count = 11
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
@@ -15481,12 +10783,6 @@ message = 'Potentially unhandled exception `ReflectionException` in `Infection\T
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "impossible-assignment"
 message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
@@ -15508,7 +10804,7 @@ count = 6
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "less-specific-nested-argument-type"
 message = 'Argument type mismatch for argument #1 of `iterator_count`: expected `Traversable<mixed, mixed>|array<array-key, mixed>`, but provided type `iterable<mixed, Infection\Process\MutantProcessContainer>` is less specific.'
-count = 5
+count = 7
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
@@ -15519,44 +10815,8 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 34
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `class@anonymous:14053425703945415052-24615:25384::__construct`: expected `Infection\Mutant\TestFrameworkMutantExecutionResultFactory`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "mixed-argument"
 message = "Invalid argument type for argument #1 of `iterator_count`: expected `Traversable<mixed, mixed>|array<array-key, mixed>`, but found `mixed`."
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Process\Runner\IndexedMutantProcessContainer::__construct`: expected `Infection\Process\MutantProcessContainer`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "mixed-method-access"
-message = "Attempting to access a method on a non-object type (`mixed`)."
-count = 17
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
@@ -15569,90 +10829,6 @@ file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Process\DummyMutantProcess` not found.'
 count = 5
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontains` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertgreaterthan` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotempty` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotfalse` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `atleastonce` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 8
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 11
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `getmockbuilder` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `identicalto` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Process\Runner\ParallelProcessRunnerTest`.'
-count = 28
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
@@ -15703,93 +10879,9 @@ message = 'Potentially unhandled exception `ReflectionException` in `Infection\T
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Process\Runner\ProcessQueue::enqueue`: expected `Infection\Process\MutantProcessContainer`, but found `mixed`.'
-count = 9
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 27
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 9
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Process\Runner\ProcessQueueTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "non-existent-method"
-message = 'Method `assertgreaterthanorequal` does not exist on type `Infection\Tests\Process\Runner\ProcessQueueTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\Runner\ProcessQueueTest`.'
-count = 9
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Process\Runner\ProcessQueueTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Process\Runner\ProcessQueueTest`.'
-count = 15
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\Process\Runner\ProcessQueueTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Process\Runner\ProcessQueueTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ProcessQueueTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Process\Runner\ProcessQueueTest`.'
-count = 19
-
-[[issues]]
 file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `commandProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Process\ShellCommandLineExecutorTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\Process\ShellCommandLineExecutorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessagematches` does not exist on type `Infection\Tests\Process\ShellCommandLineExecutorTest`.'
 count = 1
 
 [[issues]]
@@ -15865,27 +10957,9 @@ message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reflection/AnonymousClassReflectionTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reflection\AnonymousClassReflectionTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reflection/ClassReflectionTestCase.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideParentMethodCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reflection/ClassReflectionTestCase.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reflection\ClassReflectionTestCase`.'
 count = 1
 
 [[issues]]
@@ -15955,58 +11029,10 @@ message = 'Potentially unhandled exception `ReflectionException` in `Infection\T
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Reflection/CoreClassReflectionTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reflection\CoreClassReflectionTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reflection/NullReflectionTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Reflection\NullReflectionTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reflection/NullReflectionTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reflection\NullReflectionTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reflection/VisibilityTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Reflection\VisibilityTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Reflection/VisibilityTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Reflection\VisibilityTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Reporter/AdvisoryReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\AdvisoryReporterTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/DebugFileReporterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FederatedReporterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Reporter/FederatedReporterTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Reporter\FederatedReporterTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
@@ -16051,12 +11077,6 @@ message = 'Class `Infection\Tests\Fixtures\Reporter\DummyLineMutationTestingResu
 count = 7
 
 [[issues]]
-file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\FileLocationReporter\FileLocationReporterTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
 code = "imprecise-type"
 message = "Type `array` in parameter `$expectedReporterClassNames` is imprecise, equivalent to `array<array-key, mixed>`."
@@ -16072,12 +11092,6 @@ count = 1
 file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #2 of `array_map`: expected `array<('K.array_map() extends array-key), ('V.array_map() extends mixed)>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `Infection\Reporter\FileReporterFactory::__construct`: expected `Symfony\Component\Filesystem\Filesystem`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -16106,39 +11120,9 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Reporter\FileReporterFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\FileReporterFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Reporter\FileReporterFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Reporter\FileReporterFactoryTest::assertRegisteredReportersAre`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterTest.php"
@@ -16151,24 +11135,6 @@ file = "tests/phpunit/Reporter/FileReporterTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Reporter\DummyLineMutationTestingResultsReporter` not found.'
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\Reporter\FileReporterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\FileReporterTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Reporter\FileReporterTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Reporter/GitHubActionsLogTextFileReporterTest.php"
@@ -16189,63 +11155,9 @@ message = "Type `iterable` in return type of `metricsProvider` is imprecise, equ
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\GitHubAnnotationsReporterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\Reporter\GitHubAnnotationsReporterTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\GitLabCodeQualityReporterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\Reporter\GitLabCodeQualityReporterTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Html/HtmlFileReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\Html\HtmlFileReporterTest`.'
 count = 1
 
 [[issues]]
@@ -16274,18 +11186,6 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\Html\StrykerHtmlReportBuilderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Reporter\Html\StrykerHtmlReportBuilderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
 code = "possibly-null-argument"
 message = 'Argument #2 of method `Infection\Mutant\MutantExecutionResult::__construct` is possibly `null`, but parameter type `string` does not accept it.'
 count = 1
@@ -16297,63 +11197,15 @@ message = "Type `iterable` in return type of `valueProvider` is imprecise, equiv
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Reporter/Http/ResponseTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\Http\ResponseTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/ResponseTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Reporter\Http\ResponseTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideResponseStatusCodes` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\Http\StrykerDashboardClientTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Reporter\Http\StrykerDashboardClientTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/JsonReporterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/JsonReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\JsonReporterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/LineReporterAssertions.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\LineReporterAssertions`.'
 count = 1
 
 [[issues]]
@@ -16375,18 +11227,6 @@ message = "Call to documented magic method `method()` on a class that cannot han
 count = 13
 
 [[issues]]
-file = "tests/phpunit/Reporter/ShowMetricsReporter/ShowMetricsReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\ShowMetricsReporter\ShowMetricsReporterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/ShowMetricsReporter/ShowMetricsReporterTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/ShowMutationsReporterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `resultsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -16396,24 +11236,6 @@ count = 1
 file = "tests/phpunit/Reporter/ShowMutationsReporterTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/ShowMutationsReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\ShowMutationsReporterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/ShowMutationsReporterTest.php"
-code = "unused-method"
-message = "Method `creatediffcolorizermock()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/ShowMutationsReporterTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -16448,57 +11270,15 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Reporter\StrykerReporterFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\Reporter\StrykerReporterFactoryTest`.'
-count = 2
+code = "possibly-invalid-argument"
+message = '''Possible argument type mismatch for argument #1 of `PHPUnit\Framework\Assert::assertInstanceOf`: expected `class-string<'ExpectedType.phpunit\framework\assert::assertinstanceof() extends object>`, but possibly received `string`.'''
+count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/StrykerReporterTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 11
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\StrykerReporterTest`.'
-count = 11
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Reporter\StrykerReporterTest`.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Reporter\StrykerReporterTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterTest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Reporter/SummaryFileReporterTest.php"
@@ -16513,12 +11293,6 @@ message = "Type `iterable` in return type of `metricsProvider` is imprecise, equ
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Reporter/SummaryJsonReporterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Reporter\SummaryJsonReporterTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/TextFileReporterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `completeMetricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -16528,12 +11302,6 @@ count = 1
 file = "tests/phpunit/Reporter/TextFileReporterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `emptyMetricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -16561,45 +11329,9 @@ message = 'Class `Infection\Tests\Fixtures\Resource\Time\FakeTimeFormatter` not 
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `callback` does not exist on type `Infection\Tests\Resource\Listener\PerformanceLoggerSubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Resource\Listener\PerformanceLoggerSubscriberTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryFormatterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `bytesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryFormatterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Resource\Memory\MemoryFormatterTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryFormatterTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Resource\Memory\MemoryFormatterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryFormatterTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -16607,30 +11339,6 @@ file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `memoryLimitProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\Resource\Memory\MemoryLimiterEnvironmentTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Resource\Memory\MemoryLimiterEnvironmentTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\Resource\Memory\MemoryLimiterEnvironmentTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\Resource\Memory\MemoryLimiterEnvironmentTest`.'
-count = 4
 
 [[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
@@ -16642,24 +11350,6 @@ count = 2
 file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Resource\Memory\MemoryLimiterEnvironmentTest::test_it_does_not_use_the_system_ini_if_phpdbg_is_disabled_and_xdebug_handler_is_detected`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "unused-property"
-message = "Property `$originalMemoryLimit` is never used."
 count = 1
 
 [[issues]]
@@ -16676,18 +11366,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Resource\Memory\MemoryLimiter::limitMemory`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
 code = "no-value"
 message = 'Argument #2 passed to method `Infection\Resource\Memory\MemoryLimiter::limitMemory` has type `never`, meaning it cannot produce a value.'
 count = 3
@@ -16699,24 +11377,6 @@ message = 'Class `Infection\Tests\Fixtures\TestFramework\FakeAwareAdapter` not f
 count = 3
 
 [[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Resource\Memory\MemoryLimiterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\Resource\Memory\MemoryLimiterTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Resource\Memory\MemoryLimiterTest`.'
-count = 4
-
-[[issues]]
 file = "tests/phpunit/Resource/Time/StopwatchTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `timeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -16724,32 +11384,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Resource/Time/StopwatchTest.php"
-code = "non-existent-method"
-message = 'Method `assertequalswithdelta` does not exist on type `Infection\Tests\Resource\Time\StopwatchTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Time/StopwatchTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Resource\Time\StopwatchTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Resource/Time/StopwatchTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\Resource\Time\StopwatchTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Resource/Time/StopwatchTest.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `usleep`: expected `non-negative-int`, but possibly received `int`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Time/StopwatchTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -16789,18 +11425,6 @@ message = "Invalid right operand: type `mixed` cannot be reliably used in string
 count = 3
 
 [[issues]]
-file = "tests/phpunit/Resource/Time/TimeFormatterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Resource\Time\TimeFormatterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Time/TimeFormatterTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `filteredFilesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -16817,24 +11441,6 @@ file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollector
 code = "less-specific-argument"
 message = 'Argument type mismatch for argument #1 of `Infection\Tests\Source\Collector\BasicSourceCollector\BasicSourceCollectorTest::normalizePaths`: expected `array<string, SplFileInfo>`, but provided type `array<array-key, SplFileInfo>` is less specific.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertSame` does not exist on type `Infection\Tests\Source\Collector\BasicSourceCollector\BasicSourceCollectorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertequalscanonicalizing` does not exist on type `Infection\Tests\Source\Collector\BasicSourceCollector\BasicSourceCollectorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\Source\Collector\BasicSourceCollector\BasicSourceCollectorTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
@@ -16862,50 +11468,14 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Source\Collector\CachedSourceCollectorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Source\Collector\CachedSourceCollectorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Collector\CachedSourceCollectorTest::test_it_caches_the_collected_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Source/Collector/LazySourceCollectorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `decoratedCollectorProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/LazySourceCollectorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Source\Collector\LazySourceCollectorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/LazySourceCollectorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\Source\Collector\LazySourceCollectorTest`.'
 count = 1
 
 [[issues]]
@@ -16927,30 +11497,6 @@ message = "Type `iterable` in return type of `sourceFilterProvider` is imprecise
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Source/Collector/SourceCollectorFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\Source\Collector\SourceCollectorFactory::__construct`: expected `Infection\Git\Git`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/SourceCollectorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Source\Collector\SourceCollectorFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/SourceCollectorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\Source\Collector\SourceCollectorFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/SourceCollectorFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\Source\Collector\SourceCollectorFactoryTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Source/Exception/NoSourceFoundTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `changedLinesDiffProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -16963,12 +11509,6 @@ message = "Type `iterable` in return type of `plainFilterProvider` is imprecise,
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Source/Exception/NoSourceFoundTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\Source\Exception\NoSourceFoundTest`.'
-count = 3
-
-[[issues]]
 file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideLines` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -16978,24 +11518,6 @@ count = 1
 file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest`.'
 count = 1
 
 [[issues]]
@@ -17017,21 +11539,9 @@ message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceF
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Source/Matcher/SimpleSourceLineMatcherTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideLines` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/SimpleSourceLineMatcherTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Source\Matcher\SimpleSourceLineMatcherTest`.'
 count = 1
 
 [[issues]]
@@ -17041,88 +11551,10 @@ message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceF
 count = 1
 
 [[issues]]
-file = "tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringendswith` does not exist on type `Infection\Tests\StaticAnalysis\Config\StaticAnalysisConfigLocatorTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\StaticAnalysis\Config\StaticAnalysisConfigLocatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\StaticAnalysis\Config\StaticAnalysisConfigLocatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterFactoryTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideValidVersions` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\StaticAnalysis\Mago\Adapter\MagoAdapter::__construct`: expected `Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest`.'
-count = 4
 
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
@@ -17161,12 +11593,6 @@ message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\
 count = 1
 
 [[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
 code = "deprecated-method"
 message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
@@ -17179,100 +11605,10 @@ message = "Call to documented magic method `method()` on a class that cannot han
 count = 18
 
 [[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertgreaterthan` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertlessthan` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactoryTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
 code = "deprecated-method"
 message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
 count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\StaticAnalysis\Mago\Process\MagoMutantProcessFactory::__construct`: expected `Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Process\MagoMutantProcessFactoryTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Process\MagoMutantProcessFactoryTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Process\MagoMutantProcessFactoryTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Process\MagoMutantProcessFactoryTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\StaticAnalysis\Mago\Process\MagoMutantProcessFactoryTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterFactoryTest`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
@@ -17281,72 +11617,6 @@ message = "Type `iterable` in return type of `provideValidVersions` is imprecise
 count = 1
 
 [[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::__construct`: expected `Symfony\Component\Filesystem\Filesystem`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::__construct`: expected `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest`.'
-count = 12
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
 code = "deprecated-method"
 message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
@@ -17359,166 +11629,10 @@ message = "Call to documented magic method `method()` on a class that cannot han
 count = 12
 
 [[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `exactly` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
 code = "deprecated-method"
 message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
 count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory::__construct`: expected `Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactoryTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\StaticAnalysis\StaticAnalysisToolFactory::__construct`: expected `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `Infection\StaticAnalysis\StaticAnalysisToolFactory::__construct`: expected `Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\StaticAnalysis\StaticAnalysisToolFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\StaticAnalysis\StaticAnalysisToolFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\StaticAnalysis\StaticAnalysisToolFactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/StaticAnalysisToolTypesTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\StaticAnalysis\StaticAnalysisToolTypesTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/AdapterInstallationDeciderTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\TestFramework\AdapterInstallationDeciderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/AdapterInstallationDeciderTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\TestFramework\AdapterInstallationDeciderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/AdapterInstallationDeciderTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\TestFramework\AdapterInstallationDeciderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/AdapterInstallationDeciderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/CommandLineBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontains` does not exist on type `Infection\Tests\TestFramework\CommandLineBuilderTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/TestFramework/CommandLineBuilderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringendswith` does not exist on type `Infection\Tests\TestFramework\Config\TestFrameworkConfigLocatorTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\TestFramework\Config\TestFrameworkConfigLocatorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\TestFramework\Config\TestFrameworkConfigLocatorTest`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php"
@@ -17527,76 +11641,10 @@ message = "Call to documented magic method `method()` on a class that cannot han
 count = 3
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\TestFramework\Coverage\CoverageChecker\CoverageCheckerTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\CoverageChecker\CoverageCheckerTest`.'
-count = 12
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\TestFramework\Coverage\CoverageChecker\CoverageCheckerTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\TestFramework\Coverage\CoverageChecker\CoverageCheckerTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\TestFramework\Coverage\CoverageChecker\CoverageCheckerTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\TestFramework\Coverage\CoverageChecker\CoverageCheckerTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\TestFramework\Coverage\CoverageChecker\CoverageCheckerTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoverageNotFoundTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\CoverageNotFoundTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest`.'
+code = "impossible-type-comparison"
+message = 'Impossible type assertion: `$traces` of type `array<array-key, Infection\TestFramework\Tracing\Trace\Trace>` can never be `list{int(1), int(2), int(3)}`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
@@ -17645,30 +11693,6 @@ file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `reportPathnameProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
@@ -17894,54 +11918,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "non-existent-method"
-message = 'Method `assertarrayhaskey` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
 code = "redundant-docblock-type"
 message = "Redundant docblock type for variable `$actual`."
 count = 1
@@ -17971,12 +11947,6 @@ message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUn
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionBDDProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -18002,18 +11972,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::test_it_can_get_the_test_info_for_a_given_test_id`.'
 count = 1
@@ -18028,18 +11986,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
 count = 1
 
 [[issues]]
@@ -18068,81 +12014,9 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/TestFileNameNotFoundExceptionTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\TestFileNameNotFoundExceptionTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/TestFileNameNotFoundExceptionTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\TestFileNameNotFoundExceptionTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/TestFileTimeDataTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\JUnit\TestFileTimeDataTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertequalscanonicalizing` does not exist on type `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest`.'
-count = 5
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
@@ -18308,12 +12182,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/Locator/FixedLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\Locator\FixedLocatorTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/FixedLocatorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\Locator\FixedLocatorTest::test_it_can_be_instantiated_with_a_default_location`.'
 count = 1
@@ -18349,12 +12217,6 @@ message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Loc
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/Throwable/UnknownReportLocatorExceptionTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\Locator\Throwable\UnknownReportLocatorExceptionTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `defaultCovergageDirectoryProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -18371,30 +12233,6 @@ file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTe
 code = "imprecise-type"
 message = "Type `iterable` in return type of `reportPathnameProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest`.'
-count = 3
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
@@ -18638,42 +12476,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "non-existent-property"
-message = "Property `$isSourceFiltered` does not exist on interface `Throwable`."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest::test_it_provides_file_information`.'
 count = 1
@@ -18685,70 +12487,10 @@ message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Excepti
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "unused-method"
-message = "Method `teardown()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/InvalidCoverageTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\InvalidCoverageTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
 count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
@@ -18829,36 +12571,6 @@ message = "Type `iterable` in return type of `fileFixturesProvider` is imprecise
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 9
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\SourceFileInfoProvider\SourceFileInfoProviderTest`.'
-count = 9
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
 code = "imprecise-type"
 message = "Type `array` in return type of `getTestsLocations` is imprecise, equivalent to `array<array-key, mixed>`."
@@ -18874,24 +12586,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `Infection\TestFramework\Coverage\XmlReport\TestLocator::__construct`: expected `Infection\TestFramework\Tracing\Trace\TestLocations`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\TestLocatorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\TestLocatorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\TestLocatorTest`.'
 count = 1
 
 [[issues]]
@@ -18992,81 +12686,15 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
-code = "mixed-method-access"
-message = "Attempting to access a method on a non-object type (`mixed`)."
-count = 4
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
-code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\XmlCoverageParserTest::createSourceFileInfoProviderStub`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\XmlCoverageParserTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\XmlCoverageParserTest`.'
-count = 1
+code = "missing-magic-method"
+message = "Call to documented magic method `method()` on a class that cannot handle it."
+count = 2
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\XmlCoverageParserTest::lineCoverageProvider`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/FactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #3 of `Infection\TestFramework\Factory::__construct`: expected `Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/FactoryTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #4 of `Infection\TestFramework\Factory::__construct`: expected `Infection\FileSystem\Finder\TestFrameworkFinder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/FactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\TestFramework\FactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/FactoryTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\TestFramework\FactoryTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/TestFramework/FactoryTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\TestFramework\FactoryTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactoryTest`.'
-count = 3
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
@@ -19099,82 +12727,46 @@ message = "Type `iterable` in return type of `syntaxErrorOutputProvider` is impr
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\Builder\InvocationMocker::method`: expected `PHPUnit\Framework\Constraint\Constraint|PHPUnit\Framework\MockObject\Runtime\PropertyHook|string`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 15
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #5 of `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter::__construct`: expected `Infection\TestFramework\Config\InitialConfigBuilder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #6 of `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter::__construct`: expected `Infection\TestFramework\Config\MutationConfigBuilder`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `anything` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest`.'
-count = 11
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `never` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapterTest`.'
-count = 12
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideTestCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\PhpUnit\CommandLine\ArgumentsAndOptionsBuilderTest`.'
-count = 5
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$cacheResult` of type `null` can never be `string('false')`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$colors` of type `null` can never be `string('false')`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$executionOrder[0]->value` of type `null` can never be `string('reverse')`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$failOnRisky[0]->value` of type `null` can never be `string('false')`."
+count = 2
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$stdErr` of type `null` can never be `string('false')`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$stopOnFailure` of type `null` can never be `string('true')`."
+count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
@@ -19205,42 +12797,6 @@ file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderT
 code = "invalid-property-access"
 message = "Attempting to access a property on a non-object type (`never`)."
 count = 9
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertgreaterthanorequal` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest`.'
-count = 22
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotfalse` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest`.'
-count = 33
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
@@ -19423,9 +12979,51 @@ message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Excepti
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$colors` of type `null` can never be `string('false')`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$executionOrder` of type `null` can never be `string('.phpunit.result.cache.a1b2c3')`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$executionOrder` of type `null` can never be `string('default')`."
+count = 2
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$executionOrder` of type `null` can never be `string('defects')`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$executionOrder` of type `null` can never be `string('true')`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$failOnRisky[0]->value` of type `null` can never be `string('false')`."
+count = 2
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$resultAutoLoaderFilePath` of type `null` can never be `string('/tmp/infection/interceptor.autoload.a1b2c3.infection.php')`."
+count = 2
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
+code = "impossible-type-comparison"
+message = "Impossible type assertion: `$stopOnFailure` of type `null` can never be `string('true')`."
 count = 1
 
 [[issues]]
@@ -19474,42 +13072,6 @@ count = 1
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #3 of `Safe\exec`: expected `int|null`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest`.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotfalse` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest`.'
-count = 25
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `assertstringcontainsstring` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest`.'
 count = 1
 
 [[issues]]
@@ -19657,18 +13219,6 @@ message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Excepti
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/InvalidPhpUnitConfigurationTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\InvalidPhpUnitConfigurationTest`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `pathProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -19678,12 +13228,6 @@ count = 1
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
 code = "invalid-property-access"
 message = "Attempting to access a property on a non-object type (`false`)."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\Path\PathReplacerTest`.'
 count = 1
 
 [[issues]]
@@ -19718,68 +13262,14 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertcontains` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotfalse` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertxmlstringequalsxmlstring` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionmessage` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest::createXPath`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `PHPUnit\Util\Xml\XmlException` in `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest::assertItChangesXML`.'
 count = 1
 
 [[issues]]
@@ -19825,34 +13315,10 @@ message = "Type `iterable` in return type of `mainlineConfigurationsProvider` is
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationVersionProviderTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/TestFrameworkExtraOptionsFilterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutantProcessProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/TestFrameworkExtraOptionsFilterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\TestFrameworkExtraOptionsFilterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/TestFrameworkTypesTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\TestFrameworkTypesTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
@@ -19876,42 +13342,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
 code = "non-existent-class-like"
 message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\TestFramework\PhpUnit\Coverage\JUnitTimes` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
-code = "non-existent-method"
-message = 'Method `assertGreaterThan` does not exist on type `Infection\Tests\TestFramework\Tracing\TestLocationBucketSorterTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
-code = "non-existent-method"
-message = 'Method `assertgreaterthanorequal` does not exist on type `Infection\Tests\TestFramework\Tracing\TestLocationBucketSorterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Tracing\TestLocationBucketSorterTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\TestFramework\Tracing\TestLocationBucketSorterTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
-code = "non-existent-method"
-message = 'Method `expectnottoperformassertions` does not exist on type `Infection\Tests\TestFramework\Tracing\TestLocationBucketSorterTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
-code = "non-existent-method"
-message = 'Method `marktestskipped` does not exist on type `Infection\Tests\TestFramework\Tracing\TestLocationBucketSorterTest`.'
 count = 1
 
 [[issues]]
@@ -19945,30 +13375,6 @@ message = "Type `iterable` in return type of `scenarioProvider` is imprecise, eq
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestRunOrderResolverTest.php"
-code = "non-existent-method"
-message = 'Method `assertlessthan` does not exist on type `Infection\Tests\TestFramework\Tracing\TestRunOrderResolverTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestRunOrderResolverTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Tracing\TestRunOrderResolverTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestTotalTimeCalculatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Tracing\TestTotalTimeCalculatorTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Throwable/NoTraceFoundTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\TestFramework\Tracing\Throwable\NoTraceFoundTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Trace/LineRangeCalculatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideCodeAndRangeCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -19978,12 +13384,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Tracing/Trace/LineRangeCalculatorTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/LineRangeCalculatorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Tracing\Trace\LineRangeCalculatorTest`.'
 count = 1
 
 [[issues]]
@@ -20005,18 +13405,6 @@ message = "Type `iterable` in return type of `providesLineRanges` is imprecise, 
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/NodeLineRangeDataTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Tracing\Trace\NodeLineRangeDataTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/NodeLineRangeDataTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\TestFramework\Tracing\Trace\NodeLineRangeDataTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Trace/ProxyTraceTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `noTestTrace` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -20027,42 +13415,6 @@ file = "tests/phpunit/TestFramework/Tracing/Trace/ProxyTraceTest.php"
 code = "invalid-array-element-key"
 message = "Cannot use spread operator on an iterable with key type `mixed`."
 count = 4
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/ProxyTraceTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\TestFramework\Tracing\Trace\ProxyTraceTest`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/ProxyTraceTest.php"
-code = "non-existent-method"
-message = 'Method `assertequals` does not exist on type `Infection\Tests\TestFramework\Tracing\Trace\ProxyTraceTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/ProxyTraceTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\TestFramework\Tracing\Trace\ProxyTraceTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/ProxyTraceTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Tracing\Trace\ProxyTraceTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/ProxyTraceTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\TestFramework\Tracing\Trace\ProxyTraceTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/SourceMethodLineRangeTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Tracing\Trace\SourceMethodLineRangeTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Trace/TestLocationsNormalizer.php"
@@ -20107,18 +13459,6 @@ message = "Type `iterable` in return type of `locationsProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/TestLocationsNormalizerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Tracing\Trace\TestLocationsNormalizerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/TestLocationsTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Tracing\Trace\TestLocationsTest`.'
-count = 5
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Trace/TestLocationsTest.php"
 code = "possibly-undefined-variable"
 message = "Variable `$testsLocations` might not have been defined on all execution paths leading to this point."
@@ -20128,67 +13468,7 @@ count = 1
 file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
 code = "missing-magic-method"
 message = "Call to documented magic method `method()` on a class that cannot handle it."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `PHPUnit\Framework\MockObject\MockObject::expects`: expected `PHPUnit\Framework\MockObject\Rule\InvocationOrder`, but found `mixed`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "mixed-method-access"
-message = "Attempting to access a method on a non-object type (`mixed`)."
 count = 4
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::createTraceMock`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest`.'
-count = 9
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "non-existent-method"
-message = 'Method `asserttrue` does not exist on type `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "non-existent-method"
-message = 'Method `once` does not exist on type `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
@@ -20212,12 +13492,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\Tracing\Throwable\NoTraceFound` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_traverses_and_pauses_the_trace_generator_as_needed_and_caches_the_results`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
 count = 1
 
 [[issues]]
@@ -20270,39 +13544,15 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #1 of `Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder::__construct`: expected `Infection\AbstractTestFramework\TestFrameworkAdapter`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
-code = "mixed-method-access"
-message = "Attempting to access a method on a non-object type (`mixed`)."
-count = 8
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
-code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `Infection\Tests\TestFramework\Tracing\Tracer\TracerIntegrationTest::createFileSystemStub`. Saw type `mixed`.'
-count = 1
+code = "missing-magic-method"
+message = "Call to documented magic method `method()` on a class that cannot handle it."
+count = 4
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\TestFramework\Coverage\JUnit\FakeTestFileDataProvider` not found.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `createstub` does not exist on type `Infection\Tests\TestFramework\Tracing\Tracer\TracerIntegrationTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
@@ -20321,30 +13571,6 @@ file = "tests/phpunit/TestFramework/VersionParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `versionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/VersionParserTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\VersionParserTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/VersionParserTest.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\TestFramework\VersionParserTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/VersionParserTest.php"
-code = "unused-method"
-message = "Method `setup()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/InvalidXmlTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\XML\InvalidXmlTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
@@ -20372,75 +13598,9 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "non-existent-method"
-message = 'Method `assertcount` does not exist on type `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest`.'
-count = 8
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotnull` does not exist on type `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest`.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest`.'
-count = 15
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "non-existent-method"
-message = 'Method `expectexceptionobject` does not exist on type `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest`.'
-count = 20
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "non-existent-property"
 message = "Property `$attributes` does not exist on class `DOMNameSpaceNode`."
 count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::getElement`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryAttribute`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryCount`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryElement`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #2 of `Infection\TestFramework\XML\SafeDOMXPath::queryList`: expected `DOMNode|null`, but possibly received `DOMNameSpaceNode|DOMNode|null`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
@@ -20660,26 +13820,14 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Testing/BaseMutatorTestCaseIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `assertinstanceof` does not exist on type `Infection\Tests\Testing\BaseMutatorTestCaseIntegrationTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Testing/BaseMutatorTestCaseIntegrationTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Testing\BaseMutatorTestCaseIntegrationTest`.'
-count = 1
+code = "non-existent-class-like"
+message = 'Class, Interface, or Trait `Infection\Tests\Fixtures\Mutator\CustomNameMutator` does not exist.'
+count = 2
 
 [[issues]]
 file = "tests/phpunit/Testing/BaseMutatorTestCaseTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `codeToWrapInMethodProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Testing/BaseMutatorTestCaseTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\Testing\BaseMutatorTestCaseTest`.'
 count = 1
 
 [[issues]]
@@ -20701,18 +13849,6 @@ message = 'Potentially unhandled exception `Random\RandomException` in `Infectio
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestingUtility/FileSystem/MockSplFileInfoTest.php"
-code = "non-existent-method"
-message = 'Method `assertfalse` does not exist on type `Infection\Tests\TestingUtility\FileSystem\MockSplFileInfoTest`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/FileSystem/MockSplFileInfoTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestingUtility\FileSystem\MockSplFileInfoTest`.'
-count = 11
-
-[[issues]]
 file = "tests/phpunit/TestingUtility/Iterable/NonRewindableIteratorTest.php"
 code = "docblock-type-mismatch"
 message = '''Docblock return type `array<('TKey.infection\tests\testingutility\iterable\nonrewindableiteratortest::toarraywithoutrewind() extends mixed), ('TValue.infection\tests\testingutility\iterable\nonrewindableiteratortest::toarraywithoutrewind() extends mixed)>` is incompatible with native return type `array<array-key, mixed>`.'''
@@ -20722,18 +13858,6 @@ count = 1
 file = "tests/phpunit/TestingUtility/Iterable/NonRewindableIteratorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/NonRewindableIteratorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestingUtility\Iterable\NonRewindableIteratorTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/NonRewindableIteratorTest.php"
-code = "non-existent-method"
-message = 'Method `expectexception` does not exist on type `Infection\Tests\TestingUtility\Iterable\NonRewindableIteratorTest`.'
 count = 1
 
 [[issues]]
@@ -20755,51 +13879,9 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 8
 
 [[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/TrackableIteratorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestingUtility\Iterable\TrackableIteratorTest`.'
-count = 13
-
-[[issues]]
 file = "tests/phpunit/TestingUtility/Iterable/YieldOnceIteratorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/YieldOnceIteratorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestingUtility\Iterable\YieldOnceIteratorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/PHPUnit/DataProviderFactoryTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestingUtility\PHPUnit\DataProviderFactoryTest`.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/PHPUnit/ExpectsThrowables.php"
-code = "missing-return-statement"
-message = "Missing return statement in function 'expecttothrow'"
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/PHPUnit/ExpectsThrowables.php"
-code = "non-existent-method"
-message = 'Method `fail` does not exist on type `Infection\Tests\TestingUtility\PHPUnit\ExpectsThrowables`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/PHPUnit/ExpectsThrowablesTest.php"
-code = "non-existent-method"
-message = 'Method `assertnotsame` does not exist on type `Infection\Tests\TestingUtility\PHPUnit\ExpectsThrowablesTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/PHPUnit/ExpectsThrowablesTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestingUtility\PHPUnit\ExpectsThrowablesTest`.'
 count = 1
 
 [[issues]]
@@ -20827,12 +13909,6 @@ message = "Type `iterable` in return type of `attributeProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestingUtility/PhpParser/Visitor/KeepOnlyDesiredAttributesVisitor/KeepOnlyDesiredAttributesVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestingUtility\PhpParser\Visitor\KeepOnlyDesiredAttributesVisitor\KeepOnlyDesiredAttributesVisitorTest`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestingUtility/PhpParser/Visitor/SkipNodesVisitor/SkipNodesVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -20840,27 +13916,9 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestingUtility/PhpParser/Visitor/SkipNodesVisitor/SkipNodesVisitorTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\TestingUtility\PhpParser\Visitor\SkipNodesVisitor\SkipNodesVisitorTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/PhpParser/Visitor/SkipNodesVisitor/SkipNodesVisitorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\TestingUtility\PhpParser\Visitor\SkipNodesVisitor\SkipNodesVisitorTest::test_it_skips_encountered_nodes`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/UnsupportedMethodTest.php"
-code = "non-existent-method"
-message = 'Method `assertnull` does not exist on type `Infection\Tests\UnsupportedMethodTest`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/UnsupportedMethodTest.php"
-code = "non-existent-method"
-message = 'Method `assertsame` does not exist on type `Infection\Tests\UnsupportedMethodTest`.'
-count = 2
 
 [[issues]]
 file = "tests/phpunit/WithConsecutive.php"

--- a/mago.toml
+++ b/mago.toml
@@ -24,6 +24,10 @@ excludes = [
     "tests/phpunit/Command/Debug/DumpAstCommand/EchoGreeter.php",
     "tests/phpunit/Mutation/FileMutationGenerator/Fixtures",
     "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/Fixtures",
+    # Rector or PHPStan stubs can pollute Mago's Reflection inference
+    # https://github.com/carthage-software/mago/issues/1676
+    "vendor/rector/rector",
+    "vendor/phpstan",
 ]
 
 [source.glob]


### PR DESCRIPTION
Their stubs are currently picked up by Mago. Mago may improve in the future its understanding of such stubs, but arguably it is other's tools SA, they do not need to be understood nor picked up by Mago.

By excluding those, we remove a lot of misunderstandings and as a result delete 3,090 entries from the baseline.
