### PR TITLE
Add docker services for PHP 8.4, 8.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,22 @@ services:
         XDEBUG_VERSION: '3.4.1'
     volumes:
       - .:/opt/infection
+
+  php84:
+    build:
+      context: devTools
+      args:
+        PHP_VERSION: '8.4'
+        XDEBUG_VERSION: '3.4.0'
+    volumes:
+      - .:/opt/infection
+
+  php85:
+    build:
+      context: devTools
+      args:
+        PHP_VERSION: '8.5'
+        XDEBUG_VERSION: '3.5.1'
+    volumes:
+      - .:/opt/infection
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,22 +17,3 @@ services:
         XDEBUG_VERSION: '3.4.1'
     volumes:
       - .:/opt/infection
-
-  php84:
-    build:
-      context: devTools
-      args:
-        PHP_VERSION: '8.4'
-        XDEBUG_VERSION: '3.4.0'
-    volumes:
-      - .:/opt/infection
-
-  php85:
-    build:
-      context: devTools
-      args:
-        PHP_VERSION: '8.5'
-        XDEBUG_VERSION: '3.5.1'
-    volumes:
-      - .:/opt/infection
-


### PR DESCRIPTION
This is needed to easily run Infection with our supported versions, and to check bugs like https://github.com/infection/infection/issues/3243

