### PR TITLE
refactor(autoreview): Move ExtensionPoint to another location

### DIFF
--- a/tests/Architecture/PHPat/Selector/InfectionSelector.php
+++ b/tests/Architecture/PHPat/Selector/InfectionSelector.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
 use Infection\CannotBeInstantiated;
+use Infection\Tests\Architecture\PHPat\Selector\Support\ExtensionPoint;
 use PHPat\Selector\ClassImplements;
 use PHPat\Selector\Selector;
 use PHPat\Selector\SelectorInterface;

--- a/tests/Architecture/PHPat/Selector/Support/ExtensionPoint.php
+++ b/tests/Architecture/PHPat/Selector/Support/ExtensionPoint.php
@@ -33,7 +33,7 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\Support;
 
 use function in_array;
 use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/ExtensionPointTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/ExtensionPointTest.php
@@ -33,9 +33,10 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\Support;
 
 use Infection\Engine;
+use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
 use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
 use PHPat\Selector\SelectorInterface;
 use PHPUnit\Framework\Attributes\CoversClass;


### PR DESCRIPTION
There will be more such utilities in the future and I would like to keep the top level of `Selector/` about selectors.