### PR TITLE
refactor(autoreview): Move source finality checks to PHPat

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -5571,12 +5571,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "imprecise-type"
-message = "Type `iterable` in return type of `nonFinalExtensionClasses` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
-code = "imprecise-type"
 message = "Type `iterable` in return type of `nonTestedConcreteClassesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
@@ -5637,7 +5631,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "unhandled-thrown-type"
-message = "Potentially unhandled exception `ReflectionException` in `{closure:tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php:295:13}`."
+message = "Potentially unhandled exception `ReflectionException` in `{closure:tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php:273:13}`."
 count = 1
 
 [[issues]]
@@ -5662,7 +5656,7 @@ count = 1
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
-count = 3
+count = 2
 
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
@@ -5674,12 +5668,6 @@ count = 3
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest::test_non_extension_points_are_internal`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest::test_non_extension_points_are_traits_interfaces_abstracts_or_finals`.'
 count = 1
 
 [[issues]]

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -19,6 +19,18 @@ parameters:
 			path: ../src/Command/RunCommand.php
 
 		-
+			rawMessage: Infection\Config\ConsoleHelper should not exist
+			identifier: phpat.testSourceConcreteClassesAreFinals
+			count: 1
+			path: ../src/Config/ConsoleHelper.php
+
+		-
+			rawMessage: Infection\Config\Guesser\SourceDirGuesser should not exist
+			identifier: phpat.testSourceConcreteClassesAreFinals
+			count: 1
+			path: ../src/Config/Guesser/SourceDirGuesser.php
+
+		-
 			rawMessage: Variable property access on mixed.
 			identifier: property.dynamicName
 			count: 1
@@ -79,6 +91,12 @@ parameters:
 			path: ../src/Environment/BuildContextResolver.php
 
 		-
+			rawMessage: Infection\FileSystem\FileSystem should not exist
+			identifier: phpat.testSourceConcreteClassesAreFinals
+			count: 1
+			path: ../src/FileSystem/FileSystem.php
+
+		-
 			rawMessage: Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.
 			identifier: ternary.shortNotAllowed
 			count: 1
@@ -95,6 +113,12 @@ parameters:
 			identifier: offsetAccess.notFound
 			count: 1
 			path: ../src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php
+
+		-
+			rawMessage: Infection\FileSystem\Finder\TestFrameworkFinder should not exist
+			identifier: phpat.testSourceConcreteClassesAreFinals
+			count: 1
+			path: ../src/FileSystem/Finder/TestFrameworkFinder.php
 
 		-
 			rawMessage: 'Offset 1 might not exist on list{0?: string, 1?: non-empty-string}.'
@@ -165,6 +189,12 @@ parameters:
 		-
 			rawMessage: Infection\Metrics\MetricsCalculator should be final
 			identifier: phpat.testInterfaceImplementationsAreFinal
+			count: 1
+			path: ../src/Metrics/MetricsCalculator.php
+
+		-
+			rawMessage: Infection\Metrics\MetricsCalculator should not exist
+			identifier: phpat.testSourceConcreteClassesAreFinals
 			count: 1
 			path: ../src/Metrics/MetricsCalculator.php
 
@@ -310,6 +340,12 @@ parameters:
 			path: ../src/Process/Runner/ParallelProcessRunner.php
 
 		-
+			rawMessage: Infection\Process\Runner\ParallelProcessRunner should not exist
+			identifier: phpat.testSourceConcreteClassesAreFinals
+			count: 1
+			path: ../src/Process/Runner/ParallelProcessRunner.php
+
+		-
 			rawMessage: 'Method Infection\Reflection\AnonymousClassReflection::__construct() has parameter $reflectionClass with generic class ReflectionClass but does not specify its types: T'
 			identifier: missingType.generics
 			count: 1
@@ -362,6 +398,12 @@ parameters:
 			identifier: offsetAccess.notFound
 			count: 1
 			path: ../src/Reporter/Html/StrykerHtmlReportBuilder.php
+
+		-
+			rawMessage: Infection\Reporter\Http\StrykerDashboardClient should not exist
+			identifier: phpat.testSourceConcreteClassesAreFinals
+			count: 1
+			path: ../src/Reporter/Http/StrykerDashboardClient.php
 
 		-
 			rawMessage: Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.
@@ -434,6 +476,12 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+
+		-
+			rawMessage: Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder should not exist
+			identifier: phpat.testSourceConcreteClassesAreFinals
+			count: 1
+			path: ../src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
 
 		-
 			rawMessage: 'Parameter #2 $content of method Symfony\Component\Filesystem\Filesystem::dumpFile() expects resource|string, string|false given.'
@@ -669,7 +717,7 @@ parameters:
 		-
 			rawMessage: 'Parameter #1 $objectOrClass of class ReflectionClass constructor expects class-string<T of object>|T of object, string given.'
 			identifier: argument.type
-			count: 3
+			count: 2
 			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
 
 		-

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -15,7 +15,7 @@ services:
         tags:
             - phpat.test
     -
-        class: Infection\Tests\Architecture\PHPat\InterfaceImplementationsShouldBeFinalTest
+        class: Infection\Tests\Architecture\PHPat\ClassesShouldBeFinalTest
         tags:
             - phpat.test
 

--- a/src/Testing/SingletonContainer.php
+++ b/src/Testing/SingletonContainer.php
@@ -38,7 +38,6 @@ namespace Infection\Testing;
 use Infection\Container\Container;
 use Infection\Mutant\MutantCodePrinter;
 use Infection\PhpParser\InfectionPrettyPrinter;
-use Infection\Testing\PhpDoc\PHPDocParser;
 use PhpParser\NodeDumper;
 
 /**
@@ -56,8 +55,6 @@ final class SingletonContainer
 
     private static ?MutantCodePrinter $printer = null;
 
-    private static ?PHPDocParser $phpDocParser = null;
-
     public static function getContainer(): Container
     {
         return self::$container ??= Container::create();
@@ -71,10 +68,5 @@ final class SingletonContainer
     public static function getPrinter(): MutantCodePrinter
     {
         return self::$printer ??= new MutantCodePrinter(new InfectionPrettyPrinter());
-    }
-
-    public static function getPHPDocParser(): PHPDocParser
-    {
-        return self::$phpDocParser ??= new PHPDocParser();
     }
 }

--- a/tests/Architecture/PHPat/ClassesShouldBeFinalTest.php
+++ b/tests/Architecture/PHPat/ClassesShouldBeFinalTest.php
@@ -40,7 +40,7 @@ use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
 
-final class InterfaceImplementationsShouldBeFinalTest
+final class ClassesShouldBeFinalTest
 {
     public function testInterfaceImplementationsAreFinal(): Rule
     {
@@ -59,6 +59,26 @@ final class InterfaceImplementationsShouldBeFinalTest
             ->should()
             ->beFinal()
             ->because('Production interface implementations should be final by default.');
+    }
+
+    public function testSourceConcreteClassesAreFinals(): Rule
+    {
+        return PHPat::rule()
+            ->classes(
+                Selector::AllOf(
+                    Selector::inNamespace('Infection'),
+                ),
+            )
+            ->excluding(
+                Selector::inNamespace('Infection\Tests'),
+                Selector::isTrait(),
+                Selector::isInterface(),
+                Selector::isAbstract(),
+                Selector::isFinal(),
+            )
+            ->shouldNot()
+            ->exist()
+            ->because('Source concrete classes should be final or @final classes.');
     }
 
     public function testParallelProcessRunnerIsNotExtended(): Rule

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -45,8 +45,6 @@ use Infection\Command\Git\Option\BaseOption;
 use Infection\Command\Git\Option\FilterOption;
 use Infection\Command\Option\ConfigurationOption;
 use Infection\Command\Option\SourceFilterOptions;
-use Infection\Config\ConsoleHelper;
-use Infection\Config\Guesser\SourceDirGuesser;
 use Infection\Configuration\Entry\Logs;
 use Infection\Configuration\Entry\Source;
 use Infection\Configuration\ProjectDirectoryProvider\CurrentWorkingDirectoryProvider;
@@ -68,14 +66,12 @@ use Infection\FileSystem\FakeFileSystem;
 use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Finder\ConcreteComposerExecutableFinder;
 use Infection\FileSystem\Finder\NonExecutableFinder;
-use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\Framework\OperatingSystem;
 use Infection\Git\NoGitProjectFound;
 use Infection\Logger\MutationAnalysis\ConsoleProgressBarLogger;
 use Infection\Logger\MutationAnalysis\MutationAnalysisLogger;
 use Infection\Logger\MutationAnalysis\MutationAnalysisLoggerName;
 use Infection\Logger\MutationAnalysis\TeamCity\MessageName;
-use Infection\Metrics\MetricsCalculator;
 use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutator\Definition;
 use Infection\Mutator\Mutator;
@@ -84,9 +80,7 @@ use Infection\Mutator\NodeMutationGenerator;
 use Infection\PhpParser\InfectionPrettyPrinter;
 use Infection\PhpParser\Visitor\NameResolverFactory;
 use Infection\Process\Runner\IndexedMutantProcessContainer;
-use Infection\Process\Runner\ParallelProcessRunner;
 use Infection\Reporter\Http\StrykerCurlClient;
-use Infection\Reporter\Http\StrykerDashboardClient;
 use Infection\Resource\Processor\CpuCoresCountProvider;
 use Infection\Source\Collector\FakeSourceCollector;
 use Infection\Source\Collector\FixedSourceCollector;
@@ -101,7 +95,6 @@ use Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound;
 use Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound;
 use Infection\TestFramework\MapSourceClassToTestStrategy;
 use Infection\TestFramework\PhpUnit\CommandLine\FilterBuilder;
-use Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder as PhpUnitMutationConfigBuilder;
 use Infection\TestFramework\Tracing\Trace\EmptyTrace;
 use Infection\TestFramework\Tracing\Trace\NodeLineRangeData;
 use Infection\TestFramework\Tracing\Trace\SourceMethodLineRange;
@@ -189,21 +182,6 @@ final class ProjectCodeProvider
      */
     public const array CONCRETE_CLASSES_WITH_TESTS_IN_DIFFERENT_LOCATION = [
         FilterBuilder::class,
-    ];
-
-    /**
-     * This array contains all classes that are not extension points, but not final due to legacy
-     * reasons. This list should never be added to, only removed from.
-     */
-    public const array NON_FINAL_EXTENSION_CLASSES = [
-        ConsoleHelper::class,
-        FileSystem::class,
-        MetricsCalculator::class,
-        PhpUnitMutationConfigBuilder::class,
-        SourceDirGuesser::class,
-        StrykerDashboardClient::class,
-        TestFrameworkFinder::class,
-        ParallelProcessRunner::class,
     ];
 
     /**
@@ -329,13 +307,6 @@ final class ProjectCodeProvider
             ...self::NON_TESTED_CONCRETE_CLASSES,
             ...self::CONCRETE_CLASSES_WITH_TESTS_IN_DIFFERENT_LOCATION,
         ]);
-    }
-
-    public static function nonFinalExtensionClasses(): iterable
-    {
-        yield from DataProviderFactory::fromIterable(
-            self::NON_FINAL_EXTENSION_CLASSES,
-        );
     }
 
     private static function castSplFileInfoToFQCN(SplFileInfo $file): string

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php
@@ -101,21 +101,4 @@ final class ProjectCodeProviderTest extends TestCase
             ),
         );
     }
-
-    #[DataProviderExternal(ProjectCodeProvider::class, 'nonFinalExtensionClasses')]
-    public function test_non_final_extension_classes_provider_is_valid(string $className): void
-    {
-        $this->assertTrue(
-            class_exists($className, true)
-            || interface_exists($className, true)
-            || trait_exists($className, true),
-            sprintf(
-                'The "%s" class was picked up by the test files finder, but it is not a class,'
-                . ' interface or trait. Please check for typos in the class name. If the '
-                . ' class no longer exists, remove it from %s::NON_FINAL_EXTENSION_CLASSES.',
-                $className,
-                ProjectCodeProvider::class,
-            ),
-        );
-    }
 }

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
@@ -36,13 +36,10 @@ declare(strict_types=1);
 namespace Infection\Tests\AutoReview\ProjectCode;
 
 use function array_filter;
-use function array_flip;
-use function array_key_exists;
 use function array_map;
 use function in_array;
 use Infection\Framework\ClassName;
 use Infection\StreamWrapper\IncludeInterceptor;
-use Infection\Testing\SingletonContainer;
 use function is_executable;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
@@ -150,48 +147,6 @@ final class ProjectCodeTest extends TestCase
                 ProjectCodeProvider::class,
             ),
         );
-    }
-
-    #[DataProviderExternal(ProjectCodeProvider::class, 'sourceClassesProvider')]
-    public function test_non_extension_points_are_traits_interfaces_abstracts_or_finals(string $className): void
-    {
-        $reflectionClass = new ReflectionClass($className);
-
-        $tagsAsKeys = array_flip(
-            SingletonContainer::getPHPDocParser()->parse(
-                (string) $reflectionClass->getDocComment(),
-            ),
-        );
-
-        $pass = $reflectionClass->isTrait()
-            || $reflectionClass->isInterface()
-            || $reflectionClass->isAbstract()
-            || $reflectionClass->isFinal()
-            || array_key_exists('@final', $tagsAsKeys)
-        ;
-
-        if (in_array($className, ProjectCodeProvider::NON_FINAL_EXTENSION_CLASSES, true)) {
-            $this->assertFalse(
-                $pass,
-                sprintf(
-                    'The class "%s" is registered to "%s::NON_FINAL_EXTENSION_CLASSES but '
-                    . 'this should not be necessary.',
-                    $className,
-                    ProjectCodeProvider::class,
-                ),
-            );
-        } else {
-            $this->assertTrue(
-                $pass,
-                sprintf(
-                    'Expected the class "%s" to be a trait, an interface, an abstract or final '
-                    . 'class. Either fix it or if it is an extension point, add it to '
-                    . '%s::NON_FINAL_EXTENSION_CLASSES.',
-                    $className,
-                    ProjectCodeProvider::class,
-                ),
-            );
-        }
     }
 
     #[DataProviderExternal(ProjectCodeProvider::class, 'sourceClassesToCheckForPublicPropertiesProvider')]


### PR DESCRIPTION
## Description

Move the source-class finality policy from PHPUnit auto-review checks to [PHPat](https://www.phpat.dev/).

With #3228, this now makes  `ProjectCodeTest::test_non_extension_points_are_traits_interfaces_abstracts_or_finals()` completely redundant.

## Changes

- Renames `InterfaceImplementationsShouldBeFinalTest` to `ClassesShouldBeFinalTest` to better reflect the new rules it enforces.
- Adds a PHPat rule requiring concrete source classes to be final or `@final`.
- Moves legacy non-final class exceptions to the PHPStan baseline to avoid any source code change.
- Removes `ProjectCodeTest::test_non_extension_points_are_traits_interfaces_abstracts_or_finals()` and `ProjectCodeProvider::NON_FINAL_EXTENSION_CLASSES` and its provider validation test. 
- Removes the now-unused `SingletonContainer::getPHPDocParser()` helper.