### PR TITLE
ci: Disable Coderabbit automatic reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+reviews:
+    auto_review:
+        enabled: false
+        auto_incremental_review: false
+        review_status: false


### PR DESCRIPTION
Having a minimum of 2 comments as soon as you open a PR is a bit oppressive, especially if like me you like to open a PR then take some time to check it out once more in more details before assigning it for reviews.

This PR proposes to disable CodeRabbit automatic reviews. If one wish to have a review they can execute `@coderabbitai full review` or `@coderabbitai review` (incremental review).