### PR TITLE
build(sbx): Adapt the Telemetry for newer versions of Codex

### DIFF
--- a/devTools/sbx/README.md
+++ b/devTools/sbx/README.md
@@ -8,23 +8,20 @@ It uses [container-structure-test][container-structure-test] for testing the ima
 
 ## Telemetry
 
-Codex telemetry is optional, to enable it, copy the template before launching
-Codex:
+Codex telemetry is optional. The OpenTelemetry settings live in
+`devTools/sbx/codex-otel.toml` and are merged into the Codex user-level config
+by the `devTools/sbx/codex-otel-kit` kit when the sandbox starts.
 
-```shell
-cp devTools/sbx/config.toml.dist .codex/config.toml
-```
-
-The provided template assumes the OTLP gRPC collector is reachable from
-the sandbox at `http://host.docker.internal:4317`. If it runs elsewhere,
-update `.codex/config.toml`.
+The provided template assumes the OTLP HTTP collector is reachable from
+the sandbox at `http://host.docker.internal:4318`. If it runs elsewhere,
+update `devTools/sbx/codex-otel.toml`.
 
 Note that depending on the port used or your network policies, the connection
 to the host may be denied. For example, with the value above, you will need to
 execute:
 
 ```shell
-sbx policy allow network localhost:4317
+sbx policy allow network localhost:4318
 ```
 
 ## Usage
@@ -38,11 +35,14 @@ make sbx-image-build
 make _sbx-image-build
 ```
 
-Run a sandbox with the loaded template:
+Run a sandbox with the loaded template (from the repo root):
 
 ```shell
-sbx run --template=infection-sbx-php-8.4:latest codex
+sbx run codex --template=infection-sbx-php-8.4:latest --kit=./devTools/sbx/codex-otel-kit
 ```
+
+The `--kit` flag only applies when the sandbox is created. For an existing
+sandbox, recreate it or apply the kit explicitly with `sbx kit add`.
 
 [docker sandbox]: https://www.docker.com/products/docker-sandboxes/
 [docker-sandbox-templates-codex]: https://hub.docker.com/layers/docker/sandbox-templates/codex-docker/images

--- a/devTools/sbx/codex-otel-kit/files/home/.local/bin/infection-merge-codex-otel
+++ b/devTools/sbx/codex-otel-kit/files/home/.local/bin/infection-merge-codex-otel
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CONFIG_FILE="${CODEX_CONFIG_FILE:-/home/agent/.codex/config.toml}"
+WORKDIR_FILE="/home/agent/.config/infection-sbx/workdir"
+
+if [[ -f "${WORKDIR_FILE}" ]]; then
+    WORKDIR="$(tr -d '\n' < "${WORKDIR_FILE}")"
+else
+    WORKDIR="${WORKDIR:-${PWD}}"
+fi
+
+OTEL_CONFIG="${CODEX_OTEL_CONFIG_FILE:-${WORKDIR}/devTools/sbx/codex-otel.toml}"
+
+if [[ ! -f "${OTEL_CONFIG}" ]]; then
+    printf 'Codex OTEL config not found: %s\n' "${OTEL_CONFIG}" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "${CONFIG_FILE}")"
+touch "${CONFIG_FILE}"
+
+TMP_CONFIG="$(mktemp)"
+trap 'rm -f "${TMP_CONFIG}"' EXIT
+
+awk '
+    /^\[otel(\]|\.)/ {
+        skip = 1
+        next
+    }
+
+    /^\[[^]]+\]/ {
+        skip = 0
+    }
+
+    skip != 1 {
+        print
+    }
+' "${CONFIG_FILE}" > "${TMP_CONFIG}"
+
+{
+    sed -e :a -e '/^[[:space:]]*$/{$d;N;ba' -e '}' "${TMP_CONFIG}"
+    printf '\n\n'
+    cat "${OTEL_CONFIG}"
+} > "${CONFIG_FILE}"

--- a/devTools/sbx/codex-otel-kit/spec.yaml
+++ b/devTools/sbx/codex-otel-kit/spec.yaml
@@ -1,0 +1,17 @@
+schemaVersion: "1"
+kind: mixin
+name: infection-codex-otel
+displayName: Infection Codex OTEL
+description: Merge Infection OpenTelemetry settings into the generated Codex user config.
+
+commands:
+  initFiles:
+    - path: /home/agent/.config/infection-sbx/workdir
+      content: "${WORKDIR}\n"
+      mode: "0644"
+      description: Persist the sandbox workspace path for the OTEL merge script.
+  startup:
+    - command: ["/home/agent/.local/bin/infection-merge-codex-otel"]
+      user: "1000"
+      background: false
+      description: Merge Infection OTEL settings into Codex config.

--- a/devTools/sbx/codex-otel.toml
+++ b/devTools/sbx/codex-otel.toml
@@ -1,0 +1,7 @@
+[otel]
+environment = "infection"
+log_user_prompt = false
+
+exporter         = { otlp-http = { endpoint = "http://host.docker.internal:4318/v1/logs",    protocol = "binary" }}
+trace_exporter   = { otlp-http = { endpoint = "http://host.docker.internal:4318/v1/traces",  protocol = "binary" }}
+metrics_exporter = { otlp-http = { endpoint = "http://host.docker.internal:4318/v1/metrics", protocol = "binary" }}


### PR DESCRIPTION
Codex no longer accepts project specific `[otel]` settings, which is a shame. Unfortunately with [docker sandbox](https://docs.docker.com/ai/sandboxes/), sbx creates its own agent `.codex/config.toml` so one cannot just create its own within the `Dockerfile` of the template as it will get overridden.

To fix this, this PR adds an optional [Docker Sandbox kit](https://docs.docker.com/ai/sandboxes/customize/kits/) for enabling Codex OpenTelemetry inside the Infection sandbox image.

The kit keeps the OTEL settings in the repository and merges them into the generated Codex user config when the sandbox starts. This avoids requiring contributors to copy a full `.codex/config.toml` template while still preserving any existing non-OTEL Codex settings.
