### PR TITLE
refactor: Make the InfectionVersion more usable

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -6595,6 +6595,12 @@ message = "Type `iterable` in return type of `valueProvider` is imprecise, equiv
 count = 1
 
 [[issues]]
+file = "tests/phpunit/Console/ApplicationTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\ApplicationTest::test_it_uses_the_infection_version`.'
+count = 1
+
+[[issues]]
 file = "tests/phpunit/Console/E2ETest.php"
 code = "implicit-to-string-cast"
 message = 'Implicit conversion to `string` for left operand via `Symfony\Component\Finder\SplFileInfo::__toString()`.'

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -81,8 +81,9 @@ final class Application extends BaseApplication
      */
     public function __construct(
         private readonly Container $container,
+        InfectionVersion $infectionVersion = new InfectionVersion(),
     ) {
-        parent::__construct(self::NAME, InfectionVersion::prettyVersion());
+        parent::__construct(self::NAME, $infectionVersion->prettyVersion());
         $this->setDefaultCommand('run');
     }
 

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -57,7 +57,6 @@ use Infection\Configuration\Schema\SchemaValidator;
 use Infection\Configuration\SourceFilter\FakeSourceFilter;
 use Infection\Configuration\SourceFilter\GitDiffFilter;
 use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
-use Infection\Console\Application;
 use Infection\Console\XdebugHandler;
 use Infection\Differ\Tokens;
 use Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationWasStarted;
@@ -133,7 +132,6 @@ final class ProjectCodeProvider
      */
     public const array NON_TESTED_CONCRETE_CLASSES = [
         AdapterInstaller::class,
-        Application::class,
         BaseMutatorTestCase::class,
         BaseOption::class,
         ConcreteComposerExecutableFinder::class,

--- a/tests/phpunit/Console/ApplicationTest.php
+++ b/tests/phpunit/Console/ApplicationTest.php
@@ -33,55 +33,30 @@
 
 declare(strict_types=1);
 
-namespace Infection\Framework;
+namespace Infection\Tests\Console;
 
-use function class_exists;
-use Composer\InstalledVersions;
-use OutOfBoundsException;
-use function preg_quote;
-use function Safe\preg_match;
+use Infection\Console\Application;
+use Infection\Framework\InfectionVersion;
+use Infection\Testing\SingletonContainer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
-/**
- * @internal
- * @final
- */
-class InfectionVersion
+#[CoversClass(Application::class)]
+final class ApplicationTest extends TestCase
 {
-    public const string PACKAGE_NAME = 'infection/infection';
-
-    private ?string $prettyVersion = null;
-
-    /**
-     * @throws OutOfBoundsException
-     */
-    public function prettyVersion(): string
+    public function test_it_uses_the_infection_version(): void
     {
-        return $this->prettyVersion ??= $this->retrievePrettyVersion();
-    }
+        $versionMock = $this->createMock(InfectionVersion::class);
+        $versionMock
+            ->expects($this->once())
+            ->method('prettyVersion')
+            ->willReturn('1.2.3');
 
-    /**
-     * @throws OutOfBoundsException
-     */
-    private function retrievePrettyVersion(): string
-    {
-        // Pre 2.0 Composer runtime didn't have this class.
-        // @codeCoverageIgnoreStart
-        if (!class_exists(InstalledVersions::class)) {
-            return 'unknown';
-        }
-        // @codeCoverageIgnoreEnd
+        $application = new Application(
+            SingletonContainer::getContainer(),
+            $versionMock,
+        );
 
-        try {
-            return (string) InstalledVersions::getPrettyVersion(self::PACKAGE_NAME);
-            // @codeCoverageIgnoreStart
-        } catch (OutOfBoundsException $exception) {
-            if (preg_match('#package .*' . preg_quote(self::PACKAGE_NAME, '#') . '.* not installed#i', $exception->getMessage()) === 0) {
-                throw $exception;
-            }
-
-            // We have a bogus exception: how can Infection be not installed if we're here?
-            return 'not-installed';
-        }
-        // @codeCoverageIgnoreEnd
+        $this->assertSame('1.2.3', $application->getVersion());
     }
 }

--- a/tests/phpunit/Framework/InfectionVersionTest.php
+++ b/tests/phpunit/Framework/InfectionVersionTest.php
@@ -47,7 +47,7 @@ final class InfectionVersionTest extends TestCase
     {
         $expected = InstalledVersions::getPrettyVersion(InfectionVersion::PACKAGE_NAME);
 
-        $actual = InfectionVersion::prettyVersion();
+        $actual = (new InfectionVersion())->prettyVersion();
 
         $this->assertSame($expected, $actual);
     }


### PR DESCRIPTION
## Description

- Make the class mockable (remove `final` and make it non-static).
- Cache the result (it will be called multiple times if used with telemetry).

## Related issues

- #3090