### PR TITLE
build: Fix the PHAR building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,7 @@ $(MAGO): vendor
 
 $(INFECTION): vendor $(shell find bin/ src/ -type f) $(BOX) box.json.dist .git/HEAD
 	# Backup the composer files
+	mkdir -p var/phar
 	cp composer.json var/phar/composer.json.bak
 	cp composer.lock var/phar/composer.lock.bak
 


### PR DESCRIPTION
Building the PHAR failed because we tried to copy into the non-existent directory `var/phar`.

This issue was introduced in #3109.