### PR TITLE
feat(telemetry): Improve mutation count

### DIFF
--- a/src/Event/Events/MutationAnalysis/MutationGeneration/MutationGenerationWasFinished.php
+++ b/src/Event/Events/MutationAnalysis/MutationGeneration/MutationGenerationWasFinished.php
@@ -40,4 +40,11 @@ namespace Infection\Event\Events\MutationAnalysis\MutationGeneration;
  */
 final readonly class MutationGenerationWasFinished
 {
+    /**
+     * @param positive-int|0 $mutationsCount
+     */
+    public function __construct(
+        public int $mutationsCount,
+    ) {
+    }
 }

--- a/src/Mutation/MutationGenerator.php
+++ b/src/Mutation/MutationGenerator.php
@@ -91,6 +91,7 @@ class MutationGenerator
     {
         $sources = $this->sourceCollector->collect();
         $numberOfFiles = count($sources);
+        $mutationsCount = 0;
 
         $this->eventDispatcher->dispatch(new MutationGenerationWasStarted($numberOfFiles));
 
@@ -115,8 +116,13 @@ class MutationGenerator
                     $sourceFileMutationIds,
                 ),
             );
+
+            $fileMutationsCount = count($sourceFileMutationIds);
+            $mutationsCount += $fileMutationsCount;
         }
 
-        $this->eventDispatcher->dispatch(new MutationGenerationWasFinished());
+        $this->eventDispatcher->dispatch(
+            new MutationGenerationWasFinished($mutationsCount),
+        );
     }
 }

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -179,7 +179,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     private int $sourceFileCount = 0;
 
     /**
-     * @var positive-int|int
+     * @var positive-int|0
      */
     private int $mutationCount = 0;
 
@@ -242,7 +242,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
         $this->end(
             $this->mutationGenerationSpan,
-            ['infection.mutation.count' => $event->mutationsCount],
+            ['infection.mutation.generated.count' => $event->mutationsCount],
         );
         $this->mutationGenerationSpan = null;
     }

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -178,6 +178,9 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     private int $sourceFileCount = 0;
 
+    /**
+     * @var positive-int|int
+     */
     private int $mutationCount = 0;
 
     private int $evaluatedMutationCount = 0;
@@ -235,6 +238,8 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onMutationGenerationWasFinished(MutationGenerationWasFinished $event): void
     {
+        $this->mutationCount = $event->mutationsCount;
+
         $this->end($this->mutationGenerationSpan);
         $this->mutationGenerationSpan = null;
     }
@@ -329,8 +334,6 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onMutationEvaluationWasStarted(MutationEvaluationWasStarted $event): void
     {
-        $this->mutationCount = $event->mutationCount;
-
         $this->mutationEvaluationSpan = $this->startChild(
             'infection.mutation_evaluation',
             ['infection.mutation.generated.count' => $event->mutationCount],

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -240,7 +240,10 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     {
         $this->mutationCount = $event->mutationsCount;
 
-        $this->end($this->mutationGenerationSpan);
+        $this->end(
+            $this->mutationGenerationSpan,
+            ['infection.mutation.count' => $event->mutationsCount],
+        );
         $this->mutationGenerationSpan = null;
     }
 
@@ -336,7 +339,6 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     {
         $this->mutationEvaluationSpan = $this->startChild(
             'infection.mutation_evaluation',
-            ['infection.mutation.generated.count' => $event->mutationCount],
             parent: $this->mutationAnalysisSpan,
         );
     }

--- a/tests/phpunit/Event/Events/MutationAnalysis/MutationGeneration/MutationGenerationWasFinishedTest.php
+++ b/tests/phpunit/Event/Events/MutationAnalysis/MutationGeneration/MutationGenerationWasFinishedTest.php
@@ -43,12 +43,12 @@ use PHPUnit\Framework\TestCase;
 final class MutationGenerationWasFinishedTest extends TestCase
 {
     /**
-     * This class is only used to fire events, and the only functionality it needs is being instantiated
+     * This class is only used to fire events, and the only functionality it needs is exposing the generated total
      */
-    public function test_it_can_be_instantiated(): void
+    public function test_it_exposes_the_generated_total(): void
     {
-        $class = new MutationGenerationWasFinished();
+        $class = new MutationGenerationWasFinished(2);
 
-        $this->assertInstanceOf(MutationGenerationWasFinished::class, $class);
+        $this->assertSame(2, $class->mutationsCount);
     }
 }

--- a/tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php
@@ -98,7 +98,7 @@ final class MutationGenerationLoggerSubscriberTest extends TestCase
             ->method('finish');
 
         $this->dispatcher->dispatch(
-            new MutationGenerationWasFinished(),
+            new MutationGenerationWasFinished(2),
         );
     }
 }

--- a/tests/phpunit/Mutation/MutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/MutationGeneratorTest.php
@@ -114,6 +114,16 @@ final class MutationGeneratorTest extends TestCase
 
     public function test_it_dispatches_events(): void
     {
+        $mutation0 = $this->createStub(Mutation::class);
+        $mutation0
+            ->method('getHash')
+            ->willReturn('mutation-0');
+
+        $mutation1 = $this->createStub(Mutation::class);
+        $mutation1
+            ->method('getHash')
+            ->willReturn('mutation-1');
+
         $eventDispatcherMock = $this->createMock(EventDispatcher::class);
         $eventDispatcherMock
             ->expects($this->exactly(4))
@@ -122,20 +132,24 @@ final class MutationGeneratorTest extends TestCase
                 [new MutationGenerationWasStarted(2)],
                 [new MutableFileWasProcessed(
                     'path/to/fileA',
-                    [],
+                    ['mutation-0', 'mutation-1'],
                 )],
                 [new MutableFileWasProcessed(
                     'path/to/fileB',
                     [],
                 )],
-                [new MutationGenerationWasFinished()],
+                [new MutationGenerationWasFinished(2)],
             ))
         ;
 
         $fileMutationGeneratorMock = $this->createMock(FileMutationGenerator::class);
         $fileMutationGeneratorMock
             ->expects($this->exactly(2))
-            ->method('generate')->willReturn([])
+            ->method('generate')
+            ->willReturnOnConsecutiveCalls(
+                [$mutation0, $mutation1],
+                [],
+            )
         ;
 
         $sourceCollector = new FixedSourceCollector(

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -330,7 +330,8 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame('/path/to/src/Foo.php', $astParsing->getAttributes()->get('code.file.path'));
         $this->assertSame('/path/to/src/Foo.php', $astEnrichment->getAttributes()->get('code.file.path'));
         $this->assertSame(1, $mutationGeneration->getAttributes()->get('infection.source_file.count'));
-        $this->assertSame(1, $mutationEvaluation->getAttributes()->get('infection.mutation.generated.count'));
+        $this->assertSame(2, $mutationGeneration->getAttributes()->get('infection.mutation.count'));
+        $this->assertFalse($mutationEvaluation->getAttributes()->has('infection.mutation.count'));
         $this->assertSame('mutation-A', $mutationEvaluationForMutation->getAttributes()->get('infection.mutation.id'));
         $this->assertSame('For_', $mutationEvaluationForMutation->getAttributes()->get('infection.mutator.name'));
         $this->assertSame('/path/to/src/Foo.php', $mutationEvaluationForMutation->getAttributes()->get('code.file.path'));

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -188,7 +188,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->subscriber->onAstEnrichmentWasFinished(new AstEnrichmentWasFinished('/path/to/src/Foo.php'));
         $this->subscriber->onAstProcessingWasFinished(new AstProcessingWasFinished('/path/to/src/Foo.php'));
         $this->subscriber->onMutationGenerationWasStarted(new MutationGenerationWasStarted(1));
-        $this->subscriber->onMutationGenerationWasFinished(new MutationGenerationWasFinished());
+        $this->subscriber->onMutationGenerationWasFinished(new MutationGenerationWasFinished(2));
         $this->subscriber->onMutationEvaluationWasStarted(new MutationEvaluationWasStarted(1, $this->createStub(ProcessRunner::class)));
         $this->subscriber->onMutationEvaluationForMutationWasStarted(new MutationEvaluationForMutationWasStarted($mutation));
         $this->subscriber->onHeuristicSuppressionWasStarted(new HeuristicSuppressionWasStarted($mutation));
@@ -291,9 +291,9 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
 
         $this->assertSame(1, $sourceCollection->getAttributes()->get('infection.source_file.count'));
         $this->assertSame(1, $run->getAttributes()->get('infection.source_file.count'));
-        $this->assertSame(1, $run->getAttributes()->get('infection.mutation.generated.count'));
+        $this->assertSame(2, $run->getAttributes()->get('infection.mutation.generated.count'));
         $this->assertSame(1, $run->getAttributes()->get('infection.mutation.evaluated.count'));
-        $this->assertSame(0, $run->getAttributes()->get('infection.mutation.suppressed.count'));
+        $this->assertSame(1, $run->getAttributes()->get('infection.mutation.suppressed.count'));
         $this->assertSame(1, $run->getAttributes()->get('infection.mutation.eligible.count'));
         $this->assertSame(0, $run->getAttributes()->get('infection.mutation.ineligible.count'));
         $this->assertSame(1, $run->getAttributes()->get('infection.mutation.tested_eligible.count'));

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -330,7 +330,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame('/path/to/src/Foo.php', $astParsing->getAttributes()->get('code.file.path'));
         $this->assertSame('/path/to/src/Foo.php', $astEnrichment->getAttributes()->get('code.file.path'));
         $this->assertSame(1, $mutationGeneration->getAttributes()->get('infection.source_file.count'));
-        $this->assertSame(2, $mutationGeneration->getAttributes()->get('infection.mutation.count'));
+        $this->assertSame(2, $mutationGeneration->getAttributes()->get('infection.mutation.generated.count'));
         $this->assertFalse($mutationEvaluation->getAttributes()->has('infection.mutation.count'));
         $this->assertSame('mutation-A', $mutationEvaluationForMutation->getAttributes()->get('infection.mutation.id'));
         $this->assertSame('For_', $mutationEvaluationForMutation->getAttributes()->get('infection.mutator.name'));


### PR DESCRIPTION
## Description

The OpenTelemetry subscriber was using `MutationEvaluationWasStarted#mutationCount` to know the number of generated mutations. There is two issues with this:

- As a result, the mutation count is naturally added to the mutation evaluation span, instead o the mutation generation one.
- The count is not known if we execute infection with no progress.

Instead, we can add this information to the mutation generation span. This is done when ending the span, at which point we know the count regardless of the progress mode.

## Changes

- Updates `MutationGenerationWasFinished` to expose the generated mutation count.
- Updates `MutationGenerator` to count generated mutations while iterating source files and dispatch that total when generation finishes.
- Updates `OpenTelemetryTracerSubscriber` to store the generated count from `MutationGenerationWasFinished` instead of `MutationEvaluationWasStarted`, and to emit `infection.mutation.generated.count` on the mutation generation span.
- Move the attribute from the `infection.mutation_evaluation` span to `infection.mutation_generation`.

## Related issues

- #3090