### PR TITLE
feat(telemetry): Add more execution-context attributes to the run `infection.run` span

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -1369,12 +1369,6 @@ message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\
 count = 1
 
 [[issues]]
-file = "src/Framework/InfectionVersion.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Framework\InfectionVersion::prettyVersion`.'
-count = 1
-
-[[issues]]
 file = "src/Framework/Iterable/GeneratorFactory.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Exception` in `Infection\Framework\Iterable\GeneratorFactory::fromIterable`.'
@@ -2830,6 +2824,12 @@ count = 1
 file = "src/Telemetry/SDK/FailingTracerProviderFactory.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Telemetry\SDK\FailingTracerProviderFactory::createExporter`.'
+count = 1
+
+[[issues]]
+file = "src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Telemetry\Subscriber\OpenTelemetryTracerSubscriber::onApplicationExecutionWasStarted`.'
 count = 1
 
 [[issues]]
@@ -5602,6 +5602,12 @@ count = 1
 file = "tests/phpunit/Command/Debug/TelemetryConfigCommandTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Command/Debug/TelemetryConfigCommandTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Debug\TelemetryConfigCommandTest::createCommandTester`.'
 count = 1
 
 [[issues]]
@@ -11837,6 +11843,12 @@ file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory
 code = "deprecated-method"
 message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
 count = 3
+
+[[issues]]
+file = "tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Telemetry\Attribute\RunSpanAttributesProviderTest::test_it_provides_run_identity_attributes_from_the_configuration`.'
+count = 1
 
 [[issues]]
 file = "tests/phpunit/Telemetry/OpenTelemetryTracerFactoryTest.php"

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -1369,6 +1369,12 @@ message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\
 count = 1
 
 [[issues]]
+file = "src/Framework/InfectionVersion.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Framework\InfectionVersion::prettyVersion`.'
+count = 1
+
+[[issues]]
 file = "src/Framework/Iterable/GeneratorFactory.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Exception` in `Infection\Framework\Iterable\GeneratorFactory::fromIterable`.'

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -82,9 +82,15 @@ final class Application extends BaseApplication
      */
     public function __construct(
         private readonly Container $container,
-        InfectionVersion $infectionVersion = new InfectionVersion(),
+        ?InfectionVersion $infectionVersion = null,
     ) {
-        parent::__construct(self::NAME, $infectionVersion->prettyVersion());
+        $infectionVersion ??= $this->container->get(InfectionVersion::class);
+
+        parent::__construct(
+            self::NAME,
+            $infectionVersion->prettyVersion(),
+        );
+
         $this->setDefaultCommand('run');
     }
 

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -37,6 +37,7 @@ namespace Infection\Telemetry\Attribute;
 
 use Infection\Configuration\Configuration;
 use Infection\Framework\InfectionVersion;
+use OutOfBoundsException;
 use Phar;
 use Symfony\Component\Filesystem\Path;
 
@@ -57,6 +58,8 @@ final readonly class RunSpanAttributesProvider
     }
 
     /**
+     * @throws OutOfBoundsException
+     *
      * @return Attributes
      */
     public function provide(): array

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Telemetry\Attribute;
+
+use Infection\Configuration\Configuration;
+use Infection\Framework\InfectionVersion;
+use Phar;
+use Symfony\Component\Filesystem\Path;
+
+/**
+ * @phpstan-type Attribute = bool|int|float|string
+ * @phpstan-type Attributes = array<non-empty-string, Attribute>
+ *
+ * @see https://opentelemetry.io/docs/specs/semconv/general/naming/
+ *
+ * @internal
+ */
+final readonly class RunSpanAttributesProvider
+{
+    public function __construct(
+        private Configuration $configuration,
+        private InfectionVersion $infectionVersion,
+    ) {
+    }
+
+    /**
+     * @return Attributes
+     */
+    public function provide(): array
+    {
+        return [
+            'infection.project.dir' => $this->configuration->projectDirectory,
+            'infection.config.path' => $this->getConfigurationPath(),
+            'infection.version' => $this->infectionVersion->prettyVersion(),
+            'infection.distribution' => self::getDistribution(),
+            'infection.thread.count' => $this->configuration->threadCount,
+            'infection.initial_tests.skipped' => $this->configuration->skipInitialTests,
+            'infection.initial_static_analysis.skipped' => !$this->configuration->isStaticAnalysisEnabled(),
+        ];
+    }
+
+    private function getConfigurationPath(): string
+    {
+        $projectDirectory = Path::canonicalize($this->configuration->projectDirectory);
+        $configurationPathname = Path::canonicalize($this->configuration->configurationPathname);
+
+        if (Path::isBasePath($projectDirectory, $configurationPathname)) {
+            return Path::makeRelative($configurationPathname, $projectDirectory);
+        }
+
+        return $configurationPathname;
+    }
+
+    private static function getDistribution(): string
+    {
+        return Phar::running(false) === ''
+            ? 'source'
+            : 'phar';
+    }
+}

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -112,6 +112,7 @@ use Infection\Event\Events\SourceCollection\SourceCollectionWasFinished;
 use Infection\Event\Events\SourceCollection\SourceCollectionWasFinishedSubscriber;
 use Infection\Event\Events\SourceCollection\SourceCollectionWasStarted;
 use Infection\Event\Events\SourceCollection\SourceCollectionWasStartedSubscriber;
+use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
 use Infection\Telemetry\OpenTelemetryTracer;
 use Infection\Telemetry\SpanHandle;
 use function spl_object_id;
@@ -175,12 +176,16 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function __construct(
         private readonly OpenTelemetryTracer $telemetry,
+        private readonly RunSpanAttributesProvider $runSpanAttributesProvider,
     ) {
     }
 
     public function onApplicationExecutionWasStarted(ApplicationExecutionWasStarted $event): void
     {
-        $this->rootSpan = $this->telemetry->startRootSpan('infection.run');
+        $this->rootSpan = $this->telemetry->startRootSpan(
+            'infection.run',
+            $this->runSpanAttributesProvider->provide(),
+        );
     }
 
     public function onInitialTestSuiteWasStarted(InitialTestSuiteWasStarted $event): void

--- a/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
@@ -55,14 +55,20 @@ final class RunSpanAttributesProviderTest extends TestCase
             ->withStaticAnalysisTool(StaticAnalysisToolTypes::PHPSTAN)
             ->build();
 
-        $infectionVersion = new InfectionVersion();
+        $infectionVersionMock = $this->createMock(InfectionVersion::class);
+        $infectionVersionMock
+            ->method('prettyVersion')
+            ->willReturn('1.2.3');
 
-        $provider = new RunSpanAttributesProvider($configuration, $infectionVersion);
+        $provider = new RunSpanAttributesProvider(
+            $configuration,
+            $infectionVersionMock,
+        );
 
         $expected = [
             'infection.project.dir' => '/var/www/project',
             'infection.config.path' => 'config/infection.json5',
-            'infection.version' => $infectionVersion->prettyVersion(),
+            'infection.version' => '1.2.3',
             'infection.distribution' => 'source',
             'infection.thread.count' => 8,
             'infection.initial_tests.skipped' => true,

--- a/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
@@ -33,32 +33,44 @@
 
 declare(strict_types=1);
 
-namespace Infection\Telemetry\Subscriber;
+namespace Infection\Tests\Telemetry\Attribute;
 
-use Infection\Event\Subscriber\EventSubscriber;
-use Infection\Event\Subscriber\NullSubscriber;
-use Infection\Event\Subscriber\SubscriberFactory;
+use Infection\Framework\InfectionVersion;
+use Infection\StaticAnalysis\StaticAnalysisToolTypes;
 use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
-use Infection\Telemetry\OpenTelemetryTracerFactory;
+use Infection\Tests\Configuration\ConfigurationBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
-/**
- * @internal
- */
-final readonly class OpenTelemetryTracerSubscriberFactory implements SubscriberFactory
+#[CoversClass(RunSpanAttributesProvider::class)]
+final class RunSpanAttributesProviderTest extends TestCase
 {
-    public function __construct(
-        private OpenTelemetryTracerFactory $telemetryTracerFactory,
-        private RunSpanAttributesProvider $runSpanAttributesProvider,
-    ) {
-    }
-
-    public function create(): EventSubscriber
+    public function test_it_provides_run_identity_attributes_from_the_configuration(): void
     {
-        $tracer = $this->telemetryTracerFactory->create();
+        $configuration = ConfigurationBuilder::withMinimalTestData()
+            ->withProjectDirectory('/var/www/project')
+            ->withConfigPathname('/var/www/project/config/infection.json5')
+            ->withThreadCount(8)
+            ->withSkipInitialTests(true)
+            ->withStaticAnalysisTool(StaticAnalysisToolTypes::PHPSTAN)
+            ->build();
 
-        return $tracer === null
-            ? new NullSubscriber()
-            : new OpenTelemetryTracerSubscriber($tracer, $this->runSpanAttributesProvider)
-        ;
+        $infectionVersion = new InfectionVersion();
+
+        $provider = new RunSpanAttributesProvider($configuration, $infectionVersion);
+
+        $expected = [
+            'infection.project.dir' => '/var/www/project',
+            'infection.config.path' => 'config/infection.json5',
+            'infection.version' => $infectionVersion->prettyVersion(),
+            'infection.distribution' => 'source',
+            'infection.thread.count' => 8,
+            'infection.initial_tests.skipped' => true,
+            'infection.initial_static_analysis.skipped' => false,
+        ];
+
+        $actual = $provider->provide();
+
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/phpunit/Telemetry/OpenTelemetryTracerFactoryTest.php
+++ b/tests/phpunit/Telemetry/OpenTelemetryTracerFactoryTest.php
@@ -35,6 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Telemetry;
 
+use function array_filter;
+use function array_keys;
 use Exception;
 use function getenv;
 use Infection\Telemetry\OpenTelemetryTracer;
@@ -49,6 +51,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use function Safe\putenv;
+use function str_starts_with;
 use UnexpectedValueException;
 
 #[BackupGlobals(true)]
@@ -62,6 +65,7 @@ final class OpenTelemetryTracerFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->backupEnvironmentVariables();
+        self::clearTelemetryEnvironmentVariables();
     }
 
     protected function tearDown(): void
@@ -77,7 +81,7 @@ final class OpenTelemetryTracerFactoryTest extends TestCase
         array $environmentVariables,
         bool|Exception $expected,
     ): void {
-        $this->setEnvVariables($environmentVariables);
+        self::setEnvVariables($environmentVariables);
         $factory = new OpenTelemetryTracerFactory();
 
         if ($expected instanceof Exception) {
@@ -272,7 +276,7 @@ final class OpenTelemetryTracerFactoryTest extends TestCase
 
     public function test_it_sets_the_default_service_name_when_creating_a_tracer(): void
     {
-        $this->setEnvVariables([
+        self::setEnvVariables([
             Variables::OTEL_TRACES_EXPORTER => 'console',
             OpenTelemetryTracerFactory::INFECTION_TELEMETRY => 'true',
         ]);
@@ -288,7 +292,7 @@ final class OpenTelemetryTracerFactoryTest extends TestCase
 
     public function test_it_keeps_the_existing_service_name_when_creating_a_tracer(): void
     {
-        $this->setEnvVariables([
+        self::setEnvVariables([
             Variables::OTEL_TRACES_EXPORTER => 'console',
             Variables::OTEL_SERVICE_NAME => 'custom-service',
             OpenTelemetryTracerFactory::INFECTION_TELEMETRY => 'true',
@@ -306,12 +310,34 @@ final class OpenTelemetryTracerFactoryTest extends TestCase
     /**
      * @param array<string, string> $environmentVariables
      */
-    private function setEnvVariables(array $environmentVariables): void
+    private static function setEnvVariables(array $environmentVariables): void
     {
         foreach ($environmentVariables as $name => $value) {
             putenv($name . '=' . $value);
             $_SERVER[$name] = $value;
             $_ENV[$name] = $value;
         }
+    }
+
+    private static function clearTelemetryEnvironmentVariables(): void
+    {
+        foreach (self::getTelemetryEnvironmentVariableNames() as $name) {
+            putenv($name);
+            unset($_SERVER[$name], $_ENV[$name]);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function getTelemetryEnvironmentVariableNames(): array
+    {
+        $names = array_filter(
+            array_keys(getenv()),
+            static fn (string $name): bool => str_starts_with($name, 'OTEL_'),
+        );
+        $names[] = OpenTelemetryTracerFactory::INFECTION_TELEMETRY;
+
+        return $names;
     }
 }

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -75,13 +75,16 @@ use Infection\Event\Events\Reporting\ReportingWasFinished;
 use Infection\Event\Events\Reporting\ReportingWasStarted;
 use Infection\Event\Events\SourceCollection\SourceCollectionWasFinished;
 use Infection\Event\Events\SourceCollection\SourceCollectionWasStarted;
+use Infection\Framework\InfectionVersion;
 use Infection\Framework\Iterable\IterableCounter;
 use Infection\Mutant\DetectionStatus;
 use Infection\Process\MutantProcess;
 use Infection\Process\Runner\HeuristicName;
 use Infection\Process\Runner\ProcessRunner;
+use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
 use Infection\Telemetry\OpenTelemetryTracer;
 use Infection\Telemetry\Subscriber\OpenTelemetryTracerSubscriber;
+use Infection\Tests\Configuration\ConfigurationBuilder;
 use Infection\Tests\Mutant\MutantBuilder;
 use Infection\Tests\Mutant\MutantExecutionResultBuilder;
 use Infection\Tests\Mutation\MutationBuilder;
@@ -118,6 +121,12 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
             new OpenTelemetryTracer(
                 $this->tracerProvider->getTracer('infection'),
                 $this->tracerProvider,
+            ),
+            new RunSpanAttributesProvider(
+                ConfigurationBuilder::withMinimalTestData()
+                    ->withProjectDirectory('/path/to/project')
+                    ->build(),
+                new InfectionVersion(),
             ),
         );
     }
@@ -259,6 +268,13 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame($run->getSpanId(), $reporting->getParentSpanId());
 
         $this->assertSame(1, $sourceCollection->getAttributes()->get('infection.source_file.count'));
+        $this->assertSame('/path/to/project', $run->getAttributes()->get('infection.project.dir'));
+        $this->assertSame('infection.json5', $run->getAttributes()->get('infection.config.path'));
+        $this->assertSame('source', $run->getAttributes()->get('infection.distribution'));
+        $this->assertSame(1, $run->getAttributes()->get('infection.thread.count'));
+        $this->assertFalse($run->getAttributes()->get('infection.initial_tests.skipped'));
+        $this->assertTrue($run->getAttributes()->get('infection.initial_static_analysis.skipped'));
+        $this->assertIsString($run->getAttributes()->get('infection.version'));
         $this->assertSame('/path/to/src/Foo.php', $astProcessing->getAttributes()->get('code.file.path'));
         $this->assertSame('/path/to/src/Foo.php', $astParsing->getAttributes()->get('code.file.path'));
         $this->assertSame('/path/to/src/Foo.php', $astEnrichment->getAttributes()->get('code.file.path'));


### PR DESCRIPTION
## Description

Adds run-level OpenTelemetry attributes to the root `infection.run` span:

- `infection.project.dir`
- `infection.config.path`
- `infection.version`
- `infection.distribution`
- `infection.thread.count`
- `infection.initial_tests.skipped`
- `infection.initial_static_analysis.skipped`

The goal is to provide more measures that the user can use to build a dashboard with. More values will be added to the `infection.run` span, but those can already be easily added without changing much of the structure.

## Changes

- Adds `RunSpanAttributesProvider` to derive run attributes from the resolved configuration and Infection version.
- Passes the run attributes when starting the root `infection.run` span.
- Resolves `InfectionVersion` from the container by default when constructing the console application, while preserving explicit injection. This ensures the same instance is used by `Application` and `RunSpanAttributesProvider`, effectively re-using the cached value.

## Related issues

- #3090