### PR TITLE
refactor(autoreview): Use PHPStan reflection for PHPat IO selectors

### DIFF
--- a/tests/Architecture/PHPat/PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest.php
+++ b/tests/Architecture/PHPat/PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest.php
@@ -39,13 +39,19 @@ use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
 use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
+use PHPStan\Reflection\ReflectionProvider;
 
-final class PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest
+final readonly class PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest
 {
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
     public function testPHPUnitTestsNotRequiringIoDoNotBelongToIntegrationGroup(): Rule
     {
         return PHPat::rule()
-            ->classes(InfectionSelector::phpunitTestNotRequiringIoWithIntegrationGroup())
+            ->classes(InfectionSelector::phpunitTestNotRequiringIoWithIntegrationGroup($this->reflectionProvider))
             ->excluding(
                 Selector::withFilepath(
                     '#/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/#',

--- a/tests/Architecture/PHPat/PHPUnitTestsRequiringIoShouldBelongToIntegrationGroupTest.php
+++ b/tests/Architecture/PHPat/PHPUnitTestsRequiringIoShouldBelongToIntegrationGroupTest.php
@@ -39,13 +39,19 @@ use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
 use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
+use PHPStan\Reflection\ReflectionProvider;
 
-final class PHPUnitTestsRequiringIoShouldBelongToIntegrationGroupTest
+final readonly class PHPUnitTestsRequiringIoShouldBelongToIntegrationGroupTest
 {
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
     public function testPHPUnitTestsRequiringIoBelongToIntegrationGroup(): Rule
     {
         return PHPat::rule()
-            ->classes(InfectionSelector::phpunitTestRequiringIoWithoutIntegrationGroup())
+            ->classes(InfectionSelector::phpunitTestRequiringIoWithoutIntegrationGroup($this->reflectionProvider))
             ->excluding(
                 Selector::withFilepath(
                     '#/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/#',

--- a/tests/Architecture/PHPat/Selector/InfectionSelector.php
+++ b/tests/Architecture/PHPat/Selector/InfectionSelector.php
@@ -42,6 +42,7 @@ use Infection\Tests\Architecture\PHPat\Selector\Support\EventArchitecture;
 use PHPat\Selector\ClassImplements;
 use PHPat\Selector\Selector;
 use PHPat\Selector\SelectorInterface;
+use PHPStan\Reflection\ReflectionProvider;
 
 final class InfectionSelector
 {
@@ -87,17 +88,19 @@ final class InfectionSelector
         return new PHPUnitTestSupportConcreteClassWithoutCanonicalTest();
     }
 
-    public static function phpunitTestRequiringIoWithoutIntegrationGroup(): PHPUnitTestRequiringIoWithoutIntegrationGroup
+    public static function phpunitTestRequiringIoWithoutIntegrationGroup(ReflectionProvider $reflectionProvider): PHPUnitTestRequiringIoWithoutIntegrationGroup
     {
         return new PHPUnitTestRequiringIoWithoutIntegrationGroup(
             SingletonContainer::getContainer()->getFileSystem(),
+            $reflectionProvider,
         );
     }
 
-    public static function phpunitTestNotRequiringIoWithIntegrationGroup(): PHPUnitTestNotRequiringIoWithIntegrationGroup
+    public static function phpunitTestNotRequiringIoWithIntegrationGroup(ReflectionProvider $reflectionProvider): PHPUnitTestNotRequiringIoWithIntegrationGroup
     {
         return new PHPUnitTestNotRequiringIoWithIntegrationGroup(
             SingletonContainer::getContainer()->getFileSystem(),
+            $reflectionProvider,
         );
     }
 

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
@@ -39,6 +39,7 @@ use Infection\FileSystem\FileSystem;
 use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 
 final readonly class PHPUnitTestNotRequiringIoWithIntegrationGroup implements SelectorInterface
 {
@@ -46,8 +47,9 @@ final readonly class PHPUnitTestNotRequiringIoWithIntegrationGroup implements Se
 
     public function __construct(
         FileSystem $fileSystem,
+        ReflectionProvider $reflectionProvider,
     ) {
-        $this->ioRequirements = new PHPUnitTestIoRequirements($fileSystem);
+        $this->ioRequirements = new PHPUnitTestIoRequirements($fileSystem, $reflectionProvider);
     }
 
     public function getName(): string

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
@@ -49,7 +49,10 @@ final readonly class PHPUnitTestNotRequiringIoWithIntegrationGroup implements Se
         FileSystem $fileSystem,
         ReflectionProvider $reflectionProvider,
     ) {
-        $this->ioRequirements = new PHPUnitTestIoRequirements($fileSystem, $reflectionProvider);
+        $this->ioRequirements = new PHPUnitTestIoRequirements(
+            $fileSystem,
+            $reflectionProvider,
+        );
     }
 
     public function getName(): string

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
@@ -39,6 +39,7 @@ use Infection\FileSystem\FileSystem;
 use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 
 final readonly class PHPUnitTestRequiringIoWithoutIntegrationGroup implements SelectorInterface
 {
@@ -46,8 +47,9 @@ final readonly class PHPUnitTestRequiringIoWithoutIntegrationGroup implements Se
 
     public function __construct(
         FileSystem $fileSystem,
+        ReflectionProvider $reflectionProvider,
     ) {
-        $this->ioRequirements = new PHPUnitTestIoRequirements($fileSystem);
+        $this->ioRequirements = new PHPUnitTestIoRequirements($fileSystem, $reflectionProvider);
     }
 
     public function getName(): string

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
@@ -49,7 +49,10 @@ final readonly class PHPUnitTestRequiringIoWithoutIntegrationGroup implements Se
         FileSystem $fileSystem,
         ReflectionProvider $reflectionProvider,
     ) {
-        $this->ioRequirements = new PHPUnitTestIoRequirements($fileSystem, $reflectionProvider);
+        $this->ioRequirements = new PHPUnitTestIoRequirements(
+            $fileSystem,
+            $reflectionProvider,
+        );
     }
 
     public function getName(): string

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirements.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirements.php
@@ -43,10 +43,10 @@ use function interface_exists;
 use function is_string;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 use function str_starts_with;
 use function trait_exists;
 
@@ -63,6 +63,7 @@ final class PHPUnitTestIoRequirements
 
     public function __construct(
         private readonly FileSystem $fileSystem,
+        private readonly ReflectionProvider $reflectionProvider,
     ) {
     }
 
@@ -135,7 +136,7 @@ final class PHPUnitTestIoRequirements
      */
     private function testedClassUsesIo(string $sourceClassName): bool
     {
-        $classReflection = new ReflectionClass($sourceClassName);
+        $classReflection = $this->reflectionProvider->getClass($sourceClassName);
 
         do {
             if ($this->classUsesIo($classReflection)) {
@@ -143,7 +144,7 @@ final class PHPUnitTestIoRequirements
             }
 
             $classReflection = $classReflection->getParentClass();
-        } while ($classReflection !== false);
+        } while ($classReflection !== null);
 
         return false;
     }
@@ -210,10 +211,7 @@ final class PHPUnitTestIoRequirements
         );
     }
 
-    /**
-     * @param ReflectionClass<object>|ClassReflection $classReflection
-     */
-    private function classUsesIo(ReflectionClass|ClassReflection $classReflection): bool
+    private function classUsesIo(ClassReflection $classReflection): bool
     {
         $className = $classReflection->getName();
 
@@ -224,7 +222,6 @@ final class PHPUnitTestIoRequirements
         $fileName = $classReflection->getFileName();
 
         return $this->classUsesIoCache[$className] = $fileName !== null
-            && $fileName !== false
             && IoCodeDetector::codeContainsIoOperations($this->fileSystem->readFile($fileName));
     }
 

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/PHPUnitTestNotRequiringIoWithIntegrationGroupTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/PHPUnitTestNotRequiringIoWithIntegrationGroupTest.php
@@ -60,6 +60,7 @@ final class PHPUnitTestNotRequiringIoWithIntegrationGroupTest extends SelectorTe
     ): void {
         $selector = new PHPUnitTestNotRequiringIoWithIntegrationGroup(
             new FileSystem(),
+            $this->getReflectionProvider(),
         );
         $classReflection = $this->createClassReflection($className);
 

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
@@ -63,6 +63,7 @@ final class PHPUnitTestRequiringIoWithoutIntegrationGroupTest extends SelectorTe
     ): void {
         $selector = new PHPUnitTestRequiringIoWithoutIntegrationGroup(
             new FileSystem(),
+            $this->getReflectionProvider(),
         );
         $classReflection = $this->createClassReflection($className);
 
@@ -128,7 +129,7 @@ final class PHPUnitTestRequiringIoWithoutIntegrationGroupTest extends SelectorTe
             ->method('readFile')
             ->willReturn('contents');
 
-        $selector = new PHPUnitTestRequiringIoWithoutIntegrationGroup($fileSystemMock);
+        $selector = new PHPUnitTestRequiringIoWithoutIntegrationGroup($fileSystemMock, $this->getReflectionProvider());
 
         $selector->matches($this->createClassReflection(FixtureWithCoversNothingWithoutIntegrationGroupTest::class));
         $selector->matches($this->createClassReflection(FixtureWithCoveredClassWithIoTest::class));

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
@@ -131,7 +131,10 @@ final class PHPUnitTestRequiringIoWithoutIntegrationGroupTest extends SelectorTe
             ->method('readFile')
             ->willReturn('contents');
 
-        $selector = new PHPUnitTestRequiringIoWithoutIntegrationGroup($fileSystemMock, $this->getReflectionProvider());
+        $selector = new PHPUnitTestRequiringIoWithoutIntegrationGroup(
+            $fileSystemMock,
+            $this->getReflectionProvider(),
+        );
 
         $selector->matches($this->createClassReflection(FixtureWithCoversNothingWithoutIntegrationGroupTest::class));
         $selector->matches($this->createClassReflection(FixtureWithCoveredClassWithIoTest::class));

--- a/tests/phpunit/Architecture/PHPat/Selector/SelectorTestCase.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/SelectorTestCase.php
@@ -84,6 +84,11 @@ abstract class SelectorTestCase extends TestCase
         return self::$reflectionProvider->getClass($className);
     }
 
+    final protected function getReflectionProvider(): ReflectionProvider
+    {
+        return self::$reflectionProvider;
+    }
+
     final protected function createAnonymousClassReflectionFromFile(string $file): ClassReflection
     {
         $anonymousClassReflection = null;

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
@@ -64,6 +64,7 @@ final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
     ): void {
         $ioRequirements = new PHPUnitTestIoRequirements(
             new FileSystem(),
+            $this->getReflectionProvider(),
         );
         $classReflection = $this->createClassReflection($className);
 
@@ -156,7 +157,7 @@ final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
             ->method('readFile')
             ->willReturn('contents');
 
-        $ioRequirements = new PHPUnitTestIoRequirements($fileSystemMock);
+        $ioRequirements = new PHPUnitTestIoRequirements($fileSystemMock, $this->getReflectionProvider());
 
         $ioRequirements->requiresIntegrationGroup(
             $this->createClassReflection(FixtureWithCoversNothingWithoutIntegrationGroupTest::class),

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
@@ -157,7 +157,10 @@ final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
             ->method('readFile')
             ->willReturn('contents');
 
-        $ioRequirements = new PHPUnitTestIoRequirements($fileSystemMock, $this->getReflectionProvider());
+        $ioRequirements = new PHPUnitTestIoRequirements(
+            $fileSystemMock,
+            $this->getReflectionProvider(),
+        );
 
         $ioRequirements->requiresIntegrationGroup(
             $this->createClassReflection(FixtureWithCoversNothingWithoutIntegrationGroupTest::class),


### PR DESCRIPTION
## Description

Updates the PHPat selectors so covered classes are resolved with PHPStan's `ReflectionProvider` instead of native `ReflectionClass`. This keeps the selector path on PHPStan `ClassReflection` instances when checking test cases, covered classes, and parent classes.

This is a preparatory step for #3258 where the IO detection will leverage PHPStan types more.

## Changes

- Injects `ReflectionProvider` into the PHPat rules that build the PHPUnit IO selectors.
- Passes the PHPStan reflection provider through `InfectionSelector` and the two PHPUnit IO selectors.
- Updates `PHPUnitTestIoRequirements` to resolve covered classes via `ReflectionProvider::getClass()`.

