### PR TITLE
refactor(logger): Rename mutation analysis logger evaluation methods

### DIFF
--- a/src/Event/Subscriber/MutationAnalysisLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationAnalysisLoggerSubscriber.php
@@ -60,12 +60,12 @@ final readonly class MutationAnalysisLoggerSubscriber implements MutableFileWasP
 
     public function onMutationEvaluationWasStarted(MutationEvaluationWasStarted $event): void
     {
-        $this->logger->startAnalysis($event->mutationCount);
+        $this->logger->startEvaluation($event->mutationCount);
     }
 
     public function onMutationEvaluationForMutationWasStarted(MutationEvaluationForMutationWasStarted $event): void
     {
-        $this->logger->startEvaluation($event->mutation);
+        $this->logger->startEvaluationForMutation($event->mutation);
     }
 
     public function onMutableFileWasProcessed(MutableFileWasProcessed $event): void
@@ -82,11 +82,11 @@ final readonly class MutationAnalysisLoggerSubscriber implements MutableFileWasP
     {
         $executionResult = $event->executionResult;
 
-        $this->logger->finishEvaluation($executionResult);
+        $this->logger->finishEvaluationForMutation($executionResult);
     }
 
     public function onMutationEvaluationWasFinished(MutationEvaluationWasFinished $event): void
     {
-        $this->logger->finishAnalysis();
+        $this->logger->finishEvaluation();
     }
 }

--- a/src/Logger/MutationAnalysis/AbstractMutationAnalysisLogger.php
+++ b/src/Logger/MutationAnalysis/AbstractMutationAnalysisLogger.php
@@ -47,7 +47,12 @@ abstract class AbstractMutationAnalysisLogger implements MutationAnalysisLogger
 {
     protected int $callsCount = 0;
 
-    public function startAnalysis(int $mutationCount): void
+    public function startAnalysis(): void
+    {
+        // Do nothing.
+    }
+
+    public function startEvaluation(int $mutationCount): void
     {
         $this->callsCount = 0;
     }
@@ -59,17 +64,22 @@ abstract class AbstractMutationAnalysisLogger implements MutationAnalysisLogger
         // Do nothing.
     }
 
-    public function startEvaluation(Mutation $mutation): void
+    public function startEvaluationForMutation(Mutation $mutation): void
     {
         // Do nothing.
     }
 
-    public function finishEvaluation(MutantExecutionResult $executionResult): void
+    public function finishEvaluationForMutation(MutantExecutionResult $executionResult): void
     {
         ++$this->callsCount;
     }
 
+    public function finishEvaluation(): void
+    {
+    }
+
     public function finishAnalysis(): void
     {
+        // Do nothing.
     }
 }

--- a/src/Logger/MutationAnalysis/AbstractMutationAnalysisLogger.php
+++ b/src/Logger/MutationAnalysis/AbstractMutationAnalysisLogger.php
@@ -47,11 +47,6 @@ abstract class AbstractMutationAnalysisLogger implements MutationAnalysisLogger
 {
     protected int $callsCount = 0;
 
-    public function startAnalysis(): void
-    {
-        // Do nothing.
-    }
-
     public function startEvaluation(int $mutationCount): void
     {
         $this->callsCount = 0;
@@ -76,10 +71,5 @@ abstract class AbstractMutationAnalysisLogger implements MutationAnalysisLogger
 
     public function finishEvaluation(): void
     {
-    }
-
-    public function finishAnalysis(): void
-    {
-        // Do nothing.
     }
 }

--- a/src/Logger/MutationAnalysis/ConsoleDotLogger.php
+++ b/src/Logger/MutationAnalysis/ConsoleDotLogger.php
@@ -61,9 +61,9 @@ final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
     }
 
     #[Override]
-    public function startAnalysis(int $mutationCount): void
+    public function startEvaluation(int $mutationCount): void
     {
-        parent::startAnalysis($mutationCount);
+        parent::startEvaluation($mutationCount);
 
         $this->mutationCount = $mutationCount;
 
@@ -83,15 +83,15 @@ final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
     }
 
     #[Override]
-    public function startEvaluation(Mutation $mutation): void
+    public function startEvaluationForMutation(Mutation $mutation): void
     {
         // Do nothing.
     }
 
     #[Override]
-    public function finishEvaluation(MutantExecutionResult $executionResult): void
+    public function finishEvaluationForMutation(MutantExecutionResult $executionResult): void
     {
-        parent::finishEvaluation($executionResult);
+        parent::finishEvaluationForMutation($executionResult);
 
         $mutationCount = $this->mutationCount;
         Assert::notNull($mutationCount);

--- a/src/Logger/MutationAnalysis/ConsoleProgressBarLogger.php
+++ b/src/Logger/MutationAnalysis/ConsoleProgressBarLogger.php
@@ -50,24 +50,24 @@ final class ConsoleProgressBarLogger extends AbstractMutationAnalysisLogger
     }
 
     #[Override]
-    public function startAnalysis(int $mutationCount): void
+    public function startEvaluation(int $mutationCount): void
     {
-        parent::startAnalysis($mutationCount);
+        parent::startEvaluation($mutationCount);
 
         $this->progressBar->start($mutationCount);
     }
 
     #[Override]
-    public function finishEvaluation(MutantExecutionResult $executionResult): void
+    public function finishEvaluationForMutation(MutantExecutionResult $executionResult): void
     {
-        parent::finishEvaluation($executionResult);
+        parent::finishEvaluationForMutation($executionResult);
 
         $this->progressBar->advance();
     }
 
-    public function finishAnalysis(): void
+    public function finishEvaluation(): void
     {
-        parent::finishAnalysis();
+        parent::finishEvaluation();
 
         $this->progressBar->finish();
     }

--- a/src/Logger/MutationAnalysis/MutationAnalysisLogger.php
+++ b/src/Logger/MutationAnalysis/MutationAnalysisLogger.php
@@ -44,12 +44,14 @@ use Infection\Mutation\Mutation;
  */
 interface MutationAnalysisLogger
 {
+    public function startAnalysis(): void;
+
     /**
      * Records the start of the process.
      *
      * @param positive-int|IterableCounter::UNKNOWN_COUNT $mutationCount
      */
-    public function startAnalysis(int $mutationCount): void;
+    public function startEvaluation(int $mutationCount): void;
 
     /**
      * @param list<string> $mutationIds
@@ -59,15 +61,17 @@ interface MutationAnalysisLogger
         array $mutationIds,
     ): void;
 
-    public function startEvaluation(Mutation $mutation): void;
+    public function startEvaluationForMutation(Mutation $mutation): void;
 
     /**
      * Records the result of the evaluation of a mutation.
      */
-    public function finishEvaluation(MutantExecutionResult $executionResult): void;
+    public function finishEvaluationForMutation(MutantExecutionResult $executionResult): void;
 
     /**
      * Records the end of the mutation evaluation process.
      */
+    public function finishEvaluation(): void;
+
     public function finishAnalysis(): void;
 }

--- a/src/Logger/MutationAnalysis/MutationAnalysisLogger.php
+++ b/src/Logger/MutationAnalysis/MutationAnalysisLogger.php
@@ -44,8 +44,6 @@ use Infection\Mutation\Mutation;
  */
 interface MutationAnalysisLogger
 {
-    public function startAnalysis(): void;
-
     /**
      * Records the start of the process.
      *
@@ -72,6 +70,4 @@ interface MutationAnalysisLogger
      * Records the end of the mutation evaluation process.
      */
     public function finishEvaluation(): void;
-
-    public function finishAnalysis(): void;
 }

--- a/src/Logger/MutationAnalysis/TeamCity/TeamCityLogger.php
+++ b/src/Logger/MutationAnalysis/TeamCity/TeamCityLogger.php
@@ -57,7 +57,12 @@ final readonly class TeamCityLogger implements MutationAnalysisLogger
     ) {
     }
 
-    public function startAnalysis(int $mutationCount): void
+    public function startAnalysis(): void
+    {
+        // Do nothing.
+    }
+
+    public function startEvaluation(int $mutationCount): void
     {
         if ($mutationCount !== IterableCounter::UNKNOWN_COUNT) {
             $this->write(
@@ -66,7 +71,7 @@ final readonly class TeamCityLogger implements MutationAnalysisLogger
         }
     }
 
-    public function startEvaluation(Mutation $mutation): void
+    public function startEvaluationForMutation(Mutation $mutation): void
     {
         $sourceFilePath = $mutation->getOriginalFilePath();
 
@@ -75,7 +80,7 @@ final readonly class TeamCityLogger implements MutationAnalysisLogger
         $this->startTest($mutation, $testSuiteNodeId);
     }
 
-    public function finishEvaluation(MutantExecutionResult $executionResult): void
+    public function finishEvaluationForMutation(MutantExecutionResult $executionResult): void
     {
         $sourceFilePath = $executionResult->getOriginalFilePath();
 
@@ -98,9 +103,14 @@ final readonly class TeamCityLogger implements MutationAnalysisLogger
         $this->finishTestSuiteIfAllMutationsWereExecuted($sourceFilePath);
     }
 
-    public function finishAnalysis(): void
+    public function finishEvaluation(): void
     {
         $this->state->assertAllTestSuitesAreClosed();
+    }
+
+    public function finishAnalysis(): void
+    {
+        // Do nothing.
     }
 
     private function startTestSuiteIfNotStarted(string $sourceFilePath): string

--- a/src/Logger/MutationAnalysis/TeamCity/TeamCityLogger.php
+++ b/src/Logger/MutationAnalysis/TeamCity/TeamCityLogger.php
@@ -57,11 +57,6 @@ final readonly class TeamCityLogger implements MutationAnalysisLogger
     ) {
     }
 
-    public function startAnalysis(): void
-    {
-        // Do nothing.
-    }
-
     public function startEvaluation(int $mutationCount): void
     {
         if ($mutationCount !== IterableCounter::UNKNOWN_COUNT) {
@@ -106,11 +101,6 @@ final readonly class TeamCityLogger implements MutationAnalysisLogger
     public function finishEvaluation(): void
     {
         $this->state->assertAllTestSuitesAreClosed();
-    }
-
-    public function finishAnalysis(): void
-    {
-        // Do nothing.
     }
 
     private function startTestSuiteIfNotStarted(string $sourceFilePath): string

--- a/tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php
@@ -70,11 +70,11 @@ final class MutationAnalysisLoggerSubscriberTest extends TestCase
         $this->dispatcher->addSubscriber($subscriber);
     }
 
-    public function test_it_reacts_on_mutation_testing_started(): void
+    public function test_it_reacts_on_mutation_evaluation_started(): void
     {
         $this->loggerMock
             ->expects($this->once())
-            ->method('startAnalysis')
+            ->method('startEvaluation')
             ->with(1);
 
         $this->dispatcher->dispatch(
@@ -91,7 +91,7 @@ final class MutationAnalysisLoggerSubscriberTest extends TestCase
 
         $this->loggerMock
             ->expects($this->once())
-            ->method('startEvaluation')
+            ->method('startEvaluationForMutation')
         ->with($this->identicalTo($mutation));
 
         $this->dispatcher->dispatch(
@@ -137,7 +137,7 @@ final class MutationAnalysisLoggerSubscriberTest extends TestCase
 
         $this->loggerMock
             ->expects($this->once())
-            ->method('finishEvaluation')
+            ->method('finishEvaluationForMutation')
             ->with($this->identicalTo($executionResult));
 
         $this->dispatcher->dispatch(
@@ -147,11 +147,11 @@ final class MutationAnalysisLoggerSubscriberTest extends TestCase
         );
     }
 
-    public function test_it_reacts_on_mutation_testing_finished(): void
+    public function test_it_reacts_on_mutation_evaluation_finished(): void
     {
         $this->loggerMock
             ->expects($this->once())
-            ->method('finishAnalysis');
+            ->method('finishEvaluation');
 
         $this->dispatcher->dispatch(new MutationEvaluationWasFinished());
     }

--- a/tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php
@@ -89,7 +89,7 @@ final class ConsoleDotLoggerTest extends TestCase
             ),
         );
 
-        $logger->startAnalysis(10);
+        $logger->startEvaluation(10);
 
         $actual = $output->fetch();
 
@@ -106,10 +106,10 @@ final class ConsoleDotLoggerTest extends TestCase
 
         // Clear the initial output: it is already tested and it would bloat the
         // test to include it.
-        $logger->startAnalysis(10);
+        $logger->startEvaluation(10);
         $output->fetch();
 
-        $logger->finishEvaluation(
+        $logger->finishEvaluationForMutation(
             $this->createMutantExecutionResultOfType($detectionStatus),
         );
 
@@ -176,10 +176,10 @@ final class ConsoleDotLoggerTest extends TestCase
 
         $output = new BufferedOutput();
         $logger = new ConsoleDotLogger($output);
-        $logger->startAnalysis($totalMutations);
+        $logger->startEvaluation($totalMutations);
 
         for ($i = 0; $i < $totalMutations; ++$i) {
-            $logger->finishEvaluation(
+            $logger->finishEvaluationForMutation(
                 $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
             );
         }
@@ -207,10 +207,10 @@ final class ConsoleDotLoggerTest extends TestCase
 
         $output = new BufferedOutput();
         $logger = new ConsoleDotLogger($output);
-        $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+        $logger->startEvaluation(IterableCounter::UNKNOWN_COUNT);
 
         for ($i = 0; $i < $totalMutations; ++$i) {
-            $logger->finishEvaluation(
+            $logger->finishEvaluationForMutation(
                 $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
             );
         }

--- a/tests/phpunit/Logger/MutationAnalysis/FakeMutationAnalysisLogger.php
+++ b/tests/phpunit/Logger/MutationAnalysis/FakeMutationAnalysisLogger.php
@@ -42,11 +42,6 @@ use Infection\Tests\UnsupportedMethod;
 
 final class FakeMutationAnalysisLogger implements MutationAnalysisLogger
 {
-    public function startAnalysis(): void
-    {
-        throw UnsupportedMethod::method(self::class, __FUNCTION__);
-    }
-
     public function startEvaluation(int $mutationCount): void
     {
         throw UnsupportedMethod::method(self::class, __FUNCTION__);
@@ -70,11 +65,6 @@ final class FakeMutationAnalysisLogger implements MutationAnalysisLogger
     }
 
     public function finishEvaluation(): void
-    {
-        throw UnsupportedMethod::method(self::class, __FUNCTION__);
-    }
-
-    public function finishAnalysis(): void
     {
         throw UnsupportedMethod::method(self::class, __FUNCTION__);
     }

--- a/tests/phpunit/Logger/MutationAnalysis/FakeMutationAnalysisLogger.php
+++ b/tests/phpunit/Logger/MutationAnalysis/FakeMutationAnalysisLogger.php
@@ -42,7 +42,12 @@ use Infection\Tests\UnsupportedMethod;
 
 final class FakeMutationAnalysisLogger implements MutationAnalysisLogger
 {
-    public function startAnalysis(int $mutationCount): void
+    public function startAnalysis(): void
+    {
+        throw UnsupportedMethod::method(self::class, __FUNCTION__);
+    }
+
+    public function startEvaluation(int $mutationCount): void
     {
         throw UnsupportedMethod::method(self::class, __FUNCTION__);
     }
@@ -54,12 +59,17 @@ final class FakeMutationAnalysisLogger implements MutationAnalysisLogger
         throw UnsupportedMethod::method(self::class, __FUNCTION__);
     }
 
-    public function startEvaluation(Mutation $mutation): void
+    public function startEvaluationForMutation(Mutation $mutation): void
     {
         throw UnsupportedMethod::method(self::class, __FUNCTION__);
     }
 
-    public function finishEvaluation(MutantExecutionResult $executionResult): void
+    public function finishEvaluationForMutation(MutantExecutionResult $executionResult): void
+    {
+        throw UnsupportedMethod::method(self::class, __FUNCTION__);
+    }
+
+    public function finishEvaluation(): void
     {
         throw UnsupportedMethod::method(self::class, __FUNCTION__);
     }

--- a/tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php
@@ -112,7 +112,7 @@ final class TeamCityLoggerTest extends TestCase
             static function (MutationAnalysisLogger $logger): void {
                 $sourceFilePath = '/path/to/project/src/Service/UserService.php';
 
-                $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+                $logger->startEvaluation(IterableCounter::UNKNOWN_COUNT);
 
                 $mutation = self::createMutation(
                     $sourceFilePath,
@@ -121,14 +121,14 @@ final class TeamCityLoggerTest extends TestCase
                 );
                 $executionResult = self::createExecutionResult($mutation);
 
-                $logger->startEvaluation($mutation);
-                $logger->finishEvaluation($executionResult);
+                $logger->startEvaluationForMutation($mutation);
+                $logger->finishEvaluationForMutation($executionResult);
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath,
                     [$mutation->getHash()],
                 );
 
-                $logger->finishAnalysis();
+                $logger->finishEvaluation();
             },
             <<<'TEAM_CITY'
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
@@ -146,7 +146,7 @@ final class TeamCityLoggerTest extends TestCase
             static function (MutationAnalysisLogger $logger): void {
                 $sourceFilePath = '/path/to/project/src/Service/UserService.php';
 
-                $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+                $logger->startEvaluation(IterableCounter::UNKNOWN_COUNT);
 
                 $mutation = self::createMutation(
                     $sourceFilePath,
@@ -160,10 +160,10 @@ final class TeamCityLoggerTest extends TestCase
                     [$mutation->getHash()],
                 );
 
-                $logger->startEvaluation($mutation);
-                $logger->finishEvaluation($executionResult);
+                $logger->startEvaluationForMutation($mutation);
+                $logger->finishEvaluationForMutation($executionResult);
 
-                $logger->finishAnalysis();
+                $logger->finishEvaluation();
             },
             <<<'TEAM_CITY'
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
@@ -181,7 +181,7 @@ final class TeamCityLoggerTest extends TestCase
             static function (MutationAnalysisLogger $logger): void {
                 $sourceFilePath = '/path/to/project/src/Service/UserService.php';
 
-                $logger->startAnalysis(1);
+                $logger->startEvaluation(1);
 
                 $mutation = self::createMutation(
                     $sourceFilePath,
@@ -190,14 +190,14 @@ final class TeamCityLoggerTest extends TestCase
                 );
                 $executionResult = self::createExecutionResult($mutation);
 
-                $logger->startEvaluation($mutation);
-                $logger->finishEvaluation($executionResult);
+                $logger->startEvaluationForMutation($mutation);
+                $logger->finishEvaluationForMutation($executionResult);
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath,
                     [$mutation->getHash()],
                 );
 
-                $logger->finishAnalysis();
+                $logger->finishEvaluation();
             },
             <<<'TEAM_CITY'
                 ##teamcity[testCount count='1']
@@ -216,7 +216,7 @@ final class TeamCityLoggerTest extends TestCase
             static function (MutationAnalysisLogger $logger): void {
                 $sourceFilePath = '/path/to/project/src/Service/UserService.php';
 
-                $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+                $logger->startEvaluation(IterableCounter::UNKNOWN_COUNT);
 
                 $mutation = self::createMutation(
                     $sourceFilePath,
@@ -225,16 +225,16 @@ final class TeamCityLoggerTest extends TestCase
                 );
                 $executionResult = self::createExecutionResult($mutation);
 
-                $logger->startEvaluation($mutation);
+                $logger->startEvaluationForMutation($mutation);
 
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath,
                     [$mutation->getHash()],
                 );
 
-                $logger->finishEvaluation($executionResult);
+                $logger->finishEvaluationForMutation($executionResult);
 
-                $logger->finishAnalysis();
+                $logger->finishEvaluation();
             },
             <<<'TEAM_CITY'
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
@@ -252,7 +252,7 @@ final class TeamCityLoggerTest extends TestCase
             static function (MutationAnalysisLogger $logger): void {
                 $sourceFilePath = '/path/to/project/src/Service/UserService.php';
 
-                $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+                $logger->startEvaluation(IterableCounter::UNKNOWN_COUNT);
 
                 $mutation1 = self::createMutation(
                     $sourceFilePath,
@@ -274,11 +274,11 @@ final class TeamCityLoggerTest extends TestCase
                     $mutation2,
                 );
 
-                $logger->startEvaluation($mutation1);
-                $logger->finishEvaluation($executionResult1);
+                $logger->startEvaluationForMutation($mutation1);
+                $logger->finishEvaluationForMutation($executionResult1);
 
-                $logger->startEvaluation($mutation2);
-                $logger->finishEvaluation($executionResult2);
+                $logger->startEvaluationForMutation($mutation2);
+                $logger->finishEvaluationForMutation($executionResult2);
 
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath,
@@ -288,7 +288,7 @@ final class TeamCityLoggerTest extends TestCase
                     ],
                 );
 
-                $logger->finishAnalysis();
+                $logger->finishEvaluation();
             },
             <<<'TEAM_CITY'
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
@@ -308,7 +308,7 @@ final class TeamCityLoggerTest extends TestCase
 
         yield 'three mutations executed for a source file, launched in parallel' => [
             static function (MutationAnalysisLogger $logger): void {
-                $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+                $logger->startEvaluation(IterableCounter::UNKNOWN_COUNT);
 
                 $sourceFilePath = '/path/to/project/src/Service/UserService.php';
 
@@ -340,13 +340,13 @@ final class TeamCityLoggerTest extends TestCase
                     $mutation3,
                 );
 
-                $logger->startEvaluation($mutation1);
-                $logger->startEvaluation($mutation2);
-                $logger->startEvaluation($mutation3);
+                $logger->startEvaluationForMutation($mutation1);
+                $logger->startEvaluationForMutation($mutation2);
+                $logger->startEvaluationForMutation($mutation3);
 
-                $logger->finishEvaluation($executionResult2);
-                $logger->finishEvaluation($executionResult3);
-                $logger->finishEvaluation($executionResult1);
+                $logger->finishEvaluationForMutation($executionResult2);
+                $logger->finishEvaluationForMutation($executionResult3);
+                $logger->finishEvaluationForMutation($executionResult1);
 
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath,
@@ -357,7 +357,7 @@ final class TeamCityLoggerTest extends TestCase
                     ],
                 );
 
-                $logger->finishAnalysis();
+                $logger->finishEvaluation();
             },
             <<<'TEAM_CITY'
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
@@ -380,7 +380,7 @@ final class TeamCityLoggerTest extends TestCase
 
         yield 'two mutations executed for a source file, launched in parallel with the mutation generation finishing before all mutants are evaluated' => [
             static function (MutationAnalysisLogger $logger): void {
-                $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+                $logger->startEvaluation(IterableCounter::UNKNOWN_COUNT);
 
                 $sourceFilePath = '/path/to/project/src/Service/UserService.php';
 
@@ -401,10 +401,10 @@ final class TeamCityLoggerTest extends TestCase
                 // Sanity check
                 self::ensureMutationHashesAreUnique($mutation1, $mutation2);
 
-                $logger->startEvaluation($mutation1);
-                $logger->startEvaluation($mutation2);
+                $logger->startEvaluationForMutation($mutation1);
+                $logger->startEvaluationForMutation($mutation2);
 
-                $logger->finishEvaluation($executionResult2);
+                $logger->finishEvaluationForMutation($executionResult2);
 
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath,
@@ -414,9 +414,9 @@ final class TeamCityLoggerTest extends TestCase
                     ],
                 );
 
-                $logger->finishEvaluation($executionResult1);
+                $logger->finishEvaluationForMutation($executionResult1);
 
-                $logger->finishAnalysis();
+                $logger->finishEvaluation();
             },
             <<<'TEAM_CITY'
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
@@ -436,7 +436,7 @@ final class TeamCityLoggerTest extends TestCase
 
         yield 'one mutation executed for two source file, launched synchronously' => [
             static function (MutationAnalysisLogger $logger): void {
-                $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+                $logger->startEvaluation(IterableCounter::UNKNOWN_COUNT);
 
                 $sourceFilePath1 = '/path/to/project/src/Service/UserService.php';
                 $sourceFilePath2 = '/path/to/project/src/Service/ContactService.php';
@@ -458,21 +458,21 @@ final class TeamCityLoggerTest extends TestCase
                 // Sanity check
                 self::ensureMutationHashesAreUnique($mutation1, $mutation2);
 
-                $logger->startEvaluation($mutation1);
-                $logger->finishEvaluation($executionResult1);
+                $logger->startEvaluationForMutation($mutation1);
+                $logger->finishEvaluationForMutation($executionResult1);
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath1,
                     [$mutation1->getHash()],
                 );
 
-                $logger->startEvaluation($mutation2);
-                $logger->finishEvaluation($executionResult2);
+                $logger->startEvaluationForMutation($mutation2);
+                $logger->finishEvaluationForMutation($executionResult2);
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath2,
                     [$mutation2->getHash()],
                 );
 
-                $logger->finishAnalysis();
+                $logger->finishEvaluation();
             },
             <<<'TEAM_CITY'
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
@@ -496,7 +496,7 @@ final class TeamCityLoggerTest extends TestCase
 
         yield 'one mutation executed for two source file, launched in parallel' => [
             static function (MutationAnalysisLogger $logger): void {
-                $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+                $logger->startEvaluation(IterableCounter::UNKNOWN_COUNT);
 
                 $sourceFilePath1 = '/path/to/project/src/Service/UserService.php';
                 $sourceFilePath2 = '/path/to/project/src/Service/ContactService.php';
@@ -518,22 +518,22 @@ final class TeamCityLoggerTest extends TestCase
                 // Sanity check
                 self::ensureMutationHashesAreUnique($mutation1, $mutation2);
 
-                $logger->startEvaluation($mutation1);
-                $logger->startEvaluation($mutation2);
+                $logger->startEvaluationForMutation($mutation1);
+                $logger->startEvaluationForMutation($mutation2);
 
-                $logger->finishEvaluation($executionResult2);
+                $logger->finishEvaluationForMutation($executionResult2);
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath1,
                     [$mutation1->getHash()],
                 );
 
-                $logger->finishEvaluation($executionResult1);
+                $logger->finishEvaluationForMutation($executionResult1);
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath2,
                     [$mutation2->getHash()],
                 );
 
-                $logger->finishAnalysis();
+                $logger->finishEvaluation();
             },
             <<<'TEAM_CITY'
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
@@ -556,7 +556,7 @@ final class TeamCityLoggerTest extends TestCase
 
         yield 'mutations executed for multiple source file, launched in parallel (taken from a real execution)' => [
             static function (MutationAnalysisLogger $logger): void {
-                $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+                $logger->startEvaluation(IterableCounter::UNKNOWN_COUNT);
 
                 $sourceFilePath1 = '/path/to/project/src/Service/UserService.php';
                 $sourceFilePath2 = '/path/to/project/src/Service/ContactService.php';
@@ -589,27 +589,27 @@ final class TeamCityLoggerTest extends TestCase
                     $mutation2,
                 );
 
-                $logger->startEvaluation($mutation1A);
-                $logger->startEvaluation($mutation1B);
+                $logger->startEvaluationForMutation($mutation1A);
+                $logger->startEvaluationForMutation($mutation1B);
 
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath1,
                     [$mutation1A->getHash(), $mutation1B->getHash()],
                 );
 
-                $logger->startEvaluation($mutation2);
+                $logger->startEvaluationForMutation($mutation2);
 
-                $logger->finishEvaluation($executionResult1A);
-                $logger->finishEvaluation($executionResult1B);
+                $logger->finishEvaluationForMutation($executionResult1A);
+                $logger->finishEvaluationForMutation($executionResult1B);
 
                 $logger->finishMutationGenerationForFile(
                     $sourceFilePath2,
                     [$mutation2->getHash()],
                 );
 
-                $logger->finishEvaluation($executionResult2);
+                $logger->finishEvaluationForMutation($executionResult2);
 
-                $logger->finishAnalysis();
+                $logger->finishEvaluation();
             },
             <<<'TEAM_CITY'
                 ##teamcity[testSuiteStarted name='src/Service/UserService.php' nodeId='5568c7d4af5ccc7f' parentNodeId='0' locationHint='file:///path/to/project/src/Service/UserService.php']
@@ -638,7 +638,7 @@ final class TeamCityLoggerTest extends TestCase
     {
         $sourceFilePath = '/path/to/project/src/Service/UserService.php';
 
-        $this->teamCityLogger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+        $this->teamCityLogger->startEvaluation(IterableCounter::UNKNOWN_COUNT);
 
         $mutation = self::createMutation(
             $sourceFilePath,
@@ -646,13 +646,13 @@ final class TeamCityLoggerTest extends TestCase
             '49a5dfcd2f4a0b33d4a02e662812af55',
         );
 
-        $this->teamCityLogger->startEvaluation($mutation);
+        $this->teamCityLogger->startEvaluationForMutation($mutation);
 
         $this->expectExceptionMessage(
             'Expected all test suites to be closed. Found: "src/Service/UserService.php"',
         );
 
-        $this->teamCityLogger->finishAnalysis();
+        $this->teamCityLogger->finishEvaluation();
     }
 
     private static function createMutation(


### PR DESCRIPTION
## Description

Rename some methods of `MutationAnalysisLogger` to align with #3103 and the nomenclature.

## Reviewer Notes

Currently it may seem weird to read "mutation analysis logger" when in practice it is now only about the "mutation evaluation" phase. We then have the choice to either rename the logger, or add other log methods that are specific to the mutation analysis to this logger. I chose the latter, as I expect to add things there in the near future, but we can always revisit that decision.

## Related issues

- #3090