### PR TITLE
refactor(sbx): Ignore Docker Sandbox worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /.direnv/
 /.envrc.local
 /.php_cs.cache
+/.sbx/
 /.tools/
 /build/
 /devTools/Docker*.json

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -52,6 +52,7 @@ $finder = Finder::create()
         '.ci',
         '.composer',
         '.github',
+        '.sbx',
         '.tools',
         'build',
         'devTools',


### PR DESCRIPTION
When creating worktrees with Docker Sandbox, it creates them in a `.sbx/` directory.

This PR:

- Adds `.sbx/` to `.gitignore` to not accidentally commit it.
- Adds `.sbx` to the ignored path for PHP-CS-Fixer.

PHPStan, mago and Rector do not scan for `.` hence there is no need to exclude `.sbx/` there.