### PR TITLE
refactor(autoreview): Move tests are final checks to PHPAt

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -5571,12 +5571,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "imprecise-type"
-message = "Type `iterable` in return type of `classesTestProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
-code = "imprecise-type"
 message = "Type `iterable` in return type of `nonFinalExtensionClasses` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
@@ -5602,12 +5596,6 @@ count = 1
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideSourceClasses` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideTestClasses` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -5649,7 +5637,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "unhandled-thrown-type"
-message = "Potentially unhandled exception `ReflectionException` in `{closure:tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php:301:13}`."
+message = "Potentially unhandled exception `ReflectionException` in `{closure:tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php:295:13}`."
 count = 1
 
 [[issues]]
@@ -5674,19 +5662,13 @@ count = 1
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
-count = 4
+count = 3
 
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
 code = "redundant-comparison"
 message = "Avoid direct comparison with boolean literals."
 count = 3
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest::test_all_test_classes_are_trait_abstract_or_final`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -1135,6 +1135,18 @@ parameters:
 			path: ../tests/phpunit/Reflection/AnonymousClassReflectionTest.php
 
 		-
+			rawMessage: Infection\Tests\Reflection\ProtChild should be final
+			identifier: phpat.testPHPUnitTestClassesAreTraitAbstractOrFinal
+			count: 1
+			path: ../tests/phpunit/Reflection/ClassReflectionTestCase.php
+
+		-
+			rawMessage: Infection\Tests\Reflection\ProtParent should be final
+			identifier: phpat.testPHPUnitTestClassesAreTraitAbstractOrFinal
+			count: 1
+			path: ../tests/phpunit/Reflection/ClassReflectionTestCase.php
+
+		-
 			rawMessage: Unused Infection\Tests\Reflection\ProtChild::foo
 			identifier: shipmonk.deadMethod
 			count: 1

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -657,7 +657,7 @@ parameters:
 		-
 			rawMessage: 'Parameter #1 $objectOrClass of class ReflectionClass constructor expects class-string<T of object>|T of object, string given.'
 			identifier: argument.type
-			count: 4
+			count: 3
 			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
 
 		-
@@ -1277,4 +1277,3 @@ parameters:
 			identifier: property.notFound
 			count: 2
 			path: ../tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php
-

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -10,6 +10,10 @@ services:
         class: Infection\Tests\Architecture\PHPat\SrcShouldNotDependOnTestsTest
         tags:
             - phpat.test
+    -
+        class: Infection\Tests\Architecture\PHPat\PHPUnitTestClassesShouldBeTraitAbstractOrFinalTest
+        tags:
+            - phpat.test
 
 parameters:
     tmpDir: ../var/cache/phpstan

--- a/tests/Architecture/PHPat/PHPUnitTestClassesShouldBeTraitAbstractOrFinalTest.php
+++ b/tests/Architecture/PHPat/PHPUnitTestClassesShouldBeTraitAbstractOrFinalTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Architecture\PHPat;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+
+final class PHPUnitTestClassesShouldBeTraitAbstractOrFinalTest
+{
+    public function testPHPUnitTestClassesAreTraitAbstractOrFinal(): Rule
+    {
+        return PHPat::rule()
+            ->classes(
+                Selector::AllOf(
+                    Selector::inNamespace('Infection\\Tests'),
+                    Selector::withFilepath('#/tests/phpunit/#', true),
+                ),
+            )
+            ->excluding(
+                Selector::isTrait(),
+                Selector::isAbstract(),
+            )
+            ->should()
+            ->beFinal()
+            ->because('PHPUnit test classes should be traits, abstract classes, or final classes.');
+    }
+}

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -112,7 +112,6 @@ use Infection\Testing\SingletonContainer;
 use Infection\Tests\AutoReview\ConcreteClassReflector;
 use Infection\Tests\TestingUtility\PHPUnit\DataProviderFactory;
 use function iterator_to_array;
-use function ltrim;
 use function Pipeline\take;
 use ReflectionClass;
 use function sort;
@@ -231,11 +230,6 @@ final class ProjectCodeProvider
      */
     private static ?array $sourceClassesToCheckForPublicProperties = null;
 
-    /**
-     * @var string[]|null
-     */
-    private static ?array $testClasses = null;
-
     public static function provideSourceClasses(): iterable
     {
         if (self::$sourceClasses !== null) {
@@ -329,47 +323,6 @@ final class ProjectCodeProvider
         );
     }
 
-    public static function provideTestClasses(): iterable
-    {
-        if (self::$testClasses !== null) {
-            yield from self::$testClasses;
-
-            return;
-        }
-
-        $finder = Finder::create()
-            ->files()
-            ->name('*.php')
-            ->in(__DIR__ . '/../../../../tests')
-            ->notName('DummySymfony5FileSystem.php')
-            ->notName('DummySymfony6FileSystem.php')
-            ->exclude([
-                'Architecture',
-                'autoloaded',
-                'benchmark',
-                'e2e',
-                'Fixtures',
-            ])
-        ;
-
-        self::$testClasses = take($finder)
-            ->cast(self::castTestSplFileInfoToFQCN(...))
-            ->toList();
-
-        sort(self::$testClasses, SORT_STRING);
-
-        yield from self::$testClasses;
-    }
-
-    // "testClassesProvider" would be more correct but PHPUnit will then detect this method as a
-    // test instead of a test provider.
-    public static function classesTestProvider(): iterable
-    {
-        yield from DataProviderFactory::fromIterable(
-            self::provideTestClasses(),
-        );
-    }
-
     public static function nonTestedConcreteClassesProvider(): iterable
     {
         yield from DataProviderFactory::fromIterable([
@@ -392,19 +345,6 @@ final class ProjectCodeProvider
             'Infection',
             str_replace(DIRECTORY_SEPARATOR, '\\', $file->getRelativePath()),
             $file->getRelativePath() !== '' ? '\\' : '',
-            $file->getBasename('.' . $file->getExtension()),
-        );
-    }
-
-    private static function castTestSplFileInfoToFQCN(SplFileInfo $file): string
-    {
-        $fqcnPart = ltrim(str_replace('phpunit', '', $file->getRelativePath()), DIRECTORY_SEPARATOR);
-        $fqcnPart = str_replace(DIRECTORY_SEPARATOR, '\\', $fqcnPart);
-
-        return sprintf(
-            'Infection\\Tests\\%s%s%s',
-            $fqcnPart,
-            $file->getRelativePath() === 'phpunit' ? '' : '\\',
             $file->getBasename('.' . $file->getExtension()),
         );
     }

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php
@@ -102,24 +102,6 @@ final class ProjectCodeProviderTest extends TestCase
         );
     }
 
-    #[DataProviderExternal(ProjectCodeProvider::class, 'classesTestProvider')]
-    public function test_test_classes_provider_is_valid(string $className): void
-    {
-        $this->assertTrue(
-            class_exists($className, true)
-            || interface_exists($className, true)
-            || trait_exists($className, true),
-            sprintf(
-                'The "%s" class was picked up by the test files finder, but it is not a class,'
-                . ' interface or trait. Please check for typos in the class name. If the '
-                . ' problematic file is not a class file declaration, add it to the list of '
-                . 'excluded files in %s::provideTestClasses().',
-                $className,
-                ProjectCodeProvider::class,
-            ),
-        );
-    }
-
     #[DataProviderExternal(ProjectCodeProvider::class, 'nonFinalExtensionClasses')]
     public function test_non_final_extension_classes_provider_is_valid(string $className): void
     {

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
@@ -253,20 +253,4 @@ final class ProjectCodeTest extends TestCase
             ),
         );
     }
-
-    #[DataProviderExternal(ProjectCodeProvider::class, 'classesTestProvider')]
-    public function test_all_test_classes_are_trait_abstract_or_final(string $className): void
-    {
-        $reflectionClass = new ReflectionClass($className);
-
-        $this->assertTrue(
-            $reflectionClass->isTrait()
-            || $reflectionClass->isAbstract()
-            || $reflectionClass->isFinal(),
-            sprintf(
-                'The test class "%s" should be a trait, an abstract or final class.',
-                $className,
-            ),
-        );
-    }
 }

--- a/tests/phpunit/Reflection/ClassReflectionTestCase.php
+++ b/tests/phpunit/Reflection/ClassReflectionTestCase.php
@@ -101,14 +101,14 @@ abstract class ClassReflectionTestCase extends TestCase
     abstract protected static function createFromName(string $name): ClassReflection;
 }
 
-class ProtParent
+abstract class ProtParent
 {
     protected function foo(): void
     {
     }
 }
 
-class ProtChild extends ProtParent
+final class ProtChild extends ProtParent
 {
     protected function foo(): void
     {

--- a/tests/phpunit/Reflection/ClassReflectionTestCase.php
+++ b/tests/phpunit/Reflection/ClassReflectionTestCase.php
@@ -101,14 +101,14 @@ abstract class ClassReflectionTestCase extends TestCase
     abstract protected static function createFromName(string $name): ClassReflection;
 }
 
-abstract class ProtParent
+class ProtParent
 {
     protected function foo(): void
     {
     }
 }
 
-final class ProtChild extends ProtParent
+class ProtChild extends ProtParent
 {
     protected function foo(): void
     {


### PR DESCRIPTION
With [PHPAt](https://www.phpat.dev/) being introduced via https://github.com/infection/infection/pull/3084, we can now take it a step further and leverage it for existing architecture checks we have been doing with plain PHPUnit. The advantage of this, is that checks can be done more reliable (less home-made code operating on finicky regexes) and we can also leverage the PHPStan baseline.

This PR moves the check verifying that test classes are final unless they are traits or abstract (i.e. not applicable).
