### PR TITLE
feat(telemetry): Group AST processing spans

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -54,6 +54,8 @@ Infection records the following lifecycle spans for every run:
 - `infection.initial_static_analysis`
 - `infection.mutation_generation`
 - `infection.mutation_analysis`
+- `infection.ast_processing`
+- `infection.ast_processing.file` (one per processed source file)
 - `infection.mutation_evaluation`
 - `infection.mutation_evaluation.mutation` (one per started mutant evaluation)
 - `infection.mutation_evaluation.heuristic_suppression`

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -143,8 +143,10 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     private ?SpanHandle $reportingSpan = null;
 
+    private ?SpanHandle $astProcessingSpan = null;
+
     /** @var array<string, SpanHandle> */
-    private array $astProcessingSpans = [];
+    private array $astProcessingFileSpans = [];
 
     /** @var array<string, SpanHandle> */
     private array $astParsingSpans = [];
@@ -229,6 +231,8 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onMutationGenerationWasStarted(MutationGenerationWasStarted $event): void
     {
+        $this->endAstSpans();
+
         $this->mutationGenerationSpan = $this->startChild(
             'infection.mutation_generation',
             ['infection.source_file.count' => $event->mutableFilesCount],
@@ -271,22 +275,27 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onAstProcessingWasStarted(AstProcessingWasStarted $event): void
     {
-        $span = $this->startChild(
+        $this->astProcessingSpan ??= $this->startChild(
             'infection.ast_processing',
-            ['code.file.path' => $event->sourceFilePath],
             parent: $this->mutationAnalysisSpan,
         );
 
+        $span = $this->startChild(
+            'infection.ast_processing.file',
+            ['code.file.path' => $event->sourceFilePath],
+            parent: $this->astProcessingSpan,
+        );
+
         if ($span !== null) {
-            $this->astProcessingSpans[$event->sourceFilePath] = $span;
+            $this->astProcessingFileSpans[$event->sourceFilePath] = $span;
         }
     }
 
     public function onAstProcessingWasFinished(AstProcessingWasFinished $event): void
     {
-        $span = $this->astProcessingSpans[$event->sourceFilePath] ?? null;
+        $span = $this->astProcessingFileSpans[$event->sourceFilePath] ?? null;
 
-        unset($this->astProcessingSpans[$event->sourceFilePath]);
+        unset($this->astProcessingFileSpans[$event->sourceFilePath]);
 
         $this->end($span);
     }
@@ -296,7 +305,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $span = $this->startChild(
             'infection.ast_parsing',
             ['code.file.path' => $event->sourceFilePath],
-            parent: $this->astProcessingSpans[$event->sourceFilePath] ?? null,
+            parent: $this->astProcessingFileSpans[$event->sourceFilePath] ?? null,
         );
 
         if ($span !== null) {
@@ -318,7 +327,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $span = $this->startChild(
             'infection.ast_enrichment',
             ['code.file.path' => $event->sourceFilePath],
-            parent: $this->astProcessingSpans[$event->sourceFilePath] ?? null,
+            parent: $this->astProcessingFileSpans[$event->sourceFilePath] ?? null,
         );
 
         if ($span !== null) {
@@ -643,13 +652,16 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
             $this->end($span);
         }
 
-        foreach ($this->astProcessingSpans as $span) {
+        foreach ($this->astProcessingFileSpans as $span) {
             $this->end($span);
         }
 
+        $this->end($this->astProcessingSpan);
+
         $this->astParsingSpans = [];
         $this->astEnrichmentSpans = [];
-        $this->astProcessingSpans = [];
+        $this->astProcessingFileSpans = [];
+        $this->astProcessingSpan = null;
     }
 
     private function endMutationEvaluationChildSpans(string $hash): void

--- a/tests/e2e/Telemetry_Console/run_tests.bash
+++ b/tests/e2e/Telemetry_Console/run_tests.bash
@@ -72,7 +72,8 @@ assert_line_count 1 '"name": "infection.initial_tests"' var/execution-with-trace
 assert_line_count 1 '"name": "infection.initial_static_analysis"' var/execution-with-trace-exporter.stdout
 assert_line_count 1 '"name": "infection.source_collection"' var/execution-with-trace-exporter.stdout
 assert_line_count 1 '"name": "infection.mutation_analysis"' var/execution-with-trace-exporter.stdout
-assert_line_count 2 '"name": "infection.ast_processing"' var/execution-with-trace-exporter.stdout
+assert_line_count 1 '"name": "infection.ast_processing"' var/execution-with-trace-exporter.stdout
+assert_line_count 2 '"name": "infection.ast_processing.file"' var/execution-with-trace-exporter.stdout
 assert_line_count 2 '"name": "infection.ast_parsing"' var/execution-with-trace-exporter.stdout
 assert_line_count 2 '"name": "infection.ast_enrichment"' var/execution-with-trace-exporter.stdout
 assert_line_count 1 '"name": "infection.mutation_generation"' var/execution-with-trace-exporter.stdout

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -230,6 +230,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 'infection.source_collection',
                 'infection.ast_parsing',
                 'infection.ast_enrichment',
+                'infection.ast_processing.file',
                 'infection.ast_processing',
                 'infection.mutation_generation',
                 'infection.mutation_evaluation.heuristic',
@@ -256,6 +257,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $initialStaticAnalysis = $this->getSpanFromExporter('infection.initial_static_analysis');
         $mutationAnalysis = $this->getSpanFromExporter('infection.mutation_analysis');
         $astProcessing = $this->getSpanFromExporter('infection.ast_processing');
+        $astProcessingFile = $this->getSpanFromExporter('infection.ast_processing.file');
         $astParsing = $this->getSpanFromExporter('infection.ast_parsing');
         $astEnrichment = $this->getSpanFromExporter('infection.ast_enrichment');
         $mutationGeneration = $this->getSpanFromExporter('infection.mutation_generation');
@@ -276,8 +278,9 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame($run->getSpanId(), $sourceCollection->getParentSpanId());
         $this->assertSame($run->getSpanId(), $mutationAnalysis->getParentSpanId());
         $this->assertSame($mutationAnalysis->getSpanId(), $astProcessing->getParentSpanId());
-        $this->assertSame($astProcessing->getSpanId(), $astParsing->getParentSpanId());
-        $this->assertSame($astProcessing->getSpanId(), $astEnrichment->getParentSpanId());
+        $this->assertSame($astProcessing->getSpanId(), $astProcessingFile->getParentSpanId());
+        $this->assertSame($astProcessingFile->getSpanId(), $astParsing->getParentSpanId());
+        $this->assertSame($astProcessingFile->getSpanId(), $astEnrichment->getParentSpanId());
         $this->assertSame($mutationAnalysis->getSpanId(), $mutationGeneration->getParentSpanId());
         $this->assertSame($mutationAnalysis->getSpanId(), $mutationEvaluation->getParentSpanId());
         $this->assertSame($mutationEvaluation->getSpanId(), $mutationEvaluationForMutation->getParentSpanId());
@@ -326,7 +329,8 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertFalse($run->getAttributes()->has('infection.static_analysis_tool.name'));
         $this->assertFalse($run->getAttributes()->has('infection.static_analysis_tool.version'));
         $this->assertIsString($run->getAttributes()->get('infection.version'));
-        $this->assertSame('/path/to/src/Foo.php', $astProcessing->getAttributes()->get('code.file.path'));
+        $this->assertFalse($astProcessing->getAttributes()->has('code.file.path'));
+        $this->assertSame('/path/to/src/Foo.php', $astProcessingFile->getAttributes()->get('code.file.path'));
         $this->assertSame('/path/to/src/Foo.php', $astParsing->getAttributes()->get('code.file.path'));
         $this->assertSame('/path/to/src/Foo.php', $astEnrichment->getAttributes()->get('code.file.path'));
         $this->assertSame(1, $mutationGeneration->getAttributes()->get('infection.source_file.count'));
@@ -366,13 +370,14 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
 
         $this->assertSame(
             [
+                'infection.ast_parsing',
+                'infection.ast_enrichment',
+                'infection.ast_processing.file',
+                'infection.ast_processing',
                 'infection.initial_tests',
                 'infection.initial_static_analysis',
                 'infection.artefact_collection',
                 'infection.source_collection',
-                'infection.ast_parsing',
-                'infection.ast_enrichment',
-                'infection.ast_processing',
                 'infection.mutation_generation',
                 'infection.mutation_evaluation.mutation',
                 'infection.mutation_evaluation',


### PR DESCRIPTION
## Description

This PR updates the telemetry span hierarchy for AST processing so per-file AST work is grouped under a single `infection.ast_processing` span during mutation analysis. This makes trace output easier to scan while keeping file-level timing available through `infection.ast_processing.file` spans.

## Changes

- Adds a grouped `infection.ast_processing` span under `infection.mutation_analysis`.
- Renames per-file AST processing spans to `infection.ast_processing.file`.

## Reviewer Notes

- #3090