### PR TITLE
ci: Harden Github Actions token permissions usage

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -14,10 +14,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     strategy:
       matrix:

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -14,11 +14,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: 'Tests'
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,6 +48,8 @@ jobs:
       runs-on: ubuntu-latest
       timeout-minutes: 30
       name: 'Benchmarks'
+      permissions:
+          contents: read
       steps:
           - name: Checkout code
             uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -11,11 +11,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   coding-standards:
     name: Coding Standards
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -14,10 +14,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   tests:
     runs-on: ${{ matrix.operating-system }}
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     strategy:
       matrix:

--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -10,10 +10,14 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: true
 
+permissions: {}
+
 jobs:
     tests:
         runs-on: ubuntu-latest
         timeout-minutes: 30
+        permissions:
+            contents: read
 
         strategy:
             matrix:

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -25,6 +25,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   PHP_VERSION: '8.3'
   MIN_MSI: 77.0
@@ -34,6 +36,8 @@ jobs:
   mutation-testing:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     name: Infection complete run on Infection
 

--- a/.github/workflows/perf-metrics.yaml
+++ b/.github/workflows/perf-metrics.yaml
@@ -28,6 +28,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   PHP_VERSION: '8.3'
 
@@ -35,6 +37,8 @@ jobs:
   collect:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
 
     name: Collect and commit metrics
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,11 +5,15 @@ on:
     tags:
       - '*'
 
+permissions: {}
+
 jobs:
   release:
     name: Upload PHAR and signature
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
     steps:
       -
         name: Checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,10 +14,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   tests:
     runs-on: ${{ matrix.operating-system }}
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Hardens GitHub Actions token permissions reported by `zizmor`'s [`excessive-permissions`](https://docs.zizmor.sh/audits/#excessive-permissions) audit.

The affected workflows now deny all default `GITHUB_TOKEN` permissions at the workflow level and grant only the permissions each job needs. CI jobs that check out the repository receive `contents: read`, while the release job keeps `contents: write` because it uploads release assets.

## Changes

- Adds workflow-level `permissions: {}` blocks to affected workflows.
- Grants `contents: read` to CI jobs that need repository checkout.
- Grants `contents: write` only to the release job that publishes release artifacts.
