### PR TITLE
fix(git): Fix the project directory resolution when git is not available

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -7677,6 +7677,18 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Git\NoGitProjectFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_cannot_the_project_directory_when_there_is_not_git_project`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Git\NoGitProjectFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_gets_the_project_directory`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_fails_at_getting_the_modified_lines_if_getting_the_merge_base_failed_unexpectedly`.'
 count = 1
 
@@ -7726,6 +7738,12 @@ count = 1
 file = "tests/phpunit/Git/CommandLineGitTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `gitChangedLinesRangesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Git/CommandLineGitTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Git\NoGitProjectFound` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_project_directory`.'
 count = 1
 
 [[issues]]

--- a/src/Configuration/ProjectDirectoryProvider/CurrentWorkingDirectoryProvider.php
+++ b/src/Configuration/ProjectDirectoryProvider/CurrentWorkingDirectoryProvider.php
@@ -35,32 +35,15 @@ declare(strict_types=1);
 
 namespace Infection\Configuration\ProjectDirectoryProvider;
 
-use Infection\Git\Git;
-use Infection\Git\NoGitProjectFound;
-use Psr\Log\LoggerInterface;
+use function Safe\getcwd;
 
 /**
  * @internal
  */
-final readonly class GitProjectDirectoryProvider implements ProjectDirectoryProvider
+final readonly class CurrentWorkingDirectoryProvider implements ProjectDirectoryProvider
 {
-    public function __construct(
-        private Git $git,
-        private LoggerInterface $logger,
-    ) {
-    }
-
-    public function provide(): ?string
+    public function provide(): string
     {
-        try {
-            return $this->git->getProjectDirectory();
-        } catch (NoGitProjectFound $exception) {
-            $this->logger->info(
-                'Could not determine the project directory from Git.',
-                ['exception' => $exception],
-            );
-
-            return null;
-        }
+        return getcwd();
     }
 }

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -44,6 +44,7 @@ use Infection\CI\NullCiDetector;
 use Infection\Configuration\Configuration;
 use Infection\Configuration\ConfigurationFactory;
 use Infection\Configuration\ProjectDirectoryProvider\ChainProjectDirectoryProvider;
+use Infection\Configuration\ProjectDirectoryProvider\CurrentWorkingDirectoryProvider;
 use Infection\Configuration\ProjectDirectoryProvider\EnvironmentVariableBasedProjectDirectoryProvider;
 use Infection\Configuration\ProjectDirectoryProvider\GitProjectDirectoryProvider;
 use Infection\Configuration\ProjectDirectoryProvider\ProjectDirectoryProvider;
@@ -656,7 +657,11 @@ final class Container extends DIContainer
                     // See https://docs.gitlab.com/ci/variables/predefined_variables/#predefined-variables
                     'CI_PROJECT_DIR',
                 ),
-                new GitProjectDirectoryProvider($container->getGit()),
+                new GitProjectDirectoryProvider(
+                    $container->getGit(),
+                    $container->getLogger(),
+                ),
+                new CurrentWorkingDirectoryProvider(),
             ),
         ]);
 

--- a/src/Git/CommandLineGit.php
+++ b/src/Git/CommandLineGit.php
@@ -52,6 +52,7 @@ use function Safe\preg_split;
 use function sprintf;
 use function str_starts_with;
 use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Webmozart\Assert\Assert;
 
@@ -150,22 +151,20 @@ final readonly class CommandLineGit implements Git
         return $base;
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws ProcessTimedOutException
-     * @throws ProcessException
-     */
     public function getProjectDirectory(): string
     {
         // An error here should really not happen, so we are fine to let it
         // bubble up instead of throwing a dedicated exception or providing a
         // fallback.
-        $directory = $this->shellCommandLineExecutor->execute([
-            'git',
-            'rev-parse',
-            '--show-toplevel',
-        ]);
+        try {
+            $directory = $this->shellCommandLineExecutor->execute([
+                'git',
+                'rev-parse',
+                '--show-toplevel',
+            ]);
+        } catch (ProcessTimedOutException|ProcessFailedException|ProcessException $exception) {
+            throw NoGitProjectFound::create($exception);
+        }
 
         Assert::stringNotEmpty($directory);
 

--- a/src/Git/CommandLineGit.php
+++ b/src/Git/CommandLineGit.php
@@ -52,8 +52,6 @@ use function Safe\preg_split;
 use function sprintf;
 use function str_starts_with;
 use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Webmozart\Assert\Assert;
 
 /**
@@ -162,7 +160,7 @@ final readonly class CommandLineGit implements Git
                 'rev-parse',
                 '--show-toplevel',
             ]);
-        } catch (ProcessTimedOutException|ProcessFailedException|ProcessException $exception) {
+        } catch (ProcessException $exception) {
             throw NoGitProjectFound::create($exception);
         }
 

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -142,6 +142,8 @@ interface Git
      * execute this method from the working directory `/home/user/projects/my-app/src/components`,
      * it will output `/home/user/projects/my-app`.
      *
+     * @throws NoGitProjectFound
+     *
      * @return non-empty-string
      */
     public function getProjectDirectory(): string;

--- a/src/Git/NoGitProjectFound.php
+++ b/src/Git/NoGitProjectFound.php
@@ -33,34 +33,21 @@
 
 declare(strict_types=1);
 
-namespace Infection\Configuration\ProjectDirectoryProvider;
+namespace Infection\Git;
 
-use Infection\Git\Git;
-use Infection\Git\NoGitProjectFound;
-use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
 
 /**
  * @internal
  */
-final readonly class GitProjectDirectoryProvider implements ProjectDirectoryProvider
+final class NoGitProjectFound extends RuntimeException
 {
-    public function __construct(
-        private Git $git,
-        private LoggerInterface $logger,
-    ) {
-    }
-
-    public function provide(): ?string
+    public static function create(?Throwable $previous): self
     {
-        try {
-            return $this->git->getProjectDirectory();
-        } catch (NoGitProjectFound $exception) {
-            $this->logger->info(
-                'Could not determine the project directory from Git.',
-                ['exception' => $exception],
-            );
-
-            return null;
-        }
+        return new self(
+            'Could not find a git project.',
+            previous: $previous,
+        );
     }
 }

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -49,6 +49,7 @@ use Infection\Config\ConsoleHelper;
 use Infection\Config\Guesser\SourceDirGuesser;
 use Infection\Configuration\Entry\Logs;
 use Infection\Configuration\Entry\Source;
+use Infection\Configuration\ProjectDirectoryProvider\CurrentWorkingDirectoryProvider;
 use Infection\Configuration\Schema\SchemaConfiguration;
 use Infection\Configuration\Schema\SchemaConfigurationFactory;
 use Infection\Configuration\Schema\SchemaConfigurationFileLoader;
@@ -70,6 +71,7 @@ use Infection\FileSystem\Finder\ConcreteComposerExecutableFinder;
 use Infection\FileSystem\Finder\NonExecutableFinder;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\Framework\OperatingSystem;
+use Infection\Git\NoGitProjectFound;
 use Infection\Logger\MutationAnalysis\ConsoleProgressBarLogger;
 use Infection\Logger\MutationAnalysis\MutationAnalysisLogger;
 use Infection\Logger\MutationAnalysis\MutationAnalysisLoggerName;
@@ -139,6 +141,7 @@ final class ProjectCodeProvider
         ConfigurationOption::class,
         ConsoleProgressBarLogger::class,
         CpuCoresCountProvider::class,
+        CurrentWorkingDirectoryProvider::class,
         DispatchPcntlSignalSubscriber::class,
         DummyFileSystem::class,
         EmptyTrace::class,
@@ -164,6 +167,7 @@ final class ProjectCodeProvider
         MutationEvaluationWasStarted::class,
         MutatorName::class,
         NameResolverFactory::class,
+        NoGitProjectFound::class,
         NodeMutationGenerator::class,
         NoReportFound::class,
         NonExecutableFinder::class,

--- a/tests/phpunit/Configuration/ProjectDirectoryProvider/GitProjectDirectoryProviderTest.php
+++ b/tests/phpunit/Configuration/ProjectDirectoryProvider/GitProjectDirectoryProviderTest.php
@@ -37,26 +37,69 @@ namespace Infection\Tests\Configuration\ProjectDirectoryProvider;
 
 use Infection\Configuration\ProjectDirectoryProvider\GitProjectDirectoryProvider;
 use Infection\Git\Git;
+use Infection\Git\NoGitProjectFound;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+use Psr\Log\Test\TestLogger;
 
 #[CoversClass(GitProjectDirectoryProvider::class)]
 final class GitProjectDirectoryProviderTest extends TestCase
 {
+    private Git&MockObject $gitMock;
+
+    private TestLogger $logger;
+
+    private GitProjectDirectoryProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->gitMock = $this->createMock(Git::class);
+        $this->logger = new TestLogger();
+
+        $this->provider = new GitProjectDirectoryProvider(
+            $this->gitMock,
+            $this->logger,
+        );
+    }
+
     public function test_it_provides_the_project_directory(): void
     {
         $expected = '/path/to/project/directory';
 
-        $gitMock = $this->createMock(Git::class);
-        $gitMock
+        $this->gitMock
             ->expects($this->once())
             ->method('getProjectDirectory')
             ->willReturn($expected);
 
-        $provider = new GitProjectDirectoryProvider($gitMock);
-
-        $actual = $provider->provide();
+        $actual = $this->provider->provide();
 
         $this->assertSame($expected, $actual);
+        $this->assertSame([], $this->logger->records);
+    }
+
+    public function test_it_returns_null_and_logs_when_no_git_project_is_found(): void
+    {
+        $exception = NoGitProjectFound::create(null);
+
+        $this->gitMock
+            ->expects($this->once())
+            ->method('getProjectDirectory')
+            ->willThrowException($exception);
+
+        $actual = $this->provider->provide();
+
+        $this->assertNull($actual);
+        $this->assertEquals(
+            [
+                [
+                    'level' => LogLevel::INFO,
+                    'message' => 'Could not determine the project directory from Git.',
+                    'context' => ['exception' => $exception],
+                ],
+            ],
+            $this->logger->records,
+        );
     }
 }

--- a/tests/phpunit/Git/CommandLineGitIntegrationTest.php
+++ b/tests/phpunit/Git/CommandLineGitIntegrationTest.php
@@ -40,10 +40,12 @@ use function implode;
 use Infection\Framework\Str;
 use Infection\Git\CommandLineGit;
 use Infection\Git\Git;
+use Infection\Git\NoGitProjectFound;
 use Infection\Process\ShellCommandLineExecutor;
+use Infection\Tests\FileSystem\FileSystemTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\TestCase;
+use function Safe\chdir;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
 /**
@@ -52,7 +54,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
  */
 #[Group('integration')]
 #[CoversClass(CommandLineGit::class)]
-final class CommandLineGitIntegrationTest extends TestCase
+final class CommandLineGitIntegrationTest extends FileSystemTestCase
 {
     // https://github.com/infection/infection/commit/40d08afda22d5fe6d0d87ffb95fd609dcb01992a
     // At minimum we will have the following files in the entire output:
@@ -81,6 +83,9 @@ final class CommandLineGitIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+        chdir($this->cwd);
+
         $this->git = new CommandLineGit(
             new ShellCommandLineExecutor(),
         );
@@ -220,6 +225,15 @@ final class CommandLineGitIntegrationTest extends TestCase
         $projectDirectory = $this->git->getProjectDirectory();
 
         $this->assertNotSame('', $projectDirectory);
+    }
+
+    public function test_it_cannot_the_project_directory_when_there_is_not_git_project(): void
+    {
+        chdir($this->tmp);
+
+        $this->expectException(NoGitProjectFound::class);
+
+        $this->git->getProjectDirectory();
     }
 
     private function skipIfCommitReferenceIsNotAvailable(): void


### PR DESCRIPTION
## Description

https://github.com/infection/infection/pull/3009 introduced a BC break change:

>If the user was using infection without git and no environment variables, it will not longer work.

I however did not realise we expect infection to work in those conditions (see `tests/e2e/Without_Git`) – at least to a degree. So this PR addresses this BC (which at the time of writing is not released yet).

This PR swallows the exception thrown by the Git project provider (still logs the exception) and falls back to the current working directory.

## Changes

- Allow `Git::getProjectDirectory()` to throw a `NoGitProjectFound` exception.
- Make the `Git` implementation throw `NoGitProjectFound` upon any process exception thrown.
- Add a new `ProjectDirectoryProvider` to fallback to the current working directory.

## Reviewer Notes

I am not clear why this e2e test did not fail in #3009. I also noticed it failing in some other builds (e.g. https://github.com/infection/infection/actions/runs/25544899235/job/74978721841?pr=3112 or https://github.com/infection/infection/actions/runs/25455767137/job/74684687591?pr=3091) but ran fine in #3009 and still does (at the time of writing) on the master branch too: https://github.com/infection/infection/actions/runs/25308273563/job/74189031708

## Related issues

- #3009
