### PR TITLE
deps: upgrade PHP CS Fixer to version supporting PHP 8.5

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -80,7 +80,6 @@ return (new Config())
     ->setRules([
         '@PHP7x1Migration' => true,
         '@PHP7x1Migration:risky' => true,
-        '@PHPUnit6x0Migration:risky' => true,
         '@PHPUnit7x5Migration:risky' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BOX=./.tools/box
 BOX_URL="https://github.com/humbug/box/releases/download/4.5.1/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
-PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.89.2/php-cs-fixer.phar"
+PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.92.5/php-cs-fixer.phar"
 
 PHPSTAN=./vendor/bin/phpstan
 MAGO=./vendor/bin/mago

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ cs-docker: $(DOCKER_FILE_IMAGE) $(PHP_CS_FIXER)
 .PHONY: cs-check
 cs-check:		## Runs PHP-CS-Fixer in dry-run mode
 cs-check: $(PHP_CS_FIXER)
-	$(PHP_CS_FIXER) fix -v --diff --dry-run
+	$(PHP_CS_FIXER) check -v --diff
 	LC_ALL=C sort -c -u .gitignore
 	$(MAKE) check_trailing_whitespaces
 


### PR DESCRIPTION
## Description

deps: upgrade PHP CS Fixer to version supporting PHP 8.5

## Changes

Fixer version, minor config grooming

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (provide link to PR: https://github.com/infection/site/pull/XXX)
- [ ] CHANGELOG.md updated (if deprecations/breaking changes)
- [ ] Appropriate labels applied (e.g. `performance`, `feature`).

^^ none, but happy to add if you do it for deps upgrade

## Breaking Changes

none