### PR TITLE
feat(telemetry): Expose toolchain metadata on telemetry run spans

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -2839,6 +2839,12 @@ message = "Parameter `$installedExtensions` is never used."
 count = 1
 
 [[issues]]
+file = "src/Telemetry/Attribute/RunSpanAttributesProvider.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\AbstractTestFramework\InvalidVersion` in `Infection\Telemetry\Attribute\RunSpanAttributesProvider::provide`.'
+count = 1
+
+[[issues]]
 file = "src/Telemetry/SDK/FailingTracerProviderFactory.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Telemetry\SDK\FailingTracerProviderFactory::createExporter`.'
@@ -11903,6 +11909,12 @@ file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory
 code = "deprecated-method"
 message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
 count = 3
+
+[[issues]]
+file = "tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Telemetry\Attribute\RunSpanAttributesProviderTest::test_it_omits_static_analysis_tool_attributes_when_static_analysis_is_disabled`.'
+count = 1
 
 [[issues]]
 file = "tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php"

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -68,21 +68,12 @@ Infection records the following lifecycle spans for every run:
 The root `infection.run` span includes run identity, execution-context, and
 toolchain attributes that are useful for filtering dashboards:
 
-| Attribute                                     | Description                                                                 |
-|-----------------------------------------------|-----------------------------------------------------------------------------|
-| `infection.project.name`                      | Project label. Uses `INFECTION_PROJECT_NAME`, then root `composer.json` name, then project directory basename. |
-| `infection.project.dir`                       | Resolved project directory.                                                 |
-| `infection.config.path`                       | Infection configuration path, relative to `infection.project.dir` when possible. |
-| `infection.version`                           | Infection version reported by Composer metadata.                            |
-| `infection.distribution`                      | `source` or `phar`.                                                         |
-| `infection.git.sha`                           | Current `HEAD` commit SHA when the project directory is a Git checkout.     |
-| `infection.thread.count`                      | Resolved mutation runner thread count.                                      |
-| `infection.initial_tests.skipped`             | Whether the initial test run was skipped.                                   |
-| `infection.initial_static_analysis.skipped`   | Whether the initial static analysis run was skipped because no static analysis tool was enabled. |
-| `infection.test_framework.name`               | Normalized configured test framework name, for example `phpunit`.           |
-| `infection.test_framework.version`            | Version reported by the configured test framework adapter.                  |
-| `infection.static_analysis_tool.name`         | Normalized configured static analysis tool name, for example `phpstan`; only emitted when static analysis is enabled. |
-| `infection.static_analysis_tool.version`      | Version reported by the configured static analysis tool adapter; only emitted with `infection.static_analysis_tool.name`. |
+| Attribute                                | Description                                                                                                               |
+|------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `infection.test_framework.name`          | Normalized configured test framework name, for example `phpunit`.                                                         |
+| `infection.test_framework.version`       | Version reported by the configured test framework adapter.                                                                |
+| `infection.static_analysis_tool.name`    | Normalized configured static analysis tool name, for example `phpstan`; only emitted when static analysis is enabled.     |
+| `infection.static_analysis_tool.version` | Version reported by the configured static analysis tool adapter; only emitted with `infection.static_analysis_tool.name`. |
 
 ## Configuration
 

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -63,6 +63,27 @@ Infection records the following lifecycle spans for every run:
 - `infection.mutation_evaluation.mutant_evaluation`
 - `infection.mutation_evaluation.process`
 
+## Run Attributes
+
+The root `infection.run` span includes run identity, execution-context, and
+toolchain attributes that are useful for filtering dashboards:
+
+| Attribute                                     | Description                                                                 |
+|-----------------------------------------------|-----------------------------------------------------------------------------|
+| `infection.project.name`                      | Project label. Uses `INFECTION_PROJECT_NAME`, then root `composer.json` name, then project directory basename. |
+| `infection.project.dir`                       | Resolved project directory.                                                 |
+| `infection.config.path`                       | Infection configuration path, relative to `infection.project.dir` when possible. |
+| `infection.version`                           | Infection version reported by Composer metadata.                            |
+| `infection.distribution`                      | `source` or `phar`.                                                         |
+| `infection.git.sha`                           | Current `HEAD` commit SHA when the project directory is a Git checkout.     |
+| `infection.thread.count`                      | Resolved mutation runner thread count.                                      |
+| `infection.initial_tests.skipped`             | Whether the initial test run was skipped.                                   |
+| `infection.initial_static_analysis.skipped`   | Whether the initial static analysis run was skipped because no static analysis tool was enabled. |
+| `infection.test_framework.name`               | Normalized configured test framework name, for example `phpunit`.           |
+| `infection.test_framework.version`            | Version reported by the configured test framework adapter.                  |
+| `infection.static_analysis_tool.name`         | Normalized configured static analysis tool name, for example `phpstan`; only emitted when static analysis is enabled. |
+| `infection.static_analysis_tool.version`      | Version reported by the configured static analysis tool adapter; only emitted with `infection.static_analysis_tool.name`. |
+
 ## Configuration
 
 `INFECTION_TELEMETRY=true` is required before Infection creates any telemetry

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -86,6 +86,7 @@ use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\FileSystem\Locator\RootsFileLocator;
 use Infection\FileSystem\Locator\RootsFileOrDirectoryLocator;
 use Infection\FileSystem\ProjectDirProvider;
+use Infection\Framework\InfectionVersion;
 use Infection\Git\CommandLineGit;
 use Infection\Git\Git;
 use Infection\Logger\ArtefactCollection\InitialStaticAnalysisExecution\InitialStaticAnalysisExecutionLogger;
@@ -155,6 +156,7 @@ use Infection\Source\Matcher\SourceLineMatcher;
 use Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\StaticAnalysis\StaticAnalysisToolFactory;
+use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
 use Infection\Telemetry\Subscriber\OpenTelemetryTracerSubscriberFactory;
 use Infection\TestFramework\AdapterInstallationDecider;
 use Infection\TestFramework\AdapterInstaller;
@@ -315,6 +317,16 @@ final class Container extends DIContainer
                     $config,
                     $container->getStaticAnalysisToolExecutableFinder(),
                     $container->getStaticAnalysisConfigLocator(),
+                );
+            },
+            RunSpanAttributesProvider::class => static function (self $container): RunSpanAttributesProvider {
+                $config = $container->getConfiguration();
+
+                return new RunSpanAttributesProvider(
+                    $config,
+                    $container->get(InfectionVersion::class),
+                    $container->getTestFrameworkAdapter(),
+                    $config->isStaticAnalysisEnabled() ? $container->getStaticAnalysisToolAdapter() : null,
                 );
             },
             MutantFactory::class => static fn (self $container): MutantFactory => new MutantFactory(

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -326,7 +326,9 @@ final class Container extends DIContainer
                     $config,
                     $container->get(InfectionVersion::class),
                     $container->getTestFrameworkAdapter(),
-                    $config->isStaticAnalysisEnabled() ? $container->getStaticAnalysisToolAdapter() : null,
+                    $config->isStaticAnalysisEnabled()
+                        ? $container->getStaticAnalysisToolAdapter()
+                        : null,
                 );
             },
             MutantFactory::class => static fn (self $container): MutantFactory => new MutantFactory(

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -35,8 +35,11 @@ declare(strict_types=1);
 
 namespace Infection\Telemetry\Attribute;
 
+use function array_filter;
+use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Configuration\Configuration;
 use Infection\Framework\InfectionVersion;
+use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use OutOfBoundsException;
 use Phar;
 use Symfony\Component\Filesystem\Path;
@@ -54,6 +57,8 @@ final readonly class RunSpanAttributesProvider
     public function __construct(
         private Configuration $configuration,
         private InfectionVersion $infectionVersion,
+        private TestFrameworkAdapter $testFrameworkAdapter,
+        private ?StaticAnalysisToolAdapter $staticAnalysisToolAdapter,
     ) {
     }
 
@@ -64,7 +69,7 @@ final readonly class RunSpanAttributesProvider
      */
     public function provide(): array
     {
-        return [
+        return array_filter([
             'infection.project.name' => $this->configuration->projectName,
             'infection.project.dir' => $this->configuration->projectDirectory,
             'infection.config.path' => $this->getConfigurationPath(),
@@ -74,7 +79,13 @@ final readonly class RunSpanAttributesProvider
             'infection.thread.count' => $this->configuration->threadCount,
             'infection.initial_tests.skipped' => $this->configuration->skipInitialTests,
             'infection.initial_static_analysis.skipped' => !$this->configuration->isStaticAnalysisEnabled(),
-        ];
+            'infection.test_framework.name' => $this->configuration->testFramework,
+            'infection.test_framework.version' => $this->testFrameworkAdapter->getVersion(),
+            'infection.static_analysis_tool.name' => $this->configuration->staticAnalysisTool,
+            'infection.static_analysis_tool.version' => $this->configuration->isStaticAnalysisEnabled()
+                ? $this->staticAnalysisToolAdapter?->getVersion()
+                : null,
+        ], static fn (mixed $value): bool => $value !== null);
     }
 
     private function getConfigurationPath(): string

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Telemetry\Attribute;
 
-use function array_filter;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Configuration\Configuration;
 use Infection\Framework\InfectionVersion;
@@ -43,6 +42,7 @@ use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use OutOfBoundsException;
 use Phar;
 use Symfony\Component\Filesystem\Path;
+use Webmozart\Assert\Assert;
 
 /**
  * @phpstan-type Attribute = bool|int|float|string|null
@@ -69,7 +69,7 @@ final readonly class RunSpanAttributesProvider
      */
     public function provide(): array
     {
-        return array_filter([
+        $attributes = [
             'infection.project.name' => $this->configuration->projectName,
             'infection.project.dir' => $this->configuration->projectDirectory,
             'infection.config.path' => $this->getConfigurationPath(),
@@ -81,11 +81,17 @@ final readonly class RunSpanAttributesProvider
             'infection.initial_static_analysis.skipped' => !$this->configuration->isStaticAnalysisEnabled(),
             'infection.test_framework.name' => $this->configuration->testFramework,
             'infection.test_framework.version' => $this->testFrameworkAdapter->getVersion(),
-            'infection.static_analysis_tool.name' => $this->configuration->staticAnalysisTool,
-            'infection.static_analysis_tool.version' => $this->configuration->isStaticAnalysisEnabled()
-                ? $this->staticAnalysisToolAdapter?->getVersion()
-                : null,
-        ], static fn (mixed $value): bool => $value !== null);
+        ];
+
+        if ($this->configuration->isStaticAnalysisEnabled()) {
+            Assert::notNull($this->configuration->staticAnalysisTool);
+            Assert::notNull($this->staticAnalysisToolAdapter);
+
+            $attributes['infection.static_analysis_tool.name'] = $this->configuration->staticAnalysisTool;
+            $attributes['infection.static_analysis_tool.version'] = $this->staticAnalysisToolAdapter->getVersion();
+        }
+
+        return $attributes;
     }
 
     private function getConfigurationPath(): string

--- a/tests/e2e/Telemetry_Console/run_tests.bash
+++ b/tests/e2e/Telemetry_Console/run_tests.bash
@@ -87,6 +87,10 @@ assert_line_count 6 '"name": "infection.mutation_evaluation.process"' var/execut
 assert_line_count 1 '"name": "infection.reporting"' var/execution-with-trace-exporter.stdout
 assert_contains '"service.name": "infection"' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.project.name": "infection\/infection"' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.test_framework.name": "phpunit"' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.test_framework.version":' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.static_analysis_tool.name": "phpstan"' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.static_analysis_tool.version":' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.source_file.count": 2' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.mutation.count":' var/execution-with-trace-exporter.stdout
 assert_line_count 6 '"infection.mutation.status": "killed by tests"' var/execution-with-trace-exporter.stdout

--- a/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
@@ -35,7 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Telemetry\Attribute;
 
+use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Framework\InfectionVersion;
+use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\StaticAnalysis\StaticAnalysisToolTypes;
 use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
 use Infection\Tests\Configuration\ConfigurationBuilder;
@@ -61,10 +63,20 @@ final class RunSpanAttributesProviderTest extends TestCase
         $infectionVersionMock
             ->method('prettyVersion')
             ->willReturn('1.2.3');
+        $testFrameworkAdapter = $this->createStub(TestFrameworkAdapter::class);
+        $testFrameworkAdapter
+            ->method('getVersion')
+            ->willReturn('12.3.4');
+        $staticAnalysisToolAdapter = $this->createStub(StaticAnalysisToolAdapter::class);
+        $staticAnalysisToolAdapter
+            ->method('getVersion')
+            ->willReturn('2.1.17');
 
         $provider = new RunSpanAttributesProvider(
             $configuration,
             $infectionVersionMock,
+            $testFrameworkAdapter,
+            $staticAnalysisToolAdapter,
         );
 
         $expected = [
@@ -77,10 +89,44 @@ final class RunSpanAttributesProviderTest extends TestCase
             'infection.thread.count' => 8,
             'infection.initial_tests.skipped' => true,
             'infection.initial_static_analysis.skipped' => false,
+            'infection.test_framework.name' => 'phpunit',
+            'infection.test_framework.version' => '12.3.4',
+            'infection.static_analysis_tool.name' => 'phpstan',
+            'infection.static_analysis_tool.version' => '2.1.17',
         ];
 
         $actual = $provider->provide();
 
         $this->assertSame($expected, $actual);
+    }
+
+    public function test_it_omits_static_analysis_tool_attributes_when_static_analysis_is_disabled(): void
+    {
+        $configuration = ConfigurationBuilder::withMinimalTestData()
+            ->withStaticAnalysisTool(null)
+            ->build();
+
+        $infectionVersion = $this->createStub(InfectionVersion::class);
+        $infectionVersion
+            ->method('prettyVersion')
+            ->willReturn('1.2.3');
+        $testFrameworkAdapter = $this->createStub(TestFrameworkAdapter::class);
+        $testFrameworkAdapter
+            ->method('getVersion')
+            ->willReturn('12.3.4');
+
+        $provider = new RunSpanAttributesProvider(
+            $configuration,
+            $infectionVersion,
+            $testFrameworkAdapter,
+            null,
+        );
+
+        $actual = $provider->provide();
+
+        $this->assertSame('phpunit', $actual['infection.test_framework.name']);
+        $this->assertSame('12.3.4', $actual['infection.test_framework.version']);
+        $this->assertArrayNotHasKey('infection.static_analysis_tool.name', $actual);
+        $this->assertArrayNotHasKey('infection.static_analysis_tool.version', $actual);
     }
 }

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\Telemetry\Subscriber;
 
 use function array_map;
 use function array_values;
+use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Event\Events\Application\ApplicationExecutionWasFinished;
 use Infection\Event\Events\Application\ApplicationExecutionWasStarted;
 use Infection\Event\Events\ArtefactCollection\ArtefactCollectionWasFinished;
@@ -116,6 +117,10 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
     {
         $this->exporter = new InMemoryExporter();
         $this->tracerProvider = new TracerProvider(new SimpleSpanProcessor($this->exporter));
+        $testFrameworkAdapter = $this->createStub(TestFrameworkAdapter::class);
+        $testFrameworkAdapter
+            ->method('getVersion')
+            ->willReturn('12.3.4');
 
         $this->subscriber = new OpenTelemetryTracerSubscriber(
             new OpenTelemetryTracer(
@@ -127,6 +132,8 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                     ->withProjectDirectory('/path/to/project')
                     ->build(),
                 new InfectionVersion(),
+                $testFrameworkAdapter,
+                null,
             ),
         );
     }
@@ -274,6 +281,10 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame(1, $run->getAttributes()->get('infection.thread.count'));
         $this->assertFalse($run->getAttributes()->get('infection.initial_tests.skipped'));
         $this->assertTrue($run->getAttributes()->get('infection.initial_static_analysis.skipped'));
+        $this->assertSame('phpunit', $run->getAttributes()->get('infection.test_framework.name'));
+        $this->assertSame('12.3.4', $run->getAttributes()->get('infection.test_framework.version'));
+        $this->assertFalse($run->getAttributes()->has('infection.static_analysis_tool.name'));
+        $this->assertFalse($run->getAttributes()->has('infection.static_analysis_tool.version'));
         $this->assertIsString($run->getAttributes()->get('infection.version'));
         $this->assertSame('/path/to/src/Foo.php', $astProcessing->getAttributes()->get('code.file.path'));
         $this->assertSame('/path/to/src/Foo.php', $astParsing->getAttributes()->get('code.file.path'));


### PR DESCRIPTION
## Description

Adds test framework and static analysis tool metadata to the root `infection.run`
telemetry span.

These attributes make completed runs easier to filter and compare in telemetry
backends, especially when projects change test framework versions or enable
static analysis during mutation testing. Static analysis metadata is emitted only
when static analysis is enabled for the run.

## Changes

- Adds `infection.test_framework.name` and `infection.test_framework.version` to `infection.run`.
- Adds `infection.static_analysis_tool.name` and `infection.static_analysis_tool.version` to `infection.run` when static analysis is enabled.

## Related issues

- #3090