### PR TITLE
test(telemetry): Ensure the e2e Telemetry test is not affected by INFECTION_TELEMETRY

### DIFF
--- a/tests/e2e/Telemetry_Console/run_tests.bash
+++ b/tests/e2e/Telemetry_Console/run_tests.bash
@@ -46,7 +46,7 @@ assert_line_count() {
     fi
 }
 
-php $INFECTION --no-interaction --no-progress \
+INFECTION_TELEMETRY=false php $INFECTION --no-interaction --no-progress \
     1> var/execution-no-env-variable.stdout \
     2> var/execution-no-env-variable.stderr
 


### PR DESCRIPTION
## Description

Locally for example via `.envrc.local` I configure the telemetry for infection for testing. However, this e2e test may fail as a result since the environment variable used locally affect the test.

## Changes

This PR changes the script to use `INFECTION_TELEMETRY=false` explicitly. It is unneeded for people executing the test without explicitly setting this environment variable, but otherwise harmless.

## Related issues

- #3090 
