### PR TITLE
test(ci): Run PHAR e2e jobs with the compiled artifact path

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -117,7 +117,7 @@ jobs:
           ls tests/e2e/*/composer.json | xargs dirname |
              xargs -I{} -P 4 $CHRONIC composer --working-dir={} install --no-interaction --prefer-dist --no-progress || true
 
-      - name: Run the Windows compatible subset of E2E tests
+      - name: Run a subset of E2E tests
         if: runner.os == 'Windows'
         shell: bash
         run: |

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -30,8 +30,8 @@ jobs:
         include:
           - { operating-system: 'ubuntu-latest', php-version: '8.3', composer: 'composer', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
           - { operating-system: 'ubuntu-latest', php-version: '8.3', composer: 'composer', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.3', composer: 'composer', coverage-driver: 'xdebug', e2e-runner: 'bin/infection.phar' }
-          - { operating-system: 'ubuntu-latest', php-version: '8.3', composer: 'composer', coverage-driver: 'pcov', e2e-runner: 'bin/infection.phar' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.3', composer: 'composer', coverage-driver: 'xdebug', e2e-runner: 'dist/infection.phar' }
+          - { operating-system: 'ubuntu-latest', php-version: '8.3', composer: 'composer', coverage-driver: 'pcov', e2e-runner: 'dist/infection.phar' }
           - { operating-system: 'ubuntu-latest', php-version: '8.4', composer: 'composer', coverage-driver: 'xdebug', e2e-runner: 'bin/infection' }
           - { operating-system: 'ubuntu-latest', php-version: '8.4', composer: 'composer', coverage-driver: 'pcov', e2e-runner: 'bin/infection' }
 
@@ -117,7 +117,7 @@ jobs:
           ls tests/e2e/*/composer.json | xargs dirname |
              xargs -I{} -P 4 $CHRONIC composer --working-dir={} install --no-interaction --prefer-dist --no-progress || true
 
-      - name: Run a subset of E2E tests
+      - name: Run the Windows compatible subset of E2E tests
         if: runner.os == 'Windows'
         shell: bash
         run: |


### PR DESCRIPTION
## Description

Fix the PHAR e2e CI matrix so the PHAR jobs actually match the workflow step that runs the full e2e suite.

The matrix was using `bin/infection.phar`, while the PHAR execution step is gated on `dist/infection.phar`. As a result, PHP PHAR jobs with either coverage driver could skip every e2e execution step.

The issue was introduced in #3068, my mistake.

## Changes

- Updates the PHP 8.3 PHAR matrix entries from `bin/infection.phar` to `dist/infection.phar`.
