### PR TITLE
feat(teamcity): Display more information for finished tests

### DIFF
--- a/src/Logger/MutationAnalysis/TeamCity/MessageName.php
+++ b/src/Logger/MutationAnalysis/TeamCity/MessageName.php
@@ -52,4 +52,5 @@ enum MessageName: string
     case TEST_FINISHED = 'testFinished';
     case TEST_FAILED = 'testFailed';
     case TEST_IGNORED = 'testIgnored';
+    case TEST_STDOUT = 'testStdOut';
 }

--- a/src/Logger/MutationAnalysis/TeamCity/TeamCity.php
+++ b/src/Logger/MutationAnalysis/TeamCity/TeamCity.php
@@ -120,26 +120,42 @@ final readonly class TeamCity
         );
     }
 
+    /**
+     * @return list<string>
+     */
     public function testFinished(
         Test $test,
         MutantExecutionResult $executionResult,
-    ): string {
+    ): array {
         $messageName = $this->mapExecutionResultToTestStatus($executionResult);
         $attributes = $test->toFinishedAttributes($executionResult);
 
-        if ($messageName !== MessageName::TEST_FINISHED) {
-            unset($attributes['details']);
-            [$from, $to] = $this->differ->diffToArray(
-                from: $executionResult->getOriginalCode(),
-                to: $executionResult->getMutatedCode(),
+        $logs = [];
+
+        if ($messageName === MessageName::TEST_FINISHED) {
+            // Emit a standard `##teamcity[testStdOut]` service message before the closing `testFinished`
+            // event for the same name.
+            // IntelliJ collects out=… into the test's stdout buffer and renders it in the output tab of
+            // the selected test node. This works in any TeamCity consumer (TeamCity CI, PhpStorm, etc.).
+            $logs[] = $this->write(
+                MessageName::TEST_STDOUT,
+                [
+                    'name' => $attributes['name'],
+                    'out' => $attributes['message'],
+                ],
             );
 
-            $attributes['type'] = 'comparisonFailure';
-            $attributes['actual'] = $from;
-            $attributes['expected'] = $to;
+            unset($attributes['message']);
+            unset($attributes['details']);
+        } elseif ($messageName === MessageName::TEST_FAILED) {
+            $attributes = $this->replaceDetailsWithComparisonFailure($attributes, $executionResult);
+        } else {
+            unset($attributes['details']);
         }
 
-        return $this->write($messageName, $attributes);
+        $logs[] = $this->write($messageName, $attributes);
+
+        return $logs;
     }
 
     /**
@@ -161,6 +177,29 @@ final readonly class TeamCity
                 ],
             ),
         );
+    }
+
+    /**
+     * @param MessageAttributes $attributes
+     *
+     * @return MessageAttributes
+     */
+    private function replaceDetailsWithComparisonFailure(
+        array $attributes,
+        MutantExecutionResult $executionResult,
+    ): array {
+        unset($attributes['details']);
+
+        [$from, $to] = $this->differ->diffToArray(
+            from: $executionResult->getOriginalCode(),
+            to: $executionResult->getMutatedCode(),
+        );
+
+        $attributes['type'] = 'comparisonFailure';
+        $attributes['actual'] = $from;
+        $attributes['expected'] = $to;
+
+        return $attributes;
     }
 
     /**

--- a/src/Logger/MutationAnalysis/TeamCity/TeamCityLogger.php
+++ b/src/Logger/MutationAnalysis/TeamCity/TeamCityLogger.php
@@ -149,7 +149,7 @@ final readonly class TeamCityLogger implements MutationAnalysisLogger
         MutantExecutionResult $executionResult,
     ): void {
         $this->write(
-            $this->teamcity->testFinished($test, $executionResult),
+            ...$this->teamcity->testFinished($test, $executionResult),
         );
 
         $this->state->closeTest($test);
@@ -162,8 +162,10 @@ final readonly class TeamCityLogger implements MutationAnalysisLogger
         }
     }
 
-    private function write(string $messsage): void
+    private function write(string ...$messages): void
     {
-        $this->logger->warning($messsage);
+        foreach ($messages as $message) {
+            $this->logger->warning($message);
+        }
     }
 }

--- a/src/Logger/MutationAnalysis/TeamCity/Test.php
+++ b/src/Logger/MutationAnalysis/TeamCity/Test.php
@@ -89,7 +89,6 @@ final readonly class Test
     public function toFinishedAttributes(MutantExecutionResult $executionResult): array
     {
         return $this->toAttributes() + [
-            // TODO: looks like this information is not used when the test is marked as successful or ignored :/
             'message' => self::createMutationMessage($executionResult),
             'details' => $executionResult->getMutantDiff(),
             'duration' => self::getExecutionDurationInMs($executionResult),

--- a/tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php
@@ -134,7 +134,8 @@ final class TeamCityLoggerTest extends TestCase
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f' metainfo='{"mutationId":"49a5dfcd2f4a0b33d4a02e662812af55"}' locationHint='infection:///path/to/project/src/Service/UserService.php::7-42']
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' out='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' duration='120']
 
                 ##teamcity[testSuiteFinished name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f']
 
@@ -168,7 +169,8 @@ final class TeamCityLoggerTest extends TestCase
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f' metainfo='{"mutationId":"49a5dfcd2f4a0b33d4a02e662812af55"}' locationHint='infection:///path/to/project/src/Service/UserService.php::7-42']
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' out='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' duration='120']
 
                 ##teamcity[testSuiteFinished name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f']
 
@@ -202,7 +204,8 @@ final class TeamCityLoggerTest extends TestCase
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f' metainfo='{"mutationId":"49a5dfcd2f4a0b33d4a02e662812af55"}' locationHint='infection:///path/to/project/src/Service/UserService.php::7-42']
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' out='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' duration='120']
 
                 ##teamcity[testSuiteFinished name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f']
 
@@ -237,7 +240,8 @@ final class TeamCityLoggerTest extends TestCase
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f' metainfo='{"mutationId":"49a5dfcd2f4a0b33d4a02e662812af55"}' locationHint='infection:///path/to/project/src/Service/UserService.php::7-42']
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' out='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' duration='120']
 
                 ##teamcity[testSuiteFinished name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f']
 
@@ -290,10 +294,12 @@ final class TeamCityLoggerTest extends TestCase
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f' metainfo='{"mutationId":"49a5dfcd2f4a0b33d4a02e662812af55"}' locationHint='infection:///path/to/project/src/Service/UserService.php::7-42']
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' out='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' duration='120']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' parentNodeId='5568c7d4af5ccc7f' metainfo='{"mutationId":"aa35bf87f287aa4e383112a632fde848"}' locationHint='infection:///path/to/project/src/Service/UserService.php::7-42']
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' message='Mutator: For_|nMutation ID: aa35bf87f287aa4e383112a632fde848|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' out='Mutator: For_|nMutation ID: aa35bf87f287aa4e383112a632fde848|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' duration='120']
 
                 ##teamcity[testSuiteFinished name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f']
 
@@ -360,9 +366,12 @@ final class TeamCityLoggerTest extends TestCase
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' parentNodeId='5568c7d4af5ccc7f' metainfo='{"mutationId":"aa35bf87f287aa4e383112a632fde848"}' locationHint='infection:///path/to/project/src/Service/UserService.php::7-42']
                 ##teamcity[testStarted name='Infection\Mutator\Operator\Continue_ (9272ac9a2aff44767733cf23a4acb7c6)' nodeId='03fbbaaabc71e694' parentNodeId='5568c7d4af5ccc7f' metainfo='{"mutationId":"9272ac9a2aff44767733cf23a4acb7c6"}' locationHint='infection:///path/to/project/src/Service/UserService.php::7-42']
 
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' message='Mutator: For_|nMutation ID: aa35bf87f287aa4e383112a632fde848|nMutation result: killed by tests' details='mutationDiff' duration='120']
-                ##teamcity[testFinished name='Infection\Mutator\Operator\Continue_ (9272ac9a2aff44767733cf23a4acb7c6)' nodeId='03fbbaaabc71e694' message='Mutator: For_|nMutation ID: 9272ac9a2aff44767733cf23a4acb7c6|nMutation result: killed by tests' details='mutationDiff' duration='120']
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' out='Mutator: For_|nMutation ID: aa35bf87f287aa4e383112a632fde848|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Operator\Continue_ (9272ac9a2aff44767733cf23a4acb7c6)' out='Mutator: For_|nMutation ID: 9272ac9a2aff44767733cf23a4acb7c6|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Operator\Continue_ (9272ac9a2aff44767733cf23a4acb7c6)' nodeId='03fbbaaabc71e694' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' out='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' duration='120']
 
                 ##teamcity[testSuiteFinished name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f']
 
@@ -415,8 +424,10 @@ final class TeamCityLoggerTest extends TestCase
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f' metainfo='{"mutationId":"49a5dfcd2f4a0b33d4a02e662812af55"}' locationHint='infection:///path/to/project/src/Service/UserService.php::7-42']
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' parentNodeId='5568c7d4af5ccc7f' metainfo='{"mutationId":"aa35bf87f287aa4e383112a632fde848"}' locationHint='infection:///path/to/project/src/Service/UserService.php::7-42']
 
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' message='Mutator: For_|nMutation ID: aa35bf87f287aa4e383112a632fde848|nMutation result: killed by tests' details='mutationDiff' duration='120']
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' out='Mutator: For_|nMutation ID: aa35bf87f287aa4e383112a632fde848|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' out='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' duration='120']
 
                 ##teamcity[testSuiteFinished name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f']
 
@@ -467,14 +478,16 @@ final class TeamCityLoggerTest extends TestCase
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' parentNodeId='5568c7d4af5ccc7f' metainfo='{"mutationId":"49a5dfcd2f4a0b33d4a02e662812af55"}' locationHint='infection:///path/to/project/src/Service/UserService.php::7-42']
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' out='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' duration='120']
 
                 ##teamcity[testSuiteFinished name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f']
 
                 ##teamcity[testSuiteStarted name='src/Service/ContactService.php' nodeId='12f6def551a5aae7' parentNodeId='0' locationHint='file:///path/to/project/src/Service/ContactService.php']
 
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' nodeId='ea74aba5c3e84a26' parentNodeId='12f6def551a5aae7' metainfo='{"mutationId":"0a451675763250c03e95b626f7bcfb7d"}' locationHint='infection:///path/to/project/src/Service/ContactService.php::7-42']
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' nodeId='ea74aba5c3e84a26' message='Mutator: For_|nMutation ID: 0a451675763250c03e95b626f7bcfb7d|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' out='Mutator: For_|nMutation ID: 0a451675763250c03e95b626f7bcfb7d|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' nodeId='ea74aba5c3e84a26' duration='120']
 
                 ##teamcity[testSuiteFinished name='src/Service/ContactService.php' nodeId='12f6def551a5aae7']
 
@@ -530,9 +543,11 @@ final class TeamCityLoggerTest extends TestCase
                 ##teamcity[testSuiteStarted name='src/Service/ContactService.php' nodeId='12f6def551a5aae7' parentNodeId='0' locationHint='file:///path/to/project/src/Service/ContactService.php']
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' nodeId='ea74aba5c3e84a26' parentNodeId='12f6def551a5aae7' metainfo='{"mutationId":"0a451675763250c03e95b626f7bcfb7d"}' locationHint='infection:///path/to/project/src/Service/ContactService.php::7-42']
 
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' nodeId='ea74aba5c3e84a26' message='Mutator: For_|nMutation ID: 0a451675763250c03e95b626f7bcfb7d|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' out='Mutator: For_|nMutation ID: 0a451675763250c03e95b626f7bcfb7d|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (0a451675763250c03e95b626f7bcfb7d)' nodeId='ea74aba5c3e84a26' duration='120']
 
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' out='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' duration='120']
                 ##teamcity[testSuiteFinished name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f']
                 ##teamcity[testSuiteFinished name='src/Service/ContactService.php' nodeId='12f6def551a5aae7']
 
@@ -605,11 +620,14 @@ final class TeamCityLoggerTest extends TestCase
                 ##teamcity[testSuiteStarted name='src/Service/ContactService.php' nodeId='12f6def551a5aae7' parentNodeId='0' locationHint='file:///path/to/project/src/Service/ContactService.php']
                 ##teamcity[testStarted name='Infection\Mutator\Boolean\TrueValue (e3730421e94b49783edb72f8c94e02dc)' nodeId='02a0e7865ef9a594' parentNodeId='12f6def551a5aae7' metainfo='{"mutationId":"e3730421e94b49783edb72f8c94e02dc"}' locationHint='infection:///path/to/project/src/Service/ContactService.php::7-42']
 
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' message='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests' details='mutationDiff' duration='120']
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' message='Mutator: For_|nMutation ID: aa35bf87f287aa4e383112a632fde848|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' out='Mutator: For_|nMutation ID: 49a5dfcd2f4a0b33d4a02e662812af55|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalOr (49a5dfcd2f4a0b33d4a02e662812af55)' nodeId='18830ccd5b35e676' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' out='Mutator: For_|nMutation ID: aa35bf87f287aa4e383112a632fde848|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (aa35bf87f287aa4e383112a632fde848)' nodeId='a20ac7aa8518e530' duration='120']
                 ##teamcity[testSuiteFinished name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f']
 
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\TrueValue (e3730421e94b49783edb72f8c94e02dc)' nodeId='02a0e7865ef9a594' message='Mutator: For_|nMutation ID: e3730421e94b49783edb72f8c94e02dc|nMutation result: killed by tests' details='mutationDiff' duration='120']
+                ##teamcity[testStdOut name='Infection\Mutator\Boolean\TrueValue (e3730421e94b49783edb72f8c94e02dc)' out='Mutator: For_|nMutation ID: e3730421e94b49783edb72f8c94e02dc|nMutation result: killed by tests']
+                ##teamcity[testFinished name='Infection\Mutator\Boolean\TrueValue (e3730421e94b49783edb72f8c94e02dc)' nodeId='02a0e7865ef9a594' duration='120']
                 ##teamcity[testSuiteFinished name='src/Service/ContactService.php' nodeId='12f6def551a5aae7']
 
                 TEAM_CITY,

--- a/tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityTest.php
@@ -175,12 +175,15 @@ final class TeamCityTest extends TestCase
         ];
     }
 
+    /**
+     * @param list<string> $expected
+     */
     #[DataProvider('executionResultProvider')]
     public function test_it_can_map_the_execution_result_to_a_finished_test(
         bool $timeoutsAsEscaped,
         Test $test,
         MutantExecutionResult $executionResult,
-        string $expected,
+        array $expected,
     ): void {
         $teamCity = new TeamCity(
             $timeoutsAsEscaped,
@@ -209,7 +212,6 @@ final class TeamCityTest extends TestCase
             -$a = 10;
             +$a = 20;
             PHP_DIFF;
-        $escapedMutationDiff = '--- Original|n+++ Mutated|n@@ @@|n-$a = 10;|n+$a = 20;';
 
         $nominalExecutionResultBuilder = MutantExecutionResultBuilder::withMinimalTestData()
             ->withMutatorClass(LogicalAndMutator::class)
@@ -226,11 +228,10 @@ final class TeamCityTest extends TestCase
             $nominalTest,
             $nominalExecutionResultBuilder
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='{$expectedMessage}' details='{$escapedMutationDiff}' duration='3000']
-
-                TEAM_CITY,
+            self::finishedTestLogs($expectedMessage, '3000'),
         ];
+
+        $timedOutMessage = 'Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: timed out';
 
         yield 'timed-out with timeouts NOT counting as escaped' => [
             false,
@@ -238,10 +239,7 @@ final class TeamCityTest extends TestCase
             $nominalExecutionResultBuilder
                 ->withDetectionStatus(DetectionStatus::TIMED_OUT)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: timed out' details='{$escapedMutationDiff}' duration='3000']
-
-                TEAM_CITY,
+            self::finishedTestLogs($timedOutMessage, '3000'),
         ];
 
         yield 'timed-out with timeouts counting as escaped' => [
@@ -250,10 +248,9 @@ final class TeamCityTest extends TestCase
             $nominalExecutionResultBuilder
                 ->withDetectionStatus(DetectionStatus::TIMED_OUT)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testFailed name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: timed out' duration='3000' type='comparisonFailure' actual='<?php \$a = 1;' expected='<?php \$a = 2;']
-
-                TEAM_CITY,
+            [
+                "##teamcity[testFailed name='Infection\\Mutator\\Boolean\\LogicalAnd (mutantHash)' nodeId='1A' message='{$timedOutMessage}' duration='3000' type='comparisonFailure' actual='<?php \$a = 1;' expected='<?php \$a = 2;']\n",
+            ],
         ];
 
         yield 'with an evaluation process that took some time' => [
@@ -262,10 +259,7 @@ final class TeamCityTest extends TestCase
             $nominalExecutionResultBuilder
                 ->withProcessRuntime(5.772644996643066)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='{$expectedMessage}' details='{$escapedMutationDiff}' duration='5773']
-
-                TEAM_CITY,
+            self::finishedTestLogs($expectedMessage, '5773'),
         ];
 
         yield 'with an evaluation process that took some time (round half to upper)' => [
@@ -274,10 +268,7 @@ final class TeamCityTest extends TestCase
             $nominalExecutionResultBuilder
                 ->withProcessRuntime(5.7725)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='{$expectedMessage}' details='{$escapedMutationDiff}' duration='5773']
-
-                TEAM_CITY,
+            self::finishedTestLogs($expectedMessage, '5773'),
         ];
 
         yield 'with an evaluation process that did not take any time (e.g. killed by an heuristic)' => [
@@ -286,10 +277,7 @@ final class TeamCityTest extends TestCase
             $nominalExecutionResultBuilder
                 ->withProcessRuntime(0.)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='{$expectedMessage}' details='{$escapedMutationDiff}' duration='0']
-
-                TEAM_CITY,
+            self::finishedTestLogs($expectedMessage, '0'),
         ];
 
         yield 'with an evaluation process that rounds down (fractional ms < 0.5)' => [
@@ -298,10 +286,7 @@ final class TeamCityTest extends TestCase
             $nominalExecutionResultBuilder
                 ->withProcessRuntime(5.7721)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='{$expectedMessage}' details='{$escapedMutationDiff}' duration='5772']
-
-                TEAM_CITY,
+            self::finishedTestLogs($expectedMessage, '5772'),
         ];
 
         yield 'killed by static analysis' => [
@@ -311,10 +296,10 @@ final class TeamCityTest extends TestCase
                 ->withDetectionStatus(DetectionStatus::KILLED_BY_STATIC_ANALYSIS)
                 ->withProcessRuntime(3.)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: killed by SA' details='{$escapedMutationDiff}' duration='3000']
-
-                TEAM_CITY,
+            self::finishedTestLogs(
+                'Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: killed by SA',
+                '3000',
+            ),
         ];
 
         yield 'error' => [
@@ -324,10 +309,10 @@ final class TeamCityTest extends TestCase
                 ->withDetectionStatus(DetectionStatus::ERROR)
                 ->withProcessRuntime(3.)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: error' details='{$escapedMutationDiff}' duration='3000']
-
-                TEAM_CITY,
+            self::finishedTestLogs(
+                'Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: error',
+                '3000',
+            ),
         ];
 
         yield 'syntax error' => [
@@ -337,10 +322,10 @@ final class TeamCityTest extends TestCase
                 ->withDetectionStatus(DetectionStatus::SYNTAX_ERROR)
                 ->withProcessRuntime(3.)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testFinished name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: syntax error' details='{$escapedMutationDiff}' duration='3000']
-
-                TEAM_CITY,
+            self::finishedTestLogs(
+                'Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: syntax error',
+                '3000',
+            ),
         ];
 
         yield 'escaped' => [
@@ -350,10 +335,9 @@ final class TeamCityTest extends TestCase
                 ->withDetectionStatus(DetectionStatus::ESCAPED)
                 ->withProcessRuntime(3.)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testFailed name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: escaped' duration='3000' type='comparisonFailure' actual='<?php \$a = 1;' expected='<?php \$a = 2;']
-
-                TEAM_CITY,
+            [
+                "##teamcity[testFailed name='Infection\\Mutator\\Boolean\\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: escaped' duration='3000' type='comparisonFailure' actual='<?php \$a = 1;' expected='<?php \$a = 2;']\n",
+            ],
         ];
 
         yield 'skipped' => [
@@ -363,10 +347,9 @@ final class TeamCityTest extends TestCase
                 ->withDetectionStatus(DetectionStatus::SKIPPED)
                 ->withProcessRuntime(3.)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testIgnored name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: skipped' duration='3000' type='comparisonFailure' actual='<?php \$a = 1;' expected='<?php \$a = 2;']
-
-                TEAM_CITY,
+            [
+                "##teamcity[testIgnored name='Infection\\Mutator\\Boolean\\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: skipped' duration='3000']\n",
+            ],
         ];
 
         yield 'not covered' => [
@@ -376,10 +359,9 @@ final class TeamCityTest extends TestCase
                 ->withDetectionStatus(DetectionStatus::NOT_COVERED)
                 ->withProcessRuntime(3.)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testIgnored name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: not covered' duration='3000' type='comparisonFailure' actual='<?php \$a = 1;' expected='<?php \$a = 2;']
-
-                TEAM_CITY,
+            [
+                "##teamcity[testIgnored name='Infection\\Mutator\\Boolean\\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: not covered' duration='3000']\n",
+            ],
         ];
 
         yield 'ignored' => [
@@ -389,10 +371,20 @@ final class TeamCityTest extends TestCase
                 ->withDetectionStatus(DetectionStatus::IGNORED)
                 ->withProcessRuntime(3.)
                 ->build(),
-            <<<TEAM_CITY
-                ##teamcity[testIgnored name='Infection\Mutator\Boolean\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: ignored' duration='3000' type='comparisonFailure' actual='<?php \$a = 1;' expected='<?php \$a = 2;']
+            [
+                "##teamcity[testIgnored name='Infection\\Mutator\\Boolean\\LogicalAnd (mutantHash)' nodeId='1A' message='Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: ignored' duration='3000']\n",
+            ],
+        ];
+    }
 
-                TEAM_CITY,
+    /**
+     * @return list<string>
+     */
+    private static function finishedTestLogs(string $message, string $duration): array
+    {
+        return [
+            "##teamcity[testStdOut name='Infection\\Mutator\\Boolean\\LogicalAnd (mutantHash)' out='{$message}']\n",
+            "##teamcity[testFinished name='Infection\\Mutator\\Boolean\\LogicalAnd (mutantHash)' nodeId='1A' duration='{$duration}']\n",
         ];
     }
 }

--- a/tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityTest.php
@@ -228,7 +228,7 @@ final class TeamCityTest extends TestCase
             $nominalTest,
             $nominalExecutionResultBuilder
                 ->build(),
-            self::finishedTestLogs($expectedMessage, '3000'),
+            self::createFinishedTestLogs($expectedMessage, '3000'),
         ];
 
         $timedOutMessage = 'Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: timed out';
@@ -239,7 +239,7 @@ final class TeamCityTest extends TestCase
             $nominalExecutionResultBuilder
                 ->withDetectionStatus(DetectionStatus::TIMED_OUT)
                 ->build(),
-            self::finishedTestLogs($timedOutMessage, '3000'),
+            self::createFinishedTestLogs($timedOutMessage, '3000'),
         ];
 
         yield 'timed-out with timeouts counting as escaped' => [
@@ -259,7 +259,7 @@ final class TeamCityTest extends TestCase
             $nominalExecutionResultBuilder
                 ->withProcessRuntime(5.772644996643066)
                 ->build(),
-            self::finishedTestLogs($expectedMessage, '5773'),
+            self::createFinishedTestLogs($expectedMessage, '5773'),
         ];
 
         yield 'with an evaluation process that took some time (round half to upper)' => [
@@ -268,7 +268,7 @@ final class TeamCityTest extends TestCase
             $nominalExecutionResultBuilder
                 ->withProcessRuntime(5.7725)
                 ->build(),
-            self::finishedTestLogs($expectedMessage, '5773'),
+            self::createFinishedTestLogs($expectedMessage, '5773'),
         ];
 
         yield 'with an evaluation process that did not take any time (e.g. killed by an heuristic)' => [
@@ -277,7 +277,7 @@ final class TeamCityTest extends TestCase
             $nominalExecutionResultBuilder
                 ->withProcessRuntime(0.)
                 ->build(),
-            self::finishedTestLogs($expectedMessage, '0'),
+            self::createFinishedTestLogs($expectedMessage, '0'),
         ];
 
         yield 'with an evaluation process that rounds down (fractional ms < 0.5)' => [
@@ -286,7 +286,7 @@ final class TeamCityTest extends TestCase
             $nominalExecutionResultBuilder
                 ->withProcessRuntime(5.7721)
                 ->build(),
-            self::finishedTestLogs($expectedMessage, '5772'),
+            self::createFinishedTestLogs($expectedMessage, '5772'),
         ];
 
         yield 'killed by static analysis' => [
@@ -296,7 +296,7 @@ final class TeamCityTest extends TestCase
                 ->withDetectionStatus(DetectionStatus::KILLED_BY_STATIC_ANALYSIS)
                 ->withProcessRuntime(3.)
                 ->build(),
-            self::finishedTestLogs(
+            self::createFinishedTestLogs(
                 'Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: killed by SA',
                 '3000',
             ),
@@ -309,7 +309,7 @@ final class TeamCityTest extends TestCase
                 ->withDetectionStatus(DetectionStatus::ERROR)
                 ->withProcessRuntime(3.)
                 ->build(),
-            self::finishedTestLogs(
+            self::createFinishedTestLogs(
                 'Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: error',
                 '3000',
             ),
@@ -322,7 +322,7 @@ final class TeamCityTest extends TestCase
                 ->withDetectionStatus(DetectionStatus::SYNTAX_ERROR)
                 ->withProcessRuntime(3.)
                 ->build(),
-            self::finishedTestLogs(
+            self::createFinishedTestLogs(
                 'Mutator: LogicalAnd|nMutation ID: mutantHash|nMutation result: syntax error',
                 '3000',
             ),
@@ -380,7 +380,7 @@ final class TeamCityTest extends TestCase
     /**
      * @return list<string>
      */
-    private static function finishedTestLogs(string $message, string $duration): array
+    private static function createFinishedTestLogs(string $message, string $duration): array
     {
         return [
             "##teamcity[testStdOut name='Infection\\Mutator\\Boolean\\LogicalAnd (mutantHash)' out='{$message}']\n",


### PR DESCRIPTION
## Description

This PR updates the TeamCity mutation analysis logger to emit mutation details through `testStdOut` service messages for successfully finished tests, instead of attaching them to the closing `testFinished` message.

The change was motivated by https://github.com/infection/infection/issues/2902#issuecomment-4369092490.

## Changes

- Add a `testStdOut` with the properties `name` and `message` before writing the closing `testFinished` messages.
- Remove the `details` attribute for `testFinished` messages (they are ignored and filtered out by the Intellij `SMTestProxy`).
- Remove the attributes `type`, `actual` and `expected` from the `testIgnored` message (they are ignored and filtered out by the Intellij `SMTestProxy`).
## Related issues

Fixes https://github.com/infection/infection/issues/2902

Related to #2437.