### PR TITLE
feat(telemetry): Add attribute to know if the run is with progress

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -11955,6 +11955,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Telemetry\Attribute\RunSpanAttributesProviderTest::test_it_marks_runs_when_progress_output_is_enabled`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Telemetry\Attribute\RunSpanAttributesProviderTest::test_it_omits_static_analysis_tool_attributes_when_static_analysis_is_disabled`.'
 count = 1
 

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -84,6 +84,7 @@ toolchain, and run-summary attributes that are useful for filtering dashboards:
 | `vcs.ref.head.revision`                              | Current `HEAD` commit SHA when the project directory is a Git checkout.                                                   |
 | `infection.thread.count`                             | Resolved mutation runner thread count.                                                                                    |
 | `infection.run.source_filtered`                      | Whether the run used a source filter, for example `--filter`, `--git-diff-filter`, or `--git-diff-lines`.                 |
+| `infection.run.progress_enabled`                     | Whether progress output was enabled for the run after resolving CLI options and CI detection.                             |
 | `infection.timeouts_as_escaped`                      | Whether timed-out mutants are treated as escaped when calculating MSI values.                                             |
 | `infection.initial_tests.skipped`                    | Whether the initial test run was skipped.                                                                                 |
 | `infection.initial_static_analysis.skipped`          | Whether the initial static analysis run was skipped because no static analysis tool was enabled.                          |

--- a/src/Telemetry/Attribute/RunSpanAttributesProvider.php
+++ b/src/Telemetry/Attribute/RunSpanAttributesProvider.php
@@ -81,6 +81,7 @@ final readonly class RunSpanAttributesProvider
             'vcs.ref.head.revision' => $this->configuration->gitSha,
             'infection.thread.count' => $this->configuration->threadCount,
             'infection.run.source_filtered' => $this->configuration->sourceFilter !== null,
+            'infection.run.progress_enabled' => !$this->configuration->noProgress,
             'infection.timeouts_as_escaped' => $this->configuration->timeoutsAsEscaped,
             'infection.initial_tests.skipped' => $this->configuration->skipInitialTests,
             'infection.initial_static_analysis.skipped' => !$this->configuration->isStaticAnalysisEnabled(),

--- a/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
@@ -68,6 +68,7 @@ final class RunSpanAttributesProviderTest extends TestCase
             ->withStaticAnalysisTool(StaticAnalysisToolTypes::PHPSTAN)
             ->withGitSha('0123456789abcdef')
             ->withTimeoutsAsEscaped(true)
+            ->withNoProgress(true)
             ->build();
 
         $infectionVersionMock = $this->createMock(InfectionVersion::class);
@@ -103,6 +104,7 @@ final class RunSpanAttributesProviderTest extends TestCase
             'vcs.ref.head.revision' => '0123456789abcdef',
             'infection.thread.count' => 8,
             'infection.run.source_filtered' => false,
+            'infection.run.progress_enabled' => false,
             'infection.timeouts_as_escaped' => true,
             'infection.initial_tests.skipped' => true,
             'infection.initial_static_analysis.skipped' => false,
@@ -174,6 +176,34 @@ final class RunSpanAttributesProviderTest extends TestCase
         $actual = $provider->provideInitialAttributes();
 
         $this->assertTrue($actual['infection.run.source_filtered']);
+    }
+
+    public function test_it_marks_runs_when_progress_output_is_enabled(): void
+    {
+        $configuration = ConfigurationBuilder::withMinimalTestData()
+            ->withNoProgress(false)
+            ->build();
+
+        $infectionVersion = $this->createStub(InfectionVersion::class);
+        $infectionVersion
+            ->method('prettyVersion')
+            ->willReturn('1.2.3');
+        $testFrameworkAdapter = $this->createStub(TestFrameworkAdapter::class);
+        $testFrameworkAdapter
+            ->method('getVersion')
+            ->willReturn('12.3.4');
+
+        $provider = new RunSpanAttributesProvider(
+            $configuration,
+            $infectionVersion,
+            $testFrameworkAdapter,
+            null,
+            new MetricsCalculator($configuration->msiPrecision, $configuration->timeoutsAsEscaped),
+        );
+
+        $actual = $provider->provideInitialAttributes();
+
+        $this->assertTrue($actual['infection.run.progress_enabled']);
     }
 
     /**

--- a/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
+++ b/tests/phpunit/Telemetry/Attribute/RunSpanAttributesProviderTest.php
@@ -178,34 +178,6 @@ final class RunSpanAttributesProviderTest extends TestCase
         $this->assertTrue($actual['infection.run.source_filtered']);
     }
 
-    public function test_it_marks_runs_when_progress_output_is_enabled(): void
-    {
-        $configuration = ConfigurationBuilder::withMinimalTestData()
-            ->withNoProgress(false)
-            ->build();
-
-        $infectionVersion = $this->createStub(InfectionVersion::class);
-        $infectionVersion
-            ->method('prettyVersion')
-            ->willReturn('1.2.3');
-        $testFrameworkAdapter = $this->createStub(TestFrameworkAdapter::class);
-        $testFrameworkAdapter
-            ->method('getVersion')
-            ->willReturn('12.3.4');
-
-        $provider = new RunSpanAttributesProvider(
-            $configuration,
-            $infectionVersion,
-            $testFrameworkAdapter,
-            null,
-            new MetricsCalculator($configuration->msiPrecision, $configuration->timeoutsAsEscaped),
-        );
-
-        $actual = $provider->provideInitialAttributes();
-
-        $this->assertTrue($actual['infection.run.progress_enabled']);
-    }
-
     /**
      * @param list<DetectionStatus> $detectionStatuses
      * @param Attributes $expected


### PR DESCRIPTION
## Description

Whilst it will not affect the MSI score, progress or no progress can result in big execution differences time or memory wise, so it is a relevant piece of information to have when comparing metrics between runs.

## Related issues

- #3090