### PR TITLE
ci: Use gh for the release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,9 +59,10 @@ jobs:
               dist/infection.phar
 
       - name: Upload PHAR to release
-        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # latest
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/infection.phar*
-          file_glob: true
-          tag: ${{ github.ref }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "${GITHUB_REF_NAME}" > /dev/null 2>&1 \
+            || gh release create "${GITHUB_REF_NAME}" --verify-tag --title "${GITHUB_REF_NAME}"
+
+          gh release upload "${GITHUB_REF_NAME}" dist/infection.phar*


### PR DESCRIPTION
## Description

Removes the remaining unsuppressed `zizmor` finding from the release workflow.

The release job no longer depends on `svenstaro/upload-release-action` for functionality that is already available on GitHub-hosted runners. It now uses the preinstalled GitHub CLI to create the tag release when needed and upload the PHAR artifacts.

## Changes

- Replaces `svenstaro/upload-release-action` with `gh release view/create` and `gh release upload`.
