### PR TITLE
feat(telemetry): Enrich mutant process telemetry spans

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -134,6 +134,13 @@ are classified as `not_covered`.
 Finished `infection.mutation_evaluation.mutant_analysis.evaluation` spans
 include `infection.mutation.queue_wait.duration`, the accumulated queue wait
 duration for the mutant evaluation in seconds.
+Finished `infection.mutation_evaluation.mutant_analysis.evaluation.process`
+spans include `process.exit.code` when the process exposes an exit code, and
+`infection.mutation.process.timed_out`, indicating whether Infection marked the
+process as timed out. They also include
+`infection.mutation.process.test_framework`, the configured test framework
+name, and `infection.mutation.process.thread`, the worker thread assigned to
+the process.
 
 Reporter-level spans include `infection.reporter.id`, the run-local reporter
 object id, and `infection.reporter.name`, the stable reporter name configured by

--- a/src/Event/Events/MutationAnalysis/MutationEvaluation/MutantAnalysis/MutantEvaluation/MutantProcessExecutionWasStarted.php
+++ b/src/Event/Events/MutationAnalysis/MutationEvaluation/MutantAnalysis/MutantEvaluation/MutantProcessExecutionWasStarted.php
@@ -44,6 +44,7 @@ final readonly class MutantProcessExecutionWasStarted
 {
     public function __construct(
         public MutantProcess $mutantProcess,
+        public int $thread,
     ) {
     }
 }

--- a/src/Process/Runner/ParallelProcessRunner.php
+++ b/src/Process/Runner/ParallelProcessRunner.php
@@ -219,7 +219,12 @@ class ParallelProcessRunner implements ProcessRunner
     {
         $mutantProcess = $mutantProcessContainer->getCurrent();
 
-        $this->eventDispatcher->dispatch(new MutantProcessExecutionWasStarted($mutantProcess));
+        $this->eventDispatcher->dispatch(
+            new MutantProcessExecutionWasStarted(
+                $mutantProcess,
+                $threadIndex,
+            ),
+        );
 
         $mutantProcess->getProcess()->start(null, [
             'INFECTION' => '1',

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -215,6 +215,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         private readonly RunSpanAttributesProvider $runSpanAttributesProvider,
         private readonly MutationSpanAttributesProvider $mutationSpanAttributesProvider,
         private readonly ProjectRelativePathResolver $projectRelativePathResolver,
+        private readonly string $testFramework,
     ) {
     }
 
@@ -563,7 +564,11 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
 
         $span = $this->startChild(
             'infection.mutation_evaluation.mutant_analysis.evaluation.process',
-            $this->mutationSpanAttributesProvider->provide($mutation),
+            [
+                ...$this->mutationSpanAttributesProvider->provide($mutation),
+                'infection.mutation.process.test_framework' => $this->testFramework,
+                'infection.mutation.process.thread' => $event->thread,
+            ],
             parent: $this->mutantEvaluationSpans[$hash] ?? ($this->mutationEvaluationSpans[$hash] ?? null),
         );
 
@@ -579,7 +584,10 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $key = spl_object_id($event->mutantProcess);
         $hash = $event->mutantProcess->getMutant()->getMutation()->getHash();
 
-        $finishedAtNanos = $this->endAndGetEndEpochNanos($this->mutantProcessExecutionSpans[$key] ?? null);
+        $finishedAtNanos = $this->endAndGetEndEpochNanos(
+            $this->mutantProcessExecutionSpans[$key] ?? null,
+            self::processFinishAttributes($event),
+        );
 
         unset($this->mutantProcessExecutionSpans[$key]);
         unset($this->mutantProcessExecutionSpanMutationHashes[$key]);
@@ -721,13 +729,16 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         }
     }
 
-    private function endAndGetEndEpochNanos(?SpanHandle $span): ?int
+    /**
+     * @param Attributes $attributes
+     */
+    private function endAndGetEndEpochNanos(?SpanHandle $span, array $attributes = []): ?int
     {
         if ($span === null) {
             return null;
         }
 
-        $this->telemetry->end($span);
+        $this->telemetry->end($span, $attributes);
 
         return $span->span instanceof ReadableSpanInterface
             ? $span->span->toSpanData()->getEndEpochNanos()
@@ -857,5 +868,23 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
     private static function heuristicKey(string $mutationHash, string $heuristic): string
     {
         return $mutationHash . ':' . $heuristic;
+    }
+
+    /**
+     * @return Attributes
+     */
+    private static function processFinishAttributes(MutantProcessExecutionWasFinished $event): array
+    {
+        $attributes = [
+            'infection.mutation.process.timed_out' => $event->mutantProcess->isTimedOut(),
+        ];
+
+        $exitCode = $event->mutantProcess->getProcess()->getExitCode();
+
+        if ($exitCode !== null) {
+            $attributes['process.exit.code'] = $exitCode;
+        }
+
+        return $attributes;
     }
 }

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriberFactory.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriberFactory.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Telemetry\Subscriber;
 
+use Infection\Configuration\Configuration;
 use Infection\Event\Subscriber\EventSubscriber;
 use Infection\Event\Subscriber\NullSubscriber;
 use Infection\Event\Subscriber\SubscriberFactory;
@@ -53,6 +54,7 @@ final readonly class OpenTelemetryTracerSubscriberFactory implements SubscriberF
         private RunSpanAttributesProvider $runSpanAttributesProvider,
         private MutationSpanAttributesProvider $mutationSpanAttributesProvider,
         private ProjectRelativePathResolver $projectRelativePathResolver,
+        private Configuration $configuration,
     ) {
     }
 
@@ -67,6 +69,7 @@ final readonly class OpenTelemetryTracerSubscriberFactory implements SubscriberF
                 $this->runSpanAttributesProvider,
                 $this->mutationSpanAttributesProvider,
                 $this->projectRelativePathResolver,
+                $this->configuration->testFramework,
             )
         ;
     }

--- a/tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php
+++ b/tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php
@@ -165,9 +165,9 @@ final class ParallelProcessRunnerTest extends TestCase
         $currentMutantProcess = $container->getCurrent();
 
         $expectedEvents = [
-            new MutantProcessExecutionWasStarted($firstProcess),
+            new MutantProcessExecutionWasStarted($firstProcess, 1),
             new MutantProcessExecutionWasFinished($firstProcess),
-            new MutantProcessExecutionWasStarted($currentMutantProcess),
+            new MutantProcessExecutionWasStarted($currentMutantProcess, 1),
             new MutantProcessExecutionWasFinished($currentMutantProcess),
         ];
 

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -82,6 +82,7 @@ use Infection\Framework\InfectionVersion;
 use Infection\Framework\Iterable\IterableCounter;
 use Infection\Metrics\MetricsCalculator;
 use Infection\Mutant\DetectionStatus;
+use Infection\Mutant\Mutant;
 use Infection\Process\MutantProcess;
 use Infection\Process\Runner\HeuristicName;
 use Infection\Process\Runner\ProcessRunner;
@@ -108,6 +109,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use function spl_object_id;
 use function sprintf;
+use Symfony\Component\Process\Process;
 
 #[Group('integration')]
 #[CoversClass(OpenTelemetryTracerSubscriber::class)]
@@ -159,6 +161,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
             ),
             new MutationSpanAttributesProvider($projectRelativePathResolver, $configuration->timeoutsAsEscaped),
             $projectRelativePathResolver,
+            $configuration->testFramework,
         );
     }
 
@@ -179,10 +182,8 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
             ->withMutation($mutation)
             ->build();
 
-        $process0 = $this->createMock(MutantProcess::class);
-        $process0->method('getMutant')->willReturn($mutant);
-        $process1 = $this->createMock(MutantProcess::class);
-        $process1->method('getMutant')->willReturn($mutant);
+        $process0 = $this->createMutantProcess($mutant, 0);
+        $process1 = $this->createMutantProcess($mutant, 1, true);
 
         $this->subscriber->onApplicationExecutionWasStarted(new ApplicationExecutionWasStarted());
         $this->subscriber->onArtefactCollectionWasStarted(new ArtefactCollectionWasStarted());
@@ -214,9 +215,9 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->subscriber->onMutantMaterialisationWasStarted(new MutantMaterialisationWasStarted($mutant));
         $this->subscriber->onMutantMaterialisationWasFinished(new MutantMaterialisationWasFinished($mutant));
         $this->subscriber->onMutantEvaluationWasStarted(new MutantEvaluationWasStarted($mutant));
-        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($process0));
+        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($process0, 1));
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($process0));
-        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($process1));
+        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($process1, 2));
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($process1));
         $this->subscriber->onMutantEvaluationWasFinished(new MutantEvaluationWasFinished($mutant));
         $this->subscriber->onMutantAnalysisWasFinished(new MutantAnalysisWasFinished($mutant));
@@ -289,6 +290,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $mutantMaterialisation = $this->getSpanFromExporter('infection.mutation_evaluation.mutant_analysis.materialisation');
         $mutantEvaluation = $this->getSpanFromExporter('infection.mutation_evaluation.mutant_analysis.evaluation');
         $process = $this->getSpanFromExporter('infection.mutation_evaluation.mutant_analysis.evaluation.process');
+        $secondProcess = $this->getMutantProcessExecutionSpanForThread(2);
         $reporter = $this->getSpanFromExporter('infection.reporting.reporter');
         $reporting = $this->getSpanFromExporter('infection.reporting');
 
@@ -377,6 +379,14 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         }
 
         $this->assertSame(HeuristicName::IGNORED_BY_REGEX->value, $heuristic->getAttributes()->get('infection.mutation_evaluation.heuristic.id'));
+        $this->assertSame(0, $process->getAttributes()->get('process.exit.code'));
+        $this->assertFalse($process->getAttributes()->get('infection.mutation.process.timed_out'));
+        $this->assertSame('phpunit', $process->getAttributes()->get('infection.mutation.process.test_framework'));
+        $this->assertSame(1, $process->getAttributes()->get('infection.mutation.process.thread'));
+        $this->assertSame(1, $secondProcess->getAttributes()->get('process.exit.code'));
+        $this->assertTrue($secondProcess->getAttributes()->get('infection.mutation.process.timed_out'));
+        $this->assertSame('phpunit', $secondProcess->getAttributes()->get('infection.mutation.process.test_framework'));
+        $this->assertSame(2, $secondProcess->getAttributes()->get('infection.mutation.process.thread'));
         $this->assertIsFloat($mutantEvaluation->getAttributes()->get('infection.mutation.queue_wait.duration'));
         $this->assertGreaterThanOrEqual(0.0, $mutantEvaluation->getAttributes()->get('infection.mutation.queue_wait.duration'));
         $this->assertSame(DetectionStatus::KILLED_BY_TESTS->value, $mutationEvaluationForMutation->getAttributes()->get('infection.mutation.status'));
@@ -485,14 +495,10 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $mutantB = MutantBuilder::withMinimalTestData()
             ->withMutation($mutationB)
             ->build();
-        $mutationAProcess0 = $this->createMock(MutantProcess::class);
-        $mutationAProcess0->method('getMutant')->willReturn($mutantA);
-        $mutationAProcess1 = $this->createMock(MutantProcess::class);
-        $mutationAProcess1->method('getMutant')->willReturn($mutantA);
-        $mutationBProcess0 = $this->createMock(MutantProcess::class);
-        $mutationBProcess0->method('getMutant')->willReturn($mutantB);
-        $mutationBProcess1 = $this->createMock(MutantProcess::class);
-        $mutationBProcess1->method('getMutant')->willReturn($mutantB);
+        $mutationAProcess0 = $this->createMutantProcess($mutantA, 0);
+        $mutationAProcess1 = $this->createMutantProcess($mutantA, 0);
+        $mutationBProcess0 = $this->createMutantProcess($mutantB, 0);
+        $mutationBProcess1 = $this->createMutantProcess($mutantB, 0);
 
         $this->subscriber->onApplicationExecutionWasStarted(new ApplicationExecutionWasStarted());
         $this->subscriber->onMutationAnalysisWasStarted(new MutationAnalysisWasStarted());
@@ -501,11 +507,11 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $clock->setTime(2_000_000_000);
         $this->subscriber->onMutantEvaluationWasStarted(new MutantEvaluationWasStarted($mutantA));
         $clock->setTime(2_000_000_010);
-        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationAProcess0));
+        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationAProcess0, 1));
         $clock->setTime(2_000_000_030);
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($mutationAProcess0));
         $clock->setTime(2_000_000_070);
-        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationAProcess1));
+        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationAProcess1, 1));
         $clock->setTime(2_000_000_090);
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($mutationAProcess1));
         $clock->setTime(2_000_000_110);
@@ -514,11 +520,11 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $clock->setTime(3_000_000_000);
         $this->subscriber->onMutantEvaluationWasStarted(new MutantEvaluationWasStarted($mutantB));
         $clock->setTime(3_000_000_025);
-        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationBProcess0));
+        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationBProcess0, 2));
         $clock->setTime(3_000_000_055);
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($mutationBProcess0));
         $clock->setTime(3_000_000_115);
-        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationBProcess1));
+        $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationBProcess1, 2));
         $clock->setTime(3_000_000_145);
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($mutationBProcess1));
         $clock->setTime(3_000_000_200);
@@ -549,6 +555,47 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 $name,
             ),
         );
+    }
+
+    private function getMutantProcessExecutionSpanForThread(int $thread): SpanDataInterface
+    {
+        /** @var SpanDataInterface $span */
+        foreach ($this->exporter->getSpans() as $span) {
+            if (
+                $span->getName() === 'infection.mutation_evaluation.mutant_analysis.evaluation.process'
+                && $span->getAttributes()->get('infection.mutation.process.thread') === $thread
+            ) {
+                return $span;
+            }
+        }
+
+        $this->fail(
+            sprintf(
+                'Mutant process execution span for thread "%d" was not exported.',
+                $thread,
+            ),
+        );
+    }
+
+    private function createMutantProcess(Mutant $mutant, ?int $exitCode, bool $timedOut = false): MutantProcess
+    {
+        $process = $this->createMock(Process::class);
+        $process
+            ->method('getExitCode')
+            ->willReturn($exitCode);
+
+        $mutantProcess = $this->createMock(MutantProcess::class);
+        $mutantProcess
+            ->method('getMutant')
+            ->willReturn($mutant);
+        $mutantProcess
+            ->method('getProcess')
+            ->willReturn($process);
+        $mutantProcess
+            ->method('isTimedOut')
+            ->willReturn($timedOut);
+
+        return $mutantProcess;
     }
 
     private function getMutantEvaluationSpanForMutation(string $mutationHash): SpanDataInterface


### PR DESCRIPTION
## Description

Adds process-level telemetry attributes to mutant process execution spans so trace backends can explain how each process attempt behaved without capturing command lines or process output.

## Changes

Adds the following attributes to `infection.mutation_evaluation.mutant_analysis.evaluation.process` :

- `process.exit.code`
- `infection.mutation.process.timed_out`
- `infection.mutation.process.test_framework`
- `infection.mutation.process.thread`

## Related issues

- #3090