### PR TITLE
perf(ast): Avoid traversing branches which do not contain eligible nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ validate:
 profile: 	 	## Runs Blackfire
 profile:
 	$(MAKE) profile_mutation_generator
+	$(MAKE) profile_ast_processing
 	$(MAKE) profile_parse_git_diff
 	$(MAKE) profile_tracing
 
@@ -164,10 +165,25 @@ profile_mutation_generator: vendor $(BENCHMARK_MUTATION_GENERATOR_SOURCES)
 		php tests/benchmark/MutationGenerator/profile.php
 	composer dump
 
+.PHONY: profile_ast_processing
+profile_ast_processing: vendor $(BENCHMARK_TRACING_SUBMODULE) $(BENCHMARK_TRACING_COVERAGE_DIR)
+	composer dump --classmap-authoritative --quiet
+	blackfire run \
+		--title="AstProcessing" \
+		--metadata="commit=$(COMMIT_HASH)" \
+		php tests/benchmark/AstProcessing/profile.php
+	composer dump
+
 .PHONY: benchmark_mutation_generator
 benchmark_mutation_generator: vendor $(BENCHMARK_MUTATION_GENERATOR_SOURCES)
 	composer dump --classmap-authoritative --quiet
 	vendor/bin/phpbench run tests/benchmark/MutationGenerator $(PHPBENCH_REPORTS)
+	composer dump
+
+.PHONY: benchmark_ast_processing
+benchmark_ast_processing: vendor $(BENCHMARK_TRACING_SUBMODULE) $(BENCHMARK_TRACING_COVERAGE_DIR)
+	composer dump --classmap-authoritative --quiet
+	vendor/bin/phpbench run tests/benchmark/AstProcessing $(PHPBENCH_REPORTS)
 	composer dump
 
 .PHONY: profile_parse_git_diff

--- a/src/Command/Debug/DumpAstCommand.php
+++ b/src/Command/Debug/DumpAstCommand.php
@@ -72,6 +72,8 @@ final class DumpAstCommand extends BaseCommand
 
     private const string SHOW_ATTRIBUTES = 'show-attributes';
 
+    private const string SHOW_INELIGIBLE_NODES = 'show-ineligible-nodes';
+
     private const string CHANGED_LINES_RANGES = 'changed-lines-ranges';
 
     private const int CHANGED_LINES_PARTS_COUNT = 2;
@@ -106,6 +108,12 @@ final class DumpAstCommand extends BaseCommand
             'Show all the attributes',
         );
         $this->addOption(
+            self::SHOW_INELIGIBLE_NODES,
+            null,
+            InputOption::VALUE_NONE,
+            'Show AST branches that do not contain eligible nodes.',
+        );
+        $this->addOption(
             self::CHANGED_LINES_RANGES,
             null,
             InputOption::VALUE_OPTIONAL,
@@ -122,6 +130,7 @@ final class DumpAstCommand extends BaseCommand
     {
         $file = $this->getFile($io);
         $shouldShowAttributes = self::shouldShowAttributes($io);
+        $shouldShowIneligibleNodes = self::shouldShowIneligibleNodes($io);
         $changedLinesRanges = self::getChangedLinesRanges($io);
         $hasChangedLines = $changedLinesRanges !== null;
         $configFile = ConfigurationOption::get($io);
@@ -141,6 +150,7 @@ final class DumpAstCommand extends BaseCommand
             $container->getNodeDumper()->dump(
                 $nodes,
                 dumpOtherAttributes: $shouldShowAttributes || $hasChangedLines,
+                onlyVisitedNodes: !$shouldShowIneligibleNodes,
                 decorateNodes: $io->isDecorated(),
                 showLineNumbers: $hasChangedLines,
             ),
@@ -207,6 +217,11 @@ final class DumpAstCommand extends BaseCommand
     private static function shouldShowAttributes(IO $io): bool
     {
         return (bool) $io->getInput()->getOption(self::SHOW_ATTRIBUTES);
+    }
+
+    private static function shouldShowIneligibleNodes(IO $io): bool
+    {
+        return (bool) $io->getInput()->getOption(self::SHOW_INELIGIBLE_NODES);
     }
 
     /**

--- a/src/PhpParser/NodeTraverserFactory.php
+++ b/src/PhpParser/NodeTraverserFactory.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\PhpParser;
 
 use Infection\PhpParser\Visitor\AddTestsVisitor;
+use Infection\PhpParser\Visitor\ContainsEligibleNodeVisitor;
 use Infection\PhpParser\Visitor\ExcludeIgnoredNodesVisitor;
 use Infection\PhpParser\Visitor\ExcludeNonMutableCodeVisitor;
 use Infection\PhpParser\Visitor\ExcludeUnchangedLinesVisitor;
@@ -47,6 +48,7 @@ use Infection\PhpParser\Visitor\NameResolverFactory;
 use Infection\PhpParser\Visitor\NextConnectingVisitor;
 use Infection\PhpParser\Visitor\ReflectionVisitor;
 use Infection\PhpParser\Visitor\SkipIgnoredNodesVisitor;
+use Infection\PhpParser\Visitor\SkipNodesWithoutEligibleNodeVisitor;
 use Infection\Source\Matcher\SourceLineMatcher;
 use Infection\TestFramework\Tracing\Trace\LineRangeCalculator;
 use Infection\TestFramework\Tracing\Trace\Trace;
@@ -104,12 +106,15 @@ readonly class NodeTraverserFactory
             $visitors[] = new ExcludeUntestedNodesVisitor();
         }
 
+        $visitors[] = new ContainsEligibleNodeVisitor();
+
         return new NodeTraverser(...$visitors);
     }
 
     public function createMutationTraverser(NodeVisitor $mutationVisitor): NodeTraverserInterface
     {
         return new NodeTraverser(
+            new SkipNodesWithoutEligibleNodeVisitor(),
             new NodeVisitor\CloningVisitor(),
             $mutationVisitor,
         );

--- a/src/PhpParser/Visitor/ContainsEligibleNodeVisitor.php
+++ b/src/PhpParser/Visitor/ContainsEligibleNodeVisitor.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\PhpParser\Visitor;
+
+use function array_pop;
+use function count;
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use Webmozart\Assert\Assert;
+
+/**
+ * @internal
+ */
+final class ContainsEligibleNodeVisitor extends NodeVisitorAbstract
+{
+    public const string CONTAINS_ELIGIBLE_NODE = 'containsEligibleNode';
+
+    /**
+     * @var array<int, bool>
+     */
+    private array $containsEligibleNodeStack = [];
+
+    public static function containsEligibleNode(Node $node): bool
+    {
+        return $node->getAttribute(self::CONTAINS_ELIGIBLE_NODE, default: false);
+    }
+
+    public static function markAsContainingEligibleNode(Node $node): void
+    {
+        $node->setAttribute(self::CONTAINS_ELIGIBLE_NODE, true);
+    }
+
+    public function beforeTraverse(array $nodes): null
+    {
+        $this->containsEligibleNodeStack = [];
+
+        return null;
+    }
+
+    public function enterNode(Node $node): null
+    {
+        $this->containsEligibleNodeStack[] = LabelNodesAsEligibleVisitor::isEligible($node);
+
+        return null;
+    }
+
+    public function leaveNode(Node $node): null
+    {
+        $containsEligibleNode = array_pop($this->containsEligibleNodeStack);
+
+        Assert::notNull(
+            $containsEligibleNode,
+            'Cannot leave a node that was not entered.',
+        );
+
+        if ($containsEligibleNode) {
+            self::markAsContainingEligibleNode($node);
+        } else {
+            $node->setAttribute(self::CONTAINS_ELIGIBLE_NODE, false);
+        }
+
+        if ($containsEligibleNode && count($this->containsEligibleNodeStack) !== 0) {
+            $this->containsEligibleNodeStack[count($this->containsEligibleNodeStack) - 1] = true;
+        }
+
+        return null;
+    }
+}

--- a/src/PhpParser/Visitor/SkipNodesWithoutEligibleNodeVisitor.php
+++ b/src/PhpParser/Visitor/SkipNodesWithoutEligibleNodeVisitor.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\PhpParser\Visitor;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * @internal
+ */
+final class SkipNodesWithoutEligibleNodeVisitor extends NodeVisitorAbstract
+{
+    public function enterNode(Node $node): ?int
+    {
+        if (!ContainsEligibleNodeVisitor::containsEligibleNode($node)) {
+            return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+        }
+
+        return null;
+    }
+}

--- a/tests/benchmark/AstProcessing/AstProcessingBench.php
+++ b/tests/benchmark/AstProcessing/AstProcessingBench.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Benchmark\AstProcessing;
+
+use Closure;
+use const PHP_INT_MAX;
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\ParamProviders;
+use Webmozart\Assert\Assert;
+
+/**
+ * To execute this test run `make benchmark_ast_processing`
+ */
+final class AstProcessingBench
+{
+    private Closure $main;
+
+    private int $count;
+
+    public function setUp(): void
+    {
+        $this->main = (require __DIR__ . '/create-main.php')(PHP_INT_MAX);
+    }
+
+    public function tearDown(): void
+    {
+        Assert::greaterThan(
+            $this->count,
+            0,
+            'No node was entered.',
+        );
+    }
+
+    /**
+     * @param array{float} $params
+     */
+    #[BeforeMethods('setUp')]
+    #[AfterMethods('tearDown')]
+    #[Iterations(5)]
+    #[ParamProviders('providePercentile')]
+    public function bench(array $params): void
+    {
+        $percentage = (float) $params[0];
+
+        $this->count = ($this->main)($percentage);
+    }
+
+    /**
+     * @return iterable<array{float}>
+     */
+    public static function providePercentile(): iterable
+    {
+        yield '10%' => [.1];
+
+        yield '25%' => [.25];
+
+        yield '50%' => [.5];
+
+        yield '75%' => [.75];
+
+        yield '100%' => [1.];
+    }
+}

--- a/tests/benchmark/AstProcessing/README.md
+++ b/tests/benchmark/AstProcessing/README.md
@@ -1,0 +1,37 @@
+# AST Processing Benchmark
+
+Measures AST enrichment and mutation traversal for source files with existing coverage.
+
+This benchmark reuses the `benchmark-source` project and generated coverage
+fixtures used by the tracing benchmark. It parses each source file, runs the
+enrichment traversal with coverage traces, then runs the mutation traversal with
+a dummy visitor that counts entered nodes. This isolates AST processing from
+mutation generation itself.
+
+## Commands
+
+```bash
+make benchmark_ast_processing
+make profile_ast_processing
+```
+
+## Sources
+
+The benchmark depends on:
+
+- `tests/benchmark/Tracing/benchmark-source`
+- `tests/benchmark/Tracing/coverage`
+
+These are prepared by the same Makefile targets used for `benchmark_tracing`.
+
+## Script
+
+The re-usable code of the benchmark is written in [`create-main.php`](create-main.php). It can be
+orchestrated by [`profile.php`](profile.php), which is also the script used for the profiling.
+
+```synospis
+Options:
+    --max-node-count    Maximum number of nodes entered. Use -1 for no maximum.
+    --percentage        Percentage of sources to process. [0,1], defaults to 1 = 100% of the sources processed.
+    --debug             To use to execute the code without actually profiling.
+```

--- a/tests/benchmark/AstProcessing/create-main.php
+++ b/tests/benchmark/AstProcessing/create-main.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Benchmark\AstProcessing;
+
+use function array_splice;
+use function class_exists;
+use Closure;
+use function count;
+use function function_exists;
+use Infection\Container\Container;
+use Infection\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitor;
+use Infection\TestFramework\Tracing\Trace\Trace;
+use Infection\TestFramework\Tracing\TraceProvider;
+use function iterator_to_array;
+use function max;
+use function min;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitorAbstract;
+use Psr\Log\NullLogger;
+use function round;
+use function sprintf;
+use Symfony\Component\Console\Output\NullOutput;
+use Webmozart\Assert\Assert;
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+if (!class_exists(NodeCountingVisitor::class, false)) {
+    final class NodeCountingVisitor extends NodeVisitorAbstract
+    {
+        private int $count = 0;
+
+        /**
+         * @param positive-int $maxCount
+         */
+        public function __construct(private readonly int $maxCount)
+        {
+        }
+
+        public function enterNode(Node $node): ?int
+        {
+            ++$this->count;
+
+            if ($this->count >= $this->maxCount) {
+                return NodeVisitor::STOP_TRAVERSAL;
+            }
+
+            return null;
+        }
+
+        public function getCount(): int
+        {
+            return $this->count;
+        }
+    }
+}
+
+if (!function_exists('Infection\Benchmark\AstProcessing\createContainer')) {
+    function createContainer(): Container
+    {
+        return Container::create()->withValues(
+            logger: new NullLogger(),
+            output: new NullOutput(),
+            configFile: __DIR__ . '/../Tracing/infection.json5',
+            existingCoveragePath: __DIR__ . '/../Tracing/coverage',
+        );
+    }
+}
+
+if (!function_exists('Infection\Benchmark\AstProcessing\collectTraces')) {
+    /**
+     * @return Trace[]
+     */
+    function collectTraces(): array
+    {
+        // We need to use a fresh container instance, otherwise our lovely iterators are going to be consumed.
+        $traceProvider = createContainer()->get(TraceProvider::class);
+
+        return iterator_to_array(
+            $traceProvider->provideTraces(),
+            preserve_keys: false,
+        );
+    }
+}
+
+if (!function_exists('Infection\Benchmark\AstProcessing\takePercentageOfTraces')) {
+    /**
+     * @param Trace[] $traces
+     *
+     * @return Trace[]
+     */
+    function takePercentageOfTraces(float $percentage, array $traces): array
+    {
+        $tracesOffset = (int) max(
+            0,
+            min(
+                count($traces),
+                round(
+                    count($traces) * $percentage,
+                ),
+            ),
+        );
+
+        return array_splice($traces, 0, $tracesOffset);
+    }
+}
+
+/**
+ * @param positive-int $maxCount
+ *
+ * @return Closure():(positive-int|0)
+ */
+return static function (int $maxCount, float $percentage = 1.): Closure {
+    $container = createContainer();
+    $traces = collectTraces();
+    $fileParser = $container->getFileParser();
+    $traverserFactory = $container->getNodeTraverserFactory();
+
+    return static function (?float $dynamicPercentage = null) use ($fileParser, $maxCount, $percentage, $traces, $traverserFactory): int {
+        $percentage = $dynamicPercentage ?? $percentage;
+        Assert::range(
+            $percentage,
+            0,
+            1,
+            sprintf(
+                'Expected the percentage to be an element of [0., 1.]. Got "%s".',
+                $percentage,
+            ),
+        );
+
+        $tracesSubset = takePercentageOfTraces($percentage, $traces);
+
+        $count = 0;
+
+        foreach ($tracesSubset as $trace) {
+            $sourceFile = $trace->getSourceFileInfo();
+            [$initialStatements] = $fileParser->parse($sourceFile);
+
+            (new NodeTraverser(new AddIdToTraversedNodesVisitor()))->traverse($initialStatements);
+
+            $traverserFactory
+                ->createEnrichmentTraverser($sourceFile, $trace)
+                ->traverse($initialStatements);
+
+            $remainingNodeCount = $maxCount - $count;
+            Assert::positiveInteger($remainingNodeCount);
+
+            $nodeCountingVisitor = new NodeCountingVisitor($remainingNodeCount);
+
+            $traverserFactory
+                ->createMutationTraverser($nodeCountingVisitor)
+                ->traverse($initialStatements);
+
+            $count += $nodeCountingVisitor->getCount();
+
+            if ($count >= $maxCount) {
+                break;
+            }
+        }
+
+        return $count;
+    };
+};

--- a/tests/benchmark/AstProcessing/profile.php
+++ b/tests/benchmark/AstProcessing/profile.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Benchmark\AstProcessing;
+
+use Infection\Benchmark\InstrumentorFactory;
+use LogicException;
+use const PHP_INT_MAX;
+use function sprintf;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+const MAX_NODE_COUNT_OPT = 'max-node-count';
+const PERCENTAGE_OPT = 'percentage';
+const DEBUG_OPT = 'debug';
+
+$input = new ArgvInput(
+    null,
+    new InputDefinition([
+        new InputOption(
+            MAX_NODE_COUNT_OPT,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Maximum number of nodes entered. Use -1 for no maximum.',
+            5000,
+        ),
+        new InputOption(
+            PERCENTAGE_OPT,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Percentage of sources to process. [0,1], defaults to 1 = 100% of the sources processed.',
+            1.,
+        ),
+        new InputOption(
+            DEBUG_OPT,
+            null,
+            InputOption::VALUE_NONE,
+            'To use to execute the code without actually profiling.',
+        ),
+    ]),
+);
+$output = new ConsoleOutput();
+$io = new SymfonyStyle($input, $output);
+
+/** @var positive-int $maxNodeCount */
+$maxNodeCount = (static function (InputInterface $input, string $optionName): int {
+    $option = $input->getOption($optionName);
+
+    Assert::integerish(
+        $option,
+        sprintf(
+            'Expected value of option "%s" to be integerish. Got "%s".',
+            $optionName,
+            $option,
+        ),
+    );
+
+    $intValue = (int) $option;
+
+    if ($intValue === -1) {
+        return PHP_INT_MAX;
+    }
+
+    Assert::positiveInteger(
+        $intValue,
+        sprintf(
+            'Expected value of option "%s" to be a positive integer or -1. Got "%s".',
+            $optionName,
+            $intValue,
+        ),
+    );
+
+    return $intValue;
+})($input, MAX_NODE_COUNT_OPT);
+
+/** @var float $percentage */
+$percentage = (static function (InputInterface $input, string $optionName): float {
+    $option = $input->getOption($optionName);
+
+    Assert::numeric(
+        $option,
+        sprintf(
+            'Expected value of option "%s" to be numeric. Got "%s".',
+            $optionName,
+            $option,
+        ),
+    );
+
+    $floatValue = (float) $option;
+
+    Assert::range(
+        $floatValue,
+        0.,
+        1.,
+        sprintf(
+            'Expected value of option "%s" to be an element of [0,1]. Got "%s".',
+            $optionName,
+            $floatValue,
+        ),
+    );
+
+    return $floatValue;
+})($input, PERCENTAGE_OPT);
+
+$debug = $input->getOption(DEBUG_OPT);
+
+$instrumentor = InstrumentorFactory::create($debug);
+
+$count = $instrumentor->profile(
+    static fn () => (require __DIR__ . '/create-main.php')($maxNodeCount, $percentage),
+    5,
+    $io,
+);
+
+if ($count === 0) {
+    throw new LogicException('Something went wrong, no nodes were actually entered.');
+}
+
+$output->writeln(
+    sprintf(
+        '%d node(s) entered.',
+        $count,
+    ),
+);

--- a/tests/phpunit/BenchmarkSmokeTest.php
+++ b/tests/phpunit/BenchmarkSmokeTest.php
@@ -107,6 +107,19 @@ final class BenchmarkSmokeTest extends TestCase
                 STDOUT,
         ];
 
+        yield 'AstProcessing' => [
+            [
+                Path::canonicalize(self::BENCHMARK_DIR . '/AstProcessing/profile.php'),
+                '--max-node-count=1',
+                '--debug',
+            ],
+            self::BENCHMARK_DIR . '/Tracing/coverage',
+            <<<'STDOUT'
+                1 node(s) entered.
+
+                STDOUT,
+        ];
+
         yield 'ParseGitDiff' => [
             [
                 Path::canonicalize(self::BENCHMARK_DIR . '/ParseGitDiff/profile.php'),

--- a/tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php
+++ b/tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php
@@ -74,9 +74,43 @@ final class DumpAstCommandTest extends FileSystemTestCase
 
     public static function astProvider(): iterable
     {
+        yield 'hides ineligible nodes by default' => [
+            __DIR__ . '/EchoGreeter.php',
+            [],
+            <<<'AST'
+                array(
+                    0: <skipped>
+                    1: Stmt_Namespace(
+                        name: <skipped>
+                        stmts: array(
+                            0: Stmt_Class(
+                                name: <skipped>
+                                implements: array(
+                                    0: <skipped>
+                                )
+                                stmts: array(
+                                    0: Stmt_ClassMethod(
+                                        name: Identifier
+                                        returnType: Identifier
+                                        stmts: array(
+                                            0: Stmt_Echo(
+                                                exprs: array(
+                                                    0: Scalar_String
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+                AST,
+        ];
+
         yield [
             __DIR__ . '/Greeter.php',
-            [],
+            ['--show-ineligible-nodes' => null],
             <<<'AST'
                 array(
                     0: Stmt_Declare(
@@ -107,7 +141,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
 
         yield [
             __DIR__ . '/EchoGreeter.php',
-            [],
+            ['--show-ineligible-nodes' => null],
             <<<'AST'
                 array(
                     0: Stmt_Declare(
@@ -148,57 +182,60 @@ final class DumpAstCommandTest extends FileSystemTestCase
 
         yield 'with attributes' => [
             __DIR__ . '/EchoGreeter.php',
-            ['--show-attributes' => null],
+            [
+                '--show-attributes' => null,
+                '--show-ineligible-nodes' => null,
+            ],
             <<<'AST'
                 array(
                     0: Stmt_Declare(
                         declares: array(
                             0: DeclareItem(
                                 key: Identifier(
+                                    containsEligibleNode: false
                                     eligible: false
                                     nodeId: 2
-                                    origNode: nodeId(2)
                                     parent: nodeId(1)
                                 )
                                 value: Scalar_Int(
+                                    containsEligibleNode: false
                                     eligible: false
                                     kind: KIND_DEC (10)
                                     nodeId: 3
-                                    origNode: nodeId(3)
                                     parent: nodeId(1)
                                     rawValue: 1
                                 )
+                                containsEligibleNode: false
                                 eligible: false
                                 nodeId: 1
-                                origNode: nodeId(1)
                                 parent: nodeId(0)
                             )
                         )
+                        containsEligibleNode: false
                         eligible: false
                         next: nodeId(4)
                         nodeId: 0
-                        origNode: nodeId(0)
                     )
                     1: Stmt_Namespace(
                         name: Name(
+                            containsEligibleNode: false
                             eligible: false
                             nodeId: 5
-                            origNode: nodeId(5)
                             parent: nodeId(4)
                         )
                         stmts: array(
                             0: Stmt_Class(
                                 name: Identifier(
+                                    containsEligibleNode: false
                                     eligible: false
                                     nodeId: 7
-                                    origNode: nodeId(7)
                                     parent: nodeId(6)
                                 )
                                 implements: array(
                                     0: Name(
+                                        containsEligibleNode: false
                                         eligible: false
                                         nodeId: 8
-                                        origNode: nodeId(8)
                                         parent: nodeId(6)
                                         resolvedName: FullyQualified(Infection\Tests\Command\Debug\DumpAstCommand\Greeter)
                                     )
@@ -206,6 +243,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                 stmts: array(
                                     0: Stmt_ClassMethod(
                                         name: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: greet
                                             functionScope: nodeId(9)
@@ -218,6 +256,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                             tests: Closure
                                         )
                                         returnType: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: greet
                                             functionScope: nodeId(9)
@@ -233,6 +272,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                             0: Stmt_Echo(
                                                 exprs: array(
                                                     0: Scalar_String(
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         functionName: greet
                                                         functionScope: nodeId(9)
@@ -247,6 +287,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                                         tests: Closure
                                                     )
                                                 )
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 functionName: greet
                                                 functionScope: nodeId(9)
@@ -259,6 +300,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                                 tests: Closure
                                             )
                                         )
+                                        containsEligibleNode: true
                                         eligible: true
                                         functionName: greet
                                         isOnFunctionSignature: true
@@ -270,12 +312,14 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                         tests: Closure
                                     )
                                 )
+                                containsEligibleNode: true
                                 eligible: false
                                 nodeId: 6
                                 origNode: nodeId(6)
                                 parent: nodeId(4)
                             )
                         )
+                        containsEligibleNode: true
                         eligible: false
                         kind: 1
                         next: nodeId(6)
@@ -290,6 +334,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
             __DIR__ . '/EchoGreeter.php',
             [
                 '--changed-lines-ranges' => null,
+                '--show-ineligible-nodes' => null,
             ],
             <<<'AST'
                 array(
@@ -297,63 +342,63 @@ final class DumpAstCommandTest extends FileSystemTestCase
                         declares: array(
                             0: DeclareItem(
                                 key: Identifier(
+                                    containsEligibleNode: false
                                     eligible: false
                                     endLine: 34
                                     nodeId: 2
-                                    origNode: nodeId(2)
                                     parent: nodeId(1)
                                     startLine: 34
                                 )
                                 value: Scalar_Int(
+                                    containsEligibleNode: false
                                     eligible: false
                                     endLine: 34
                                     kind: KIND_DEC (10)
                                     nodeId: 3
-                                    origNode: nodeId(3)
                                     parent: nodeId(1)
                                     rawValue: 1
                                     startLine: 34
                                 )
+                                containsEligibleNode: false
                                 eligible: false
                                 endLine: 34
                                 nodeId: 1
-                                origNode: nodeId(1)
                                 parent: nodeId(0)
                                 startLine: 34
                             )
                         )
+                        containsEligibleNode: false
                         eligible: false
                         endLine: 34
                         next: nodeId(4)
                         nodeId: 0
-                        origNode: nodeId(0)
                         startLine: 34
                     )
                     1: Stmt_Namespace(
                         name: Name(
+                            containsEligibleNode: false
                             eligible: false
                             endLine: 36
                             nodeId: 5
-                            origNode: nodeId(5)
                             parent: nodeId(4)
                             startLine: 36
                         )
                         stmts: array(
                             0: Stmt_Class(
                                 name: Identifier(
+                                    containsEligibleNode: false
                                     eligible: false
                                     endLine: 38
                                     nodeId: 7
-                                    origNode: nodeId(7)
                                     parent: nodeId(6)
                                     startLine: 38
                                 )
                                 implements: array(
                                     0: Name(
+                                        containsEligibleNode: false
                                         eligible: false
                                         endLine: 38
                                         nodeId: 8
-                                        origNode: nodeId(8)
                                         parent: nodeId(6)
                                         resolvedName: FullyQualified(Infection\Tests\Command\Debug\DumpAstCommand\Greeter)
                                         startLine: 38
@@ -362,6 +407,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                 stmts: array(
                                     0: Stmt_ClassMethod(
                                         name: Identifier(
+                                            containsEligibleNode: false
                                             eligible: false
                                             endLine: 40
                                             functionName: greet
@@ -369,12 +415,12 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                             isInsideFunction: true
                                             isStrictTypes: true
                                             nodeId: 10
-                                            origNode: nodeId(10)
                                             parent: nodeId(9)
                                             reflectionClass: Infection\Reflection\CoreClassReflection
                                             startLine: 40
                                         )
                                         returnType: Identifier(
+                                            containsEligibleNode: false
                                             eligible: false
                                             endLine: 40
                                             functionName: greet
@@ -382,7 +428,6 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                             isInsideFunction: true
                                             isStrictTypes: true
                                             nodeId: 11
-                                            origNode: nodeId(11)
                                             parent: nodeId(9)
                                             reflectionClass: Infection\Reflection\CoreClassReflection
                                             startLine: 40
@@ -391,6 +436,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                             0: Stmt_Echo(
                                                 exprs: array(
                                                     0: Scalar_String(
+                                                        containsEligibleNode: false
                                                         eligible: false
                                                         endLine: 42
                                                         functionName: greet
@@ -399,13 +445,13 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                                         isStrictTypes: true
                                                         kind: KIND_SINGLE_QUOTED (1)
                                                         nodeId: 13
-                                                        origNode: nodeId(13)
                                                         parent: nodeId(12)
                                                         rawValue: 'Hello world!'
                                                         reflectionClass: Infection\Reflection\CoreClassReflection
                                                         startLine: 42
                                                     )
                                                 )
+                                                containsEligibleNode: false
                                                 eligible: false
                                                 endLine: 42
                                                 functionName: greet
@@ -413,38 +459,37 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                                 isInsideFunction: true
                                                 isStrictTypes: true
                                                 nodeId: 12
-                                                origNode: nodeId(12)
                                                 parent: nodeId(9)
                                                 reflectionClass: Infection\Reflection\CoreClassReflection
                                                 startLine: 42
                                             )
                                         )
+                                        containsEligibleNode: false
                                         eligible: false
                                         endLine: 43
                                         functionName: greet
                                         isOnFunctionSignature: true
                                         isStrictTypes: true
                                         nodeId: 9
-                                        origNode: nodeId(9)
                                         parent: nodeId(6)
                                         reflectionClass: Infection\Reflection\CoreClassReflection
                                         startLine: 40
                                     )
                                 )
+                                containsEligibleNode: false
                                 eligible: false
                                 endLine: 44
                                 nodeId: 6
-                                origNode: nodeId(6)
                                 parent: nodeId(4)
                                 startLine: 38
                             )
                         )
+                        containsEligibleNode: false
                         eligible: false
                         endLine: 44
                         kind: 1
                         next: nodeId(6)
                         nodeId: 4
-                        origNode: nodeId(4)
                         startLine: 36
                     )
                 )
@@ -455,6 +500,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
             __DIR__ . '/EchoGreeter.php',
             [
                 '--changed-lines-ranges' => '42:42,40:42',
+                '--show-ineligible-nodes' => null,
             ],
             <<<'AST'
                 array(
@@ -462,63 +508,63 @@ final class DumpAstCommandTest extends FileSystemTestCase
                         declares: array(
                             0: DeclareItem(
                                 key: Identifier(
+                                    containsEligibleNode: false
                                     eligible: false
                                     endLine: 34
                                     nodeId: 2
-                                    origNode: nodeId(2)
                                     parent: nodeId(1)
                                     startLine: 34
                                 )
                                 value: Scalar_Int(
+                                    containsEligibleNode: false
                                     eligible: false
                                     endLine: 34
                                     kind: KIND_DEC (10)
                                     nodeId: 3
-                                    origNode: nodeId(3)
                                     parent: nodeId(1)
                                     rawValue: 1
                                     startLine: 34
                                 )
+                                containsEligibleNode: false
                                 eligible: false
                                 endLine: 34
                                 nodeId: 1
-                                origNode: nodeId(1)
                                 parent: nodeId(0)
                                 startLine: 34
                             )
                         )
+                        containsEligibleNode: false
                         eligible: false
                         endLine: 34
                         next: nodeId(4)
                         nodeId: 0
-                        origNode: nodeId(0)
                         startLine: 34
                     )
                     1: Stmt_Namespace(
                         name: Name(
+                            containsEligibleNode: false
                             eligible: false
                             endLine: 36
                             nodeId: 5
-                            origNode: nodeId(5)
                             parent: nodeId(4)
                             startLine: 36
                         )
                         stmts: array(
                             0: Stmt_Class(
                                 name: Identifier(
+                                    containsEligibleNode: false
                                     eligible: false
                                     endLine: 38
                                     nodeId: 7
-                                    origNode: nodeId(7)
                                     parent: nodeId(6)
                                     startLine: 38
                                 )
                                 implements: array(
                                     0: Name(
+                                        containsEligibleNode: false
                                         eligible: false
                                         endLine: 38
                                         nodeId: 8
-                                        origNode: nodeId(8)
                                         parent: nodeId(6)
                                         resolvedName: FullyQualified(Infection\Tests\Command\Debug\DumpAstCommand\Greeter)
                                         startLine: 38
@@ -527,6 +573,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                 stmts: array(
                                     0: Stmt_ClassMethod(
                                         name: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             endLine: 40
                                             functionName: greet
@@ -541,6 +588,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                             tests: Closure
                                         )
                                         returnType: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             endLine: 40
                                             functionName: greet
@@ -558,6 +606,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                             0: Stmt_Echo(
                                                 exprs: array(
                                                     0: Scalar_String(
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         endLine: 42
                                                         functionName: greet
@@ -574,6 +623,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                                         tests: Closure
                                                     )
                                                 )
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 endLine: 42
                                                 functionName: greet
@@ -588,6 +638,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                                 tests: Closure
                                             )
                                         )
+                                        containsEligibleNode: true
                                         eligible: true
                                         endLine: 43
                                         functionName: greet
@@ -601,6 +652,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                         tests: Closure
                                     )
                                 )
+                                containsEligibleNode: true
                                 eligible: false
                                 endLine: 44
                                 nodeId: 6
@@ -609,6 +661,7 @@ final class DumpAstCommandTest extends FileSystemTestCase
                                 startLine: 38
                             )
                         )
+                        containsEligibleNode: true
                         eligible: false
                         endLine: 44
                         kind: 1

--- a/tests/phpunit/PhpParser/NodeTraverserFactoryTest.php
+++ b/tests/phpunit/PhpParser/NodeTraverserFactoryTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\PhpParser;
 use function array_map;
 use Infection\PhpParser\NodeTraverserFactory;
 use Infection\PhpParser\Visitor\AddTestsVisitor;
+use Infection\PhpParser\Visitor\ContainsEligibleNodeVisitor;
 use Infection\PhpParser\Visitor\ExcludeIgnoredNodesVisitor;
 use Infection\PhpParser\Visitor\ExcludeNonMutableCodeVisitor;
 use Infection\PhpParser\Visitor\ExcludeUnchangedLinesVisitor;
@@ -46,6 +47,7 @@ use Infection\PhpParser\Visitor\LabelNodesAsEligibleVisitor;
 use Infection\PhpParser\Visitor\NextConnectingVisitor;
 use Infection\PhpParser\Visitor\ReflectionVisitor;
 use Infection\PhpParser\Visitor\SkipIgnoredNodesVisitor;
+use Infection\PhpParser\Visitor\SkipNodesWithoutEligibleNodeVisitor;
 use Infection\Source\Matcher\NullSourceLineMatcher;
 use Infection\TestFramework\Tracing\Trace\EmptyTrace;
 use Infection\TestFramework\Tracing\Trace\LineRangeCalculator;
@@ -105,7 +107,10 @@ final class NodeTraverserFactoryTest extends TestCase
 
         yield 'without only covered' => [
             false,
-            $baseVisitors,
+            [
+                ...$baseVisitors,
+                ContainsEligibleNodeVisitor::class,
+            ],
         ];
 
         yield 'with only covered' => [
@@ -113,6 +118,7 @@ final class NodeTraverserFactoryTest extends TestCase
             [
                 ...$baseVisitors,
                 ExcludeUntestedNodesVisitor::class,
+                ContainsEligibleNodeVisitor::class,
             ],
         ];
     }
@@ -126,6 +132,7 @@ final class NodeTraverserFactoryTest extends TestCase
         $this->assertTraverserVisitorsAre(
             $traverser,
             [
+                SkipNodesWithoutEligibleNodeVisitor::class,
                 CloningVisitor::class,
                 FakeVisitor::class,
             ],

--- a/tests/phpunit/PhpParser/Visitor/ContainsEligibleNodeVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ContainsEligibleNodeVisitorTest.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\PhpParser\Visitor;
+
+use Infection\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitor;
+use Infection\PhpParser\Visitor\ContainsEligibleNodeVisitor;
+use Infection\PhpParser\Visitor\LabelNodesAsEligibleVisitor;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
+use PhpParser\NodeTraverser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(ContainsEligibleNodeVisitor::class)]
+final class ContainsEligibleNodeVisitorTest extends VisitorTestCase
+{
+    /**
+     * @param list<int> $eligibleNodeIds
+     */
+    #[DataProvider('nodeProvider')]
+    public function test_it_marks_nodes_containing_an_eligible_node(
+        string $code,
+        array $eligibleNodeIds,
+        string $expected,
+    ): void {
+        $nodes = $this->parse($code);
+
+        $nodesById = $this->addIdsToNodes($nodes);
+        $this->markNodesAsEligible($nodesById, $eligibleNodeIds);
+
+        (new NodeTraverser(
+            new ContainsEligibleNodeVisitor(),
+        ))->traverse($nodes);
+
+        $this->keepOnlyDesiredAttributes(
+            $nodes,
+            AddIdToTraversedNodesVisitor::NODE_ID_ATTRIBUTE,
+            LabelNodesAsEligibleVisitor::ELIGIBLE,
+            ContainsEligibleNodeVisitor::CONTAINS_ELIGIBLE_NODE,
+        );
+
+        $actual = $this->dumper->dump($nodes, onlyVisitedNodes: false);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function nodeProvider(): iterable
+    {
+        yield 'no eligible nodes' => [
+            <<<'PHP'
+                <?php
+
+                $x = 1 + 2;
+
+                PHP,
+            [],
+            <<<'AST'
+                array(
+                    0: Stmt_Expression(
+                        expr: Expr_Assign(
+                            var: Expr_Variable(
+                                containsEligibleNode: false
+                                nodeId: 2
+                            )
+                            expr: Expr_BinaryOp_Plus(
+                                left: Scalar_Int(
+                                    containsEligibleNode: false
+                                    nodeId: 4
+                                )
+                                right: Scalar_Int(
+                                    containsEligibleNode: false
+                                    nodeId: 5
+                                )
+                                containsEligibleNode: false
+                                nodeId: 3
+                            )
+                            containsEligibleNode: false
+                            nodeId: 1
+                        )
+                        containsEligibleNode: false
+                        nodeId: 0
+                    )
+                )
+                AST,
+        ];
+
+        yield 'eligible leaf marks its ancestors' => [
+            <<<'PHP'
+                <?php
+
+                $x = 1 + 2;
+
+                PHP,
+            [4],
+            <<<'AST'
+                array(
+                    0: Stmt_Expression(
+                        expr: Expr_Assign(
+                            var: Expr_Variable(
+                                containsEligibleNode: false
+                                nodeId: 2
+                            )
+                            expr: Expr_BinaryOp_Plus(
+                                left: Scalar_Int(
+                                    containsEligibleNode: true
+                                    eligible: true
+                                    nodeId: 4
+                                )
+                                right: Scalar_Int(
+                                    containsEligibleNode: false
+                                    nodeId: 5
+                                )
+                                containsEligibleNode: true
+                                nodeId: 3
+                            )
+                            containsEligibleNode: true
+                            nodeId: 1
+                        )
+                        containsEligibleNode: true
+                        nodeId: 0
+                    )
+                )
+                AST,
+        ];
+
+        yield 'eligible root does not mark its children' => [
+            <<<'PHP'
+                <?php
+
+                $x = 1 + 2;
+
+                PHP,
+            [0],
+            <<<'AST'
+                array(
+                    0: Stmt_Expression(
+                        expr: Expr_Assign(
+                            var: Expr_Variable(
+                                containsEligibleNode: false
+                                nodeId: 2
+                            )
+                            expr: Expr_BinaryOp_Plus(
+                                left: Scalar_Int(
+                                    containsEligibleNode: false
+                                    nodeId: 4
+                                )
+                                right: Scalar_Int(
+                                    containsEligibleNode: false
+                                    nodeId: 5
+                                )
+                                containsEligibleNode: false
+                                nodeId: 3
+                            )
+                            containsEligibleNode: false
+                            nodeId: 1
+                        )
+                        containsEligibleNode: true
+                        eligible: true
+                        nodeId: 0
+                    )
+                )
+                AST,
+        ];
+
+        yield 'unrelated branches remain unmarked' => [
+            <<<'PHP'
+                <?php
+
+                $x = 1 + 2;
+                $y = 3 + 4;
+
+                PHP,
+            [4],
+            <<<'AST'
+                array(
+                    0: Stmt_Expression(
+                        expr: Expr_Assign(
+                            var: Expr_Variable(
+                                containsEligibleNode: false
+                                nodeId: 2
+                            )
+                            expr: Expr_BinaryOp_Plus(
+                                left: Scalar_Int(
+                                    containsEligibleNode: true
+                                    eligible: true
+                                    nodeId: 4
+                                )
+                                right: Scalar_Int(
+                                    containsEligibleNode: false
+                                    nodeId: 5
+                                )
+                                containsEligibleNode: true
+                                nodeId: 3
+                            )
+                            containsEligibleNode: true
+                            nodeId: 1
+                        )
+                        containsEligibleNode: true
+                        nodeId: 0
+                    )
+                    1: Stmt_Expression(
+                        expr: Expr_Assign(
+                            var: Expr_Variable(
+                                containsEligibleNode: false
+                                nodeId: 8
+                            )
+                            expr: Expr_BinaryOp_Plus(
+                                left: Scalar_Int(
+                                    containsEligibleNode: false
+                                    nodeId: 10
+                                )
+                                right: Scalar_Int(
+                                    containsEligibleNode: false
+                                    nodeId: 11
+                                )
+                                containsEligibleNode: false
+                                nodeId: 9
+                            )
+                            containsEligibleNode: false
+                            nodeId: 7
+                        )
+                        containsEligibleNode: false
+                        nodeId: 6
+                    )
+                )
+                AST,
+        ];
+    }
+}

--- a/tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php
+++ b/tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php
@@ -103,52 +103,16 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
             null,
             <<<'AST'
                 array(
-                    0: Stmt_Declare(
-                        declares: array(
-                            0: DeclareItem(
-                                key: Identifier(
-                                    eligible: false
-                                    nodeId: 2
-                                    origNode: nodeId(2)
-                                    parent: nodeId(1)
-                                )
-                                value: Scalar_Int(
-                                    eligible: false
-                                    kind: KIND_DEC (10)
-                                    nodeId: 3
-                                    origNode: nodeId(3)
-                                    parent: nodeId(1)
-                                    rawValue: 1
-                                )
-                                eligible: false
-                                nodeId: 1
-                                origNode: nodeId(1)
-                                parent: nodeId(0)
-                            )
-                        )
-                        eligible: false
-                        next: nodeId(4)
-                        nodeId: 0
-                        origNode: nodeId(0)
-                    )
+                    0: <skipped>
                     1: Stmt_Namespace(
-                        name: Name(
-                            eligible: false
-                            nodeId: 5
-                            origNode: nodeId(5)
-                            parent: nodeId(4)
-                        )
+                        name: <skipped>
                         stmts: array(
                             0: Stmt_Class(
-                                name: Identifier(
-                                    eligible: false
-                                    nodeId: 7
-                                    origNode: nodeId(7)
-                                    parent: nodeId(6)
-                                )
+                                name: <skipped>
                                 stmts: array(
                                     0: Stmt_ClassMethod(
                                         name: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: first
                                             functionScope: nodeId(8)
@@ -161,6 +125,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             tests: Closure
                                         )
                                         returnType: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: first
                                             functionScope: nodeId(8)
@@ -176,6 +141,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             0: Stmt_Return(
                                                 expr: Expr_BinaryOp_Plus(
                                                     left: Scalar_Int(
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         functionName: first
                                                         functionScope: nodeId(8)
@@ -190,6 +156,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                         tests: Closure
                                                     )
                                                     right: Scalar_Int(
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         functionName: first
                                                         functionScope: nodeId(8)
@@ -203,6 +170,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                         reflectionClass: Infection\Reflection\CoreClassReflection
                                                         tests: Closure
                                                     )
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: first
                                                     functionScope: nodeId(8)
@@ -214,6 +182,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     reflectionClass: Infection\Reflection\CoreClassReflection
                                                     tests: Closure
                                                 )
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 functionName: first
                                                 functionScope: nodeId(8)
@@ -226,6 +195,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                 tests: Closure
                                             )
                                         )
+                                        containsEligibleNode: true
                                         eligible: true
                                         functionName: first
                                         isOnFunctionSignature: true
@@ -238,6 +208,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                     )
                                     1: Stmt_ClassMethod(
                                         name: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: second
                                             functionScope: nodeId(15)
@@ -250,6 +221,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             tests: Closure
                                         )
                                         returnType: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: second
                                             functionScope: nodeId(15)
@@ -265,6 +237,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             0: Stmt_Return(
                                                 expr: Expr_BinaryOp_Minus(
                                                     left: Scalar_Int(
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         functionName: second
                                                         functionScope: nodeId(15)
@@ -279,6 +252,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                         tests: Closure
                                                     )
                                                     right: Scalar_Int(
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         functionName: second
                                                         functionScope: nodeId(15)
@@ -292,6 +266,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                         reflectionClass: Infection\Reflection\CoreClassReflection
                                                         tests: Closure
                                                     )
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: second
                                                     functionScope: nodeId(15)
@@ -303,6 +278,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     reflectionClass: Infection\Reflection\CoreClassReflection
                                                     tests: Closure
                                                 )
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 functionName: second
                                                 functionScope: nodeId(15)
@@ -315,6 +291,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                 tests: Closure
                                             )
                                         )
+                                        containsEligibleNode: true
                                         eligible: true
                                         functionName: second
                                         isOnFunctionSignature: true
@@ -326,12 +303,14 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                         tests: Closure
                                     )
                                 )
+                                containsEligibleNode: true
                                 eligible: false
                                 nodeId: 6
                                 origNode: nodeId(6)
                                 parent: nodeId(4)
                             )
                         )
+                        containsEligibleNode: true
                         eligible: false
                         kind: 1
                         next: nodeId(6)
@@ -347,131 +326,8 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
             null,
             <<<'AST'
                 array(
-                    0: Stmt_Declare(
-                        declares: array(
-                            0: DeclareItem(
-                                key: Identifier(
-                                    eligible: false
-                                    nodeId: 2
-                                    origNode: nodeId(2)
-                                    parent: nodeId(1)
-                                )
-                                value: Scalar_Int(
-                                    eligible: false
-                                    kind: KIND_DEC (10)
-                                    nodeId: 3
-                                    origNode: nodeId(3)
-                                    parent: nodeId(1)
-                                    rawValue: 1
-                                )
-                                eligible: false
-                                nodeId: 1
-                                origNode: nodeId(1)
-                                parent: nodeId(0)
-                            )
-                        )
-                        eligible: false
-                        next: nodeId(4)
-                        nodeId: 0
-                        origNode: nodeId(0)
-                    )
-                    1: Stmt_Namespace(
-                        name: Name(
-                            eligible: false
-                            nodeId: 5
-                            origNode: nodeId(5)
-                            parent: nodeId(4)
-                        )
-                        stmts: array(
-                            0: Stmt_Function(
-                                name: Identifier(
-                                    eligible: false
-                                    nodeId: 7
-                                    origNode: nodeId(7)
-                                    parent: nodeId(6)
-                                )
-                                params: array(
-                                    0: Param(
-                                        type: Identifier(
-                                            eligible: false
-                                            nodeId: 9
-                                            origNode: nodeId(9)
-                                            parent: nodeId(8)
-                                        )
-                                        var: Expr_Variable(
-                                            eligible: false
-                                            nodeId: 10
-                                            origNode: nodeId(10)
-                                            parent: nodeId(8)
-                                        )
-                                        eligible: false
-                                        nodeId: 8
-                                        origNode: nodeId(8)
-                                        parent: nodeId(6)
-                                    )
-                                    1: Param(
-                                        type: Identifier(
-                                            eligible: false
-                                            nodeId: 12
-                                            origNode: nodeId(12)
-                                            parent: nodeId(11)
-                                        )
-                                        var: Expr_Variable(
-                                            eligible: false
-                                            nodeId: 13
-                                            origNode: nodeId(13)
-                                            parent: nodeId(11)
-                                        )
-                                        eligible: false
-                                        nodeId: 11
-                                        origNode: nodeId(11)
-                                        parent: nodeId(6)
-                                    )
-                                )
-                                returnType: Identifier(
-                                    eligible: false
-                                    nodeId: 14
-                                    origNode: nodeId(14)
-                                    parent: nodeId(6)
-                                )
-                                stmts: array(
-                                    0: Stmt_Return(
-                                        expr: Expr_BinaryOp_Identical(
-                                            left: Expr_Variable(
-                                                eligible: false
-                                                nodeId: 17
-                                                origNode: nodeId(17)
-                                                parent: nodeId(16)
-                                            )
-                                            right: Expr_Variable(
-                                                eligible: false
-                                                nodeId: 18
-                                                origNode: nodeId(18)
-                                                parent: nodeId(16)
-                                            )
-                                            eligible: false
-                                            nodeId: 16
-                                            origNode: nodeId(16)
-                                            parent: nodeId(15)
-                                        )
-                                        eligible: false
-                                        nodeId: 15
-                                        origNode: nodeId(15)
-                                        parent: nodeId(6)
-                                    )
-                                )
-                                eligible: false
-                                isStrictTypes: true
-                                nodeId: 6
-                                origNode: nodeId(6)
-                                parent: nodeId(4)
-                            )
-                        )
-                        eligible: false
-                        kind: 1
-                        nodeId: 4
-                        origNode: nodeId(4)
-                    )
+                    0: <skipped>
+                    1: <skipped>
                 )
                 AST,
         ];
@@ -481,107 +337,18 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
             null,
             <<<'AST'
                 array(
-                    0: Stmt_Declare(
-                        declares: array(
-                            0: DeclareItem(
-                                key: Identifier(
-                                    eligible: false
-                                    nodeId: 2
-                                    origNode: nodeId(2)
-                                    parent: nodeId(1)
-                                )
-                                value: Scalar_Int(
-                                    eligible: false
-                                    kind: KIND_DEC (10)
-                                    nodeId: 3
-                                    origNode: nodeId(3)
-                                    parent: nodeId(1)
-                                    rawValue: 1
-                                )
-                                eligible: false
-                                nodeId: 1
-                                origNode: nodeId(1)
-                                parent: nodeId(0)
-                            )
-                        )
-                        eligible: false
-                        next: nodeId(4)
-                        nodeId: 0
-                        origNode: nodeId(0)
-                    )
+                    0: <skipped>
                     1: Stmt_Namespace(
-                        name: Name(
-                            eligible: false
-                            nodeId: 5
-                            origNode: nodeId(5)
-                            parent: nodeId(4)
-                        )
+                        name: <skipped>
                         stmts: array(
                             0: Stmt_Trait(
-                                name: Identifier(
-                                    eligible: false
-                                    nodeId: 7
-                                    origNode: nodeId(7)
-                                    parent: nodeId(6)
-                                )
+                                name: <skipped>
                                 stmts: array(
-                                    0: Stmt_ClassConst(
-                                        consts: array(
-                                            0: Const(
-                                                name: Identifier(
-                                                    eligible: false
-                                                    nodeId: 10
-                                                    origNode: nodeId(10)
-                                                    parent: nodeId(9)
-                                                )
-                                                value: Scalar_String(
-                                                    eligible: false
-                                                    kind: KIND_SINGLE_QUOTED (1)
-                                                    nodeId: 11
-                                                    origNode: nodeId(11)
-                                                    parent: nodeId(9)
-                                                    rawValue: ''
-                                                )
-                                                eligible: false
-                                                nodeId: 9
-                                                origNode: nodeId(9)
-                                                parent: nodeId(8)
-                                            )
-                                        )
-                                        eligible: false
-                                        nodeId: 8
-                                        origNode: nodeId(8)
-                                        parent: nodeId(6)
-                                    )
-                                    1: Stmt_ClassMethod(
-                                        name: Identifier(
-                                            nodeId: 13
-                                            origNode: nodeId(13)
-                                        )
-                                        params: array(
-                                            0: Param(
-                                                type: Identifier(
-                                                    nodeId: 15
-                                                    origNode: nodeId(15)
-                                                )
-                                                var: Expr_Variable(
-                                                    nodeId: 16
-                                                    origNode: nodeId(16)
-                                                )
-                                                nodeId: 14
-                                                origNode: nodeId(14)
-                                            )
-                                        )
-                                        returnType: Identifier(
-                                            nodeId: 17
-                                            origNode: nodeId(17)
-                                        )
-                                        eligible: false
-                                        nodeId: 12
-                                        origNode: nodeId(12)
-                                    )
+                                    0: <skipped>
+                                    1: <skipped>
                                     2: Stmt_ClassMethod(
                                         name: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: concreteMethod
                                             functionScope: nodeId(18)
@@ -596,6 +363,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                         params: array(
                                             0: Param(
                                                 type: Identifier(
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: concreteMethod
                                                     functionScope: nodeId(18)
@@ -609,6 +377,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     tests: Closure
                                                 )
                                                 var: Expr_Variable(
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: concreteMethod
                                                     functionScope: nodeId(18)
@@ -621,6 +390,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     reflectionClass: Infection\Reflection\CoreClassReflection
                                                     tests: Closure
                                                 )
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 functionName: concreteMethod
                                                 functionScope: nodeId(18)
@@ -635,6 +405,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             )
                                         )
                                         returnType: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: concreteMethod
                                             functionScope: nodeId(18)
@@ -646,6 +417,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             reflectionClass: Infection\Reflection\CoreClassReflection
                                             tests: Closure
                                         )
+                                        containsEligibleNode: true
                                         eligible: true
                                         functionName: concreteMethod
                                         isOnFunctionSignature: true
@@ -657,6 +429,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                         tests: Closure
                                     )
                                 )
+                                containsEligibleNode: true
                                 eligible: false
                                 next: nodeId(8)
                                 nodeId: 6
@@ -664,6 +437,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                 parent: nodeId(4)
                             )
                         )
+                        containsEligibleNode: true
                         eligible: false
                         kind: 1
                         next: nodeId(6)
@@ -679,106 +453,8 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
             null,
             <<<'AST'
                 array(
-                    0: Stmt_Declare(
-                        declares: array(
-                            0: DeclareItem(
-                                key: Identifier(
-                                    eligible: false
-                                    nodeId: 2
-                                    origNode: nodeId(2)
-                                    parent: nodeId(1)
-                                )
-                                value: Scalar_Int(
-                                    eligible: false
-                                    kind: KIND_DEC (10)
-                                    nodeId: 3
-                                    origNode: nodeId(3)
-                                    parent: nodeId(1)
-                                    rawValue: 1
-                                )
-                                eligible: false
-                                nodeId: 1
-                                origNode: nodeId(1)
-                                parent: nodeId(0)
-                            )
-                        )
-                        eligible: false
-                        next: nodeId(4)
-                        nodeId: 0
-                        origNode: nodeId(0)
-                    )
-                    1: Stmt_Namespace(
-                        name: Name(
-                            eligible: false
-                            nodeId: 5
-                            origNode: nodeId(5)
-                            parent: nodeId(4)
-                        )
-                        stmts: array(
-                            0: Stmt_Interface(
-                                name: Identifier(
-                                    nodeId: 7
-                                    origNode: nodeId(7)
-                                )
-                                stmts: array(
-                                    0: Stmt_ClassConst(
-                                        consts: array(
-                                            0: Const(
-                                                name: Identifier(
-                                                    nodeId: 10
-                                                    origNode: nodeId(10)
-                                                )
-                                                value: Scalar_String(
-                                                    kind: KIND_SINGLE_QUOTED (1)
-                                                    nodeId: 11
-                                                    origNode: nodeId(11)
-                                                    rawValue: ''
-                                                )
-                                                nodeId: 9
-                                                origNode: nodeId(9)
-                                            )
-                                        )
-                                        nodeId: 8
-                                        origNode: nodeId(8)
-                                    )
-                                    1: Stmt_ClassMethod(
-                                        name: Identifier(
-                                            nodeId: 13
-                                            origNode: nodeId(13)
-                                        )
-                                        params: array(
-                                            0: Param(
-                                                type: Identifier(
-                                                    nodeId: 15
-                                                    origNode: nodeId(15)
-                                                )
-                                                var: Expr_Variable(
-                                                    nodeId: 16
-                                                    origNode: nodeId(16)
-                                                )
-                                                nodeId: 14
-                                                origNode: nodeId(14)
-                                            )
-                                        )
-                                        returnType: Identifier(
-                                            nodeId: 17
-                                            origNode: nodeId(17)
-                                        )
-                                        nodeId: 12
-                                        origNode: nodeId(12)
-                                    )
-                                )
-                                eligible: false
-                                nodeId: 6
-                                origNode: nodeId(6)
-                            )
-                        )
-                        eligible: false
-                        kind: 1
-                        next: nodeId(6)
-                        nodeId: 4
-                        origNode: nodeId(4)
-                    )
+                    0: <skipped>
+                    1: <skipped>
                 )
                 AST,
         ];
@@ -788,96 +464,18 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
             null,
             <<<'AST'
                 array(
-                    0: Stmt_Declare(
-                        declares: array(
-                            0: DeclareItem(
-                                key: Identifier(
-                                    eligible: false
-                                    nodeId: 2
-                                    origNode: nodeId(2)
-                                    parent: nodeId(1)
-                                )
-                                value: Scalar_Int(
-                                    eligible: false
-                                    kind: KIND_DEC (10)
-                                    nodeId: 3
-                                    origNode: nodeId(3)
-                                    parent: nodeId(1)
-                                    rawValue: 1
-                                )
-                                eligible: false
-                                nodeId: 1
-                                origNode: nodeId(1)
-                                parent: nodeId(0)
-                            )
-                        )
-                        eligible: false
-                        next: nodeId(4)
-                        nodeId: 0
-                        origNode: nodeId(0)
-                    )
+                    0: <skipped>
                     1: Stmt_Namespace(
-                        name: Name(
-                            eligible: false
-                            nodeId: 5
-                            origNode: nodeId(5)
-                            parent: nodeId(4)
-                        )
+                        name: <skipped>
                         stmts: array(
                             0: Stmt_Class(
-                                name: Identifier(
-                                    eligible: false
-                                    nodeId: 7
-                                    origNode: nodeId(7)
-                                    parent: nodeId(6)
-                                )
+                                name: <skipped>
                                 stmts: array(
-                                    0: Stmt_TraitUse(
-                                        traits: array(
-                                            0: Name(
-                                                eligible: false
-                                                nodeId: 9
-                                                origNode: nodeId(9)
-                                                parent: nodeId(8)
-                                                resolvedName: FullyQualified(Infection\Tests\PhpParser\Visitor\EnrichmentTraverse\Fixtures\TraitExample)
-                                            )
-                                        )
-                                        eligible: false
-                                        next: nodeId(10)
-                                        nodeId: 8
-                                        origNode: nodeId(8)
-                                        parent: nodeId(6)
-                                    )
-                                    1: Stmt_ClassConst(
-                                        consts: array(
-                                            0: Const(
-                                                name: Identifier(
-                                                    eligible: false
-                                                    nodeId: 12
-                                                    origNode: nodeId(12)
-                                                    parent: nodeId(11)
-                                                )
-                                                value: Scalar_String(
-                                                    eligible: false
-                                                    kind: KIND_SINGLE_QUOTED (1)
-                                                    nodeId: 13
-                                                    origNode: nodeId(13)
-                                                    parent: nodeId(11)
-                                                    rawValue: ''
-                                                )
-                                                eligible: false
-                                                nodeId: 11
-                                                origNode: nodeId(11)
-                                                parent: nodeId(10)
-                                            )
-                                        )
-                                        eligible: false
-                                        nodeId: 10
-                                        origNode: nodeId(10)
-                                        parent: nodeId(6)
-                                    )
+                                    0: <skipped>
+                                    1: <skipped>
                                     2: Stmt_ClassMethod(
                                         name: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: concreteMethod
                                             functionScope: nodeId(14)
@@ -892,6 +490,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                         params: array(
                                             0: Param(
                                                 type: Identifier(
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: concreteMethod
                                                     functionScope: nodeId(14)
@@ -905,6 +504,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     tests: Closure
                                                 )
                                                 var: Expr_Variable(
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: concreteMethod
                                                     functionScope: nodeId(14)
@@ -917,6 +517,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     reflectionClass: Infection\Reflection\CoreClassReflection
                                                     tests: Closure
                                                 )
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 functionName: concreteMethod
                                                 functionScope: nodeId(14)
@@ -931,6 +532,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             )
                                         )
                                         returnType: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: concreteMethod
                                             functionScope: nodeId(14)
@@ -946,6 +548,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             0: Stmt_If(
                                                 cond: Expr_BinaryOp_Identical(
                                                     left: Expr_Variable(
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         functionName: concreteMethod
                                                         functionScope: nodeId(14)
@@ -959,6 +562,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     )
                                                     right: Expr_ConstFetch(
                                                         name: Name(
+                                                            containsEligibleNode: true
                                                             eligible: true
                                                             functionName: concreteMethod
                                                             functionScope: nodeId(14)
@@ -971,6 +575,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                             reflectionClass: Infection\Reflection\CoreClassReflection
                                                             tests: Closure
                                                         )
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         functionName: concreteMethod
                                                         functionScope: nodeId(14)
@@ -982,6 +587,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                         reflectionClass: Infection\Reflection\CoreClassReflection
                                                         tests: Closure
                                                     )
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: concreteMethod
                                                     functionScope: nodeId(14)
@@ -997,6 +603,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     0: Stmt_Echo(
                                                         exprs: array(
                                                             0: Scalar_String(
+                                                                containsEligibleNode: true
                                                                 eligible: true
                                                                 functionName: concreteMethod
                                                                 functionScope: nodeId(14)
@@ -1011,6 +618,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                                 tests: Closure
                                                             )
                                                         )
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         functionName: concreteMethod
                                                         functionScope: nodeId(14)
@@ -1029,6 +637,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                         0: Stmt_Expression(
                                                             expr: Expr_FuncCall(
                                                                 name: Expr_Variable(
+                                                                    containsEligibleNode: true
                                                                     eligible: true
                                                                     functionName: concreteMethod
                                                                     functionScope: nodeId(14)
@@ -1040,6 +649,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                                     reflectionClass: Infection\Reflection\CoreClassReflection
                                                                     tests: Closure
                                                                 )
+                                                                containsEligibleNode: true
                                                                 eligible: true
                                                                 functionName: concreteMethod
                                                                 functionScope: nodeId(14)
@@ -1051,6 +661,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                                 reflectionClass: Infection\Reflection\CoreClassReflection
                                                                 tests: Closure
                                                             )
+                                                            containsEligibleNode: true
                                                             eligible: true
                                                             functionName: concreteMethod
                                                             functionScope: nodeId(14)
@@ -1063,6 +674,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                             tests: Closure
                                                         )
                                                     )
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: concreteMethod
                                                     functionScope: nodeId(14)
@@ -1075,6 +687,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     reflectionClass: Infection\Reflection\CoreClassReflection
                                                     tests: Closure
                                                 )
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 functionName: concreteMethod
                                                 functionScope: nodeId(14)
@@ -1088,6 +701,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                 tests: Closure
                                             )
                                         )
+                                        containsEligibleNode: true
                                         eligible: true
                                         functionName: concreteMethod
                                         isOnFunctionSignature: true
@@ -1100,6 +714,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                     )
                                     3: Stmt_ClassMethod(
                                         name: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: abstractMethod
                                             functionScope: nodeId(31)
@@ -1114,6 +729,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                         params: array(
                                             0: Param(
                                                 type: Identifier(
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: abstractMethod
                                                     functionScope: nodeId(31)
@@ -1127,6 +743,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     tests: Closure
                                                 )
                                                 var: Expr_Variable(
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: abstractMethod
                                                     functionScope: nodeId(31)
@@ -1139,6 +756,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     reflectionClass: Infection\Reflection\CoreClassReflection
                                                     tests: Closure
                                                 )
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 functionName: abstractMethod
                                                 functionScope: nodeId(31)
@@ -1153,6 +771,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             )
                                         )
                                         returnType: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: abstractMethod
                                             functionScope: nodeId(31)
@@ -1164,6 +783,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             reflectionClass: Infection\Reflection\CoreClassReflection
                                             tests: Closure
                                         )
+                                        containsEligibleNode: true
                                         eligible: true
                                         functionName: abstractMethod
                                         isOnFunctionSignature: true
@@ -1175,6 +795,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                         tests: Closure
                                     )
                                 )
+                                containsEligibleNode: true
                                 eligible: false
                                 next: nodeId(8)
                                 nodeId: 6
@@ -1182,6 +803,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                 parent: nodeId(4)
                             )
                         )
+                        containsEligibleNode: true
                         eligible: false
                         kind: 1
                         next: nodeId(6)
@@ -1197,193 +819,26 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
             [ChangedLinesRange::forLine(46)],
             <<<'AST'
                 array(
-                    0: Stmt_Declare(
-                        declares: array(
-                            0: DeclareItem(
-                                key: Identifier(
-                                    eligible: false
-                                    endLine: 34
-                                    nodeId: 2
-                                    origNode: nodeId(2)
-                                    parent: nodeId(1)
-                                    startLine: 34
-                                )
-                                value: Scalar_Int(
-                                    eligible: false
-                                    endLine: 34
-                                    kind: KIND_DEC (10)
-                                    nodeId: 3
-                                    origNode: nodeId(3)
-                                    parent: nodeId(1)
-                                    rawValue: 1
-                                    startLine: 34
-                                )
-                                eligible: false
-                                endLine: 34
-                                nodeId: 1
-                                origNode: nodeId(1)
-                                parent: nodeId(0)
-                                startLine: 34
-                            )
-                        )
-                        eligible: false
-                        endLine: 34
-                        next: nodeId(4)
-                        nodeId: 0
-                        origNode: nodeId(0)
-                        startLine: 34
-                    )
+                    0: <skipped>
                     1: Stmt_Namespace(
-                        name: Name(
-                            eligible: false
-                            endLine: 36
-                            nodeId: 5
-                            origNode: nodeId(5)
-                            parent: nodeId(4)
-                            startLine: 36
-                        )
+                        name: <skipped>
                         stmts: array(
                             0: Stmt_Class(
-                                name: Identifier(
-                                    eligible: false
-                                    endLine: 38
-                                    nodeId: 7
-                                    origNode: nodeId(7)
-                                    parent: nodeId(6)
-                                    startLine: 38
-                                )
+                                name: <skipped>
                                 stmts: array(
-                                    0: Stmt_TraitUse(
-                                        traits: array(
-                                            0: Name(
-                                                eligible: false
-                                                endLine: 40
-                                                nodeId: 9
-                                                origNode: nodeId(9)
-                                                parent: nodeId(8)
-                                                resolvedName: FullyQualified(Infection\Tests\PhpParser\Visitor\EnrichmentTraverse\Fixtures\TraitExample)
-                                                startLine: 40
-                                            )
-                                        )
-                                        eligible: false
-                                        endLine: 40
-                                        next: nodeId(10)
-                                        nodeId: 8
-                                        origNode: nodeId(8)
-                                        parent: nodeId(6)
-                                        startLine: 40
-                                    )
-                                    1: Stmt_ClassConst(
-                                        consts: array(
-                                            0: Const(
-                                                name: Identifier(
-                                                    eligible: false
-                                                    endLine: 42
-                                                    nodeId: 12
-                                                    origNode: nodeId(12)
-                                                    parent: nodeId(11)
-                                                    startLine: 42
-                                                )
-                                                value: Scalar_String(
-                                                    eligible: false
-                                                    endLine: 42
-                                                    kind: KIND_SINGLE_QUOTED (1)
-                                                    nodeId: 13
-                                                    origNode: nodeId(13)
-                                                    parent: nodeId(11)
-                                                    rawValue: ''
-                                                    startLine: 42
-                                                )
-                                                eligible: false
-                                                endLine: 42
-                                                nodeId: 11
-                                                origNode: nodeId(11)
-                                                parent: nodeId(10)
-                                                startLine: 42
-                                            )
-                                        )
-                                        eligible: false
-                                        endLine: 42
-                                        nodeId: 10
-                                        origNode: nodeId(10)
-                                        parent: nodeId(6)
-                                        startLine: 42
-                                    )
+                                    0: <skipped>
+                                    1: <skipped>
                                     2: Stmt_ClassMethod(
-                                        name: Identifier(
-                                            eligible: false
-                                            endLine: 44
-                                            functionName: concreteMethod
-                                            functionScope: nodeId(14)
-                                            isInsideFunction: true
-                                            isStrictTypes: true
-                                            nodeId: 15
-                                            origNode: nodeId(15)
-                                            parent: nodeId(14)
-                                            reflectionClass: Infection\Reflection\CoreClassReflection
-                                            startLine: 44
-                                        )
+                                        name: <skipped>
                                         params: array(
-                                            0: Param(
-                                                type: Identifier(
-                                                    eligible: false
-                                                    endLine: 44
-                                                    functionName: concreteMethod
-                                                    functionScope: nodeId(14)
-                                                    isInsideFunction: true
-                                                    isOnFunctionSignature: true
-                                                    isStrictTypes: true
-                                                    nodeId: 17
-                                                    origNode: nodeId(17)
-                                                    parent: nodeId(16)
-                                                    reflectionClass: Infection\Reflection\CoreClassReflection
-                                                    startLine: 44
-                                                )
-                                                var: Expr_Variable(
-                                                    eligible: false
-                                                    endLine: 44
-                                                    functionName: concreteMethod
-                                                    functionScope: nodeId(14)
-                                                    isInsideFunction: true
-                                                    isOnFunctionSignature: true
-                                                    isStrictTypes: true
-                                                    nodeId: 18
-                                                    origNode: nodeId(18)
-                                                    parent: nodeId(16)
-                                                    reflectionClass: Infection\Reflection\CoreClassReflection
-                                                    startLine: 44
-                                                )
-                                                eligible: false
-                                                endLine: 44
-                                                functionName: concreteMethod
-                                                functionScope: nodeId(14)
-                                                isInsideFunction: true
-                                                isOnFunctionSignature: true
-                                                isStrictTypes: true
-                                                nodeId: 16
-                                                origNode: nodeId(16)
-                                                parent: nodeId(14)
-                                                reflectionClass: Infection\Reflection\CoreClassReflection
-                                                startLine: 44
-                                            )
+                                            0: <skipped>
                                         )
-                                        returnType: Identifier(
-                                            eligible: false
-                                            endLine: 44
-                                            functionName: concreteMethod
-                                            functionScope: nodeId(14)
-                                            isInsideFunction: true
-                                            isStrictTypes: true
-                                            nodeId: 19
-                                            origNode: nodeId(19)
-                                            parent: nodeId(14)
-                                            reflectionClass: Infection\Reflection\CoreClassReflection
-                                            startLine: 44
-                                        )
+                                        returnType: <skipped>
                                         stmts: array(
                                             0: Stmt_If(
                                                 cond: Expr_BinaryOp_Identical(
                                                     left: Expr_Variable(
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         endLine: 46
                                                         functionName: concreteMethod
@@ -1399,6 +854,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     )
                                                     right: Expr_ConstFetch(
                                                         name: Name(
+                                                            containsEligibleNode: true
                                                             eligible: true
                                                             endLine: 46
                                                             functionName: concreteMethod
@@ -1413,6 +869,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                             startLine: 46
                                                             tests: Closure
                                                         )
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         endLine: 46
                                                         functionName: concreteMethod
@@ -1426,6 +883,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                         startLine: 46
                                                         tests: Closure
                                                     )
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     endLine: 46
                                                     functionName: concreteMethod
@@ -1440,93 +898,10 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     tests: Closure
                                                 )
                                                 stmts: array(
-                                                    0: Stmt_Echo(
-                                                        exprs: array(
-                                                            0: Scalar_String(
-                                                                eligible: false
-                                                                endLine: 47
-                                                                functionName: concreteMethod
-                                                                functionScope: nodeId(14)
-                                                                isInsideFunction: true
-                                                                isStrictTypes: true
-                                                                kind: KIND_SINGLE_QUOTED (1)
-                                                                nodeId: 26
-                                                                origNode: nodeId(26)
-                                                                parent: nodeId(25)
-                                                                rawValue: 'nothing to do'
-                                                                reflectionClass: Infection\Reflection\CoreClassReflection
-                                                                startLine: 47
-                                                            )
-                                                        )
-                                                        eligible: false
-                                                        endLine: 47
-                                                        functionName: concreteMethod
-                                                        functionScope: nodeId(14)
-                                                        isInsideFunction: true
-                                                        isStrictTypes: true
-                                                        next: nodeId(27)
-                                                        nodeId: 25
-                                                        origNode: nodeId(25)
-                                                        parent: nodeId(20)
-                                                        reflectionClass: Infection\Reflection\CoreClassReflection
-                                                        startLine: 47
-                                                    )
+                                                    0: <skipped>
                                                 )
-                                                else: Stmt_Else(
-                                                    stmts: array(
-                                                        0: Stmt_Expression(
-                                                            expr: Expr_FuncCall(
-                                                                name: Expr_Variable(
-                                                                    eligible: false
-                                                                    endLine: 49
-                                                                    functionName: concreteMethod
-                                                                    functionScope: nodeId(14)
-                                                                    isInsideFunction: true
-                                                                    isStrictTypes: true
-                                                                    nodeId: 30
-                                                                    origNode: nodeId(30)
-                                                                    parent: nodeId(29)
-                                                                    reflectionClass: Infection\Reflection\CoreClassReflection
-                                                                    startLine: 49
-                                                                )
-                                                                eligible: false
-                                                                endLine: 49
-                                                                functionName: concreteMethod
-                                                                functionScope: nodeId(14)
-                                                                isInsideFunction: true
-                                                                isStrictTypes: true
-                                                                nodeId: 29
-                                                                origNode: nodeId(29)
-                                                                parent: nodeId(28)
-                                                                reflectionClass: Infection\Reflection\CoreClassReflection
-                                                                startLine: 49
-                                                            )
-                                                            eligible: false
-                                                            endLine: 49
-                                                            functionName: concreteMethod
-                                                            functionScope: nodeId(14)
-                                                            isInsideFunction: true
-                                                            isStrictTypes: true
-                                                            nodeId: 28
-                                                            origNode: nodeId(28)
-                                                            parent: nodeId(27)
-                                                            reflectionClass: Infection\Reflection\CoreClassReflection
-                                                            startLine: 49
-                                                        )
-                                                    )
-                                                    eligible: false
-                                                    endLine: 50
-                                                    functionName: concreteMethod
-                                                    functionScope: nodeId(14)
-                                                    isInsideFunction: true
-                                                    isStrictTypes: true
-                                                    next: nodeId(28)
-                                                    nodeId: 27
-                                                    origNode: nodeId(27)
-                                                    parent: nodeId(20)
-                                                    reflectionClass: Infection\Reflection\CoreClassReflection
-                                                    startLine: 48
-                                                )
+                                                else: <skipped>
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 endLine: 50
                                                 functionName: concreteMethod
@@ -1542,6 +917,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                 tests: Closure
                                             )
                                         )
+                                        containsEligibleNode: true
                                         eligible: true
                                         endLine: 51
                                         functionName: concreteMethod
@@ -1554,89 +930,9 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                         startLine: 44
                                         tests: Closure
                                     )
-                                    3: Stmt_ClassMethod(
-                                        name: Identifier(
-                                            eligible: false
-                                            endLine: 53
-                                            functionName: abstractMethod
-                                            functionScope: nodeId(31)
-                                            isInsideFunction: true
-                                            isStrictTypes: true
-                                            nodeId: 32
-                                            origNode: nodeId(32)
-                                            parent: nodeId(31)
-                                            reflectionClass: Infection\Reflection\CoreClassReflection
-                                            startLine: 53
-                                        )
-                                        params: array(
-                                            0: Param(
-                                                type: Identifier(
-                                                    eligible: false
-                                                    endLine: 53
-                                                    functionName: abstractMethod
-                                                    functionScope: nodeId(31)
-                                                    isInsideFunction: true
-                                                    isOnFunctionSignature: true
-                                                    isStrictTypes: true
-                                                    nodeId: 34
-                                                    origNode: nodeId(34)
-                                                    parent: nodeId(33)
-                                                    reflectionClass: Infection\Reflection\CoreClassReflection
-                                                    startLine: 53
-                                                )
-                                                var: Expr_Variable(
-                                                    eligible: false
-                                                    endLine: 53
-                                                    functionName: abstractMethod
-                                                    functionScope: nodeId(31)
-                                                    isInsideFunction: true
-                                                    isOnFunctionSignature: true
-                                                    isStrictTypes: true
-                                                    nodeId: 35
-                                                    origNode: nodeId(35)
-                                                    parent: nodeId(33)
-                                                    reflectionClass: Infection\Reflection\CoreClassReflection
-                                                    startLine: 53
-                                                )
-                                                eligible: false
-                                                endLine: 53
-                                                functionName: abstractMethod
-                                                functionScope: nodeId(31)
-                                                isInsideFunction: true
-                                                isOnFunctionSignature: true
-                                                isStrictTypes: true
-                                                nodeId: 33
-                                                origNode: nodeId(33)
-                                                parent: nodeId(31)
-                                                reflectionClass: Infection\Reflection\CoreClassReflection
-                                                startLine: 53
-                                            )
-                                        )
-                                        returnType: Identifier(
-                                            eligible: false
-                                            endLine: 53
-                                            functionName: abstractMethod
-                                            functionScope: nodeId(31)
-                                            isInsideFunction: true
-                                            isStrictTypes: true
-                                            nodeId: 36
-                                            origNode: nodeId(36)
-                                            parent: nodeId(31)
-                                            reflectionClass: Infection\Reflection\CoreClassReflection
-                                            startLine: 53
-                                        )
-                                        eligible: false
-                                        endLine: 55
-                                        functionName: abstractMethod
-                                        isOnFunctionSignature: true
-                                        isStrictTypes: true
-                                        nodeId: 31
-                                        origNode: nodeId(31)
-                                        parent: nodeId(6)
-                                        reflectionClass: Infection\Reflection\CoreClassReflection
-                                        startLine: 53
-                                    )
+                                    3: <skipped>
                                 )
+                                containsEligibleNode: true
                                 eligible: false
                                 endLine: 56
                                 next: nodeId(8)
@@ -1646,6 +942,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                 startLine: 38
                             )
                         )
+                        containsEligibleNode: true
                         eligible: false
                         endLine: 56
                         kind: 1
@@ -1663,123 +960,19 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
             null,
             <<<'AST'
                 array(
-                    0: Stmt_Declare(
-                        declares: array(
-                            0: DeclareItem(
-                                key: Identifier(
-                                    eligible: false
-                                    nodeId: 2
-                                    origNode: nodeId(2)
-                                    parent: nodeId(1)
-                                )
-                                value: Scalar_Int(
-                                    eligible: false
-                                    kind: KIND_DEC (10)
-                                    nodeId: 3
-                                    origNode: nodeId(3)
-                                    parent: nodeId(1)
-                                    rawValue: 1
-                                )
-                                eligible: false
-                                nodeId: 1
-                                origNode: nodeId(1)
-                                parent: nodeId(0)
-                            )
-                        )
-                        eligible: false
-                        next: nodeId(4)
-                        nodeId: 0
-                        origNode: nodeId(0)
-                    )
+                    0: <skipped>
                     1: Stmt_Namespace(
-                        name: Name(
-                            eligible: false
-                            nodeId: 5
-                            origNode: nodeId(5)
-                            parent: nodeId(4)
-                        )
+                        name: <skipped>
                         stmts: array(
                             0: Stmt_Class(
-                                name: Identifier(
-                                    eligible: false
-                                    nodeId: 7
-                                    origNode: nodeId(7)
-                                    parent: nodeId(6)
-                                )
+                                name: <skipped>
                                 stmts: array(
-                                    0: Stmt_TraitUse(
-                                        traits: array(
-                                            0: Name(
-                                                eligible: false
-                                                nodeId: 9
-                                                origNode: nodeId(9)
-                                                parent: nodeId(8)
-                                                resolvedName: FullyQualified(Infection\Tests\PhpParser\Visitor\EnrichmentTraverse\Fixtures\TraitExample)
-                                            )
-                                        )
-                                        eligible: false
-                                        next: nodeId(10)
-                                        nodeId: 8
-                                        origNode: nodeId(8)
-                                        parent: nodeId(6)
-                                    )
-                                    1: Stmt_ClassConst(
-                                        consts: array(
-                                            0: Const(
-                                                name: Identifier(
-                                                    eligible: false
-                                                    nodeId: 12
-                                                    origNode: nodeId(12)
-                                                    parent: nodeId(11)
-                                                )
-                                                value: Scalar_String(
-                                                    eligible: false
-                                                    kind: KIND_SINGLE_QUOTED (1)
-                                                    nodeId: 13
-                                                    origNode: nodeId(13)
-                                                    parent: nodeId(11)
-                                                    rawValue: ''
-                                                )
-                                                eligible: false
-                                                nodeId: 11
-                                                origNode: nodeId(11)
-                                                parent: nodeId(10)
-                                            )
-                                        )
-                                        eligible: false
-                                        nodeId: 10
-                                        origNode: nodeId(10)
-                                        parent: nodeId(6)
-                                    )
-                                    2: Stmt_ClassMethod(
-                                        name: Identifier(
-                                            nodeId: 15
-                                            origNode: nodeId(15)
-                                        )
-                                        params: array(
-                                            0: Param(
-                                                type: Identifier(
-                                                    nodeId: 17
-                                                    origNode: nodeId(17)
-                                                )
-                                                var: Expr_Variable(
-                                                    nodeId: 18
-                                                    origNode: nodeId(18)
-                                                )
-                                                nodeId: 16
-                                                origNode: nodeId(16)
-                                            )
-                                        )
-                                        returnType: Identifier(
-                                            nodeId: 19
-                                            origNode: nodeId(19)
-                                        )
-                                        eligible: false
-                                        nodeId: 14
-                                        origNode: nodeId(14)
-                                    )
+                                    0: <skipped>
+                                    1: <skipped>
+                                    2: <skipped>
                                     3: Stmt_ClassMethod(
                                         name: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: concreteMethod
                                             functionScope: nodeId(20)
@@ -1794,6 +987,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                         params: array(
                                             0: Param(
                                                 type: Identifier(
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: concreteMethod
                                                     functionScope: nodeId(20)
@@ -1807,6 +1001,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     tests: Closure
                                                 )
                                                 var: Expr_Variable(
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: concreteMethod
                                                     functionScope: nodeId(20)
@@ -1819,6 +1014,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     reflectionClass: Infection\Reflection\NullReflection
                                                     tests: Closure
                                                 )
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 functionName: concreteMethod
                                                 functionScope: nodeId(20)
@@ -1833,6 +1029,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             )
                                         )
                                         returnType: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: concreteMethod
                                             functionScope: nodeId(20)
@@ -1844,6 +1041,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             reflectionClass: Infection\Reflection\NullReflection
                                             tests: Closure
                                         )
+                                        containsEligibleNode: true
                                         eligible: true
                                         functionName: concreteMethod
                                         isOnFunctionSignature: true
@@ -1855,6 +1053,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                         tests: Closure
                                     )
                                 )
+                                containsEligibleNode: true
                                 eligible: false
                                 next: nodeId(8)
                                 nodeId: 6
@@ -1862,6 +1061,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                 parent: nodeId(4)
                             )
                         )
+                        containsEligibleNode: true
                         eligible: false
                         kind: 1
                         next: nodeId(6)
@@ -1878,106 +1078,18 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
             null,
             <<<'AST'
                 array(
-                    0: Stmt_Declare(
-                        declares: array(
-                            0: DeclareItem(
-                                key: Identifier(
-                                    eligible: false
-                                    nodeId: 2
-                                    origNode: nodeId(2)
-                                    parent: nodeId(1)
-                                )
-                                value: Scalar_Int(
-                                    eligible: false
-                                    kind: KIND_DEC (10)
-                                    nodeId: 3
-                                    origNode: nodeId(3)
-                                    parent: nodeId(1)
-                                    rawValue: 1
-                                )
-                                eligible: false
-                                nodeId: 1
-                                origNode: nodeId(1)
-                                parent: nodeId(0)
-                            )
-                        )
-                        eligible: false
-                        next: nodeId(4)
-                        nodeId: 0
-                        origNode: nodeId(0)
-                    )
+                    0: <skipped>
                     1: Stmt_Namespace(
-                        name: Name(
-                            eligible: false
-                            nodeId: 5
-                            origNode: nodeId(5)
-                            parent: nodeId(4)
-                        )
+                        name: <skipped>
                         stmts: array(
-                            0: Stmt_Use(
-                                uses: array(
-                                    0: UseItem(
-                                        name: Name(
-                                            eligible: false
-                                            nodeId: 8
-                                            origNode: nodeId(8)
-                                            parent: nodeId(7)
-                                        )
-                                        alias: Identifier(
-                                            eligible: false
-                                            nodeId: 9
-                                            origNode: nodeId(9)
-                                            parent: nodeId(7)
-                                        )
-                                        eligible: false
-                                        nodeId: 7
-                                        origNode: nodeId(7)
-                                        parent: nodeId(6)
-                                    )
-                                )
-                                eligible: false
-                                next: nodeId(10)
-                                nodeId: 6
-                                origNode: nodeId(6)
-                                parent: nodeId(4)
-                            )
-                            1: Stmt_Use(
-                                uses: array(
-                                    0: UseItem(
-                                        name: Name(
-                                            eligible: false
-                                            nodeId: 12
-                                            origNode: nodeId(12)
-                                            parent: nodeId(11)
-                                        )
-                                        alias: Identifier(
-                                            eligible: false
-                                            nodeId: 13
-                                            origNode: nodeId(13)
-                                            parent: nodeId(11)
-                                        )
-                                        eligible: false
-                                        nodeId: 11
-                                        origNode: nodeId(11)
-                                        parent: nodeId(10)
-                                    )
-                                )
-                                eligible: false
-                                next: nodeId(14)
-                                nodeId: 10
-                                origNode: nodeId(10)
-                                parent: nodeId(4)
-                            )
+                            0: <skipped>
+                            1: <skipped>
                             2: Stmt_Class(
-                                name: Identifier(
-                                    eligible: false
-                                    nodeId: 15
-                                    origNode: nodeId(15)
-                                    parent: nodeId(14)
-                                )
+                                name: <skipped>
                                 stmts: array(
                                     0: Stmt_ClassMethod(
                                         name: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: check
                                             functionScope: nodeId(16)
@@ -1992,6 +1104,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                         params: array(
                                             0: Param(
                                                 type: Identifier(
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: check
                                                     functionScope: nodeId(16)
@@ -2005,6 +1118,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     tests: Closure
                                                 )
                                                 var: Expr_Variable(
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: check
                                                     functionScope: nodeId(16)
@@ -2017,6 +1131,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     reflectionClass: Infection\Reflection\NullReflection
                                                     tests: Closure
                                                 )
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 functionName: check
                                                 functionScope: nodeId(16)
@@ -2031,6 +1146,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                             )
                                         )
                                         returnType: Identifier(
+                                            containsEligibleNode: true
                                             eligible: true
                                             functionName: check
                                             functionScope: nodeId(16)
@@ -2047,6 +1163,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                 expr: Expr_BinaryOp_BooleanOr(
                                                     left: Expr_Instanceof(
                                                         expr: Expr_Variable(
+                                                            containsEligibleNode: true
                                                             eligible: true
                                                             functionName: check
                                                             functionScope: nodeId(16)
@@ -2059,6 +1176,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                             tests: Closure
                                                         )
                                                         class: Name(
+                                                            containsEligibleNode: true
                                                             eligible: true
                                                             functionName: check
                                                             functionScope: nodeId(16)
@@ -2071,6 +1189,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                             resolvedName: FullyQualified(RuntimeException)
                                                             tests: Closure
                                                         )
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         functionName: check
                                                         functionScope: nodeId(16)
@@ -2084,6 +1203,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     )
                                                     right: Expr_Instanceof(
                                                         expr: Expr_Variable(
+                                                            containsEligibleNode: true
                                                             eligible: true
                                                             functionName: check
                                                             functionScope: nodeId(16)
@@ -2096,6 +1216,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                             tests: Closure
                                                         )
                                                         class: Name(
+                                                            containsEligibleNode: true
                                                             eligible: true
                                                             functionName: check
                                                             functionScope: nodeId(16)
@@ -2108,6 +1229,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                             resolvedName: FullyQualified(InvalidArgumentException)
                                                             tests: Closure
                                                         )
+                                                        containsEligibleNode: true
                                                         eligible: true
                                                         functionName: check
                                                         functionScope: nodeId(16)
@@ -2119,6 +1241,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                         reflectionClass: Infection\Reflection\NullReflection
                                                         tests: Closure
                                                     )
+                                                    containsEligibleNode: true
                                                     eligible: true
                                                     functionName: check
                                                     functionScope: nodeId(16)
@@ -2130,6 +1253,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                     reflectionClass: Infection\Reflection\NullReflection
                                                     tests: Closure
                                                 )
+                                                containsEligibleNode: true
                                                 eligible: true
                                                 functionName: check
                                                 functionScope: nodeId(16)
@@ -2142,6 +1266,7 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                                 tests: Closure
                                             )
                                         )
+                                        containsEligibleNode: true
                                         eligible: true
                                         functionName: check
                                         isOnFunctionSignature: true
@@ -2153,12 +1278,14 @@ final class EnrichmentTraverseIntegrationTest extends VisitorTestCase
                                         tests: Closure
                                     )
                                 )
+                                containsEligibleNode: true
                                 eligible: false
                                 nodeId: 14
                                 origNode: nodeId(14)
                                 parent: nodeId(4)
                             )
                         )
+                        containsEligibleNode: true
                         eligible: false
                         kind: 1
                         next: nodeId(6)

--- a/tests/phpunit/PhpParser/Visitor/SkipNodesWithoutEligibleNodeVisitorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/SkipNodesWithoutEligibleNodeVisitorTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\PhpParser\Visitor;
+
+use function array_flip;
+use function array_intersect_key;
+use Infection\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitor;
+use Infection\PhpParser\Visitor\ContainsEligibleNodeVisitor;
+use Infection\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor;
+use Infection\PhpParser\Visitor\SkipNodesWithoutEligibleNodeVisitor;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCase;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(SkipNodesWithoutEligibleNodeVisitor::class)]
+final class SkipNodesWithoutEligibleNodeVisitorTest extends VisitorTestCase
+{
+    /**
+     * @param list<int> $containsEligibleNodeIds
+     */
+    #[DataProvider('nodeProvider')]
+    public function test_it_skips_nodes_without_eligible_nodes(
+        string $code,
+        array $containsEligibleNodeIds,
+        string $expected,
+    ): void {
+        $nodes = $this->parse($code);
+
+        $nodesById = $this->addIdsToNodes($nodes);
+        $this->markNodesAsContainingEligibleNode($nodesById, $containsEligibleNodeIds);
+
+        (new NodeTraverser(
+            new SkipNodesWithoutEligibleNodeVisitor(),
+            new MarkTraversedNodesAsVisitedVisitor(),
+        ))->traverse($nodes);
+
+        $this->keepOnlyDesiredAttributes(
+            $nodes,
+            AddIdToTraversedNodesVisitor::NODE_ID_ATTRIBUTE,
+            ContainsEligibleNodeVisitor::CONTAINS_ELIGIBLE_NODE,
+        );
+
+        $actual = $this->dumper->dump($nodes);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function nodeProvider(): iterable
+    {
+        $phpCode = <<<'PHP'
+            <?php
+
+            $x = 1 + 2;
+            $y = 3 + 4;
+
+            PHP;
+
+        yield 'no branch with eligible nodes' => [
+            $phpCode,
+            [],
+            <<<'AST'
+                array(
+                    0: <skipped>
+                    1: <skipped>
+                )
+                AST,
+        ];
+
+        yield 'one branch with eligible nodes' => [
+            $phpCode,
+            [0, 1, 3, 4, 5],
+            <<<'AST'
+                array(
+                    0: Stmt_Expression(
+                        expr: Expr_Assign(
+                            var: <skipped>
+                            expr: Expr_BinaryOp_Plus(
+                                left: Scalar_Int(
+                                    containsEligibleNode: true
+                                    nodeId: 4
+                                )
+                                right: Scalar_Int(
+                                    containsEligibleNode: true
+                                    nodeId: 5
+                                )
+                                containsEligibleNode: true
+                                nodeId: 3
+                            )
+                            containsEligibleNode: true
+                            nodeId: 1
+                        )
+                        containsEligibleNode: true
+                        nodeId: 0
+                    )
+                    1: <skipped>
+                )
+                AST,
+        ];
+    }
+
+    /**
+     * @param array<positive-int|0, Node> $nodesById
+     * @param list<int> $nodeIds
+     */
+    private function markNodesAsContainingEligibleNode(array $nodesById, array $nodeIds): void
+    {
+        $nodes = array_intersect_key(
+            $nodesById,
+            array_flip($nodeIds),
+        );
+
+        foreach ($nodes as $node) {
+            ContainsEligibleNodeVisitor::markAsContainingEligibleNode($node);
+        }
+    }
+}


### PR DESCRIPTION
_This PR is under heavy development, it is not ready for review in any way._

Notes for myself:

- Extract the benchmark, ensure it is comprehensive enough to capture the AST processing phase without prior overhead and without the overhead of generating mutations. For completeness the parsed files should be partially covered.
- Verify that the PR works as expected (it does at first glance but requires a more in-depth review).
- Measure the performance gains.

## Description

As of #3026, we now have a complete separation between the first traverse which is to enrich the AST and the second traverse which is for generating mutations.

As a result of the first mutation, we know which nodes are eligible, hence we can also deduce if a node contains any eligible child. If it does not, we could skip this branch entirely during the 2nd traverse.

## Changes

- Adds/Fixes/Updates ...

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (provide link to PR: https://github.com/infection/site/pull/XXX)
- [ ] CHANGELOG.md updated (if deprecations/breaking changes)
- [ ] Appropriate labels applied (e.g. `performance`, `feature`).


## Breaking Changes

<!-- Remove if not applicable -->


## Reviewer Notes

<!-- What should reviewers focus on? Any areas of concern? -->

## Related issues

- https://github.com/infection/infection/issues/2797
