### PR TITLE
build(sbx): Add PIE to the Docker Sandbox template

### DIFF
--- a/devTools/sbx/Dockerfile
+++ b/devTools/sbx/Dockerfile
@@ -17,9 +17,20 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         php${PHP_VERSION}-mbstring \
         php${PHP_VERSION}-xml \
         php${PHP_VERSION}-zip \
+        # CA bundle used by curl/PIE for HTTPS downloads
+        ca-certificates \
+        # Downloads the PIE PHAR during image build
+        curl \
     && rm -rf /tmp/*
 
 COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
+
+# PIE
+# https://github.com/php/pie#one-liner
+RUN set -o errexit -o nounset -o pipefail \
+    && curl -fL --output /tmp/pie.phar https://github.com/php/pie/releases/latest/download/pie.phar \
+    && mv /tmp/pie.phar /usr/local/bin/pie \
+    && chmod +x /usr/local/bin/pie
 
 ENV NO_PROXY="${NO_PROXY:+${NO_PROXY},}host.docker.internal,169.254.1.1,localhost,127.0.0.1,::1,gateway.docker.internal"
 ENV no_proxy="$NO_PROXY"

--- a/devTools/sbx/test.yaml
+++ b/devTools/sbx/test.yaml
@@ -12,6 +12,11 @@ commandTests:
         args: ["--version"]
         exitCode: 0
 
+    -   name: "PIE is executable"
+        command: "pie"
+        args: ["--version"]
+        exitCode: 0
+
     - name: "Container runs as agent user"
       command: "whoami"
       expectedOutput: ["(?m)^agent$"]


### PR DESCRIPTION
Like for the extensions currently installed, we could and should add used extensions to the `Dockerfile`. However, the docker sandbox is also a development environment where one should be able to develop as they do on their machine and may need to be able to install an extension to try something. As such, [PIE](https://github.com/php/pie) is useful to have.