### PR TITLE
feat: Register a new testing framework Testo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,13 +306,13 @@ $(MAGO): vendor
 	touch -c $@
 
 $(INFECTION): vendor $(shell find bin/ src/ -type f) $(BOX) box.json.dist .git/HEAD
-	composer require infection/codeception-adapter infection/phpspec-adapter
+	composer require infection/codeception-adapter infection/phpspec-adapter testo/bridge-infection
 	# Workaround for https://github.com/box-project/box/issues/580
 	composer install --no-dev
 	$(BOX) --version
 	$(BOX) validate
 	$(BOX) compile
-	composer remove infection/codeception-adapter infection/phpspec-adapter
+	composer remove infection/codeception-adapter infection/phpspec-adapter testo/bridge-infection
 	composer install
 	touch -c $@
 

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -641,7 +641,8 @@
             "anyOf": [
                 "phpunit",
                 "phpspec",
-                "codeception"
+                "codeception",
+                "testo"
             ]
         },
         "staticAnalysisTool": {

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -63,6 +63,7 @@ use Infection\Metrics\MinMsiCheckFailed;
 use Infection\Process\Runner\InitialTestsFailed;
 use Infection\Source\Exception\NoSourceFound;
 use Infection\StaticAnalysis\StaticAnalysisToolTypes;
+use Infection\TestFramework\AdapterInstaller;
 use Infection\TestFramework\TestFrameworkTypes;
 use InvalidArgumentException;
 use const PHP_SAPI;
@@ -504,8 +505,8 @@ final class RunCommand extends BaseCommand
 
         $io->newLine();
         $io->writeln(sprintf(
-            'Installing <comment>infection/%s-adapter</comment>...',
-            $adapterName,
+            'Installing <comment>%s</comment>...',
+            AdapterInstaller::OFFICIAL_ADAPTERS_MAP[$adapterName],
         ));
 
         $container->getAdapterInstaller()->install($adapterName);

--- a/src/TestFramework/AdapterInstallationDecider.php
+++ b/src/TestFramework/AdapterInstallationDecider.php
@@ -50,6 +50,7 @@ final readonly class AdapterInstallationDecider
     private const array ADAPTER_NAME_TO_CLASS_MAP = [
         TestFrameworkTypes::CODECEPTION => 'Infection\TestFramework\Codeception\CodeceptionAdapter',
         TestFrameworkTypes::PHPSPEC => 'Infection\TestFramework\PhpSpec\PhpSpecAdapter',
+        TestFrameworkTypes::TESTO => 'Testo\Bridge\Infection\TestoAdapter',
     ];
 
     public function __construct(

--- a/src/TestFramework/AdapterInstaller.php
+++ b/src/TestFramework/AdapterInstaller.php
@@ -48,6 +48,7 @@ final readonly class AdapterInstaller
     public const array OFFICIAL_ADAPTERS_MAP = [
         TestFrameworkTypes::CODECEPTION => 'infection/codeception-adapter',
         TestFrameworkTypes::PHPSPEC => 'infection/phpspec-adapter',
+        TestFrameworkTypes::TESTO => 'testo/bridge-infection',
     ];
 
     // 2 minutes

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -52,6 +52,7 @@ final readonly class TestFrameworkConfigLocator implements TestFrameworkConfigLo
         'yml.dist',
         'dist.xml',
         'dist.yml',
+        'php',
     ];
 
     public function __construct(

--- a/src/TestFramework/TestFrameworkTypes.php
+++ b/src/TestFramework/TestFrameworkTypes.php
@@ -51,6 +51,8 @@ final class TestFrameworkTypes
 
     public const string CODECEPTION = 'codeception';
 
+    public const string TESTO = 'testo';
+
     /**
      * @var string[]
      */
@@ -58,6 +60,7 @@ final class TestFrameworkTypes
         self::PHPUNIT,
         self::PHPSPEC,
         self::CODECEPTION,
+        self::TESTO,
     ];
 
     /**

--- a/tests/phpunit/TestFramework/TestFrameworkTypesTest.php
+++ b/tests/phpunit/TestFramework/TestFrameworkTypesTest.php
@@ -52,6 +52,7 @@ final class TestFrameworkTypesTest extends TestCase
                 TestFrameworkTypes::PHPUNIT,
                 TestFrameworkTypes::PHPSPEC,
                 TestFrameworkTypes::CODECEPTION,
+                TestFrameworkTypes::TESTO,
             ],
             $types,
         );
@@ -74,6 +75,7 @@ final class TestFrameworkTypesTest extends TestCase
                 TestFrameworkTypes::PHPUNIT,
                 TestFrameworkTypes::PHPSPEC,
                 TestFrameworkTypes::CODECEPTION,
+                TestFrameworkTypes::TESTO,
                 'dummy',
             ],
             $types,


### PR DESCRIPTION
## Description

Adds support for [Testo](https://github.com/php-testo/testo) as a recognized test framework in Infection. The bridge lives in a separate package, [`testo/bridge-infection`](https://github.com/php-testo/bridge-infection), following the shape of `infection/codeception-adapter`; this PR adds the minimal core changes so `testFramework: "testo"` validates against the schema and `AdapterInstaller` can resolve the bridge package.

Testo's config is a PHP file (`testo.php`), so the config locator is also extended to recognize `.php` as a supported extension.

With these changes, Infection [runs end-to-end against the Testo repository](https://github.com/php-testo/testo/actions/workflows/infection.yml), where the integration is already in use.

## Changes
                                                                                                                                                                                                                                                                                                            
- Registered Testo as a new test framework type (`TestFrameworkTypes::TESTO`) and added it to the default types list.
- Mapped Testo to its official adapter package `testo/bridge-infection` in `AdapterInstaller::OFFICIAL_ADAPTERS_MAP`.
- Added `"testo"` as an allowed value for `testFramework` in `resources/schema.json`.
- Added `"php"` to the supported config file extensions in `TestFrameworkConfigLocator`, enabling PHP-based framework configs.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (provide link to PR: https://github.com/infection/site/pull/297)
- [x] CHANGELOG.md updated (if deprecations/breaking changes)
- [x] Appropriate labels applied (e.g. `performance`, `feature`).

## Reviewer Notes

Adding `php` to the locator's supported extensions applies to all frameworks, not just Testo. `xml`/`yml` variants are still tried first, so existing setups are unaffected; the change only matters when no `xml`/`yml` config is present and a `<framework>.php` file exists in the config dir. Discussed in #3053.

## Related issues

Fixes #3053
