### PR TITLE
build(sbx): Add Xdebug with coverage mode to the Docker Sandbox template

### DIFF
--- a/devTools/sbx/Dockerfile
+++ b/devTools/sbx/Dockerfile
@@ -17,10 +17,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         php${PHP_VERSION}-mbstring \
         php${PHP_VERSION}-xml \
         php${PHP_VERSION}-zip \
+        # Coverage driver
+        php${PHP_VERSION}-xdebug \
         # CA bundle used by curl/PIE for HTTPS downloads
         ca-certificates \
         # Downloads the PIE PHAR during image build
         curl \
+    && echo 'xdebug.mode=coverage' > /etc/php/${PHP_VERSION}/cli/conf.d/xdebug.ini \
     && rm -rf /tmp/*
 
 COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer

--- a/devTools/sbx/test.yaml
+++ b/devTools/sbx/test.yaml
@@ -7,6 +7,13 @@ commandTests:
         expectedOutput: ['^PHP 8\.4\.\d+ \(cli\) ']
         exitCode: 0
 
+    -   name: "Xdebug coverage mode is enabled"
+        command: "bash"
+        # The pipe needs a shell; "-c" asks bash to execute this string.
+        args: ["-c", "php -i | grep 'xdebug.mode'"]
+        expectedOutput: ['(?m)^xdebug\.mode => coverage => coverage$']
+        exitCode: 0
+
     -   name: "composer is executable"
         command: "composer"
         args: ["--version"]


### PR DESCRIPTION
This makes it easier to execute infection from within the sandbox.