### PR TITLE
ci: Make Zizmor fail in the CI on warning severity

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Install Linux dependencies for E2E tests
         if: runner.os != 'Windows'
-        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # v1
+        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # v1.5.3
         with:
           packages: expect moreutils
 

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -38,4 +38,3 @@ jobs:
           advanced-security: false
           annotations: true
           inputs: .github
-          min-severity: high

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,4 +1,4 @@
-name: GitHub Actions Security Analysis with zizmor
+name: GitHub Actions Security Analysis
 
 on:
   pull_request:


### PR DESCRIPTION
- Mirror the configuration of the `make zizmor` command.
- Rename the workflow to make it a bit less lengthy.

Note that the workflow is not added to the branch protection rules, this is because its run is conditional.