### PR TITLE
refactor: Leverage interfaces instead of specific implementations

### DIFF
--- a/src/StaticAnalysis/Mago/Adapter/MagoAdapter.php
+++ b/src/StaticAnalysis/Mago/Adapter/MagoAdapter.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\StaticAnalysis\Mago\Adapter;
 
 use function array_merge;
+use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Process\Factory\LazyMutantProcessFactory;
-use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
 use Infection\StaticAnalysis\Mago\Process\MagoMutantProcessFactory;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\TestFramework\CommandLineBuilder;
@@ -60,7 +60,7 @@ final class MagoAdapter implements StaticAnalysisToolAdapter
      * @param list<string> $staticAnalysisToolOptions
      */
     public function __construct(
-        private readonly MagoMutantExecutionResultFactory $mutantExecutionResultFactory,
+        private readonly MutantExecutionResultFactory $mutantExecutionResultFactory,
         private readonly string $staticAnalysisConfigPath,
         private readonly string $staticAnalysisToolExecutable,
         private readonly CommandLineBuilder $commandLineBuilder,

--- a/src/StaticAnalysis/Mago/Process/MagoMutantProcessFactory.php
+++ b/src/StaticAnalysis/Mago/Process/MagoMutantProcessFactory.php
@@ -37,9 +37,9 @@ namespace Infection\StaticAnalysis\Mago\Process;
 
 use function array_merge;
 use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Process\Factory\LazyMutantProcessFactory;
 use Infection\Process\MutantProcess;
-use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
 use Infection\TestFramework\CommandLineBuilder;
 use Symfony\Component\Process\Process;
 
@@ -52,7 +52,7 @@ final readonly class MagoMutantProcessFactory implements LazyMutantProcessFactor
      * @param list<string> $staticAnalysisToolOptions
      */
     public function __construct(
-        private MagoMutantExecutionResultFactory $mutantExecutionResultFactory,
+        private MutantExecutionResultFactory $mutantExecutionResultFactory,
         private string $staticAnalysisToolExecutable,
         private CommandLineBuilder $commandLineBuilder,
         private float $timeout,

--- a/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
+++ b/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
@@ -37,8 +37,8 @@ namespace Infection\StaticAnalysis\PHPStan\Adapter;
 
 use function array_merge;
 use function explode;
+use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Process\Factory\LazyMutantProcessFactory;
-use Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory;
 use Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\TestFramework\CommandLineBuilder;
@@ -64,7 +64,7 @@ final class PHPStanAdapter implements StaticAnalysisToolAdapter
      */
     public function __construct(
         private readonly Filesystem $fileSystem,
-        private readonly PHPStanMutantExecutionResultFactory $mutantExecutionResultFactory,
+        private readonly MutantExecutionResultFactory $mutantExecutionResultFactory,
         private readonly string $staticAnalysisConfigPath,
         private readonly string $staticAnalysisToolExecutable,
         private readonly CommandLineBuilder $commandLineBuilder,

--- a/src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php
+++ b/src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php
@@ -37,9 +37,9 @@ namespace Infection\StaticAnalysis\PHPStan\Process;
 
 use function array_merge;
 use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Process\Factory\LazyMutantProcessFactory;
 use Infection\Process\MutantProcess;
-use Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory;
 use Infection\TestFramework\CommandLineBuilder;
 use function sprintf;
 use Symfony\Component\Filesystem\Filesystem;
@@ -55,7 +55,7 @@ final readonly class PHPStanMutantProcessFactory implements LazyMutantProcessFac
      */
     public function __construct(
         private Filesystem $fileSystem,
-        private PHPStanMutantExecutionResultFactory $mutantExecutionResultFactory,
+        private MutantExecutionResultFactory $mutantExecutionResultFactory,
         private string $staticAnalysisConfigPath,
         private string $staticAnalysisToolExecutable,
         private CommandLineBuilder $commandLineBuilder,

--- a/src/StaticAnalysis/StaticAnalysisToolFactory.php
+++ b/src/StaticAnalysis/StaticAnalysisToolFactory.php
@@ -38,9 +38,9 @@ namespace Infection\StaticAnalysis;
 use function implode;
 use Infection\Configuration\Configuration;
 use Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder;
-use Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator;
 use Infection\StaticAnalysis\Mago\Adapter\MagoAdapterFactory;
 use Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterFactory;
+use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use InvalidArgumentException;
 use function sprintf;
 
@@ -52,7 +52,7 @@ final readonly class StaticAnalysisToolFactory
     public function __construct(
         private Configuration $infectionConfig,
         private StaticAnalysisToolExecutableFinder $staticAnalysisToolExecutableFiner,
-        private StaticAnalysisConfigLocator $staticAnalysisConfigLocator,
+        private TestFrameworkConfigLocatorInterface $staticAnalysisConfigLocator,
     ) {
     }
 

--- a/tests/phpunit/Fixtures/Process/DummyMutantProcess.php
+++ b/tests/phpunit/Fixtures/Process/DummyMutantProcess.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Fixtures\Process;
 
 use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Mutant\TestFrameworkMutantExecutionResultFactory;
 use Infection\Process\MutantProcess;
 use PHPUnit\Framework\Assert;
@@ -15,7 +16,7 @@ final class DummyMutantProcess extends MutantProcess
     public function __construct(
         private readonly Process $process,
         Mutant $mutant,
-        TestFrameworkMutantExecutionResultFactory $mutantExecutionResultFactory,
+        MutantExecutionResultFactory $mutantExecutionResultFactory,
         private readonly bool $expectTimeOut
     ) {
         parent::__construct($process, $mutant, $mutantExecutionResultFactory);

--- a/tests/phpunit/Process/MutantProcessTest.php
+++ b/tests/phpunit/Process/MutantProcessTest.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Process;
 
 use Infection\Mutant\Mutant;
-use Infection\Mutant\TestFrameworkMutantExecutionResultFactory;
+use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessContainer;
 use Infection\Tests\Mutant\MutantBuilder;
@@ -58,7 +58,7 @@ final class MutantProcessTest extends TestCase
     {
         $this->processStub = $this->createStub(Process::class);
         $this->mutant = MutantBuilder::withMinimalTestData()->build();
-        $mutantExecutionResultFactory = $this->createMock(TestFrameworkMutantExecutionResultFactory::class);
+        $mutantExecutionResultFactory = $this->createMock(MutantExecutionResultFactory::class);
 
         $this->mutantProcess = new MutantProcess(
             $this->processStub,

--- a/tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php
+++ b/tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php
@@ -40,6 +40,7 @@ use function count;
 use DuoClock\TimeSpy;
 use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\Mutant;
+use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Mutant\TestFrameworkMutantExecutionResultFactory;
 use Infection\Process\Factory\LazyMutantProcessFactory;
 use Infection\Process\MutantProcess;
@@ -441,7 +442,7 @@ final class ParallelProcessRunnerTest extends TestCase
             $mutantProcess = new DummyMutantProcess(
                 $process,
                 MutantBuilder::withMinimalTestData()->build(),
-                $this->createStub(TestFrameworkMutantExecutionResultFactory::class),
+                $this->createStub(MutantExecutionResultFactory::class),
                 false,
             );
 
@@ -502,7 +503,7 @@ final class ParallelProcessRunnerTest extends TestCase
             $mutantProcess = new DummyMutantProcess(
                 $process,
                 MutantBuilder::withMinimalTestData()->build(),
-                $this->createStub(TestFrameworkMutantExecutionResultFactory::class),
+                $this->createStub(MutantExecutionResultFactory::class),
                 false,
             );
 
@@ -563,7 +564,7 @@ final class ParallelProcessRunnerTest extends TestCase
             new DummyMutantProcess(
                 $processMock,
                 MutantBuilder::withMinimalTestData()->build(),
-                $this->createStub(TestFrameworkMutantExecutionResultFactory::class),
+                $this->createStub(MutantExecutionResultFactory::class),
                 false,
             ),
             [],
@@ -629,9 +630,9 @@ final class ParallelProcessRunnerTest extends TestCase
                 false,
             ),
             [
-                new readonly class($this->createStub(TestFrameworkMutantExecutionResultFactory::class), $nextProcessMock) implements LazyMutantProcessFactory {
+                new readonly class($this->createStub(MutantExecutionResultFactory::class), $nextProcessMock) implements LazyMutantProcessFactory {
                     public function __construct(
-                        private TestFrameworkMutantExecutionResultFactory $mutantExecutionResultFactory,
+                        private MutantExecutionResultFactory $mutantExecutionResultFactory,
                         private Process $nextProcessMock,
                     ) {
                     }
@@ -671,7 +672,7 @@ final class ParallelProcessRunnerTest extends TestCase
             new DummyMutantProcess(
                 $processMock,
                 MutantBuilder::withMinimalTestData()->build(),
-                $this->createStub(TestFrameworkMutantExecutionResultFactory::class),
+                $this->createStub(MutantExecutionResultFactory::class),
                 true,
             ),
             [],

--- a/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php
@@ -35,8 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Tests\StaticAnalysis\Mago\Adapter;
 
+use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\StaticAnalysis\Mago\Adapter\MagoAdapter;
-use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
 use Infection\StaticAnalysis\Mago\Process\MagoMutantProcessFactory;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\VersionParser;
@@ -61,7 +61,7 @@ final class MagoAdapterTest extends TestCase
         $this->commandLineBuilder = $this->createMock(CommandLineBuilder::class);
 
         $this->adapter = new MagoAdapter(
-            $this->createStub(MagoMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/mago-config-path',
             '/path/to/mago',
             $this->commandLineBuilder,
@@ -96,7 +96,7 @@ final class MagoAdapterTest extends TestCase
     public function test_it_builds_initial_run_command_line_with_single_option(): void
     {
         $adapter = new MagoAdapter(
-            $this->createStub(MagoMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/mago-config-path',
             '/path/to/mago',
             $this->commandLineBuilder,
@@ -127,7 +127,7 @@ final class MagoAdapterTest extends TestCase
     public function test_it_builds_initial_run_command_line_with_multiple_options(): void
     {
         $adapter = new MagoAdapter(
-            $this->createStub(MagoMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/mago-config-path',
             '/path/to/mago',
             $this->commandLineBuilder,
@@ -159,7 +159,7 @@ final class MagoAdapterTest extends TestCase
     public function test_it_builds_initial_run_command_line_with_complex_options(): void
     {
         $adapter = new MagoAdapter(
-            $this->createStub(MagoMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/mago-config-path',
             '/path/to/mago',
             $this->commandLineBuilder,
@@ -209,7 +209,7 @@ final class MagoAdapterTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         $adapter = new MagoAdapter(
-            $this->createStub(MagoMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/mago-config-path',
             '/path/to/mago',
             $this->commandLineBuilder,
@@ -227,7 +227,7 @@ final class MagoAdapterTest extends TestCase
     public function test_it_rejects_invalid_versions(string $version): void
     {
         $adapter = new MagoAdapter(
-            $this->createStub(MagoMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/mago-config-path',
             '/path/to/mago',
             $this->commandLineBuilder,

--- a/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php
@@ -35,8 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Tests\StaticAnalysis\PHPStan\Adapter;
 
+use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter;
-use Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory;
 use Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\VersionParser;
@@ -63,7 +63,7 @@ final class PHPStanAdapterTest extends TestCase
 
         $this->adapter = new PHPStanAdapter(
             $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/phpstan-config-path',
             '/path/to/phpstan',
             $this->commandLineBuilder,
@@ -100,7 +100,7 @@ final class PHPStanAdapterTest extends TestCase
     {
         $adapter = new PHPStanAdapter(
             $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/phpstan-config-path',
             '/path/to/phpstan',
             $this->commandLineBuilder,
@@ -133,7 +133,7 @@ final class PHPStanAdapterTest extends TestCase
     {
         $adapter = new PHPStanAdapter(
             $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/phpstan-config-path',
             '/path/to/phpstan',
             $this->commandLineBuilder,
@@ -168,7 +168,7 @@ final class PHPStanAdapterTest extends TestCase
     {
         $adapter = new PHPStanAdapter(
             $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/phpstan-config-path',
             '/path/to/phpstan',
             $this->commandLineBuilder,
@@ -221,7 +221,7 @@ final class PHPStanAdapterTest extends TestCase
 
         $adapter = new PHPStanAdapter(
             $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/phpstan-config-path',
             '/path/to/phpstan',
             $this->commandLineBuilder,
@@ -241,7 +241,7 @@ final class PHPStanAdapterTest extends TestCase
     {
         $adapter = new PHPStanAdapter(
             $this->createStub(Filesystem::class),
-            $this->createStub(PHPStanMutantExecutionResultFactory::class),
+            $this->createStub(MutantExecutionResultFactory::class),
             '/path/to/phpstan-config-path',
             '/path/to/phpstan',
             $this->commandLineBuilder,

--- a/tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php
@@ -36,8 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\StaticAnalysis;
 
 use Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder;
-use Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator;
 use Infection\StaticAnalysis\StaticAnalysisToolFactory;
+use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\Tests\Configuration\ConfigurationBuilder;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -51,7 +51,7 @@ final class StaticAnalysisToolFactoryTest extends TestCase
         $factory = new StaticAnalysisToolFactory(
             ConfigurationBuilder::withMinimalTestData()->build(),
             $this->createStub(StaticAnalysisToolExecutableFinder::class),
-            $this->createStub(StaticAnalysisConfigLocator::class),
+            $this->createStub(TestFrameworkConfigLocatorInterface::class),
         );
 
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## Description

Identified in #3228, in a few places we were enforcing a specific implementation instead the interfaces already available.

## Changes

- Typehint against `MutantExecutionResultFactory` instead of `{Mago,PhpStan}MutantExecutionResultFactory`
- Typehint against `TestFrameworkConfigLocatorInterface` instead of `StaticAnalysisConfigLocator`
- Typehint against `MutantExecutionResultFactory` instead of `TestFrameworkMutantExecutionResultFactory`

