### PR TITLE
build(sbx): Allow to use telemetry with Codex with the Docker sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 /.tools/
 /build/
 /devTools/Docker*.json
-/devTools/sbx/codex-config.toml
 /dist/
 /infection-cache
 /infection.log

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /.tools/
 /build/
 /devTools/Docker*.json
+/devTools/sbx/codex-config.toml
 /dist/
 /infection-cache
 /infection.log

--- a/devTools/sbx/Dockerfile
+++ b/devTools/sbx/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
 
-ENV NO_PROXY='host.docker.internal,169.254.1.1,localhost,127.0.0.1,::1,gateway.docker.internal'
+ENV NO_PROXY="${NO_PROXY:+${NO_PROXY},}host.docker.internal,169.254.1.1,localhost,127.0.0.1,::1,gateway.docker.internal"
 ENV no_proxy="$NO_PROXY"
 
 # Restore the default non-root user that the sandbox agent runs as.

--- a/devTools/sbx/Dockerfile
+++ b/devTools/sbx/Dockerfile
@@ -21,5 +21,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
 
+ENV NO_PROXY='host.docker.internal,169.254.1.1,localhost,127.0.0.1,::1,gateway.docker.internal'
+ENV no_proxy="$NO_PROXY"
+
 # Restore the default non-root user that the sandbox agent runs as.
 USER agent

--- a/devTools/sbx/README.md
+++ b/devTools/sbx/README.md
@@ -6,6 +6,27 @@ It extends [`docker/sandbox-templates:codex-docker`][docker-sandbox-templates-co
 
 It uses [container-structure-test][container-structure-test] for testing the image.
 
+## Telemetry
+
+Codex telemetry is optional, to enable it, copy the template before launching
+Codex:
+
+```shell
+cp devTools/sbx/config.toml.dist .codex/config.toml
+```
+
+The provided template assumes the OTLP gRPC collector is reachable from
+the sandbox at `http://host.docker.internal:4317`. If it runs elsewhere,
+update `codex-config.toml`.
+
+Note that depending of the port used or your network policies, the connection
+to the host may be denied. For example, with the value above, you will need to
+execute:
+
+```shell
+sbx policy allow network localhost:4317
+```
+
 ## Usage
 
 Build the image:

--- a/devTools/sbx/README.md
+++ b/devTools/sbx/README.md
@@ -17,9 +17,9 @@ cp devTools/sbx/config.toml.dist .codex/config.toml
 
 The provided template assumes the OTLP gRPC collector is reachable from
 the sandbox at `http://host.docker.internal:4317`. If it runs elsewhere,
-update `codex-config.toml`.
+update `.codex/config.toml`.
 
-Note that depending of the port used or your network policies, the connection
+Note that depending on the port used or your network policies, the connection
 to the host may be denied. For example, with the value above, you will need to
 execute:
 


### PR DESCRIPTION
Adjust the Docker sandbox image configuration to be able to use the [telemetry for Codex](https://developers.openai.com/codex/config-advanced#observability-and-telemetry).

Also add guidance for enabling Codex OTEL from the sandbox.