### PR TITLE
ci: Harden GitHub Actions checkout steps

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
@@ -45,6 +47,8 @@ jobs:
       steps:
           - name: Checkout code
             uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            with:
+                persist-credentials: false
 
           - name: Setup PHP
             uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0

--- a/.github/workflows/conductor.yaml
+++ b/.github/workflows/conductor.yaml
@@ -19,7 +19,9 @@ jobs:
       COMPOSER_AUTH: ${{ secrets.CONDUCTOR_COMPOSER_AUTH }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout
+        # zizmor: ignore[artipacked] Conductor updates dependencies and needs the checkout token persisted for repository writes.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install PHP
         uses: "shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f" # master

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0

--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -26,6 +26,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
+                  persist-credentials: false
             - name: Setup PHP
               uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
               with:

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP for coverage
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0

--- a/.github/workflows/perf-metrics.yaml
+++ b/.github/workflows/perf-metrics.yaml
@@ -45,6 +45,7 @@ jobs:
           # When ref input is provided, checkout from upstream (where tags exist)
           repository: ${{ github.event.inputs.ref && 'infection/infection' || github.repository }}
           ref: ${{ github.event.inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Setup PHP for coverage
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # master
@@ -130,6 +131,7 @@ jobs:
 
       - name: Checkout metrics repository
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        # zizmor: ignore[artipacked] This checkout persists the SSH key used by the later git push to the metrics repository.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: infection/infection-metrics

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       -
         name: Setup PHP

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0


### PR DESCRIPTION
## Description

Hardens GitHub Actions checkout steps reported by `zizmor`'s [`artipacked`](https://docs.zizmor.sh/audits/#artipacked) audit.

Most workflows only need repository contents during checkout, so they now disable persisted checkout credentials. The two checkout steps that intentionally keep credentials for later repository writes are documented with explicit `zizmor` suppressions.

## Changes

- Adds `persist-credentials: false` to checkout steps.
- Keeps persisted credentials for the Private Packagist Conductor checkout because that workflow performs dependency updates and needs repository write credentials.
- Keeps persisted SSH credentials for the performance metrics repository checkout because the workflow later pushes metrics updates to `infection/infection-metrics`.
- Adds inline `zizmor: ignore[artipacked]` comments for those two intentional exceptions, with the reason documented next to each checkout.
