### PR TITLE
Allow installing the latest symfony packages during tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
         php-version: [ '8.3', '8.4', '8.5' ]
         dependencies: [ locked, lowest, highest ]
         coverage-driver: [ pcov, xdebug ]
-        symfony-version: [ '6.4.*', '7.*.*', '8.0.*' ]
+        symfony-version: [ '6.4.*', '7.*.*', '8.*.*' ]
         include:
           - operating-system: windows-latest
             php-version: '8.3'
@@ -41,7 +41,7 @@ jobs:
           - dependencies: 'locked'
             symfony-version: '7.*.*'
           - php-version: '8.3'
-            symfony-version: '8.0.*'
+            symfony-version: '8.*.*'
 
     name: Tests on ${{ matrix.operating-system }} with PHP ${{ matrix.php-version }} (${{ matrix.dependencies }}; Symfony ${{ matrix.symfony-version }}), using ${{ matrix.coverage-driver }}
 

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "nikic/php-parser": "^5.6.2",
         "ondram/ci-detector": "^4.1.0",
         "psr/log": "^2.0 || ^3.0",
-        "sanmai/di-container": "^0.1.15",
+        "sanmai/di-container": "^0.1.16",
         "sanmai/duoclock": "^0.1.0",
         "sanmai/later": "^0.1.7",
         "sanmai/pipeline": "^7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9138a8466c454a43bc10d151b01db7eb",
+    "content-hash": "ddf82b7422ecc6d0567d1d56f2a43f8d",
     "packages": [
         {
             "name": "colinodell/json5",
@@ -961,16 +961,16 @@
         },
         {
             "name": "sanmai/di-container",
-            "version": "0.1.15",
+            "version": "0.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sanmai/di-container.git",
-                "reference": "6fdff5805fb07f01898b3c33b6c53f0f6a1cc110"
+                "reference": "8b8a8859e992297259b220a92179439f9d185838"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sanmai/di-container/zipball/6fdff5805fb07f01898b3c33b6c53f0f6a1cc110",
-                "reference": "6fdff5805fb07f01898b3c33b6c53f0f6a1cc110",
+                "url": "https://api.github.com/repos/sanmai/di-container/zipball/8b8a8859e992297259b220a92179439f9d185838",
+                "reference": "8b8a8859e992297259b220a92179439f9d185838",
                 "shasum": ""
             },
             "require": {
@@ -1028,7 +1028,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sanmai/di-container/issues",
-                "source": "https://github.com/sanmai/di-container/tree/0.1.15"
+                "source": "https://github.com/sanmai/di-container/tree/0.1.16"
             },
             "funding": [
                 {
@@ -1036,7 +1036,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-30T08:52:45+00:00"
+            "time": "2026-05-30T11:27:18+00:00"
         },
         {
             "name": "sanmai/duoclock",


### PR DESCRIPTION
This should find issues like https://github.com/infection/infection/issues/3243 reproduced for Syfmony 8.1 `symfony/console` package.

- [x] ~Now the build should pass as sanmai already provided a fix: https://github.com/sanmai/di-container/releases/tag/0.1.13~ 
  - Actually this build confirms it's still fails
  - 0.1.14 doesn't fix this as well
- [x] waiting for the fix to make the build green (should fix  #3243)


Failed build: https://github.com/infection/infection/actions/runs/26676882874/job/78630265564?pr=3244#step:14:20

```

1) Infection\Tests\Container\ContainerTest::test_it_can_provide_all_services with data set "getAdapterInstallationDecider" ('Infection\TestFramework\Adapt...ecider', 'getAdapterInstallationDecider', Infection\Container\Container Object (), Infection\Tests\Reflection\ContainerReflection Object (...))
ReflectionException: Class "Symfony\Contracts\EventDispatcher\EventDispatcherInterface" does not exist

/home/runner/work/infection/infection/vendor/sanmai/di-container/src/Container.php:260
/home/runner/work/infection/infection/vendor/sanmai/pipeline/src/Standard.php:430
/home/runner/work/infection/infection/vendor/sanmai/pipeline/src/Standard.php:750
/home/runner/work/infection/infection/vendor/sanmai/di-container/src/Container.php:221
/home/runner/work/infection/infection/vendor/sanmai/di-container/src/Container.php:191
/home/runner/work/infection/infection/vendor/sanmai/di-container/src/Container.php:261
/home/runner/work/infection/infection/vendor/sanmai/pipeline/src/Standard.php:430
/home/runner/work/infection/infection/vendor/sanmai/pipeline/src/Standard.php:750
/home/runner/work/infection/infection/vendor/sanmai/di-container/src/Container.php:221
/home/runner/work/infection/infection/vendor/sanmai/di-container/src/Container.php:191
/home/runner/work/infection/infection/src/Container/Container.php:1006
/home/runner/work/infection/infection/tests/phpunit/Container/ContainerTest.php:202
```
