### PR TITLE
refactor: Extract the Application version into a re-usable utility

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -901,12 +901,6 @@ message = 'Invalid return type for function `Infection\Configuration\SourceFilte
 count = 1
 
 [[issues]]
-file = "src/Console/Application.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Console\Application::getPrettyVersion`.'
-count = 1
-
-[[issues]]
 file = "src/Console/LogVerbosity.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
@@ -5529,6 +5523,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Debug\DumpAstCommand\DumpAstCommandTest::createCommandTester`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Debug\DumpAstCommand\DumpAstCommandTest::test_it_outputs_the_ast_of_a_file`.'
 count = 1
 
@@ -5536,6 +5536,12 @@ count = 1
 file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidTimeValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Debug\MockTeamCityCommandTest::createCommandTester`.'
 count = 1
 
 [[issues]]
@@ -5554,6 +5560,30 @@ count = 1
 file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Debug\MockTeamCityCommandTest::test_it_reads_log_from_stdin_when_no_file_provided`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/DescribeCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\DescribeCommandTest::test_it_can_describe_a_mutator_when_asked_for_a_name`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/DescribeCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\DescribeCommandTest::test_it_described_the_remedy`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/DescribeCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\DescribeCommandTest::test_it_describes`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/DescribeCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\DescribeCommandTest::test_it_errors_when_mutator_does_not_exist`.'
 count = 1
 
 [[issues]]
@@ -5583,6 +5613,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::createCommandTester`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_outputs_the_base_reference_with_provided_base`.'
 count = 1
 
@@ -5590,6 +5626,12 @@ count = 1
 file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `commandExecutionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Git\GitChangedFilesCommandTest::createCommandTester`.'
 count = 1
 
 [[issues]]
@@ -5607,7 +5649,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::createCommandTester`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::test_it_outputs_changed_lines`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Git\GitDefaultBaseCommandTest::createCommandTester`.'
 count = 1
 
 [[issues]]
@@ -5631,6 +5685,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::createCommandTester`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::executeCommand`.'
 count = 1
 
@@ -5643,6 +5703,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::test_it_lists_source_files`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::test_it_lists_source_files`.'
 count = 1
 
@@ -5650,6 +5716,42 @@ count = 1
 file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
 code = "redundant-docblock-type"
 message = "Redundant docblock type for variable `$fileSystemMock`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_create_custom_mutator_when_name_is_not_provided_at_command_call`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_create_custom_mutator_when_name_is_provided`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_trims_the_argument_value`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_trims_the_value_from_quetion_helper`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_uppercases_first_letter_of_argument_value`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_uppercases_the_value_from_quetion_helper`.'
 count = 1
 
 [[issues]]
@@ -5734,6 +5836,18 @@ count = 1
 file = "tests/phpunit/Command/RunCommandHelperTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `providesUsesGitHubLogger` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/RunCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_show_mutations_value_is_string_but_not_max`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/RunCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_threads_value_is_string_but_not_max`.'
 count = 1
 
 [[issues]]
@@ -6538,6 +6652,12 @@ count = 1
 file = "tests/phpunit/Console/E2ETest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\FileSystem\Finder\Exception\FinderException` in `Infection\Tests\Console\E2ETest::installComposerDeps`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/E2ETest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\E2ETest::runInfection`.'
 count = 1
 
 [[issues]]
@@ -7702,6 +7822,12 @@ count = 3
 file = "tests/phpunit/Framework/Enum/ImplodableEnum/ImplodableEnumTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `separatorProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Framework/InfectionVersionTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Framework\InfectionVersionTest::test_it_returns_the_package_pretty_version`.'
 count = 1
 
 [[issues]]

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -48,9 +48,9 @@ use Infection\Config\ValueProvider\SourceDirsProvider;
 use Infection\Config\ValueProvider\TestFrameworkConfigPathProvider;
 use Infection\Config\ValueProvider\TextLogFileProvider;
 use Infection\Configuration\Schema\SchemaConfigurationLoader;
-use Infection\Console\Application;
 use Infection\Console\IO;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
+use Infection\Framework\InfectionVersion;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use Infection\TestFramework\TestFrameworkTypes;
 use const JSON_PRETTY_PRINT;
@@ -255,7 +255,7 @@ final class ConfigureCommand extends BaseCommand
         }
 
         try {
-            $version = InstalledVersions::getPrettyVersion(Application::PACKAGE_NAME);
+            $version = InstalledVersions::getPrettyVersion(InfectionVersion::PACKAGE_NAME);
 
             if ($version === null || str_starts_with($version, 'dev-')) {
                 $version = 'master';

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -50,6 +50,7 @@ use Infection\Command\MakeCustomMutatorCommand;
 use Infection\Command\RunCommand;
 use Infection\Container\Container;
 use Infection\Framework\InfectionVersion;
+use OutOfBoundsException;
 use Override;
 use function sprintf;
 use Symfony\Component\Console\Application as BaseApplication;
@@ -75,6 +76,9 @@ final class Application extends BaseApplication
 
 ';
 
+    /**
+     * @throws OutOfBoundsException
+     */
     public function __construct(
         private readonly Container $container,
     ) {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -36,8 +36,6 @@ declare(strict_types=1);
 namespace Infection\Console;
 
 use function array_merge;
-use function class_exists;
-use Composer\InstalledVersions;
 use Infection\Command\ConfigureCommand;
 use Infection\Command\Debug\DumpAstCommand;
 use Infection\Command\Debug\MockTeamCityCommand;
@@ -51,10 +49,8 @@ use Infection\Command\ListSourcesCommand;
 use Infection\Command\MakeCustomMutatorCommand;
 use Infection\Command\RunCommand;
 use Infection\Container\Container;
-use OutOfBoundsException;
+use Infection\Framework\InfectionVersion;
 use Override;
-use function preg_quote;
-use function Safe\preg_match;
 use function sprintf;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
@@ -66,8 +62,6 @@ use function trim;
  */
 final class Application extends BaseApplication
 {
-    public const string PACKAGE_NAME = 'infection/infection';
-
     private const string NAME = 'Infection - PHP Mutation Testing Framework';
 
     private const string LOGO = '
@@ -84,7 +78,7 @@ final class Application extends BaseApplication
     public function __construct(
         private readonly Container $container,
     ) {
-        parent::__construct(self::NAME, self::getPrettyVersion());
+        parent::__construct(self::NAME, InfectionVersion::prettyVersion());
         $this->setDefaultCommand('run');
     }
 
@@ -143,28 +137,5 @@ final class Application extends BaseApplication
         }
 
         OutputFormatterStyleConfigurator::configure($output);
-    }
-
-    private static function getPrettyVersion(): string
-    {
-        // Pre 2.0 Composer runtime didn't have this class.
-        // @codeCoverageIgnoreStart
-        if (!class_exists(InstalledVersions::class)) {
-            return 'unknown';
-        }
-        // @codeCoverageIgnoreEnd
-
-        try {
-            return (string) InstalledVersions::getPrettyVersion(self::PACKAGE_NAME);
-            // @codeCoverageIgnoreStart
-        } catch (OutOfBoundsException $e) {
-            if (preg_match('#package .*' . preg_quote(self::PACKAGE_NAME, '#') . '.* not installed#i', $e->getMessage()) === 0) {
-                throw $e;
-            }
-
-            // We have a bogus exception: how can Infection be not installed if we're here?
-            return 'not-installed';
-        }
-        // @codeCoverageIgnoreEnd
     }
 }

--- a/src/Framework/InfectionVersion.php
+++ b/src/Framework/InfectionVersion.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Framework;
+
+use function class_exists;
+use Composer\InstalledVersions;
+use OutOfBoundsException;
+use function preg_quote;
+use function Safe\preg_match;
+
+/**
+ * @internal
+ */
+final class InfectionVersion
+{
+    public const string PACKAGE_NAME = 'infection/infection';
+
+    /**
+     * @throws OutOfBoundsException
+     */
+    public static function prettyVersion(): string
+    {
+        // Pre 2.0 Composer runtime didn't have this class.
+        // @codeCoverageIgnoreStart
+        if (!class_exists(InstalledVersions::class)) {
+            return 'unknown';
+        }
+        // @codeCoverageIgnoreEnd
+
+        try {
+            return (string) InstalledVersions::getPrettyVersion(self::PACKAGE_NAME);
+            // @codeCoverageIgnoreStart
+        } catch (OutOfBoundsException $exception) {
+            if (preg_match('#package .*' . preg_quote(self::PACKAGE_NAME, '#') . '.* not installed#i', $exception->getMessage()) === 0) {
+                throw $exception;
+            }
+
+            // We have a bogus exception: how can Infection be not installed if we're here?
+            return 'not-installed';
+        }
+        // @codeCoverageIgnoreEnd
+    }
+}

--- a/tests/phpunit/Framework/InfectionVersionTest.php
+++ b/tests/phpunit/Framework/InfectionVersionTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Framework;
+
+use Composer\InstalledVersions;
+use Infection\Framework\InfectionVersion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(InfectionVersion::class)]
+final class InfectionVersionTest extends TestCase
+{
+    public function test_it_returns_the_package_pretty_version(): void
+    {
+        $expected = InstalledVersions::getPrettyVersion(InfectionVersion::PACKAGE_NAME);
+
+        $actual = InfectionVersion::prettyVersion();
+
+        $this->assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
## Description

In #3161 I plan to add the infection version to the span attributes. To do so, we need the same logic as currently done for `Application::getPrettyVersion()`. So this PR extracts this piece of code to a re-usable utility.

Note that #3161 is still on its feature branch, however I believe those changes to master are harmless even if we were to not merge the telemetry feature at all.

## Related issues

- #3090