### PR TITLE
test(architecture): Move PHPStan and PHPAt tests under tests/architecture

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,8 +115,8 @@
     "autoload-dev": {
         "psr-4": {
             "Infection\\Benchmark\\": "tests/benchmark",
-            "Infection\\Tests\\": "tests/phpunit",
-            "Infection\\DevTools\\": "devTools/"
+            "Infection\\Tests\\Architecture\\": "tests/Architecture",
+            "Infection\\Tests\\": "tests/phpunit"
         },
         "classmap": [
             "tests/autoloaded"

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -3,11 +3,11 @@ includes:
     - phpstan-baseline.neon
 
 rules:
-    - Infection\DevTools\PHPStan\Rules\InfectionContainerRule
+    - Infection\Tests\Architecture\PHPStan\Rules\InfectionContainerRule
 
 services:
     -
-        class: Infection\DevTools\PHPat\SrcShouldNotDependOnTestsTest
+        class: Infection\Tests\Architecture\PHPat\SrcShouldNotDependOnTestsTest
         tags:
             - phpat.test
 
@@ -130,7 +130,7 @@ parameters:
         # so shipmonk's dead-code detector cannot see the call sites.
         -
             identifier: shipmonk.deadMethod
-            path: ./PHPat/*
+            path: ../tests/Architecture/PHPat/*
 
         # Test enum fixtures have cases that exist as test data, not all are used
         -
@@ -226,10 +226,9 @@ parameters:
     level: 8
     paths:
         - ../src
+        - ../tests/Architecture
         - ../tests/phpunit
         - ../tests/benchmark
-        - ./PHPStan/
-        - ./PHPat/
     excludePaths:
         - %currentWorkingDirectory%/src/FileSystem/DummyFileSystem.php
         - %currentWorkingDirectory%/src/CustomMutator/templates/__Name__.php

--- a/mago.toml
+++ b/mago.toml
@@ -16,6 +16,7 @@ includes = ["vendor"]
 excludes = [
     "src/FileSystem/DummyFileSystem.php",
     "src/CustomMutator/templates",
+    "tests/Architecture",
     "tests/benchmark/MutationGenerator/sources",
     "tests/benchmark/Tracing/benchmark-source",
     "tests/benchmark/Tracing/coverage",

--- a/mago.toml
+++ b/mago.toml
@@ -8,6 +8,7 @@ workspace = "."
 paths = [
     "src",
     "tests/autoloaded",
+    "tests/Architecture",
     "tests/benchmark",
     "tests/phpunit"
 ]

--- a/tests/Architecture/PHPStan/Rules/InfectionContainerRule.php
+++ b/tests/Architecture/PHPStan/Rules/InfectionContainerRule.php
@@ -33,8 +33,10 @@
 
 declare(strict_types=1);
 
-namespace Infection\DevTools\PHPStan\Rules;
+namespace Infection\Tests\Architecture\PHPStan\Rules;
 
+use function array_map;
+use function in_array;
 use Infection\Container\Container;
 use Infection\Testing\SingletonContainer;
 use PhpParser\Node;
@@ -42,23 +44,26 @@ use PhpParser\Node\Expr\New_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use Symfony\Component\Filesystem\Path;
 use function sprintf;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @implements Rule<New_>
  */
-final class InfectionContainerRule implements Rule {
+final class InfectionContainerRule implements Rule
+{
     /**
      * @var string[]|null
      */
     private static $containerFiles;
 
-    public function getNodeType(): string {
+    public function getNodeType(): string
+    {
         return New_::class;
     }
 
-    public function processNode(Node $node, Scope $scope): array {
+    public function processNode(Node $node, Scope $scope): array
+    {
         if (
             $node->class instanceof Node\Name
             && $node->class->toString() === Container::class
@@ -80,10 +85,10 @@ final class InfectionContainerRule implements Rule {
     private function getContainerFiles(): array
     {
         return self::$containerFiles ??= array_map(
-            static fn (string $path): string => Path::canonicalize($path),
+            Path::canonicalize(...),
             [
-                __DIR__ . '/../../../tests/phpunit/Container/ContainerTest.php',
-                __DIR__ . '/../../../tests/phpunit/MockedContainer.php',
+                __DIR__ . '/../../../phpunit/Container/ContainerTest.php',
+                __DIR__ . '/../../../phpunit/MockedContainer.php',
             ],
         );
     }

--- a/tests/Architecture/PHPat/SrcShouldNotDependOnTestsTest.php
+++ b/tests/Architecture/PHPat/SrcShouldNotDependOnTestsTest.php
@@ -33,7 +33,7 @@
 
 declare(strict_types=1);
 
-namespace Infection\DevTools\PHPat;
+namespace Infection\Tests\Architecture\PHPat;
 
 use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
@@ -48,7 +48,6 @@ final class SrcShouldNotDependOnTestsTest
             ->excluding(
                 Selector::inNamespace('Infection\\Tests'),
                 Selector::inNamespace('Infection\\Benchmark'),
-                Selector::inNamespace('Infection\\DevTools'),
             )
             ->shouldNot()
             ->dependOn()

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -346,6 +346,7 @@ final class ProjectCodeProvider
             ->notName('DummySymfony5FileSystem.php')
             ->notName('DummySymfony6FileSystem.php')
             ->exclude([
+                'Architecture',
                 'autoloaded',
                 'benchmark',
                 'e2e',


### PR DESCRIPTION
Follow up of https://github.com/infection/infection/pull/3084#discussion_r3178194879.