### PR TITLE
ci: Break the e2e test step for the scoped PHAR

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -117,7 +117,7 @@ jobs:
           ls tests/e2e/*/composer.json | xargs dirname |
              xargs -I{} -P 4 $CHRONIC composer --working-dir={} install --no-interaction --prefer-dist --no-progress || true
 
-      - name: Run a subset of E2E tests
+      - name: Run the Windows compatible subset of E2E tests
         if: runner.os == 'Windows'
         shell: bash
         run: |
@@ -129,15 +129,19 @@ jobs:
           TERM: xterm-256color
         run: make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=bin/infection
 
+      - name: Compile the prefixed PHAR
+        if: &prefixed-phar-condition runner.os != 'Windows' && matrix.e2e-runner == 'dist/infection.phar' && matrix.php-version == '8.3'
+        run: make compile
+
+      - name: Check the prefixed PHAR works from a subfolder
+        if: *prefixed-phar-condition
+        run: cd dist && ./infection.phar -V
+
       - name: Run the whole set of E2E tests with prefixed PHAR
-        if: runner.os != 'Windows' && matrix.e2e-runner == 'dist/infection.phar' && matrix.php-version == '8.3'
+        if: *prefixed-phar-condition
         env:
           TERM: xterm-256color
-        run: |
-          make compile
-          # test PHAR works from subfolder
-          cd dist && ./infection.phar -V && cd ..
-          make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=dist/infection.phar BENCHMARK_SOURCES=
+        run: make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=dist/infection.phar BENCHMARK_SOURCES=
 
   # This is a meta job to avoid to have to constantly change the protection rules
   # whenever we touch the matrix.


### PR DESCRIPTION
This allows to reduce the noise when inspecting this step upon failure as it now contains only the failure of the e2e test.
