### PR TITLE
fix(autoreview): Improve the IO detection to detect Infection's FileSystem

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -763,6 +763,30 @@ parameters:
 			path: ../src/Testing/SingletonContainer.php
 
 		-
+			rawMessage: Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup\PHPUnitTestNotRequiringIoWithIntegrationGroupTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/PHPUnitTestNotRequiringIoWithIntegrationGroupTest.php
+
+		-
+			rawMessage: Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestSupportConcreteClassWithoutCanonicalTestTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestSupportConcreteClassWithoutCanonicalTestTest.php
+
+		-
+			rawMessage: Infection\Tests\Architecture\PHPat\Selector\Support\Analyser\AnalyserTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Architecture/PHPat/Selector/Support/Analyser/AnalyserTest.php
+
+		-
+			rawMessage: Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirementsTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
+
+		-
 			rawMessage: Infection\Tests\AutoReview\ConcreteClassReflector should not exist
 			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
 			count: 1
@@ -937,6 +961,12 @@ parameters:
 			path: ../tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
 
 		-
+			rawMessage: Infection\Tests\Configuration\ProjectDirectoryProvider\EnvironmentVariableBasedProjectDirectoryProviderTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Configuration/ProjectDirectoryProvider/EnvironmentVariableBasedProjectDirectoryProviderTest.php
+
+		-
 			rawMessage: Infection\Tests\Configuration\ProjectDirectoryProvider\FixedProjectDirectoryProvider should not exist
 			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
 			count: 1
@@ -947,6 +977,12 @@ parameters:
 			identifier: ternary.shortNotAllowed
 			count: 1
 			path: ../tests/phpunit/Console/E2ETest.php
+
+		-
+			rawMessage: Infection\Tests\Container\Builder\IndexXmlCoverageParserBuilderTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Container/Builder/IndexXmlCoverageParserBuilderTest.php
 
 		-
 			rawMessage: Variable method call on Infection\Container\Container.
@@ -971,6 +1007,12 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/Environment/StrykerApiKeyResolverTest.php
+
+		-
+			rawMessage: Infection\Tests\FileSystem\FileStoreTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/FileSystem/FileStoreTest.php
 
 		-
 			rawMessage: 'Call to an undefined method object::setFilter().'
@@ -1127,6 +1169,12 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php
+
+		-
+			rawMessage: Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php
 
 		-
 			rawMessage: 'Parameter #2 $stmts of class PhpParser\Node\Stmt\Namespace_ constructor expects array<PhpParser\Node\Stmt>|null, array<int, PhpParser\Node\Scalar\Int_> given.'
@@ -1645,6 +1693,12 @@ parameters:
 			path: ../tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php
 
 		-
+			rawMessage: Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php
+
+		-
 			rawMessage: Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterFactoryTest should not exist
 			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
 			count: 1
@@ -1675,16 +1729,16 @@ parameters:
 			path: ../tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php
 
 		-
-			rawMessage: Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\XmlCoverageParserTest should not exist
-			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php
-
-		-
 			rawMessage: Infection\Tests\TestFramework\FactoryTest should not exist
 			identifier: phpat.testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup
 			count: 1
 			path: ../tests/phpunit/TestFramework/FactoryTest.php
+
+		-
+			rawMessage: Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapter\PhpUnitAdapterTest should not exist
+			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
+			count: 1
+			path: ../tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
 
 		-
 			rawMessage: 'Method Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::queryXpath() return type with generic class DOMNodeList does not specify its types: TNode'

--- a/tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php
+++ b/tests/phpunit/AutoReview/IntegrationGroup/IoCodeDetector.php
@@ -270,6 +270,7 @@ final class IoCodeDetector
         'XMLWriter::openUri(',
         'XMLWriter::toStream(',
         'XMLWriter::toUri(',
+        'use Infection\FileSystem\FileSystem;',
         'use Symfony\Component\Filesystem\Filesystem;',
     ];
 


### PR DESCRIPTION
When `Infection\FileSystem\FileSystem` was introduced in #2588, I did not realise the `FileSystem` needed updating. This PR fixes that.