### PR TITLE
build(sbx): Ignore local sandbox user files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 !/.tools/.gitkeep
 !/dist/.gitkeep
 !/var/cache/.gitkeep
+.DS_Store
+.claude/
+.codex/
+.idea/
 .phpunit.*
 /*.phar
 /.box_dump/
@@ -8,7 +12,6 @@
 /.composer/
 /.direnv/
 /.envrc.local
-/.idea
 /.php_cs.cache
 /.tools/
 /build/
@@ -35,3 +38,6 @@
 /tests/phpunit/**/*/generated_index.xml
 /var/
 /vendor/
+Desktop.ini
+Thumbs.db
+ehthumbs.db


### PR DESCRIPTION
Updates the repository ignore rules so local files created by the Docker sandbox
or host operating systems do not show up as untracked project changes.

This covers Codex and Claude local configuration, nested IDE project files, and
common macOS/Windows filesystem metadata that may appear when the repository is
mounted from a host machine.