### PR TITLE
fix: Use the correct source to display the test framework package name 

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -63,6 +63,7 @@ use Infection\Metrics\MinMsiCheckFailed;
 use Infection\Process\Runner\InitialTestsFailed;
 use Infection\Source\Exception\NoSourceFound;
 use Infection\StaticAnalysis\StaticAnalysisToolTypes;
+use Infection\TestFramework\AdapterInstaller;
 use Infection\TestFramework\TestFrameworkTypes;
 use InvalidArgumentException;
 use const PHP_SAPI;
@@ -504,8 +505,8 @@ final class RunCommand extends BaseCommand
 
         $io->newLine();
         $io->writeln(sprintf(
-            'Installing <comment>infection/%s-adapter</comment>...',
-            $adapterName,
+            'Installing <comment>%s</comment>...',
+            AdapterInstaller::OFFICIAL_ADAPTERS_MAP[$adapterName],
         ));
 
         $container->getAdapterInstaller()->install($adapterName);

--- a/src/TestFramework/AdapterInstallationDecider.php
+++ b/src/TestFramework/AdapterInstallationDecider.php
@@ -50,7 +50,6 @@ final readonly class AdapterInstallationDecider
     private const array ADAPTER_NAME_TO_CLASS_MAP = [
         TestFrameworkTypes::CODECEPTION => 'Infection\TestFramework\Codeception\CodeceptionAdapter',
         TestFrameworkTypes::PHPSPEC => 'Infection\TestFramework\PhpSpec\PhpSpecAdapter',
-        TestFrameworkTypes::TESTO => 'Testo\Bridge\Infection\TestoAdapter',
     ];
 
     public function __construct(

--- a/src/TestFramework/AdapterInstallationDecider.php
+++ b/src/TestFramework/AdapterInstallationDecider.php
@@ -50,6 +50,7 @@ final readonly class AdapterInstallationDecider
     private const array ADAPTER_NAME_TO_CLASS_MAP = [
         TestFrameworkTypes::CODECEPTION => 'Infection\TestFramework\Codeception\CodeceptionAdapter',
         TestFrameworkTypes::PHPSPEC => 'Infection\TestFramework\PhpSpec\PhpSpecAdapter',
+        TestFrameworkTypes::TESTO => 'Testo\Bridge\Infection\TestoAdapter',
     ];
 
     public function __construct(


### PR DESCRIPTION
Extracted from #3107 for better visibility.

Currently this has no effect as all the official packages matches that pattern, but this changes with #3107.