### PR TITLE
feat(telemetry): Add telemetry spans for source collection, artefact collection and reporting

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -7219,6 +7219,24 @@ message = 'Class `Infection\Tests\Fixtures\Event\IONullSubscriber` not found.'
 count = 3
 
 [[issues]]
+file = "tests/phpunit/Event/Subscriber/ReportAfterMutationTestingFinishedSubscriberTest.php"
+code = "impossible-assignment"
+message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/ReportAfterMutationTestingFinishedSubscriberTest.php"
+code = "no-value"
+message = 'Argument #2 passed to method `Infection\Event\Subscriber\ReportAfterMutationTestingFinishedSubscriber::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Event/Subscriber/ReportAfterMutationTestingFinishedSubscriberTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not found.'
+count = 1
+
+[[issues]]
 file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
 code = "invalid-method-access"
 message = 'Attempting to access a method on a non-object type (`unknown-ref(Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher)`).'
@@ -11290,6 +11308,30 @@ count = 1
 file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Collector\CachedSourceCollectorTest::test_it_caches_the_collected_files`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Source/Collector/EventDispatchingSourceCollectorTest.php"
+code = "impossible-assignment"
+message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Source/Collector/EventDispatchingSourceCollectorTest.php"
+code = "no-value"
+message = 'Argument #2 passed to method `Infection\Source\Collector\EventDispatchingSourceCollector::__construct` has type `never`, meaning it cannot produce a value.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Source/Collector/EventDispatchingSourceCollectorTest.php"
+code = "non-existent-class"
+message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not found.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Source/Collector/EventDispatchingSourceCollectorTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Collector\EventDispatchingSourceCollectorTest::test_it_dispatches_source_collection_events_around_the_decorated_collector`.'
 count = 1
 
 [[issues]]

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Container;
 
+use Infection\Source\Collector\EventDispatchingSourceCollector;
 use function array_filter;
 use Closure;
 use DIContainer\Container as DIContainer;
@@ -625,18 +626,21 @@ final class Container extends DIContainer
             SourceCollectorFactory::class => static fn (self $container): SourceCollectorFactory => new SourceCollectorFactory(
                 $container->getGit(),
             ),
-            SourceCollector::class => static fn (self $container): SourceCollector => new LazySourceCollector(
-                static function () use ($container): SourceCollector {
-                    $configuration = $container->getConfiguration();
+            SourceCollector::class => static fn (self $container): SourceCollector => new EventDispatchingSourceCollector(
+                new LazySourceCollector(
+                    static function () use ($container): SourceCollector {
+                        $configuration = $container->getConfiguration();
 
-                    return new CachedSourceCollector(
-                        $container->get(SourceCollectorFactory::class)->create(
-                            $configuration->configurationPathname,
-                            $configuration->source,
-                            $configuration->sourceFilter,
-                        ),
-                    );
-                },
+                        return new CachedSourceCollector(
+                            $container->get(SourceCollectorFactory::class)->create(
+                                $configuration->configurationPathname,
+                                $configuration->source,
+                                $configuration->sourceFilter,
+                            ),
+                        );
+                    },
+                ),
+                $container->getEventDispatcher(),
             ),
             TeamCity::class => static fn (self $container): TeamCity => new TeamCity(
                 $container->getConfiguration()->timeoutsAsEscaped,

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Container;
 
-use Infection\Source\Collector\EventDispatchingSourceCollector;
 use function array_filter;
 use Closure;
 use DIContainer\Container as DIContainer;
@@ -143,6 +142,7 @@ use Infection\Resource\Memory\MemoryLimiterEnvironment;
 use Infection\Resource\Time\Stopwatch;
 use Infection\Resource\Time\TimeFormatter;
 use Infection\Source\Collector\CachedSourceCollector;
+use Infection\Source\Collector\EventDispatchingSourceCollector;
 use Infection\Source\Collector\LazySourceCollector;
 use Infection\Source\Collector\SourceCollector;
 use Infection\Source\Collector\SourceCollectorFactory;

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection;
 
-use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasFinished;
-use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasStarted;
 use function explode;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Configuration\Configuration;
 use Infection\Console\ConsoleOutput;
 use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\Events\Application\ApplicationExecutionWasFinished;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasFinished;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasStarted;
 use Infection\Metrics\MaxTimeoutCountReached;
 use Infection\Metrics\MaxTimeoutsChecker;
 use Infection\Metrics\MetricsCalculator;
@@ -140,7 +140,7 @@ final readonly class Engine
      * @throws InitialStaticAnalysisRunFailed
      * @throws InitialTestsFailed
      */
-    private function collectArtefacts(): string
+    private function collectArtefacts(): ?string
     {
         $this->eventDispatcher->dispatch(new ArtefactCollectionWasStarted());
 

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -35,6 +35,8 @@ declare(strict_types=1);
 
 namespace Infection;
 
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasFinished;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasStarted;
 use function explode;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Configuration\Configuration;
@@ -105,8 +107,7 @@ final readonly class Engine
      */
     public function execute(): void
     {
-        $initialTestSuiteOutput = $this->runInitialTestSuite();
-        $this->runInitialStaticAnalysis();
+        $initialTestSuiteOutput = $this->collectArtefacts();
 
         /*
          * Limit the memory used for the mutation processes based on the memory
@@ -133,6 +134,22 @@ final readonly class Engine
         } finally {
             $this->eventDispatcher->dispatch(new ApplicationExecutionWasFinished());
         }
+    }
+
+    /**
+     * @throws InitialStaticAnalysisRunFailed
+     * @throws InitialTestsFailed
+     */
+    private function collectArtefacts(): string
+    {
+        $this->eventDispatcher->dispatch(new ArtefactCollectionWasStarted());
+
+        $initialTestSuiteOutput = $this->runInitialTestSuite();
+        $this->runInitialStaticAnalysis();
+
+        $this->eventDispatcher->dispatch(new ArtefactCollectionWasFinished());
+
+        return $initialTestSuiteOutput;
     }
 
     private function runInitialTestSuite(): ?string

--- a/src/Event/Events/ArtefactCollection/ArtefactCollectionWasFinished.php
+++ b/src/Event/Events/ArtefactCollection/ArtefactCollectionWasFinished.php
@@ -33,36 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
-
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+namespace Infection\Event\Events\ArtefactCollection;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+final readonly class ArtefactCollectionWasFinished
 {
-    public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
-    ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
-    {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
-    }
 }

--- a/src/Event/Events/ArtefactCollection/ArtefactCollectionWasFinishedSubscriber.php
+++ b/src/Event/Events/ArtefactCollection/ArtefactCollectionWasFinishedSubscriber.php
@@ -33,36 +33,14 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
+namespace Infection\Event\Events\ArtefactCollection;
 
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+use Infection\Event\Subscriber\EventSubscriber;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+interface ArtefactCollectionWasFinishedSubscriber extends EventSubscriber
 {
-    public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
-    ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
-    {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
-    }
+    public function onArtefactCollectionWasFinished(ArtefactCollectionWasFinished $event): void;
 }

--- a/src/Event/Events/ArtefactCollection/ArtefactCollectionWasStarted.php
+++ b/src/Event/Events/ArtefactCollection/ArtefactCollectionWasStarted.php
@@ -33,36 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
-
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+namespace Infection\Event\Events\ArtefactCollection;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+final readonly class ArtefactCollectionWasStarted
 {
-    public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
-    ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
-    {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
-    }
 }

--- a/src/Event/Events/ArtefactCollection/ArtefactCollectionWasStartedSubscriber.php
+++ b/src/Event/Events/ArtefactCollection/ArtefactCollectionWasStartedSubscriber.php
@@ -33,36 +33,14 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
+namespace Infection\Event\Events\ArtefactCollection;
 
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+use Infection\Event\Subscriber\EventSubscriber;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+interface ArtefactCollectionWasStartedSubscriber extends EventSubscriber
 {
-    public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
-    ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
-    {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
-    }
+    public function onArtefactCollectionWasStarted(ArtefactCollectionWasStarted $event): void;
 }

--- a/src/Event/Events/Reporting/ReportingWasFinished.php
+++ b/src/Event/Events/Reporting/ReportingWasFinished.php
@@ -40,7 +40,4 @@ namespace Infection\Event\Events\Reporting;
  */
 final readonly class ReportingWasFinished
 {
-    public function __construct()
-    {
-    }
 }

--- a/src/Event/Events/Reporting/ReportingWasFinished.php
+++ b/src/Event/Events/Reporting/ReportingWasFinished.php
@@ -33,36 +33,14 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
-
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+namespace Infection\Event\Events\Reporting;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+final readonly class ReportingWasFinished
 {
-    public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
-    ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
+    public function __construct()
     {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
     }
 }

--- a/src/Event/Events/Reporting/ReportingWasFinishedSubscriber.php
+++ b/src/Event/Events/Reporting/ReportingWasFinishedSubscriber.php
@@ -33,36 +33,14 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
+namespace Infection\Event\Events\Reporting;
 
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+use Infection\Event\Subscriber\EventSubscriber;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+interface ReportingWasFinishedSubscriber extends EventSubscriber
 {
-    public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
-    ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
-    {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
-    }
+    public function onReportingWasFinished(ReportingWasFinished $event): void;
 }

--- a/src/Event/Events/Reporting/ReportingWasStarted.php
+++ b/src/Event/Events/Reporting/ReportingWasStarted.php
@@ -40,7 +40,4 @@ namespace Infection\Event\Events\Reporting;
  */
 final readonly class ReportingWasStarted
 {
-    public function __construct()
-    {
-    }
 }

--- a/src/Event/Events/Reporting/ReportingWasStarted.php
+++ b/src/Event/Events/Reporting/ReportingWasStarted.php
@@ -33,36 +33,14 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
-
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+namespace Infection\Event\Events\Reporting;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+final readonly class ReportingWasStarted
 {
-    public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
-    ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
+    public function __construct()
     {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
     }
 }

--- a/src/Event/Events/Reporting/ReportingWasStartedSubscriber.php
+++ b/src/Event/Events/Reporting/ReportingWasStartedSubscriber.php
@@ -33,36 +33,14 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
+namespace Infection\Event\Events\Reporting;
 
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+use Infection\Event\Subscriber\EventSubscriber;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+interface ReportingWasStartedSubscriber extends EventSubscriber
 {
-    public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
-    ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
-    {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
-    }
+    public function onReportingWasStarted(ReportingWasStarted $event): void;
 }

--- a/src/Event/Events/SourceCollection/SourceCollectionWasFinished.php
+++ b/src/Event/Events/SourceCollection/SourceCollectionWasFinished.php
@@ -33,36 +33,18 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
-
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+namespace Infection\Event\Events\SourceCollection;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+final readonly class SourceCollectionWasFinished
 {
+    /**
+     * @param positive-int|0 $sourcesCount
+     */
     public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
+        public int $sourcesCount,
     ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
-    {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
     }
 }

--- a/src/Event/Events/SourceCollection/SourceCollectionWasFinishedSubscriber.php
+++ b/src/Event/Events/SourceCollection/SourceCollectionWasFinishedSubscriber.php
@@ -33,36 +33,14 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
+namespace Infection\Event\Events\SourceCollection;
 
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+use Infection\Event\Subscriber\EventSubscriber;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+interface SourceCollectionWasFinishedSubscriber extends EventSubscriber
 {
-    public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
-    ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
-    {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
-    }
+    public function onSourceCollectionWasFinished(SourceCollectionWasFinished $event): void;
 }

--- a/src/Event/Events/SourceCollection/SourceCollectionWasStarted.php
+++ b/src/Event/Events/SourceCollection/SourceCollectionWasStarted.php
@@ -33,36 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
-
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+namespace Infection\Event\Events\SourceCollection;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+final readonly class SourceCollectionWasStarted
 {
-    public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
-    ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
-    {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
-    }
 }

--- a/src/Event/Events/SourceCollection/SourceCollectionWasStartedSubscriber.php
+++ b/src/Event/Events/SourceCollection/SourceCollectionWasStartedSubscriber.php
@@ -33,36 +33,14 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
+namespace Infection\Event\Events\SourceCollection;
 
-use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+use Infection\Event\Subscriber\EventSubscriber;
 
 /**
  * @internal
  */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+interface SourceCollectionWasStartedSubscriber extends EventSubscriber
 {
-    public function __construct(
-        private Reporter $reporter,
-        private EventDispatcher $eventDispatcher,
-    ) {
-    }
-
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
-    {
-        $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
-        );
-
-        $this->reporter->report();
-
-        $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
-        );
-    }
+    public function onSourceCollectionWasStarted(SourceCollectionWasStarted $event): void;
 }

--- a/src/Source/Collector/EventDispatchingSourceCollector.php
+++ b/src/Source/Collector/EventDispatchingSourceCollector.php
@@ -40,6 +40,9 @@ use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\Events\SourceCollection\SourceCollectionWasFinished;
 use Infection\Event\Events\SourceCollection\SourceCollectionWasStarted;
 
+/**
+ * @internal
+ */
 final readonly class EventDispatchingSourceCollector implements SourceCollector
 {
     public function __construct(

--- a/src/Source/Collector/EventDispatchingSourceCollector.php
+++ b/src/Source/Collector/EventDispatchingSourceCollector.php
@@ -33,36 +33,35 @@
 
 declare(strict_types=1);
 
-namespace Infection\Event\Subscriber;
+namespace Infection\Source\Collector;
 
+use function count;
 use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Reporter\Reporter;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasFinished;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasStarted;
 
-/**
- * @internal
- */
-final readonly class ReportAfterMutationTestingFinishedSubscriber implements MutationTestingWasFinishedSubscriber
+final readonly class EventDispatchingSourceCollector implements SourceCollector
 {
     public function __construct(
-        private Reporter $reporter,
+        private SourceCollector $decoratedSourceCollector,
         private EventDispatcher $eventDispatcher,
     ) {
     }
 
-    public function onMutationTestingWasFinished(MutationTestingWasFinished $event): void
+    public function collect(): array
     {
         $this->eventDispatcher->dispatch(
-            new ReportingWasStarted(),
+            new SourceCollectionWasStarted(),
         );
 
-        $this->reporter->report();
+        $sources = $this->decoratedSourceCollector->collect();
 
         $this->eventDispatcher->dispatch(
-            new ReportingWasFinished(),
+            new SourceCollectionWasFinished(
+                count($sources),
+            ),
         );
+
+        return $sources;
     }
 }

--- a/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
+++ b/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
@@ -171,6 +171,9 @@ final class PHPStanAdapter implements StaticAnalysisToolAdapter
         );
 
         $process = new Process($testFrameworkVersionExecutable);
+        $process->setEnv([
+            'SHELL_VERBOSITY' => '0',
+        ]);
         $process->mustRun();
 
         return $this->versionParser->parse($process->getOutput());

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -39,6 +39,10 @@ use Infection\Event\Events\Application\ApplicationExecutionWasFinished;
 use Infection\Event\Events\Application\ApplicationExecutionWasFinishedSubscriber;
 use Infection\Event\Events\Application\ApplicationExecutionWasStarted;
 use Infection\Event\Events\Application\ApplicationExecutionWasStartedSubscriber;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasFinished;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasFinishedSubscriber;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasStarted;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasStartedSubscriber;
 use Infection\Event\Events\ArtefactCollection\InitialStaticAnalysis\InitialStaticAnalysisRunWasFinished;
 use Infection\Event\Events\ArtefactCollection\InitialStaticAnalysis\InitialStaticAnalysisRunWasFinishedSubscriber;
 use Infection\Event\Events\ArtefactCollection\InitialStaticAnalysis\InitialStaticAnalysisRunWasStarted;
@@ -59,15 +63,27 @@ use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinishedSubscriber;
 use Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationTestingWasStartedSubscriber;
+use Infection\Event\Events\Reporting\ReportingWasFinished;
+use Infection\Event\Events\Reporting\ReportingWasFinishedSubscriber;
+use Infection\Event\Events\Reporting\ReportingWasStarted;
+use Infection\Event\Events\Reporting\ReportingWasStartedSubscriber;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasFinished;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasFinishedSubscriber;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasStarted;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasStartedSubscriber;
 use Infection\Telemetry\OpenTelemetryTracer;
 use Infection\Telemetry\SpanHandle;
 
 /**
  * @internal
  */
-final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFinishedSubscriber, ApplicationExecutionWasStartedSubscriber, InitialStaticAnalysisRunWasFinishedSubscriber, InitialStaticAnalysisRunWasStartedSubscriber, InitialTestSuiteWasFinishedSubscriber, InitialTestSuiteWasStartedSubscriber, MutantProcessWasFinishedSubscriber, MutationEvaluationWasStartedSubscriber, MutationGenerationWasFinishedSubscriber, MutationGenerationWasStartedSubscriber, MutationTestingWasFinishedSubscriber, MutationTestingWasStartedSubscriber
+final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFinishedSubscriber, ApplicationExecutionWasStartedSubscriber, InitialStaticAnalysisRunWasFinishedSubscriber, InitialStaticAnalysisRunWasStartedSubscriber, InitialTestSuiteWasFinishedSubscriber, InitialTestSuiteWasStartedSubscriber, MutantProcessWasFinishedSubscriber, MutationEvaluationWasStartedSubscriber, MutationGenerationWasFinishedSubscriber, MutationGenerationWasStartedSubscriber, MutationTestingWasFinishedSubscriber, MutationTestingWasStartedSubscriber, ArtefactCollectionWasStartedSubscriber, ArtefactCollectionWasFinishedSubscriber, ReportingWasStartedSubscriber, ReportingWasFinishedSubscriber, SourceCollectionWasStartedSubscriber, SourceCollectionWasFinishedSubscriber
 {
     private ?SpanHandle $rootSpan = null;
+
+    private ?SpanHandle $sourceCollectionSpan = null;
+
+    private ?SpanHandle $artefactCollectionSpan = null;
 
     private ?SpanHandle $initialTestsSpan = null;
 
@@ -76,6 +92,8 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     private ?SpanHandle $mutationGenerationSpan = null;
 
     private ?SpanHandle $mutationTestingSpan = null;
+
+    private ?SpanHandle $reportingSpan = null;
 
     /** @var array<string, SpanHandle> */
     private array $mutationEvaluationSpans = [];
@@ -92,7 +110,10 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onInitialTestSuiteWasStarted(InitialTestSuiteWasStarted $event): void
     {
-        $this->initialTestsSpan = $this->startChild('infection.initial_tests');
+        $this->initialTestsSpan = $this->startChild(
+            'infection.initial_tests',
+            parent: $this->artefactCollectionSpan,
+        );
     }
 
     public function onInitialTestSuiteWasFinished(InitialTestSuiteWasFinished $event): void
@@ -103,7 +124,10 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onInitialStaticAnalysisRunWasStarted(InitialStaticAnalysisRunWasStarted $event): void
     {
-        $this->initialStaticAnalysisSpan = $this->startChild('infection.initial_static_analysis');
+        $this->initialStaticAnalysisSpan = $this->startChild(
+            'infection.initial_static_analysis',
+            parent: $this->artefactCollectionSpan,
+        );
     }
 
     public function onInitialStaticAnalysisRunWasFinished(InitialStaticAnalysisRunWasFinished $event): void
@@ -219,5 +243,35 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         if ($span !== null) {
             $this->telemetry->end($span, $attributes);
         }
+    }
+
+    public function onArtefactCollectionWasFinished(ArtefactCollectionWasFinished $event): void
+    {
+        $this->end($this->artefactCollectionSpan);
+    }
+
+    public function onArtefactCollectionWasStarted(ArtefactCollectionWasStarted $event): void
+    {
+        $this->artefactCollectionSpan = $this->startChild('infection.artefact_collection');
+    }
+
+    public function onReportingWasFinished(ReportingWasFinished $event): void
+    {
+        $this->end($this->reportingSpan);
+    }
+
+    public function onReportingWasStarted(ReportingWasStarted $event): void
+    {
+        $this->reportingSpan = $this->startChild('infection.reporting');
+    }
+
+    public function onSourceCollectionWasFinished(SourceCollectionWasFinished $event): void
+    {
+        $this->end($this->sourceCollectionSpan);
+    }
+
+    public function onSourceCollectionWasStarted(SourceCollectionWasStarted $event): void
+    {
+        $this->sourceCollectionSpan = $this->startChild('infection.source_collection');
     }
 }

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -77,7 +77,7 @@ use Infection\Telemetry\SpanHandle;
 /**
  * @internal
  */
-final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFinishedSubscriber, ApplicationExecutionWasStartedSubscriber, InitialStaticAnalysisRunWasFinishedSubscriber, InitialStaticAnalysisRunWasStartedSubscriber, InitialTestSuiteWasFinishedSubscriber, InitialTestSuiteWasStartedSubscriber, MutantProcessWasFinishedSubscriber, MutationEvaluationWasStartedSubscriber, MutationGenerationWasFinishedSubscriber, MutationGenerationWasStartedSubscriber, MutationTestingWasFinishedSubscriber, MutationTestingWasStartedSubscriber, ArtefactCollectionWasStartedSubscriber, ArtefactCollectionWasFinishedSubscriber, ReportingWasStartedSubscriber, ReportingWasFinishedSubscriber, SourceCollectionWasStartedSubscriber, SourceCollectionWasFinishedSubscriber
+final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFinishedSubscriber, ApplicationExecutionWasStartedSubscriber, ArtefactCollectionWasFinishedSubscriber, ArtefactCollectionWasStartedSubscriber, InitialStaticAnalysisRunWasFinishedSubscriber, InitialStaticAnalysisRunWasStartedSubscriber, InitialTestSuiteWasFinishedSubscriber, InitialTestSuiteWasStartedSubscriber, MutantProcessWasFinishedSubscriber, MutationEvaluationWasStartedSubscriber, MutationGenerationWasFinishedSubscriber, MutationGenerationWasStartedSubscriber, MutationTestingWasFinishedSubscriber, MutationTestingWasStartedSubscriber, ReportingWasFinishedSubscriber, ReportingWasStartedSubscriber, SourceCollectionWasFinishedSubscriber, SourceCollectionWasStartedSubscriber
 {
     private ?SpanHandle $rootSpan = null;
 
@@ -211,6 +211,8 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     {
         $this->end($this->initialTestsSpan);
         $this->end($this->initialStaticAnalysisSpan);
+        $this->end($this->artefactCollectionSpan);
+        $this->end($this->sourceCollectionSpan);
         $this->end($this->mutationGenerationSpan);
 
         foreach ($this->mutationEvaluationSpans as $span) {
@@ -218,8 +220,45 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         }
 
         $this->end($this->mutationTestingSpan);
+        $this->end($this->reportingSpan);
         $this->end($this->rootSpan);
         $this->telemetry->shutdown();
+    }
+
+    public function onArtefactCollectionWasFinished(ArtefactCollectionWasFinished $event): void
+    {
+        $this->end($this->artefactCollectionSpan);
+        $this->artefactCollectionSpan = null;
+    }
+
+    public function onArtefactCollectionWasStarted(ArtefactCollectionWasStarted $event): void
+    {
+        $this->artefactCollectionSpan = $this->startChild('infection.artefact_collection');
+    }
+
+    public function onReportingWasFinished(ReportingWasFinished $event): void
+    {
+        $this->end($this->reportingSpan);
+        $this->reportingSpan = null;
+    }
+
+    public function onReportingWasStarted(ReportingWasStarted $event): void
+    {
+        $this->reportingSpan = $this->startChild('infection.reporting');
+    }
+
+    public function onSourceCollectionWasFinished(SourceCollectionWasFinished $event): void
+    {
+        $this->end(
+            $this->sourceCollectionSpan,
+            ['infection.source_file.count' => $event->sourcesCount],
+        );
+        $this->sourceCollectionSpan = null;
+    }
+
+    public function onSourceCollectionWasStarted(SourceCollectionWasStarted $event): void
+    {
+        $this->sourceCollectionSpan = $this->startChild('infection.source_collection');
     }
 
     /**
@@ -243,35 +282,5 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         if ($span !== null) {
             $this->telemetry->end($span, $attributes);
         }
-    }
-
-    public function onArtefactCollectionWasFinished(ArtefactCollectionWasFinished $event): void
-    {
-        $this->end($this->artefactCollectionSpan);
-    }
-
-    public function onArtefactCollectionWasStarted(ArtefactCollectionWasStarted $event): void
-    {
-        $this->artefactCollectionSpan = $this->startChild('infection.artefact_collection');
-    }
-
-    public function onReportingWasFinished(ReportingWasFinished $event): void
-    {
-        $this->end($this->reportingSpan);
-    }
-
-    public function onReportingWasStarted(ReportingWasStarted $event): void
-    {
-        $this->reportingSpan = $this->startChild('infection.reporting');
-    }
-
-    public function onSourceCollectionWasFinished(SourceCollectionWasFinished $event): void
-    {
-        $this->end($this->sourceCollectionSpan);
-    }
-
-    public function onSourceCollectionWasStarted(SourceCollectionWasStarted $event): void
-    {
-        $this->sourceCollectionSpan = $this->startChild('infection.source_collection');
     }
 }

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -171,6 +171,9 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         );
 
         $process = new Process($testFrameworkVersionExecutable);
+        $process->setEnv([
+            'SHELL_VERBOSITY' => '0',
+        ]);
         $process->mustRun();
 
         return $this->versionParser->parse($process->getOutput());

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -171,9 +171,6 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         );
 
         $process = new Process($testFrameworkVersionExecutable);
-        $process->setEnv([
-            'SHELL_VERBOSITY' => '0',
-        ]);
         $process->mustRun();
 
         return $this->versionParser->parse($process->getOutput());

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -60,7 +60,13 @@ use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
 use Infection\Console\Application;
 use Infection\Console\XdebugHandler;
 use Infection\Differ\Tokens;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasFinished;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationWasStarted;
+use Infection\Event\Events\Reporting\ReportingWasFinished;
+use Infection\Event\Events\Reporting\ReportingWasStarted;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasFinished;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasStarted;
 use Infection\Event\Subscriber\DispatchPcntlSignalSubscriber;
 use Infection\Event\Subscriber\NullSubscriber;
 use Infection\Event\Subscriber\StopInfectionOnSigintSignalSubscriber;
@@ -137,6 +143,8 @@ final class ProjectCodeProvider
     public const array NON_TESTED_CONCRETE_CLASSES = [
         AdapterInstaller::class,
         Application::class,
+        ArtefactCollectionWasStarted::class,
+        ArtefactCollectionWasFinished::class,
         BaseMutatorTestCase::class,
         BaseOption::class,
         ConcreteComposerExecutableFinder::class,
@@ -179,9 +187,13 @@ final class ProjectCodeProvider
         NullSubscriber::class,
         OpenTelemetryTracerSubscriberFactory::class,
         OperatingSystem::class,
+        ReportingWasFinished::class,
+        ReportingWasStarted::class,
         SchemaConfiguration::class,
         SingletonContainer::class,
         Source::class,
+        SourceCollectionWasStarted::class,
+        SourceCollectionWasFinished::class,
         SpanHandle::class,
         StopInfectionOnSigintSignalSubscriber::class,
         StrykerCurlClient::class,

--- a/tests/phpunit/EngineTest.php
+++ b/tests/phpunit/EngineTest.php
@@ -61,7 +61,6 @@ use Infection\TestFramework\Coverage\CoverageChecker;
 use Infection\TestFramework\TestFrameworkExtraOptionsFilter;
 use Infection\Tests\Configuration\ConfigurationBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
@@ -89,9 +88,7 @@ final class EngineTest extends TestCase
         $coverageChecker = $this->createMock(CoverageChecker::class);
         $coverageChecker->expects($this->never())->method($this->anything());
 
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $this->expectDispatchedEvents(
-            $eventDispatcher,
+        $eventDispatcher = $this->createEventDispatcherMock(
             ArtefactCollectionWasStarted::class,
         );
 
@@ -194,9 +191,7 @@ final class EngineTest extends TestCase
             ->method('checkCoverageHasBeenGenerated')
         ;
 
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $this->expectDispatchedEvents(
-            $eventDispatcher,
+        $eventDispatcher = $this->createEventDispatcherMock(
             ArtefactCollectionWasStarted::class,
             ArtefactCollectionWasFinished::class,
             ApplicationExecutionWasFinished::class,
@@ -316,9 +311,7 @@ final class EngineTest extends TestCase
             ->method('checkCoverageHasBeenGenerated')
         ;
 
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $this->expectDispatchedEvents(
-            $eventDispatcher,
+        $eventDispatcher = $this->createEventDispatcherMock(
             ArtefactCollectionWasStarted::class,
             ArtefactCollectionWasFinished::class,
             ApplicationExecutionWasFinished::class,
@@ -464,9 +457,7 @@ final class EngineTest extends TestCase
             ->method('checkCoverageExists')
         ;
 
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $this->expectDispatchedEvents(
-            $eventDispatcher,
+        $eventDispatcher = $this->createEventDispatcherMock(
             ArtefactCollectionWasStarted::class,
             ArtefactCollectionWasFinished::class,
             ApplicationExecutionWasFinished::class,
@@ -560,9 +551,7 @@ final class EngineTest extends TestCase
             ->method('checkCoverageExists')
         ;
 
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $this->expectDispatchedEvents(
-            $eventDispatcher,
+        $eventDispatcher = $this->createEventDispatcherMock(
             ArtefactCollectionWasStarted::class,
             ArtefactCollectionWasFinished::class,
             ApplicationExecutionWasFinished::class,
@@ -666,9 +655,7 @@ final class EngineTest extends TestCase
             ->method('checkCoverageExists')
         ;
 
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $this->expectDispatchedEvents(
-            $eventDispatcher,
+        $eventDispatcher = $this->createEventDispatcherMock(
             ArtefactCollectionWasStarted::class,
             ArtefactCollectionWasFinished::class,
             ApplicationExecutionWasFinished::class,
@@ -757,9 +744,7 @@ final class EngineTest extends TestCase
             ->method('checkCoverageExists')
         ;
 
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $this->expectDispatchedEvents(
-            $eventDispatcher,
+        $eventDispatcher = $this->createEventDispatcherMock(
             ArtefactCollectionWasStarted::class,
             ArtefactCollectionWasFinished::class,
             ApplicationExecutionWasFinished::class,
@@ -855,21 +840,30 @@ final class EngineTest extends TestCase
     /**
      * @param class-string ...$expectedEventClasses
      */
-    private function expectDispatchedEvents(
-        EventDispatcher&MockObject $eventDispatcher,
+    private function createEventDispatcherMock(
         string ...$expectedEventClasses,
-    ): void {
-        $eventDispatcher
-            ->expects($this->exactly(count($expectedEventClasses)))
-            ->method('dispatch')
-            ->willReturnCallback(static function (object $event) use (&$expectedEventClasses): void {
-                self::assertNotSame([], $expectedEventClasses);
+    ): EventDispatcher {
+        $expectedEventClassesCount = count($expectedEventClasses);
+        $eventDispatcherMock = $this->createMock(EventDispatcher::class);
 
-                $expectedEventClass = array_shift($expectedEventClasses);
-                self::assertNotNull($expectedEventClass);
+        if ($expectedEventClassesCount === 0) {
+            $eventDispatcherMock
+                ->expects($this->never())
+                ->method($this->anything());
+        } else {
+            $eventDispatcherMock
+                ->expects($this->exactly($expectedEventClassesCount))
+                ->method('dispatch')
+                ->willReturnCallback(static function (object $event) use (&$expectedEventClasses): void {
+                    self::assertNotSame([], $expectedEventClasses);
 
-                self::assertInstanceOf($expectedEventClass, $event);
-            })
-        ;
+                    $expectedEventClass = array_shift($expectedEventClasses);
+                    self::assertNotNull($expectedEventClass);
+
+                    self::assertInstanceOf($expectedEventClass, $event);
+                });
+        }
+
+        return $eventDispatcherMock;
     }
 }

--- a/tests/phpunit/EngineTest.php
+++ b/tests/phpunit/EngineTest.php
@@ -35,11 +35,15 @@ declare(strict_types=1);
 
 namespace Infection\Tests;
 
+use function array_shift;
+use function count;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Console\ConsoleOutput;
 use Infection\Engine;
 use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\Events\Application\ApplicationExecutionWasFinished;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasFinished;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasStarted;
 use Infection\Metrics\MaxTimeoutCountReached;
 use Infection\Metrics\MaxTimeoutsChecker;
 use Infection\Metrics\MetricsCalculator;
@@ -57,6 +61,7 @@ use Infection\TestFramework\Coverage\CoverageChecker;
 use Infection\TestFramework\TestFrameworkExtraOptionsFilter;
 use Infection\Tests\Configuration\ConfigurationBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
@@ -85,7 +90,10 @@ final class EngineTest extends TestCase
         $coverageChecker->expects($this->never())->method($this->anything());
 
         $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher->expects($this->never())->method($this->anything());
+        $this->expectDispatchedEvents(
+            $eventDispatcher,
+            ArtefactCollectionWasStarted::class,
+        );
 
         $process = $this->createMock(Process::class);
         $process
@@ -187,10 +195,12 @@ final class EngineTest extends TestCase
         ;
 
         $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
+        $this->expectDispatchedEvents(
+            $eventDispatcher,
+            ArtefactCollectionWasStarted::class,
+            ArtefactCollectionWasFinished::class,
+            ApplicationExecutionWasFinished::class,
+        );
 
         $process = $this->createMock(Process::class);
         $process
@@ -307,10 +317,12 @@ final class EngineTest extends TestCase
         ;
 
         $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
+        $this->expectDispatchedEvents(
+            $eventDispatcher,
+            ArtefactCollectionWasStarted::class,
+            ArtefactCollectionWasFinished::class,
+            ApplicationExecutionWasFinished::class,
+        );
 
         $initialTestProcess = $this->createMock(Process::class);
         $initialTestProcess
@@ -453,10 +465,12 @@ final class EngineTest extends TestCase
         ;
 
         $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
+        $this->expectDispatchedEvents(
+            $eventDispatcher,
+            ArtefactCollectionWasStarted::class,
+            ArtefactCollectionWasFinished::class,
+            ApplicationExecutionWasFinished::class,
+        );
 
         $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
         $initialTestsRunner->expects($this->never())->method($this->anything());
@@ -547,10 +561,12 @@ final class EngineTest extends TestCase
         ;
 
         $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
+        $this->expectDispatchedEvents(
+            $eventDispatcher,
+            ArtefactCollectionWasStarted::class,
+            ArtefactCollectionWasFinished::class,
+            ApplicationExecutionWasFinished::class,
+        );
 
         $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
         $initialTestsRunner->expects($this->never())->method($this->anything());
@@ -651,10 +667,12 @@ final class EngineTest extends TestCase
         ;
 
         $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
+        $this->expectDispatchedEvents(
+            $eventDispatcher,
+            ArtefactCollectionWasStarted::class,
+            ArtefactCollectionWasFinished::class,
+            ApplicationExecutionWasFinished::class,
+        );
 
         $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
         $initialTestsRunner->expects($this->never())->method($this->anything());
@@ -740,10 +758,12 @@ final class EngineTest extends TestCase
         ;
 
         $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
+        $this->expectDispatchedEvents(
+            $eventDispatcher,
+            ArtefactCollectionWasStarted::class,
+            ArtefactCollectionWasFinished::class,
+            ApplicationExecutionWasFinished::class,
+        );
 
         $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
         $initialTestsRunner->expects($this->never())->method($this->anything());
@@ -830,5 +850,26 @@ final class EngineTest extends TestCase
         $this->expectException(MinMsiCheckFailed::class);
 
         $engine->execute();
+    }
+
+    /**
+     * @param class-string ...$expectedEventClasses
+     */
+    private function expectDispatchedEvents(
+        EventDispatcher&MockObject $eventDispatcher,
+        string ...$expectedEventClasses,
+    ): void {
+        $eventDispatcher
+            ->expects($this->exactly(count($expectedEventClasses)))
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $event) use (&$expectedEventClasses): void {
+                self::assertNotSame([], $expectedEventClasses);
+
+                $expectedEventClass = array_shift($expectedEventClasses);
+                self::assertNotNull($expectedEventClass);
+
+                self::assertInstanceOf($expectedEventClass, $event);
+            })
+        ;
     }
 }

--- a/tests/phpunit/Source/Collector/EventDispatchingSourceCollectorTest.php
+++ b/tests/phpunit/Source/Collector/EventDispatchingSourceCollectorTest.php
@@ -33,46 +33,41 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Event\Subscriber;
+namespace Infection\Tests\Source\Collector;
 
-use Infection\Event\EventDispatcher\SyncEventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasFinished;
-use Infection\Event\Events\Reporting\ReportingWasStarted;
-use Infection\Event\Subscriber\ReportAfterMutationTestingFinishedSubscriber;
-use Infection\Reporter\Reporter;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasFinished;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasStarted;
+use Infection\Source\Collector\EventDispatchingSourceCollector;
+use Infection\Source\Collector\FixedSourceCollector;
+use Infection\Testing\FileSystem\MockSplFileInfo;
 use Infection\Tests\Fixtures\Event\EventDispatcherCollector;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(ReportAfterMutationTestingFinishedSubscriber::class)]
-final class ReportAfterMutationTestingFinishedSubscriberTest extends TestCase
+#[CoversClass(EventDispatchingSourceCollector::class)]
+final class EventDispatchingSourceCollectorTest extends TestCase
 {
-    public function test_it_reacts_on_mutation_testing_finished(): void
+    public function test_it_dispatches_source_collection_events_around_the_decorated_collector(): void
     {
-        $reporter = $this->createMock(Reporter::class);
-        $reporter
-            ->expects($this->once())
-            ->method('report');
+        $files = [
+            new MockSplFileInfo('src/File1.php'),
+            new MockSplFileInfo('src/File2.php'),
+        ];
+        $eventDispatcher = new EventDispatcherCollector();
 
-        $reportingEventDispatcher = new EventDispatcherCollector();
-
-        $dispatcher = new SyncEventDispatcher();
-        $dispatcher->addSubscriber(
-            new ReportAfterMutationTestingFinishedSubscriber(
-                $reporter,
-                $reportingEventDispatcher,
-            ),
+        $collector = new EventDispatchingSourceCollector(
+            new FixedSourceCollector($files),
+            $eventDispatcher,
         );
 
-        $dispatcher->dispatch(new MutationTestingWasFinished());
+        $this->assertSame($files, $collector->collect());
 
         $this->assertEquals(
             [
-                new ReportingWasStarted(),
-                new ReportingWasFinished(),
+                new SourceCollectionWasStarted(),
+                new SourceCollectionWasFinished(2),
             ],
-            $reportingEventDispatcher->getEvents(),
+            $eventDispatcher->getEvents(),
         );
     }
 }

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -39,6 +39,8 @@ use function array_map;
 use function array_values;
 use Infection\Event\Events\Application\ApplicationExecutionWasFinished;
 use Infection\Event\Events\Application\ApplicationExecutionWasStarted;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasFinished;
+use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasStarted;
 use Infection\Event\Events\ArtefactCollection\InitialStaticAnalysis\InitialStaticAnalysisRunWasFinished;
 use Infection\Event\Events\ArtefactCollection\InitialStaticAnalysis\InitialStaticAnalysisRunWasStarted;
 use Infection\Event\Events\ArtefactCollection\InitialTestExecution\InitialTestSuiteWasFinished;
@@ -49,6 +51,10 @@ use Infection\Event\Events\MutationAnalysis\MutationGeneration\MutationGeneratio
 use Infection\Event\Events\MutationAnalysis\MutationGeneration\MutationGenerationWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted;
+use Infection\Event\Events\Reporting\ReportingWasFinished;
+use Infection\Event\Events\Reporting\ReportingWasStarted;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasFinished;
+use Infection\Event\Events\SourceCollection\SourceCollectionWasStarted;
 use Infection\Framework\Iterable\IterableCounter;
 use Infection\Mutant\DetectionStatus;
 use Infection\Process\Runner\ProcessRunner;
@@ -107,10 +113,14 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
             ->build();
 
         $this->subscriber->onApplicationExecutionWasStarted(new ApplicationExecutionWasStarted());
+        $this->subscriber->onArtefactCollectionWasStarted(new ArtefactCollectionWasStarted());
         $this->subscriber->onInitialTestSuiteWasStarted(new InitialTestSuiteWasStarted());
         $this->subscriber->onInitialTestSuiteWasFinished(new InitialTestSuiteWasFinished('Test suite output'));
         $this->subscriber->onInitialStaticAnalysisRunWasStarted(new InitialStaticAnalysisRunWasStarted());
         $this->subscriber->onInitialStaticAnalysisRunWasFinished(new InitialStaticAnalysisRunWasFinished('Static analysis output'));
+        $this->subscriber->onArtefactCollectionWasFinished(new ArtefactCollectionWasFinished());
+        $this->subscriber->onSourceCollectionWasStarted(new SourceCollectionWasStarted());
+        $this->subscriber->onSourceCollectionWasFinished(new SourceCollectionWasFinished(1));
         $this->subscriber->onMutationGenerationWasStarted(new MutationGenerationWasStarted(1));
         $this->subscriber->onMutationGenerationWasFinished(new MutationGenerationWasFinished());
         $this->subscriber->onMutationTestingWasStarted(new MutationTestingWasStarted(1, $this->createStub(ProcessRunner::class)));
@@ -122,6 +132,8 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 ->withProcessRuntime(0.123)
                 ->build(),
         ));
+        $this->subscriber->onReportingWasStarted(new ReportingWasStarted());
+        $this->subscriber->onReportingWasFinished(new ReportingWasFinished());
         $this->subscriber->onMutationTestingWasFinished(new MutationTestingWasFinished());
         $this->subscriber->onApplicationExecutionWasFinished(new ApplicationExecutionWasFinished());
 
@@ -129,8 +141,11 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
             [
                 'infection.initial_tests',
                 'infection.initial_static_analysis',
+                'infection.artefact_collection',
+                'infection.source_collection',
                 'infection.mutation_generation',
                 'infection.mutation_evaluation',
+                'infection.reporting',
                 'infection.mutation_testing',
                 'infection.run',
             ],
@@ -138,19 +153,26 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         );
 
         $run = $this->getSpanFromExporter('infection.run');
+        $artefactCollection = $this->getSpanFromExporter('infection.artefact_collection');
+        $sourceCollection = $this->getSpanFromExporter('infection.source_collection');
         $initialTests = $this->getSpanFromExporter('infection.initial_tests');
         $initialStaticAnalysis = $this->getSpanFromExporter('infection.initial_static_analysis');
         $mutationGeneration = $this->getSpanFromExporter('infection.mutation_generation');
         $mutationTesting = $this->getSpanFromExporter('infection.mutation_testing');
         $mutationEvaluation = $this->getSpanFromExporter('infection.mutation_evaluation');
+        $reporting = $this->getSpanFromExporter('infection.reporting');
 
         $this->assertSame(self::ROOT_SPAN_PARENT_ID, $run->getParentSpanId());
-        $this->assertSame($run->getSpanId(), $initialTests->getParentSpanId());
-        $this->assertSame($run->getSpanId(), $initialStaticAnalysis->getParentSpanId());
+        $this->assertSame($run->getSpanId(), $artefactCollection->getParentSpanId());
+        $this->assertSame($artefactCollection->getSpanId(), $initialTests->getParentSpanId());
+        $this->assertSame($artefactCollection->getSpanId(), $initialStaticAnalysis->getParentSpanId());
+        $this->assertSame($run->getSpanId(), $sourceCollection->getParentSpanId());
         $this->assertSame($run->getSpanId(), $mutationGeneration->getParentSpanId());
         $this->assertSame($run->getSpanId(), $mutationTesting->getParentSpanId());
         $this->assertSame($mutationTesting->getSpanId(), $mutationEvaluation->getParentSpanId());
+        $this->assertSame($run->getSpanId(), $reporting->getParentSpanId());
 
+        $this->assertSame(1, $sourceCollection->getAttributes()->get('infection.source_file.count'));
         $this->assertSame(1, $mutationGeneration->getAttributes()->get('infection.source_file.count'));
         $this->assertSame(1, $mutationTesting->getAttributes()->get('infection.mutation.count'));
         $this->assertSame('mutation-A', $mutationEvaluation->getAttributes()->get('infection.mutation.id'));
@@ -170,20 +192,26 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $mutation = MutationBuilder::withMinimalTestData()->build();
 
         $this->subscriber->onApplicationExecutionWasStarted(new ApplicationExecutionWasStarted());
+        $this->subscriber->onArtefactCollectionWasStarted(new ArtefactCollectionWasStarted());
         $this->subscriber->onInitialTestSuiteWasStarted(new InitialTestSuiteWasStarted());
         $this->subscriber->onInitialStaticAnalysisRunWasStarted(new InitialStaticAnalysisRunWasStarted());
+        $this->subscriber->onSourceCollectionWasStarted(new SourceCollectionWasStarted());
         $this->subscriber->onMutationGenerationWasStarted(new MutationGenerationWasStarted(1));
         $this->subscriber->onMutationTestingWasStarted(new MutationTestingWasStarted(IterableCounter::UNKNOWN_COUNT, $this->createStub(ProcessRunner::class)));
         $this->subscriber->onMutationEvaluationWasStarted(new MutationEvaluationWasStarted($mutation));
+        $this->subscriber->onReportingWasStarted(new ReportingWasStarted());
         $this->subscriber->onApplicationExecutionWasFinished(new ApplicationExecutionWasFinished());
 
         $this->assertSame(
             [
                 'infection.initial_tests',
                 'infection.initial_static_analysis',
+                'infection.artefact_collection',
+                'infection.source_collection',
                 'infection.mutation_generation',
                 'infection.mutation_evaluation',
                 'infection.mutation_testing',
+                'infection.reporting',
                 'infection.run',
             ],
             $this->getExportedSpanNames(),


### PR DESCRIPTION
## Description

Adds lifecycle events for source collection, artefact collection and reporting. Those events are also wired into OpenTelemetry tracing. Those phases were described in https://github.com/infection/infection/pull/3103 and allows us to have more insights on the trace execution.

Before:

<img width="1438" height="200" alt="Screenshot 2026-05-10 at 09 33 32" src="https://github.com/user-attachments/assets/cfe5a419-91ba-4878-a5ee-2493285928bb" />


After:

<img width="1437" height="228" alt="Screenshot 2026-05-10 at 09 33 21" src="https://github.com/user-attachments/assets/0e288373-f27d-4271-84ef-6a28e613a6d8" />


## Changes

This introduces:

- `infection.source_collection`,
- `infection.artefact_collection`
- `infection.reporting spans`

The initial tests and static analysis spans are now grouped under `infection.artefact_collection`.

## Reviewer Notes

The screenshot from the description section are from my local Jaeger instance, but those changes will also be observable on our Sentry instance.

## Related issues

- #3090
