### PR TITLE
refactor(autoreview): Extract PHPat selector fixture exclusions

### DIFF
--- a/tests/Architecture/PHPat/PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest.php
+++ b/tests/Architecture/PHPat/PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Architecture\PHPat;
 
 use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
-use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
 
@@ -46,12 +45,7 @@ final class PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest
     {
         return PHPat::rule()
             ->classes(InfectionSelector::phpunitTestNotRequiringIoWithIntegrationGroup())
-            ->excluding(
-                Selector::withFilepath(
-                    '#/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/#',
-                    true,
-                ),
-            )
+            ->excluding(InfectionSelector::selectorFixtures())
             ->shouldNot()
             ->exist()
             ->because('PHPUnit tests covering code without detected I/O should not be marked with the integration group.');

--- a/tests/Architecture/PHPat/PHPUnitTestsRequiringIoShouldBelongToIntegrationGroupTest.php
+++ b/tests/Architecture/PHPat/PHPUnitTestsRequiringIoShouldBelongToIntegrationGroupTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Architecture\PHPat;
 
 use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
-use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
 
@@ -46,12 +45,7 @@ final class PHPUnitTestsRequiringIoShouldBelongToIntegrationGroupTest
     {
         return PHPat::rule()
             ->classes(InfectionSelector::phpunitTestRequiringIoWithoutIntegrationGroup())
-            ->excluding(
-                Selector::withFilepath(
-                    '#/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/#',
-                    true,
-                ),
-            )
+            ->excluding(InfectionSelector::selectorFixtures())
             ->shouldNot()
             ->exist()
             ->because('PHPUnit tests using I/O should be marked with the integration group.');

--- a/tests/Architecture/PHPat/Selector/InfectionSelector.php
+++ b/tests/Architecture/PHPat/Selector/InfectionSelector.php
@@ -72,6 +72,11 @@ final class InfectionSelector
         );
     }
 
+    public static function selectorFixtures(): SelectorInterface
+    {
+        return Selector::withFilepath('#/tests/phpunit/Architecture/PHPat/Selector/.+?/Fixture(s)?#', true);
+    }
+
     public static function extensionPoint(): ExtensionPoint
     {
         return new ExtensionPoint();

--- a/tests/phpunit/Architecture/PHPat/Selector/InfectionSelectorTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/InfectionSelectorTest.php
@@ -37,7 +37,11 @@ namespace Infection\Tests\Architecture\PHPat\Selector;
 
 use Infection\Benchmark\Instrumentor;
 use Infection\Engine;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\CoveredClassWithIo;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\PHPUnitTestRequiringIoWithoutIntegrationGroupTest;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(InfectionSelector::class)]
@@ -62,5 +66,34 @@ final class InfectionSelectorTest extends SelectorTestCase
 
             $this->assertSame($expected, $actual, $message);
         }
+    }
+
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('selectorFixturesClassProvider')]
+    public function test_it_matches_selector_fixtures(
+        string $className,
+        bool $expected,
+    ): void {
+        $selector = InfectionSelector::selectorFixtures();
+        $classReflection = $this->createClassReflection($className);
+
+        $actual = $selector->matches($classReflection);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function selectorFixturesClassProvider(): iterable
+    {
+        yield 'selector test fixture' => [CoveredClassWithIo::class, true];
+
+        yield 'selector test fixtures' => [FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest::class, true];
+
+        yield 'selector test' => [PHPUnitTestRequiringIoWithoutIntegrationGroupTest::class, false];
+
+        yield 'selector class' => [InfectionSelector::class, false];
+
+        yield 'infection PHPUnit test class' => [self::class, false];
     }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
@@ -48,9 +48,11 @@ use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutInt
 use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(PHPUnitTestRequiringIoWithoutIntegrationGroup::class)]
+#[Group('integration')]
 final class PHPUnitTestRequiringIoWithoutIntegrationGroupTest extends SelectorTestCase
 {
     /**


### PR DESCRIPTION
## Description

Extracts a shared `InfectionSelector::selectorFixtures()` selector for PHPat selector fixture paths. This removes duplicated filepath regex exclusions from the PHPUnit integration-group architecture rules and narrows the exclusion to fixture directories.

## Changes

- Adds `InfectionSelector::selectorFixtures()` for PHPat selector fixture paths.
- Updates the PHPUnit integration-group PHPat rules to exclude selector fixtures through the shared selector.
- Marks `PHPUnitTestRequiringIoWithoutIntegrationGroupTest` as an integration test now that it is no longer excluded by the fixture-only selector.