### PR TITLE
refactor: Refactor metrics counting helpers

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -128,7 +128,7 @@ final readonly class Engine
             );
 
             $this->minMsiChecker->checkMetrics(
-                $this->metricsCalculator->getTestedMutantsCount(),
+                $this->metricsCalculator->getEligibleCount(),
                 $this->metricsCalculator->getMutationScoreIndicator(),
                 $this->metricsCalculator->getCoveredCodeMutationScoreIndicator(),
                 $this->consoleOutput,

--- a/src/Metrics/Calculator.php
+++ b/src/Metrics/Calculator.php
@@ -51,25 +51,19 @@ final class Calculator
 
     public function __construct(
         private readonly int $roundingPrecision,
-        private readonly int $killedCount,
-        private readonly int $errorCount,
-        private readonly int $timedOutCount,
-        private readonly int $notTestedCount,
-        private readonly int $totalCount,
-        private readonly bool $timeoutsAsEscaped = false,
+        private readonly int $coveredCount,
+        private readonly int $testedEligibleCount,
+        private readonly int $eligibleCount,
     ) {
     }
 
-    public static function fromMetrics(MetricsCalculator $calculator, bool $timeoutsAsEscaped = false): self
+    public static function fromMetrics(MetricsCalculator $calculator): self
     {
         return new self(
             $calculator->getRoundingPrecision(),
-            $calculator->getKilledByTestsCount() + $calculator->getKilledByStaticAnalysisCount(),
-            $calculator->getErrorCount() + $calculator->getSyntaxErrorCount(),
-            $calculator->getTimedOutCount(),
-            $calculator->getNotTestedCount(),
-            $calculator->getTestedMutantsCount(),
-            $timeoutsAsEscaped,
+            $calculator->getCoveredCount(),
+            $calculator->getTestedEligibleCount(),
+            $calculator->getEligibleCount(),
         );
     }
 
@@ -83,16 +77,9 @@ final class Calculator
         }
 
         $score = 0.;
-        $coveredTotal = $this->killedCount + $this->errorCount;
 
-        if (!$this->timeoutsAsEscaped) {
-            $coveredTotal += $this->timedOutCount;
-        }
-
-        $totalCount = $this->totalCount;
-
-        if ($totalCount !== 0) {
-            $score = 100 * $coveredTotal / $totalCount;
+        if ($this->eligibleCount !== 0) {
+            $score = 100 * $this->coveredCount / $this->eligibleCount;
         }
 
         return $this->mutationScoreIndicator = $this->round($score);
@@ -108,11 +95,9 @@ final class Calculator
         }
 
         $coveredRate = 0.;
-        $totalCount = $this->totalCount;
-        $testedTotal = $totalCount - $this->notTestedCount;
 
-        if ($totalCount !== 0) {
-            $coveredRate = 100 * $testedTotal / $totalCount;
+        if ($this->eligibleCount !== 0) {
+            $coveredRate = 100 * $this->testedEligibleCount / $this->eligibleCount;
         }
 
         return $this->coverageRate = $this->round($coveredRate);
@@ -128,15 +113,9 @@ final class Calculator
         }
 
         $score = 0.;
-        $testedTotal = $this->totalCount - $this->notTestedCount;
-        $coveredTotal = $this->killedCount + $this->errorCount;
 
-        if (!$this->timeoutsAsEscaped) {
-            $coveredTotal += $this->timedOutCount;
-        }
-
-        if ($testedTotal !== 0) {
-            $score = 100 * $coveredTotal / $testedTotal;
+        if ($this->testedEligibleCount !== 0) {
+            $score = 100 * $this->coveredCount / $this->testedEligibleCount;
         }
 
         return $this->coveredMutationScoreIndicator = $this->round($score);

--- a/src/Metrics/MetricsCalculator.php
+++ b/src/Metrics/MetricsCalculator.php
@@ -158,9 +158,71 @@ class MetricsCalculator implements Collector
         return $this->totalMutantsCount;
     }
 
-    public function getTestedMutantsCount(): int
+    /**
+     * Mutations that do not contribute to the MSI.
+     */
+    public function getIneligibleCount(): int
     {
-        return $this->getTotalMutantsCount() - $this->getSkippedCount() - $this->getIgnoredCount();
+        return $this->getSkippedCount() + $this->getIgnoredCount();
+    }
+
+    /**
+     * Mutations eligible for MSI. Excludes mutations for which there is no test,
+     * which is only relevant if allowed in the first place, in which case it is important to be able to
+     * calculate the coverage rate and covered MSI.
+     */
+    public function getTestedEligibleCount(): int
+    {
+        return $this->getEligibleCount() - $this->getNotTestedCount();
+    }
+
+    /**
+     * Mutations eligible for MSI.
+     */
+    public function getEligibleCount(): int
+    {
+        return $this->getTotalMutantsCount() - $this->getIneligibleCount();
+    }
+
+    /**
+     * Mutations eligible for MSI contributing positively.
+     */
+    public function getCoveredCount(): int
+    {
+        $coveredCount = $this->getKilledByTestsCount()
+            + $this->getKilledByStaticAnalysisCount()
+            + $this->getErrorCount()
+            + $this->getSyntaxErrorCount();
+
+        if (!$this->timeoutsAsEscaped) {
+            $coveredCount += $this->getTimedOutCount();
+        }
+
+        return $coveredCount;
+    }
+
+    /**
+     * Mutations eligible for MSI contributing negatively. Excludes mutations for which there is no test,
+     * which is only relevant if allowed in the first place, in which case it is important to be able to
+     * calculate the coverage rate and covered MSI.
+     */
+    public function getTestedNotCoveredCount(): int
+    {
+        $notCoveredCount = $this->getEscapedCount();
+
+        if ($this->timeoutsAsEscaped) {
+            $notCoveredCount += $this->getTimedOutCount();
+        }
+
+        return $notCoveredCount;
+    }
+
+    /**
+     * Mutations eligible for MSI contributing negatively.
+     */
+    public function getNotCoveredCount(): int
+    {
+        return $this->getTestedNotCoveredCount() + $this->getNotTestedCount();
     }
 
     /**
@@ -219,7 +281,7 @@ class MetricsCalculator implements Collector
 
     private function getCalculator(): Calculator
     {
-        return $this->calculator ??= Calculator::fromMetrics($this, $this->timeoutsAsEscaped);
+        return $this->calculator ??= Calculator::fromMetrics($this);
     }
 
     private static function foldToZero(float $value): float

--- a/tests/phpunit/EngineTest.php
+++ b/tests/phpunit/EngineTest.php
@@ -261,7 +261,7 @@ final class EngineTest extends TestCase
         $metricsCalculator = $this->createMock(MetricsCalculator::class);
         $metricsCalculator
             ->expects($this->once())
-            ->method('getTestedMutantsCount')
+            ->method('getEligibleCount')
             ->willReturn(1000)
         ;
         $metricsCalculator
@@ -406,7 +406,7 @@ final class EngineTest extends TestCase
         $metricsCalculator = $this->createMock(MetricsCalculator::class);
         $metricsCalculator
             ->expects($this->once())
-            ->method('getTestedMutantsCount')
+            ->method('getEligibleCount')
             ->willReturn(100)
         ;
         $metricsCalculator
@@ -507,7 +507,7 @@ final class EngineTest extends TestCase
         $metricsCalculator = $this->createMock(MetricsCalculator::class);
         $metricsCalculator
             ->expects($this->once())
-            ->method('getTestedMutantsCount')
+            ->method('getEligibleCount')
             ->willReturn(0)
         ;
         $metricsCalculator
@@ -608,7 +608,7 @@ final class EngineTest extends TestCase
         ;
         $metricsCalculator
             ->expects($this->once())
-            ->method('getTestedMutantsCount')
+            ->method('getEligibleCount')
             ->willReturn(0)
         ;
         $metricsCalculator
@@ -807,7 +807,7 @@ final class EngineTest extends TestCase
         ;
         $metricsCalculator
             ->expects($this->once())
-            ->method('getTestedMutantsCount')
+            ->method('getEligibleCount')
             ->willReturn(100)
         ;
         $metricsCalculator

--- a/tests/phpunit/Metrics/CalculatorTest.php
+++ b/tests/phpunit/Metrics/CalculatorTest.php
@@ -62,10 +62,13 @@ final class CalculatorTest extends TestCase
     ): void {
         $calculator = new Calculator(
             $roundingPrecision,
-            $killedCount,
-            $errorCount,
-            $timedOutCount,
-            $notTestedCount,
+            $killedCount + $errorCount + $timedOutCount,
+            array_sum([
+                $killedCount,
+                $errorCount,
+                $escapedCount,
+                $timedOutCount,
+            ]),
             array_sum([
                 $killedCount,
                 $errorCount,

--- a/tests/phpunit/Metrics/MetricsCalculatorTest.php
+++ b/tests/phpunit/Metrics/MetricsCalculatorTest.php
@@ -56,6 +56,12 @@ final class MetricsCalculatorTest extends TestCase
         $this->assertSame(0, $calculator->getTimedOutCount());
         $this->assertSame(0, $calculator->getNotTestedCount());
         $this->assertSame(0, $calculator->getTotalMutantsCount());
+        $this->assertSame(0, $calculator->getIneligibleCount());
+        $this->assertSame(0, $calculator->getEligibleCount());
+        $this->assertSame(0, $calculator->getTestedEligibleCount());
+        $this->assertSame(0, $calculator->getCoveredCount());
+        $this->assertSame(0, $calculator->getTestedNotCoveredCount());
+        $this->assertSame(0, $calculator->getNotCoveredCount());
 
         $this->assertSame(0.0, $calculator->getMutationScoreIndicator());
         $this->assertSame(0.0, $calculator->getCoverageRate());
@@ -91,17 +97,60 @@ final class MetricsCalculatorTest extends TestCase
             DetectionStatus::NOT_COVERED,
             1,
         );
+        $this->addMutantExecutionResult(
+            $calculator,
+            DetectionStatus::SKIPPED,
+            3,
+        );
+        $this->addMutantExecutionResult(
+            $calculator,
+            DetectionStatus::IGNORED,
+            4,
+        );
 
         $this->assertSame(7, $calculator->getKilledByTestsCount());
         $this->assertSame(2, $calculator->getErrorCount());
         $this->assertSame(2, $calculator->getEscapedCount());
         $this->assertSame(2, $calculator->getTimedOutCount());
         $this->assertSame(1, $calculator->getNotTestedCount());
+        $this->assertSame(3, $calculator->getSkippedCount());
+        $this->assertSame(4, $calculator->getIgnoredCount());
 
-        $this->assertSame(14, $calculator->getTotalMutantsCount());
+        $this->assertSame(21, $calculator->getTotalMutantsCount());
+        $this->assertSame(7, $calculator->getIneligibleCount());
+        $this->assertSame(14, $calculator->getEligibleCount());
+        $this->assertSame(13, $calculator->getTestedEligibleCount());
+        $this->assertSame(11, $calculator->getCoveredCount());
+        $this->assertSame(2, $calculator->getTestedNotCoveredCount());
+        $this->assertSame(3, $calculator->getNotCoveredCount());
         $this->assertSame(78.57, $calculator->getMutationScoreIndicator());
         $this->assertSame(92.86, $calculator->getCoverageRate());
         $this->assertSame(84.62, $calculator->getCoveredCodeMutationScoreIndicator());
+    }
+
+    public function test_it_excludes_timeouts_from_the_covered_count_when_timeouts_are_escaped(): void
+    {
+        $calculator = new MetricsCalculator(2, true);
+
+        $this->addMutantExecutionResult(
+            $calculator,
+            DetectionStatus::KILLED_BY_TESTS,
+            1,
+        );
+        $this->addMutantExecutionResult(
+            $calculator,
+            DetectionStatus::ERROR,
+            1,
+        );
+        $this->addMutantExecutionResult(
+            $calculator,
+            DetectionStatus::TIMED_OUT,
+            1,
+        );
+
+        $this->assertSame(2, $calculator->getCoveredCount());
+        $this->assertSame(1, $calculator->getTestedNotCoveredCount());
+        $this->assertSame(1, $calculator->getNotCoveredCount());
     }
 
     public function test_its_metrics_are_properly_updated_when_adding_a_new_process(): void


### PR DESCRIPTION
## Description

Clarifies the mutation metrics model by exposing named count helpers for MSI eligibility, tested eligibility, covered mutations, and negative outcomes. `Calculator` now consumes these pre-computed counts from `MetricsCalculator`, keeping the score formulas unchanged while making the underlying buckets easier to reuse for telemetry and reporting.

I believe more changes are in order in regards to those two classes in the future, but I will get to it with #3018 and #3017. Meanwhile, this PR goal is provide nicer primitives to add more metrics to the `infection.run` spans for telemetry purposes, to avoid having to do calculations on the APM.

## Changes

- Adds explicit metrics count helpers for eligible, ineligible, tested eligible, covered, tested not covered, and not covered mutations.
- Simplifies `Calculator` so it receives the derived counts instead of recomputing status combinations and timeout policy locally.

## Related issues

- #3090