### PR TITLE
feat(telemetry): Add mutation result summaries to telemetry run spans

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -2841,7 +2841,7 @@ count = 1
 [[issues]]
 file = "src/Telemetry/Attribute/RunSpanAttributesProvider.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\AbstractTestFramework\InvalidVersion` in `Infection\Telemetry\Attribute\RunSpanAttributesProvider::provide`.'
+message = 'Potentially unhandled exception `Infection\AbstractTestFramework\InvalidVersion` in `Infection\Telemetry\Attribute\RunSpanAttributesProvider::provideInitialAttributes`.'
 count = 1
 
 [[issues]]

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -65,24 +65,42 @@ Infection records the following lifecycle spans for every run:
 
 ## Run Attributes
 
-The root `infection.run` span includes run identity, execution-context, and
-toolchain attributes that are useful for filtering dashboards:
+The root `infection.run` span includes run identity, execution-context,
+toolchain, and run-summary attributes that are useful for filtering dashboards:
 
-| Attribute                                   | Description                                                                                                               |
-|---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `infection.project.name`                    | Project label. Uses `INFECTION_PROJECT_NAME`, then root `composer.json` name, then project directory basename.            |
-| `infection.project.dir`                     | Resolved project directory.                                                                                               |
-| `infection.config.path`                     | Infection configuration path, relative to `infection.project.dir` when possible.                                          |
-| `infection.version`                         | Infection version reported by Composer metadata.                                                                          |
-| `infection.distribution`                    | `source` or `phar`.                                                                                                       |
-| `infection.git.sha`                         | Current `HEAD` commit SHA when the project directory is a Git checkout.                                                   |
-| `infection.thread.count`                    | Resolved mutation runner thread count.                                                                                    |
-| `infection.initial_tests.skipped`           | Whether the initial test run was skipped.                                                                                 |
-| `infection.initial_static_analysis.skipped` | Whether the initial static analysis run was skipped because no static analysis tool was enabled.                          |
-| `infection.test_framework.name`             | Normalised configured test framework name, for example `phpunit`.                                                         |
-| `infection.test_framework.version`          | Version reported by the configured test framework adapter.                                                                |
-| `infection.static_analysis_tool.name`       | Normalised configured static analysis tool name, for example `phpstan`; only emitted when static analysis is enabled.     |
-| `infection.static_analysis_tool.version`    | Version reported by the configured static analysis tool adapter; only emitted with `infection.static_analysis_tool.name`. |
+| Attribute                                            | Description                                                                                                               |
+|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `infection.project.name`                             | Project label. Uses `INFECTION_PROJECT_NAME`, then root `composer.json` name, then project directory basename.            |
+| `infection.project.dir`                              | Resolved project directory.                                                                                               |
+| `infection.config.path`                              | Infection configuration path, relative to `infection.project.dir` when possible.                                          |
+| `infection.version`                                  | Infection version reported by Composer metadata.                                                                          |
+| `infection.distribution`                             | `source` or `phar`.                                                                                                       |
+| `infection.git.sha`                                  | Current `HEAD` commit SHA when the project directory is a Git checkout.                                                   |
+| `infection.thread.count`                             | Resolved mutation runner thread count.                                                                                    |
+| `infection.initial_tests.skipped`                    | Whether the initial test run was skipped.                                                                                 |
+| `infection.initial_static_analysis.skipped`          | Whether the initial static analysis run was skipped because no static analysis tool was enabled.                          |
+| `infection.test_framework.name`                      | Normalised configured test framework name, for example `phpunit`.                                                         |
+| `infection.test_framework.version`                   | Version reported by the configured test framework adapter.                                                                |
+| `infection.static_analysis_tool.name`                | Normalised configured static analysis tool name, for example `phpstan`; only emitted when static analysis is enabled.     |
+| `infection.static_analysis_tool.version`             | Version reported by the configured static analysis tool adapter; only emitted with `infection.static_analysis_tool.name`. |
+| `infection.source_file.count`                        | Number of source files collected for the run.                                                                             |
+| `infection.mutation.count`                           | Number of generated mutations selected for mutation evaluation.                                                           |
+| `infection.mutation.suppressed.count`                | Number of generated mutations suppressed before mutant evaluation, including heuristic suppression.                       |
+| `infection.mutation.evaluated.count`                 | Number of mutations evaluated.                                                                                            |
+| `infection.mutation.killed_by_tests.count`           | Number of mutation results with `killed by tests` detection status.                                                       |
+| `infection.mutation.killed_by_static_analysis.count` | Number of mutation results with `killed by static analysis` detection status.                                             |
+| `infection.mutation.escaped.count`                   | Number of mutation results with `escaped` detection status.                                                               |
+| `infection.mutation.error.count`                     | Number of mutation results with `error` detection status.                                                                 |
+| `infection.mutation.timed_out.count`                 | Number of mutation results with `timed out` detection status.                                                             |
+| `infection.mutation.skipped.count`                   | Number of mutation results with `skipped` detection status.                                                               |
+| `infection.mutation.syntax_error.count`              | Number of mutation results with `syntax error` detection status.                                                          |
+| `infection.mutation.not_covered.count`               | Number of mutation results with `not covered` detection status.                                                           |
+| `infection.mutation.ignored.count`                   | Number of mutation results with `ignored` detection status.                                                               |
+| `infection.msi`                                      | Final Mutation Score Indicator percentage.                                                                                |
+| `infection.covered_msi`                              | Final covered-code Mutation Score Indicator percentage.                                                                   |
+| `infection.msi.threshold`                            | Effective minimum MSI threshold, or `0.0` when no threshold is configured.                                                |
+| `infection.covered_msi.threshold`                    | Effective minimum covered-code MSI threshold, or `0.0` when no threshold is configured.                                   |
+
 
 ## Configuration
 

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -329,6 +329,7 @@ final class Container extends DIContainer
                     $config->isStaticAnalysisEnabled()
                         ? $container->getStaticAnalysisToolAdapter()
                         : null,
+                    $container->getMetricsCalculator(),
                 );
             },
             MutantFactory::class => static fn (self $container): MutantFactory => new MutantFactory(

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -108,15 +108,10 @@ final readonly class RunSpanAttributesProvider
             $this->metricsCalculator->getTotalMutantsCount(),
         );
 
-        $suppressedCount = max(
-            0,
-            $mutationCount - $evaluatedMutationCount,
-        );
-
         return [
             'infection.source_file.count' => $sourceFileCount,
             'infection.mutation.count' => $mutationCount,
-            'infection.mutation.suppressed.count' => $suppressedCount,
+            'infection.mutation.suppressed.count' => $mutationCount - $evaluatedMutationCount,
             'infection.mutation.evaluated.count' => $evaluatedMutationCount,
             'infection.mutation.killed_by_tests.count' => $this->metricsCalculator->getKilledByTestsCount(),
             'infection.mutation.killed_by_static_analysis.count' => $this->metricsCalculator->getKilledByStaticAnalysisCount(),

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -38,7 +38,9 @@ namespace Infection\Telemetry\Attribute;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Configuration\Configuration;
 use Infection\Framework\InfectionVersion;
+use Infection\Metrics\MetricsCalculator;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
+use function max;
 use OutOfBoundsException;
 use Phar;
 use Symfony\Component\Filesystem\Path;
@@ -59,6 +61,7 @@ final readonly class RunSpanAttributesProvider
         private InfectionVersion $infectionVersion,
         private TestFrameworkAdapter $testFrameworkAdapter,
         private ?StaticAnalysisToolAdapter $staticAnalysisToolAdapter,
+        private MetricsCalculator $metricsCalculator,
     ) {
     }
 
@@ -67,7 +70,7 @@ final readonly class RunSpanAttributesProvider
      *
      * @return Attributes
      */
-    public function provide(): array
+    public function provideInitialAttributes(): array
     {
         $attributes = [
             'infection.project.name' => $this->configuration->projectName,
@@ -92,6 +95,43 @@ final readonly class RunSpanAttributesProvider
         }
 
         return $attributes;
+    }
+
+    /**
+     * @return Attributes
+     */
+    public function provideSummaryAttributes(int $sourceFileCount, int $mutationCount, int $evaluatedMutationCount): array
+    {
+        $mutationCount = max(
+            $mutationCount,
+            $evaluatedMutationCount,
+            $this->metricsCalculator->getTotalMutantsCount(),
+        );
+
+        $suppressedCount = max(
+            0,
+            $mutationCount - $evaluatedMutationCount,
+        );
+
+        return [
+            'infection.source_file.count' => $sourceFileCount,
+            'infection.mutation.count' => $mutationCount,
+            'infection.mutation.suppressed.count' => $suppressedCount,
+            'infection.mutation.evaluated.count' => $evaluatedMutationCount,
+            'infection.mutation.killed_by_tests.count' => $this->metricsCalculator->getKilledByTestsCount(),
+            'infection.mutation.killed_by_static_analysis.count' => $this->metricsCalculator->getKilledByStaticAnalysisCount(),
+            'infection.mutation.escaped.count' => $this->metricsCalculator->getEscapedCount(),
+            'infection.mutation.error.count' => $this->metricsCalculator->getErrorCount(),
+            'infection.mutation.timed_out.count' => $this->metricsCalculator->getTimedOutCount(),
+            'infection.mutation.skipped.count' => $this->metricsCalculator->getSkippedCount(),
+            'infection.mutation.syntax_error.count' => $this->metricsCalculator->getSyntaxErrorCount(),
+            'infection.mutation.not_covered.count' => $this->metricsCalculator->getNotTestedCount(),
+            'infection.mutation.ignored.count' => $this->metricsCalculator->getIgnoredCount(),
+            'infection.msi' => $this->metricsCalculator->getMutationScoreIndicator(),
+            'infection.covered_msi' => $this->metricsCalculator->getCoveredCodeMutationScoreIndicator(),
+            'infection.msi.threshold' => $this->configuration->minMsi ?? 0.0,
+            'infection.covered_msi.threshold' => $this->configuration->minCoveredMsi ?? 0.0,
+        ];
     }
 
     private function getConfigurationPath(): string

--- a/src/Telemetry/OpenTelemetryTracer.php
+++ b/src/Telemetry/OpenTelemetryTracer.php
@@ -83,7 +83,7 @@ final readonly class OpenTelemetryTracer
     }
 
     /**
-     * @param array<non-empty-string, bool|int|float|string> $attributes
+     * @param Attributes $attributes
      */
     public function end(SpanHandle $span, array $attributes = []): void
     {

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -119,6 +119,8 @@ use function spl_object_id;
 use function str_starts_with;
 
 /**
+ * @phpstan-import-type Attributes from RunSpanAttributesProvider
+ *
  * @internal
  */
 final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFinishedSubscriber, ApplicationExecutionWasStartedSubscriber, ArtefactCollectionWasFinishedSubscriber, ArtefactCollectionWasStartedSubscriber, AstEnrichmentWasFinishedSubscriber, AstEnrichmentWasStartedSubscriber, AstParsingWasFinishedSubscriber, AstParsingWasStartedSubscriber, AstProcessingWasFinishedSubscriber, AstProcessingWasStartedSubscriber, HeuristicSuppressionWasFinishedSubscriber, HeuristicSuppressionWasStartedSubscriber, HeuristicWasFinishedSubscriber, HeuristicWasStartedSubscriber, InitialStaticAnalysisRunWasFinishedSubscriber, InitialStaticAnalysisRunWasStartedSubscriber, InitialTestSuiteWasFinishedSubscriber, InitialTestSuiteWasStartedSubscriber, MutantAnalysisWasFinishedSubscriber, MutantAnalysisWasStartedSubscriber, MutantEvaluationWasFinishedSubscriber, MutantEvaluationWasStartedSubscriber, MutantMaterialisationWasFinishedSubscriber, MutantMaterialisationWasStartedSubscriber, MutantProcessExecutionWasFinishedSubscriber, MutantProcessExecutionWasStartedSubscriber, MutationAnalysisWasFinishedSubscriber, MutationAnalysisWasStartedSubscriber, MutationEvaluationForMutationWasFinishedSubscriber, MutationEvaluationForMutationWasStartedSubscriber, MutationEvaluationWasFinishedSubscriber, MutationEvaluationWasStartedSubscriber, MutationGenerationWasFinishedSubscriber, MutationGenerationWasStartedSubscriber, ReportingWasFinishedSubscriber, ReportingWasStartedSubscriber, SourceCollectionWasFinishedSubscriber, SourceCollectionWasStartedSubscriber
@@ -174,6 +176,12 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     /** @var array<int, string> */
     private array $mutantProcessExecutionSpanMutationHashes = [];
 
+    private int $sourceFileCount = 0;
+
+    private int $mutationCount = 0;
+
+    private int $evaluatedMutationCount = 0;
+
     public function __construct(
         private readonly OpenTelemetryTracer $telemetry,
         private readonly RunSpanAttributesProvider $runSpanAttributesProvider,
@@ -184,7 +192,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     {
         $this->rootSpan = $this->telemetry->startRootSpan(
             'infection.run',
-            $this->runSpanAttributesProvider->provide(),
+            $this->runSpanAttributesProvider->provideInitialAttributes(),
         );
     }
 
@@ -321,6 +329,8 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onMutationEvaluationWasStarted(MutationEvaluationWasStarted $event): void
     {
+        $this->mutationCount = $event->mutationCount;
+
         $this->mutationEvaluationSpan = $this->startChild(
             'infection.mutation_evaluation',
             ['infection.mutation.count' => $event->mutationCount],
@@ -469,6 +479,8 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     {
         $hash = $event->mutant->getMutation()->getHash();
 
+        ++$this->evaluatedMutationCount;
+
         $span = $this->startChild(
             'infection.mutation_evaluation.mutant_evaluation',
             parent: $this->mutantAnalysisSpans[$hash] ?? ($this->mutationEvaluationSpans[$hash] ?? null),
@@ -544,7 +556,14 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $this->end($this->mutationEvaluationSpan);
         $this->end($this->mutationAnalysisSpan);
         $this->end($this->reportingSpan);
-        $this->end($this->rootSpan);
+        $this->end(
+            $this->rootSpan,
+            $this->runSpanAttributesProvider->provideSummaryAttributes(
+                $this->sourceFileCount,
+                $this->mutationCount,
+                $this->evaluatedMutationCount,
+            ),
+        );
         $this->telemetry->shutdown();
     }
 
@@ -572,6 +591,8 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onSourceCollectionWasFinished(SourceCollectionWasFinished $event): void
     {
+        $this->sourceFileCount = $event->sourcesCount;
+
         $this->end(
             $this->sourceCollectionSpan,
             ['infection.source_file.count' => $event->sourcesCount],
@@ -598,7 +619,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     }
 
     /**
-     * @param array<non-empty-string, bool|int|float|string> $attributes
+     * @param Attributes $attributes
      */
     private function end(?SpanHandle $span, array $attributes = []): void
     {

--- a/tests/e2e/Telemetry_Console/run_tests.bash
+++ b/tests/e2e/Telemetry_Console/run_tests.bash
@@ -92,5 +92,20 @@ assert_contains '"infection.test_framework.version":' var/execution-with-trace-e
 assert_contains '"infection.static_analysis_tool.name": "phpstan"' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.static_analysis_tool.version":' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.source_file.count": 2' var/execution-with-trace-exporter.stdout
-assert_contains '"infection.mutation.count":' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.count": 6' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.suppressed.count": 0' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.evaluated.count": 6' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.killed_by_tests.count": 6' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.killed_by_static_analysis.count": 0' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.escaped.count": 0' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.error.count": 0' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.timed_out.count": 0' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.skipped.count": 0' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.syntax_error.count": 0' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.not_covered.count": 0' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutation.ignored.count": 0' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.msi": 100' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.covered_msi": 100' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.msi.threshold": 0' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.covered_msi.threshold": 0' var/execution-with-trace-exporter.stdout
 assert_line_count 6 '"infection.mutation.status": "killed by tests"' var/execution-with-trace-exporter.stdout

--- a/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
@@ -35,15 +35,24 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Telemetry\Attribute;
 
+use Generator;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\Configuration\Configuration;
 use Infection\Framework\InfectionVersion;
+use Infection\Metrics\MetricsCalculator;
+use Infection\Mutant\DetectionStatus;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\StaticAnalysis\StaticAnalysisToolTypes;
 use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
 use Infection\Tests\Configuration\ConfigurationBuilder;
+use Infection\Tests\Mutant\MutantExecutionResultBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @phpstan-import-type Attributes from RunSpanAttributesProvider
+ */
 #[CoversClass(RunSpanAttributesProvider::class)]
 final class RunSpanAttributesProviderTest extends TestCase
 {
@@ -77,6 +86,7 @@ final class RunSpanAttributesProviderTest extends TestCase
             $infectionVersionMock,
             $testFrameworkAdapter,
             $staticAnalysisToolAdapter,
+            new MetricsCalculator($configuration->msiPrecision, $configuration->timeoutsAsEscaped),
         );
 
         $expected = [
@@ -95,7 +105,7 @@ final class RunSpanAttributesProviderTest extends TestCase
             'infection.static_analysis_tool.version' => '2.1.17',
         ];
 
-        $actual = $provider->provide();
+        $actual = $provider->provideInitialAttributes();
 
         $this->assertSame($expected, $actual);
     }
@@ -120,13 +130,129 @@ final class RunSpanAttributesProviderTest extends TestCase
             $infectionVersion,
             $testFrameworkAdapter,
             null,
+            new MetricsCalculator($configuration->msiPrecision, $configuration->timeoutsAsEscaped),
         );
 
-        $actual = $provider->provide();
+        $actual = $provider->provideInitialAttributes();
 
         $this->assertSame('phpunit', $actual['infection.test_framework.name']);
         $this->assertSame('12.3.4', $actual['infection.test_framework.version']);
         $this->assertArrayNotHasKey('infection.static_analysis_tool.name', $actual);
         $this->assertArrayNotHasKey('infection.static_analysis_tool.version', $actual);
+    }
+
+    /**
+     * @param list<DetectionStatus> $detectionStatuses
+     * @param Attributes $expected
+     */
+    #[DataProvider('summaryAttributesProvider')]
+    public function test_it_provides_summary_attributes(
+        Configuration $configuration,
+        array $detectionStatuses,
+        int $sourceFileCount,
+        int $mutationCount,
+        int $evaluatedMutationCount,
+        array $expected,
+    ): void {
+        $metricsCalculator = new MetricsCalculator(
+            $configuration->msiPrecision,
+            $configuration->timeoutsAsEscaped,
+        );
+
+        foreach ($detectionStatuses as $index => $status) {
+            $metricsCalculator->collect(
+                MutantExecutionResultBuilder::withMinimalTestData()
+                    ->withMutantHash('mutation-' . $index)
+                    ->withDetectionStatus($status)
+                    ->build(),
+            );
+        }
+
+        $provider = new RunSpanAttributesProvider(
+            $configuration,
+            $this->createStub(InfectionVersion::class),
+            $this->createStub(TestFrameworkAdapter::class),
+            null,
+            $metricsCalculator,
+        );
+
+        $actual = $provider->provideSummaryAttributes(
+            $sourceFileCount,
+            $mutationCount,
+            $evaluatedMutationCount,
+        );
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function summaryAttributesProvider(): Generator
+    {
+        yield 'zero-valued counts and default thresholds' => [
+            ConfigurationBuilder::withMinimalTestData()->build(),
+            [],
+            0,
+            0,
+            0,
+            [
+                'infection.source_file.count' => 0,
+                'infection.mutation.count' => 0,
+                'infection.mutation.suppressed.count' => 0,
+                'infection.mutation.evaluated.count' => 0,
+                'infection.mutation.killed_by_tests.count' => 0,
+                'infection.mutation.killed_by_static_analysis.count' => 0,
+                'infection.mutation.escaped.count' => 0,
+                'infection.mutation.error.count' => 0,
+                'infection.mutation.timed_out.count' => 0,
+                'infection.mutation.skipped.count' => 0,
+                'infection.mutation.syntax_error.count' => 0,
+                'infection.mutation.not_covered.count' => 0,
+                'infection.mutation.ignored.count' => 0,
+                'infection.msi' => 0.0,
+                'infection.covered_msi' => 0.0,
+                'infection.msi.threshold' => 0.0,
+                'infection.covered_msi.threshold' => 0.0,
+            ],
+        ];
+
+        yield 'counts scores thresholds and suppression invariants' => [
+            ConfigurationBuilder::withMinimalTestData()
+                ->withMinMsi(72.3)
+                ->withMinCoveredMsi(81.5)
+                ->build(),
+            [
+                DetectionStatus::KILLED_BY_TESTS,
+                DetectionStatus::KILLED_BY_TESTS,
+                DetectionStatus::KILLED_BY_STATIC_ANALYSIS,
+                DetectionStatus::ERROR,
+                DetectionStatus::SYNTAX_ERROR,
+                DetectionStatus::ESCAPED,
+                DetectionStatus::TIMED_OUT,
+                DetectionStatus::SKIPPED,
+                DetectionStatus::NOT_COVERED,
+                DetectionStatus::IGNORED,
+            ],
+            3,
+            12,
+            10,
+            [
+                'infection.source_file.count' => 3,
+                'infection.mutation.count' => 12,
+                'infection.mutation.suppressed.count' => 2,
+                'infection.mutation.evaluated.count' => 10,
+                'infection.mutation.killed_by_tests.count' => 2,
+                'infection.mutation.killed_by_static_analysis.count' => 1,
+                'infection.mutation.escaped.count' => 1,
+                'infection.mutation.error.count' => 1,
+                'infection.mutation.timed_out.count' => 1,
+                'infection.mutation.skipped.count' => 1,
+                'infection.mutation.syntax_error.count' => 1,
+                'infection.mutation.not_covered.count' => 1,
+                'infection.mutation.ignored.count' => 1,
+                'infection.msi' => 75.0,
+                'infection.covered_msi' => 85.71,
+                'infection.msi.threshold' => 72.3,
+                'infection.covered_msi.threshold' => 81.5,
+            ],
+        ];
     }
 }

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -78,6 +78,7 @@ use Infection\Event\Events\SourceCollection\SourceCollectionWasFinished;
 use Infection\Event\Events\SourceCollection\SourceCollectionWasStarted;
 use Infection\Framework\InfectionVersion;
 use Infection\Framework\Iterable\IterableCounter;
+use Infection\Metrics\MetricsCalculator;
 use Infection\Mutant\DetectionStatus;
 use Infection\Process\MutantProcess;
 use Infection\Process\Runner\HeuristicName;
@@ -113,10 +114,22 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
 
     private OpenTelemetryTracerSubscriber $subscriber;
 
+    private MetricsCalculator $metricsCalculator;
+
     protected function setUp(): void
     {
         $this->exporter = new InMemoryExporter();
         $this->tracerProvider = new TracerProvider(new SimpleSpanProcessor($this->exporter));
+
+        $configuration = ConfigurationBuilder::withMinimalTestData()
+            ->withProjectDirectory('/path/to/project')
+            ->build();
+
+        $this->metricsCalculator = new MetricsCalculator(
+            $configuration->msiPrecision,
+            $configuration->timeoutsAsEscaped,
+        );
+
         $testFrameworkAdapter = $this->createStub(TestFrameworkAdapter::class);
         $testFrameworkAdapter
             ->method('getVersion')
@@ -128,12 +141,11 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 $this->tracerProvider,
             ),
             new RunSpanAttributesProvider(
-                ConfigurationBuilder::withMinimalTestData()
-                    ->withProjectDirectory('/path/to/project')
-                    ->build(),
+                $configuration,
                 new InfectionVersion(),
                 $testFrameworkAdapter,
                 null,
+                $this->metricsCalculator,
             ),
         );
     }
@@ -153,6 +165,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $mutant = MutantBuilder::withMinimalTestData()
             ->withMutation($mutation)
             ->build();
+
         $process0 = $this->createMock(MutantProcess::class);
         $process0->method('getMutant')->willReturn($mutant);
         $process1 = $this->createMock(MutantProcess::class);
@@ -194,13 +207,15 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($process1));
         $this->subscriber->onMutantEvaluationWasFinished(new MutantEvaluationWasFinished($mutant));
         $this->subscriber->onMutantAnalysisWasFinished(new MutantAnalysisWasFinished($mutant));
-        $this->subscriber->onMutationEvaluationForMutationWasFinished(new MutationEvaluationForMutationWasFinished(
-            MutantExecutionResultBuilder::withMinimalTestData()
-                ->withMutantHash($mutation->getHash())
-                ->withDetectionStatus(DetectionStatus::KILLED_BY_TESTS)
-                ->withProcessRuntime(0.123)
-                ->build(),
-        ));
+
+        $executionResult = MutantExecutionResultBuilder::withMinimalTestData()
+            ->withMutantHash($mutation->getHash())
+            ->withDetectionStatus(DetectionStatus::KILLED_BY_TESTS)
+            ->withProcessRuntime(0.123)
+            ->build();
+        $this->metricsCalculator->collect($executionResult);
+
+        $this->subscriber->onMutationEvaluationForMutationWasFinished(new MutationEvaluationForMutationWasFinished($executionResult));
         $this->subscriber->onReportingWasStarted(new ReportingWasStarted());
         $this->subscriber->onReportingWasFinished(new ReportingWasFinished());
         $this->subscriber->onMutationEvaluationWasFinished(new MutationEvaluationWasFinished());
@@ -275,6 +290,23 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame($run->getSpanId(), $reporting->getParentSpanId());
 
         $this->assertSame(1, $sourceCollection->getAttributes()->get('infection.source_file.count'));
+        $this->assertSame(1, $run->getAttributes()->get('infection.source_file.count'));
+        $this->assertSame(1, $run->getAttributes()->get('infection.mutation.count'));
+        $this->assertSame(0, $run->getAttributes()->get('infection.mutation.suppressed.count'));
+        $this->assertSame(1, $run->getAttributes()->get('infection.mutation.evaluated.count'));
+        $this->assertSame(1, $run->getAttributes()->get('infection.mutation.killed_by_tests.count'));
+        $this->assertSame(0, $run->getAttributes()->get('infection.mutation.killed_by_static_analysis.count'));
+        $this->assertSame(0, $run->getAttributes()->get('infection.mutation.escaped.count'));
+        $this->assertSame(0, $run->getAttributes()->get('infection.mutation.error.count'));
+        $this->assertSame(0, $run->getAttributes()->get('infection.mutation.timed_out.count'));
+        $this->assertSame(0, $run->getAttributes()->get('infection.mutation.skipped.count'));
+        $this->assertSame(0, $run->getAttributes()->get('infection.mutation.syntax_error.count'));
+        $this->assertSame(0, $run->getAttributes()->get('infection.mutation.not_covered.count'));
+        $this->assertSame(0, $run->getAttributes()->get('infection.mutation.ignored.count'));
+        $this->assertSame(100.0, $run->getAttributes()->get('infection.msi'));
+        $this->assertSame(100.0, $run->getAttributes()->get('infection.covered_msi'));
+        $this->assertSame(0.0, $run->getAttributes()->get('infection.msi.threshold'));
+        $this->assertSame(0.0, $run->getAttributes()->get('infection.covered_msi.threshold'));
         $this->assertSame('/path/to/project', $run->getAttributes()->get('infection.project.dir'));
         $this->assertSame('infection.json5', $run->getAttributes()->get('infection.config.path'));
         $this->assertSame('source', $run->getAttributes()->get('infection.distribution'));


### PR DESCRIPTION
## Description

Adds mutation result summary attributes to the root `infection.run` telemetry span.

These attributes make run summary dashboards easier to build from the canonical run span, without requiring every dashboard query to derive totals from per-mutation spans. They cover the mutation funnel, `DetectionStatus` outcome
counts, final MSI values, and the effective MSI thresholds for the run.

## Changes

- Adds root-span summary attributes for source file count, generated mutations, suppressed mutations, and evaluated mutations.
- Adds root-span `DetectionStatus` outcome counts for killed, escaped, error, timed out, skipped, syntax-error, not-covered, and ignored mutations.
- Adds `infection.msi`, `infection.covered_msi`, `infection.msi.threshold`, and `infection.covered_msi.threshold` to `infection.run`.
- Splits `RunSpanAttributesProvider` into initial and summary attribute methods so late-computed values are attached before the root span ends.
- Updates the OpenTelemetry tracer subscriber to track source file, mutation, and evaluated mutation counts during the run.

## Related issues

- #3090