### PR TITLE
feat(logger): Make dots-per-row configurable in the dot progress formatter

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -789,7 +789,7 @@ count = 1
 [[issues]]
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #21 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `int|null|string`, but found `mixed`.'
+message = '''Invalid argument type for argument #21 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `null|positive-int|string('max')`, but found `mixed`.'''
 count = 1
 
 [[issues]]
@@ -5637,6 +5637,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Command/RunCommandHelperTest.php"
 code = "imprecise-type"
+message = "Type `iterable` in return type of `providesDotsPerRow` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/RunCommandHelperTest.php"
+code = "imprecise-type"
 message = "Type `iterable` in return type of `providesGetStringOption` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
@@ -7816,6 +7822,18 @@ count = 1
 file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `detectionStatusProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
+code = "imprecise-type"
+message = "Type `iterable` in return type of `totalMutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
+code = "imprecise-type"
+message = "Type `iterable` in return type of `unknownTotalProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -375,7 +375,7 @@ count = 1
 [[issues]]
 file = "src/Command/RunCommand.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #37 of `Infection\Container\Container::withValues`: expected `null|string`, but found `mixed`.'
+message = 'Invalid argument type for argument #38 of `Infection\Container\Container::withValues`: expected `null|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -478,13 +478,13 @@ count = 1
 file = "src/Command/RunCommandHelper.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #2 of `sprintf`: expected `Stringable|null|scalar`, but found `nonnull`."
-count = 3
+count = 4
 
 [[issues]]
 file = "src/Command/RunCommandHelper.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 4
+count = 5
 
 [[issues]]
 file = "src/Command/RunCommandHelper.php"
@@ -784,6 +784,12 @@ count = 1
 file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #20 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `int|null|string`, but found `mixed`.'
+count = 1
+
+[[issues]]
+file = "src/Configuration/Schema/SchemaConfigurationFactory.php"
+code = "mixed-argument"
+message = 'Invalid argument type for argument #21 of `Infection\Configuration\Schema\SchemaConfiguration::__construct`: expected `int|null|string`, but found `mixed`.'
 count = 1
 
 [[issues]]
@@ -5889,13 +5895,13 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "invalid-argument"
-message = '''Invalid argument type for argument #1 of `array_values`: expected `array<('K.array_values() extends array-key), mixed>`, but found `array{'bootstrap': null, 'ignoreMsiWithNoMutations': null, 'initialTestsPhpOptions': null, 'logs': infection\configuration\entry\logs, 'mago': Infection\Configuration\Entry\Mago, 'maxTimeouts': null, 'minCoveredMsi': null, 'minMsi': null, 'mutators': array{}, 'path': string('/path/to/config'), 'phpStan': Infection\Configuration\Entry\PhpStan, 'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source, 'staticAnalysisTool': null, 'staticAnalysisToolOptions': null, 'testFramework': null, 'testFrameworkOptions': null, 'threadCount': null, 'timeout': null, 'timeoutsAsEscaped': null, 'tmpDir': null, ...<array<string, mixed>, mixed>}`.'''
+message = '''Invalid argument type for argument #1 of `array_values`: expected `array<('K.array_values() extends array-key), mixed>`, but found `array{'bootstrap': null, 'dotsPerRow': null, 'ignoreMsiWithNoMutations': null, 'initialTestsPhpOptions': null, 'logs': infection\configuration\entry\logs, 'mago': Infection\Configuration\Entry\Mago, 'maxTimeouts': null, 'minCoveredMsi': null, 'minMsi': null, 'mutators': array{}, 'path': string('/path/to/config'), 'phpStan': Infection\Configuration\Entry\PhpStan, 'phpunit': Infection\Configuration\Entry\PhpUnit, 'source': Infection\Configuration\Entry\Source, 'staticAnalysisTool': null, 'staticAnalysisToolOptions': null, 'testFramework': null, 'testFrameworkOptions': null, 'threadCount': null, 'timeout': null, 'timeoutsAsEscaped': null, 'tmpDir': null, ...<array<string, mixed>, mixed>}`.'''
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "invalid-argument"
-message = "Invalid argument type for argument #2 of `array_merge`: expected `array<string('bootstrap')|string('ignoreMsiWithNoMutations')|string('initialTestsPhpOptions')|string('logs')|string('mago')|string('maxTimeouts')|string('minCoveredMsi')|string('minMsi')|string('mutators')|string('path')|string('phpStan')|string('phpunit')|string('source')|string('staticAnalysisTool')|string('staticAnalysisToolOptions')|string('testFramework')|string('testFrameworkOptions')|string('threadCount')|string('timeout')|string('timeoutsAsEscaped')|string('tmpDir'), mixed>`, but found `array<array<string, mixed>, mixed>`."
+message = "Invalid argument type for argument #2 of `array_merge`: expected `array<string('bootstrap')|string('dotsPerRow')|string('ignoreMsiWithNoMutations')|string('initialTestsPhpOptions')|string('logs')|string('mago')|string('maxTimeouts')|string('minCoveredMsi')|string('minMsi')|string('mutators')|string('path')|string('phpStan')|string('phpunit')|string('source')|string('staticAnalysisTool')|string('staticAnalysisToolOptions')|string('testFramework')|string('testFrameworkOptions')|string('threadCount')|string('timeout')|string('timeoutsAsEscaped')|string('tmpDir'), mixed>`, but found `array<array<string, mixed>, mixed>`."
 count = 1
 
 [[issues]]

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -26,6 +26,19 @@
                 }
             ]
         },
+        "dotsPerRow": {
+            "description": "Number of dots per row in the dot progress formatter. Use \"max\" to fit the terminal width.",
+            "oneOf": [
+                {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                {
+                    "type": "string",
+                    "enum": ["max"]
+                }
+            ]
+        },
         "source": {
             "type": "object",
             "required": [

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -82,6 +82,8 @@ final class RunCommand extends BaseCommand
 {
     public const string OPTION_THREADS = 'threads';
 
+    public const string OPTION_DOTS_PER_ROW = 'dots-per-row';
+
     public const string OPTION_LOGGER_GITHUB = 'logger-github';
 
     public const string OPTION_SHOW_MUTATIONS = 'show-mutations';
@@ -175,6 +177,13 @@ final class RunCommand extends BaseCommand
                 InputOption::VALUE_REQUIRED,
                 'Number of threads to use by the runner when executing the mutations. Use "max" to auto calculate it.',
                 Container::DEFAULT_THREAD_COUNT,
+            )
+            ->addOption(
+                self::OPTION_DOTS_PER_ROW,
+                'r',
+                InputOption::VALUE_REQUIRED,
+                'Number of dots per row in the dot progress formatter. Use "max" to fit the terminal width.',
+                Container::DEFAULT_DOTS_PER_ROW,
             )
             ->addOption(
                 self::OPTION_WITH_UNCOVERED,
@@ -474,6 +483,7 @@ final class RunCommand extends BaseCommand
             staticAnalysisToolOptions: $commandHelper->getStringOption(self::OPTION_STATIC_ANALYSIS_TOOL_OPTIONS, Container::DEFAULT_STATIC_ANALYSIS_TOOL_OPTIONS),
             sourceFilter: SourceFilterOptions::get($io),
             threadCount: $commandHelper->getThreadCount(),
+            dotsPerRow: $commandHelper->getDotsPerRow(),
             // To keep in sync with Container::DEFAULT_DRY_RUN
             dryRun: (bool) $input->getOption(self::OPTION_DRY_RUN),
             useGitHubLogger: $commandHelper->getUseGitHubLogger(),

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -180,7 +180,7 @@ final class RunCommand extends BaseCommand
             )
             ->addOption(
                 self::OPTION_DOTS_PER_ROW,
-                'r',
+                null,
                 InputOption::VALUE_REQUIRED,
                 'Number of dots per row in the dot progress formatter. Use "max" to fit the terminal width.',
                 Container::DEFAULT_DOTS_PER_ROW,

--- a/src/Command/RunCommandHelper.php
+++ b/src/Command/RunCommandHelper.php
@@ -35,11 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Command;
 
+use function ctype_digit;
 use function getenv;
 use Infection\Container\Container;
 use Infection\Resource\Processor\CpuCoresCountProvider;
 use InvalidArgumentException;
 use function is_numeric;
+use function is_string;
 use function max;
 use function sprintf;
 use Symfony\Component\Console\Input\InputInterface;
@@ -133,22 +135,21 @@ final readonly class RunCommandHelper
     {
         $dotsPerRow = $this->input->getOption(RunCommand::OPTION_DOTS_PER_ROW);
 
-        // user didn't pass `--dots-per-row` option
         if ($dotsPerRow === null) {
             return null;
         }
 
-        // user passed `--dots-per-row=<int>` option
-        if (is_numeric($dotsPerRow)) {
+        $error = sprintf('The value of option `--dots-per-row` must be a positive integer or string "max". "%s" provided.', $dotsPerRow);
+
+        if (is_string($dotsPerRow) && ctype_digit($dotsPerRow)) {
             $value = (int) $dotsPerRow;
 
-            Assert::positiveInteger($value, sprintf('The value of option `--dots-per-row` must be a positive integer or string "max". %d provided.', $value));
+            Assert::positiveInteger($value, $error);
 
             return $value;
         }
 
-        // user passed `--dots-per-row=max` option
-        Assert::same($dotsPerRow, 'max', sprintf('The value of option `--dots-per-row` must be a positive integer or string "max". String "%s" provided.', $dotsPerRow));
+        Assert::same($dotsPerRow, 'max', $error);
 
         return 'max';
     }

--- a/src/Command/RunCommandHelper.php
+++ b/src/Command/RunCommandHelper.php
@@ -126,6 +126,33 @@ final readonly class RunCommandHelper
         return max(1, CpuCoresCountProvider::provide() - 1);
     }
 
+    /**
+     * @return positive-int|'max'|null
+     */
+    public function getDotsPerRow(): string|int|null
+    {
+        $dotsPerRow = $this->input->getOption(RunCommand::OPTION_DOTS_PER_ROW);
+
+        // user didn't pass `--dots-per-row` option
+        if ($dotsPerRow === null) {
+            return null;
+        }
+
+        // user passed `--dots-per-row=<int>` option
+        if (is_numeric($dotsPerRow)) {
+            $value = (int) $dotsPerRow;
+
+            Assert::positiveInteger($value, sprintf('The value of option `--dots-per-row` must be a positive integer or string "max". %d provided.', $value));
+
+            return $value;
+        }
+
+        // user passed `--dots-per-row=max` option
+        Assert::same($dotsPerRow, 'max', sprintf('The value of option `--dots-per-row` must be a positive integer or string "max". String "%s" provided.', $dotsPerRow));
+
+        return 'max';
+    }
+
     public function getNumberOfShownMutations(): ?int
     {
         $shownMutations = $this->input->getOption(RunCommand::OPTION_SHOW_MUTATIONS);

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -46,6 +46,7 @@ use Infection\Configuration\SourceFilter\SourceFilter;
 use Infection\Mutator\Mutator;
 use Infection\StaticAnalysis\StaticAnalysisToolTypes;
 use Infection\TestFramework\TestFrameworkTypes;
+use function is_string;
 use function ltrim;
 use PhpParser\Node;
 use Webmozart\Assert\Assert;
@@ -65,6 +66,7 @@ readonly class Configuration
     /**
      * @param array<string, Mutator<Node>> $mutators
      * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
+     * @param positive-int|'max' $dotsPerRow
      * @param non-empty-string $configurationPathname
      * @param non-empty-string $projectDirectory Absolute path.
      */
@@ -98,6 +100,7 @@ readonly class Configuration
         public ?int $maxTimeouts,
         public int $msiPrecision,
         public int $threadCount,
+        public int|string $dotsPerRow,
         public bool $isDryRun,
         public array $ignoreSourceCodeMutatorsMap,
         public bool $executeOnlyCoveringTestCases,
@@ -114,6 +117,12 @@ readonly class Configuration
         Assert::nullOrOneOf($staticAnalysisTool, StaticAnalysisToolTypes::getTypes());
         Assert::nullOrGreaterThanEq($minMsi, 0.);
         Assert::greaterThanEq($threadCount, 0);
+
+        if (is_string($dotsPerRow)) {
+            Assert::same($dotsPerRow, 'max');
+        } else {
+            Assert::greaterThanEq($dotsPerRow, 1);
+        }
     }
 
     public function isStaticAnalysisEnabled(): bool

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -55,7 +55,6 @@ use Infection\Configuration\SourceFilter\SourceFilter;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\FileSystem\TmpDirProvider;
 use Infection\Git\Git;
-use Infection\Logger\MutationAnalysis\ConsoleDotLogger;
 use Infection\Mutator\ConfigurableMutator;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorFactory;
@@ -65,7 +64,6 @@ use Infection\Reporter\FileReporter;
 use Infection\Resource\Processor\CpuCoresCountProvider;
 use Infection\Source\Exception\NoSourceFound;
 use Infection\TestFramework\TestFrameworkTypes;
-use function is_int;
 use function is_numeric;
 use function max;
 use OndraM\CiDetector\CiDetector;
@@ -88,6 +86,8 @@ class ConfigurationFactory
      */
     private const int DEFAULT_TIMEOUT = 10;
 
+    private const int DEFAULT_DOTS_PER_ROW = 50;
+
     public function __construct(
         private readonly TmpDirProvider $tmpDirProvider,
         private readonly MutatorResolver $mutatorResolver,
@@ -101,6 +101,7 @@ class ConfigurationFactory
 
     /**
      * @param non-empty-string|null $projectDirectory Absolute path.
+     * @param positive-int|'max'|null $dotsPerRow
      *
      * @throws FileOrDirectoryNotFound
      * @throws NoSourceFound
@@ -474,21 +475,13 @@ class ConfigurationFactory
     }
 
     /**
+     * @param positive-int|'max'|null $dotsPerRow
+     *
      * @return positive-int|'max'
      */
     private static function retrieveDotsPerRow(string|int|null $dotsPerRow, SchemaConfiguration $schema): int|string
     {
-        $value = $dotsPerRow ?? $schema->dotsPerRow ?? ConsoleDotLogger::DEFAULT_DOTS_PER_ROW;
-
-        if (is_int($value)) {
-            Assert::positiveInteger($value, sprintf('The value of `dotsPerRow` must be a positive integer or string "max". %d provided.', $value));
-
-            return $value;
-        }
-
-        Assert::same($value, 'max', sprintf('The value of `dotsPerRow` must be a positive integer or string "max". String "%s" provided.', $value));
-
-        return 'max';
+        return $dotsPerRow ?? $schema->dotsPerRow ?? self::DEFAULT_DOTS_PER_ROW;
     }
 
     /**

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -55,6 +55,7 @@ use Infection\Configuration\SourceFilter\SourceFilter;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\FileSystem\TmpDirProvider;
 use Infection\Git\Git;
+use Infection\Logger\MutationAnalysis\ConsoleDotLogger;
 use Infection\Mutator\ConfigurableMutator;
 use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorFactory;
@@ -64,6 +65,7 @@ use Infection\Reporter\FileReporter;
 use Infection\Resource\Processor\CpuCoresCountProvider;
 use Infection\Source\Exception\NoSourceFound;
 use Infection\TestFramework\TestFrameworkTypes;
+use function is_int;
 use function is_numeric;
 use function max;
 use OndraM\CiDetector\CiDetector;
@@ -125,6 +127,7 @@ class ConfigurationFactory
         ?string $staticAnalysisToolOptions,
         PlainFilter|IncompleteGitDiffFilter|null $sourceFilter,
         ?int $threadCount,
+        string|int|null $dotsPerRow,
         bool $dryRun,
         ?bool $useGitHubLogger,
         ?string $gitlabLogFilePath,
@@ -192,6 +195,7 @@ class ConfigurationFactory
             maxTimeouts: self::retrieveMaxTimeouts($maxTimeouts, $schema),
             msiPrecision: $msiPrecision,
             threadCount: $this->retrieveThreadCount($threadCount, $schema),
+            dotsPerRow: self::retrieveDotsPerRow($dotsPerRow, $schema),
             isDryRun: $dryRun,
             ignoreSourceCodeMutatorsMap: $ignoreSourceCodeMutatorsMap,
             executeOnlyCoveringTestCases: $executeOnlyCoveringTestCases,
@@ -467,6 +471,24 @@ class ConfigurationFactory
 
         // we subtract 1 here to not use all the available cores by Infection
         return max(1, CpuCoresCountProvider::provide() - 1);
+    }
+
+    /**
+     * @return positive-int|'max'
+     */
+    private static function retrieveDotsPerRow(string|int|null $dotsPerRow, SchemaConfiguration $schema): int|string
+    {
+        $value = $dotsPerRow ?? $schema->dotsPerRow ?? ConsoleDotLogger::DEFAULT_DOTS_PER_ROW;
+
+        if (is_int($value)) {
+            Assert::positiveInteger($value, sprintf('The value of `dotsPerRow` must be a positive integer or string "max". %d provided.', $value));
+
+            return $value;
+        }
+
+        Assert::same($value, 'max', sprintf('The value of `dotsPerRow` must be a positive integer or string "max". String "%s" provided.', $value));
+
+        return 'max';
     }
 
     /**

--- a/src/Configuration/Schema/SchemaConfiguration.php
+++ b/src/Configuration/Schema/SchemaConfiguration.php
@@ -76,6 +76,7 @@ final readonly class SchemaConfiguration
         public ?string $testFrameworkExtraOptions,
         public ?string $staticAnalysisToolOptions,
         public string|int|null $threads,
+        public string|int|null $dotsPerRow,
         public ?string $staticAnalysisTool,
     ) {
         Assert::nullOrGreaterThanEq($timeout, 0);

--- a/src/Configuration/Schema/SchemaConfiguration.php
+++ b/src/Configuration/Schema/SchemaConfiguration.php
@@ -53,6 +53,7 @@ final readonly class SchemaConfiguration
      * @param non-empty-string $pathname
      * @param array<string, mixed> $mutators
      * @param TestFrameworkTypes::*|null $testFramework
+     * @param positive-int|'max'|null $dotsPerRow
      * @param StaticAnalysisToolTypes::*|null $staticAnalysisTool
      */
     public function __construct(

--- a/src/Configuration/Schema/SchemaConfigurationFactory.php
+++ b/src/Configuration/Schema/SchemaConfigurationFactory.php
@@ -84,6 +84,7 @@ class SchemaConfigurationFactory
             testFrameworkExtraOptions: self::normalizeString($rawConfig->testFrameworkOptions ?? null),
             staticAnalysisToolOptions: self::normalizeString($rawConfig->staticAnalysisToolOptions ?? null),
             threads: $rawConfig->threads ?? null,
+            dotsPerRow: $rawConfig->dotsPerRow ?? null,
             staticAnalysisTool: self::getStaticAnalysisTool($rawConfig),
         );
     }

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -260,6 +260,8 @@ final class Container extends DIContainer
 
     public const null DEFAULT_THREAD_COUNT = null;
 
+    public const null DEFAULT_DOTS_PER_ROW = null;
+
     public const bool DEFAULT_DRY_RUN = false;
 
     public const null DEFAULT_MAP_SOURCE_CLASS_TO_TEST_STRATEGY = null;
@@ -701,6 +703,7 @@ final class Container extends DIContainer
         ?string $staticAnalysisToolOptions = self::DEFAULT_STATIC_ANALYSIS_TOOL_OPTIONS,
         PlainFilter|IncompleteGitDiffFilter|null $sourceFilter = null,
         ?int $threadCount = self::DEFAULT_THREAD_COUNT,
+        string|int|null $dotsPerRow = self::DEFAULT_DOTS_PER_ROW,
         bool $dryRun = self::DEFAULT_DRY_RUN,
         ?bool $useGitHubLogger = self::DEFAULT_USE_GITHUB_LOGGER,
         ?string $gitlabLogFilePath = self::DEFAULT_GITLAB_LOGGER_PATH,
@@ -749,7 +752,10 @@ final class Container extends DIContainer
 
         $clone->offsetSet(
             MutationAnalysisLogger::class,
-            static fn (self $container): MutationAnalysisLogger => $container->getMutationAnalysisLoggerFactory()->create($loggerName),
+            static fn (self $container): MutationAnalysisLogger => $container->getMutationAnalysisLoggerFactory()->create(
+                $loggerName,
+                $container->getConfiguration()->dotsPerRow,
+            ),
         );
 
         $clone->offsetSet(
@@ -780,6 +786,7 @@ final class Container extends DIContainer
                 staticAnalysisToolOptions: $staticAnalysisToolOptions,
                 sourceFilter: $sourceFilter,
                 threadCount: $threadCount,
+                dotsPerRow: $dotsPerRow,
                 dryRun: $dryRun,
                 useGitHubLogger: $useGitHubLogger,
                 gitlabLogFilePath: $gitlabLogFilePath,

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -676,6 +676,7 @@ final class Container extends DIContainer
     /**
      * @param non-empty-string|null $configFile
      * @param non-empty-string|null $projectDirectory Absolute path.
+     * @param positive-int|'max'|null $dotsPerRow
      */
     public function withValues(
         LoggerInterface $logger,

--- a/src/Logger/MutationAnalysis/ConsoleDotLogger.php
+++ b/src/Logger/MutationAnalysis/ConsoleDotLogger.php
@@ -39,11 +39,15 @@ use Infection\Framework\Iterable\IterableCounter;
 use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutation\Mutation;
+use function is_string;
+use function max;
+use function min;
 use Override;
 use function sprintf;
 use function str_repeat;
 use function strlen;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
 use Webmozart\Assert\Assert;
 
 /**
@@ -51,13 +55,34 @@ use Webmozart\Assert\Assert;
  */
 final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
 {
-    private const int DOTS_PER_ROW = 50;
+    public const int DEFAULT_DOTS_PER_ROW = 50;
+
+    private const int UNKNOWN_COUNT_SUFFIX_LENGTH = 10;
+
+    /**
+     * Fixed characters in the known-count row suffix `   (<n> / <total>)`:
+     * three spaces, parens, slash with surrounding spaces. The `<n>` and
+     * `<total>` widths are added on top of this.
+     */
+    private const int KNOWN_COUNT_SUFFIX_FIXED_LENGTH = 8;
 
     private ?int $mutationCount = null;
 
+    private int $dotsPerRow = self::DEFAULT_DOTS_PER_ROW;
+
+    /**
+     * @param int|'max' $dotsPerRowSetting
+     */
     public function __construct(
         private readonly OutputInterface $output,
+        private readonly int|string $dotsPerRowSetting = self::DEFAULT_DOTS_PER_ROW,
+        private readonly ?Terminal $terminal = null,
     ) {
+        if (is_string($dotsPerRowSetting)) {
+            Assert::same($dotsPerRowSetting, 'max');
+        } else {
+            Assert::greaterThanEq($dotsPerRowSetting, 1);
+        }
     }
 
     #[Override]
@@ -66,6 +91,7 @@ final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
         parent::startAnalysis($mutationCount);
 
         $this->mutationCount = $mutationCount;
+        $this->dotsPerRow = $this->resolveDotsPerRow($mutationCount);
 
         $this->output->writeln([
             '',
@@ -100,12 +126,12 @@ final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
             self::getCharacter($executionResult),
         );
 
-        $remainder = $this->callsCount % self::DOTS_PER_ROW;
+        $remainder = $this->callsCount % $this->dotsPerRow;
         $endOfRow = $remainder === 0;
         $lastDot = $mutationCount === $this->callsCount;
 
         if ($lastDot && !$endOfRow) {
-            $this->output->write(str_repeat(' ', self::DOTS_PER_ROW - $remainder));
+            $this->output->write(str_repeat(' ', $this->dotsPerRow - $remainder));
         }
 
         if ($lastDot || $endOfRow) {
@@ -122,6 +148,33 @@ final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
                 $this->output->writeln('');
             }
         }
+    }
+
+    private function resolveDotsPerRow(int $mutationCount): int
+    {
+        if (!is_string($this->dotsPerRowSetting)) {
+            return $this->dotsPerRowSetting;
+        }
+
+        $terminalWidth = ($this->terminal ?? new Terminal())->getWidth();
+        $resolved = max(1, $terminalWidth - self::suffixLength($mutationCount));
+
+        if ($mutationCount === IterableCounter::UNKNOWN_COUNT) {
+            return $resolved;
+        }
+
+        return min($resolved, $mutationCount);
+    }
+
+    private static function suffixLength(int $mutationCount): int
+    {
+        if ($mutationCount === IterableCounter::UNKNOWN_COUNT) {
+            return self::UNKNOWN_COUNT_SUFFIX_LENGTH;
+        }
+
+        $countWidth = strlen((string) $mutationCount);
+
+        return self::KNOWN_COUNT_SUFFIX_FIXED_LENGTH + $countWidth + $countWidth;
     }
 
     private static function getCharacter(MutantExecutionResult $executionResult): string

--- a/src/Logger/MutationAnalysis/ConsoleDotLogger.php
+++ b/src/Logger/MutationAnalysis/ConsoleDotLogger.php
@@ -39,7 +39,7 @@ use Infection\Framework\Iterable\IterableCounter;
 use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutation\Mutation;
-use function is_string;
+use function is_int;
 use function max;
 use function min;
 use Override;
@@ -55,34 +55,23 @@ use Webmozart\Assert\Assert;
  */
 final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
 {
-    public const int DEFAULT_DOTS_PER_ROW = 50;
-
-    private const int UNKNOWN_COUNT_SUFFIX_LENGTH = 10;
+    private const int SUFFIX_FIXED_LENGTH = 8;
 
     /**
-     * Fixed characters in the known-count row suffix `   (<n> / <total>)`:
-     * three spaces, parens, slash with surrounding spaces. The `<n>` and
-     * `<total>` widths are added on top of this.
+     * @var positive-int|IterableCounter::UNKNOWN_COUNT|null
      */
-    private const int KNOWN_COUNT_SUFFIX_FIXED_LENGTH = 8;
-
     private ?int $mutationCount = null;
 
-    private int $dotsPerRow = self::DEFAULT_DOTS_PER_ROW;
+    private ?int $resolvedDotsPerRow = null;
 
     /**
-     * @param int|'max' $dotsPerRowSetting
+     * @param positive-int|'max' $dotsPerRow
      */
     public function __construct(
         private readonly OutputInterface $output,
-        private readonly int|string $dotsPerRowSetting = self::DEFAULT_DOTS_PER_ROW,
-        private readonly ?Terminal $terminal = null,
+        private readonly int|string $dotsPerRow,
+        private readonly Terminal $terminal,
     ) {
-        if (is_string($dotsPerRowSetting)) {
-            Assert::same($dotsPerRowSetting, 'max');
-        } else {
-            Assert::greaterThanEq($dotsPerRowSetting, 1);
-        }
     }
 
     #[Override]
@@ -91,7 +80,7 @@ final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
         parent::startAnalysis($mutationCount);
 
         $this->mutationCount = $mutationCount;
-        $this->dotsPerRow = $this->resolveDotsPerRow($mutationCount);
+        $this->resolvedDotsPerRow = null;
 
         $this->output->writeln([
             '',
@@ -126,12 +115,13 @@ final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
             self::getCharacter($executionResult),
         );
 
-        $remainder = $this->callsCount % $this->dotsPerRow;
+        $dotsPerRow = $this->getDotsPerRow();
+        $remainder = $this->callsCount % $dotsPerRow;
         $endOfRow = $remainder === 0;
         $lastDot = $mutationCount === $this->callsCount;
 
         if ($lastDot && !$endOfRow) {
-            $this->output->write(str_repeat(' ', $this->dotsPerRow - $remainder));
+            $this->output->write(str_repeat(' ', $dotsPerRow - $remainder));
         }
 
         if ($lastDot || $endOfRow) {
@@ -150,14 +140,27 @@ final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
         }
     }
 
-    private function resolveDotsPerRow(int $mutationCount): int
+    private function getDotsPerRow(): int
     {
-        if (!is_string($this->dotsPerRowSetting)) {
-            return $this->dotsPerRowSetting;
+        if ($this->resolvedDotsPerRow !== null) {
+            return $this->resolvedDotsPerRow;
         }
 
-        $terminalWidth = ($this->terminal ?? new Terminal())->getWidth();
-        $resolved = max(1, $terminalWidth - self::suffixLength($mutationCount));
+        Assert::notNull($this->mutationCount);
+
+        return $this->resolvedDotsPerRow = $this->resolveDotsPerRow($this->mutationCount);
+    }
+
+    /**
+     * @param positive-int|IterableCounter::UNKNOWN_COUNT $mutationCount
+     */
+    private function resolveDotsPerRow(int $mutationCount): int
+    {
+        if (is_int($this->dotsPerRow)) {
+            return $this->dotsPerRow;
+        }
+
+        $resolved = max(1, $this->terminal->getWidth() - self::suffixLength($mutationCount));
 
         if ($mutationCount === IterableCounter::UNKNOWN_COUNT) {
             return $resolved;
@@ -166,15 +169,14 @@ final class ConsoleDotLogger extends AbstractMutationAnalysisLogger
         return min($resolved, $mutationCount);
     }
 
+    /**
+     * @param positive-int|IterableCounter::UNKNOWN_COUNT $mutationCount
+     */
     private static function suffixLength(int $mutationCount): int
     {
-        if ($mutationCount === IterableCounter::UNKNOWN_COUNT) {
-            return self::UNKNOWN_COUNT_SUFFIX_LENGTH;
-        }
-
         $countWidth = strlen((string) $mutationCount);
 
-        return self::KNOWN_COUNT_SUFFIX_FIXED_LENGTH + $countWidth + $countWidth;
+        return self::SUFFIX_FIXED_LENGTH + $countWidth + $countWidth;
     }
 
     private static function getCharacter(MutantExecutionResult $executionResult): string

--- a/src/Logger/MutationAnalysis/MutationAnalysisLoggerFactory.php
+++ b/src/Logger/MutationAnalysis/MutationAnalysisLoggerFactory.php
@@ -42,6 +42,7 @@ use Infection\Logger\MutationAnalysis\TeamCity\TeamCityLogger;
 use Infection\Logger\MutationAnalysis\TeamCity\TeamCityLoggerState;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
 
 /**
  * @internal
@@ -60,13 +61,13 @@ final readonly class MutationAnalysisLoggerFactory
      */
     public function create(
         MutationAnalysisLoggerName $name,
-        int|string $dotsPerRow = ConsoleDotLogger::DEFAULT_DOTS_PER_ROW,
+        int|string $dotsPerRow,
     ): MutationAnalysisLogger {
         return match ($name) {
             MutationAnalysisLoggerName::PROGRESS => new ConsoleProgressBarLogger(
                 new ProgressBar($this->output),
             ),
-            MutationAnalysisLoggerName::DOT => new ConsoleDotLogger($this->output, $dotsPerRow),
+            MutationAnalysisLoggerName::DOT => new ConsoleDotLogger($this->output, $dotsPerRow, new Terminal()),
             MutationAnalysisLoggerName::TEAMCITY => new TeamCityLogger(
                 $this->teamCity,
                 new TeamCityLoggerState(),

--- a/src/Logger/MutationAnalysis/MutationAnalysisLoggerFactory.php
+++ b/src/Logger/MutationAnalysis/MutationAnalysisLoggerFactory.php
@@ -55,13 +55,18 @@ final readonly class MutationAnalysisLoggerFactory
     ) {
     }
 
-    public function create(MutationAnalysisLoggerName $name): MutationAnalysisLogger
-    {
+    /**
+     * @param positive-int|'max' $dotsPerRow
+     */
+    public function create(
+        MutationAnalysisLoggerName $name,
+        int|string $dotsPerRow = ConsoleDotLogger::DEFAULT_DOTS_PER_ROW,
+    ): MutationAnalysisLogger {
         return match ($name) {
             MutationAnalysisLoggerName::PROGRESS => new ConsoleProgressBarLogger(
                 new ProgressBar($this->output),
             ),
-            MutationAnalysisLoggerName::DOT => new ConsoleDotLogger($this->output),
+            MutationAnalysisLoggerName::DOT => new ConsoleDotLogger($this->output, $dotsPerRow),
             MutationAnalysisLoggerName::TEAMCITY => new TeamCityLogger(
                 $this->teamCity,
                 new TeamCityLoggerState(),

--- a/tests/phpunit/Command/RunCommandHelperTest.php
+++ b/tests/phpunit/Command/RunCommandHelperTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Command;
 use Infection\Command\RunCommand;
 use Infection\Command\RunCommandHelper;
 use Infection\Container\Container;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -96,11 +97,8 @@ final class RunCommandHelperTest extends TestCase
         yield [5, '5'];
     }
 
-    /**
-     * @param int|'max'|null $expected
-     */
     #[DataProvider('providesDotsPerRow')]
-    public function test_dots_per_row_from_option(string|int|null $expected, mixed $optionValue): void
+    public function test_dots_per_row_from_option(string|int|InvalidArgumentException|null $expected, mixed $optionValue): void
     {
         $this->inputMock->expects($this->once())
             ->method('getOption')
@@ -108,12 +106,18 @@ final class RunCommandHelperTest extends TestCase
             ->willReturn($optionValue);
 
         $commandHelper = new RunCommandHelper($this->inputMock);
-        $this->assertSame($expected, $commandHelper->getDotsPerRow());
+
+        if ($expected instanceof InvalidArgumentException) {
+            $this->expectExceptionObject($expected);
+        }
+
+        $actual = $commandHelper->getDotsPerRow();
+
+        if (!$expected instanceof InvalidArgumentException) {
+            $this->assertSame($expected, $actual);
+        }
     }
 
-    /**
-     * @return iterable<string, array{0: int|'max'|null, 1: string|null}>
-     */
     public static function providesDotsPerRow(): iterable
     {
         yield 'not provided' => [null, null];
@@ -121,6 +125,26 @@ final class RunCommandHelperTest extends TestCase
         yield 'provided as numeric string' => [20, '20'];
 
         yield 'provided as max' => ['max', 'max'];
+
+        yield 'provided as negative integer string' => [
+            new InvalidArgumentException('The value of option `--dots-per-row` must be a positive integer or string "max". "-1" provided.'),
+            '-1',
+        ];
+
+        yield 'provided as float string' => [
+            new InvalidArgumentException('The value of option `--dots-per-row` must be a positive integer or string "max". "1.5" provided.'),
+            '1.5',
+        ];
+
+        yield 'provided as random string' => [
+            new InvalidArgumentException('The value of option `--dots-per-row` must be a positive integer or string "max". "foo" provided.'),
+            'foo',
+        ];
+
+        yield 'provided as empty string' => [
+            new InvalidArgumentException('The value of option `--dots-per-row` must be a positive integer or string "max". "" provided.'),
+            '',
+        ];
     }
 
     #[DataProvider('providesNumberOfShownMutations')]

--- a/tests/phpunit/Command/RunCommandHelperTest.php
+++ b/tests/phpunit/Command/RunCommandHelperTest.php
@@ -96,6 +96,33 @@ final class RunCommandHelperTest extends TestCase
         yield [5, '5'];
     }
 
+    /**
+     * @param int|'max'|null $expected
+     */
+    #[DataProvider('providesDotsPerRow')]
+    public function test_dots_per_row_from_option(string|int|null $expected, mixed $optionValue): void
+    {
+        $this->inputMock->expects($this->once())
+            ->method('getOption')
+            ->with(RunCommand::OPTION_DOTS_PER_ROW)
+            ->willReturn($optionValue);
+
+        $commandHelper = new RunCommandHelper($this->inputMock);
+        $this->assertSame($expected, $commandHelper->getDotsPerRow());
+    }
+
+    /**
+     * @return iterable<string, array{0: int|'max'|null, 1: string|null}>
+     */
+    public static function providesDotsPerRow(): iterable
+    {
+        yield 'not provided' => [null, null];
+
+        yield 'provided as numeric string' => [20, '20'];
+
+        yield 'provided as max' => ['max', 'max'];
+    }
+
     #[DataProvider('providesNumberOfShownMutations')]
     public function test_it_returns_number_of_shown_mutations(?int $expected, mixed $optionValue): void
     {

--- a/tests/phpunit/Configuration/ConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/ConfigurationBuilder.php
@@ -61,6 +61,7 @@ final class ConfigurationBuilder
     /**
      * @param array<string, Mutator<Node>> $mutators
      * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
+     * @param positive-int|'max' $dotsPerRow
      * @param non-empty-string $configPathname
      * @param non-empty-string $projectDirectory
      */
@@ -94,6 +95,7 @@ final class ConfigurationBuilder
         private ?int $maxTimeouts,
         private int $msiPrecision,
         private int $threadCount,
+        private int|string $dotsPerRow,
         private bool $dryRun,
         private array $ignoreSourceCodeMutatorsMap,
         private bool $executeOnlyCoveringTestCases,
@@ -139,6 +141,7 @@ final class ConfigurationBuilder
             maxTimeouts: $configuration->maxTimeouts,
             msiPrecision: $configuration->msiPrecision,
             threadCount: $configuration->threadCount,
+            dotsPerRow: $configuration->dotsPerRow,
             dryRun: $configuration->isDryRun,
             ignoreSourceCodeMutatorsMap: $configuration->ignoreSourceCodeMutatorsMap,
             executeOnlyCoveringTestCases: $configuration->executeOnlyCoveringTestCases,
@@ -182,6 +185,7 @@ final class ConfigurationBuilder
             maxTimeouts: null,
             msiPrecision: 2,
             threadCount: 1,
+            dotsPerRow: 50,
             dryRun: false,
             ignoreSourceCodeMutatorsMap: [],
             executeOnlyCoveringTestCases: false,
@@ -247,6 +251,7 @@ final class ConfigurationBuilder
             maxTimeouts: 5,
             msiPrecision: 2,
             threadCount: 4,
+            dotsPerRow: 80,
             dryRun: true,
             ignoreSourceCodeMutatorsMap: [
                 'Foo\\Bar' => ['.*test.*'],
@@ -523,6 +528,17 @@ final class ConfigurationBuilder
         return $clone;
     }
 
+    /**
+     * @param positive-int|'max' $dotsPerRow
+     */
+    public function withDotsPerRow(int|string $dotsPerRow): self
+    {
+        $clone = clone $this;
+        $clone->dotsPerRow = $dotsPerRow;
+
+        return $clone;
+    }
+
     public function withDryRun(bool $dryRun): self
     {
         $clone = clone $this;
@@ -628,6 +644,7 @@ final class ConfigurationBuilder
             maxTimeouts: $this->maxTimeouts,
             msiPrecision: $this->msiPrecision,
             threadCount: $this->threadCount,
+            dotsPerRow: $this->dotsPerRow,
             isDryRun: $this->dryRun,
             ignoreSourceCodeMutatorsMap: $this->ignoreSourceCodeMutatorsMap,
             executeOnlyCoveringTestCases: $this->executeOnlyCoveringTestCases,

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryInputBuilder.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryInputBuilder.php
@@ -43,6 +43,7 @@ final class ConfigurationFactoryInputBuilder
 {
     /**
      * @param non-empty-string|null $projectDirectory
+     * @param positive-int|'max'|null $dotsPerRow
      */
     public function __construct(
         private ?string $existingCoveragePath,
@@ -65,6 +66,7 @@ final class ConfigurationFactoryInputBuilder
         private ?string $staticAnalysisToolOptions,
         private PlainFilter|IncompleteGitDiffFilter|null $sourceFilter,
         private ?int $threadCount,
+        private string|int|null $dotsPerRow,
         private bool $dryRun,
         private ?bool $useGitHubLogger,
         private ?string $gitlabLogFilePath,
@@ -240,6 +242,17 @@ final class ConfigurationFactoryInputBuilder
         return $clone;
     }
 
+    /**
+     * @param positive-int|'max'|null $dotsPerRow
+     */
+    public function withDotsPerRow(string|int|null $dotsPerRow): self
+    {
+        $clone = clone $this;
+        $clone->dotsPerRow = $dotsPerRow;
+
+        return $clone;
+    }
+
     public function withDryRun(bool $dryRun): self
     {
         $clone = clone $this;
@@ -362,18 +375,19 @@ final class ConfigurationFactoryInputBuilder
      *     18: string|null,
      *     19: PlainFilter|IncompleteGitDiffFilter|null,
      *     20: int|null,
-     *     21: bool,
-     *     22: bool|null,
-     *     23: string|null,
+     *     21: positive-int|'max'|null,
+     *     22: bool,
+     *     23: bool|null,
      *     24: string|null,
      *     25: string|null,
      *     26: string|null,
-     *     27: bool,
+     *     27: string|null,
      *     28: bool,
-     *     29: string|null,
-     *     30: non-empty-string|null,
-     *     31: string|null,
-     *     32: string|null
+     *     29: bool,
+     *     30: string|null,
+     *     31: non-empty-string|null,
+     *     32: string|null,
+     *     33: string|null
      * }
      */
     public function build(SchemaConfiguration $schema): array
@@ -400,6 +414,7 @@ final class ConfigurationFactoryInputBuilder
             $this->staticAnalysisToolOptions,
             $this->sourceFilter,
             $this->threadCount,
+            $this->dotsPerRow,
             $this->dryRun,
             $this->useGitHubLogger,
             $this->gitlabLogFilePath,

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryScenario.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryScenario.php
@@ -420,6 +420,35 @@ final class ConfigurationFactoryScenario
             );
     }
 
+    /**
+     * @param positive-int|'max'|null $dotsPerRowFromSchemaConfiguration
+     * @param positive-int|'max'|null $dotsPerRowFromInput
+     * @param positive-int|'max' $expectedDotsPerRow
+     */
+    public function forValueForDotsPerRow(
+        string|int|null $dotsPerRowFromSchemaConfiguration,
+        string|int|null $dotsPerRowFromInput,
+        string|int $expectedDotsPerRow,
+    ): self {
+        $previousExpected = $this->expected;
+        Assert::isInstanceOf($previousExpected, Configuration::class);
+
+        return $this
+            ->withSchema(
+                $this->schemaBuilder
+                    ->withDotsPerRow($dotsPerRowFromSchemaConfiguration),
+            )
+            ->withInput(
+                $this->inputBuilder
+                    ->withDotsPerRow($dotsPerRowFromInput),
+            )
+            ->withExpected(
+                ConfigurationBuilder::from($previousExpected)
+                    ->withDotsPerRow($expectedDotsPerRow)
+                    ->build(),
+            );
+    }
+
     public function forValueForMinCoveredMsi(
         ?float $minCoveredMsiFromSchemaConfiguration,
         ?float $minCoveredMsiFromInput,

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -143,6 +143,7 @@ final class ConfigurationFactoryTest extends TestCase
             testFrameworkExtraOptions: null,
             staticAnalysisToolOptions: null,
             threads: null,
+            dotsPerRow: null,
             staticAnalysisTool: StaticAnalysisToolTypes::PHPSTAN,
         );
 
@@ -176,6 +177,7 @@ final class ConfigurationFactoryTest extends TestCase
                 staticAnalysisToolOptions: null,
                 sourceFilter: null,
                 threadCount: 0,
+                dotsPerRow: null,
                 dryRun: false,
                 useGitHubLogger: false,
                 gitlabLogFilePath: null,
@@ -219,6 +221,7 @@ final class ConfigurationFactoryTest extends TestCase
             testFrameworkExtraOptions: null,
             staticAnalysisToolOptions: null,
             threads: null,
+            dotsPerRow: null,
             staticAnalysisTool: null,
         );
         $defaultSchemaBuilder = SchemaConfigurationBuilder::from($defaultSchema);
@@ -244,6 +247,7 @@ final class ConfigurationFactoryTest extends TestCase
             staticAnalysisToolOptions: null,
             sourceFilter: new IncompleteGitDiffFilter('AM', 'master'),
             threadCount: 1,
+            dotsPerRow: null,
             dryRun: false,
             useGitHubLogger: true,
             gitlabLogFilePath: null,
@@ -288,6 +292,7 @@ final class ConfigurationFactoryTest extends TestCase
             maxTimeouts: null,
             msiPrecision: 2,
             threadCount: 1,
+            dotsPerRow: 50,
             isDryRun: false,
             ignoreSourceCodeMutatorsMap: [],
             executeOnlyCoveringTestCases: true,
@@ -704,6 +709,46 @@ final class ConfigurationFactoryTest extends TestCase
                 33.3,
                 21.2,
                 21.2,
+            ),
+        ];
+
+        yield 'dotsPerRow not specified in schema and not specified in input' => [
+            $defaultScenario->forValueForDotsPerRow(
+                null,
+                null,
+                50,
+            ),
+        ];
+
+        yield 'dotsPerRow specified in schema and not specified in input' => [
+            $defaultScenario->forValueForDotsPerRow(
+                80,
+                null,
+                80,
+            ),
+        ];
+
+        yield 'dotsPerRow not specified in schema and specified in input' => [
+            $defaultScenario->forValueForDotsPerRow(
+                null,
+                20,
+                20,
+            ),
+        ];
+
+        yield 'dotsPerRow specified in schema and specified in input' => [
+            $defaultScenario->forValueForDotsPerRow(
+                80,
+                20,
+                20,
+            ),
+        ];
+
+        yield 'dotsPerRow set to max in schema' => [
+            $defaultScenario->forValueForDotsPerRow(
+                'max',
+                null,
+                'max',
             ),
         ];
 
@@ -1266,6 +1311,7 @@ final class ConfigurationFactoryTest extends TestCase
                         'src/Bar.php',
                     ]),
                     threadCount: 4,
+                    dotsPerRow: null,
                     dryRun: true,
                     useGitHubLogger: false,
                     gitlabLogFilePath: null,

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationBuilder.php
@@ -51,6 +51,7 @@ final class SchemaConfigurationBuilder
      * @param non-empty-string $pathname
      * @param array<string, mixed> $mutators
      * @param TestFrameworkTypes::*|null $testFramework
+     * @param positive-int|'max'|null $dotsPerRow
      * @param StaticAnalysisToolTypes::*|null $staticAnalysisTool
      */
     private function __construct(
@@ -343,6 +344,9 @@ final class SchemaConfigurationBuilder
         return $clone;
     }
 
+    /**
+     * @param positive-int|'max'|null $dotsPerRow
+     */
     public function withDotsPerRow(string|int|null $dotsPerRow): self
     {
         $clone = clone $this;

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationBuilder.php
@@ -74,6 +74,7 @@ final class SchemaConfigurationBuilder
         private ?string $testFrameworkExtraOptions,
         private ?string $staticAnalysisToolOptions,
         private string|int|null $threads,
+        private string|int|null $dotsPerRow,
         private ?string $staticAnalysisTool,
     ) {
     }
@@ -101,6 +102,7 @@ final class SchemaConfigurationBuilder
             testFrameworkExtraOptions: $schema->testFrameworkExtraOptions,
             staticAnalysisToolOptions: $schema->staticAnalysisToolOptions,
             threads: $schema->threads,
+            dotsPerRow: $schema->dotsPerRow,
             staticAnalysisTool: $schema->staticAnalysisTool,
         );
     }
@@ -128,6 +130,7 @@ final class SchemaConfigurationBuilder
             testFrameworkExtraOptions: null,
             staticAnalysisToolOptions: null,
             threads: null,
+            dotsPerRow: null,
             staticAnalysisTool: null,
         );
     }
@@ -166,6 +169,7 @@ final class SchemaConfigurationBuilder
             testFrameworkExtraOptions: '--verbose',
             staticAnalysisToolOptions: '--level=max',
             threads: 4,
+            dotsPerRow: 80,
             staticAnalysisTool: StaticAnalysisToolTypes::PHPSTAN,
         );
     }
@@ -339,6 +343,14 @@ final class SchemaConfigurationBuilder
         return $clone;
     }
 
+    public function withDotsPerRow(string|int|null $dotsPerRow): self
+    {
+        $clone = clone $this;
+        $clone->dotsPerRow = $dotsPerRow;
+
+        return $clone;
+    }
+
     /**
      * @param StaticAnalysisToolTypes::*|null $staticAnalysisTool
      */
@@ -373,6 +385,7 @@ final class SchemaConfigurationBuilder
             testFrameworkExtraOptions: $this->testFrameworkExtraOptions,
             staticAnalysisToolOptions: $this->staticAnalysisToolOptions,
             threads: $this->threads,
+            dotsPerRow: $this->dotsPerRow,
             staticAnalysisTool: $this->staticAnalysisTool,
         );
     }

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -2727,6 +2727,7 @@ final class SchemaConfigurationFactoryTest extends TestCase
             'testFrameworkOptions' => null,
             'staticAnalysisToolOptions' => null,
             'threadCount' => null,
+            'dotsPerRow' => null,
             'staticAnalysisTool' => null,
         ];
 

--- a/tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php
@@ -55,10 +55,14 @@ final class ConsoleDotLoggerTest extends TestCase
 {
     private const int ANY_PRIME_NUMBER = 127;
 
+    private const int DEFAULT_DOTS_PER_ROW = 50;
+
+    private const int ANY_TERMINAL_WIDTH = 80;
+
     public function test_begins_by_displaying_a_legend(): void
     {
         $output = new BufferedOutput();
-        $logger = new ConsoleDotLogger($output);
+        $logger = new ConsoleDotLogger($output, self::DEFAULT_DOTS_PER_ROW, $this->createTerminal(self::ANY_TERMINAL_WIDTH));
 
         $expected = Str::toSystemLineEndings(
             implode(
@@ -103,7 +107,7 @@ final class ConsoleDotLoggerTest extends TestCase
         string $expected,
     ): void {
         $output = new BufferedOutput();
-        $logger = new ConsoleDotLogger($output);
+        $logger = new ConsoleDotLogger($output, self::DEFAULT_DOTS_PER_ROW, $this->createTerminal(self::ANY_TERMINAL_WIDTH));
 
         // Clear the initial output: it is already tested and it would bloat the
         // test to include it.
@@ -171,12 +175,20 @@ final class ConsoleDotLoggerTest extends TestCase
         $bucket->assertIsEmpty();
     }
 
-    public function test_it_prints_total_number_of_mutations(): void
-    {
-        $totalMutations = self::ANY_PRIME_NUMBER;
-
+    /**
+     * @param positive-int $totalMutations
+     * @param positive-int|'max' $dotsPerRowSetting
+     * @param positive-int $terminalWidth
+     */
+    #[DataProvider('totalMutationsProvider')]
+    public function test_it_prints_total_number_of_mutations(
+        int $totalMutations,
+        string|int $dotsPerRowSetting,
+        int $terminalWidth,
+        string $expected,
+    ): void {
         $output = new BufferedOutput();
-        $logger = new ConsoleDotLogger($output);
+        $logger = new ConsoleDotLogger($output, $dotsPerRowSetting, $this->createTerminal($terminalWidth));
         $logger->startAnalysis($totalMutations);
 
         for ($i = 0; $i < $totalMutations; ++$i) {
@@ -185,7 +197,17 @@ final class ConsoleDotLoggerTest extends TestCase
             );
         }
 
-        $expected = Str::toSystemLineEndings(
+        $actual = strip_tags($output->fetch());
+
+        $this->assertSame(Str::toSystemLineEndings($expected), $actual);
+    }
+
+    public static function totalMutationsProvider(): iterable
+    {
+        yield 'default 50 dots per row' => [
+            self::ANY_PRIME_NUMBER,
+            self::DEFAULT_DOTS_PER_ROW,
+            self::ANY_TERMINAL_WIDTH,
             <<<'TXT'
 
                 .: killed by tests, A: killed by SA, M: escaped, U: uncovered
@@ -195,59 +217,12 @@ final class ConsoleDotLoggerTest extends TestCase
                 ..................................................   (100 / 127)
                 ...........................                          (127 / 127)
                 TXT,
-        );
+        ];
 
-        $actual = strip_tags($output->fetch());
-
-        $this->assertSame($expected, $actual);
-    }
-
-    public function test_it_prints_current_number_of_processed_mutations_when_the_total_number_is_not_known(): void
-    {
-        $totalMutations = self::ANY_PRIME_NUMBER;
-
-        $output = new BufferedOutput();
-        $logger = new ConsoleDotLogger($output);
-        $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
-
-        for ($i = 0; $i < $totalMutations; ++$i) {
-            $logger->finishEvaluation(
-                $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
-            );
-        }
-
-        $expected = Str::toSystemLineEndings(
-            <<<'TXT'
-
-                .: killed by tests, A: killed by SA, M: escaped, U: uncovered
-                E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
-
-                ..................................................   (   50)
-                ..................................................   (  100)
-                ...........................
-                TXT,
-        );
-
-        $actual = strip_tags($output->fetch());
-
-        $this->assertSame($expected, $actual);
-    }
-
-    public function test_it_honors_a_custom_dots_per_row(): void
-    {
-        $totalMutations = 23;
-
-        $output = new BufferedOutput();
-        $logger = new ConsoleDotLogger($output, dotsPerRowSetting: 10);
-        $logger->startAnalysis($totalMutations);
-
-        for ($i = 0; $i < $totalMutations; ++$i) {
-            $logger->finishEvaluation(
-                $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
-            );
-        }
-
-        $expected = Str::toSystemLineEndings(
+        yield 'custom 10 dots per row' => [
+            23,
+            10,
+            self::ANY_TERMINAL_WIDTH,
             <<<'TXT'
 
                 .: killed by tests, A: killed by SA, M: escaped, U: uncovered
@@ -257,34 +232,14 @@ final class ConsoleDotLoggerTest extends TestCase
                 ..........   (20 / 23)
                 ...          (23 / 23)
                 TXT,
-        );
+        ];
 
-        $actual = strip_tags($output->fetch());
-
-        $this->assertSame($expected, $actual);
-    }
-
-    public function test_it_resolves_max_to_terminal_width_minus_suffix(): void
-    {
         // With a 30-column terminal and a 2-digit total, the (NN / NN) suffix
         // takes 12 characters, leaving 18 columns for dots.
-        $totalMutations = 25;
-
-        $output = new BufferedOutput();
-        $logger = new ConsoleDotLogger(
-            $output,
-            dotsPerRowSetting: 'max',
-            terminal: $this->terminalWithWidth(30),
-        );
-        $logger->startAnalysis($totalMutations);
-
-        for ($i = 0; $i < $totalMutations; ++$i) {
-            $logger->finishEvaluation(
-                $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
-            );
-        }
-
-        $expected = Str::toSystemLineEndings(
+        yield 'max fits the terminal width minus the suffix' => [
+            25,
+            'max',
+            30,
             <<<'TXT'
 
                 .: killed by tests, A: killed by SA, M: escaped, U: uncovered
@@ -293,34 +248,14 @@ final class ConsoleDotLoggerTest extends TestCase
                 ..................   (18 / 25)
                 .......              (25 / 25)
                 TXT,
-        );
+        ];
 
-        $actual = strip_tags($output->fetch());
-
-        $this->assertSame($expected, $actual);
-    }
-
-    public function test_it_falls_back_to_one_dot_per_row_when_the_terminal_is_narrower_than_the_suffix(): void
-    {
         // Width 5 is below the 10-character (n / total) suffix length for a
         // 1-digit total, so the resolved row width is floored at 1.
-        $totalMutations = 3;
-
-        $output = new BufferedOutput();
-        $logger = new ConsoleDotLogger(
-            $output,
-            dotsPerRowSetting: 'max',
-            terminal: $this->terminalWithWidth(5),
-        );
-        $logger->startAnalysis($totalMutations);
-
-        for ($i = 0; $i < $totalMutations; ++$i) {
-            $logger->finishEvaluation(
-                $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
-            );
-        }
-
-        $expected = Str::toSystemLineEndings(
+        yield 'max falls back to a single dot per row on very narrow terminals' => [
+            3,
+            'max',
+            5,
             <<<'TXT'
 
                 .: killed by tests, A: killed by SA, M: escaped, U: uncovered
@@ -330,32 +265,12 @@ final class ConsoleDotLoggerTest extends TestCase
                 .   (2 / 3)
                 .   (3 / 3)
                 TXT,
-        );
+        ];
 
-        $actual = strip_tags($output->fetch());
-
-        $this->assertSame($expected, $actual);
-    }
-
-    public function test_it_caps_max_at_the_total_mutation_count(): void
-    {
-        $totalMutations = 7;
-
-        $output = new BufferedOutput();
-        $logger = new ConsoleDotLogger(
-            $output,
-            dotsPerRowSetting: 'max',
-            terminal: $this->terminalWithWidth(500),
-        );
-        $logger->startAnalysis($totalMutations);
-
-        for ($i = 0; $i < $totalMutations; ++$i) {
-            $logger->finishEvaluation(
-                $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
-            );
-        }
-
-        $expected = Str::toSystemLineEndings(
+        yield 'max is capped at the total mutation count' => [
+            7,
+            'max',
+            500,
             <<<'TXT'
 
                 .: killed by tests, A: killed by SA, M: escaped, U: uncovered
@@ -363,11 +278,117 @@ final class ConsoleDotLoggerTest extends TestCase
 
                 .......   (7 / 7)
                 TXT,
-        );
+        ];
+    }
+
+    /**
+     * @param positive-int $evaluationsCount
+     * @param positive-int|'max' $dotsPerRowSetting
+     * @param positive-int $terminalWidth
+     */
+    #[DataProvider('unknownTotalProvider')]
+    public function test_it_prints_current_number_of_processed_mutations_when_the_total_number_is_not_known(
+        int $evaluationsCount,
+        string|int $dotsPerRowSetting,
+        int $terminalWidth,
+        string $expected,
+    ): void {
+        $output = new BufferedOutput();
+        $logger = new ConsoleDotLogger($output, $dotsPerRowSetting, $this->createTerminal($terminalWidth));
+        $logger->startAnalysis(IterableCounter::UNKNOWN_COUNT);
+
+        for ($i = 0; $i < $evaluationsCount; ++$i) {
+            $logger->finishEvaluation(
+                $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
+            );
+        }
 
         $actual = strip_tags($output->fetch());
 
-        $this->assertSame($expected, $actual);
+        $this->assertSame(Str::toSystemLineEndings($expected), $actual);
+    }
+
+    public static function unknownTotalProvider(): iterable
+    {
+        yield 'default 50 dots per row' => [
+            self::ANY_PRIME_NUMBER,
+            self::DEFAULT_DOTS_PER_ROW,
+            self::ANY_TERMINAL_WIDTH,
+            <<<'TXT'
+
+                .: killed by tests, A: killed by SA, M: escaped, U: uncovered
+                E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
+
+                ..................................................   (   50)
+                ..................................................   (  100)
+                ...........................
+                TXT,
+        ];
+
+        yield 'custom 10 dots per row' => [
+            23,
+            10,
+            self::ANY_TERMINAL_WIDTH,
+            <<<'TXT'
+
+                .: killed by tests, A: killed by SA, M: escaped, U: uncovered
+                E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
+
+                ..........   (   10)
+                ..........   (   20)
+                ...
+                TXT,
+        ];
+
+        // With a 30-column terminal and a 10-character (NNNNN) suffix, 20
+        // columns remain for dots.
+        yield 'max fits the terminal width minus the suffix' => [
+            25,
+            'max',
+            30,
+            <<<'TXT'
+
+                .: killed by tests, A: killed by SA, M: escaped, U: uncovered
+                E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
+
+                ....................   (   20)
+                .....
+                TXT,
+        ];
+
+        yield 'max falls back to a single dot per row on very narrow terminals' => [
+            3,
+            'max',
+            5,
+            <<<'TXT'
+
+                .: killed by tests, A: killed by SA, M: escaped, U: uncovered
+                E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
+
+                .   (    1)
+                .   (    2)
+                .   (    3)
+
+                TXT,
+        ];
+    }
+
+    public function test_max_setting_resolves_the_terminal_width_only_once(): void
+    {
+        $totalMutations = 5;
+
+        $terminal = $this->createMock(Terminal::class);
+        $terminal->expects($this->once())->method('getWidth')->willReturn(self::ANY_TERMINAL_WIDTH);
+
+        $output = new BufferedOutput();
+        $logger = new ConsoleDotLogger($output, 'max', $terminal);
+        $logger->startAnalysis($totalMutations);
+
+        for ($i = 0; $i < $totalMutations; ++$i) {
+            $logger->finishEvaluation(
+                $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
+            );
+        }
     }
 
     private function createMutantExecutionResultOfType(DetectionStatus $detectionStatus): MutantExecutionResult
@@ -377,7 +398,7 @@ final class ConsoleDotLoggerTest extends TestCase
             ->build();
     }
 
-    private function terminalWithWidth(int $width): Terminal
+    private function createTerminal(int $width): Terminal
     {
         $terminal = $this->createMock(Terminal::class);
         $terminal->method('getWidth')->willReturn($width);

--- a/tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php
@@ -48,6 +48,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use function strip_tags;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Terminal;
 
 #[CoversClass(ConsoleDotLogger::class)]
 final class ConsoleDotLoggerTest extends TestCase
@@ -232,10 +233,155 @@ final class ConsoleDotLoggerTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function test_it_honors_a_custom_dots_per_row(): void
+    {
+        $totalMutations = 23;
+
+        $output = new BufferedOutput();
+        $logger = new ConsoleDotLogger($output, dotsPerRowSetting: 10);
+        $logger->startAnalysis($totalMutations);
+
+        for ($i = 0; $i < $totalMutations; ++$i) {
+            $logger->finishEvaluation(
+                $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
+            );
+        }
+
+        $expected = Str::toSystemLineEndings(
+            <<<'TXT'
+
+                .: killed by tests, A: killed by SA, M: escaped, U: uncovered
+                E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
+
+                ..........   (10 / 23)
+                ..........   (20 / 23)
+                ...          (23 / 23)
+                TXT,
+        );
+
+        $actual = strip_tags($output->fetch());
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function test_it_resolves_max_to_terminal_width_minus_suffix(): void
+    {
+        // With a 30-column terminal and a 2-digit total, the (NN / NN) suffix
+        // takes 12 characters, leaving 18 columns for dots.
+        $totalMutations = 25;
+
+        $output = new BufferedOutput();
+        $logger = new ConsoleDotLogger(
+            $output,
+            dotsPerRowSetting: 'max',
+            terminal: $this->terminalWithWidth(30),
+        );
+        $logger->startAnalysis($totalMutations);
+
+        for ($i = 0; $i < $totalMutations; ++$i) {
+            $logger->finishEvaluation(
+                $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
+            );
+        }
+
+        $expected = Str::toSystemLineEndings(
+            <<<'TXT'
+
+                .: killed by tests, A: killed by SA, M: escaped, U: uncovered
+                E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
+
+                ..................   (18 / 25)
+                .......              (25 / 25)
+                TXT,
+        );
+
+        $actual = strip_tags($output->fetch());
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function test_it_falls_back_to_one_dot_per_row_when_the_terminal_is_narrower_than_the_suffix(): void
+    {
+        // Width 5 is below the 10-character (n / total) suffix length for a
+        // 1-digit total, so the resolved row width is floored at 1.
+        $totalMutations = 3;
+
+        $output = new BufferedOutput();
+        $logger = new ConsoleDotLogger(
+            $output,
+            dotsPerRowSetting: 'max',
+            terminal: $this->terminalWithWidth(5),
+        );
+        $logger->startAnalysis($totalMutations);
+
+        for ($i = 0; $i < $totalMutations; ++$i) {
+            $logger->finishEvaluation(
+                $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
+            );
+        }
+
+        $expected = Str::toSystemLineEndings(
+            <<<'TXT'
+
+                .: killed by tests, A: killed by SA, M: escaped, U: uncovered
+                E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
+
+                .   (1 / 3)
+                .   (2 / 3)
+                .   (3 / 3)
+                TXT,
+        );
+
+        $actual = strip_tags($output->fetch());
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function test_it_caps_max_at_the_total_mutation_count(): void
+    {
+        $totalMutations = 7;
+
+        $output = new BufferedOutput();
+        $logger = new ConsoleDotLogger(
+            $output,
+            dotsPerRowSetting: 'max',
+            terminal: $this->terminalWithWidth(500),
+        );
+        $logger->startAnalysis($totalMutations);
+
+        for ($i = 0; $i < $totalMutations; ++$i) {
+            $logger->finishEvaluation(
+                $this->createMutantExecutionResultOfType(DetectionStatus::KILLED_BY_TESTS),
+            );
+        }
+
+        $expected = Str::toSystemLineEndings(
+            <<<'TXT'
+
+                .: killed by tests, A: killed by SA, M: escaped, U: uncovered
+                E: fatal error, X: syntax error, T: timed out, S: skipped, I: ignored
+
+                .......   (7 / 7)
+                TXT,
+        );
+
+        $actual = strip_tags($output->fetch());
+
+        $this->assertSame($expected, $actual);
+    }
+
     private function createMutantExecutionResultOfType(DetectionStatus $detectionStatus): MutantExecutionResult
     {
         return MutantExecutionResultBuilder::withMinimalTestData()
             ->withDetectionStatus($detectionStatus)
             ->build();
+    }
+
+    private function terminalWithWidth(int $width): Terminal
+    {
+        $terminal = $this->createMock(Terminal::class);
+        $terminal->method('getWidth')->willReturn($width);
+
+        return $terminal;
     }
 }

--- a/tests/phpunit/Logger/MutationAnalysis/MutationAnalysisLoggerFactoryTest.php
+++ b/tests/phpunit/Logger/MutationAnalysis/MutationAnalysisLoggerFactoryTest.php
@@ -73,7 +73,7 @@ final class MutationAnalysisLoggerFactoryTest extends TestCase
             '/path/to/project/infection.json5',
         );
 
-        $logger = $factory->create($name);
+        $logger = $factory->create($name, 50);
 
         $this->assertInstanceOf($expectedFormatterClassName, $logger);
     }


### PR DESCRIPTION
## Description

Adds a new `dotsPerRow` option to the configuration schema and a matching `--dots-per-row` / `-r` CLI flag for the dot progress formatter. The default stays at 50, so existing users see no change. Set an explicit positive integer for a fixed width, or `"max"` to fit the terminal width.

`infection.json5`:

```json5
{
    "source": { "directories": ["src"] },
    "dotsPerRow": 80
}
```

CLI:

```bash
vendor/bin/infection --dots-per-row=max
vendor/bin/infection -r 20
```

## Reviewer Notes

The `int|"max"` setting is carried unresolved through `Configuration::$dotsPerRow` and resolved inside `ConsoleDotLogger::startAnalysis()` rather than at config build time. This is the only place where both the real terminal width and the mutation count are known, which the `"max"` semantics need; the resolved width subtracts the `   (n / total)` suffix so the counter still fits, and is capped at the total mutation count to avoid trailing whitespace on short runs.

The new `int|"max"` argument lives on `MutationAnalysisLoggerFactory::create()` rather than the constructor; the DI container's reflection-based autowiring rejects union types on factory constructors.

`Symfony\Component\Console\Terminal` is injected as an optional constructor argument on `ConsoleDotLogger` so tests can mock the terminal width.

## Related issues

Closes #3122.