### PR TITLE
feat(telemetry): Add Timeout Handling Telemetry Attribute

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -78,6 +78,7 @@ toolchain, and run-summary attributes that are useful for filtering dashboards:
 | `vcs.ref.head.revision`                              | Current `HEAD` commit SHA when the project directory is a Git checkout.                                                   |
 | `infection.thread.count`                             | Resolved mutation runner thread count.                                                                                    |
 | `infection.run.source_filtered`                      | Whether the run used a source filter, for example `--filter`, `--git-diff-filter`, or `--git-diff-lines`.                 |
+| `infection.timeouts_as_escaped`                      | Whether timed-out mutants are treated as escaped when calculating MSI values.                                             |
 | `infection.initial_tests.skipped`                    | Whether the initial test run was skipped.                                                                                 |
 | `infection.initial_static_analysis.skipped`          | Whether the initial static analysis run was skipped because no static analysis tool was enabled.                          |
 | `infection.test_framework.name`                      | Normalised configured test framework name, for example `phpunit`.                                                         |

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -81,6 +81,7 @@ final readonly class RunSpanAttributesProvider
             'vcs.ref.head.revision' => $this->configuration->gitSha,
             'infection.thread.count' => $this->configuration->threadCount,
             'infection.run.source_filtered' => $this->configuration->sourceFilter !== null,
+            'infection.timeouts_as_escaped' => $this->configuration->timeoutsAsEscaped,
             'infection.initial_tests.skipped' => $this->configuration->skipInitialTests,
             'infection.initial_static_analysis.skipped' => !$this->configuration->isStaticAnalysisEnabled(),
             'infection.test_framework.name' => $this->configuration->testFramework,

--- a/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
@@ -67,6 +67,7 @@ final class RunSpanAttributesProviderTest extends TestCase
             ->withSkipInitialTests(true)
             ->withStaticAnalysisTool(StaticAnalysisToolTypes::PHPSTAN)
             ->withGitSha('0123456789abcdef')
+            ->withTimeoutsAsEscaped(true)
             ->build();
 
         $infectionVersionMock = $this->createMock(InfectionVersion::class);
@@ -102,6 +103,7 @@ final class RunSpanAttributesProviderTest extends TestCase
             'vcs.ref.head.revision' => '0123456789abcdef',
             'infection.thread.count' => 8,
             'infection.run.source_filtered' => false,
+            'infection.timeouts_as_escaped' => true,
             'infection.initial_tests.skipped' => true,
             'infection.initial_static_analysis.skipped' => false,
             'infection.test_framework.name' => 'phpunit',


### PR DESCRIPTION
## Description

Adds a run-level telemetry attribute that records whether timed-out mutants are treated as escaped for MSI calculation. This makes trace consumers able to interpret MSI values and timeout counts with the effective timeout policy attached to the run.

## Changes

- Adds `infection.timeouts_as_escaped` to the root `infection.run` span attributes.


## Related issues

- #3090