### PR TITLE
feat(telemetry): Propagate mutation attributes to telemetry child spans

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -120,6 +120,11 @@ toolchain, and run-summary attributes that are useful for filtering dashboards:
 File-level spans use `code.file.path` for the source file path. The value is
 emitted relative to `infection.project.path`.
 
+Mutation-level spans and their child spans include `infection.mutation.id`,
+`infection.mutator.name`, `code.file.path`, `code.line.start`, and
+`code.line.end`. This makes mutation child spans queryable on their own in
+backends that do not support grouping or filtering by parent span attributes.
+
 ## Configuration
 
 `INFECTION_TELEMETRY=true` is required before Infection creates any telemetry

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -156,7 +156,9 @@ use Infection\Source\Matcher\SourceLineMatcher;
 use Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\StaticAnalysis\StaticAnalysisToolFactory;
+use Infection\Telemetry\Attribute\MutationSpanAttributesProvider;
 use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
+use Infection\Telemetry\ProjectRelativePathResolver;
 use Infection\Telemetry\Subscriber\OpenTelemetryTracerSubscriberFactory;
 use Infection\TestFramework\AdapterInstallationDecider;
 use Infection\TestFramework\AdapterInstaller;
@@ -332,6 +334,12 @@ final class Container extends DIContainer
                     $container->getMetricsCalculator(),
                 );
             },
+            MutationSpanAttributesProvider::class => static fn (self $container): MutationSpanAttributesProvider => new MutationSpanAttributesProvider(
+                $container->get(ProjectRelativePathResolver::class),
+            ),
+            ProjectRelativePathResolver::class => static fn (self $container): ProjectRelativePathResolver => new ProjectRelativePathResolver(
+                $container->getConfiguration(),
+            ),
             MutantFactory::class => static fn (self $container): MutantFactory => new MutantFactory(
                 $container->getConfiguration()->tmpDir,
                 $container->getDiffer(),

--- a/src/Telemetry/Attribute/MutationSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/MutationSpanAttributesProvider.php
@@ -33,41 +33,34 @@
 
 declare(strict_types=1);
 
-namespace Infection\Telemetry\Subscriber;
+namespace Infection\Telemetry\Attribute;
 
-use Infection\Event\Subscriber\EventSubscriber;
-use Infection\Event\Subscriber\NullSubscriber;
-use Infection\Event\Subscriber\SubscriberFactory;
-use Infection\Telemetry\Attribute\MutationSpanAttributesProvider;
-use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
-use Infection\Telemetry\OpenTelemetryTracerFactory;
+use Infection\Mutation\Mutation;
 use Infection\Telemetry\ProjectRelativePathResolver;
 
 /**
+ * @phpstan-import-type Attributes from RunSpanAttributesProvider
+ *
  * @internal
  */
-final readonly class OpenTelemetryTracerSubscriberFactory implements SubscriberFactory
+final readonly class MutationSpanAttributesProvider
 {
     public function __construct(
-        private OpenTelemetryTracerFactory $telemetryTracerFactory,
-        private RunSpanAttributesProvider $runSpanAttributesProvider,
-        private MutationSpanAttributesProvider $mutationSpanAttributesProvider,
         private ProjectRelativePathResolver $projectRelativePathResolver,
     ) {
     }
 
-    public function create(): EventSubscriber
+    /** @return Attributes */
+    public function provide(Mutation $mutation): array
     {
-        $tracer = $this->telemetryTracerFactory->create();
-
-        return $tracer === null
-            ? new NullSubscriber()
-            : new OpenTelemetryTracerSubscriber(
-                $tracer,
-                $this->runSpanAttributesProvider,
-                $this->mutationSpanAttributesProvider,
-                $this->projectRelativePathResolver,
-            )
-        ;
+        return [
+            'infection.mutation.id' => $mutation->getHash(),
+            'infection.mutator.name' => $mutation->getMutatorName(),
+            'code.file.path' => $this->projectRelativePathResolver->resolve(
+                $mutation->getOriginalFilePath(),
+            ),
+            'code.line.start' => $mutation->getOriginalStartingLine(),
+            'code.line.end' => $mutation->getOriginalEndingLine(),
+        ];
     }
 }

--- a/src/Telemetry/OpenTelemetryTracer.php
+++ b/src/Telemetry/OpenTelemetryTracer.php
@@ -69,7 +69,7 @@ final readonly class OpenTelemetryTracer
 
     /**
      * @param non-empty-string $name
-     * @param array<non-empty-string, bool|int|float|string> $attributes
+     * @param Attributes $attributes
      */
     public function startChildSpan(SpanHandle $parent, string $name, array $attributes = []): SpanHandle
     {

--- a/src/Telemetry/ProjectRelativePathResolver.php
+++ b/src/Telemetry/ProjectRelativePathResolver.php
@@ -33,41 +33,46 @@
 
 declare(strict_types=1);
 
-namespace Infection\Telemetry\Subscriber;
+namespace Infection\Telemetry;
 
-use Infection\Event\Subscriber\EventSubscriber;
-use Infection\Event\Subscriber\NullSubscriber;
-use Infection\Event\Subscriber\SubscriberFactory;
-use Infection\Telemetry\Attribute\MutationSpanAttributesProvider;
-use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
-use Infection\Telemetry\OpenTelemetryTracerFactory;
-use Infection\Telemetry\ProjectRelativePathResolver;
+use Infection\Configuration\Configuration;
+use Symfony\Component\Filesystem\Path;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal
  */
-final readonly class OpenTelemetryTracerSubscriberFactory implements SubscriberFactory
+final class ProjectRelativePathResolver
 {
+    /** @var array<string, non-empty-string> */
+    private array $cache = [];
+
     public function __construct(
-        private OpenTelemetryTracerFactory $telemetryTracerFactory,
-        private RunSpanAttributesProvider $runSpanAttributesProvider,
-        private MutationSpanAttributesProvider $mutationSpanAttributesProvider,
-        private ProjectRelativePathResolver $projectRelativePathResolver,
+        private readonly Configuration $configuration,
     ) {
     }
 
-    public function create(): EventSubscriber
+    /**
+     * @return non-empty-string
+     */
+    public function resolve(string $path): string
     {
-        $tracer = $this->telemetryTracerFactory->create();
+        if (isset($this->cache[$path])) {
+            return $this->cache[$path];
+        }
 
-        return $tracer === null
-            ? new NullSubscriber()
-            : new OpenTelemetryTracerSubscriber(
-                $tracer,
-                $this->runSpanAttributesProvider,
-                $this->mutationSpanAttributesProvider,
-                $this->projectRelativePathResolver,
-            )
-        ;
+        if (!Path::isAbsolute($path)) {
+            Assert::stringNotEmpty($path);
+
+            return $this->cache[$path] = $path;
+        }
+
+        $relativePath = Path::makeRelative(
+            Path::canonicalize($path),
+            Path::canonicalize($this->configuration->projectDirectory),
+        );
+        Assert::stringNotEmpty($relativePath);
+
+        return $this->cache[$path] = $relativePath;
     }
 }

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Telemetry\Subscriber;
 
 use function array_keys;
-use Infection\Configuration\Configuration;
 use Infection\Event\Events\Application\ApplicationExecutionWasFinished;
 use Infection\Event\Events\Application\ApplicationExecutionWasFinishedSubscriber;
 use Infection\Event\Events\Application\ApplicationExecutionWasStarted;
@@ -113,13 +112,13 @@ use Infection\Event\Events\SourceCollection\SourceCollectionWasFinished;
 use Infection\Event\Events\SourceCollection\SourceCollectionWasFinishedSubscriber;
 use Infection\Event\Events\SourceCollection\SourceCollectionWasStarted;
 use Infection\Event\Events\SourceCollection\SourceCollectionWasStartedSubscriber;
+use Infection\Telemetry\Attribute\MutationSpanAttributesProvider;
 use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
 use Infection\Telemetry\OpenTelemetryTracer;
+use Infection\Telemetry\ProjectRelativePathResolver;
 use Infection\Telemetry\SpanHandle;
 use function spl_object_id;
 use function str_starts_with;
-use Symfony\Component\Filesystem\Path;
-use Webmozart\Assert\Assert;
 
 /**
  * @phpstan-import-type Attributes from RunSpanAttributesProvider
@@ -181,9 +180,6 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     /** @var array<int, string> */
     private array $mutantProcessExecutionSpanMutationHashes = [];
 
-    /** @var array<non-empty-string, non-empty-string> */
-    private array $projectRelativePathCache = [];
-
     private int $sourceFileCount = 0;
 
     /**
@@ -200,8 +196,9 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function __construct(
         private readonly OpenTelemetryTracer $telemetry,
-        private readonly Configuration $configuration,
         private readonly RunSpanAttributesProvider $runSpanAttributesProvider,
+        private readonly MutationSpanAttributesProvider $mutationSpanAttributesProvider,
+        private readonly ProjectRelativePathResolver $projectRelativePathResolver,
     ) {
     }
 
@@ -298,7 +295,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
         $span = $this->startChild(
             'infection.ast_processing.file',
-            ['code.file.path' => $this->getProjectRelativePath($event->sourceFilePath)],
+            ['code.file.path' => $this->projectRelativePathResolver->resolve($event->sourceFilePath)],
             parent: $this->astProcessingSpan,
         );
 
@@ -320,7 +317,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     {
         $span = $this->startChild(
             'infection.ast_processing.file.parsing',
-            ['code.file.path' => $this->getProjectRelativePath($event->sourceFilePath)],
+            ['code.file.path' => $this->projectRelativePathResolver->resolve($event->sourceFilePath)],
             parent: $this->astProcessingFileSpans[$event->sourceFilePath] ?? null,
         );
 
@@ -342,7 +339,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     {
         $span = $this->startChild(
             'infection.ast_processing.file.enrichment',
-            ['code.file.path' => $this->getProjectRelativePath($event->sourceFilePath)],
+            ['code.file.path' => $this->projectRelativePathResolver->resolve($event->sourceFilePath)],
             parent: $this->astProcessingFileSpans[$event->sourceFilePath] ?? null,
         );
 
@@ -374,13 +371,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
         $span = $this->startChild(
             'infection.mutation_evaluation.mutation',
-            [
-                'infection.mutation.id' => $mutation->getHash(),
-                'infection.mutator.name' => $mutation->getMutatorName(),
-                'code.file.path' => $this->getProjectRelativePath($mutation->getOriginalFilePath()),
-                'code.line.start' => $mutation->getOriginalStartingLine(),
-                'code.line.end' => $mutation->getOriginalEndingLine(),
-            ],
+            $this->mutationSpanAttributesProvider->provide($mutation),
             $this->mutationEvaluationSpan,
         );
 
@@ -414,6 +405,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
         $span = $this->startChild(
             'infection.mutation_evaluation.mutation.heuristic_suppression',
+            $this->mutationSpanAttributesProvider->provide($event->mutation),
             parent: $this->mutationEvaluationSpans[$hash] ?? null,
         );
 
@@ -439,7 +431,10 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
         $span = $this->startChild(
             'infection.mutation_evaluation.mutation.heuristic',
-            ['infection.mutation_evaluation.heuristic.id' => $event->heuristic->value],
+            [
+                ...$this->mutationSpanAttributesProvider->provide($event->mutation),
+                'infection.mutation_evaluation.heuristic.id' => $event->heuristic->value,
+            ],
             $this->heuristicSuppressionSpans[$hash] ?? ($this->mutationEvaluationSpans[$hash] ?? null),
         );
 
@@ -459,10 +454,12 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onMutantAnalysisWasStarted(MutantAnalysisWasStarted $event): void
     {
-        $hash = $event->mutant->getMutation()->getHash();
+        $mutation = $event->mutant->getMutation();
+        $hash = $mutation->getHash();
 
         $span = $this->startChild(
             'infection.mutation_evaluation.mutant_analysis',
+            $this->mutationSpanAttributesProvider->provide($mutation),
             parent: $this->mutationEvaluationSpans[$hash] ?? null,
         );
 
@@ -484,10 +481,12 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onMutantMaterialisationWasStarted(MutantMaterialisationWasStarted $event): void
     {
-        $hash = $event->mutant->getMutation()->getHash();
+        $mutation = $event->mutant->getMutation();
+        $hash = $mutation->getHash();
 
         $span = $this->startChild(
             'infection.mutation_evaluation.mutant_analysis.materialisation',
+            $this->mutationSpanAttributesProvider->provide($mutation),
             parent: $this->mutantAnalysisSpans[$hash] ?? ($this->mutationEvaluationSpans[$hash] ?? null),
         );
 
@@ -507,12 +506,14 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onMutantEvaluationWasStarted(MutantEvaluationWasStarted $event): void
     {
-        $hash = $event->mutant->getMutation()->getHash();
+        $mutation = $event->mutant->getMutation();
+        $hash = $mutation->getHash();
 
         ++$this->evaluatedMutationCount;
 
         $span = $this->startChild(
             'infection.mutation_evaluation.mutant_analysis.evaluation',
+            $this->mutationSpanAttributesProvider->provide($mutation),
             parent: $this->mutantAnalysisSpans[$hash] ?? ($this->mutationEvaluationSpans[$hash] ?? null),
         );
 
@@ -533,11 +534,13 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     public function onMutantProcessExecutionWasStarted(MutantProcessExecutionWasStarted $event): void
     {
-        $hash = $event->mutantProcess->getMutant()->getMutation()->getHash();
+        $mutation = $event->mutantProcess->getMutant()->getMutation();
+        $hash = $mutation->getHash();
         $key = spl_object_id($event->mutantProcess);
 
         $span = $this->startChild(
             'infection.mutation_evaluation.mutant_analysis.evaluation.process',
+            $this->mutationSpanAttributesProvider->provide($mutation),
             parent: $this->mutantEvaluationSpans[$hash] ?? ($this->mutationEvaluationSpans[$hash] ?? null),
         );
 
@@ -638,7 +641,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
     /**
      * @param non-empty-string $name
-     * @param array<non-empty-string, bool|int|float|string> $attributes
+     * @param Attributes $attributes
      */
     private function startChild(string $name, array $attributes = [], ?SpanHandle $parent = null): ?SpanHandle
     {
@@ -657,30 +660,6 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         if ($span !== null) {
             $this->telemetry->end($span, $attributes);
         }
-    }
-
-    /**
-     * @return non-empty-string
-     */
-    private function getProjectRelativePath(string $path): string
-    {
-        if (isset($this->projectRelativePathCache[$path])) {
-            return $this->projectRelativePathCache[$path];
-        }
-
-        if (!Path::isAbsolute($path)) {
-            Assert::stringNotEmpty($path);
-
-            return $this->projectRelativePathCache[$path] = $path;
-        }
-
-        $relativePath = Path::makeRelative(
-            Path::canonicalize($path),
-            Path::canonicalize($this->configuration->projectDirectory),
-        );
-        Assert::stringNotEmpty($relativePath);
-
-        return $relativePath;
     }
 
     private function endAstSpans(): void

--- a/tests/phpunit/Framework/ClassNameTest.php
+++ b/tests/phpunit/Framework/ClassNameTest.php
@@ -126,7 +126,7 @@ final class ClassNameTest extends TestCase
         yield 'source located in tests' => [
             'Infection\Tests\Console\Application',
             [
-                'Infection\Tests\Console\ApplicationTest',
+                ApplicationTest::class,
                 'Infection\Tests\Console\Application\ApplicationTest',
             ],
         ];
@@ -135,7 +135,7 @@ final class ClassNameTest extends TestCase
         // is it clear that it is a case want to support.
         // Nonetheless, we have this test case to pin this scenario.
         yield 'already a test' => [
-            'Infection\Tests\Console\ApplicationTest',
+            ApplicationTest::class,
             [
                 'Infection\Tests\Console\ApplicationTestTest',
                 'Infection\Tests\Console\ApplicationTest\ApplicationTestTest',
@@ -210,7 +210,7 @@ final class ClassNameTest extends TestCase
     public static function notTestClassNamesProvider(): iterable
     {
         yield 'non-ambiguous case' => [
-            'Infection\Tests\Console\ApplicationTest',
+            ApplicationTest::class,
             [Application::class],
         ];
 

--- a/tests/phpunit/Framework/ClassNameTest.php
+++ b/tests/phpunit/Framework/ClassNameTest.php
@@ -126,7 +126,7 @@ final class ClassNameTest extends TestCase
         yield 'source located in tests' => [
             'Infection\Tests\Console\Application',
             [
-                ApplicationTest::class,
+                'Infection\Tests\Console\ApplicationTest',
                 'Infection\Tests\Console\Application\ApplicationTest',
             ],
         ];
@@ -135,7 +135,7 @@ final class ClassNameTest extends TestCase
         // is it clear that it is a case want to support.
         // Nonetheless, we have this test case to pin this scenario.
         yield 'already a test' => [
-            ApplicationTest::class,
+            'Infection\Tests\Console\ApplicationTest',
             [
                 'Infection\Tests\Console\ApplicationTestTest',
                 'Infection\Tests\Console\ApplicationTest\ApplicationTestTest',
@@ -210,7 +210,7 @@ final class ClassNameTest extends TestCase
     public static function notTestClassNamesProvider(): iterable
     {
         yield 'non-ambiguous case' => [
-            ApplicationTest::class,
+            'Infection\Tests\Console\ApplicationTest',
             [Application::class],
         ];
 

--- a/tests/phpunit/Telemetry/Attribute/MutationSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/MutationSpanAttributesProviderTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Telemetry\Attribute;
+
+use Infection\Telemetry\Attribute\MutationSpanAttributesProvider;
+use Infection\Telemetry\ProjectRelativePathResolver;
+use Infection\Tests\Configuration\ConfigurationBuilder;
+use Infection\Tests\Mutation\MutationBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MutationSpanAttributesProvider::class)]
+#[CoversClass(ProjectRelativePathResolver::class)]
+final class MutationSpanAttributesProviderTest extends TestCase
+{
+    public function test_it_provides_mutation_identity_and_location_attributes(): void
+    {
+        $configuration = ConfigurationBuilder::withMinimalTestData()
+            ->withProjectDirectory('/path/to/project')
+            ->build();
+        $provider = new MutationSpanAttributesProvider(new ProjectRelativePathResolver($configuration));
+        $mutation = MutationBuilder::withMinimalTestData()
+            ->withHash('mutation-A')
+            ->withOriginalFilePath('/path/to/project/src/Foo.php')
+            ->withMutatorName('For_')
+            ->build();
+
+        $this->assertSame(
+            [
+                'infection.mutation.id' => 'mutation-A',
+                'infection.mutator.name' => 'For_',
+                'code.file.path' => 'src/Foo.php',
+                'code.line.start' => 10,
+                'code.line.end' => 15,
+            ],
+            $provider->provide($mutation),
+        );
+    }
+
+    public function test_it_keeps_relative_file_paths_unchanged(): void
+    {
+        $configuration = ConfigurationBuilder::withMinimalTestData()
+            ->withProjectDirectory('/path/to/project')
+            ->build();
+        $provider = new MutationSpanAttributesProvider(new ProjectRelativePathResolver($configuration));
+        $mutation = MutationBuilder::withMinimalTestData()
+            ->withHash('mutation-A')
+            ->withOriginalFilePath('src/Foo.php')
+            ->build();
+
+        $this->assertSame('src/Foo.php', $provider->provide($mutation)['code.file.path']);
+    }
+}

--- a/tests/phpunit/Telemetry/Attribute/MutationSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/MutationSpanAttributesProviderTest.php
@@ -51,7 +51,9 @@ final class MutationSpanAttributesProviderTest extends TestCase
         $configuration = ConfigurationBuilder::withMinimalTestData()
             ->withProjectDirectory('/path/to/project')
             ->build();
-        $provider = new MutationSpanAttributesProvider(new ProjectRelativePathResolver($configuration));
+        $provider = new MutationSpanAttributesProvider(
+            new ProjectRelativePathResolver($configuration),
+        );
         $mutation = MutationBuilder::withMinimalTestData()
             ->withHash('mutation-A')
             ->withOriginalFilePath('/path/to/project/src/Foo.php')
@@ -76,11 +78,15 @@ final class MutationSpanAttributesProviderTest extends TestCase
             ->withProjectDirectory('/path/to/project')
             ->build();
         $provider = new MutationSpanAttributesProvider(new ProjectRelativePathResolver($configuration));
+
+        $sourceFileRelativePath = 'src/Foo.php';
         $mutation = MutationBuilder::withMinimalTestData()
             ->withHash('mutation-A')
-            ->withOriginalFilePath('src/Foo.php')
+            ->withOriginalFilePath($sourceFileRelativePath)
             ->build();
 
-        $this->assertSame('src/Foo.php', $provider->provide($mutation)['code.file.path']);
+        $actual = $provider->provide($mutation)['code.file.path'];
+
+        $this->assertSame($sourceFileRelativePath, $actual);
     }
 }

--- a/tests/phpunit/Telemetry/ProjectRelativePathResolverTest.php
+++ b/tests/phpunit/Telemetry/ProjectRelativePathResolverTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Telemetry;
+
+use Infection\Telemetry\ProjectRelativePathResolver;
+use Infection\Tests\Configuration\ConfigurationBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ProjectRelativePathResolver::class)]
+final class ProjectRelativePathResolverTest extends TestCase
+{
+    public function test_it_keeps_relative_paths_unchanged(): void
+    {
+        $resolver = new ProjectRelativePathResolver(
+            ConfigurationBuilder::withMinimalTestData()
+                ->withProjectDirectory('/path/to/project')
+                ->build(),
+        );
+
+        $this->assertSame(
+            'src/File.php',
+            $resolver->resolve('src/File.php'),
+        );
+    }
+
+    public function test_it_makes_absolute_paths_project_relative(): void
+    {
+        $resolver = new ProjectRelativePathResolver(
+            ConfigurationBuilder::withMinimalTestData()
+                ->withProjectDirectory('/path/to/project')
+                ->build(),
+        );
+
+        $this->assertSame(
+            'src/File.php',
+            $resolver->resolve('/path/to/project/src/File.php'),
+        );
+    }
+
+    public function test_it_canonicalizes_absolute_paths_before_resolving_them(): void
+    {
+        $resolver = new ProjectRelativePathResolver(
+            ConfigurationBuilder::withMinimalTestData()
+                ->withProjectDirectory('/path/to/project/../project')
+                ->build(),
+        );
+
+        $this->assertSame(
+            'src/File.php',
+            $resolver->resolve('/path/to/project/./src/../src/File.php'),
+        );
+    }
+
+    public function test_it_keeps_paths_outside_the_project_relative_to_the_project_directory(): void
+    {
+        $resolver = new ProjectRelativePathResolver(
+            ConfigurationBuilder::withMinimalTestData()
+                ->withProjectDirectory('/path/to/project')
+                ->build(),
+        );
+
+        $this->assertSame(
+            '../vendor/package/File.php',
+            $resolver->resolve('/path/to/vendor/package/File.php'),
+        );
+    }
+
+    public function test_it_caches_resolved_paths(): void
+    {
+        $resolver = new ProjectRelativePathResolver(
+            ConfigurationBuilder::withMinimalTestData()
+                ->withProjectDirectory('/path/to/project')
+                ->build(),
+        );
+
+        $this->assertSame(
+            'src/File.php',
+            $resolver->resolve('/path/to/project/src/../src/File.php'),
+        );
+        $this->assertSame(
+            'src/File.php',
+            $resolver->resolve('/path/to/project/src/../src/File.php'),
+        );
+    }
+}

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -83,8 +83,10 @@ use Infection\Mutant\DetectionStatus;
 use Infection\Process\MutantProcess;
 use Infection\Process\Runner\HeuristicName;
 use Infection\Process\Runner\ProcessRunner;
+use Infection\Telemetry\Attribute\MutationSpanAttributesProvider;
 use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
 use Infection\Telemetry\OpenTelemetryTracer;
+use Infection\Telemetry\ProjectRelativePathResolver;
 use Infection\Telemetry\Subscriber\OpenTelemetryTracerSubscriber;
 use Infection\Tests\Configuration\ConfigurationBuilder;
 use Infection\Tests\Mutant\MutantBuilder;
@@ -134,13 +136,13 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $testFrameworkAdapter
             ->method('getVersion')
             ->willReturn('12.3.4');
+        $projectRelativePathResolver = new ProjectRelativePathResolver($configuration);
 
         $this->subscriber = new OpenTelemetryTracerSubscriber(
             new OpenTelemetryTracer(
                 $this->tracerProvider->getTracer('infection'),
                 $this->tracerProvider,
             ),
-            $configuration,
             new RunSpanAttributesProvider(
                 $configuration,
                 new InfectionVersion(),
@@ -148,6 +150,8 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 null,
                 $this->metricsCalculator,
             ),
+            new MutationSpanAttributesProvider($projectRelativePathResolver),
+            $projectRelativePathResolver,
         );
     }
 
@@ -344,6 +348,15 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->assertSame('src/Foo.php', $mutationEvaluationForMutation->getAttributes()->get('code.file.path'));
         $this->assertSame(10, $mutationEvaluationForMutation->getAttributes()->get('code.line.start'));
         $this->assertSame(15, $mutationEvaluationForMutation->getAttributes()->get('code.line.end'));
+
+        foreach ([$heuristicSuppression, $heuristic, $mutantAnalysis, $mutantMaterialisation, $mutantEvaluation, $process] as $mutationChildSpan) {
+            $this->assertSame('mutation-A', $mutationChildSpan->getAttributes()->get('infection.mutation.id'));
+            $this->assertSame('For_', $mutationChildSpan->getAttributes()->get('infection.mutator.name'));
+            $this->assertSame('src/Foo.php', $mutationChildSpan->getAttributes()->get('code.file.path'));
+            $this->assertSame(10, $mutationChildSpan->getAttributes()->get('code.line.start'));
+            $this->assertSame(15, $mutationChildSpan->getAttributes()->get('code.line.end'));
+        }
+
         $this->assertSame(HeuristicName::IGNORED_BY_REGEX->value, $heuristic->getAttributes()->get('infection.mutation_evaluation.heuristic.id'));
         $this->assertSame(DetectionStatus::KILLED_BY_TESTS->value, $mutationEvaluationForMutation->getAttributes()->get('infection.mutation.status'));
         $this->assertSame(0.123, $mutationEvaluationForMutation->getAttributes()->get('infection.mutation.runtime'));


### PR DESCRIPTION
## Description

Propagates mutation identity, mutator name, and source-location attributes to mutation child spans so telemetry backends can query those spans directly.

This matters for dashboards such as "process time by mutator": backends like Sentry generally aggregate the selected span's own attributes, so process spans need the mutator and source metadata without relying on parent-span joins.

## Changes

- Adds `MutationSpanAttributesProvider` for mutation identity and source-location attributes.
- Adds `ProjectRelativePathResolver` so telemetry span emitters share project-relative path resolution and caching.
- Propagates mutation ID, mutator name, source file path, and source line range to mutation child spans.

## Related issues

- #3090
