### PR TITLE
ci(telemetry): Add telemetry to for the partial mutation run

### DIFF
--- a/.github/workflows/mt-annotations.yaml
+++ b/.github/workflows/mt-annotations.yaml
@@ -60,6 +60,13 @@ jobs:
                   composer install --no-interaction --prefer-dist --no-progress
 
             - name: Run Infection for changed lines only
+              env:
+                  INFECTION_TELEMETRY: true
+                  OTEL_TRACES_EXPORTER: otlp
+                  OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
+                  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${{ secrets.SENTRY_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
+                  OTEL_EXPORTER_OTLP_TRACES_HEADERS: ${{ secrets.SENTRY_OTEL_EXPORTER_OTLP_TRACES_HEADERS }}
+                  OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: gzip
               run: |
                   git fetch origin $GITHUB_BASE_REF
                   php bin/infection \


### PR DESCRIPTION
## Description

This PR enables the telemetry for the partial run. Note that this will only work for PRs for which the source is this repository, not a fork, as otherwise the secret will not be populated.

The goal is to provide more realistic data set to Sentry and get a better understanding on how to manipulate data from partial runs, which for some projects is the only way infection will be used.

I am not entirely sure if it is to stay and I will add an entry #3108 to re-evaluate it before merging it to the main branch.

## Related issues

- #3090