### PR TITLE
ci: Export infection traces from the CI to Sentry

### DIFF
--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -92,6 +92,12 @@ jobs:
       - name: Run Infection on the full codebase
         env:
           INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
+          INFECTION_TELEMETRY: true
+          OTEL_TRACES_EXPORTER: otlp
+          OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
+          OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${{ secrets.SENTRY_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
+          OTEL_EXPORTER_OTLP_TRACES_HEADERS: ${{ secrets.SENTRY_OTEL_EXPORTER_OTLP_TRACES_HEADERS }}
+          OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: gzip
         run: |
           php bin/infection \
             --skip-initial-tests \


### PR DESCRIPTION
## Description

Make the CI execution of infection against its codebase (Mutation Testing / Run Infection on the full codebase) also export the generated traces to Sentry.

## Related issues

- #3090 