### PR TITLE
Disable code review status comments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+reviews:
+  review_status: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,2 +1,3 @@
 reviews:
   review_status: false
+  high_level_summary: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,4 @@
 reviews:
   review_status: false
   high_level_summary: false
+  poem: false


### PR DESCRIPTION
See https://github.com/infection/infection/pull/3086#issuecomment-4334153437

See https://docs.coderabbit.ai/reference/configuration#param-review-status

from claude:

> CodeRabbit may still post a minimal walkthrough comment on the PR. The only fully-clean way to eliminate it is via the dashboard (Repositories → Reviews → "Disable Walkthrough"), which isn't exposed as a YAML key.

^ we will probably need to test this later as well. Posting 2 comments after PR is craeted (see below) is ... too much.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Disabled poem in Walkthrough 🤦  (`poem: false`)

<img width="362" height="183" alt="image" src="https://github.com/user-attachments/assets/215ef5c4-9c6b-4c0c-af18-ec90fd15cbdd" />

Also, disabled this "Summary by CodeRabbit" 👇 (`high_level_summary: false`)

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings to adjust review behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->