### PR TITLE
refactor(event): Rename MutantProcessWasFinished to MutationEvaluationForMutationWasFinished

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -10701,7 +10701,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertAreSameEvents`: expected `array<array-key, Infection\Event\Events\MutationAnalysis\MutationEvaluationWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluationWasStarted|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasStarted>`, but found `mixed`.'
+message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertAreSameEvents`: expected `array<array-key, Infection\Event\Events\MutationAnalysis\MutationEvaluationWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluationWasStarted|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasStarted>`, but found `mixed`.'
 count = 7
 
 [[issues]]
@@ -10749,7 +10749,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "non-existent-property"
-message = 'Property `$mutationCount` does not exist on class `Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished`.'
+message = 'Property `$mutationCount` does not exist on class `Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished`.'
 count = 1
 
 [[issues]]

--- a/src/Event/Events/MutationAnalysis/MutationEvaluation/MutationEvaluationForMutationWasFinished.php
+++ b/src/Event/Events/MutationAnalysis/MutationEvaluation/MutationEvaluationForMutationWasFinished.php
@@ -35,12 +35,15 @@ declare(strict_types=1);
 
 namespace Infection\Event\Events\MutationAnalysis\MutationEvaluation;
 
-use Infection\Event\Subscriber\EventSubscriber;
+use Infection\Mutant\MutantExecutionResult;
 
 /**
  * @internal
  */
-interface MutantProcessWasFinishedSubscriber extends EventSubscriber
+final readonly class MutationEvaluationForMutationWasFinished
 {
-    public function onMutantProcessWasFinished(MutantProcessWasFinished $event): void;
+    public function __construct(
+        public MutantExecutionResult $executionResult,
+    ) {
+    }
 }

--- a/src/Event/Events/MutationAnalysis/MutationEvaluation/MutationEvaluationForMutationWasFinishedSubscriber.php
+++ b/src/Event/Events/MutationAnalysis/MutationEvaluation/MutationEvaluationForMutationWasFinishedSubscriber.php
@@ -35,15 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Event\Events\MutationAnalysis\MutationEvaluation;
 
-use Infection\Mutant\MutantExecutionResult;
+use Infection\Event\Subscriber\EventSubscriber;
 
 /**
  * @internal
  */
-final readonly class MutantProcessWasFinished
+interface MutationEvaluationForMutationWasFinishedSubscriber extends EventSubscriber
 {
-    public function __construct(
-        public MutantExecutionResult $executionResult,
-    ) {
-    }
+    public function onMutationEvaluationForMutationWasFinished(MutationEvaluationForMutationWasFinished $event): void;
 }

--- a/src/Event/Subscriber/DispatchPcntlSignalSubscriber.php
+++ b/src/Event/Subscriber/DispatchPcntlSignalSubscriber.php
@@ -36,16 +36,16 @@ declare(strict_types=1);
 namespace Infection\Event\Subscriber;
 
 use function function_exists;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinishedSubscriber;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinishedSubscriber;
 use function Safe\pcntl_signal_dispatch;
 
 /**
  * @internal
  */
-final class DispatchPcntlSignalSubscriber implements MutantProcessWasFinishedSubscriber
+final class DispatchPcntlSignalSubscriber implements MutationEvaluationForMutationWasFinishedSubscriber
 {
-    public function onMutantProcessWasFinished(MutantProcessWasFinished $event): void
+    public function onMutationEvaluationForMutationWasFinished(MutationEvaluationForMutationWasFinished $event): void
     {
         if (!function_exists('pcntl_signal_dispatch')) {
             return;

--- a/src/Event/Subscriber/MutationAnalysisLoggerSubscriber.php
+++ b/src/Event/Subscriber/MutationAnalysisLoggerSubscriber.php
@@ -40,8 +40,8 @@ use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasFinishedSubscriber;
 use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasStartedSubscriber;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinishedSubscriber;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinishedSubscriber;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasStartedSubscriber;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluationWasFinished;
@@ -55,7 +55,7 @@ use Infection\Logger\MutationAnalysis\MutationAnalysisLogger;
 /**
  * @internal
  */
-final readonly class MutationAnalysisLoggerSubscriber implements MutableFileWasProcessedSubscriber, MutantProcessWasFinishedSubscriber, MutationAnalysisWasFinishedSubscriber, MutationAnalysisWasStartedSubscriber, MutationEvaluationForMutationWasStartedSubscriber, MutationEvaluationWasFinishedSubscriber, MutationEvaluationWasStartedSubscriber
+final readonly class MutationAnalysisLoggerSubscriber implements MutableFileWasProcessedSubscriber, MutationAnalysisWasFinishedSubscriber, MutationAnalysisWasStartedSubscriber, MutationEvaluationForMutationWasFinishedSubscriber, MutationEvaluationForMutationWasStartedSubscriber, MutationEvaluationWasFinishedSubscriber, MutationEvaluationWasStartedSubscriber
 {
     public function __construct(
         private MutationAnalysisLogger $logger,
@@ -87,7 +87,7 @@ final readonly class MutationAnalysisLoggerSubscriber implements MutableFileWasP
         }
     }
 
-    public function onMutantProcessWasFinished(MutantProcessWasFinished $event): void
+    public function onMutationEvaluationForMutationWasFinished(MutationEvaluationForMutationWasFinished $event): void
     {
         $executionResult = $event->executionResult;
 

--- a/src/Event/Subscriber/MutationTestingResultsCollectorSubscriber.php
+++ b/src/Event/Subscriber/MutationTestingResultsCollectorSubscriber.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Event\Subscriber;
 
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinishedSubscriber;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinishedSubscriber;
 use Infection\Metrics\Collector;
 
 /**
  * @internal
  */
-final readonly class MutationTestingResultsCollectorSubscriber implements MutantProcessWasFinishedSubscriber
+final readonly class MutationTestingResultsCollectorSubscriber implements MutationEvaluationForMutationWasFinishedSubscriber
 {
     /** @var Collector[] */
     private array $collectors;
@@ -52,7 +52,7 @@ final readonly class MutationTestingResultsCollectorSubscriber implements Mutant
         $this->collectors = $collectors;
     }
 
-    public function onMutantProcessWasFinished(MutantProcessWasFinished $event): void
+    public function onMutationEvaluationForMutationWasFinished(MutationEvaluationForMutationWasFinished $event): void
     {
         $executionResult = $event->executionResult;
 

--- a/src/Process/Runner/MutationTestingRunner.php
+++ b/src/Process/Runner/MutationTestingRunner.php
@@ -38,7 +38,7 @@ namespace Infection\Process\Runner;
 use function array_key_exists;
 use Infection\Differ\DiffSourceCodeMatcher;
 use Infection\Event\EventDispatcher\EventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluationWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluationWasStarted;
@@ -138,7 +138,7 @@ class MutationTestingRunner
                 continue;
             }
 
-            $this->eventDispatcher->dispatch(new MutantProcessWasFinished(
+            $this->eventDispatcher->dispatch(new MutationEvaluationForMutationWasFinished(
                 MutantExecutionResult::createFromIgnoredMutant($mutant),
             ));
 
@@ -155,7 +155,7 @@ class MutationTestingRunner
             return true;
         }
 
-        $this->eventDispatcher->dispatch(new MutantProcessWasFinished(
+        $this->eventDispatcher->dispatch(new MutationEvaluationForMutationWasFinished(
             MutantExecutionResult::createFromNonCoveredMutant($mutant),
         ));
 
@@ -169,7 +169,7 @@ class MutationTestingRunner
             return true;
         }
 
-        $this->eventDispatcher->dispatch(new MutantProcessWasFinished(
+        $this->eventDispatcher->dispatch(new MutationEvaluationForMutationWasFinished(
             MutantExecutionResult::createFromTimeSkippedMutant($mutant),
         ));
 
@@ -183,8 +183,8 @@ class MutationTestingRunner
         return $this->processFactory->create($mutant, $testFrameworkExtraOptions);
     }
 
-    private static function containerToFinishedEvent(MutantProcessContainer $container): MutantProcessWasFinished
+    private static function containerToFinishedEvent(MutantProcessContainer $container): MutationEvaluationForMutationWasFinished
     {
-        return new MutantProcessWasFinished($container->getCurrent()->getMutantExecutionResult());
+        return new MutationEvaluationForMutationWasFinished($container->getCurrent()->getMutantExecutionResult());
     }
 }

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -67,8 +67,8 @@ use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasFinishedSubscriber;
 use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasStartedSubscriber;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinishedSubscriber;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinishedSubscriber;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasStartedSubscriber;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluationWasFinished;
@@ -93,7 +93,7 @@ use Infection\Telemetry\SpanHandle;
 /**
  * @internal
  */
-final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFinishedSubscriber, ApplicationExecutionWasStartedSubscriber, ArtefactCollectionWasFinishedSubscriber, ArtefactCollectionWasStartedSubscriber, AstEnrichmentWasFinishedSubscriber, AstEnrichmentWasStartedSubscriber, AstParsingWasFinishedSubscriber, AstParsingWasStartedSubscriber, AstProcessingWasFinishedSubscriber, AstProcessingWasStartedSubscriber, InitialStaticAnalysisRunWasFinishedSubscriber, InitialStaticAnalysisRunWasStartedSubscriber, InitialTestSuiteWasFinishedSubscriber, InitialTestSuiteWasStartedSubscriber, MutantProcessWasFinishedSubscriber, MutationAnalysisWasFinishedSubscriber, MutationAnalysisWasStartedSubscriber, MutationEvaluationForMutationWasStartedSubscriber, MutationEvaluationWasFinishedSubscriber, MutationEvaluationWasStartedSubscriber, MutationGenerationWasFinishedSubscriber, MutationGenerationWasStartedSubscriber, ReportingWasFinishedSubscriber, ReportingWasStartedSubscriber, SourceCollectionWasFinishedSubscriber, SourceCollectionWasStartedSubscriber
+final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFinishedSubscriber, ApplicationExecutionWasStartedSubscriber, ArtefactCollectionWasFinishedSubscriber, ArtefactCollectionWasStartedSubscriber, AstEnrichmentWasFinishedSubscriber, AstEnrichmentWasStartedSubscriber, AstParsingWasFinishedSubscriber, AstParsingWasStartedSubscriber, AstProcessingWasFinishedSubscriber, AstProcessingWasStartedSubscriber, InitialStaticAnalysisRunWasFinishedSubscriber, InitialStaticAnalysisRunWasStartedSubscriber, InitialTestSuiteWasFinishedSubscriber, InitialTestSuiteWasStartedSubscriber, MutationAnalysisWasFinishedSubscriber, MutationAnalysisWasStartedSubscriber, MutationEvaluationForMutationWasFinishedSubscriber, MutationEvaluationForMutationWasStartedSubscriber, MutationEvaluationWasFinishedSubscriber, MutationEvaluationWasStartedSubscriber, MutationGenerationWasFinishedSubscriber, MutationGenerationWasStartedSubscriber, ReportingWasFinishedSubscriber, ReportingWasStartedSubscriber, SourceCollectionWasFinishedSubscriber, SourceCollectionWasStartedSubscriber
 {
     private ?SpanHandle $rootSpan = null;
 
@@ -296,7 +296,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         }
     }
 
-    public function onMutantProcessWasFinished(MutantProcessWasFinished $event): void
+    public function onMutationEvaluationForMutationWasFinished(MutationEvaluationForMutationWasFinished $event): void
     {
         $result = $event->executionResult;
         $hash = $result->getMutantHash();

--- a/tests/phpunit/Event/Events/MutationAnalysis/MutationEvaluation/MutationEvaluationForMutationWasFinishedTest.php
+++ b/tests/phpunit/Event/Events/MutationAnalysis/MutationEvaluation/MutationEvaluationForMutationWasFinishedTest.php
@@ -35,19 +35,19 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Event\Events\MutationAnalysis\MutationEvaluation;
 
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished;
 use Infection\Mutant\MutantExecutionResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(MutantProcessWasFinished::class)]
-final class MutantProcessWasFinishedTest extends TestCase
+#[CoversClass(MutationEvaluationForMutationWasFinished::class)]
+final class MutationEvaluationForMutationWasFinishedTest extends TestCase
 {
     public function test_it_exposes_its_mutant_process(): void
     {
         $executionResultMock = $this->createStub(MutantExecutionResult::class);
 
-        $event = new MutantProcessWasFinished($executionResultMock);
+        $event = new MutationEvaluationForMutationWasFinished($executionResultMock);
 
         $this->assertSame($executionResultMock, $event->executionResult);
     }

--- a/tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationAnalysisLoggerSubscriberTest.php
@@ -39,7 +39,7 @@ use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\EventDispatcher\SyncEventDispatcher;
 use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasStarted;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluationWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluationWasStarted;
@@ -154,7 +154,7 @@ final class MutationAnalysisLoggerSubscriberTest extends TestCase
             ->with($this->identicalTo($executionResult));
 
         $this->dispatcher->dispatch(
-            new MutantProcessWasFinished(
+            new MutationEvaluationForMutationWasFinished(
                 $executionResult,
             ),
         );

--- a/tests/phpunit/Event/Subscriber/MutationTestingResultsCollectorSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationTestingResultsCollectorSubscriberTest.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Event\Subscriber;
 
 use Infection\Event\EventDispatcher\SyncEventDispatcher;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished;
 use Infection\Event\Subscriber\MutationTestingResultsCollectorSubscriber;
 use Infection\Metrics\Collector;
 use Infection\Tests\Mutant\MutantExecutionResultBuilder;
@@ -67,7 +67,7 @@ final class MutationTestingResultsCollectorSubscriberTest extends TestCase
         ));
 
         $dispatcher->dispatch(
-            new MutantProcessWasFinished(
+            new MutationEvaluationForMutationWasFinished(
                 MutantExecutionResultBuilder::withMinimalTestData()->build(),
             ),
         );

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -41,7 +41,7 @@ use function count;
 use function implode;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\Differ\DiffSourceCodeMatcher;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluationWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluationWasStarted;
@@ -208,11 +208,11 @@ final class MutationTestingRunnerTest extends TestCase
                 new MutationEvaluationForMutationWasStarted($mutation0),
                 new MutationEvaluationForMutationWasStarted($mutation1),
                 new MutationEvaluationForMutationWasStarted($mutation2),
-                new MutantProcessWasFinished(
+                new MutationEvaluationForMutationWasFinished(
                     MutantExecutionResultBuilder::withMinimalTestData()->build(),
                 ),
                 new MutationEvaluationForMutationWasStarted($mutation3),
-                new MutantProcessWasFinished(
+                new MutationEvaluationForMutationWasFinished(
                     MutantExecutionResultBuilder::withMinimalTestData()->build(),
                 ),
                 new MutationEvaluationWasFinished(),
@@ -220,7 +220,7 @@ final class MutationTestingRunnerTest extends TestCase
             $this->eventDispatcher->getEvents(),
         );
 
-        /** @var MutantProcessWasFinished $secondSkippedEvent */
+        /** @var MutationEvaluationForMutationWasFinished $secondSkippedEvent */
         $secondSkippedEvent = $this->eventDispatcher->getEvents()[6];
 
         $this->assertSame(
@@ -298,7 +298,7 @@ final class MutationTestingRunnerTest extends TestCase
             [
                 new MutationEvaluationWasStarted(4, $this->processRunnerMock),
                 new MutationEvaluationForMutationWasStarted($mutation0),
-                new MutantProcessWasFinished(
+                new MutationEvaluationForMutationWasFinished(
                     MutantExecutionResultBuilder::withMinimalTestData()->build(),
                 ),
                 new MutationEvaluationWasFinished(),
@@ -447,7 +447,7 @@ final class MutationTestingRunnerTest extends TestCase
             [
                 new MutationEvaluationWasStarted(0, $this->processRunnerMock),
                 new MutationEvaluationForMutationWasStarted($mutation0),
-                new MutantProcessWasFinished(MutantExecutionResult::createFromNonCoveredMutant($mutant)),
+                new MutationEvaluationForMutationWasFinished(MutantExecutionResult::createFromNonCoveredMutant($mutant)),
                 new MutationEvaluationWasFinished(),
             ],
             $this->eventDispatcher->getEvents(),
@@ -629,7 +629,7 @@ final class MutationTestingRunnerTest extends TestCase
         $result = $this->invokeMethod('uncoveredByTest', $mutant);
 
         $this->assertFalse($result);
-        $this->assertHasEvent(MutantProcessWasFinished::class, $this->eventDispatcher->getEvents());
+        $this->assertHasEvent(MutationEvaluationForMutationWasFinished::class, $this->eventDispatcher->getEvents());
     }
 
     public function test_container_to_finished_event(): void
@@ -647,7 +647,7 @@ final class MutationTestingRunnerTest extends TestCase
             ->willReturn($process);
 
         $result = $this->invokeMethod('containerToFinishedEvent', $container);
-        $this->assertInstanceOf(MutantProcessWasFinished::class, $result);
+        $this->assertInstanceOf(MutationEvaluationForMutationWasFinished::class, $result);
     }
 
     private function invokeMethod(string $methodName, mixed ...$args): mixed
@@ -672,8 +672,8 @@ final class MutationTestingRunnerTest extends TestCase
     }
 
     /**
-     * @param array<MutationEvaluationWasStarted|MutationEvaluationForMutationWasStarted|MutationEvaluationWasFinished|MutantProcessWasFinished> $expectedEvents
-     * @param array<MutationEvaluationWasStarted|MutationEvaluationForMutationWasStarted|MutationEvaluationWasFinished|MutantProcessWasFinished> $actualEvents
+     * @param array<MutationEvaluationWasStarted|MutationEvaluationForMutationWasStarted|MutationEvaluationWasFinished|MutationEvaluationForMutationWasFinished> $expectedEvents
+     * @param array<MutationEvaluationWasStarted|MutationEvaluationForMutationWasStarted|MutationEvaluationWasFinished|MutationEvaluationForMutationWasFinished> $actualEvents
      */
     private function assertAreSameEvents(array $expectedEvents, array $actualEvents): void
     {
@@ -681,7 +681,7 @@ final class MutationTestingRunnerTest extends TestCase
             MutationEvaluationWasStarted::class,
             MutationEvaluationForMutationWasStarted::class,
             MutationEvaluationWasFinished::class,
-            MutantProcessWasFinished::class,
+            MutationEvaluationForMutationWasFinished::class,
         ];
 
         $assertionErrorMessage = sprintf(

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -53,7 +53,7 @@ use Infection\Event\Events\Ast\AstProcessingWasFinished;
 use Infection\Event\Events\Ast\AstProcessingWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationAnalysisWasStarted;
-use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished;
+use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationForMutationWasStarted;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluationWasFinished;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluationWasStarted;
@@ -140,7 +140,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->subscriber->onMutationGenerationWasFinished(new MutationGenerationWasFinished());
         $this->subscriber->onMutationEvaluationWasStarted(new MutationEvaluationWasStarted(1, $this->createStub(ProcessRunner::class)));
         $this->subscriber->onMutationEvaluationForMutationWasStarted(new MutationEvaluationForMutationWasStarted($mutation));
-        $this->subscriber->onMutantProcessWasFinished(new MutantProcessWasFinished(
+        $this->subscriber->onMutationEvaluationForMutationWasFinished(new MutationEvaluationForMutationWasFinished(
             MutantExecutionResultBuilder::withMinimalTestData()
                 ->withMutantHash($mutation->getHash())
                 ->withDetectionStatus(DetectionStatus::KILLED_BY_TESTS)


### PR DESCRIPTION
Renames the final per-mutant result event from `MutantProcessWasFinished` to `MutationEvaluationForMutationWasFinished`, as it represents a completed mutation evaluation result rather than the completion of a concrete process. This keeps the event naming aligned with `MutationEvaluationForMutationWasStarted` and the mutation evaluation lifecycle terminology used by the telemetry branch (see #3103).

## Related issues

- #3090
