### PR TITLE
feat(telemetry): Partial run attribute

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -11913,6 +11913,12 @@ count = 3
 [[issues]]
 file = "tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Telemetry\Attribute\RunSpanAttributesProviderTest::test_it_marks_partial_runs_when_a_source_filter_is_configured`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Telemetry\Attribute\RunSpanAttributesProviderTest::test_it_omits_static_analysis_tool_attributes_when_static_analysis_is_disabled`.'
 count = 1
 

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -77,6 +77,7 @@ toolchain, and run-summary attributes that are useful for filtering dashboards:
 | `infection.distribution`                             | `source` or `phar`.                                                                                                       |
 | `infection.git.sha`                                  | Current `HEAD` commit SHA when the project directory is a Git checkout.                                                   |
 | `infection.thread.count`                             | Resolved mutation runner thread count.                                                                                    |
+| `infection.run.partial`                              | Whether the run used a source filter, for example `--filter`, `--git-diff-filter`, or `--git-diff-lines`.                 |
 | `infection.initial_tests.skipped`                    | Whether the initial test run was skipped.                                                                                 |
 | `infection.initial_static_analysis.skipped`          | Whether the initial static analysis run was skipped because no static analysis tool was enabled.                          |
 | `infection.test_framework.name`                      | Normalised configured test framework name, for example `phpunit`.                                                         |

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -80,6 +80,7 @@ final readonly class RunSpanAttributesProvider
             'infection.distribution' => self::getDistribution(),
             'infection.git.sha' => $this->configuration->gitSha,
             'infection.thread.count' => $this->configuration->threadCount,
+            'infection.run.partial' => $this->configuration->sourceFilter !== null,
             'infection.initial_tests.skipped' => $this->configuration->skipInitialTests,
             'infection.initial_static_analysis.skipped' => !$this->configuration->isStaticAnalysisEnabled(),
             'infection.test_framework.name' => $this->configuration->testFramework,

--- a/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Telemetry\Attribute;
 use Generator;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Configuration\Configuration;
+use Infection\Configuration\SourceFilter\PlainFilter;
 use Infection\Framework\InfectionVersion;
 use Infection\Metrics\MetricsCalculator;
 use Infection\Mutant\DetectionStatus;
@@ -86,7 +87,10 @@ final class RunSpanAttributesProviderTest extends TestCase
             $infectionVersionMock,
             $testFrameworkAdapter,
             $staticAnalysisToolAdapter,
-            new MetricsCalculator($configuration->msiPrecision, $configuration->timeoutsAsEscaped),
+            new MetricsCalculator(
+                $configuration->msiPrecision,
+                $configuration->timeoutsAsEscaped,
+            ),
         );
 
         $expected = [
@@ -97,6 +101,7 @@ final class RunSpanAttributesProviderTest extends TestCase
             'infection.distribution' => 'source',
             'infection.git.sha' => '0123456789abcdef',
             'infection.thread.count' => 8,
+            'infection.run.partial' => false,
             'infection.initial_tests.skipped' => true,
             'infection.initial_static_analysis.skipped' => false,
             'infection.test_framework.name' => 'phpunit',
@@ -139,6 +144,34 @@ final class RunSpanAttributesProviderTest extends TestCase
         $this->assertSame('12.3.4', $actual['infection.test_framework.version']);
         $this->assertArrayNotHasKey('infection.static_analysis_tool.name', $actual);
         $this->assertArrayNotHasKey('infection.static_analysis_tool.version', $actual);
+    }
+
+    public function test_it_marks_partial_runs_when_a_source_filter_is_configured(): void
+    {
+        $configuration = ConfigurationBuilder::withMinimalTestData()
+            ->withSourceFilter(new PlainFilter(['src/Foo.php']))
+            ->build();
+
+        $infectionVersion = $this->createStub(InfectionVersion::class);
+        $infectionVersion
+            ->method('prettyVersion')
+            ->willReturn('1.2.3');
+        $testFrameworkAdapter = $this->createStub(TestFrameworkAdapter::class);
+        $testFrameworkAdapter
+            ->method('getVersion')
+            ->willReturn('12.3.4');
+
+        $provider = new RunSpanAttributesProvider(
+            $configuration,
+            $infectionVersion,
+            $testFrameworkAdapter,
+            null,
+            new MetricsCalculator($configuration->msiPrecision, $configuration->timeoutsAsEscaped),
+        );
+
+        $actual = $provider->provideInitialAttributes();
+
+        $this->assertTrue($actual['infection.run.partial']);
     }
 
     /**

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -311,6 +311,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame('infection.json5', $run->getAttributes()->get('infection.config.path'));
         $this->assertSame('source', $run->getAttributes()->get('infection.distribution'));
         $this->assertSame(1, $run->getAttributes()->get('infection.thread.count'));
+        $this->assertFalse($run->getAttributes()->get('infection.run.partial'));
         $this->assertFalse($run->getAttributes()->get('infection.initial_tests.skipped'));
         $this->assertTrue($run->getAttributes()->get('infection.initial_static_analysis.skipped'));
         $this->assertSame('phpunit', $run->getAttributes()->get('infection.test_framework.name'));


### PR DESCRIPTION
## Description

Adds a root-span telemetry attribute that identifies whether an Infection run was partial. This is useful to allow one to filter traces, metrics or spans.

## Changes

- Adds the `infection.run.partial` run attribute.

## Related issues

- #3090