### PR TITLE
feat(telemetry): Add the project name to the `infection.run` span

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -692,6 +692,24 @@ count = 1
 
 [[issues]]
 file = "src/Configuration/ConfigurationFactory.php"
+code = "mixed-assignment"
+message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
+count = 1
+
+[[issues]]
+file = "src/Configuration/ConfigurationFactory.php"
+code = "redundant-type-comparison"
+message = "Redundant type assertion: `$directoryName` of type `non-empty-string` is always not `non-empty-string`."
+count = 1
+
+[[issues]]
+file = "src/Configuration/ConfigurationFactory.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Configuration\ConfigurationFactory::getRootComposerPackageName`.'
+count = 1
+
+[[issues]]
+file = "src/Configuration/ConfigurationFactory.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `UnexpectedValueException` in `Infection\Configuration\ConfigurationFactory::resolveMutators`.'
 count = 1
@@ -5991,6 +6009,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
 code = "imprecise-type"
+message = "Type `iterable` in return type of `projectNameProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
+code = "imprecise-type"
 message = "Type `iterable` in return type of `valueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
@@ -6021,6 +6045,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryTest::test_it_resolves_project_name`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryTest::test_it_throws_exception_when_not_known_static_analysis_tool_used_as_input`.'
 count = 1
 
@@ -6033,7 +6063,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryTest::test_it_resolves_project_name`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryTest::test_it_throws_exception_when_not_known_static_analysis_tool_used_as_input`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryTest::test_it_resolves_project_name`.'
 count = 1
 
 [[issues]]

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -69,6 +69,7 @@ readonly class Configuration
      * @param positive-int|'max' $dotsPerRow
      * @param non-empty-string $configurationPathname
      * @param non-empty-string $projectDirectory Absolute path.
+     * @param non-empty-string $projectName
      */
     public function __construct(
         public float $processTimeout,
@@ -106,6 +107,7 @@ readonly class Configuration
         public bool $executeOnlyCoveringTestCases,
         public ?string $mapSourceClassToTestStrategy,
         public string $projectDirectory,
+        public string $projectName,
         public ?string $staticAnalysisTool,
         public ?string $mutantId,
         public string $configurationPathname,

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -40,9 +40,11 @@ use function array_key_exists;
 use function array_map;
 use function array_unique;
 use function array_values;
+use function basename;
 use function dirname;
 use function explode;
 use function file_exists;
+use function getenv;
 use function implode;
 use function in_array;
 use Infection\Configuration\Entry\Logs;
@@ -55,6 +57,7 @@ use Infection\Configuration\SourceFilter\GitDiffFilter;
 use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
 use Infection\Configuration\SourceFilter\PlainFilter;
 use Infection\Configuration\SourceFilter\SourceFilter;
+use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\FileSystem\TmpDirProvider;
 use Infection\Git\Git;
@@ -67,16 +70,21 @@ use Infection\Reporter\FileReporter;
 use Infection\Resource\Processor\CpuCoresCountProvider;
 use Infection\Source\Exception\NoSourceFound;
 use Infection\TestFramework\TestFrameworkTypes;
+use function is_array;
 use function is_numeric;
+use function is_string;
 use function ltrim;
 use function max;
 use OndraM\CiDetector\CiDetector;
 use OndraM\CiDetector\CiDetectorInterface;
 use OndraM\CiDetector\Exception\CiNotDetectedException;
 use PhpParser\Node;
+use Safe\Exceptions\JsonException;
+use function Safe\json_decode;
 use function sprintf;
 use Symfony\Component\Filesystem\Path;
 use function sys_get_temp_dir;
+use function trim;
 use Webmozart\Assert\Assert;
 
 /**
@@ -85,6 +93,8 @@ use Webmozart\Assert\Assert;
  */
 class ConfigurationFactory
 {
+    public const string INFECTION_PROJECT_NAME = 'INFECTION_PROJECT_NAME';
+
     /**
      * Default allowed timeout (on a test basis) in seconds
      */
@@ -100,6 +110,7 @@ class ConfigurationFactory
         private readonly CiDetectorInterface $ciDetector,
         private readonly Git $git,
         private readonly ProjectDirectoryProvider $projectDirectoryProvider,
+        private readonly FileSystem $fileSystem,
     ) {
     }
 
@@ -169,6 +180,7 @@ class ConfigurationFactory
         $ignoreSourceCodeMutatorsMap = $this->retrieveIgnoreSourceCodeMutatorsMap($resolvedMutatorsArray);
 
         $sourceFilter = $this->refineFilterIfNecessary($sourceFilter);
+        $projectDirectory = $this->retrieveProjectDirectory($projectDirectory);
 
         return new Configuration(
             processTimeout: $schema->timeout ?? self::DEFAULT_TIMEOUT,
@@ -209,7 +221,8 @@ class ConfigurationFactory
             ignoreSourceCodeMutatorsMap: $ignoreSourceCodeMutatorsMap,
             executeOnlyCoveringTestCases: $executeOnlyCoveringTestCases,
             mapSourceClassToTestStrategy: $mapSourceClassToTestStrategy,
-            projectDirectory: $this->retrieveProjectDirectory($projectDirectory),
+            projectDirectory: $projectDirectory,
+            projectName: $this->retrieveProjectName($projectDirectory),
             staticAnalysisTool: $resultStaticAnalysisTool,
             mutantId: $mutantId,
             configurationPathname: $schema->pathname,
@@ -551,5 +564,65 @@ class ConfigurationFactory
         );
 
         return $resolvedProjectDirectory;
+    }
+
+    /**
+     * @param non-empty-string $projectDirectory
+     *
+     * @return non-empty-string
+     */
+    private function retrieveProjectName(string $projectDirectory): string
+    {
+        $projectName = trim((string) getenv(self::INFECTION_PROJECT_NAME));
+
+        if ($projectName !== '') {
+            return $projectName;
+        }
+
+        $composerPackageName = $this->getRootComposerPackageName($projectDirectory);
+
+        if ($composerPackageName !== null) {
+            return $composerPackageName;
+        }
+
+        $directoryName = basename($projectDirectory);
+        Assert::stringNotEmpty($directoryName);
+
+        return $directoryName;
+    }
+
+    /**
+     * @param non-empty-string $projectDirectory
+     *
+     * @return non-empty-string|null
+     */
+    private function getRootComposerPackageName(string $projectDirectory): ?string
+    {
+        $composerJsonPath = $projectDirectory . '/composer.json';
+
+        if (!$this->fileSystem->isReadableFile($composerJsonPath)) {
+            return null;
+        }
+
+        try {
+            $composerJson = json_decode(
+                $this->fileSystem->readFile($composerJsonPath),
+                true,
+            );
+        } catch (JsonException) {
+            return null;
+        }
+
+        if (
+            !is_array($composerJson)
+            || !isset($composerJson['name'])
+            || !is_string($composerJson['name'])
+        ) {
+            return null;
+        }
+
+        $name = trim($composerJson['name']);
+
+        return $name === '' ? null : $name;
     }
 }

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -65,6 +65,7 @@ final readonly class RunSpanAttributesProvider
     public function provide(): array
     {
         return [
+            'infection.project.name' => $this->configuration->projectName,
             'infection.project.dir' => $this->configuration->projectDirectory,
             'infection.config.path' => $this->getConfigurationPath(),
             'infection.version' => $this->infectionVersion->prettyVersion(),

--- a/tests/e2e/Telemetry_Console/run_tests.bash
+++ b/tests/e2e/Telemetry_Console/run_tests.bash
@@ -86,6 +86,7 @@ assert_line_count 6 '"name": "infection.mutation_evaluation.mutant_evaluation"' 
 assert_line_count 6 '"name": "infection.mutation_evaluation.process"' var/execution-with-trace-exporter.stdout
 assert_line_count 1 '"name": "infection.reporting"' var/execution-with-trace-exporter.stdout
 assert_contains '"service.name": "infection"' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.project.name": "infection\/infection"' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.source_file.count": 2' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.mutation.count":' var/execution-with-trace-exporter.stdout
 assert_line_count 6 '"infection.mutation.status": "killed by tests"' var/execution-with-trace-exporter.stdout

--- a/tests/phpunit/Configuration/ConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/ConfigurationBuilder.php
@@ -64,6 +64,7 @@ final class ConfigurationBuilder
      * @param positive-int|'max' $dotsPerRow
      * @param non-empty-string $configPathname
      * @param non-empty-string $projectDirectory
+     * @param non-empty-string $projectName
      */
     private function __construct(
         private float $timeout,
@@ -101,6 +102,7 @@ final class ConfigurationBuilder
         private bool $executeOnlyCoveringTestCases,
         private ?string $mapSourceClassToTestStrategy,
         private string $projectDirectory,
+        private string $projectName,
         private ?string $staticAnalysisTool,
         private ?string $mutantId,
         private string $configPathname,
@@ -147,6 +149,7 @@ final class ConfigurationBuilder
             executeOnlyCoveringTestCases: $configuration->executeOnlyCoveringTestCases,
             mapSourceClassToTestStrategy: $configuration->mapSourceClassToTestStrategy,
             projectDirectory: $configuration->projectDirectory,
+            projectName: $configuration->projectName,
             staticAnalysisTool: $configuration->staticAnalysisTool,
             mutantId: $configuration->mutantId,
             configPathname: $configuration->configurationPathname,
@@ -191,6 +194,7 @@ final class ConfigurationBuilder
             executeOnlyCoveringTestCases: false,
             mapSourceClassToTestStrategy: null,
             projectDirectory: '/var/www/project',
+            projectName: 'project',
             staticAnalysisTool: null,
             mutantId: null,
             configPathname: '/path/to/project/infection.json5',
@@ -259,6 +263,7 @@ final class ConfigurationBuilder
             executeOnlyCoveringTestCases: true,
             mapSourceClassToTestStrategy: MapSourceClassToTestStrategy::SIMPLE,
             projectDirectory: '/var/www/project',
+            projectName: 'project',
             staticAnalysisTool: StaticAnalysisToolTypes::PHPSTAN,
             mutantId: 'abc123def456',
             configPathname: '/path/to/project/infection.json5',
@@ -585,6 +590,17 @@ final class ConfigurationBuilder
         return $clone;
     }
 
+    /**
+     * @param non-empty-string $projectName
+     */
+    public function withProjectName(string $projectName): self
+    {
+        $clone = clone $this;
+        $clone->projectName = $projectName;
+
+        return $clone;
+    }
+
     public function withStaticAnalysisTool(?string $staticAnalysisTool): self
     {
         $clone = clone $this;
@@ -650,6 +666,7 @@ final class ConfigurationBuilder
             executeOnlyCoveringTestCases: $this->executeOnlyCoveringTestCases,
             mapSourceClassToTestStrategy: $this->mapSourceClassToTestStrategy,
             projectDirectory: $this->projectDirectory,
+            projectName: $this->projectName,
             staticAnalysisTool: $this->staticAnalysisTool,
             mutantId: $this->mutantId,
             configurationPathname: $this->configPathname,

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryInputBuilder.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryInputBuilder.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Configuration\ConfigurationFactory;
 use Infection\Configuration\Schema\SchemaConfiguration;
 use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
 use Infection\Configuration\SourceFilter\PlainFilter;
+use Infection\Console\LogVerbosity;
 
 final class ConfigurationFactoryInputBuilder
 {
@@ -80,6 +81,45 @@ final class ConfigurationFactoryInputBuilder
         private ?string $staticAnalysisTool,
         private ?string $mutantId,
     ) {
+    }
+
+    public static function withMinimalTestData(): self
+    {
+        return new self(
+            existingCoveragePath: null,
+            initialTestsPhpOptions: null,
+            skipInitialTests: false,
+            logVerbosity: LogVerbosity::NONE,
+            debug: false,
+            withUncovered: false,
+            noProgress: false,
+            ignoreMsiWithNoMutations: false,
+            minMsi: null,
+            numberOfShownMutations: 0,
+            minCoveredMsi: null,
+            timeoutsAsEscaped: false,
+            maxTimeouts: null,
+            msiPrecision: 2,
+            mutatorsInput: '',
+            testFramework: null,
+            testFrameworkExtraOptions: null,
+            staticAnalysisToolOptions: null,
+            sourceFilter: null,
+            threadCount: 1,
+            dotsPerRow: null,
+            dryRun: false,
+            useGitHubLogger: false,
+            gitlabLogFilePath: null,
+            htmlLogFilePath: null,
+            textLogFilePath: null,
+            summaryJsonLogFilePath: null,
+            useNoopMutators: false,
+            executeOnlyCoveringTestCases: false,
+            mapSourceClassToTestStrategy: null,
+            projectDirectory: null,
+            staticAnalysisTool: null,
+            mutantId: null,
+        );
     }
 
     public function withExistingCoveragePath(?string $existingCoveragePath): self

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -50,6 +50,8 @@ use Infection\Configuration\SourceFilter\GitDiffFilter;
 use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
 use Infection\Configuration\SourceFilter\PlainFilter;
 use Infection\Console\LogVerbosity;
+use Infection\FileSystem\FileSystem;
+use Infection\FileSystem\InMemoryFileSystem;
 use Infection\FileSystem\TmpDirProvider;
 use Infection\Mutator\Arithmetic\AssignmentEqual;
 use Infection\Mutator\Boolean\EqualIdentical;
@@ -68,19 +70,25 @@ use Infection\Testing\SingletonContainer;
 use Infection\Tests\Configuration\ConfigurationBuilder;
 use Infection\Tests\Configuration\Entry\LogsBuilder;
 use Infection\Tests\Configuration\Schema\SchemaConfigurationBuilder;
+use Infection\Tests\EnvVariableManipulation\BacksUpEnvironmentVariables;
 use Infection\Tests\Fixtures\DummyCiDetector;
 use Infection\Tests\Fixtures\Mutator\CustomMutator;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use function Safe\putenv;
 use function sys_get_temp_dir;
 
+#[BackupGlobals(true)]
 #[Group('integration')]
 #[CoversClass(ConfigurationFactory::class)]
 final class ConfigurationFactoryTest extends TestCase
 {
+    use BacksUpEnvironmentVariables;
+
     private const string GIT_DEFAULT_BASE = 'test/default';
 
     private const string DEFAULT_PROJECT_DIRECTORY = '/ci/path/to/project';
@@ -93,6 +101,18 @@ final class ConfigurationFactoryTest extends TestCase
     public static function tearDownAfterClass(): void
     {
         self::$mutators = null;
+    }
+
+    protected function setUp(): void
+    {
+        $this->backupEnvironmentVariables();
+
+        putenv(ConfigurationFactory::INFECTION_PROJECT_NAME);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreEnvironmentVariables();
     }
 
     #[DataProvider('valueProvider')]
@@ -192,6 +212,85 @@ final class ConfigurationFactoryTest extends TestCase
                 mutantId: null,
             )
         ;
+    }
+
+    /**
+     * @param array<string, string> $environmentVariables
+     */
+    #[DataProvider('projectNameProvider')]
+    public function test_it_resolves_project_name(
+        array $environmentVariables,
+        ?string $composerJsonContent,
+        string $expected,
+    ): void {
+        foreach ($environmentVariables as $name => $value) {
+            putenv($name . '=' . $value);
+        }
+
+        $fileSystem = new InMemoryFileSystem();
+
+        if ($composerJsonContent !== null) {
+            $fileSystem
+                ->dumpFile(
+                    self::DEFAULT_PROJECT_DIRECTORY . '/composer.json',
+                    $composerJsonContent,
+                );
+        }
+
+        $schema = SchemaConfigurationBuilder::withMinimalTestData()->build();
+
+        $actual = $this
+            ->createConfigurationFactory(
+                ciDetected: false,
+                githubActionsDetected: false,
+                projectDirectory: self::DEFAULT_PROJECT_DIRECTORY,
+                fileSystem: $fileSystem,
+            )
+            ->create(
+                ...ConfigurationFactoryInputBuilder::withMinimalTestData()
+                    ->build($schema),
+            );
+
+        $this->assertSame($expected, $actual->projectName);
+    }
+
+    public static function projectNameProvider(): iterable
+    {
+        yield 'environment variable and no composer.json' => [
+            [ConfigurationFactory::INFECTION_PROJECT_NAME => 'example/package'],
+            null,
+            'example/package',
+        ];
+
+        yield 'no environment variable; composer.json' => [
+            [],
+            '{"name": "example/package"}',
+            'example/package',
+        ];
+
+        yield 'no environment variable and no composer.json' => [
+            [],
+            null,
+            'project',
+        ];
+
+        yield 'environment variable and composer.json' => [
+            [ConfigurationFactory::INFECTION_PROJECT_NAME => 'example/package'],
+            '{"name": "example/another-package"}',
+            'example/package',
+        ];
+
+        yield 'no environment variable; composer.json without a package name' => [
+            [],
+            '{}',
+            'project',
+        ];
+
+        yield 'no environment variable; composer.json with an invalid package name' => [
+            [],
+            '{"name": 10}',
+            'project',
+        ];
     }
 
     public static function valueProvider(): iterable
@@ -298,6 +397,7 @@ final class ConfigurationFactoryTest extends TestCase
             executeOnlyCoveringTestCases: true,
             mapSourceClassToTestStrategy: MapSourceClassToTestStrategy::SIMPLE,
             projectDirectory: self::DEFAULT_PROJECT_DIRECTORY,
+            projectName: 'project',
             staticAnalysisTool: null,
             mutantId: null,
             configurationPathname: '/path/to/infection.json',
@@ -1529,6 +1629,7 @@ final class ConfigurationFactoryTest extends TestCase
         bool $ciDetected,
         bool $githubActionsDetected,
         ?string $projectDirectory,
+        ?FileSystem $fileSystem = null,
     ): ConfigurationFactory {
         $projectDirectoryProviderMock = $this->createMock(ProjectDirectoryProvider::class);
         $projectDirectoryProviderMock
@@ -1545,6 +1646,7 @@ final class ConfigurationFactoryTest extends TestCase
                 self::GIT_DEFAULT_BASE,
             ),
             $projectDirectoryProviderMock,
+            $fileSystem ?? new InMemoryFileSystem(),
         );
     }
 }

--- a/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
@@ -49,6 +49,7 @@ final class RunSpanAttributesProviderTest extends TestCase
     {
         $configuration = ConfigurationBuilder::withMinimalTestData()
             ->withProjectDirectory('/var/www/project')
+            ->withProjectName('acme/package')
             ->withConfigPathname('/var/www/project/config/infection.json5')
             ->withThreadCount(8)
             ->withSkipInitialTests(true)
@@ -66,6 +67,7 @@ final class RunSpanAttributesProviderTest extends TestCase
         );
 
         $expected = [
+            'infection.project.name' => 'acme/package',
             'infection.project.dir' => '/var/www/project',
             'infection.config.path' => 'config/infection.json5',
             'infection.version' => '1.2.3',


### PR DESCRIPTION
## Description

Adds a resolved project name to the configuration and includes it in the root `infection.run` span attributes.

The project name is resolved once while building the configuration, then reused by telemetry. This keeps project identity handling outside the span attribute provider while allowing traces to identify the analysed package more clearly.

## Changes

- Adds `Configuration::$projectName`.
- Resolves the project name from `INFECTION_PROJECT_NAME`, the root `composer.json` package name, or the project directory basename.
- Adds `infection.project.name` to `RunSpanAttributesProvider`.

## Related issues

- #3090