### PR TITLE
feat(telemetry): Add mutated file count as a span attribute

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -88,6 +88,7 @@ toolchain, and run-summary attributes that are useful for filtering dashboards:
 | `infection.static_analysis_tool.name`                | Normalised configured static analysis tool name, for example `phpstan`; only emitted when static analysis is enabled.     |
 | `infection.static_analysis_tool.version`             | Version reported by the configured static analysis tool adapter; only emitted with `infection.static_analysis_tool.name`. |
 | `infection.source_file.count`                        | Number of source files collected for the run.                                                                             |
+| `infection.mutated_file.count`                       | Number of source files for which at least one mutation was generated.                                                     |
 | `infection.mutation.generated.count`                 | Number of generated mutations selected for mutation evaluation.                                                           |
 | `infection.mutation.evaluated.count`                 | Number of mutations evaluated.                                                                                            |
 | `infection.mutation.suppressed.count`                | Number of generated mutations suppressed before mutant evaluation, including heuristic suppression.                       |

--- a/src/Event/Events/MutationAnalysis/MutationGeneration/MutationGenerationWasFinished.php
+++ b/src/Event/Events/MutationAnalysis/MutationGeneration/MutationGenerationWasFinished.php
@@ -42,9 +42,11 @@ final readonly class MutationGenerationWasFinished
 {
     /**
      * @param positive-int|0 $mutationsCount
+     * @param positive-int|0 $mutatedFilesCount
      */
     public function __construct(
         public int $mutationsCount,
+        public int $mutatedFilesCount,
     ) {
     }
 }

--- a/src/Mutation/MutationGenerator.php
+++ b/src/Mutation/MutationGenerator.php
@@ -92,6 +92,7 @@ class MutationGenerator
         $sources = $this->sourceCollector->collect();
         $numberOfFiles = count($sources);
         $mutationsCount = 0;
+        $mutatedFilesCount = 0;
 
         $this->eventDispatcher->dispatch(new MutationGenerationWasStarted($numberOfFiles));
 
@@ -119,10 +120,14 @@ class MutationGenerator
 
             $fileMutationsCount = count($sourceFileMutationIds);
             $mutationsCount += $fileMutationsCount;
+
+            if ($fileMutationsCount > 0) {
+                ++$mutatedFilesCount;
+            }
         }
 
         $this->eventDispatcher->dispatch(
-            new MutationGenerationWasFinished($mutationsCount),
+            new MutationGenerationWasFinished($mutationsCount, $mutatedFilesCount),
         );
     }
 }

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -102,8 +102,12 @@ final readonly class RunSpanAttributesProvider
     /**
      * @return Attributes
      */
-    public function provideSummaryAttributes(int $sourceFileCount, int $mutationCount, int $evaluatedMutationCount): array
-    {
+    public function provideSummaryAttributes(
+        int $sourceFileCount,
+        int $mutatedFileCount,
+        int $mutationCount,
+        int $evaluatedMutationCount,
+    ): array {
         $mutationCount = max(
             $mutationCount,
             $evaluatedMutationCount,
@@ -112,6 +116,7 @@ final readonly class RunSpanAttributesProvider
 
         return [
             'infection.source_file.count' => $sourceFileCount,
+            'infection.mutated_file.count' => $mutatedFileCount,
             'infection.mutation.generated.count' => $mutationCount,
             'infection.mutation.evaluated.count' => $evaluatedMutationCount,
             'infection.mutation.suppressed.count' => $mutationCount - $evaluatedMutationCount,

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -189,6 +189,11 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     /**
      * @var positive-int|0
      */
+    private int $mutatedFileCount = 0;
+
+    /**
+     * @var positive-int|0
+     */
     private int $mutationCount = 0;
 
     private int $evaluatedMutationCount = 0;
@@ -250,10 +255,14 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     public function onMutationGenerationWasFinished(MutationGenerationWasFinished $event): void
     {
         $this->mutationCount = $event->mutationsCount;
+        $this->mutatedFileCount = $event->mutatedFilesCount;
 
         $this->end(
             $this->mutationGenerationSpan,
-            ['infection.mutation.generated.count' => $event->mutationsCount],
+            [
+                'infection.mutated_file.count' => $event->mutatedFilesCount,
+                'infection.mutation.generated.count' => $event->mutationsCount,
+            ],
         );
         $this->mutationGenerationSpan = null;
     }
@@ -581,6 +590,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
             $this->rootSpan,
             $this->runSpanAttributesProvider->provideSummaryAttributes(
                 $this->sourceFileCount,
+                $this->mutatedFileCount,
                 $this->mutationCount,
                 $this->evaluatedMutationCount,
             ),

--- a/tests/e2e/Telemetry_Console/run_tests.bash
+++ b/tests/e2e/Telemetry_Console/run_tests.bash
@@ -95,6 +95,7 @@ assert_contains '"infection.static_analysis_tool.version":' var/execution-with-t
 assert_contains '"code.file.path": "tests\/e2e\/Telemetry_Console\/src\/SourceClass.php"' var/execution-with-trace-exporter.stdout
 assert_contains '"code.file.path": "tests\/e2e\/Telemetry_Console\/src\/AnotherSourceClass.php"' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.source_file.count": 2' var/execution-with-trace-exporter.stdout
+assert_contains '"infection.mutated_file.count": 2' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.mutation.generated.count": 6' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.mutation.evaluated.count": 6' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.mutation.suppressed.count": 0' var/execution-with-trace-exporter.stdout

--- a/tests/phpunit/Event/Events/MutationAnalysis/MutationGeneration/MutationGenerationWasFinishedTest.php
+++ b/tests/phpunit/Event/Events/MutationAnalysis/MutationGeneration/MutationGenerationWasFinishedTest.php
@@ -43,12 +43,13 @@ use PHPUnit\Framework\TestCase;
 final class MutationGenerationWasFinishedTest extends TestCase
 {
     /**
-     * This class is only used to fire events, and the only functionality it needs is exposing the generated total
+     * This class is only used to fire events, and the only functionality it needs is exposing the generation totals.
      */
-    public function test_it_exposes_the_generated_total(): void
+    public function test_it_exposes_the_generation_totals(): void
     {
-        $class = new MutationGenerationWasFinished(2);
+        $class = new MutationGenerationWasFinished(2, 1);
 
         $this->assertSame(2, $class->mutationsCount);
+        $this->assertSame(1, $class->mutatedFilesCount);
     }
 }

--- a/tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php
+++ b/tests/phpunit/Event/Subscriber/MutationGenerationLoggerSubscriberTest.php
@@ -98,7 +98,7 @@ final class MutationGenerationLoggerSubscriberTest extends TestCase
             ->method('finish');
 
         $this->dispatcher->dispatch(
-            new MutationGenerationWasFinished(2),
+            new MutationGenerationWasFinished(2, 1),
         );
     }
 }

--- a/tests/phpunit/Mutation/MutationGeneratorTest.php
+++ b/tests/phpunit/Mutation/MutationGeneratorTest.php
@@ -138,7 +138,7 @@ final class MutationGeneratorTest extends TestCase
                     'path/to/fileB',
                     [],
                 )],
-                [new MutationGenerationWasFinished(2)],
+                [new MutationGenerationWasFinished(2, 1)],
             ))
         ;
 

--- a/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
@@ -185,6 +185,7 @@ final class RunSpanAttributesProviderTest extends TestCase
         Configuration $configuration,
         array $detectionStatuses,
         int $sourceFileCount,
+        int $mutatedFileCount,
         int $mutationCount,
         int $evaluatedMutationCount,
         array $expected,
@@ -213,6 +214,7 @@ final class RunSpanAttributesProviderTest extends TestCase
 
         $actual = $provider->provideSummaryAttributes(
             $sourceFileCount,
+            $mutatedFileCount,
             $mutationCount,
             $evaluatedMutationCount,
         );
@@ -228,8 +230,10 @@ final class RunSpanAttributesProviderTest extends TestCase
             0,
             0,
             0,
+            0,
             [
                 'infection.source_file.count' => 0,
+                'infection.mutated_file.count' => 0,
                 'infection.mutation.generated.count' => 0,
                 'infection.mutation.evaluated.count' => 0,
                 'infection.mutation.suppressed.count' => 0,
@@ -274,10 +278,12 @@ final class RunSpanAttributesProviderTest extends TestCase
                 DetectionStatus::IGNORED,
             ],
             3,
+            2,
             12,
             10,
             [
                 'infection.source_file.count' => 3,
+                'infection.mutated_file.count' => 2,
                 'infection.mutation.generated.count' => 12,
                 'infection.mutation.evaluated.count' => 10,
                 'infection.mutation.suppressed.count' => 2,

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -189,7 +189,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->subscriber->onAstEnrichmentWasFinished(new AstEnrichmentWasFinished('/path/to/project/src/Foo.php'));
         $this->subscriber->onAstProcessingWasFinished(new AstProcessingWasFinished('/path/to/project/src/Foo.php'));
         $this->subscriber->onMutationGenerationWasStarted(new MutationGenerationWasStarted(1));
-        $this->subscriber->onMutationGenerationWasFinished(new MutationGenerationWasFinished(2));
+        $this->subscriber->onMutationGenerationWasFinished(new MutationGenerationWasFinished(2, 1));
         $this->subscriber->onMutationEvaluationWasStarted(new MutationEvaluationWasStarted(1, $this->createStub(ProcessRunner::class)));
         $this->subscriber->onMutationEvaluationForMutationWasStarted(new MutationEvaluationForMutationWasStarted($mutation));
         $this->subscriber->onHeuristicSuppressionWasStarted(new HeuristicSuppressionWasStarted($mutation));
@@ -295,6 +295,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
 
         $this->assertSame(1, $sourceCollection->getAttributes()->get('infection.source_file.count'));
         $this->assertSame(1, $run->getAttributes()->get('infection.source_file.count'));
+        $this->assertSame(1, $run->getAttributes()->get('infection.mutated_file.count'));
         $this->assertSame(2, $run->getAttributes()->get('infection.mutation.generated.count'));
         $this->assertSame(1, $run->getAttributes()->get('infection.mutation.evaluated.count'));
         $this->assertSame(1, $run->getAttributes()->get('infection.mutation.suppressed.count'));
@@ -335,6 +336,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame('src/Foo.php', $astParsing->getAttributes()->get('code.file.path'));
         $this->assertSame('src/Foo.php', $astEnrichment->getAttributes()->get('code.file.path'));
         $this->assertSame(1, $mutationGeneration->getAttributes()->get('infection.source_file.count'));
+        $this->assertSame(1, $mutationGeneration->getAttributes()->get('infection.mutated_file.count'));
         $this->assertSame(2, $mutationGeneration->getAttributes()->get('infection.mutation.generated.count'));
         $this->assertFalse($mutationEvaluation->getAttributes()->has('infection.mutation.count'));
         $this->assertSame('mutation-A', $mutationEvaluationForMutation->getAttributes()->get('infection.mutation.id'));


### PR DESCRIPTION
## Description

This gives telemetry consumers a run-level signal distinct from the total collected source files and the total generated mutation count.

## Changes

- Extends `MutationGenerationWasFinished` with the mutated file count.
- Counts mutated files during mutation generation when a source file produces at least one mutation.
- Emits `infection.mutated_file.count` on the mutation-generation span and the run summary attributes.

## Related issues

- #3090
