### PR TITLE
ci: Add zizmor to the autoreview

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -136,15 +136,15 @@ jobs:
         run: make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=bin/infection
 
       - name: Compile the prefixed PHAR
-        if: &prefixed-phar-condition runner.os != 'Windows' && matrix.e2e-runner == 'dist/infection.phar' && matrix.php-version == '8.3'
+        if: runner.os != 'Windows' && matrix.e2e-runner == 'dist/infection.phar' && matrix.php-version == '8.3'
         run: make compile
 
       - name: Check the prefixed PHAR works from a subfolder
-        if: *prefixed-phar-condition
+        if: runner.os != 'Windows' && matrix.e2e-runner == 'dist/infection.phar' && matrix.php-version == '8.3'
         run: cd dist && ./infection.phar -V
 
       - name: Run the whole set of E2E tests with prefixed PHAR
-        if: *prefixed-phar-condition
+        if: runner.os != 'Windows' && matrix.e2e-runner == 'dist/infection.phar' && matrix.php-version == '8.3'
         env:
           TERM: xterm-256color
         run: make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=dist/infection.phar BENCHMARK_SOURCES=

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -136,15 +136,15 @@ jobs:
         run: make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=bin/infection
 
       - name: Compile the prefixed PHAR
-        if: runner.os != 'Windows' && matrix.e2e-runner == 'dist/infection.phar' && matrix.php-version == '8.3'
+        if: &prefixed-phar-condition runner.os != 'Windows' && matrix.e2e-runner == 'dist/infection.phar' && matrix.php-version == '8.3'
         run: make compile
 
       - name: Check the prefixed PHAR works from a subfolder
-        if: runner.os != 'Windows' && matrix.e2e-runner == 'dist/infection.phar' && matrix.php-version == '8.3'
+        if: *prefixed-phar-condition
         run: cd dist && ./infection.phar -V
 
       - name: Run the whole set of E2E tests with prefixed PHAR
-        if: runner.os != 'Windows' && matrix.e2e-runner == 'dist/infection.phar' && matrix.php-version == '8.3'
+        if: *prefixed-phar-condition
         env:
           TERM: xterm-256color
         run: make test-e2e E2E_PHPUNIT_GROUP=e2e INFECTION=dist/infection.phar BENCHMARK_SOURCES=

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ benchmark_tracing: vendor $(BENCHMARK_TRACING_SUBMODULE) $(BENCHMARK_TRACING_COV
 
 .PHONY: autoreview
 autoreview: 	 	## Runs various checks (static analysis & AutoReview test suite)
-autoreview: cs-check phpstan mago validate test-autoreview rector-check detect-collisions zizmor
+autoreview: cs-check phpstan mago validate test-autoreview rector-check detect-collisions $(if $(CI),,zizmor)
 
 .PHONY: test
 test:		 	## Runs all the tests

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ benchmark_tracing: vendor $(BENCHMARK_TRACING_SUBMODULE) $(BENCHMARK_TRACING_COV
 
 .PHONY: autoreview
 autoreview: 	 	## Runs various checks (static analysis & AutoReview test suite)
-autoreview: cs-check phpstan mago validate test-autoreview rector-check detect-collisions
+autoreview: cs-check phpstan mago validate test-autoreview rector-check detect-collisions zizmor
 
 .PHONY: test
 test:		 	## Runs all the tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # If you need a token, a short-lived classic token with read:packages is enough.
   zizmor:
     image: ghcr.io/zizmorcore/zizmor:1.25.2
-    command: --no-exit-codes .github
+    command: --quiet --quiet .github
     working_dir: /opt/infection
     volumes:
       - .:/opt/infection


### PR DESCRIPTION
- `make autoreview` now includes the `make zizmor` command.
- Adjust zizmor verbosity to no longer show the warning about YAML anchors.
- Make zizmor fail when a warning or higher is found.
