### PR TITLE
refactor(autoreview): Move extension-point architecture checks to PHPat

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -5595,12 +5595,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "imprecise-type"
-message = "Type `iterable` in return type of `sourceClassesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
-code = "imprecise-type"
 message = "Type `iterable` in return type of `sourceClassesToCheckForPublicPropertiesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
@@ -5631,7 +5625,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
 code = "unhandled-thrown-type"
-message = "Potentially unhandled exception `ReflectionException` in `{closure:tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php:273:13}`."
+message = "Potentially unhandled exception `ReflectionException` in `{closure:tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php:266:13}`."
 count = 1
 
 [[issues]]
@@ -5656,19 +5650,13 @@ count = 1
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
-count = 2
+count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
 code = "redundant-comparison"
 message = "Avoid direct comparison with boolean literals."
 count = 3
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest::test_non_extension_points_are_internal`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php"

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -553,6 +553,12 @@ parameters:
 			path: ../src/Testing/BaseMutatorTestCase.php
 
 		-
+			rawMessage: Infection\Testing\BaseMutatorTestCase should not exist
+			identifier: phpat.testExtensionPointsHaveDocBlock
+			count: 1
+			path: ../src/Testing/BaseMutatorTestCase.php
+
+		-
 			rawMessage: 'Parameter #1 $objectOrClass of class ReflectionClass constructor expects class-string<T of object>|T of object, string given.'
 			identifier: argument.type
 			count: 1
@@ -717,7 +723,7 @@ parameters:
 		-
 			rawMessage: 'Parameter #1 $objectOrClass of class ReflectionClass constructor expects class-string<T of object>|T of object, string given.'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
 
 		-

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -18,6 +18,14 @@ services:
         class: Infection\Tests\Architecture\PHPat\ClassesShouldBeFinalTest
         tags:
             - phpat.test
+    -
+        class: Infection\Tests\Architecture\PHPat\SourceClassesShouldBeInternalTest
+        tags:
+            - phpat.test
+    -
+        class: Infection\Tests\Architecture\PHPat\ExtensionPointsShouldHaveDocBlockTest
+        tags:
+            - phpat.test
 
 parameters:
     tmpDir: ../var/cache/phpstan

--- a/tests/Architecture/PHPat/ExtensionPointsShouldHaveDocBlockTest.php
+++ b/tests/Architecture/PHPat/ExtensionPointsShouldHaveDocBlockTest.php
@@ -33,57 +33,30 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
+use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
 use PHPat\Selector\Selector;
-use PHPat\Selector\SelectorInterface;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
 
-final class InfectionSelector
+final class ExtensionPointsShouldHaveDocBlockTest
 {
-    use CannotBeInstantiated;
-
-    public static function code(): InfectionCode
+    public function testExtensionPointsHaveDocBlock(): Rule
     {
-        return new InfectionCode();
-    }
-
-    public static function sourceCode(): InfectionSourceCode
-    {
-        return new InfectionSourceCode();
-    }
-
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
-
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
-        );
-    }
-
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
-
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
+        return PHPat::rule()
+            ->classes(
+                Selector::AllOf(
+                    InfectionSelector::sourceCode(),
+                    Selector::Not(InfectionSelector::hasDocBlock()),
+                    Selector::Not(InfectionSelector::hasInternalDocBlock()),
+                ),
+            )
+            ->excluding(
+                InfectionSelector::isAnonymousClass(),
+            )
+            ->shouldNot()
+            ->exist()
+            ->because('Extension points should have a PHP doc-block to improve usability.');
     }
 }

--- a/tests/Architecture/PHPat/ExtensionPointsShouldHaveDocBlockTest.php
+++ b/tests/Architecture/PHPat/ExtensionPointsShouldHaveDocBlockTest.php
@@ -47,9 +47,8 @@ final class ExtensionPointsShouldHaveDocBlockTest
         return PHPat::rule()
             ->classes(
                 Selector::AllOf(
-                    InfectionSelector::sourceCode(),
+                    InfectionSelector::extensionPoint(),
                     Selector::Not(InfectionSelector::hasDocBlock()),
-                    Selector::Not(InfectionSelector::hasInternalDocBlock()),
                 ),
             )
             ->excluding(

--- a/tests/Architecture/PHPat/Selector/ExtensionPoint.php
+++ b/tests/Architecture/PHPat/Selector/ExtensionPoint.php
@@ -35,60 +35,24 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
-use PHPat\Selector\Selector;
+use function in_array;
+use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
 use PHPat\Selector\SelectorInterface;
+use PHPStan\Reflection\ClassReflection;
 
-final class InfectionSelector
+final class ExtensionPoint implements SelectorInterface
 {
-    use CannotBeInstantiated;
-
-    public static function code(): InfectionCode
+    public function getName(): string
     {
-        return new InfectionCode();
+        return 'Infection extension point';
     }
 
-    public static function sourceCode(): InfectionSourceCode
+    public function matches(ClassReflection $classReflection): bool
     {
-        return new InfectionSourceCode();
-    }
-
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
-
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
+        return in_array(
+            ClassReflectionAccessor::getName($classReflection),
+            ProjectCodeProvider::EXTENSION_POINTS,
+            true,
         );
-    }
-
-    public static function extensionPoint(): ExtensionPoint
-    {
-        return new ExtensionPoint();
-    }
-
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
-
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
     }
 }

--- a/tests/Architecture/PHPat/Selector/HasDocBlock.php
+++ b/tests/Architecture/PHPat/Selector/HasDocBlock.php
@@ -35,55 +35,22 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
-use PHPat\Selector\Selector;
 use PHPat\Selector\SelectorInterface;
+use PHPStan\Reflection\ClassReflection;
+use function trim;
 
-final class InfectionSelector
+final class HasDocBlock implements SelectorInterface
 {
-    use CannotBeInstantiated;
-
-    public static function code(): InfectionCode
+    public function getName(): string
     {
-        return new InfectionCode();
+        return 'has a PHP doc-block';
     }
 
-    public static function sourceCode(): InfectionSourceCode
+    public function matches(ClassReflection $classReflection): bool
     {
-        return new InfectionSourceCode();
-    }
+        $docComment = $classReflection->getNativeReflection()->getDocComment();
 
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
-
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
-        );
-    }
-
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
-
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
+        return $docComment !== false
+            && trim($docComment) !== '';
     }
 }

--- a/tests/Architecture/PHPat/Selector/HasInternalDocBlock.php
+++ b/tests/Architecture/PHPat/Selector/HasInternalDocBlock.php
@@ -35,55 +35,22 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
-use PHPat\Selector\Selector;
 use PHPat\Selector\SelectorInterface;
+use PHPStan\Reflection\ClassReflection;
+use function str_contains;
 
-final class InfectionSelector
+final class HasInternalDocBlock implements SelectorInterface
 {
-    use CannotBeInstantiated;
-
-    public static function code(): InfectionCode
+    public function getName(): string
     {
-        return new InfectionCode();
+        return 'has an @internal PHP doc-block';
     }
 
-    public static function sourceCode(): InfectionSourceCode
+    public function matches(ClassReflection $classReflection): bool
     {
-        return new InfectionSourceCode();
-    }
+        $docComment = $classReflection->getNativeReflection()->getDocComment();
 
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
-
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
-        );
-    }
-
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
-
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
+        return $docComment !== false
+            && str_contains($docComment, '@internal');
     }
 }

--- a/tests/Architecture/PHPat/SourceClassesShouldBeInternalTest.php
+++ b/tests/Architecture/PHPat/SourceClassesShouldBeInternalTest.php
@@ -35,14 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat;
 
-use function array_map;
-use function implode;
 use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
-use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
 use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
-use function preg_quote;
 
 final class SourceClassesShouldBeInternalTest
 {
@@ -56,7 +52,7 @@ final class SourceClassesShouldBeInternalTest
                 ),
             )
             ->excluding(
-                Selector::classname($this->extensionPointsRegex(), true),
+                InfectionSelector::extensionPoint(),
             )
             ->shouldNot()
             ->exist()
@@ -68,28 +64,12 @@ final class SourceClassesShouldBeInternalTest
         return PHPat::rule()
             ->classes(
                 Selector::AllOf(
-                    Selector::classname($this->extensionPointsRegex(), true),
+                    InfectionSelector::extensionPoint(),
                     InfectionSelector::hasInternalDocBlock(),
                 ),
             )
             ->shouldNot()
             ->exist()
             ->because('Extension points should not be tagged @internal.');
-    }
-
-    /**
-     * @return non-empty-string
-     */
-    private function extensionPointsRegex(): string
-    {
-        return '#^('
-            . implode(
-                '|',
-                array_map(
-                    static fn (string $className): string => preg_quote($className, '#'),
-                    ProjectCodeProvider::EXTENSION_POINTS,
-                ),
-            )
-            . ')$#';
     }
 }

--- a/tests/Architecture/PHPat/SourceClassesShouldBeInternalTest.php
+++ b/tests/Architecture/PHPat/SourceClassesShouldBeInternalTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Architecture\PHPat;
+
+use function array_map;
+use function implode;
+use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
+use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+use function preg_quote;
+
+final class SourceClassesShouldBeInternalTest
+{
+    public function testNonExtensionPointsAreInternal(): Rule
+    {
+        return PHPat::rule()
+            ->classes(
+                Selector::AllOf(
+                    InfectionSelector::sourceCode(),
+                    Selector::Not(InfectionSelector::hasInternalDocBlock()),
+                ),
+            )
+            ->excluding(
+                Selector::classname($this->extensionPointsRegex(), true),
+            )
+            ->shouldNot()
+            ->exist()
+            ->because('Source classes should be marked @internal unless they are extension points.');
+    }
+
+    public function testExtensionPointsAreNotInternal(): Rule
+    {
+        return PHPat::rule()
+            ->classes(
+                Selector::AllOf(
+                    Selector::classname($this->extensionPointsRegex(), true),
+                    InfectionSelector::hasInternalDocBlock(),
+                ),
+            )
+            ->shouldNot()
+            ->exist()
+            ->because('Extension points should not be tagged @internal.');
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private function extensionPointsRegex(): string
+    {
+        return '#^('
+            . implode(
+                '|',
+                array_map(
+                    static fn (string $className): string => preg_quote($className, '#'),
+                    ProjectCodeProvider::EXTENSION_POINTS,
+                ),
+            )
+            . ')$#';
+    }
+}

--- a/tests/phpunit/Architecture/PHPat/Selector/ExtensionPointTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/ExtensionPointTest.php
@@ -35,60 +35,62 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
-use PHPat\Selector\Selector;
+use Infection\Engine;
+use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
 use PHPat\Selector\SelectorInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 
-final class InfectionSelector
+#[CoversClass(ExtensionPoint::class)]
+final class ExtensionPointTest extends SelectorTestCase
 {
-    use CannotBeInstantiated;
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('classProvider')]
+    public function test_it_matches_extension_points(
+        string $className,
+        bool $expected,
+    ): void {
+        $selector = new ExtensionPoint();
+        $classReflection = $this->createClassReflection($className);
 
-    public static function code(): InfectionCode
-    {
-        return new InfectionCode();
+        $actual = $selector->matches($classReflection);
+
+        $this->assertSame($expected, $actual);
     }
 
-    public static function sourceCode(): InfectionSourceCode
+    public static function classProvider(): iterable
     {
-        return new InfectionSourceCode();
-    }
+        yield 'extension point' => [
+            ProjectCodeProvider::EXTENSION_POINTS[0],
+            true,
+        ];
 
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
+        yield 'source class' => [
+            Engine::class,
+            false,
+        ];
 
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
-        );
-    }
+        yield 'architecture test class' => [
+            self::class,
+            false,
+        ];
 
-    public static function extensionPoint(): ExtensionPoint
-    {
-        return new ExtensionPoint();
-    }
+        yield 'project code provider' => [
+            ProjectCodeProvider::class,
+            false,
+        ];
 
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
+        yield 'vendor class' => [
+            TestCase::class,
+            false,
+        ];
 
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
+        yield 'phpat selector interface' => [
+            SelectorInterface::class,
+            false,
+        ];
     }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/HasDocBlock/ClassWithComment.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/HasDocBlock/ClassWithComment.php
@@ -33,57 +33,9 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\HasDocBlock;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
-use PHPat\Selector\Selector;
-use PHPat\Selector\SelectorInterface;
-
-final class InfectionSelector
+// Comment.
+final class ClassWithComment
 {
-    use CannotBeInstantiated;
-
-    public static function code(): InfectionCode
-    {
-        return new InfectionCode();
-    }
-
-    public static function sourceCode(): InfectionSourceCode
-    {
-        return new InfectionSourceCode();
-    }
-
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
-
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
-        );
-    }
-
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
-
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
-    }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/HasDocBlock/ClassWithDocBlock.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/HasDocBlock/ClassWithDocBlock.php
@@ -33,57 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\HasDocBlock;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
-use PHPat\Selector\Selector;
-use PHPat\Selector\SelectorInterface;
-
-final class InfectionSelector
+/**
+ * PHPDoc block.
+ */
+final class ClassWithDocBlock
 {
-    use CannotBeInstantiated;
-
-    public static function code(): InfectionCode
-    {
-        return new InfectionCode();
-    }
-
-    public static function sourceCode(): InfectionSourceCode
-    {
-        return new InfectionSourceCode();
-    }
-
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
-
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
-        );
-    }
-
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
-
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
-    }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/HasDocBlock/ClassWithoutDocBlockOrComment.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/HasDocBlock/ClassWithoutDocBlockOrComment.php
@@ -33,57 +33,8 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\HasDocBlock;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
-use PHPat\Selector\Selector;
-use PHPat\Selector\SelectorInterface;
-
-final class InfectionSelector
+final class ClassWithoutDocBlockOrComment
 {
-    use CannotBeInstantiated;
-
-    public static function code(): InfectionCode
-    {
-        return new InfectionCode();
-    }
-
-    public static function sourceCode(): InfectionSourceCode
-    {
-        return new InfectionSourceCode();
-    }
-
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
-
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
-        );
-    }
-
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
-
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
-    }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/HasDocBlock/HasDocBlockTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/HasDocBlock/HasDocBlockTest.php
@@ -33,57 +33,47 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\HasDocBlock;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
-use PHPat\Selector\Selector;
-use PHPat\Selector\SelectorInterface;
+use Infection\Tests\Architecture\PHPat\Selector\HasDocBlock;
+use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-final class InfectionSelector
+#[CoversClass(HasDocBlock::class)]
+final class HasDocBlockTest extends SelectorTestCase
 {
-    use CannotBeInstantiated;
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('classProvider')]
+    public function test_it_matches_classes_with_doc_blocks(
+        string $className,
+        bool $expected,
+    ): void {
+        $selector = new HasDocBlock();
+        $classReflection = $this->createClassReflection($className);
 
-    public static function code(): InfectionCode
-    {
-        return new InfectionCode();
+        $actual = $selector->matches($classReflection);
+
+        $this->assertSame($expected, $actual);
     }
 
-    public static function sourceCode(): InfectionSourceCode
+    public static function classProvider(): iterable
     {
-        return new InfectionSourceCode();
-    }
+        yield 'with docblock' => [
+            ClassWithDocBlock::class,
+            true,
+        ];
 
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
+        yield 'with comment' => [
+            ClassWithComment::class,
+            false,
+        ];
 
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
-        );
-    }
-
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
-
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
+        yield 'without docblock or comment' => [
+            ClassWithoutDocBlockOrComment::class,
+            false,
+        ];
     }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/HasInternalDocBlock/HasInternalDocBlockTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/HasInternalDocBlock/HasInternalDocBlockTest.php
@@ -33,57 +33,42 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\HasInternalDocBlock;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
-use PHPat\Selector\Selector;
-use PHPat\Selector\SelectorInterface;
+use Infection\Tests\Architecture\PHPat\Selector\HasInternalDocBlock;
+use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-final class InfectionSelector
+#[CoversClass(HasInternalDocBlock::class)]
+final class HasInternalDocBlockTest extends SelectorTestCase
 {
-    use CannotBeInstantiated;
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('classProvider')]
+    public function test_it_matches_classes_with_internal_doc_blocks(
+        string $className,
+        bool $expected,
+    ): void {
+        $selector = new HasInternalDocBlock();
+        $classReflection = $this->createClassReflection($className);
 
-    public static function code(): InfectionCode
-    {
-        return new InfectionCode();
+        $actual = $selector->matches($classReflection);
+
+        $this->assertSame($expected, $actual);
     }
 
-    public static function sourceCode(): InfectionSourceCode
+    public static function classProvider(): iterable
     {
-        return new InfectionSourceCode();
-    }
+        yield 'with internal docblock' => [
+            HasInternalDocBlockTestFixtureWithInternalDocBlock::class,
+            true,
+        ];
 
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
-
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
-        );
-    }
-
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
-
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
+        yield 'without internal docblock' => [
+            HasInternalDocBlockTestFixtureWithoutInternalDocBlock::class,
+            false,
+        ];
     }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/HasInternalDocBlock/HasInternalDocBlockTestFixtureWithInternalDocBlock.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/HasInternalDocBlock/HasInternalDocBlockTestFixtureWithInternalDocBlock.php
@@ -33,57 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\HasInternalDocBlock;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
-use PHPat\Selector\Selector;
-use PHPat\Selector\SelectorInterface;
-
-final class InfectionSelector
+/**
+ * @internal
+ */
+final class HasInternalDocBlockTestFixtureWithInternalDocBlock
 {
-    use CannotBeInstantiated;
-
-    public static function code(): InfectionCode
-    {
-        return new InfectionCode();
-    }
-
-    public static function sourceCode(): InfectionSourceCode
-    {
-        return new InfectionSourceCode();
-    }
-
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
-
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
-        );
-    }
-
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
-
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
-    }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/HasInternalDocBlock/HasInternalDocBlockTestFixtureWithoutInternalDocBlock.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/HasInternalDocBlock/HasInternalDocBlockTestFixtureWithoutInternalDocBlock.php
@@ -33,57 +33,11 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\HasInternalDocBlock;
 
-use Infection\CannotBeInstantiated;
-use PHPat\Selector\ClassImplements;
-use PHPat\Selector\Selector;
-use PHPat\Selector\SelectorInterface;
-
-final class InfectionSelector
+/**
+ * Fixture docblock.
+ */
+final class HasInternalDocBlockTestFixtureWithoutInternalDocBlock
 {
-    use CannotBeInstantiated;
-
-    public static function code(): InfectionCode
-    {
-        return new InfectionCode();
-    }
-
-    public static function sourceCode(): InfectionSourceCode
-    {
-        return new InfectionSourceCode();
-    }
-
-    public static function testCode(): InfectionTestCode
-    {
-        return new InfectionTestCode();
-    }
-
-    public static function phpunitTestCode(): SelectorInterface
-    {
-        return Selector::AllOf(
-            self::testCode(),
-            Selector::withFilepath('#/tests/phpunit/#', true),
-        );
-    }
-
-    public static function hasDocBlock(): HasDocBlock
-    {
-        return new HasDocBlock();
-    }
-
-    public static function hasInternalDocBlock(): HasInternalDocBlock
-    {
-        return new HasInternalDocBlock();
-    }
-
-    public static function isAnonymousClass(): IsAnonymousClass
-    {
-        return new IsAnonymousClass();
-    }
-
-    public static function implementsAnyInterface(): ClassImplements
-    {
-        return Selector::implements('/.*/', true);
-    }
 }

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
@@ -235,13 +235,6 @@ final class ProjectCodeProvider
         yield from self::$sourceClasses;
     }
 
-    public static function sourceClassesProvider(): iterable
-    {
-        yield from DataProviderFactory::fromIterable(
-            self::provideSourceClasses(),
-        );
-    }
-
     public static function provideConcreteSourceClasses(): iterable
     {
         yield from ConcreteClassReflector::filterByConcreteClasses(iterator_to_array(

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\AutoReview\ProjectCode;
 
 use function class_exists;
-use function interface_exists;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\TestCase;
@@ -46,24 +45,6 @@ use function trait_exists;
 #[CoversClass(ProjectCodeProvider::class)]
 final class ProjectCodeProviderTest extends TestCase
 {
-    #[DataProviderExternal(ProjectCodeProvider::class, 'sourceClassesProvider')]
-    public function test_source_class_provider_is_valid(string $className): void
-    {
-        $this->assertTrue(
-            class_exists($className, true)
-            || interface_exists($className, true)
-            || trait_exists($className, true),
-            sprintf(
-                'The "%s" class was picked up by the source files finder, but it is not a '
-                . 'class, interface or trait. Please check for typos in the class name. If the '
-                . ' problematic file is not a class file declaration, add it to the list of '
-                . 'excluded files in %s::provideSourceClasses().',
-                $className,
-                ProjectCodeProvider::class,
-            ),
-        );
-    }
-
     #[DataProviderExternal(ProjectCodeProvider::class, 'concreteSourceClassesProvider')]
     public function test_concrete_class_provider_is_valid(string $className): void
     {

--- a/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
+++ b/tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
@@ -105,50 +105,6 @@ final class ProjectCodeTest extends TestCase
         ));
     }
 
-    #[DataProviderExternal(ProjectCodeProvider::class, 'sourceClassesProvider')]
-    public function test_non_extension_points_are_internal(string $className): void
-    {
-        $reflectionClass = new ReflectionClass($className);
-
-        $docBlock = DocBlockParser::parse((string) $reflectionClass->getDocComment());
-
-        if (in_array($className, ProjectCodeProvider::EXTENSION_POINTS, true)) {
-            if ($docBlock === '') {
-                $this->markTestSkipped(
-                    sprintf(
-                        'The "%s" class is an extension point, but does not have a PHP '
-                        . 'doc-block or an empty one. Consider adding one to improve usability.',
-                        $className,
-                    ),
-                );
-            }
-
-            $this->assertStringNotContainsString(
-                '@internal',
-                $docBlock,
-                sprintf(
-                    'The "%s" class is marked as an extension point in %s::EXTENSION_POINTS'
-                    . '; It should either not be tagged as "@internal" or not be listed there.',
-                    $className,
-                    ProjectCodeProvider::class,
-                ),
-            );
-
-            return;
-        }
-
-        $this->assertStringContainsString(
-            '@internal',
-            $docBlock,
-            sprintf(
-                'The "%s" class is not an extension point: it should be marked as internal'
-                . ' or listed as an extension point in %s::EXTENSION_POINTS.',
-                $className,
-                ProjectCodeProvider::class,
-            ),
-        );
-    }
-
     #[DataProviderExternal(ProjectCodeProvider::class, 'sourceClassesToCheckForPublicPropertiesProvider')]
     public function test_source_classes_do_not_expose_public_properties(string $className): void
     {


### PR DESCRIPTION
## Description

This PR moves the source-class extension-point checks from the PHPUnit AutoReview test into PHPat architecture tests.

## Changes

- Adds PHPat rules asserting that non-extension-point source classes are marked `@internal`, and that extension points are not marked `@internal`.
- Adds a PHPat rule requiring extension points to have a PHP doc-block.
- Introduces reusable PHPat selectors for extension points, PHP doc-blocks, and `@internal` doc-blocks.
- Registers the new PHPat rules in the PHPStan configuration and updates the PHPStan baseline for the current violations.
- Removes the equivalent extension-point/internal-source assertion from `ProjectCodeTest`.
- Adds PHPUnit coverage for the new PHPat selectors and their fixtures.

