### PR TITLE
refactor(autoreview): Inject PHPUnit IO requirements into PHPat selectors

### DIFF
--- a/tests/Architecture/PHPat/Selector/InfectionSelector.php
+++ b/tests/Architecture/PHPat/Selector/InfectionSelector.php
@@ -39,16 +39,22 @@ use Infection\CannotBeInstantiated;
 use Infection\Testing\SingletonContainer;
 use Infection\Tests\Architecture\PHPat\Selector\Support\Analyser\Analyser;
 use Infection\Tests\Architecture\PHPat\Selector\Support\EventArchitecture;
+use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPat\Selector\ClassImplements;
 use PHPat\Selector\Selector;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ReflectionProvider;
+use Webmozart\Assert\Assert;
 
 final class InfectionSelector
 {
     use CannotBeInstantiated;
 
     private static ?EventArchitecture $eventArchitecture = null;
+
+    private static ?PHPUnitTestIoRequirements $phpUnitTestIoRequirements = null;
+
+    private static ?ReflectionProvider $phpUnitTestIoRequirementsReflectionProvider = null;
 
     public static function code(): InfectionCode
     {
@@ -96,16 +102,14 @@ final class InfectionSelector
     public static function phpunitTestRequiringIoWithoutIntegrationGroup(ReflectionProvider $reflectionProvider): PHPUnitTestRequiringIoWithoutIntegrationGroup
     {
         return new PHPUnitTestRequiringIoWithoutIntegrationGroup(
-            SingletonContainer::getContainer()->getFileSystem(),
-            $reflectionProvider,
+            self::phpUnitTestIoRequirements($reflectionProvider),
         );
     }
 
     public static function phpunitTestNotRequiringIoWithIntegrationGroup(ReflectionProvider $reflectionProvider): PHPUnitTestNotRequiringIoWithIntegrationGroup
     {
         return new PHPUnitTestNotRequiringIoWithIntegrationGroup(
-            SingletonContainer::getContainer()->getFileSystem(),
-            $reflectionProvider,
+            self::phpUnitTestIoRequirements($reflectionProvider),
         );
     }
 
@@ -174,5 +178,25 @@ final class InfectionSelector
     private static function eventArchitecture(): EventArchitecture
     {
         return self::$eventArchitecture ??= EventArchitecture::createDefault();
+    }
+
+    private static function phpUnitTestIoRequirements(ReflectionProvider $reflectionProvider): PHPUnitTestIoRequirements
+    {
+        if (self::$phpUnitTestIoRequirements === null) {
+            self::$phpUnitTestIoRequirementsReflectionProvider = $reflectionProvider;
+
+            return self::$phpUnitTestIoRequirements = new PHPUnitTestIoRequirements(
+                SingletonContainer::getContainer()->getFileSystem(),
+                $reflectionProvider,
+            );
+        }
+
+        Assert::same(
+            self::$phpUnitTestIoRequirementsReflectionProvider,
+            $reflectionProvider,
+            'PHPUnit test IO requirements must be requested with the same reflection provider.',
+        );
+
+        return self::$phpUnitTestIoRequirements;
     }
 }

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
@@ -35,24 +35,15 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
-use Infection\FileSystem\FileSystem;
 use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 
 final readonly class PHPUnitTestNotRequiringIoWithIntegrationGroup implements SelectorInterface
 {
-    private PHPUnitTestIoRequirements $ioRequirements;
-
     public function __construct(
-        FileSystem $fileSystem,
-        ReflectionProvider $reflectionProvider,
+        private PHPUnitTestIoRequirements $ioRequirements,
     ) {
-        $this->ioRequirements = new PHPUnitTestIoRequirements(
-            $fileSystem,
-            $reflectionProvider,
-        );
     }
 
     public function getName(): string

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
@@ -35,24 +35,15 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
-use Infection\FileSystem\FileSystem;
 use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 
 final readonly class PHPUnitTestRequiringIoWithoutIntegrationGroup implements SelectorInterface
 {
-    private PHPUnitTestIoRequirements $ioRequirements;
-
     public function __construct(
-        FileSystem $fileSystem,
-        ReflectionProvider $reflectionProvider,
+        private PHPUnitTestIoRequirements $ioRequirements,
     ) {
-        $this->ioRequirements = new PHPUnitTestIoRequirements(
-            $fileSystem,
-            $reflectionProvider,
-        );
     }
 
     public function getName(): string

--- a/tests/phpunit/Architecture/PHPat/Selector/InfectionSelectorTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/InfectionSelectorTest.php
@@ -40,6 +40,8 @@ use Infection\Engine;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\CoveredClassWithIo;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\PHPUnitTestRequiringIoWithoutIntegrationGroupTest;
+use LogicException;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -95,5 +97,17 @@ final class InfectionSelectorTest extends SelectorTestCase
         yield 'selector class' => [InfectionSelector::class, false];
 
         yield 'infection PHPUnit test class' => [self::class, false];
+    }
+
+    public function test_it_rejects_different_reflection_providers_for_phpunit_test_io_requirements(): void
+    {
+        InfectionSelector::phpunitTestRequiringIoWithoutIntegrationGroup($this->getReflectionProvider());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('PHPUnit test IO requirements must be requested with the same reflection provider.');
+
+        InfectionSelector::phpunitTestNotRequiringIoWithIntegrationGroup(
+            $this->createStub(ReflectionProvider::class),
+        );
     }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/PHPUnitTestNotRequiringIoWithIntegrationGroupTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/PHPUnitTestNotRequiringIoWithIntegrationGroupTest.php
@@ -43,6 +43,7 @@ use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutInt
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoversNothingWithIntegrationGroupTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithIoInTestCaseTest;
 use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
+use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -59,8 +60,10 @@ final class PHPUnitTestNotRequiringIoWithIntegrationGroupTest extends SelectorTe
         bool $expected,
     ): void {
         $selector = new PHPUnitTestNotRequiringIoWithIntegrationGroup(
-            new FileSystem(),
-            $this->getReflectionProvider(),
+            new PHPUnitTestIoRequirements(
+                new FileSystem(),
+                $this->getReflectionProvider(),
+            ),
         );
         $classReflection = $this->createClassReflection($className);
 

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
@@ -46,6 +46,7 @@ use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutInt
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithIoInTestCaseTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithMultipleCoveredClassesTest;
 use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
+use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -64,8 +65,10 @@ final class PHPUnitTestRequiringIoWithoutIntegrationGroupTest extends SelectorTe
         bool $expected,
     ): void {
         $selector = new PHPUnitTestRequiringIoWithoutIntegrationGroup(
-            new FileSystem(),
-            $this->getReflectionProvider(),
+            new PHPUnitTestIoRequirements(
+                new FileSystem(),
+                $this->getReflectionProvider(),
+            ),
         );
         $classReflection = $this->createClassReflection($className);
 
@@ -132,8 +135,10 @@ final class PHPUnitTestRequiringIoWithoutIntegrationGroupTest extends SelectorTe
             ->willReturn('contents');
 
         $selector = new PHPUnitTestRequiringIoWithoutIntegrationGroup(
-            $fileSystemMock,
-            $this->getReflectionProvider(),
+            new PHPUnitTestIoRequirements(
+                $fileSystemMock,
+                $this->getReflectionProvider(),
+            ),
         );
 
         $selector->matches($this->createClassReflection(FixtureWithCoversNothingWithoutIntegrationGroupTest::class));


### PR DESCRIPTION
## Description

Updates the PHPat PHPUnit IO selectors so they receive `PHPUnitTestIoRequirements` instead of constructing it internally. `InfectionSelector` now owns the shared `PHPUnitTestIoRequirements` instance used by those selectors and guards that it is always requested with the same PHPStan `ReflectionProvider`.

## Changes

- Injects `PHPUnitTestIoRequirements` into `PHPUnitTestRequiringIoWithoutIntegrationGroup`.
- Injects `PHPUnitTestIoRequirements` into `PHPUnitTestNotRequiringIoWithIntegrationGroup`.
- Adds a singleton `PHPUnitTestIoRequirements` factory inside `InfectionSelector`.
- Tracks the first `ReflectionProvider` used for the singleton and fails when a later request passes a different provider.
- Updates selector tests to construct and pass `PHPUnitTestIoRequirements` directly.
- Adds guard coverage for mismatched reflection providers.