### PR TITLE
refactor(telemetry): Inject the OpenTelemetry clock

### DIFF
--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -223,6 +223,21 @@ parameters:
             identifier: offsetAccess.notFound
             count: 6
             path: ../src/TestFramework/PhpUnit/CommandLine/TestFrameworkExtraArgs.php
+
+        # Legitimate report. We have a fairly simple usage of this class so if it proves
+        # problematic we can always create our own clock instead at any time.
+        -
+            message: '#TestClock#'
+            identifier: property.internalClass
+            path: ../tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+        -
+            message: '#TestClock#'
+            identifier: method.internalClass
+            path: ../tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+        -
+            message: '#TestClock#'
+            identifier: new.internalClass
+            path: ../tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
     level: 8
     paths:
         - ../src

--- a/src/Telemetry/OpenTelemetryTracer.php
+++ b/src/Telemetry/OpenTelemetryTracer.php
@@ -36,6 +36,8 @@ declare(strict_types=1);
 namespace Infection\Telemetry;
 
 use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
+use OpenTelemetry\API\Common\Time\ClockInterface;
+use OpenTelemetry\API\Common\Time\SystemClock;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
 
@@ -49,6 +51,7 @@ final readonly class OpenTelemetryTracer
     public function __construct(
         private TracerInterface $tracer,
         private ?TracerProviderInterface $tracerProvider,
+        private ClockInterface $clock = new SystemClock(),
     ) {
     }
 
@@ -63,6 +66,7 @@ final readonly class OpenTelemetryTracer
                 ->spanBuilder($name)
                 ->setParent(false)
                 ->setAttributes($attributes)
+                ->setStartTimestamp($this->clock->now())
                 ->startSpan(),
         );
     }
@@ -78,6 +82,7 @@ final readonly class OpenTelemetryTracer
                 ->spanBuilder($name)
                 ->setParent($parent->getContext())
                 ->setAttributes($attributes)
+                ->setStartTimestamp($this->clock->now())
                 ->startSpan(),
         );
     }
@@ -85,13 +90,18 @@ final readonly class OpenTelemetryTracer
     /**
      * @param Attributes $attributes
      */
-    public function end(SpanHandle $span, array $attributes = []): void
-    {
+    public function end(
+        SpanHandle $span,
+        array $attributes = [],
+        ?int $endEpochInNs = null,
+    ): void {
         if ($attributes !== []) {
             $span->span->setAttributes($attributes);
         }
 
-        $span->span->end();
+        $span->span->end(
+            $endEpochInNs ?? $this->clock->now(),
+        );
     }
 
     public function shutdown(): void

--- a/src/Telemetry/OpenTelemetryTracer.php
+++ b/src/Telemetry/OpenTelemetryTracer.php
@@ -37,7 +37,6 @@ namespace Infection\Telemetry;
 
 use Infection\Telemetry\Attribute\RunSpanAttributesProvider;
 use OpenTelemetry\API\Common\Time\ClockInterface;
-use OpenTelemetry\API\Common\Time\SystemClock;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
 
@@ -51,7 +50,7 @@ final readonly class OpenTelemetryTracer
     public function __construct(
         private TracerInterface $tracer,
         private ?TracerProviderInterface $tracerProvider,
-        private ClockInterface $clock = new SystemClock(),
+        private ClockInterface $clock,
     ) {
     }
 

--- a/src/Telemetry/OpenTelemetryTracerFactory.php
+++ b/src/Telemetry/OpenTelemetryTracerFactory.php
@@ -43,6 +43,7 @@ use function implode;
 use function in_array;
 use Infection\Telemetry\SDK\FailingTracerProviderFactory;
 use InvalidArgumentException;
+use OpenTelemetry\API\Common\Time\Clock;
 use OpenTelemetry\SDK\Common\Configuration\Variables;
 use RuntimeException;
 use function Safe\putenv;
@@ -91,6 +92,7 @@ final readonly class OpenTelemetryTracerFactory
         return new OpenTelemetryTracer(
             $tracerProvider->getTracer(self::TRACER_NAME),
             $tracerProvider,
+            Clock::getDefault(),
         );
     }
 

--- a/tests/phpunit/Telemetry/FakeClock.php
+++ b/tests/phpunit/Telemetry/FakeClock.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Telemetry;
+
+use Infection\Tests\UnsupportedMethod;
+use OpenTelemetry\API\Common\Time\ClockInterface;
+
+/**
+ * @internal
+ */
+final class FakeClock implements ClockInterface
+{
+    public function now(): int
+    {
+        throw UnsupportedMethod::method(self::class, __FUNCTION__);
+    }
+}

--- a/tests/phpunit/Telemetry/OpenTelemetryTracerTest.php
+++ b/tests/phpunit/Telemetry/OpenTelemetryTracerTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\Telemetry;
 
 use Infection\Telemetry\OpenTelemetryTracer;
 use Infection\Telemetry\SpanHandle;
+use OpenTelemetry\API\Common\Time\Clock;
 use OpenTelemetry\API\Trace\NoopTracer;
 use OpenTelemetry\API\Trace\SpanContextValidator;
 use OpenTelemetry\SDK\Trace\SpanDataInterface;
@@ -68,6 +69,7 @@ final class OpenTelemetryTracerTest extends TestCase
         $this->tracer = new OpenTelemetryTracer(
             $this->tracerProvider->getTracer('infection'),
             $this->tracerProvider,
+            Clock::getDefault(),
         );
     }
 
@@ -125,6 +127,7 @@ final class OpenTelemetryTracerTest extends TestCase
         $tracer = new OpenTelemetryTracer(
             NoopTracer::getInstance(),
             null,
+            Clock::getDefault(),
         );
 
         $tracer->shutdown();

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -97,8 +97,9 @@ use Infection\Tests\Mutant\MutantBuilder;
 use Infection\Tests\Mutant\MutantExecutionResultBuilder;
 use Infection\Tests\Mutation\MutationBuilder;
 use Infection\Tests\Reporter\FakeReporter;
+use Infection\Tests\Telemetry\FakeClock;
 use OpenTelemetry\API\Common\Time\Clock;
-use OpenTelemetry\API\Common\Time\ClockInterface;
+use OpenTelemetry\API\Common\Time\TestClock;
 use OpenTelemetry\API\Trace\SpanContextValidator;
 use OpenTelemetry\SDK\Trace\SpanDataInterface;
 use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
@@ -127,10 +128,14 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
 
     private MetricsCalculator $metricsCalculator;
 
+    private TestClock $clock;
+
     protected function setUp(): void
     {
         $this->exporter = new InMemoryExporter();
         $this->tracerProvider = new TracerProvider(new SimpleSpanProcessor($this->exporter));
+        $this->clock = new TestClock(1_000_000_000);
+        Clock::setDefault(new FakeClock());
 
         $configuration = ConfigurationBuilder::withMinimalTestData()
             ->withProjectDirectory('/path/to/project')
@@ -151,6 +156,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
             new OpenTelemetryTracer(
                 $this->tracerProvider->getTracer('infection'),
                 $this->tracerProvider,
+                $this->clock,
             ),
             new RunSpanAttributesProvider(
                 $configuration,
@@ -214,7 +220,9 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->subscriber->onMutantAnalysisWasStarted(new MutantAnalysisWasStarted($mutant));
         $this->subscriber->onMutantMaterialisationWasStarted(new MutantMaterialisationWasStarted($mutant));
         $this->subscriber->onMutantMaterialisationWasFinished(new MutantMaterialisationWasFinished($mutant));
+        $this->clock->setTime(2_000_000_000);
         $this->subscriber->onMutantEvaluationWasStarted(new MutantEvaluationWasStarted($mutant));
+        $this->clock->setTime(2_000_000_010);
         $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($process0, 1));
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($process0));
         $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($process1, 2));
@@ -488,24 +496,6 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
 
     public function test_it_calculates_the_queue_wait_duration_for_each_mutant_evaluation(): void
     {
-        $clock = new class(1_000_000_000) implements ClockInterface {
-            public function __construct(
-                private int $time,
-            ) {
-            }
-
-            public function setTime(int $time): void
-            {
-                $this->time = $time;
-            }
-
-            public function now(): int
-            {
-                return $this->time;
-            }
-        };
-        Clock::setDefault($clock);
-
         $mutationA = MutationBuilder::withMinimalTestData()
             ->withHash('mutation-A')
             ->build();
@@ -527,30 +517,30 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
         $this->subscriber->onMutationAnalysisWasStarted(new MutationAnalysisWasStarted());
         $this->subscriber->onMutationEvaluationWasStarted(new MutationEvaluationWasStarted(2, $this->createStub(ProcessRunner::class)));
 
-        $clock->setTime(2_000_000_000);
+        $this->clock->setTime(2_000_000_000);
         $this->subscriber->onMutantEvaluationWasStarted(new MutantEvaluationWasStarted($mutantA));
-        $clock->setTime(2_000_000_010);
+        $this->clock->setTime(2_000_000_010);
         $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationAProcess0, 1));
-        $clock->setTime(2_000_000_030);
+        $this->clock->setTime(2_000_000_030);
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($mutationAProcess0));
-        $clock->setTime(2_000_000_070);
+        $this->clock->setTime(2_000_000_070);
         $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationAProcess1, 1));
-        $clock->setTime(2_000_000_090);
+        $this->clock->setTime(2_000_000_090);
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($mutationAProcess1));
-        $clock->setTime(2_000_000_110);
+        $this->clock->setTime(2_000_000_110);
         $this->subscriber->onMutantEvaluationWasFinished(new MutantEvaluationWasFinished($mutantA));
 
-        $clock->setTime(3_000_000_000);
+        $this->clock->setTime(3_000_000_000);
         $this->subscriber->onMutantEvaluationWasStarted(new MutantEvaluationWasStarted($mutantB));
-        $clock->setTime(3_000_000_025);
+        $this->clock->setTime(3_000_000_025);
         $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationBProcess0, 2));
-        $clock->setTime(3_000_000_055);
+        $this->clock->setTime(3_000_000_055);
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($mutationBProcess0));
-        $clock->setTime(3_000_000_115);
+        $this->clock->setTime(3_000_000_115);
         $this->subscriber->onMutantProcessExecutionWasStarted(new MutantProcessExecutionWasStarted($mutationBProcess1, 2));
-        $clock->setTime(3_000_000_145);
+        $this->clock->setTime(3_000_000_145);
         $this->subscriber->onMutantProcessExecutionWasFinished(new MutantProcessExecutionWasFinished($mutationBProcess1));
-        $clock->setTime(3_000_000_200);
+        $this->clock->setTime(3_000_000_200);
         $this->subscriber->onMutantEvaluationWasFinished(new MutantEvaluationWasFinished($mutantB));
 
         $this->assertSame(


### PR DESCRIPTION
## Description

OpenTelemetry uses a global clock factory. This makes `OpenTelemetryTracerSubscriberTest` clock usages a bit more awkward, having to tweak the global state.

This PR injects the clock, removing the need to touch the global state. Since we should not be using a clock from the global state anymore, a `FakeClock` is also added and registered as the default global clock.

## Changes

- Updates `OpenTelemetryTracer` to accept an injectable OpenTelemetry `ClockInterface`, defaulting to `SystemClock`.
- Sets explicit start and end timestamps when starting and ending spans through the tracer wrapper.
- Updates `OpenTelemetryTracerSubscriberTest` to use a shared `TestClock` injected through `OpenTelemetryTracer`.
- Adds a telemetry `FakeClock` test helper that throws via `UnsupportedMethod` when the OpenTelemetry global default clock is used.
- Registers the fake global clock in the subscriber test so the test fails if span timing falls back to OpenTelemetry global state.

## Related issues

- #3090
