### PR TITLE
build(sbx): Introduce a `make sbx-create` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,15 @@ compile-docker:	 	## Bundles Infection into a PHAR using docker
 compile-docker: $(DOCKER_FILE_IMAGE)
 	$(DOCKER_RUN_82) make compile
 
+.PHONY: sbx-create
+sbx-create:	## Drops the existing PHP sbx image and create it anew
+sbx-create:
+	sbx-image-build
+	sbx rm codex-infection || true
+	sbx run codex \
+		--template=infection-sbx-php-8.4:latest \
+		--kit=./devTools/sbx/codex-otel-kit
+
 .PHONY: sbx-image-build
 sbx-image-build:	## Builds the PHP sbx image
 sbx-image-build:

--- a/devTools/sbx/README.md
+++ b/devTools/sbx/README.md
@@ -26,7 +26,20 @@ sbx policy allow network localhost:4318
 
 ## Usage
 
-Build the image:
+```shell
+make sbx-create
+```
+
+This will create the Docker Sandbox image with the template and OTEL kit for the current
+branch and will make it available with:
+
+```shell
+sbx run codex-infection
+```
+
+Be aware that this command will drop the existing `codex-infection` sandbox.
+
+If you wish to only build the image:
 
 ```shell
 make sbx-image-build
@@ -35,14 +48,18 @@ make sbx-image-build
 make _sbx-image-build
 ```
 
-Run a sandbox with the loaded template (from the repo root):
+To run a sandbox manually with the loaded template from the repository root:
 
 ```shell
-sbx run codex --template=infection-sbx-php-8.4:latest --kit=./devTools/sbx/codex-otel-kit
+sbx run codex \
+  --template=infection-sbx-php-8.4:latest \
+  --kit=./devTools/sbx/codex-otel-kit
 ```
 
 The `--kit` flag only applies when the sandbox is created. For an existing
 sandbox, recreate it or apply the kit explicitly with `sbx kit add`.
+
+You can use the `--branch` or `--name` option to further adjust your setup.
 
 [docker sandbox]: https://www.docker.com/products/docker-sandboxes/
 [docker-sandbox-templates-codex]: https://hub.docker.com/layers/docker/sandbox-templates/codex-docker/images

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -261,6 +261,7 @@ final class MakefileTest extends BaseMakefileTestCase
 
             [33mcompile:[0m	 	 Bundles Infection into a PHAR
             [33mcompile-docker:[0m	 	 Bundles Infection into a PHAR using docker
+            [33msbx-create:[0m	 Drops the existing PHP sbx image and create it anew
             [33msbx-image-build:[0m	 Builds the PHP sbx image
             [33msbx-image-test:[0m	 Verifies the PHP sbx image contains the expected tooling
             [33mcs:[0m	  	 	 Runs PHP-CS-Fixer


### PR DESCRIPTION
Introduce the `make sbx-create` to make it a bit easier to get started/recreate a fresh sandbox.