### PR TITLE
feat(telemetry): Expose MSI category on mutation telemetry spans

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -126,6 +126,11 @@ Mutation-level spans and their child spans include `infection.mutation.id`,
 `infection.mutator.name`, `code.file.path`, `code.line.start`, and
 `code.line.end`. This makes mutation child spans queryable on their own in
 backends that do not support grouping or filtering by parent span attributes.
+Finished `infection.mutation_evaluation.mutation` spans also include
+`infection.mutation.msi.category`, which classifies the mutation's contribution
+to MSI as `covered`, `not_covered`, or `ineligible`. Timeouts are classified as
+`covered` unless `infection.timeouts_as_escaped` is enabled, in which case they
+are classified as `not_covered`.
 
 Reporter-level spans include `infection.reporter.id`, the run-local reporter
 object id, and `infection.reporter.name`, the stable reporter name configured by

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -336,9 +336,14 @@ final class Container extends DIContainer
                     $container->getMetricsCalculator(),
                 );
             },
-            MutationSpanAttributesProvider::class => static fn (self $container): MutationSpanAttributesProvider => new MutationSpanAttributesProvider(
-                $container->get(ProjectRelativePathResolver::class),
-            ),
+            MutationSpanAttributesProvider::class => static function (self $container): MutationSpanAttributesProvider {
+                $config = $container->getConfiguration();
+
+                return new MutationSpanAttributesProvider(
+                    $container->get(ProjectRelativePathResolver::class),
+                    $config->timeoutsAsEscaped,
+                );
+            },
             ProjectRelativePathResolver::class => static fn (self $container): ProjectRelativePathResolver => new ProjectRelativePathResolver(
                 $container->getConfiguration(),
             ),

--- a/src/Telemetry/Attribute/MutationSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/MutationSpanAttributesProvider.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Telemetry\Attribute;
 
+use Infection\Mutant\DetectionStatus;
 use Infection\Mutation\Mutation;
 use Infection\Telemetry\ProjectRelativePathResolver;
 
@@ -47,6 +48,7 @@ final readonly class MutationSpanAttributesProvider
 {
     public function __construct(
         private ProjectRelativePathResolver $projectRelativePathResolver,
+        private bool $timeoutsAsEscaped,
     ) {
     }
 
@@ -62,5 +64,31 @@ final readonly class MutationSpanAttributesProvider
             'code.line.start' => $mutation->getOriginalStartingLine(),
             'code.line.end' => $mutation->getOriginalEndingLine(),
         ];
+    }
+
+    /** @return Attributes */
+    public function provideResultAttributes(DetectionStatus $detectionStatus): array
+    {
+        return [
+            'infection.mutation.msi.category' => $this->getMsiCategory($detectionStatus),
+        ];
+    }
+
+    // TODO: to rework this in regards to MetricsCalculator...
+    private function getMsiCategory(DetectionStatus $detectionStatus): string
+    {
+        return match ($detectionStatus) {
+            DetectionStatus::KILLED_BY_TESTS,
+            DetectionStatus::KILLED_BY_STATIC_ANALYSIS,
+            DetectionStatus::ERROR,
+            DetectionStatus::SYNTAX_ERROR => 'covered',
+            DetectionStatus::TIMED_OUT => $this->timeoutsAsEscaped
+                ? 'not_covered'
+                : 'covered',
+            DetectionStatus::ESCAPED,
+            DetectionStatus::NOT_COVERED => 'not_covered',
+            DetectionStatus::SKIPPED,
+            DetectionStatus::IGNORED => 'ineligible',
+        };
     }
 }

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -402,6 +402,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
             [
                 'infection.mutation.status' => $result->getDetectionStatus()->value,
                 'infection.mutation.runtime' => $result->getProcessRuntime(),
+                ...$this->mutationSpanAttributesProvider->provideResultAttributes($result->getDetectionStatus()),
             ],
         );
     }

--- a/tests/phpunit/Telemetry/Attribute/MutationSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/MutationSpanAttributesProviderTest.php
@@ -35,11 +35,13 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Telemetry\Attribute;
 
+use Infection\Mutant\DetectionStatus;
 use Infection\Telemetry\Attribute\MutationSpanAttributesProvider;
 use Infection\Telemetry\ProjectRelativePathResolver;
 use Infection\Tests\Configuration\ConfigurationBuilder;
 use Infection\Tests\Mutation\MutationBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(MutationSpanAttributesProvider::class)]
@@ -53,6 +55,7 @@ final class MutationSpanAttributesProviderTest extends TestCase
             ->build();
         $provider = new MutationSpanAttributesProvider(
             new ProjectRelativePathResolver($configuration),
+            $configuration->timeoutsAsEscaped,
         );
         $mutation = MutationBuilder::withMinimalTestData()
             ->withHash('mutation-A')
@@ -77,7 +80,10 @@ final class MutationSpanAttributesProviderTest extends TestCase
         $configuration = ConfigurationBuilder::withMinimalTestData()
             ->withProjectDirectory('/path/to/project')
             ->build();
-        $provider = new MutationSpanAttributesProvider(new ProjectRelativePathResolver($configuration));
+        $provider = new MutationSpanAttributesProvider(
+            new ProjectRelativePathResolver($configuration),
+            $configuration->timeoutsAsEscaped,
+        );
 
         $sourceFileRelativePath = 'src/Foo.php';
         $mutation = MutationBuilder::withMinimalTestData()
@@ -88,5 +94,51 @@ final class MutationSpanAttributesProviderTest extends TestCase
         $actual = $provider->provide($mutation)['code.file.path'];
 
         $this->assertSame($sourceFileRelativePath, $actual);
+    }
+
+    #[DataProvider('msiCategoryProvider')]
+    public function test_it_provides_the_msi_category(
+        DetectionStatus $detectionStatus,
+        bool $timeoutsAsEscaped,
+        string $expectedCategory,
+    ): void {
+        $configuration = ConfigurationBuilder::withMinimalTestData()
+            ->withTimeoutsAsEscaped($timeoutsAsEscaped)
+            ->build();
+        $provider = new MutationSpanAttributesProvider(
+            new ProjectRelativePathResolver($configuration),
+            $configuration->timeoutsAsEscaped,
+        );
+
+        $this->assertSame(
+            ['infection.mutation.msi.category' => $expectedCategory],
+            $provider->provideResultAttributes($detectionStatus),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{DetectionStatus, bool, string}>
+     */
+    public static function msiCategoryProvider(): iterable
+    {
+        yield 'killed by tests' => [DetectionStatus::KILLED_BY_TESTS, false, 'covered'];
+
+        yield 'killed by static analysis' => [DetectionStatus::KILLED_BY_STATIC_ANALYSIS, false, 'covered'];
+
+        yield 'error' => [DetectionStatus::ERROR, false, 'covered'];
+
+        yield 'syntax error' => [DetectionStatus::SYNTAX_ERROR, false, 'covered'];
+
+        yield 'timed out counted as covered' => [DetectionStatus::TIMED_OUT, false, 'covered'];
+
+        yield 'timed out counted as not covered' => [DetectionStatus::TIMED_OUT, true, 'not_covered'];
+
+        yield 'escaped' => [DetectionStatus::ESCAPED, false, 'not_covered'];
+
+        yield 'not covered' => [DetectionStatus::NOT_COVERED, false, 'not_covered'];
+
+        yield 'skipped' => [DetectionStatus::SKIPPED, false, 'ineligible'];
+
+        yield 'ignored' => [DetectionStatus::IGNORED, false, 'ineligible'];
     }
 }

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -155,7 +155,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 null,
                 $this->metricsCalculator,
             ),
-            new MutationSpanAttributesProvider($projectRelativePathResolver),
+            new MutationSpanAttributesProvider($projectRelativePathResolver, $configuration->timeoutsAsEscaped),
             $projectRelativePathResolver,
         );
     }
@@ -375,6 +375,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
 
         $this->assertSame(HeuristicName::IGNORED_BY_REGEX->value, $heuristic->getAttributes()->get('infection.mutation_evaluation.heuristic.id'));
         $this->assertSame(DetectionStatus::KILLED_BY_TESTS->value, $mutationEvaluationForMutation->getAttributes()->get('infection.mutation.status'));
+        $this->assertSame('covered', $mutationEvaluationForMutation->getAttributes()->get('infection.mutation.msi.category'));
         $this->assertSame(0.123, $mutationEvaluationForMutation->getAttributes()->get('infection.mutation.runtime'));
 
         $this->assertAllSpansAreFinished();


### PR DESCRIPTION
## Description

Adds an explicit telemetry attribute for each completed mutation evaluation so users can query whether a mutation counted as `covered`, `not_covered`, or `ineligible` for MSI.

This removes the need to infer MSI contribution from the raw detection status and the `timeoutsAsEscaped` configuration.

## Changes

- Adds `infection.mutation.msi.category` to finished `infection.mutation_evaluation.mutation` spans.
- Derives the category from the mutation detection status and the configured timeout handling.
- Wires `timeoutsAsEscaped` into the mutation span attribute provider from the canonical configuration.

## Related issues

- #3090