### PR TITLE
feat(telemetry): Clarify telemetry span names

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -56,14 +56,16 @@ Infection records the following lifecycle spans for every run:
 - `infection.mutation_analysis`
 - `infection.ast_processing`
 - `infection.ast_processing.file` (one per processed source file)
+- `infection.ast_processing.file.parsing`
+- `infection.ast_processing.file.enrichment`
 - `infection.mutation_evaluation`
 - `infection.mutation_evaluation.mutation` (one per started mutant evaluation)
-- `infection.mutation_evaluation.heuristic_suppression`
-- `infection.mutation_evaluation.heuristic`
+- `infection.mutation_evaluation.mutation.heuristic_suppression`
+- `infection.mutation_evaluation.mutation.heuristic`
 - `infection.mutation_evaluation.mutant_analysis`
-- `infection.mutation_evaluation.mutant_materialisation`
-- `infection.mutation_evaluation.mutant_evaluation`
-- `infection.mutation_evaluation.process`
+- `infection.mutation_evaluation.mutant_analysis.materialisation`
+- `infection.mutation_evaluation.mutant_analysis.evaluation`
+- `infection.mutation_evaluation.mutant_analysis.evaluation.process`
 
 ## Run Attributes
 

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -319,7 +319,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     public function onAstParsingWasStarted(AstParsingWasStarted $event): void
     {
         $span = $this->startChild(
-            'infection.ast_parsing',
+            'infection.ast_processing.file.parsing',
             ['code.file.path' => $this->getProjectRelativePath($event->sourceFilePath)],
             parent: $this->astProcessingFileSpans[$event->sourceFilePath] ?? null,
         );
@@ -341,7 +341,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     public function onAstEnrichmentWasStarted(AstEnrichmentWasStarted $event): void
     {
         $span = $this->startChild(
-            'infection.ast_enrichment',
+            'infection.ast_processing.file.enrichment',
             ['code.file.path' => $this->getProjectRelativePath($event->sourceFilePath)],
             parent: $this->astProcessingFileSpans[$event->sourceFilePath] ?? null,
         );
@@ -413,7 +413,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $hash = $event->mutation->getHash();
 
         $span = $this->startChild(
-            'infection.mutation_evaluation.heuristic_suppression',
+            'infection.mutation_evaluation.mutation.heuristic_suppression',
             parent: $this->mutationEvaluationSpans[$hash] ?? null,
         );
 
@@ -438,7 +438,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $key = self::heuristicKey($hash, $event->heuristic->value);
 
         $span = $this->startChild(
-            'infection.mutation_evaluation.heuristic',
+            'infection.mutation_evaluation.mutation.heuristic',
             ['infection.mutation_evaluation.heuristic.id' => $event->heuristic->value],
             $this->heuristicSuppressionSpans[$hash] ?? ($this->mutationEvaluationSpans[$hash] ?? null),
         );
@@ -487,7 +487,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $hash = $event->mutant->getMutation()->getHash();
 
         $span = $this->startChild(
-            'infection.mutation_evaluation.mutant_materialisation',
+            'infection.mutation_evaluation.mutant_analysis.materialisation',
             parent: $this->mutantAnalysisSpans[$hash] ?? ($this->mutationEvaluationSpans[$hash] ?? null),
         );
 
@@ -512,7 +512,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         ++$this->evaluatedMutationCount;
 
         $span = $this->startChild(
-            'infection.mutation_evaluation.mutant_evaluation',
+            'infection.mutation_evaluation.mutant_analysis.evaluation',
             parent: $this->mutantAnalysisSpans[$hash] ?? ($this->mutationEvaluationSpans[$hash] ?? null),
         );
 
@@ -537,7 +537,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $key = spl_object_id($event->mutantProcess);
 
         $span = $this->startChild(
-            'infection.mutation_evaluation.process',
+            'infection.mutation_evaluation.mutant_analysis.evaluation.process',
             parent: $this->mutantEvaluationSpans[$hash] ?? ($this->mutationEvaluationSpans[$hash] ?? null),
         );
 

--- a/tests/e2e/Telemetry_Console/run_tests.bash
+++ b/tests/e2e/Telemetry_Console/run_tests.bash
@@ -74,17 +74,17 @@ assert_line_count 1 '"name": "infection.source_collection"' var/execution-with-t
 assert_line_count 1 '"name": "infection.mutation_analysis"' var/execution-with-trace-exporter.stdout
 assert_line_count 1 '"name": "infection.ast_processing"' var/execution-with-trace-exporter.stdout
 assert_line_count 2 '"name": "infection.ast_processing.file"' var/execution-with-trace-exporter.stdout
-assert_line_count 2 '"name": "infection.ast_parsing"' var/execution-with-trace-exporter.stdout
-assert_line_count 2 '"name": "infection.ast_enrichment"' var/execution-with-trace-exporter.stdout
+assert_line_count 2 '"name": "infection.ast_processing.file.parsing"' var/execution-with-trace-exporter.stdout
+assert_line_count 2 '"name": "infection.ast_processing.file.enrichment"' var/execution-with-trace-exporter.stdout
 assert_line_count 1 '"name": "infection.mutation_generation"' var/execution-with-trace-exporter.stdout
 assert_line_count 1 '"name": "infection.mutation_evaluation"' var/execution-with-trace-exporter.stdout
 assert_line_count 6 '"name": "infection.mutation_evaluation.mutation"' var/execution-with-trace-exporter.stdout
-assert_line_count 6 '"name": "infection.mutation_evaluation.heuristic_suppression"' var/execution-with-trace-exporter.stdout
-assert_line_count 18 '"name": "infection.mutation_evaluation.heuristic"' var/execution-with-trace-exporter.stdout
+assert_line_count 6 '"name": "infection.mutation_evaluation.mutation.heuristic_suppression"' var/execution-with-trace-exporter.stdout
+assert_line_count 18 '"name": "infection.mutation_evaluation.mutation.heuristic"' var/execution-with-trace-exporter.stdout
 assert_line_count 6 '"name": "infection.mutation_evaluation.mutant_analysis"' var/execution-with-trace-exporter.stdout
-assert_line_count 6 '"name": "infection.mutation_evaluation.mutant_materialisation"' var/execution-with-trace-exporter.stdout
-assert_line_count 6 '"name": "infection.mutation_evaluation.mutant_evaluation"' var/execution-with-trace-exporter.stdout
-assert_line_count 6 '"name": "infection.mutation_evaluation.process"' var/execution-with-trace-exporter.stdout
+assert_line_count 6 '"name": "infection.mutation_evaluation.mutant_analysis.materialisation"' var/execution-with-trace-exporter.stdout
+assert_line_count 6 '"name": "infection.mutation_evaluation.mutant_analysis.evaluation"' var/execution-with-trace-exporter.stdout
+assert_line_count 6 '"name": "infection.mutation_evaluation.mutant_analysis.evaluation.process"' var/execution-with-trace-exporter.stdout
 assert_line_count 1 '"name": "infection.reporting"' var/execution-with-trace-exporter.stdout
 assert_contains '"service.name": "infection"' var/execution-with-trace-exporter.stdout
 assert_contains '"infection.project.name": "infection\/infection"' var/execution-with-trace-exporter.stdout

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -229,18 +229,18 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 'infection.initial_static_analysis',
                 'infection.artefact_collection',
                 'infection.source_collection',
-                'infection.ast_parsing',
-                'infection.ast_enrichment',
+                'infection.ast_processing.file.parsing',
+                'infection.ast_processing.file.enrichment',
                 'infection.ast_processing.file',
                 'infection.ast_processing',
                 'infection.mutation_generation',
-                'infection.mutation_evaluation.heuristic',
-                'infection.mutation_evaluation.heuristic',
-                'infection.mutation_evaluation.heuristic_suppression',
-                'infection.mutation_evaluation.mutant_materialisation',
-                'infection.mutation_evaluation.process',
-                'infection.mutation_evaluation.process',
-                'infection.mutation_evaluation.mutant_evaluation',
+                'infection.mutation_evaluation.mutation.heuristic',
+                'infection.mutation_evaluation.mutation.heuristic',
+                'infection.mutation_evaluation.mutation.heuristic_suppression',
+                'infection.mutation_evaluation.mutant_analysis.materialisation',
+                'infection.mutation_evaluation.mutant_analysis.evaluation.process',
+                'infection.mutation_evaluation.mutant_analysis.evaluation.process',
+                'infection.mutation_evaluation.mutant_analysis.evaluation',
                 'infection.mutation_evaluation.mutant_analysis',
                 'infection.mutation_evaluation.mutation',
                 'infection.reporting',
@@ -259,17 +259,17 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $mutationAnalysis = $this->getSpanFromExporter('infection.mutation_analysis');
         $astProcessing = $this->getSpanFromExporter('infection.ast_processing');
         $astProcessingFile = $this->getSpanFromExporter('infection.ast_processing.file');
-        $astParsing = $this->getSpanFromExporter('infection.ast_parsing');
-        $astEnrichment = $this->getSpanFromExporter('infection.ast_enrichment');
+        $astParsing = $this->getSpanFromExporter('infection.ast_processing.file.parsing');
+        $astEnrichment = $this->getSpanFromExporter('infection.ast_processing.file.enrichment');
         $mutationGeneration = $this->getSpanFromExporter('infection.mutation_generation');
         $mutationEvaluation = $this->getSpanFromExporter('infection.mutation_evaluation');
         $mutationEvaluationForMutation = $this->getSpanFromExporter('infection.mutation_evaluation.mutation');
-        $heuristic = $this->getSpanFromExporter('infection.mutation_evaluation.heuristic');
-        $heuristicSuppression = $this->getSpanFromExporter('infection.mutation_evaluation.heuristic_suppression');
+        $heuristic = $this->getSpanFromExporter('infection.mutation_evaluation.mutation.heuristic');
+        $heuristicSuppression = $this->getSpanFromExporter('infection.mutation_evaluation.mutation.heuristic_suppression');
         $mutantAnalysis = $this->getSpanFromExporter('infection.mutation_evaluation.mutant_analysis');
-        $mutantMaterialisation = $this->getSpanFromExporter('infection.mutation_evaluation.mutant_materialisation');
-        $mutantEvaluation = $this->getSpanFromExporter('infection.mutation_evaluation.mutant_evaluation');
-        $process = $this->getSpanFromExporter('infection.mutation_evaluation.process');
+        $mutantMaterialisation = $this->getSpanFromExporter('infection.mutation_evaluation.mutant_analysis.materialisation');
+        $mutantEvaluation = $this->getSpanFromExporter('infection.mutation_evaluation.mutant_analysis.evaluation');
+        $process = $this->getSpanFromExporter('infection.mutation_evaluation.mutant_analysis.evaluation.process');
         $reporting = $this->getSpanFromExporter('infection.reporting');
 
         $this->assertSame(self::ROOT_SPAN_PARENT_ID, $run->getParentSpanId());
@@ -373,8 +373,8 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
 
         $this->assertSame(
             [
-                'infection.ast_parsing',
-                'infection.ast_enrichment',
+                'infection.ast_processing.file.parsing',
+                'infection.ast_processing.file.enrichment',
                 'infection.ast_processing.file',
                 'infection.ast_processing',
                 'infection.initial_tests',


### PR DESCRIPTION
## Description

Updates telemetry span names so repeated file, mutation, heuristic, mutant-analysis, and process spans are easier to distinguish from run-level phase spans when inspecting traces.

## Related issues

- #3090