### PR TITLE
feat(telemetry): Emit Relative Telemetry File Paths

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -54,6 +54,8 @@ Infection records the following lifecycle spans for every run:
 - `infection.initial_static_analysis`
 - `infection.mutation_generation`
 - `infection.mutation_analysis`
+- `infection.ast_processing`
+- `infection.ast_processing.file` (one per processed source file)
 - `infection.mutation_evaluation`
 - `infection.mutation_evaluation.mutation` (one per started mutant evaluation)
 - `infection.mutation_evaluation.heuristic_suppression`

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -112,6 +112,10 @@ toolchain, and run-summary attributes that are useful for filtering dashboards:
 | `infection.msi.threshold`                            | Effective minimum MSI threshold, or `0.0` when no threshold is configured.                                                |
 | `infection.covered_msi.threshold`                    | Effective minimum covered-code MSI threshold, or `0.0` when no threshold is configured.                                   |
 
+## Span Attributes
+
+File-level spans use `code.file.path` for the source file path. The value is
+emitted relative to `infection.project.path`.
 
 ## Configuration
 

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -181,6 +181,9 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     /** @var array<int, string> */
     private array $mutantProcessExecutionSpanMutationHashes = [];
 
+    /** @var array<non-empty-string, non-empty-string> */
+    private array $projectRelativePathCache = [];
+
     private int $sourceFileCount = 0;
 
     /**
@@ -647,14 +650,18 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     }
 
     /**
-     * @param non-empty-string $path
-     *
      * @return non-empty-string
      */
     private function getProjectRelativePath(string $path): string
     {
+        if (isset($this->projectRelativePathCache[$path])) {
+            return $this->projectRelativePathCache[$path];
+        }
+
         if (!Path::isAbsolute($path)) {
-            return $path;
+            Assert::stringNotEmpty($path);
+
+            return $this->projectRelativePathCache[$path] = $path;
         }
 
         $relativePath = Path::makeRelative(

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -143,8 +143,10 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     private ?SpanHandle $reportingSpan = null;
 
+    private ?SpanHandle $astProcessingSpan = null;
+
     /** @var array<string, SpanHandle> */
-    private array $astProcessingSpans = [];
+    private array $astProcessingFileSpans = [];
 
     /** @var array<string, SpanHandle> */
     private array $astParsingSpans = [];
@@ -229,6 +231,8 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onMutationGenerationWasStarted(MutationGenerationWasStarted $event): void
     {
+        $this->endAstSpans();
+
         $this->mutationGenerationSpan = $this->startChild(
             'infection.mutation_generation',
             ['infection.source_file.count' => $event->mutableFilesCount],
@@ -271,22 +275,27 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onAstProcessingWasStarted(AstProcessingWasStarted $event): void
     {
-        $span = $this->startChild(
+        $this->astProcessingSpan ??= $this->startChild(
             'infection.ast_processing',
-            ['code.file.path' => $event->sourceFilePath],
             parent: $this->mutationAnalysisSpan,
         );
 
+        $span = $this->startChild(
+            'infection.ast_processing.file',
+            ['code.file.path' => $event->sourceFilePath],
+            parent: $this->astProcessingSpan,
+        );
+
         if ($span !== null) {
-            $this->astProcessingSpans[$event->sourceFilePath] = $span;
+            $this->astProcessingFileSpans[$event->sourceFilePath] = $span;
         }
     }
 
     public function onAstProcessingWasFinished(AstProcessingWasFinished $event): void
     {
-        $span = $this->astProcessingSpans[$event->sourceFilePath] ?? null;
+        $span = $this->astProcessingFileSpans[$event->sourceFilePath] ?? null;
 
-        unset($this->astProcessingSpans[$event->sourceFilePath]);
+        unset($this->astProcessingFileSpans[$event->sourceFilePath]);
 
         $this->end($span);
     }
@@ -296,7 +305,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $span = $this->startChild(
             'infection.ast_parsing',
             ['code.file.path' => $event->sourceFilePath],
-            parent: $this->astProcessingSpans[$event->sourceFilePath] ?? null,
+            parent: $this->astProcessingFileSpans[$event->sourceFilePath] ?? null,
         );
 
         if ($span !== null) {
@@ -318,7 +327,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $span = $this->startChild(
             'infection.ast_enrichment',
             ['code.file.path' => $event->sourceFilePath],
-            parent: $this->astProcessingSpans[$event->sourceFilePath] ?? null,
+            parent: $this->astProcessingFileSpans[$event->sourceFilePath] ?? null,
         );
 
         if ($span !== null) {
@@ -643,13 +652,16 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
             $this->end($span);
         }
 
-        foreach ($this->astProcessingSpans as $span) {
+        foreach ($this->astProcessingFileSpans as $span) {
             $this->end($span);
         }
 
+        $this->end($this->astProcessingSpan);
+
         $this->astParsingSpans = [];
         $this->astEnrichmentSpans = [];
-        $this->astProcessingSpans = [];
+        $this->astProcessingFileSpans = [];
+        $this->astProcessingSpan = null;
     }
 
     private function endMutationEvaluationChildSpans(string $hash): void

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Telemetry\Subscriber;
 
 use function array_keys;
+use Infection\Configuration\Configuration;
 use Infection\Event\Events\Application\ApplicationExecutionWasFinished;
 use Infection\Event\Events\Application\ApplicationExecutionWasFinishedSubscriber;
 use Infection\Event\Events\Application\ApplicationExecutionWasStarted;
@@ -117,6 +118,8 @@ use Infection\Telemetry\OpenTelemetryTracer;
 use Infection\Telemetry\SpanHandle;
 use function spl_object_id;
 use function str_starts_with;
+use Symfony\Component\Filesystem\Path;
+use Webmozart\Assert\Assert;
 
 /**
  * @phpstan-import-type Attributes from RunSpanAttributesProvider
@@ -189,6 +192,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function __construct(
         private readonly OpenTelemetryTracer $telemetry,
+        private readonly Configuration $configuration,
         private readonly RunSpanAttributesProvider $runSpanAttributesProvider,
     ) {
     }
@@ -282,7 +286,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
         $span = $this->startChild(
             'infection.ast_processing.file',
-            ['code.file.path' => $event->sourceFilePath],
+            ['code.file.path' => $this->getProjectRelativePath($event->sourceFilePath)],
             parent: $this->astProcessingSpan,
         );
 
@@ -304,7 +308,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     {
         $span = $this->startChild(
             'infection.ast_parsing',
-            ['code.file.path' => $event->sourceFilePath],
+            ['code.file.path' => $this->getProjectRelativePath($event->sourceFilePath)],
             parent: $this->astProcessingFileSpans[$event->sourceFilePath] ?? null,
         );
 
@@ -326,7 +330,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     {
         $span = $this->startChild(
             'infection.ast_enrichment',
-            ['code.file.path' => $event->sourceFilePath],
+            ['code.file.path' => $this->getProjectRelativePath($event->sourceFilePath)],
             parent: $this->astProcessingFileSpans[$event->sourceFilePath] ?? null,
         );
 
@@ -361,7 +365,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
             [
                 'infection.mutation.id' => $mutation->getHash(),
                 'infection.mutator.name' => $mutation->getMutatorName(),
-                'code.file.path' => $mutation->getOriginalFilePath(),
+                'code.file.path' => $this->getProjectRelativePath($mutation->getOriginalFilePath()),
                 'code.line.start' => $mutation->getOriginalStartingLine(),
                 'code.line.end' => $mutation->getOriginalEndingLine(),
             ],
@@ -640,6 +644,26 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         if ($span !== null) {
             $this->telemetry->end($span, $attributes);
         }
+    }
+
+    /**
+     * @param non-empty-string $path
+     *
+     * @return non-empty-string
+     */
+    private function getProjectRelativePath(string $path): string
+    {
+        if (!Path::isAbsolute($path)) {
+            return $path;
+        }
+
+        $relativePath = Path::makeRelative(
+            Path::canonicalize($path),
+            Path::canonicalize($this->configuration->projectDirectory),
+        );
+        Assert::stringNotEmpty($relativePath);
+
+        return $relativePath;
     }
 
     private function endAstSpans(): void

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriberFactory.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriberFactory.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Telemetry\Subscriber;
 
+use Infection\Configuration\Configuration;
 use Infection\Event\Subscriber\EventSubscriber;
 use Infection\Event\Subscriber\NullSubscriber;
 use Infection\Event\Subscriber\SubscriberFactory;
@@ -48,6 +49,7 @@ final readonly class OpenTelemetryTracerSubscriberFactory implements SubscriberF
 {
     public function __construct(
         private OpenTelemetryTracerFactory $telemetryTracerFactory,
+        private Configuration $configuration,
         private RunSpanAttributesProvider $runSpanAttributesProvider,
     ) {
     }
@@ -58,7 +60,7 @@ final readonly class OpenTelemetryTracerSubscriberFactory implements SubscriberF
 
         return $tracer === null
             ? new NullSubscriber()
-            : new OpenTelemetryTracerSubscriber($tracer, $this->runSpanAttributesProvider)
+            : new OpenTelemetryTracerSubscriber($tracer, $this->configuration, $this->runSpanAttributesProvider)
         ;
     }
 }

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriberFactory.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriberFactory.php
@@ -60,7 +60,11 @@ final readonly class OpenTelemetryTracerSubscriberFactory implements SubscriberF
 
         return $tracer === null
             ? new NullSubscriber()
-            : new OpenTelemetryTracerSubscriber($tracer, $this->configuration, $this->runSpanAttributesProvider)
+            : new OpenTelemetryTracerSubscriber(
+                $tracer,
+                $this->configuration,
+                $this->runSpanAttributesProvider,
+            )
         ;
     }
 }

--- a/tests/e2e/Telemetry_Console/run_tests.bash
+++ b/tests/e2e/Telemetry_Console/run_tests.bash
@@ -72,7 +72,8 @@ assert_line_count 1 '"name": "infection.initial_tests"' var/execution-with-trace
 assert_line_count 1 '"name": "infection.initial_static_analysis"' var/execution-with-trace-exporter.stdout
 assert_line_count 1 '"name": "infection.source_collection"' var/execution-with-trace-exporter.stdout
 assert_line_count 1 '"name": "infection.mutation_analysis"' var/execution-with-trace-exporter.stdout
-assert_line_count 2 '"name": "infection.ast_processing"' var/execution-with-trace-exporter.stdout
+assert_line_count 1 '"name": "infection.ast_processing"' var/execution-with-trace-exporter.stdout
+assert_line_count 2 '"name": "infection.ast_processing.file"' var/execution-with-trace-exporter.stdout
 assert_line_count 2 '"name": "infection.ast_parsing"' var/execution-with-trace-exporter.stdout
 assert_line_count 2 '"name": "infection.ast_enrichment"' var/execution-with-trace-exporter.stdout
 assert_line_count 1 '"name": "infection.mutation_generation"' var/execution-with-trace-exporter.stdout

--- a/tests/e2e/Telemetry_Console/run_tests.bash
+++ b/tests/e2e/Telemetry_Console/run_tests.bash
@@ -92,6 +92,8 @@ assert_contains '"infection.test_framework.name": "phpunit"' var/execution-with-
 assert_contains '"infection.test_framework.version":' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.static_analysis_tool.name": "phpstan"' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.static_analysis_tool.version":' var/execution-with-trace-exporter.stdout
+assert_contains '"code.file.path": "tests\/e2e\/Telemetry_Console\/src\/SourceClass.php"' var/execution-with-trace-exporter.stdout
+assert_contains '"code.file.path": "tests\/e2e\/Telemetry_Console\/src\/AnotherSourceClass.php"' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.source_file.count": 2' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.mutation.generated.count": 6' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.mutation.evaluated.count": 6' var/execution-with-trace-exporter.stdout

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -140,6 +140,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 $this->tracerProvider->getTracer('infection'),
                 $this->tracerProvider,
             ),
+            $configuration,
             new RunSpanAttributesProvider(
                 $configuration,
                 new InfectionVersion(),
@@ -159,7 +160,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
     {
         $mutation = MutationBuilder::withMinimalTestData()
             ->withHash('mutation-A')
-            ->withOriginalFilePath('/path/to/src/Foo.php')
+            ->withOriginalFilePath('/path/to/project/src/Foo.php')
             ->withMutatorName('For_')
             ->build();
         $mutant = MutantBuilder::withMinimalTestData()
@@ -181,12 +182,12 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->subscriber->onSourceCollectionWasStarted(new SourceCollectionWasStarted());
         $this->subscriber->onSourceCollectionWasFinished(new SourceCollectionWasFinished(1));
         $this->subscriber->onMutationAnalysisWasStarted(new MutationAnalysisWasStarted());
-        $this->subscriber->onAstProcessingWasStarted(new AstProcessingWasStarted('/path/to/src/Foo.php'));
-        $this->subscriber->onAstParsingWasStarted(new AstParsingWasStarted('/path/to/src/Foo.php'));
-        $this->subscriber->onAstParsingWasFinished(new AstParsingWasFinished('/path/to/src/Foo.php'));
-        $this->subscriber->onAstEnrichmentWasStarted(new AstEnrichmentWasStarted('/path/to/src/Foo.php'));
-        $this->subscriber->onAstEnrichmentWasFinished(new AstEnrichmentWasFinished('/path/to/src/Foo.php'));
-        $this->subscriber->onAstProcessingWasFinished(new AstProcessingWasFinished('/path/to/src/Foo.php'));
+        $this->subscriber->onAstProcessingWasStarted(new AstProcessingWasStarted('/path/to/project/src/Foo.php'));
+        $this->subscriber->onAstParsingWasStarted(new AstParsingWasStarted('/path/to/project/src/Foo.php'));
+        $this->subscriber->onAstParsingWasFinished(new AstParsingWasFinished('/path/to/project/src/Foo.php'));
+        $this->subscriber->onAstEnrichmentWasStarted(new AstEnrichmentWasStarted('/path/to/project/src/Foo.php'));
+        $this->subscriber->onAstEnrichmentWasFinished(new AstEnrichmentWasFinished('/path/to/project/src/Foo.php'));
+        $this->subscriber->onAstProcessingWasFinished(new AstProcessingWasFinished('/path/to/project/src/Foo.php'));
         $this->subscriber->onMutationGenerationWasStarted(new MutationGenerationWasStarted(1));
         $this->subscriber->onMutationGenerationWasFinished(new MutationGenerationWasFinished(2));
         $this->subscriber->onMutationEvaluationWasStarted(new MutationEvaluationWasStarted(1, $this->createStub(ProcessRunner::class)));
@@ -330,15 +331,15 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertFalse($run->getAttributes()->has('infection.static_analysis_tool.version'));
         $this->assertIsString($run->getAttributes()->get('infection.version'));
         $this->assertFalse($astProcessing->getAttributes()->has('code.file.path'));
-        $this->assertSame('/path/to/src/Foo.php', $astProcessingFile->getAttributes()->get('code.file.path'));
-        $this->assertSame('/path/to/src/Foo.php', $astParsing->getAttributes()->get('code.file.path'));
-        $this->assertSame('/path/to/src/Foo.php', $astEnrichment->getAttributes()->get('code.file.path'));
+        $this->assertSame('src/Foo.php', $astProcessingFile->getAttributes()->get('code.file.path'));
+        $this->assertSame('src/Foo.php', $astParsing->getAttributes()->get('code.file.path'));
+        $this->assertSame('src/Foo.php', $astEnrichment->getAttributes()->get('code.file.path'));
         $this->assertSame(1, $mutationGeneration->getAttributes()->get('infection.source_file.count'));
         $this->assertSame(2, $mutationGeneration->getAttributes()->get('infection.mutation.generated.count'));
         $this->assertFalse($mutationEvaluation->getAttributes()->has('infection.mutation.count'));
         $this->assertSame('mutation-A', $mutationEvaluationForMutation->getAttributes()->get('infection.mutation.id'));
         $this->assertSame('For_', $mutationEvaluationForMutation->getAttributes()->get('infection.mutator.name'));
-        $this->assertSame('/path/to/src/Foo.php', $mutationEvaluationForMutation->getAttributes()->get('code.file.path'));
+        $this->assertSame('src/Foo.php', $mutationEvaluationForMutation->getAttributes()->get('code.file.path'));
         $this->assertSame(10, $mutationEvaluationForMutation->getAttributes()->get('code.line.start'));
         $this->assertSame(15, $mutationEvaluationForMutation->getAttributes()->get('code.line.end'));
         $this->assertSame(HeuristicName::IGNORED_BY_REGEX->value, $heuristic->getAttributes()->get('infection.mutation_evaluation.heuristic.id'));
@@ -359,9 +360,9 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->subscriber->onInitialStaticAnalysisRunWasStarted(new InitialStaticAnalysisRunWasStarted());
         $this->subscriber->onSourceCollectionWasStarted(new SourceCollectionWasStarted());
         $this->subscriber->onMutationAnalysisWasStarted(new MutationAnalysisWasStarted());
-        $this->subscriber->onAstProcessingWasStarted(new AstProcessingWasStarted('/path/to/src/Foo.php'));
-        $this->subscriber->onAstParsingWasStarted(new AstParsingWasStarted('/path/to/src/Foo.php'));
-        $this->subscriber->onAstEnrichmentWasStarted(new AstEnrichmentWasStarted('/path/to/src/Foo.php'));
+        $this->subscriber->onAstProcessingWasStarted(new AstProcessingWasStarted('/path/to/project/src/Foo.php'));
+        $this->subscriber->onAstParsingWasStarted(new AstParsingWasStarted('/path/to/project/src/Foo.php'));
+        $this->subscriber->onAstEnrichmentWasStarted(new AstEnrichmentWasStarted('/path/to/project/src/Foo.php'));
         $this->subscriber->onMutationGenerationWasStarted(new MutationGenerationWasStarted(1));
         $this->subscriber->onMutationEvaluationWasStarted(new MutationEvaluationWasStarted(IterableCounter::UNKNOWN_COUNT, $this->createStub(ProcessRunner::class)));
         $this->subscriber->onMutationEvaluationForMutationWasStarted(new MutationEvaluationForMutationWasStarted($mutation));

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -230,6 +230,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 'infection.source_collection',
                 'infection.ast_parsing',
                 'infection.ast_enrichment',
+                'infection.ast_processing.file',
                 'infection.ast_processing',
                 'infection.mutation_generation',
                 'infection.mutation_evaluation.heuristic',
@@ -256,6 +257,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $initialStaticAnalysis = $this->getSpanFromExporter('infection.initial_static_analysis');
         $mutationAnalysis = $this->getSpanFromExporter('infection.mutation_analysis');
         $astProcessing = $this->getSpanFromExporter('infection.ast_processing');
+        $astProcessingFile = $this->getSpanFromExporter('infection.ast_processing.file');
         $astParsing = $this->getSpanFromExporter('infection.ast_parsing');
         $astEnrichment = $this->getSpanFromExporter('infection.ast_enrichment');
         $mutationGeneration = $this->getSpanFromExporter('infection.mutation_generation');
@@ -276,8 +278,9 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame($run->getSpanId(), $sourceCollection->getParentSpanId());
         $this->assertSame($run->getSpanId(), $mutationAnalysis->getParentSpanId());
         $this->assertSame($mutationAnalysis->getSpanId(), $astProcessing->getParentSpanId());
-        $this->assertSame($astProcessing->getSpanId(), $astParsing->getParentSpanId());
-        $this->assertSame($astProcessing->getSpanId(), $astEnrichment->getParentSpanId());
+        $this->assertSame($astProcessing->getSpanId(), $astProcessingFile->getParentSpanId());
+        $this->assertSame($astProcessingFile->getSpanId(), $astParsing->getParentSpanId());
+        $this->assertSame($astProcessingFile->getSpanId(), $astEnrichment->getParentSpanId());
         $this->assertSame($mutationAnalysis->getSpanId(), $mutationGeneration->getParentSpanId());
         $this->assertSame($mutationAnalysis->getSpanId(), $mutationEvaluation->getParentSpanId());
         $this->assertSame($mutationEvaluation->getSpanId(), $mutationEvaluationForMutation->getParentSpanId());
@@ -326,7 +329,8 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertFalse($run->getAttributes()->has('infection.static_analysis_tool.name'));
         $this->assertFalse($run->getAttributes()->has('infection.static_analysis_tool.version'));
         $this->assertIsString($run->getAttributes()->get('infection.version'));
-        $this->assertSame('/path/to/src/Foo.php', $astProcessing->getAttributes()->get('code.file.path'));
+        $this->assertFalse($astProcessing->getAttributes()->has('code.file.path'));
+        $this->assertSame('/path/to/src/Foo.php', $astProcessingFile->getAttributes()->get('code.file.path'));
         $this->assertSame('/path/to/src/Foo.php', $astParsing->getAttributes()->get('code.file.path'));
         $this->assertSame('/path/to/src/Foo.php', $astEnrichment->getAttributes()->get('code.file.path'));
         $this->assertSame(1, $mutationGeneration->getAttributes()->get('infection.source_file.count'));
@@ -366,13 +370,14 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
 
         $this->assertSame(
             [
+                'infection.ast_parsing',
+                'infection.ast_enrichment',
+                'infection.ast_processing.file',
+                'infection.ast_processing',
                 'infection.initial_tests',
                 'infection.initial_static_analysis',
                 'infection.artefact_collection',
                 'infection.source_collection',
-                'infection.ast_parsing',
-                'infection.ast_enrichment',
-                'infection.ast_processing',
                 'infection.mutation_generation',
                 'infection.mutation_evaluation.mutation',
                 'infection.mutation_evaluation',


### PR DESCRIPTION
## Description

This PR updates telemetry file-path attributes so `code.file.path` is emitted relative to `infection.project.path`. This keeps file-level span data consistent with the project root already reported on the run span and avoids exposing redundant absolute path prefixes in telemetry output.

## Changes

- Updates OpenTelemetry span attributes to use project-relative `code.file.path` values.
- Adds a small subscriber-local cache for relative path conversion to avoid repeating path canonicalisation for the same source files.
- Limit the transformation to the telemetry to not impact the application performances (however small it would be) when telemetry is not used.
- Passes the resolved Infection configuration into the telemetry subscriber so path attributes can be made relative to the configured project directory.

## Related issues

- #3090