### PR TITLE
fix(telemetry): Fix inconsistent attribute names

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -106,8 +106,8 @@ toolchain, and run-summary attributes that are useful for filtering dashboards:
 | `infection.mutation.ignored.count`                   | Number of mutation results with `ignored` detection status.                                                               |
 | `infection.msi.value`                                | Final Mutation Score Indicator percentage.                                                                                |
 | `infection.mutation.coverage_rate.value`             | Final mutation code coverage percentage.                                                                                  |
-| `infection.covered_msi`                              | Final covered-code Mutation Score Indicator percentage.                                                                   |
-| `infection.msi.threshold.value`                      | Effective minimum MSI threshold, or `0.0` when no threshold is configured.                                                |
+| `infection.covered_msi.value`                        | Final covered-code Mutation Score Indicator percentage.                                                                   |
+| `infection.msi.threshold`                            | Effective minimum MSI threshold, or `0.0` when no threshold is configured.                                                |
 | `infection.covered_msi.threshold`                    | Effective minimum covered-code MSI threshold, or `0.0` when no threshold is configured.                                   |
 
 

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -132,8 +132,8 @@ final readonly class RunSpanAttributesProvider
             'infection.mutation.ignored.count' => $this->metricsCalculator->getIgnoredCount(),
             'infection.msi.value' => $this->metricsCalculator->getMutationScoreIndicator(),
             'infection.mutation.coverage_rate.value' => $this->metricsCalculator->getCoverageRate(),
-            'infection.covered_msi' => $this->metricsCalculator->getCoveredCodeMutationScoreIndicator(),
-            'infection.msi.threshold.value' => $this->configuration->minMsi ?? 0.0,
+            'infection.covered_msi.value' => $this->metricsCalculator->getCoveredCodeMutationScoreIndicator(),
+            'infection.msi.threshold' => $this->configuration->minMsi ?? 0.0,
             'infection.covered_msi.threshold' => $this->configuration->minCoveredMsi ?? 0.0,
         ];
     }

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -333,7 +333,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
         $this->mutationEvaluationSpan = $this->startChild(
             'infection.mutation_evaluation',
-            ['infection.mutation.count' => $event->mutationCount],
+            ['infection.mutation.generated.count' => $event->mutationCount],
             parent: $this->mutationAnalysisSpan,
         );
     }

--- a/tests/e2e/Telemetry_Console/run_tests.bash
+++ b/tests/e2e/Telemetry_Console/run_tests.bash
@@ -112,7 +112,7 @@ assert_contains '"infection.mutation.syntax_error.count": 0' var/execution-with-
 assert_contains '"infection.mutation.ignored.count": 0' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.msi.value": 100' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.mutation.coverage_rate.value": 100' var/execution-with-trace-exporter.stdout
-assert_contains '"infection.covered_msi": 100' var/execution-with-trace-exporter.stdout
-assert_contains '"infection.msi.threshold.value": 0' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.covered_msi.value": 100' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.msi.threshold": 0' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.covered_msi.threshold": 0' var/execution-with-trace-exporter.stdout
 assert_line_count 6 '"infection.mutation.status": "killed by tests"' var/execution-with-trace-exporter.stdout

--- a/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
@@ -250,8 +250,8 @@ final class RunSpanAttributesProviderTest extends TestCase
                 'infection.mutation.ignored.count' => 0,
                 'infection.msi.value' => 0.0,
                 'infection.mutation.coverage_rate.value' => 0.0,
-                'infection.covered_msi' => 0.0,
-                'infection.msi.threshold.value' => 0.0,
+                'infection.covered_msi.value' => 0.0,
+                'infection.msi.threshold' => 0.0,
                 'infection.covered_msi.threshold' => 0.0,
             ],
         ];
@@ -298,8 +298,8 @@ final class RunSpanAttributesProviderTest extends TestCase
                 'infection.mutation.ignored.count' => 1,
                 'infection.msi.value' => 75.0,
                 'infection.mutation.coverage_rate.value' => 87.5,
-                'infection.covered_msi' => 85.71,
-                'infection.msi.threshold.value' => 72.3,
+                'infection.covered_msi.value' => 85.71,
+                'infection.msi.threshold' => 72.3,
                 'infection.covered_msi.threshold' => 81.5,
             ],
         ];

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -311,8 +311,8 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame(0, $run->getAttributes()->get('infection.mutation.ignored.count'));
         $this->assertSame(100.0, $run->getAttributes()->get('infection.msi.value'));
         $this->assertSame(100.0, $run->getAttributes()->get('infection.mutation.coverage_rate.value'));
-        $this->assertSame(100.0, $run->getAttributes()->get('infection.covered_msi'));
-        $this->assertSame(0.0, $run->getAttributes()->get('infection.msi.threshold.value'));
+        $this->assertSame(100.0, $run->getAttributes()->get('infection.covered_msi.value'));
+        $this->assertSame(0.0, $run->getAttributes()->get('infection.msi.threshold'));
         $this->assertSame(0.0, $run->getAttributes()->get('infection.covered_msi.threshold'));
         $this->assertSame('/path/to/project', $run->getAttributes()->get('infection.project.path'));
         $this->assertSame('infection.json5', $run->getAttributes()->get('infection.config.path'));
@@ -330,7 +330,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame('/path/to/src/Foo.php', $astParsing->getAttributes()->get('code.file.path'));
         $this->assertSame('/path/to/src/Foo.php', $astEnrichment->getAttributes()->get('code.file.path'));
         $this->assertSame(1, $mutationGeneration->getAttributes()->get('infection.source_file.count'));
-        $this->assertSame(1, $mutationEvaluation->getAttributes()->get('infection.mutation.count'));
+        $this->assertSame(1, $mutationEvaluation->getAttributes()->get('infection.mutation.generated.count'));
         $this->assertSame('mutation-A', $mutationEvaluationForMutation->getAttributes()->get('infection.mutation.id'));
         $this->assertSame('For_', $mutationEvaluationForMutation->getAttributes()->get('infection.mutator.name'));
         $this->assertSame('/path/to/src/Foo.php', $mutationEvaluationForMutation->getAttributes()->get('code.file.path'));


### PR DESCRIPTION
## Description

A few attributes were renamed in the root span but not the child span or some names were inconsistent or out of sync with the documentation. This PR fixes this.

## Changes

- Rename the `infection.mutation.count` attribute from the child `infection.mutation_evaluation` span to `infection.mutation.generated.count`, to match the `infection.run` root summary attribute.
- Rename the covered-code MSI attribute from `infection.covered_msi` to `infection.covered_msi.value`. This was a mistake that slipped through in https://github.com/infection/infection/pull/3181.
- Renames the MSI threshold attribute from `infection.msi.threshold.value` to `infection.msi.threshold`. This was a mistake that slipped through in https://github.com/infection/infection/pull/3181.

## Related issues

- #3090