### PR TITLE
refactor(tracing): Improve the documentation of the TestFileDataProvider

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -483,7 +483,7 @@ count = 1
 [[issues]]
 file = "src/Command/RunCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Command\RunCommand::executeCommand`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Command\RunCommand::executeCommand`.'
 count = 1
 
 [[issues]]
@@ -3003,7 +3003,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder::createCompleteTestLocationsGenerator`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder::createCompleteTestLocationsGenerator`.'
 count = 1
 
 [[issues]]
@@ -3441,7 +3441,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/Tracing/TraceProviderAdapterTracer.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\TestFramework\Tracing\TraceProviderAdapterTracer::getTraceGenerator`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\TestFramework\Tracing\TraceProviderAdapterTracer::getTraceGenerator`.'
 count = 1
 
 [[issues]]
@@ -4761,7 +4761,7 @@ count = 1
 [[issues]]
 file = "tests/benchmark/Tracing/create-main.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Benchmark\Tracing\collectSources`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Benchmark\Tracing\collectSources`.'
 count = 1
 
 [[issues]]
@@ -6681,7 +6681,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Container/ContainerTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\Container\ContainerTest::test_it_can_build_lazy_source_file_data_factory_that_fails_on_use`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\Container\ContainerTest::test_it_can_build_lazy_source_file_data_factory_that_fails_on_use`.'
 count = 1
 
 [[issues]]
@@ -6969,43 +6969,43 @@ count = 1
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/EngineTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
 count = 1
 
 [[issues]]
@@ -8343,13 +8343,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
 count = 1
 
 [[issues]]
@@ -11655,7 +11655,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
 count = 1
 
 [[issues]]
@@ -11931,19 +11931,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_adds_if_junit_is_provided`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_adds_if_junit_is_provided`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_add_if_junit_is_not_provided`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_add_if_junit_is_not_provided`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_load_the_trace_tests_until_necessary`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_load_the_trace_tests_until_necessary`.'
 count = 1
 
 [[issues]]
@@ -11973,13 +11973,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::test_it_can_get_the_test_info_for_a_given_test_id`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::test_it_can_get_the_test_info_for_a_given_test_id`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::test_it_is_idempotent`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::test_it_is_idempotent`.'
 count = 1
 
 [[issues]]
@@ -12015,7 +12015,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
 count = 1
 
 [[issues]]
@@ -12501,7 +12501,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
 count = 1
 
 [[issues]]

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -57,7 +57,7 @@ use Infection\Resource\Memory\MemoryLimiter;
 use Infection\Source\Exception\NoSourceFound;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\TestFramework\Coverage\CoverageChecker;
-use Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException;
+use Infection\TestFramework\Coverage\JUnit\TestNotFound;
 use Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound;
 use Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable;
 use Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound;
@@ -101,7 +101,7 @@ final readonly class Engine
      * @throws NoReportFound
      * @throws TooManyReportsFound
      * @throws ReportLocationThrowable
-     * @throws TestFileNameNotFoundException
+     * @throws TestNotFound
      */
     public function execute(): void
     {
@@ -213,7 +213,7 @@ final readonly class Engine
      * @throws NoReportFound
      * @throws TooManyReportsFound
      * @throws ReportLocationThrowable
-     * @throws TestFileNameNotFoundException
+     * @throws TestNotFound
      */
     private function runMutationAnalysis(): void
     {

--- a/src/Mutation/MutationGenerator.php
+++ b/src/Mutation/MutationGenerator.php
@@ -44,7 +44,7 @@ use Infection\Mutator\Mutator;
 use Infection\PhpParser\UnparsableFile;
 use Infection\Source\Collector\SourceCollector;
 use Infection\Source\Exception\NoSourceFound;
-use Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException;
+use Infection\TestFramework\Coverage\JUnit\TestNotFound;
 use Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound;
 use Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable;
 use Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound;
@@ -83,7 +83,7 @@ class MutationGenerator
      * @throws NoReportFound
      * @throws TooManyReportsFound
      * @throws ReportLocationThrowable
-     * @throws TestFileNameNotFoundException
+     * @throws TestNotFound
      *
      * @return iterable<Mutation>
      */

--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -62,7 +62,7 @@ class JUnitTestExecutionInfoAdder
     /**
      * @param iterable<Trace> $traces
      *
-     * @throws TestFileNameNotFoundException
+     * @throws TestNotFound
      *
      * @return iterable<Trace>
      */
@@ -78,7 +78,7 @@ class JUnitTestExecutionInfoAdder
     /**
      * @param iterable<Trace> $traces
      *
-     * @throws TestFileNameNotFoundException
+     * @throws TestNotFound
      *
      * @return iterable<Trace>
      */
@@ -112,7 +112,7 @@ class JUnitTestExecutionInfoAdder
     }
 
     /**
-     * @throws TestFileNameNotFoundException
+     * @throws TestNotFound
      */
     private function createCompleteTestLocation(TestLocation $test): TestLocation
     {

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -88,19 +88,19 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
     /**
      * @return iterable<string, string>
      */
-    private static function testCaseMapGenerator(string $fullyQualifiedClassName): iterable
+    private static function testCaseMapGenerator(string $testId): iterable
     {
         // A default format for <testsuite>
-        yield '//testsuite[@name="%s"][1]' => $fullyQualifiedClassName;
+        yield '//testsuite[@name="%s"][1]' => $testId;
 
         // A format where the class name is inside `class` attribute of `testcase` tag
-        yield '//testcase[@class="%s"][1]' => $fullyQualifiedClassName;
+        yield '//testcase[@class="%s"][1]' => $testId;
 
         // A format where the class name is inside `file` attribute of `testcase` tag
-        yield '//testcase[contains(@file, "%s")][1]' => preg_replace('/^(.*):+.*$/', '$1.feature', $fullyQualifiedClassName);
+        yield '//testcase[contains(@file, "%s")][1]' => preg_replace('/^(.*):+.*$/', '$1.feature', $testId);
 
         // A format where the class name parsed from feature and is inside `class` attribute of `testcase` tag
-        yield '//testcase[@class="%s"][1]' => preg_replace('/^(.*):+.*$/', '$1', $fullyQualifiedClassName);
+        yield '//testcase[@class="%s"][1]' => preg_replace('/^(.*):+.*$/', '$1', $testId);
     }
 
     private function getXPath(): SafeDOMXPath

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -53,14 +53,14 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
     ) {
     }
 
-    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData
+    public function getTestFileInfo(string $testId): TestFileTimeData
     {
         $xPath = $this->getXPath();
 
         $node = null;
         $testFound = false;
 
-        foreach (self::testCaseMapGenerator($fullyQualifiedClassName) as $queryString => $placeholder) {
+        foreach (self::testCaseMapGenerator($testId) as $queryString => $placeholder) {
             $node = $xPath->queryElement(sprintf($queryString, $placeholder));
 
             if ($node !== null) {
@@ -72,7 +72,7 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
 
         if (!$testFound) {
             throw TestFileNameNotFoundException::notFoundFromFQN(
-                $fullyQualifiedClassName,
+                $testId,
                 $this->jUnitLocator->locate(),
             );
         }

--- a/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider.php
@@ -71,7 +71,7 @@ final class JUnitTestFileDataProvider implements TestFileDataProvider
         }
 
         if (!$testFound) {
-            throw TestFileNameNotFoundException::notFoundFromFQN(
+            throw TestNotFound::forTestId(
                 $testId,
                 $this->jUnitLocator->locate(),
             );

--- a/src/TestFramework/Coverage/JUnit/MemoizedTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/MemoizedTestFileDataProvider.php
@@ -52,12 +52,12 @@ final class MemoizedTestFileDataProvider implements TestFileDataProvider
     ) {
     }
 
-    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData
+    public function getTestFileInfo(string $testId): TestFileTimeData
     {
-        if (!array_key_exists($fullyQualifiedClassName, $this->cache)) {
-            $this->cache[$fullyQualifiedClassName] = $this->provider->getTestFileInfo($fullyQualifiedClassName);
+        if (!array_key_exists($testId, $this->cache)) {
+            $this->cache[$testId] = $this->provider->getTestFileInfo($testId);
         }
 
-        return $this->cache[$fullyQualifiedClassName];
+        return $this->cache[$testId];
     }
 }

--- a/src/TestFramework/Coverage/JUnit/TestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/TestFileDataProvider.php
@@ -52,7 +52,7 @@ interface TestFileDataProvider
      * - 'Codeception_With_Suite_Overridings\Tests\unit\Covered\CalculatorTest:testMultiplication'
      * - 'calculator:Dividing two numbers'
      *
-     * @throws TestFileNameNotFoundException
+     * @throws TestNotFound
      */
     public function getTestFileInfo(string $testId): TestFileTimeData;
 }

--- a/src/TestFramework/Coverage/JUnit/TestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/TestFileDataProvider.php
@@ -41,16 +41,18 @@ namespace Infection\TestFramework\Coverage\JUnit;
 interface TestFileDataProvider
 {
     /**
-     * Provides 1) file name of the test file that contains passed as a parameter test class
-     *          2) Time test was executed with
+     * Provides the test location and time information for a given test ID.
      *
-     * Example for file name:
-     *      param:  '\NameSpace\Sub\TestClass'
-     *      return: '/path/to/NameSpace/Sub/TestClass.php'
+     * Examples for PHPUnit:
+     * - 'Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest'
+     * - 'Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest::test_multiply'
+     *
+     * Examples for Codeception:
+     * - 'Codeception_With_Suite_Overridings\Tests\unit\Covered\CalculatorTest'
+     * - 'Codeception_With_Suite_Overridings\Tests\unit\Covered\CalculatorTest:testMultiplication'
+     * - 'calculator:Dividing two numbers'
      *
      * @throws TestFileNameNotFoundException
-     *
-     * @return TestFileTimeData file path and time
      */
-    public function getTestFileInfo(string $fullyQualifiedClassName): TestFileTimeData;
+    public function getTestFileInfo(string $testId): TestFileTimeData;
 }

--- a/src/TestFramework/Coverage/JUnit/TestFileTimeData.php
+++ b/src/TestFramework/Coverage/JUnit/TestFileTimeData.php
@@ -40,6 +40,10 @@ namespace Infection\TestFramework\Coverage\JUnit;
  */
 final class TestFileTimeData
 {
+    /**
+     * @param string $path Absolute path to the test file.
+     * @param float  $time Test execution time in seconds.
+     */
     public function __construct(
         public string $path,
         public float $time,

--- a/src/TestFramework/Coverage/JUnit/TestFileTimeData.php
+++ b/src/TestFramework/Coverage/JUnit/TestFileTimeData.php
@@ -42,7 +42,7 @@ final class TestFileTimeData
 {
     /**
      * @param string $path Absolute path to the test file.
-     * @param float  $time Test execution time in seconds.
+     * @param float $time Test execution time in seconds.
      */
     public function __construct(
         public string $path,

--- a/src/TestFramework/Coverage/JUnit/TestNotFound.php
+++ b/src/TestFramework/Coverage/JUnit/TestNotFound.php
@@ -35,16 +35,24 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Coverage\JUnit;
 
-use Exception;
+use RuntimeException;
 use function sprintf;
 
 /**
  * @internal
  */
-final class TestFileNameNotFoundException extends Exception
+final class TestNotFound extends RuntimeException
 {
-    public static function notFoundFromFQN(string $fqn, string $jUnitFilePath): self
-    {
-        return new self(sprintf('For FQCN: %s. Junit report: %s', $fqn, $jUnitFilePath));
+    public static function forTestId(
+        string $testId,
+        string $reportPathname,
+    ): self {
+        return new self(
+            sprintf(
+                'Could not find any information for the test "%s" in the coverage file "%s".',
+                $testId,
+                $reportPathname,
+            ),
+        );
     }
 }

--- a/src/TestFramework/Tracing/TraceProvider.php
+++ b/src/TestFramework/Tracing/TraceProvider.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\TestFramework\Tracing;
 
 use Infection\Source\Exception\NoSourceFound;
-use Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException;
+use Infection\TestFramework\Coverage\JUnit\TestNotFound;
 use Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound;
 use Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable;
 use Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound;
@@ -54,7 +54,7 @@ interface TraceProvider
      * @throws NoReportFound
      * @throws TooManyReportsFound
      * @throws ReportLocationThrowable
-     * @throws TestFileNameNotFoundException
+     * @throws TestNotFound
      *
      * @return iterable<Trace>
      */

--- a/tests/phpunit/Fixtures/TestFramework/Coverage/JUnit/FakeTestFileDataProvider.php
+++ b/tests/phpunit/Fixtures/TestFramework/Coverage/JUnit/FakeTestFileDataProvider.php
@@ -10,7 +10,7 @@ use Infection\Tests\UnsupportedMethod;
 
 final class FakeTestFileDataProvider implements TestFileDataProvider
 {
-    public function getTestFileInfo(string $fullyQualifiedClassName): never
+    public function getTestFileInfo(string $testId): never
     {
         throw UnsupportedMethod::method(self::class, __FUNCTION__);
     }

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionBDDProvider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionBDDProvider.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
 
 use Infection\CannotBeInstantiated;
-use Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
+use Infection\TestFramework\Coverage\JUnit\TestNotFound;
 use InvalidArgumentException;
 use function Safe\file_get_contents;
 use Symfony\Component\Filesystem\Path;
@@ -73,7 +73,7 @@ final class CodeceptionBDDProvider
         yield 'test ID of a simple test (ID found in a JUnit report)' => [
             $junitXml,
             'Calculator: Dividing two numbers',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a simple test (ID found in a CoverageXML report)' => [
@@ -88,13 +88,13 @@ final class CodeceptionBDDProvider
         yield 'test method of a simple test' => [
             $junitXml,
             'Dividing two numbers',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a scenario outline (ID found in a JUnit report)' => [
             $junitXml,
             'Calculator: Checking if numbers are positive | 5, true',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a scenario outline (ID found in a CoverageXML report)' => [
@@ -109,13 +109,13 @@ final class CodeceptionBDDProvider
         yield 'test method of a test with a scenario outline' => [
             $junitXml,
             'Checking if numbers are positive',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a scenario outline with a placeholder in the scenario title (ID found in a JUnit report)' => [
             $junitXml,
             'Calculator: Computing absolute value with label &quot;&lt;label&gt;&quot; | 42, 5, 5',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a scenario outline with a placeholder in the scenario title (ID found in a CoverageXML report)' => [
@@ -130,19 +130,19 @@ final class CodeceptionBDDProvider
         yield 'test ID of a test with a scenario outline with a placeholder in the scenario title with special characters (ID found in a JUnit report)' => [
             $junitXml,
             'Calculator: Computing absolute value with label &quot;&lt;label&gt;&quot; | with special chars (\'&quot;#::&amp;), -15, 15',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a scenario outline with a placeholder in the scenario title with special characters (ID found in a CoverageXML report)' => [
             $junitXml,
             'calculator:Computing absolute value with label &quot;&lt;label&gt;&quot; | with special chars (\'&quot;#::&amp;), -15, 15',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a test with a scenario outline with a placeholder in the scenario title' => [
             $junitXml,
             'Computing absolute value with label &quot;&lt;label&gt;&quot;',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
     }
 }

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionCestProvider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionCestProvider.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
 
 use Infection\CannotBeInstantiated;
-use Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
+use Infection\TestFramework\Coverage\JUnit\TestNotFound;
 use function Safe\file_get_contents;
 use Symfony\Component\Filesystem\Path;
 
@@ -84,7 +84,7 @@ final class CodeceptionCestProvider
         yield 'test method of a simple test' => [
             $junitXml,
             'testIsPositive',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         // Codeception does not understand PHPUnit data providers.

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionUnitProvider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionUnitProvider.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
 
 use Infection\CannotBeInstantiated;
-use Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
+use Infection\TestFramework\Coverage\JUnit\TestNotFound;
 use function Safe\file_get_contents;
 use Symfony\Component\Filesystem\Path;
 
@@ -84,7 +84,7 @@ final class CodeceptionUnitProvider
         yield 'test method of a simple test' => [
             $junitXml,
             'testMultiplication',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         // Codeception does not understand PHPUnit data providers.

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit09Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit09Provider.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
 
 use Infection\CannotBeInstantiated;
-use Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
+use Infection\TestFramework\Coverage\JUnit\TestNotFound;
 use function Safe\file_get_contents;
 use Symfony\Component\Filesystem\Path;
 
@@ -65,37 +65,37 @@ final readonly class PhpUnit09Provider
         yield 'test ID of a simple test' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_09_3\Tests\Covered\CalculatorTest::test_multiply',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a simple test' => [
             $junitXml,
             'test_multiply',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a numerical key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_09_3\Tests\Covered\CalculatorTest::test_subtract#0',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a string key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_09_3\Tests\Covered\CalculatorTest::test_subtract#with a key',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a string key with special characters' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_09_3\Tests\Covered\CalculatorTest::test_subtract#with a key with (\'&quot;#::&amp;) special characters',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a test with a data provider' => [
             $junitXml,
             'test_subtract',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test case of a data provider' => [
@@ -110,25 +110,25 @@ final readonly class PhpUnit09Provider
         yield 'test ID of a test with an external data provider with a numerical key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_09_3\Tests\Covered\CalculatorTest::test_add#0',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with an external data provider with a string key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_09_3\Tests\Covered\CalculatorTest::test_add#with a key',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with an external data provider with a string key with special characters' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_09_3\Tests\Covered\CalculatorTest::test_add#with a key with (\'&quot;#::&amp;) special characters',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a test with an external data provider' => [
             $junitXml,
             'test_add',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test case of an external data provider' => [

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit10Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit10Provider.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
 
 use Infection\CannotBeInstantiated;
-use Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
+use Infection\TestFramework\Coverage\JUnit\TestNotFound;
 use function Safe\file_get_contents;
 use Symfony\Component\Filesystem\Path;
 
@@ -65,37 +65,37 @@ final class PhpUnit10Provider
         yield 'test ID of a simple test' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_10_1\Tests\Covered\CalculatorTest::test_multiply',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a simple test' => [
             $junitXml,
             'test_multiply',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a numerical key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_10_1\Tests\Covered\CalculatorTest::test_subtract#0',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a string key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_10_1\Tests\Covered\CalculatorTest::test_subtract#with a key',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a string key with special characters' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_10_1\Tests\Covered\CalculatorTest::test_subtract#with a key with (\'&quot;#::&amp;) special characters',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a test with a data provider' => [
             $junitXml,
             'test_subtract',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test case of a data provider' => [
@@ -110,25 +110,25 @@ final class PhpUnit10Provider
         yield 'test ID of a test with an external data provider with a numerical key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_10_1\Tests\Covered\CalculatorTest::test_add#0',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with an external data provider with a string key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_10_1\Tests\Covered\CalculatorTest::test_add#with a key',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with an external data provider with a string key with special characters' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_10_1\Tests\Covered\CalculatorTest::test_add#with a key with (\'&quot;#::&amp;) special characters',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a test with an external data provider' => [
             $junitXml,
             'test_add',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test case of an external data provider' => [

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit11Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit11Provider.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
 
 use Infection\CannotBeInstantiated;
-use Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
+use Infection\TestFramework\Coverage\JUnit\TestNotFound;
 use function Safe\file_get_contents;
 use Symfony\Component\Filesystem\Path;
 
@@ -65,37 +65,37 @@ final class PhpUnit11Provider
         yield 'test ID of a simple test' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_11\Tests\Covered\CalculatorTest::test_multiply',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a simple test' => [
             $junitXml,
             'test_multiply',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a numerical key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_11\Tests\Covered\CalculatorTest::test_subtract#0',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a string key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_11\Tests\Covered\CalculatorTest::test_subtract#with a key',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a string key with special characters' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_11\Tests\Covered\CalculatorTest::test_subtract#with a key with (\'&quot;#::&amp;) special characters',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a test with a data provider' => [
             $junitXml,
             'test_subtract',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test case of a data provider' => [
@@ -110,25 +110,25 @@ final class PhpUnit11Provider
         yield 'test ID of a test with an external data provider with a numerical key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_11\Tests\Covered\CalculatorTest::test_add#0',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with an external data provider with a string key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_11\Tests\Covered\CalculatorTest::test_add#with a key',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with an external data provider with a string key with special characters' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_11\Tests\Covered\CalculatorTest::test_add#with a key with (\'&quot;#::&amp;) special characters',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a test with an external data provider' => [
             $junitXml,
             'test_add',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test case of an external data provider' => [

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit12Provider.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit12Provider.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
 
 use Infection\CannotBeInstantiated;
-use Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
+use Infection\TestFramework\Coverage\JUnit\TestNotFound;
 use function Safe\file_get_contents;
 use Symfony\Component\Filesystem\Path;
 
@@ -65,37 +65,37 @@ final class PhpUnit12Provider
         yield 'test ID of a simple test' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest::test_multiply',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a simple test' => [
             $junitXml,
             'test_multiply',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a numerical key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest::test_subtract#0',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a string key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest::test_subtract#with a key',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with a data provider with a string key with special characters' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest::test_subtract#with a key with (\'&quot;#::&amp;) special characters',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a test with a data provider' => [
             $junitXml,
             'test_subtract',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test case of a data provider' => [
@@ -110,25 +110,25 @@ final class PhpUnit12Provider
         yield 'test ID of a test with an external data provider with a numerical key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest::test_add#0',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with an external data provider with a string key' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest::test_add#with a key',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test ID of a test with an external data provider with a string key with special characters' => [
             $junitXml,
             'Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest::test_add#with a key with (\'&quot;#::&amp;) special characters',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test method of a test with an external data provider' => [
             $junitXml,
             'test_add',
-            TestFileNameNotFoundException::class,
+            TestNotFound::class,
         ];
 
         yield 'test case of an external data provider' => [

--- a/tests/phpunit/TestFramework/Coverage/JUnit/TestNotFoundTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/TestNotFoundTest.php
@@ -35,18 +35,24 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Coverage\JUnit;
 
-use Infection\TestFramework\Coverage\JUnit\TestFileNameNotFoundException;
+use Infection\TestFramework\Coverage\JUnit\TestNotFound;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(TestFileNameNotFoundException::class)]
-final class TestFileNameNotFoundExceptionTest extends TestCase
+#[CoversClass(TestNotFound::class)]
+final class TestNotFoundTest extends TestCase
 {
-    public function test_from_fqn(): void
+    public function test_it_can_be_created_for_a_test_id_of_a_junit_report(): void
     {
-        $exception = TestFileNameNotFoundException::notFoundFromFQN('Foo\Bar', '/path/to/junit/xml');
+        $exception = TestNotFound::forTestId(
+            'calculator:Dividing two numbers',
+            '/path/to/codeception-bdd-junit.xml',
+        );
 
-        $this->assertInstanceOf(TestFileNameNotFoundException::class, $exception);
-        $this->assertSame('For FQCN: Foo\Bar. Junit report: /path/to/junit/xml', $exception->getMessage());
+        $expected = new TestNotFound(
+            'Could not find any information for the test "calculator:Dividing two numbers" in the coverage file "/path/to/codeception-bdd-junit.xml".',
+        );
+
+        $this->assertEquals($expected, $exception);
     }
 }


### PR DESCRIPTION
## Description

The `$fullyQualifiedClassName` parameter of `TestFileDataProvider::getTestFileInfo()` is incorrect as what is passed is a test ID, i.e. the id used by the testing tool when generating the coverage report to refer to a specific test or test suite. This ID _happens_ to be FQCN when the test is a PHPUnit test suite or some of Codeception test suites, but it can be different. For examples (taken from `JUnitTestFileDataProviderTest`):

- `Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest::test_add#with a key with (\'&quot;#::&amp;) special characters`
- `calculator:Dividing two numbers`

So to clarify, with the first example, all the following are valid test IDs:

- `Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest::test_add#with a key with (\'&quot;#::&amp;) special characters`: a specific test
- `Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest::test_add`: a test case (constructed by a data provider)
- `Infection\E2ETests\PHPUnit_12_0\Tests\Covered\CalculatorTest`: another test case (base PHPUnit class – which can contain more individual tests and/or test cases).

I also added more documentation to `TestFileTimeData` because it is otherwise really not clear what `TestFileTimeData#path` and `TestFileTimeData#time` are like.

As a side-effect, `TestFileNameNotFoundException::forFqcn()` no longer makes sense and has been renamed to ` TestNotFound::forTestId()`.

## Related issues

- https://github.com/infection/infection/issues/2816