### PR TITLE
refactor(autoreview): Extract a `ConcreteClassReflection` utility

### DIFF
--- a/tests/Architecture/PHPat/Selector/PHPUnitTestSupportConcreteClassWithoutCanonicalTest.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestSupportConcreteClassWithoutCanonicalTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\Architecture\PHPat\Selector;
 
 use function in_array;
 use Infection\Framework\ClassName;
+use Infection\Tests\Architecture\PHPat\Selector\Support\ConcreteClassReflection;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
 use PHPUnit\Framework\TestCase;
@@ -80,7 +81,7 @@ final class PHPUnitTestSupportConcreteClassWithoutCanonicalTest implements Selec
     public function matches(ClassReflection $classReflection): bool
     {
         if (
-            !self::isConcreteClass($classReflection)
+            !ConcreteClassReflection::isConcreteClass($classReflection)
             || InfectionSelector::isAnonymousClass()->matches($classReflection)
             || self::isPHPUnitTestClass($classReflection)
             || self::isKnownPhpUnitDataProviderClass($classReflection)
@@ -94,13 +95,6 @@ final class PHPUnitTestSupportConcreteClassWithoutCanonicalTest implements Selec
         $className = $classReflection->getName();
 
         return ClassName::getCanonicalTestClassName($className) === null;
-    }
-
-    private static function isConcreteClass(ClassReflection $classReflection): bool
-    {
-        return !$classReflection->isAbstract()
-            && !$classReflection->isInterface()
-            && !$classReflection->isTrait();
     }
 
     private static function isPHPUnitTestSupportCode(ClassReflection $classReflection): bool

--- a/tests/Architecture/PHPat/Selector/Support/ConcreteClassReflection.php
+++ b/tests/Architecture/PHPat/Selector/Support/ConcreteClassReflection.php
@@ -33,30 +33,19 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\Support;
 
-use Infection\Framework\ClassName;
-use Infection\Tests\Architecture\PHPat\Selector\Support\ConcreteClassReflection;
-use PHPat\Selector\SelectorInterface;
+use Infection\CannotBeInstantiated;
 use PHPStan\Reflection\ClassReflection;
 
-final class SourceConcreteClassWithoutCanonicalTest implements SelectorInterface
+final class ConcreteClassReflection
 {
-    public function getName(): string
+    use CannotBeInstantiated;
+
+    public static function isConcreteClass(ClassReflection $classReflection): bool
     {
-        return 'source concrete class without canonical test';
-    }
-
-    public function matches(ClassReflection $classReflection): bool
-    {
-        if (!ConcreteClassReflection::isConcreteClass($classReflection)
-            || !InfectionSelector::sourceCode()->matches($classReflection)
-        ) {
-            return false;
-        }
-
-        $className = $classReflection->getName();
-
-        return ClassName::getCanonicalTestClassName($className) === null;
+        return !$classReflection->isAbstract()
+            && !$classReflection->isInterface()
+            && !$classReflection->isTrait();
     }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/ConcreteClassReflectionTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/ConcreteClassReflectionTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Architecture\PHPat\Selector\Support;
+
+use Infection\CannotBeInstantiated;
+use Infection\Command\BaseCommand;
+use Infection\Engine;
+use Infection\Mutator\Mutator;
+use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(ConcreteClassReflection::class)]
+final class ConcreteClassReflectionTest extends SelectorTestCase
+{
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('classProvider')]
+    public function test_it_detects_concrete_classes(
+        string $className,
+        bool $expected,
+    ): void {
+        $classReflection = $this->createClassReflection($className);
+
+        $actual = ConcreteClassReflection::isConcreteClass($classReflection);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function classProvider(): iterable
+    {
+        yield 'concrete class' => [
+            Engine::class,
+            true,
+        ];
+
+        yield 'abstract class' => [
+            BaseCommand::class,
+            false,
+        ];
+
+        yield 'interface' => [
+            Mutator::class,
+            false,
+        ];
+
+        yield 'trait' => [
+            CannotBeInstantiated::class,
+            false,
+        ];
+    }
+}


### PR DESCRIPTION
This piece of code is duplicated and will be used more in future PRs so I am extracting it now.
