### PR TITLE
refactor(testFramework): Inject PHP executable finder into command line builder

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -3159,7 +3159,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
 code = "falsable-return-statement"
-message = "Function `38891935849420780:4236` is declared to return `string` but possibly returns 'false' (inferred as `false|string`)."
+message = "Function `38891935849420780:4287` is declared to return `string` but possibly returns 'false' (inferred as `false|string`)."
 count = 1
 
 [[issues]]
@@ -3171,7 +3171,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
 code = "invalid-return-statement"
-message = "Invalid return type for function `38891935849420780:4236`: expected `string`, but found `false|string`."
+message = "Invalid return type for function `38891935849420780:4287`: expected `string`, but found `false|string`."
 count = 1
 
 [[issues]]

--- a/src/StaticAnalysis/Mago/Adapter/MagoAdapterFactory.php
+++ b/src/StaticAnalysis/Mago/Adapter/MagoAdapterFactory.php
@@ -40,6 +40,7 @@ use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapterFactory;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\VersionParser;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 /**
  * @internal
@@ -60,7 +61,9 @@ final class MagoAdapterFactory implements StaticAnalysisToolAdapterFactory
             new MagoMutantExecutionResultFactory(),
             $staticAnalysisConfigPath,
             $staticAnalysisToolExecutable,
-            new CommandLineBuilder(),
+            new CommandLineBuilder(
+                new PhpExecutableFinder(),
+            ),
             new VersionParser(),
             $timeout,
             $staticAnalysisToolOptions,

--- a/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterFactory.php
+++ b/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterFactory.php
@@ -41,6 +41,7 @@ use Infection\StaticAnalysis\StaticAnalysisToolAdapterFactory;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\VersionParser;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 /**
  * @internal
@@ -62,7 +63,9 @@ final class PHPStanAdapterFactory implements StaticAnalysisToolAdapterFactory
             new PHPStanMutantExecutionResultFactory(),
             $staticAnalysisConfigPath,
             $staticAnalysisToolExecutable,
-            new CommandLineBuilder(),
+            new CommandLineBuilder(
+                new PhpExecutableFinder(),
+            ),
             new VersionParser(),
             $timeout,
             $tmpDir,

--- a/src/TestFramework/CommandLineBuilder.php
+++ b/src/TestFramework/CommandLineBuilder.php
@@ -55,6 +55,11 @@ class CommandLineBuilder
     /** @var string[]|null */
     private ?array $cachedPhpCmdLine = null;
 
+    public function __construct(
+        private readonly PhpExecutableFinder $phpExecutableFinder,
+    ) {
+    }
+
     /**
      * @param string[] $frameworkArgs
      * @param string[] $phpExtraArgs
@@ -106,7 +111,7 @@ class CommandLineBuilder
             return $cachedPhpCmdLine;
         }
 
-        $phpExec = (new PhpExecutableFinder())->find(false);
+        $phpExec = $this->phpExecutableFinder->find(false);
 
         if ($phpExec === false) {
             throw FinderException::phpExecutableNotFound();

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -51,6 +51,7 @@ use Infection\TestFramework\VersionParser;
 use function Safe\file_get_contents;
 use SplFileInfo;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Webmozart\Assert\Assert;
 
 /**
@@ -118,7 +119,9 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
                 $mapSourceClassToTestStrategy,
             ),
             new VersionParser(),
-            new CommandLineBuilder(),
+            new CommandLineBuilder(
+                new PhpExecutableFinder(),
+            ),
         );
     }
 

--- a/tests/phpunit/TestFramework/CommandLineBuilderTest.php
+++ b/tests/phpunit/TestFramework/CommandLineBuilderTest.php
@@ -37,10 +37,10 @@ namespace Infection\Tests\TestFramework;
 
 use Infection\TestFramework\CommandLineBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\PhpExecutableFinder;
 
-#[Group('integration')]
 #[CoversClass(CommandLineBuilder::class)]
 final class CommandLineBuilderTest extends TestCase
 {
@@ -48,30 +48,86 @@ final class CommandLineBuilderTest extends TestCase
 
     private const array TEST_FRAMEWORK_ARGS = ['--filter XYZ', '--exclude-group=integration'];
 
+    private MockObject&PhpExecutableFinder $phpExecutableFinderMock;
+
     private CommandLineBuilder $commandLineBuilder;
 
     protected function setUp(): void
     {
-        parent::setUp();
-
-        $this->commandLineBuilder = new CommandLineBuilder();
+        $this->phpExecutableFinderMock = $this->createMock(PhpExecutableFinder::class);
+        $this->commandLineBuilder = new CommandLineBuilder($this->phpExecutableFinderMock);
     }
 
     public function test_it_builds_command_line_for_batch_file(): void
     {
-        $commandLine = $this->commandLineBuilder->build('phpunit.bat', self::PHP_EXTRA_ARGS, self::TEST_FRAMEWORK_ARGS);
+        $this->phpExecutableFinderMock
+            ->expects($this->never())
+            ->method('find');
 
-        $this->assertContains('phpunit.bat', $commandLine);
-        $this->assertContains('--filter XYZ', $commandLine);
-        $this->assertContains('--exclude-group=integration', $commandLine);
+        $commandLine = $this->commandLineBuilder->build(
+            'phpunit.bat',
+            self::PHP_EXTRA_ARGS,
+            self::TEST_FRAMEWORK_ARGS,
+        );
+
+        $this->assertSame(
+            [
+                'phpunit.bat',
+                '--filter XYZ',
+                '--exclude-group=integration',
+            ],
+            $commandLine,
+        );
     }
 
     public function test_it_builds_command_line_with_empty_php_args(): void
     {
-        $commandLine = $this->commandLineBuilder->build('vendor/bin/phpunit', [], self::TEST_FRAMEWORK_ARGS);
+        $this->phpExecutableFinderMock
+            ->expects($this->once())
+            ->method('find')
+            ->with(false)
+            ->willReturn('/custom/php');
 
-        $this->assertContains('vendor/bin/phpunit', $commandLine);
-        $this->assertContains('--filter XYZ', $commandLine);
-        $this->assertContains('--exclude-group=integration', $commandLine);
+        $commandLine = $this->commandLineBuilder->build(
+            testFrameworkExecutable: 'non-executable-phpunit',
+            phpExtraArgs: [],
+            frameworkArgs: self::TEST_FRAMEWORK_ARGS,
+        );
+
+        $this->assertSame(
+            ['/custom/php', 'non-executable-phpunit', '--filter XYZ', '--exclude-group=integration'],
+            $commandLine,
+        );
+    }
+
+    public function test_it_uses_the_injected_php_executable_finder_and_caches_its_result(): void
+    {
+        $this->phpExecutableFinderMock
+            ->expects($this->once())
+            ->method('find')
+            ->with(false)
+            ->willReturn('/custom/php');
+
+        $firstCommandLine = $this->commandLineBuilder->build(
+            'vendor/bin/phpunit',
+            self::PHP_EXTRA_ARGS,
+            self::TEST_FRAMEWORK_ARGS,
+        );
+        $secondCommandLine = $this->commandLineBuilder->build(
+            'vendor/bin/phpunit',
+            self::PHP_EXTRA_ARGS,
+            self::TEST_FRAMEWORK_ARGS,
+        );
+
+        $expectedCommandLine = [
+            '/custom/php',
+            '-d zend_extension=xdebug.so',
+            'vendor/bin/phpunit',
+            '--filter XYZ',
+            '--exclude-group=integration',
+        ];
+
+        $this->assertSame($expectedCommandLine, $firstCommandLine);
+        $this->assertSame($expectedCommandLine, $secondCommandLine);
     }
 }

--- a/tests/phpunit/TestFramework/CommandLineBuilderTest.php
+++ b/tests/phpunit/TestFramework/CommandLineBuilderTest.php
@@ -37,10 +37,12 @@ namespace Infection\Tests\TestFramework;
 
 use Infection\TestFramework\CommandLineBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\PhpExecutableFinder;
 
+#[Group('integration')]
 #[CoversClass(CommandLineBuilder::class)]
 final class CommandLineBuilderTest extends TestCase
 {


### PR DESCRIPTION
## Description

Refactors `CommandLineBuilder` to receive a `PhpExecutableFinder` through its constructor instead of instantiating one inside `findPhp()`. This makes command-line building easier to test because tests can inject a mock finder and assert the exact generated command without depending on Symfony's PHP executable discovery behaviour across environments.

This is a preparatory step for #3133.

## Changes

- Updates `CommandLineBuilder` to depend on an injected `PhpExecutableFinder`.
- Wires `PhpExecutableFinder` explicitly in the PHPUnit, PHPStan, and Mago adapter factories. At some point I believe the Factory should receive and forward an instance, but this will be work for under #2863.
- Tightens `CommandLineBuilderTest` to use a mocked finder and exact command-line assertions.

## Related issues

- #3133
