### PR TITLE
refactor(autoreview): Enforce integration group only for PHPUnit tests requiring I/O

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -775,6 +775,12 @@ parameters:
 			path: ../tests/phpunit/AutoReview/ConcreteClassReflector.php
 
 		-
+			rawMessage: Infection\Tests\AutoReview\EnvVariableManipulation\EnvManipulationTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulationTest.php
+
+		-
 			rawMessage: 'Method Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestCaseForEnvManipulations() should return string|null but returns string|false.'
 			identifier: return.type
 			count: 2
@@ -805,6 +811,18 @@ parameters:
 			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
 
 		-
+			rawMessage: Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProviderTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProviderTest.php
+
+		-
+			rawMessage: Infection\Tests\AutoReview\IntegrationGroup\IoCodeDetectorTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetectorTest.php
+
+		-
 			rawMessage: 'Cannot call method getPrerequisites() on Fidry\Makefile\Rule|null.'
 			identifier: method.nonObject
 			count: 2
@@ -815,6 +833,12 @@ parameters:
 			identifier: argument.type
 			count: 2
 			path: ../tests/phpunit/AutoReview/Mutator/MutatorProviderTest.php
+
+		-
+			rawMessage: Infection\Tests\AutoReview\Mutator\MutatorTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/AutoReview/Mutator/MutatorTest.php
 
 		-
 			rawMessage: 'Method Infection\Tests\AutoReview\Mutator\MutatorTest::getPublicMethods() has parameter $reflectionClass with generic class ReflectionClass but does not specify its types: T'
@@ -853,10 +877,22 @@ parameters:
 			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
 
 		-
+			rawMessage: Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
+
+		-
 			rawMessage: 'Parameter #1 $objectOrClass of class ReflectionClass constructor expects class-string<T of object>|T of object, string given.'
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
+
+		-
+			rawMessage: Infection\Tests\BenchmarkSmokeTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/BenchmarkSmokeTest.php
 
 		-
 			rawMessage: Infection\Tests\CI\ConfigurableEnv should not exist
@@ -869,6 +905,12 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/CI/MemoizedCiDetectorTest.php
+
+		-
+			rawMessage: Infection\Tests\Command\RunCommandTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Command/RunCommandTest.php
 
 		-
 			rawMessage: 'Method Infection\Tests\Configuration\ConfigurationBuilder::withMutators() has parameter $mutators with generic interface Infection\Mutator\Mutator but does not specify its types: TNode'
@@ -991,6 +1033,12 @@ parameters:
 			path: ../tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
 
 		-
+			rawMessage: Infection\Tests\Framework\Enum\ImplodableEnum\ImplodableEnumTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Framework/Enum/ImplodableEnum/ImplodableEnumTest.php
+
+		-
 			rawMessage: Infection\Tests\Logger\Console\BufferedOutputWithStdErrOutput should not exist
 			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
 			count: 1
@@ -1057,6 +1105,24 @@ parameters:
 			path: ../tests/phpunit/MockedContainer.php
 
 		-
+			rawMessage: Infection\Tests\Mutant\MutantAssertionsTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutant/MutantAssertionsTest.php
+
+		-
+			rawMessage: Infection\Tests\Mutant\MutantExecutionResultAssertionsTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutant/MutantExecutionResultAssertionsTest.php
+
+		-
+			rawMessage: Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorIntegrationTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php
+
+		-
 			rawMessage: 'Parameter #3 $mutators of method Infection\Mutation\FileMutationGenerator::generate() expects array<Infection\Mutator\Mutator<PhpParser\Node>>, array{Infection\Mutator\Arithmetic\Plus} given.'
 			identifier: argument.type
 			count: 1
@@ -1121,6 +1187,18 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/Mutator/Extensions/MBStringConfigTest.php
+
+		-
+			rawMessage: Infection\Tests\Mutator\FunctionSignature\ProtectedVisibilityTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php
+
+		-
+			rawMessage: Infection\Tests\Mutator\FunctionSignature\PublicVisibilityTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php
 
 		-
 			rawMessage: 'Property Infection\Tests\Mutator\IgnoreMutatorTest::$mutatorMock with generic interface Infection\Mutator\Mutator does not specify its types: TNode'
@@ -1255,6 +1333,12 @@ parameters:
 			path: ../tests/phpunit/Mutator/MutatorRobustnessTest.php
 
 		-
+			rawMessage: Infection\Tests\Mutator\MutatorRobustnessTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutator/MutatorRobustnessTest.php
+
+		-
 			rawMessage: Instantiation of internal class PHPUnit\Framework\AssertionFailedError.
 			identifier: new.internalClass
 			count: 1
@@ -1297,10 +1381,46 @@ parameters:
 			path: ../tests/phpunit/Mutator/ProfileListProvider.php
 
 		-
+			rawMessage: Infection\Tests\Mutator\ProfileListProviderTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutator/ProfileListProviderTest.php
+
+		-
 			rawMessage: 'Method Infection\Tests\Mutator\ProfileListTest::test_all_mutator_profiles_are_sorted_lexicographically() has parameter $profileOrMutators with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../tests/phpunit/Mutator/ProfileListTest.php
+
+		-
+			rawMessage: Infection\Tests\Mutator\Removal\ArrayItemRemovalTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php
+
+		-
+			rawMessage: Infection\Tests\Mutator\ReturnValue\ArrayOneItemTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php
+
+		-
+			rawMessage: Infection\Tests\Mutator\ReturnValue\FunctionCallTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php
+
+		-
+			rawMessage: Infection\Tests\Mutator\ReturnValue\NewObjectTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutator/ReturnValue/NewObjectTest.php
+
+		-
+			rawMessage: Infection\Tests\Mutator\ReturnValue\ThisTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutator/ReturnValue/ThisTest.php
 
 		-
 			rawMessage: 'Property Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::$testSubjectStub with generic class Infection\Mutator\Util\AbstractValueToNullReturnValue does not specify its types: TNode'
@@ -1339,6 +1459,18 @@ parameters:
 			path: ../tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/StopAtSkippedArgVisitor.php
 
 		-
+			rawMessage: Infection\Tests\PhpParser\Visitor\MutationCollectorVisitorTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/PhpParser/Visitor/MutationCollectorVisitorTest.php
+
+		-
+			rawMessage: Infection\Tests\PhpParser\Visitor\MutatorVisitorTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php
+
+		-
 			rawMessage: Infection\Tests\PhpParser\Visitor\SkipIgnoredNodesVisitor\IdNodeIgnorer should not exist
 			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
 			count: 1
@@ -1349,6 +1481,24 @@ parameters:
 			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
 			count: 1
 			path: ../tests/phpunit/PhpParser/Visitor/VisitorTestCase/ConcreteVisitorTestCase.php
+
+		-
+			rawMessage: Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCaseTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php
+
+		-
+			rawMessage: Infection\Tests\Process\Runner\InitialStaticAnalysisRunnerTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php
+
+		-
+			rawMessage: Infection\Tests\Process\Runner\InitialTestsRunnerTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Process/Runner/InitialTestsRunnerTest.php
 
 		-
 			rawMessage: 'Method Infection\Tests\Process\Runner\MutationTestingRunnerTest::emptyIterable() return type with generic class PHPUnit\Framework\Constraint\Callback does not specify its types: CallbackInput'
@@ -1367,6 +1517,12 @@ parameters:
 			identifier: missingType.generics
 			count: 1
 			path: ../tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+
+		-
+			rawMessage: Infection\Tests\Process\ShellCommandLineExecutorTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Process/ShellCommandLineExecutorTest.php
 
 		-
 			rawMessage: 'Parameter #1 $className of static method Infection\Reflection\AnonymousClassReflection::fromClassName() expects class-string, string given.'
@@ -1429,16 +1585,52 @@ parameters:
 			path: ../tests/phpunit/Reporter/FileReporterFactoryTest.php
 
 		-
+			rawMessage: Infection\Tests\Reporter\GitHubAnnotationsReporterTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php
+
+		-
+			rawMessage: Infection\Tests\Reporter\GitLabCodeQualityReporterTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php
+
+		-
 			rawMessage: 'Parameter #2 $processOutput of class Infection\Mutant\MutantExecutionResult constructor expects string, string|null given.'
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php
 
 		-
+			rawMessage: Infection\Tests\Reporter\JsonReporterTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Reporter/JsonReporterTest.php
+
+		-
+			rawMessage: Infection\Tests\Reporter\StrykerReporterFactoryTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Reporter/StrykerReporterFactoryTest.php
+
+		-
 			rawMessage: 'Parameter #1 $expected of method PHPUnit\Framework\Assert::assertInstanceOf() expects class-string<object>, string given.'
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/Reporter/StrykerReporterFactoryTest.php
+
+		-
+			rawMessage: Infection\Tests\Reporter\SummaryJsonReporterTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Reporter/SummaryJsonReporterTest.php
+
+		-
+			rawMessage: Infection\Tests\Resource\Memory\MemoryLimiterEnvironmentTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php
 
 		-
 			rawMessage: 'Parameter $sourceDirectories of static method Infection\Source\Collector\BasicSourceCollector::create() expects array<non-empty-string>, array{string} given.'
@@ -1453,6 +1645,24 @@ parameters:
 			path: ../tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php
 
 		-
+			rawMessage: Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterFactoryTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterFactoryTest.php
+
+		-
+			rawMessage: Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php
+
+		-
+			rawMessage: Infection\Tests\TestFramework\Coverage\CoverageChecker\CoverageCheckerTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/TestFramework/Coverage/CoverageChecker/CoverageCheckerTest.php
+
+		-
 			rawMessage: Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\DemoReportLocator should not exist
 			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
 			count: 1
@@ -1463,6 +1673,18 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php
+
+		-
+			rawMessage: Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\XmlCoverageParserTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php
+
+		-
+			rawMessage: Infection\Tests\TestFramework\FactoryTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/TestFramework/FactoryTest.php
 
 		-
 			rawMessage: 'Method Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::queryXpath() return type with generic class DOMNodeList does not specify its types: TNode'
@@ -1519,6 +1741,12 @@ parameters:
 			path: ../tests/phpunit/TestFramework/Tracing/DummyTracer.php
 
 		-
+			rawMessage: Infection\Tests\TestFramework\Tracing\TestLocationBucketSorterTest should not exist
+			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php
+
+		-
 			rawMessage: 'Only numeric types are allowed in /, float|null given on the right side.'
 			identifier: div.rightNonNumeric
 			count: 1
@@ -1573,85 +1801,13 @@ parameters:
 			path: ../tests/phpunit/TestingUtility/Console/Command/TestOptionCommand.php
 
 		-
-			rawMessage: Infection\Tests\TestingUtility\Process\TestPhpExecutableFinder should not exist
-			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
-			count: 1
-			path: ../tests/phpunit/TestingUtility/Process/TestPhpExecutableFinder.php
-
-		-
-			rawMessage: Infection\Tests\AutoReview\EnvVariableManipulation\EnvManipulationTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulationTest.php
-
-		-
-			rawMessage: Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProviderTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProviderTest.php
-
-		-
-			rawMessage: Infection\Tests\AutoReview\IntegrationGroup\IoCodeDetectorTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetectorTest.php
-
-		-
-			rawMessage: Infection\Tests\AutoReview\Mutator\MutatorTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/AutoReview/Mutator/MutatorTest.php
-
-		-
-			rawMessage: Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
-
-		-
-			rawMessage: Infection\Tests\BenchmarkSmokeTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/BenchmarkSmokeTest.php
-
-		-
-			rawMessage: Infection\Tests\Framework\Enum\ImplodableEnum\ImplodableEnumTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/Framework/Enum/ImplodableEnum/ImplodableEnumTest.php
-
-		-
-			rawMessage: Infection\Tests\Mutant\MutantAssertionsTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/Mutant/MutantAssertionsTest.php
-
-		-
-			rawMessage: Infection\Tests\Mutant\MutantExecutionResultAssertionsTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/Mutant/MutantExecutionResultAssertionsTest.php
-
-		-
-			rawMessage: Infection\Tests\Mutator\MutatorRobustnessTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/Mutator/MutatorRobustnessTest.php
-
-		-
-			rawMessage: Infection\Tests\Mutator\ProfileListProviderTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/Mutator/ProfileListProviderTest.php
-
-		-
-			rawMessage: Infection\Tests\PhpParser\Visitor\VisitorTestCase\VisitorTestCaseTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/PhpParser/Visitor/VisitorTestCase/VisitorTestCaseTest.php
-
-		-
 			rawMessage: Infection\Tests\TestingUtility\PHPUnit\ExpectsThrowablesTest should not exist
 			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
 			count: 1
 			path: ../tests/phpunit/TestingUtility/PHPUnit/ExpectsThrowablesTest.php
+
+		-
+			rawMessage: Infection\Tests\TestingUtility\Process\TestPhpExecutableFinder should not exist
+			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
+			count: 1
+			path: ../tests/phpunit/TestingUtility/Process/TestPhpExecutableFinder.php

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -39,6 +39,10 @@ services:
         tags:
             - phpat.test
     -
+        class: Infection\Tests\Architecture\PHPat\PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest
+        tags:
+            - phpat.test
+    -
         class: Infection\Tests\Architecture\PHPat\EventClassesShouldFollowConventionsTest
         tags:
             - phpat.test

--- a/tests/Architecture/PHPat/PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest.php
+++ b/tests/Architecture/PHPat/PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest.php
@@ -33,32 +33,27 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat;
 
-use Infection\FileSystem\FileSystem;
-use PHPat\Selector\SelectorInterface;
-use PHPStan\Reflection\ClassReflection;
+use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
 
-final readonly class PHPUnitTestRequiringIoWithoutIntegrationGroup implements SelectorInterface
+final class PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest
 {
-    private PHPUnitTestIoRequirements $ioRequirements;
-
-    public function __construct(
-        FileSystem $fileSystem,
-    ) {
-        $this->ioRequirements = new PHPUnitTestIoRequirements($fileSystem);
-    }
-
-    public function getName(): string
+    public function testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup(): Rule
     {
-        return 'PHPUnit test requiring I/O without integration group';
-    }
-
-    public function matches(ClassReflection $classReflection): bool
-    {
-        return InfectionSelector::phpunitTestCode()->matches($classReflection)
-            && InfectionSelector::concretePHPUnitTestClass()->matches($classReflection)
-            && $this->ioRequirements->requiresIntegrationGroup($classReflection)
-            && !$this->ioRequirements->hasIntegrationGroup($classReflection);
+        return PHPat::rule()
+            ->classes(InfectionSelector::phpunitTestNotRequiringIoWithIntegrationGroup())
+            ->excluding(
+                Selector::withFilepath(
+                    '#/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/#',
+                    true,
+                ),
+            )
+            ->shouldNot()
+            ->exist()
+            ->because('PHPUnit tests covering code without detected I/O should not be marked with the integration group.');
     }
 }

--- a/tests/Architecture/PHPat/Selector/InfectionSelector.php
+++ b/tests/Architecture/PHPat/Selector/InfectionSelector.php
@@ -94,6 +94,13 @@ final class InfectionSelector
         );
     }
 
+    public static function phpunitTestNotRequiringIoWithIntegrationGroup(): PHPUnitTestNotRequiringIoWithIntegrationGroup
+    {
+        return new PHPUnitTestNotRequiringIoWithIntegrationGroup(
+            SingletonContainer::getContainer()->getFileSystem(),
+        );
+    }
+
     public static function concretePHPUnitTestClass(): ConcretePHPUnitTestClass
     {
         return new ConcretePHPUnitTestClass();

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestIoRequirements.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestIoRequirements.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Architecture\PHPat\Selector;
+
+use function class_exists;
+use function count;
+use Infection\FileSystem\FileSystem;
+use Infection\Tests\AutoReview\IntegrationGroup\IoCodeDetector;
+use function interface_exists;
+use function is_string;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
+use PHPStan\Reflection\ClassReflection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use function str_starts_with;
+use function trait_exists;
+
+final class PHPUnitTestIoRequirements
+{
+    private const string COVERS_ATTRIBUTE_NAMESPACE = 'PHPUnit\\Framework\\Attributes\\Covers';
+
+    private const string GROUP_NAME = 'integration';
+
+    /**
+     * @var array<class-string, bool>
+     */
+    private array $classUsesIoCache = [];
+
+    public function __construct(
+        private readonly FileSystem $fileSystem,
+    ) {
+    }
+
+    public function requiresIntegrationGroup(ClassReflection $testCaseReflection): bool
+    {
+        if ($this->testCaseUsesIo($testCaseReflection)) {
+            return true;
+        }
+
+        $coveredClassNames = self::getCoveredClassNames($testCaseReflection);
+
+        if ($coveredClassNames === null) {
+            return true;
+        }
+
+        foreach ($coveredClassNames as $coveredClassName) {
+            if ($this->testedClassUsesIo($coveredClassName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function hasCoveredClass(ClassReflection $testCaseReflection): bool
+    {
+        return self::getCoveredClassNames($testCaseReflection) !== null;
+    }
+
+    public function hasIntegrationGroup(ClassReflection $classReflection): bool
+    {
+        foreach (self::getAttributes($classReflection) as $groupAttribute) {
+            if (self::isIntegrationGroup($groupAttribute)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check the test case code.
+     */
+    private function testCaseUsesIo(ClassReflection $testCaseReflection): bool
+    {
+        if ($this->classUsesIo($testCaseReflection)) {
+            return true;
+        }
+
+        $parentTestCaseClassReflection = $testCaseReflection->getParentClass();
+
+        while (
+            $parentTestCaseClassReflection !== null
+            && $parentTestCaseClassReflection->getName() !== TestCase::class
+        ) {
+            if ($this->classUsesIo($parentTestCaseClassReflection)) {
+                return true;
+            }
+
+            $parentTestCaseClassReflection = $parentTestCaseClassReflection->getParentClass();
+        }
+
+        return false;
+    }
+
+    /**
+     * Check the source class code.
+     *
+     * @param class-string $sourceClassName
+     */
+    private function testedClassUsesIo(string $sourceClassName): bool
+    {
+        $classReflection = new ReflectionClass($sourceClassName);
+
+        do {
+            if ($this->classUsesIo($classReflection)) {
+                return true;
+            }
+
+            $classReflection = $classReflection->getParentClass();
+        } while ($classReflection !== false);
+
+        return false;
+    }
+
+    /**
+     * @return list<class-string>|null
+     */
+    private static function getCoveredClassNames(ClassReflection $testCaseReflection): ?array
+    {
+        $coveredClassNames = [];
+        $hasCoverageAttribute = false;
+
+        foreach (self::getAttributes($testCaseReflection) as $attribute) {
+            if (!self::isCoverageAttribute($attribute)) {
+                continue;
+            }
+
+            $hasCoverageAttribute = true;
+
+            $coveredClassName = self::getCoveredClassName($attribute);
+
+            if ($coveredClassName === null) {
+                return null;
+            }
+
+            $coveredClassNames[] = $coveredClassName;
+        }
+
+        return $hasCoverageAttribute && count($coveredClassNames) > 0
+            ? $coveredClassNames
+            : null;
+    }
+
+    /**
+     * TODO: eventually we should support functions, methods and traits too.
+     * @see CoversClass
+     *
+     * @return class-string|null
+     */
+    private static function getCoveredClassName(ReflectionAttribute $attribute): ?string
+    {
+        if ($attribute->getName() !== CoversClass::class) {
+            return null;
+        }
+
+        $arguments = $attribute->getArguments();
+        $coveredClassName = $arguments[0] ?? $arguments['className'] ?? null;
+
+        $classNameExists = !is_string($coveredClassName)
+            || (
+                !class_exists($coveredClassName)
+                && !interface_exists($coveredClassName)
+                && !trait_exists($coveredClassName)
+            );
+
+        return $classNameExists ? null : $coveredClassName;
+    }
+
+    private static function isCoverageAttribute(ReflectionAttribute $attribute): bool
+    {
+        return str_starts_with(
+            $attribute->getName(),
+            self::COVERS_ATTRIBUTE_NAMESPACE,
+        );
+    }
+
+    /**
+     * @param ReflectionClass<object>|ClassReflection $classReflection
+     */
+    private function classUsesIo(ReflectionClass|ClassReflection $classReflection): bool
+    {
+        $className = $classReflection->getName();
+
+        if (isset($this->classUsesIoCache[$className])) {
+            return $this->classUsesIoCache[$className];
+        }
+
+        $fileName = $classReflection->getFileName();
+
+        return $this->classUsesIoCache[$className] = $fileName !== null
+            && $fileName !== false
+            && IoCodeDetector::codeContainsIoOperations($this->fileSystem->readFile($fileName));
+    }
+
+    /**
+     * @see Group
+     */
+    private static function isIntegrationGroup(ReflectionAttribute $attribute): bool
+    {
+        if ($attribute->getName() !== Group::class) {
+            return false;
+        }
+
+        $arguments = $attribute->getArguments();
+        $groupName = $arguments[0] ?? $arguments['name'] ?? null;
+
+        return $groupName === self::GROUP_NAME;
+    }
+
+    /**
+     * @return iterable<ReflectionAttribute>
+     */
+    private static function getAttributes(ClassReflection $classReflection): iterable
+    {
+        $attributes = $classReflection->getNativeReflection()->getAttributes();
+
+        foreach ($attributes as $attribute) {
+            if ($attribute instanceof ReflectionAttribute) {
+                yield $attribute;
+            }
+        }
+    }
+}

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
 use Infection\FileSystem\FileSystem;
+use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
 

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
@@ -39,7 +39,7 @@ use Infection\FileSystem\FileSystem;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
 
-final readonly class PHPUnitTestRequiringIoWithoutIntegrationGroup implements SelectorInterface
+final readonly class PHPUnitTestNotRequiringIoWithIntegrationGroup implements SelectorInterface
 {
     private PHPUnitTestIoRequirements $ioRequirements;
 
@@ -51,14 +51,15 @@ final readonly class PHPUnitTestRequiringIoWithoutIntegrationGroup implements Se
 
     public function getName(): string
     {
-        return 'PHPUnit test requiring I/O without integration group';
+        return 'PHPUnit test not requiring I/O with integration group';
     }
 
     public function matches(ClassReflection $classReflection): bool
     {
         return InfectionSelector::phpunitTestCode()->matches($classReflection)
             && InfectionSelector::concretePHPUnitTestClass()->matches($classReflection)
-            && $this->ioRequirements->requiresIntegrationGroup($classReflection)
-            && !$this->ioRequirements->hasIntegrationGroup($classReflection);
+            && $this->ioRequirements->hasCoveredClass($classReflection)
+            && !$this->ioRequirements->requiresIntegrationGroup($classReflection)
+            && $this->ioRequirements->hasIntegrationGroup($classReflection);
     }
 }

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
 use Infection\FileSystem\FileSystem;
+use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
 

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirements.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirements.php
@@ -33,7 +33,7 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\Support;
 
 use function class_exists;
 use function count;

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/Fixtures/FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/Fixtures/FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest.php
@@ -33,32 +33,19 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup\Fixtures;
 
-use Infection\FileSystem\FileSystem;
-use PHPat\Selector\SelectorInterface;
-use PHPStan\Reflection\ClassReflection;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\CoveredClassWithoutIo;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
 
-final readonly class PHPUnitTestRequiringIoWithoutIntegrationGroup implements SelectorInterface
+#[CoversClass(CoveredClassWithoutIo::class)]
+#[Group('integration')]
+final class FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest extends TestCase
 {
-    private PHPUnitTestIoRequirements $ioRequirements;
-
-    public function __construct(
-        FileSystem $fileSystem,
-    ) {
-        $this->ioRequirements = new PHPUnitTestIoRequirements($fileSystem);
-    }
-
-    public function getName(): string
+    public function test_fixture(): void
     {
-        return 'PHPUnit test requiring I/O without integration group';
-    }
-
-    public function matches(ClassReflection $classReflection): bool
-    {
-        return InfectionSelector::phpunitTestCode()->matches($classReflection)
-            && InfectionSelector::concretePHPUnitTestClass()->matches($classReflection)
-            && $this->ioRequirements->requiresIntegrationGroup($classReflection)
-            && !$this->ioRequirements->hasIntegrationGroup($classReflection);
+        $this->expectNotToPerformAssertions();
     }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/PHPUnitTestNotRequiringIoWithIntegrationGroupTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/PHPUnitTestNotRequiringIoWithIntegrationGroupTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup;
+
+use Infection\FileSystem\FileSystem;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithIoTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoversNothingWithIntegrationGroupTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithIoInTestCaseTest;
+use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PHPUnitTestNotRequiringIoWithIntegrationGroup::class)]
+final class PHPUnitTestNotRequiringIoWithIntegrationGroupTest extends SelectorTestCase
+{
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('classProvider')]
+    public function test_it_matches_phpunit_tests_not_requiring_io_with_the_integration_group(
+        string $className,
+        bool $expected,
+    ): void {
+        $selector = new PHPUnitTestNotRequiringIoWithIntegrationGroup(
+            new FileSystem(),
+        );
+        $classReflection = $this->createClassReflection($className);
+
+        $actual = $selector->matches($classReflection);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function classProvider(): iterable
+    {
+        yield 'test covering class without I/O with integration group' => [
+            FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest::class,
+            true,
+        ];
+
+        yield 'test covering class without I/O without integration group' => [
+            FixtureWithCoveredClassWithoutIoTest::class,
+            false,
+        ];
+
+        yield 'test with CoversNothing with integration group' => [
+            FixtureWithCoversNothingWithIntegrationGroupTest::class,
+            false,
+        ];
+
+        yield 'test covering class with I/O without integration group' => [
+            FixtureWithCoveredClassWithIoTest::class,
+            false,
+        ];
+
+        yield 'test case with I/O' => [
+            FixtureWithIoInTestCaseTest::class,
+            false,
+        ];
+
+        yield 'vendor test case' => [
+            TestCase::class,
+            false,
+        ];
+    }
+}

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Architecture\PHPat\Selector\Support;
+
+use Infection\FileSystem\FileSystem;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithFileSystemIoAndDirectIoTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithFileSystemIoTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithIoTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoversNothingWithIntegrationGroupTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoversNothingWithoutIntegrationGroupTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithIoInTestCaseTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithMultipleCoveredClassesTest;
+use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(PHPUnitTestIoRequirements::class)]
+final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
+{
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('classProvider')]
+    public function test_it_detects_phpunit_test_io_requirements(
+        string $className,
+        bool $expectedRequiresIntegrationGroup,
+        bool $expectedHasCoveredClass,
+        bool $expectedHasIntegrationGroup,
+    ): void {
+        $ioRequirements = new PHPUnitTestIoRequirements(
+            new FileSystem(),
+        );
+        $classReflection = $this->createClassReflection($className);
+
+        $this->assertSame(
+            $expectedRequiresIntegrationGroup,
+            $ioRequirements->requiresIntegrationGroup($classReflection),
+        );
+        $this->assertSame(
+            $expectedHasCoveredClass,
+            $ioRequirements->hasCoveredClass($classReflection),
+        );
+        $this->assertSame(
+            $expectedHasIntegrationGroup,
+            $ioRequirements->hasIntegrationGroup($classReflection),
+        );
+    }
+
+    public static function classProvider(): iterable
+    {
+        yield 'test with CoversNothing without integration group' => [
+            FixtureWithCoversNothingWithoutIntegrationGroupTest::class,
+            true,
+            false,
+            false,
+        ];
+
+        yield 'test with CoversNothing with integration group' => [
+            FixtureWithCoversNothingWithIntegrationGroupTest::class,
+            true,
+            false,
+            true,
+        ];
+
+        yield 'test covering class without I/O' => [
+            FixtureWithCoveredClassWithoutIoTest::class,
+            false,
+            true,
+            false,
+        ];
+
+        yield 'test covering class without I/O with integration group' => [
+            FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest::class,
+            false,
+            true,
+            true,
+        ];
+
+        yield 'test covering class with I/O' => [
+            FixtureWithCoveredClassWithIoTest::class,
+            true,
+            true,
+            false,
+        ];
+
+        yield 'test covering class with I/O behind FileSystem abstraction' => [
+            FixtureWithCoveredClassWithFileSystemIoTest::class,
+            true,
+            true,
+            false,
+        ];
+
+        yield 'test covering class with I/O behind FileSystem abstraction and direct I/O' => [
+            FixtureWithCoveredClassWithFileSystemIoAndDirectIoTest::class,
+            true,
+            true,
+            false,
+        ];
+
+        yield 'test covering multiple classes with I/O in one class' => [
+            FixtureWithMultipleCoveredClassesTest::class,
+            true,
+            true,
+            false,
+        ];
+
+        yield 'test case with I/O' => [
+            FixtureWithIoInTestCaseTest::class,
+            true,
+            true,
+            false,
+        ];
+    }
+
+    public function test_it_caches_io_detection_per_class(): void
+    {
+        $fileSystemMock = $this->createMock(FileSystem::class);
+        $fileSystemMock
+            // 3 tests cases + their respective covered classes, with one covered class reused
+            ->expects($this->exactly(5))
+            ->method('readFile')
+            ->willReturn('contents');
+
+        $ioRequirements = new PHPUnitTestIoRequirements($fileSystemMock);
+
+        $ioRequirements->requiresIntegrationGroup(
+            $this->createClassReflection(FixtureWithCoversNothingWithoutIntegrationGroupTest::class),
+        );
+        $ioRequirements->requiresIntegrationGroup(
+            $this->createClassReflection(FixtureWithCoveredClassWithIoTest::class),
+        );
+        $ioRequirements->requiresIntegrationGroup(
+            $this->createClassReflection(FixtureWithCoveredClassWithIoTest::class),
+        );
+        $ioRequirements->requiresIntegrationGroup(
+            $this->createClassReflection(FixtureWithMultipleCoveredClassesTest::class),
+        );
+        $ioRequirements->requiresIntegrationGroup(
+            $this->createClassReflection(FixtureWithMultipleCoveredClassesTest::class),
+        );
+    }
+}


### PR DESCRIPTION
## Description

Adds the counterpart to the existing PHPat rule that requires PHPUnit tests using I/O to belong to the `integration` group.

The new rule flags PHPUnit tests that cover a resolvable class, have no detected I/O requirement, and still carry the `integration` group. The shared I/O, coverage, and group detection logic is extracted so both rules use the same semantics.

## Changes

- Adds `PHPUnitTestNotRequiringIoWithIntegrationGroup` and registers it as a PHPat test.
- Extracts common PHPUnit I/O requirement detection into the selector support helper `PHPUnitTestIoRequirements`.
- Updates the existing `PHPUnitTestRequiringIoWithoutIntegrationGroup` selector to use the shared detector.
