### PR TITLE
build(sbx): Add the curl extension to the PHP of the Docker Sandbox

### DIFF
--- a/devTools/sbx/Dockerfile
+++ b/devTools/sbx/Dockerfile
@@ -14,6 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         # CLI SAPI
         php${PHP_VERSION}-cli \
         # Extensions used by infection to not have to rely on polyfills
+        php${PHP_VERSION}-curl \
         php${PHP_VERSION}-mbstring \
         php${PHP_VERSION}-xml \
         php${PHP_VERSION}-zip \

--- a/devTools/sbx/test.yaml
+++ b/devTools/sbx/test.yaml
@@ -14,6 +14,11 @@ commandTests:
         expectedOutput: ['(?m)^xdebug\.mode => coverage => coverage$']
         exitCode: 0
 
+    -   name: "curl PHP extension is loaded"
+        command: "php"
+        args: ["-r", "exit(extension_loaded('curl') ? 0 : 1);"]
+        exitCode: 0
+
     -   name: "composer is executable"
         command: "composer"
         args: ["--version"]


### PR DESCRIPTION
A few operations such as `composer install/update` were horribly slow due to this.