### PR TITLE
build: Ensure the PHAR building works in interactive environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,14 +320,18 @@ $(MAGO): vendor
 	touch -c $@
 
 $(INFECTION): vendor $(shell find bin/ src/ -type f) $(BOX) box.json.dist .git/HEAD
-	composer require infection/codeception-adapter infection/phpspec-adapter testo/bridge-infection
+	composer require --no-interaction \
+		infection/codeception-adapter \
+		infection/phpspec-adapter \
+		testo/bridge-infection
+
 	# Workaround for https://github.com/box-project/box/issues/580
-	composer install --no-dev
+	composer install --no-interaction --no-dev
 	$(BOX) --version
-	$(BOX) validate
-	$(BOX) compile
+	$(BOX) validate --no-interaction
+	$(BOX) compile --no-interaction
 	composer remove infection/codeception-adapter infection/phpspec-adapter testo/bridge-infection
-	composer install
+	composer install --no-interaction
 	touch -c $@
 
 vendor: composer.lock


### PR DESCRIPTION
In an interactive environment, a `composer` or `box` command may end up prompting a question preventing the `make dist/infection.phar` command to complete.

This is not an issue in the CI as it is typically not an interactive environment, but it can be locally.