### PR TITLE
feat(telemetry): Fix the end of the mutation analysis

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -429,12 +429,12 @@ final class Container extends DIContainer
                     $container->get(MutationGenerationLoggerSubscriber::class),
                     $container->get(MutationTestingResultsCollectorSubscriber::class),
                     $container->get(MutationAnalysisLoggerSubscriber::class),
+                    $container->get(OpenTelemetryTracerSubscriberFactory::class),
                     $container->get(ReportAfterMutationEvaluationFinishedSubscriber::class),
                     $container->get(PerformanceLoggerSubscriber::class),
                     $container->getCleanUpAfterMutationTestingFinishedSubscriberFactory(),
                     $container->get(StopInfectionOnSigintSignalSubscriber::class),
                     $container->get(DispatchPcntlSignalSubscriber::class),
-                    $container->get(OpenTelemetryTracerSubscriberFactory::class),
                 ];
 
                 if ($container->getConfiguration()->isStaticAnalysisEnabled()) {

--- a/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
+++ b/src/Telemetry/Subscriber/OpenTelemetryTracerSubscriber.php
@@ -317,8 +317,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $this->mutationEvaluationSpans = [];
         $this->end($this->mutationEvaluationSpan, event: $event);
         $this->mutationEvaluationSpan = null;
-        $this->end($this->mutationAnalysisSpan, event: $event);
-        $this->mutationAnalysisSpan = null;
+        $this->endMutationAnalysisSpan($event);
     }
 
     public function onAstProcessingWasStarted(AstProcessingWasStarted $event): void
@@ -655,6 +654,7 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $this->mutationEvaluationSpans = [];
         $this->end($this->mutationEvaluationSpan, event: $event);
         $this->mutationEvaluationSpan = null;
+        $this->endMutationAnalysisSpan($event);
     }
 
     public function onApplicationExecutionWasFinished(ApplicationExecutionWasFinished $event): void
@@ -848,6 +848,16 @@ final class OpenTelemetryTracerSubscriber implements ApplicationExecutionWasFini
         $this->astProcessingSpan = null;
         $this->astProcessingFileCount = null;
         $this->processedAstFileCount = 0;
+    }
+
+    private function endMutationAnalysisSpan(object $event): void
+    {
+        if ($this->mutationGenerationSpan !== null || $this->astProcessingSpan !== null) {
+            return;
+        }
+
+        $this->end($this->mutationAnalysisSpan, event: $event);
+        $this->mutationAnalysisSpan = null;
     }
 
     private function endAstProcessingSpanIfComplete(object $event): void

--- a/tests/phpunit/Container/ContainerTest.php
+++ b/tests/phpunit/Container/ContainerTest.php
@@ -36,9 +36,14 @@ declare(strict_types=1);
 namespace Infection\Tests\Container;
 
 use function array_keys;
+use function array_map;
+use function array_search;
 use Error;
 use Infection\Configuration\SourceFilter\PlainFilter;
 use Infection\Container\Container;
+use Infection\Event\Subscriber\ChainSubscriberFactory;
+use Infection\Event\Subscriber\ReportAfterMutationEvaluationFinishedSubscriber;
+use Infection\Telemetry\Subscriber\OpenTelemetryTracerSubscriberFactory;
 use Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable;
 use Infection\Testing\SingletonContainer;
 use Infection\Tests\Reflection\ContainerReflection;
@@ -48,6 +53,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use ReflectionProperty;
 use function sprintf;
 use Symfony\Component\Console\Output\NullOutput;
 use Webmozart\Assert\InvalidArgumentException as AssertException;
@@ -101,6 +107,31 @@ final class ContainerTest extends TestCase
         $container = SingletonContainer::getContainer();
 
         $container->getFileSystem();
+    }
+
+    public function test_it_registers_telemetry_before_the_reporting_trigger_subscriber(): void
+    {
+        $containerReflection = new ContainerReflection(SingletonContainer::getContainer());
+        $chainSubscriberFactory = $containerReflection->getService(ChainSubscriberFactory::class);
+        $subscriberFactoriesProperty = new ReflectionProperty(ChainSubscriberFactory::class, 'subscribersAndFactories');
+
+        $this->assertInstanceOf(ChainSubscriberFactory::class, $chainSubscriberFactory);
+
+        $subscriberFactories = $subscriberFactoriesProperty->getValue($chainSubscriberFactory);
+        $this->assertIsArray($subscriberFactories);
+
+        /** @var list<object> $subscriberFactories */
+        $subscriberFactoryClasses = array_map(
+            static fn (object $subscriberOrFactory): string => $subscriberOrFactory::class,
+            $subscriberFactories,
+        );
+
+        $telemetryPosition = array_search(OpenTelemetryTracerSubscriberFactory::class, $subscriberFactoryClasses, true);
+        $reportingPosition = array_search(ReportAfterMutationEvaluationFinishedSubscriber::class, $subscriberFactoryClasses, true);
+
+        $this->assertIsInt($telemetryPosition);
+        $this->assertIsInt($reportingPosition);
+        $this->assertLessThan($reportingPosition, $telemetryPosition);
     }
 
     public function test_it_can_build_lazy_source_file_data_factory_that_fails_on_use(): void

--- a/tests/phpunit/Container/ContainerTest.php
+++ b/tests/phpunit/Container/ContainerTest.php
@@ -36,14 +36,9 @@ declare(strict_types=1);
 namespace Infection\Tests\Container;
 
 use function array_keys;
-use function array_map;
-use function array_search;
 use Error;
 use Infection\Configuration\SourceFilter\PlainFilter;
 use Infection\Container\Container;
-use Infection\Event\Subscriber\ChainSubscriberFactory;
-use Infection\Event\Subscriber\ReportAfterMutationEvaluationFinishedSubscriber;
-use Infection\Telemetry\Subscriber\OpenTelemetryTracerSubscriberFactory;
 use Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable;
 use Infection\Testing\SingletonContainer;
 use Infection\Tests\Reflection\ContainerReflection;
@@ -53,7 +48,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
-use ReflectionProperty;
 use function sprintf;
 use Symfony\Component\Console\Output\NullOutput;
 use Webmozart\Assert\InvalidArgumentException as AssertException;
@@ -107,31 +101,6 @@ final class ContainerTest extends TestCase
         $container = SingletonContainer::getContainer();
 
         $container->getFileSystem();
-    }
-
-    public function test_it_registers_telemetry_before_the_reporting_trigger_subscriber(): void
-    {
-        $containerReflection = new ContainerReflection(SingletonContainer::getContainer());
-        $chainSubscriberFactory = $containerReflection->getService(ChainSubscriberFactory::class);
-        $subscriberFactoriesProperty = new ReflectionProperty(ChainSubscriberFactory::class, 'subscribersAndFactories');
-
-        $this->assertInstanceOf(ChainSubscriberFactory::class, $chainSubscriberFactory);
-
-        $subscriberFactories = $subscriberFactoriesProperty->getValue($chainSubscriberFactory);
-        $this->assertIsArray($subscriberFactories);
-
-        /** @var list<object> $subscriberFactories */
-        $subscriberFactoryClasses = array_map(
-            static fn (object $subscriberOrFactory): string => $subscriberOrFactory::class,
-            $subscriberFactories,
-        );
-
-        $telemetryPosition = array_search(OpenTelemetryTracerSubscriberFactory::class, $subscriberFactoryClasses, true);
-        $reportingPosition = array_search(ReportAfterMutationEvaluationFinishedSubscriber::class, $subscriberFactoryClasses, true);
-
-        $this->assertIsInt($telemetryPosition);
-        $this->assertIsInt($reportingPosition);
-        $this->assertLessThan($reportingPosition, $telemetryPosition);
     }
 
     public function test_it_can_build_lazy_source_file_data_factory_that_fails_on_use(): void

--- a/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
+++ b/tests/phpunit/Telemetry/Subscriber/OpenTelemetryTracerSubscriberTest.php
@@ -238,11 +238,11 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 new MutantEvaluationWasFinished($mutant),
                 new MutantAnalysisWasFinished($mutant),
                 new MutationEvaluationForMutationWasFinished($executionResult),
+                new MutationEvaluationWasFinished(),
                 new ReportingWasStarted(),
                 new ReporterWasStarted($reporterId, $reporterName),
                 new ReporterWasFinished($reporterId, $reporterName),
                 new ReportingWasFinished(),
-                new MutationEvaluationWasFinished(),
                 new MutationAnalysisWasFinished(),
                 new ApplicationExecutionWasFinished(),
             ],
@@ -268,10 +268,10 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 'infection.mutation_evaluation.mutant_analysis.evaluation',
                 'infection.mutation_evaluation.mutant_analysis',
                 'infection.mutation_evaluation.mutation',
-                'infection.reporting.reporter',
-                'infection.reporting',
                 'infection.mutation_evaluation',
                 'infection.mutation_analysis',
+                'infection.reporting.reporter',
+                'infection.reporting',
                 'infection.run',
             ],
             $this->exporter->getSpanNames(),
@@ -394,7 +394,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
             $initialStaticAnalysis,
         );
         $this->assertSpanAttributesEquals(
-            self::createAttributes(MutationAnalysisWasStarted::class, MutationAnalysisWasFinished::class),
+            self::createAttributes(MutationAnalysisWasStarted::class, MutationEvaluationWasFinished::class),
             $mutationAnalysis,
         );
         $this->assertSpanAttributesEquals(
@@ -660,13 +660,13 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                         ->withMutantHash('mutation-B')
                         ->build(),
                 ),
+                new MutationEvaluationWasFinished(),
                 new ReportingWasStarted(),
                 new ReporterWasStarted(123, ReporterName::FILE_REPORTERS),
                 new ReporterWasFinished(123, ReporterName::FILE_REPORTERS),
                 new ReporterWasStarted(456, ReporterName::SHOW_METRICS),
                 new ReporterWasFinished(456, ReporterName::SHOW_METRICS),
                 new ReportingWasFinished(),
-                new MutationEvaluationWasFinished(),
                 new MutationAnalysisWasFinished(),
                 new ApplicationExecutionWasFinished(),
             ],
@@ -676,13 +676,13 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                     infection.initial_tests [30, 40]
                     infection.initial_static_analysis [50, 60]
                   infection.source_collection [80, 90]
-                  infection.mutation_analysis [100, 650]
+                  infection.mutation_analysis [100, 590]
                     infection.mutation_generation [110, 200]
                       infection.ast_processing [120, 190]
                         infection.ast_processing.file [130, 180]
                           infection.ast_processing.file.parsing [140, 150]
                           infection.ast_processing.file.enrichment [160, 170]
-                    infection.mutation_evaluation [210, 640]
+                    infection.mutation_evaluation [210, 580]
                       infection.mutation_evaluation.mutation [220, 490]
                         infection.mutation_evaluation.mutation.heuristic_suppression [230, 280]
                           infection.mutation_evaluation.mutation.heuristic [240, 250]
@@ -701,9 +701,9 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                           infection.mutation_evaluation.mutant_analysis.evaluation [500, 550]
                             infection.mutation_evaluation.mutant_analysis.evaluation.process [510, 520]
                             infection.mutation_evaluation.mutant_analysis.evaluation.process [530, 540]
-                  infection.reporting [580, 630]
-                    infection.reporting.reporter [590, 600]
+                  infection.reporting [600, 650]
                     infection.reporting.reporter [610, 620]
+                    infection.reporting.reporter [630, 640]
                 TXT,
         ];
 
@@ -782,6 +782,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                         ->withMutantHash('mutation-B')
                         ->build(),
                 ),
+                new MutationEvaluationWasFinished(),
                 new ReportingWasStarted(),
                 new ReporterWasStarted(123, ReporterName::FILE_REPORTERS),
                 new ReporterWasFinished(123, ReporterName::FILE_REPORTERS),
@@ -790,7 +791,6 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 new ReporterWasStarted(789, ReporterName::ADVISORY),
                 new ReporterWasFinished(789, ReporterName::ADVISORY),
                 new ReportingWasFinished(),
-                new MutationEvaluationWasFinished(),
                 new MutationAnalysisWasFinished(),
                 new ApplicationExecutionWasFinished(),
             ],
@@ -800,8 +800,8 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                     infection.initial_tests [30, 40]
                     infection.initial_static_analysis [50, 60]
                   infection.source_collection [80, 90]
-                  infection.mutation_analysis [100, 770]
-                    infection.mutation_evaluation [110, 760]
+                  infection.mutation_analysis [100, 690]
+                    infection.mutation_evaluation [110, 680]
                       infection.mutation_evaluation.mutation [200, 590]
                         infection.mutation_evaluation.mutation.heuristic_suppression [210, 280]
                           infection.mutation_evaluation.mutation.heuristic [220, 230]
@@ -830,10 +830,10 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                         infection.ast_processing.file [320, 370]
                           infection.ast_processing.file.parsing [330, 340]
                           infection.ast_processing.file.enrichment [350, 360]
-                  infection.reporting [680, 750]
-                    infection.reporting.reporter [690, 700]
+                  infection.reporting [700, 770]
                     infection.reporting.reporter [710, 720]
                     infection.reporting.reporter [730, 740]
+                    infection.reporting.reporter [750, 760]
                 TXT,
         ];
     }
@@ -908,6 +908,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
             [
                 'infection.mutation_evaluation.mutation',
                 'infection.mutation_evaluation',
+                'infection.mutation_analysis',
             ],
             $this->exporter->getSpanNames(),
         );
@@ -952,6 +953,7 @@ final class OpenTelemetryTracerSubscriberTest extends TestCase
                 'infection.mutation_evaluation.mutant_analysis',
                 'infection.mutation_evaluation.mutation',
                 'infection.mutation_evaluation',
+                'infection.mutation_analysis',
             ],
             $this->exporter->getSpanNames(),
         );


### PR DESCRIPTION
## Description

Due to the registration order of the subscribers, the reporting was done before the mutation analysis was finished (for the spans).

## Related issues

- #3090
