### PR TITLE
fix(process): Return Composer commands as argv tokens

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -5071,18 +5071,6 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 3
 
 [[issues]]
-file = "tests/benchmark/Tracing/profile.php"
-code = "redundant-docblock-type"
-message = "Redundant docblock type for variable `$maxTraceCount`."
-count = 1
-
-[[issues]]
-file = "tests/benchmark/Tracing/profile.php"
-code = "redundant-docblock-type"
-message = "Redundant docblock type for variable `$percentage`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/BuildConfigYmlTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `providesYamlFilesForTesting` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -7342,6 +7330,18 @@ count = 5
 file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
 code = "string-member-selector"
 message = "This member selector uses a non-literal string type (`string`); its specific value cannot be statically determined."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest::createComposerExecutableFixture`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest::createPhpUnitExecutableFixture`.'
 count = 1
 
 [[issues]]

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -229,12 +229,6 @@ parameters:
 			path: ../src/FileSystem/Finder/ConcreteComposerExecutableFinder.php
 
 		-
-			rawMessage: Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.
-			identifier: ternary.shortNotAllowed
-			count: 1
-			path: ../src/FileSystem/Finder/ConcreteComposerExecutableFinder.php
-
-		-
 			rawMessage: Infection\FileSystem\Finder\NonExecutableFinder should not exist
 			identifier: phpat.testConcreteSourceClassesHaveTests
 			count: 1

--- a/src/FileSystem/Finder/ComposerExecutableFinder.php
+++ b/src/FileSystem/Finder/ComposerExecutableFinder.php
@@ -40,5 +40,8 @@ namespace Infection\FileSystem\Finder;
  */
 interface ComposerExecutableFinder
 {
-    public function find(): string;
+    /**
+     * @return list<string>
+     */
+    public function find(): array;
 }

--- a/src/FileSystem/Finder/ConcreteComposerExecutableFinder.php
+++ b/src/FileSystem/Finder/ConcreteComposerExecutableFinder.php
@@ -38,7 +38,6 @@ namespace Infection\FileSystem\Finder;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use function Safe\getcwd;
 use function Safe\realpath;
-use function sprintf;
 use function str_contains;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -48,7 +47,10 @@ use Symfony\Component\Process\PhpExecutableFinder;
  */
 final readonly class ConcreteComposerExecutableFinder implements ComposerExecutableFinder
 {
-    public function find(): string
+    /**
+     * @return list<string>
+     */
+    public function find(): array
     {
         $probable = ['composer', 'composer.phar'];
         $finder = new ExecutableFinder();
@@ -59,7 +61,7 @@ final readonly class ConcreteComposerExecutableFinder implements ComposerExecuta
 
             if ($path !== null) {
                 if (!str_contains($path, '.phar')) {
-                    return $path;
+                    return [$path];
                 }
 
                 return $this->makeExecutable($path);
@@ -80,12 +82,16 @@ final readonly class ConcreteComposerExecutableFinder implements ComposerExecuta
         throw FinderException::composerNotFound();
     }
 
-    private function makeExecutable(string $path): string
+    /**
+     * @return list<string>
+     */
+    private function makeExecutable(string $path): array
     {
-        return sprintf(
-            '%s %s',
-            (new PhpExecutableFinder())->find() ?: 'php',
+        $phpExecutable = (new PhpExecutableFinder())->find();
+
+        return [
+            $phpExecutable === false ? 'php' : $phpExecutable,
             $path,
-        );
+        ];
     }
 }

--- a/src/FileSystem/Finder/MemoizedComposerExecutableFinder.php
+++ b/src/FileSystem/Finder/MemoizedComposerExecutableFinder.php
@@ -43,7 +43,7 @@ use function Later\later;
  */
 final readonly class MemoizedComposerExecutableFinder implements ComposerExecutableFinder
 {
-    /** @var Deferred<string> */
+    /** @var Deferred<list<string>> */
     private Deferred $result;
 
     public function __construct(
@@ -52,7 +52,10 @@ final readonly class MemoizedComposerExecutableFinder implements ComposerExecuta
         $this->result = later(fn () => yield $this->composerExecutableFinder->find());
     }
 
-    public function find(): string
+    /**
+     * @return list<string>
+     */
+    public function find(): array
     {
         return $this->result->get();
     }

--- a/src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php
+++ b/src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php
@@ -111,7 +111,7 @@ class StaticAnalysisToolExecutableFinder
 
         try {
             $process = new Process([
-                $this->findComposer(),
+                ...$this->findComposer(),
                 'config',
                 'bin-dir',
             ]);
@@ -132,7 +132,10 @@ class StaticAnalysisToolExecutableFinder
         }
     }
 
-    private function findComposer(): string
+    /**
+     * @return list<string>
+     */
+    private function findComposer(): array
     {
         return $this->executableFinder->find();
     }

--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -111,7 +111,7 @@ class TestFrameworkFinder
 
         try {
             $process = new Process([
-                $this->findComposer(),
+                ...$this->findComposer(),
                 'config',
                 'bin-dir',
             ]);
@@ -132,7 +132,10 @@ class TestFrameworkFinder
         }
     }
 
-    private function findComposer(): string
+    /**
+     * @return list<string>
+     */
+    private function findComposer(): array
     {
         return $this->executableFinder->find();
     }

--- a/src/TestFramework/AdapterInstaller.php
+++ b/src/TestFramework/AdapterInstaller.php
@@ -64,7 +64,7 @@ final readonly class AdapterInstaller
         Assert::keyExists(self::OFFICIAL_ADAPTERS_MAP, $adapterName);
 
         $process = new Process([
-            $this->composerExecutableFinder->find(),
+            ...$this->composerExecutableFinder->find(),
             'require',
             '--dev',
             self::OFFICIAL_ADAPTERS_MAP[$adapterName],

--- a/tests/phpunit/Console/E2ETest.php
+++ b/tests/phpunit/Console/E2ETest.php
@@ -241,7 +241,7 @@ final class E2ETest extends TestCase
 
             try {
                 $process = new Process([
-                    (new ConcreteComposerExecutableFinder())->find(),
+                    ...(new ConcreteComposerExecutableFinder())->find(),
                     'install',
                 ]);
                 $process->setTimeout(300);

--- a/tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/MemoizedComposerExecutableFinderTest.php
@@ -46,7 +46,7 @@ final class MemoizedComposerExecutableFinderTest extends TestCase
 {
     public function test_it(): void
     {
-        $pathToComposer = '/path/to/composer';
+        $pathToComposer = ['/path/to/composer'];
 
         $mockFinder = $this->createMock(ComposerExecutableFinder::class);
         $mockFinder->expects($this->once())

--- a/tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php
@@ -95,7 +95,7 @@ final class StaticAnalysisToolExecutableFinderTest extends FileSystemTestCase
 
         $this->composerFinder = $this->createMock(ComposerExecutableFinder::class);
         $this->composerFinder->method('find')
-            ->willReturn('/usr/bin/composer');
+            ->willReturn(['/usr/bin/composer']);
     }
 
     protected function tearDown(): void

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\FileSystem\Finder;
 
 use function explode;
 use function getenv;
+use Infection\FileSystem\Finder\ConcreteComposerExecutableFinder;
 use Infection\FileSystem\Finder\ComposerExecutableFinder;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
@@ -50,6 +51,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use function Safe\chdir;
+use function Safe\chmod;
+use function Safe\mkdir;
 use function Safe\putenv;
 use function Safe\realpath;
 use function sprintf;
@@ -159,6 +162,47 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
             strlen($path),
             strlen($pathAfterTest),
             'PATH with vendor added is shorter than without it added, make sure it isn\'t overwritten.',
+        );
+    }
+
+    public function test_it_adds_vendor_bin_to_path_with_a_local_composer_phar(): void
+    {
+        chdir($this->tmp);
+
+        $composerBinDir = $this->tmp . '/composer-bin';
+        mkdir($composerBinDir);
+
+        $this->fileSystem->dumpFile(
+            $this->tmp . '/composer.phar',
+            <<<'PHP'
+                #!/usr/bin/env php
+                <?php
+
+                if (($argv[1] ?? null) === 'config' && ($argv[2] ?? null) === 'bin-dir') {
+                    echo __DIR__ . '/composer-bin';
+
+                    exit(0);
+                }
+
+                fwrite(STDERR, 'Unexpected Composer command: ' . implode(' ', $argv));
+
+                exit(1);
+                PHP,
+        );
+        chmod($this->tmp . '/composer.phar', 0755);
+
+        $phpUnitPath = $composerBinDir . '/phpunit';
+        $this->fileSystem->dumpFile($phpUnitPath, '#!/usr/bin/env php');
+        chmod($phpUnitPath, 0755);
+
+        putenv(sprintf('%s=%s', self::$pathName, $this->tmp));
+        putenv('PATHEXT=');
+
+        $frameworkFinder = new TestFrameworkFinder(new ConcreteComposerExecutableFinder());
+
+        $this->assertSame(
+            Path::canonicalize($phpUnitPath),
+            Path::canonicalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
         );
     }
 

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -95,7 +95,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
 
         $this->composerFinder = $this->createMock(ComposerExecutableFinder::class);
         $this->composerFinder->method('find')
-            ->willReturn('/usr/bin/composer');
+            ->willReturn(['/usr/bin/composer']);
     }
 
     protected function tearDown(): void

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -37,8 +37,8 @@ namespace Infection\Tests\FileSystem\Finder;
 
 use function explode;
 use function getenv;
-use Infection\FileSystem\Finder\ConcreteComposerExecutableFinder;
 use Infection\FileSystem\Finder\ComposerExecutableFinder;
+use Infection\FileSystem\Finder\ConcreteComposerExecutableFinder;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\Framework\OperatingSystem;
@@ -169,41 +169,23 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
     {
         chdir($this->tmp);
 
-        $composerBinDir = $this->tmp . '/composer-bin';
-        mkdir($composerBinDir);
+        $composerBinDir = $this->createComposerExecutableFixture();
 
-        $this->fileSystem->dumpFile(
-            $this->tmp . '/composer.phar',
-            <<<'PHP'
-                #!/usr/bin/env php
-                <?php
-
-                if (($argv[1] ?? null) === 'config' && ($argv[2] ?? null) === 'bin-dir') {
-                    echo __DIR__ . '/composer-bin';
-
-                    exit(0);
-                }
-
-                fwrite(STDERR, 'Unexpected Composer command: ' . implode(' ', $argv));
-
-                exit(1);
-                PHP,
-        );
-        chmod($this->tmp . '/composer.phar', 0755);
-
-        $phpUnitPath = $composerBinDir . '/phpunit';
-        $this->fileSystem->dumpFile($phpUnitPath, '#!/usr/bin/env php');
-        chmod($phpUnitPath, 0755);
+        $phpUnitPath = $this->createPhpUnitExecutableFixture($composerBinDir);
 
         putenv(sprintf('%s=%s', self::$pathName, $this->tmp));
         putenv('PATHEXT=');
 
-        $frameworkFinder = new TestFrameworkFinder(new ConcreteComposerExecutableFinder());
-
-        $this->assertSame(
-            Path::canonicalize($phpUnitPath),
-            Path::canonicalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
+        $frameworkFinder = new TestFrameworkFinder(
+            new ConcreteComposerExecutableFinder(),
         );
+
+        $expected = Path::canonicalize($phpUnitPath);
+        $actual = Path::canonicalize(
+            $frameworkFinder->find(TestFrameworkTypes::PHPUNIT),
+        );
+
+        $this->assertSame($expected, $actual);
     }
 
     public function test_it_finds_framework_executable(): void
@@ -255,5 +237,41 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         yield 'composer-bat' => ['setUpComposerBatchTest'];
 
         yield 'project-bat' => ['setUpProjectBatchTest'];
+    }
+
+    private function createComposerExecutableFixture(): string
+    {
+        $composerBinDir = $this->tmp . '/composer-bin';
+        mkdir($composerBinDir);
+
+        $this->fileSystem->dumpFile(
+            $this->tmp . '/composer.phar',
+            <<<'PHP'
+                #!/usr/bin/env php
+                <?php
+
+                if (($argv[1] ?? null) === 'config' && ($argv[2] ?? null) === 'bin-dir') {
+                    echo __DIR__ . '/composer-bin';
+
+                    exit(0);
+                }
+
+                fwrite(STDERR, 'Unexpected Composer command: ' . implode(' ', $argv));
+
+                exit(1);
+                PHP,
+        );
+        chmod($this->tmp . '/composer.phar', 0755);
+
+        return $composerBinDir;
+    }
+
+    private function createPhpUnitExecutableFixture(string $composerBinDir): string
+    {
+        $phpUnitPath = $composerBinDir . '/phpunit';
+        $this->fileSystem->dumpFile($phpUnitPath, '#!/usr/bin/env php');
+        chmod($phpUnitPath, 0755);
+
+        return $phpUnitPath;
     }
 }


### PR DESCRIPTION
## Description

This PR changes Composer executable resolution to return an argv prefix instead of a single string. This avoids treating commands such as `php /path/to/composer.phar` as one executable name when they are passed to Symfony Process in array mode.

The previous `string` contract was ambiguous: it could represent either an executable path or a complete command fragment. Returning `list<string>` lets callers append Composer arguments safely while preserving the correct executable and script tokens.

## Changes

- Updates `ComposerExecutableFinder::find()` to return `list<string>`.
- Updates the concrete and memoized Composer finders to preserve tokenised Composer commands.
- Spreads the Composer command prefix in test framework, static analysis, adapter installation, and E2E Composer process creation.

## Related issues

Fixes https://github.com/infection/infection/issues/3253.