### PR TITLE
refactor(autoreview): Allow analyser to handle non-concrete classes

### DIFF
--- a/tests/Architecture/PHPat/Selector/Support/Analyser/Analyser.php
+++ b/tests/Architecture/PHPat/Selector/Support/Analyser/Analyser.php
@@ -58,12 +58,11 @@ final readonly class Analyser
 
     public function analyse(ClassReflection $classReflection): AnalysisResult
     {
-        Assert::true(
-            ConcreteClassReflection::isConcreteClass($classReflection),
-            // This limitation is enough for the current selectors and keeps the
-            // analysis rules narrow. It can be expanded when another use case needs it.
-            'Only concrete classes can be analysed.',
-        );
+        if (!ConcreteClassReflection::isConcreteClass($classReflection)) {
+            return new AnalysisResult(
+                hasTrivialImplementation: false,
+            );
+        }
 
         $nodes = $this->parse($classReflection);
 

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/Analyser/AnalyserTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/Analyser/AnalyserTest.php
@@ -35,18 +35,21 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector\Support\Analyser;
 
+use Infection\CannotBeInstantiated;
+use Infection\Command\BaseCommand;
 use Infection\FileSystem\FileSystem;
+use Infection\Mutator\Mutator;
 use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
 use PhpParser\ErrorHandler\Throwing;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Parser;
 use PHPStan\Reflection\ClassReflection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
 #[CoversClass(Analyser::class)]
 #[CoversClass(AnalysisResult::class)]
-#[CoversClass(DetectConcreteClassMeaningfulImplementationVisitor::class)]
 final class AnalyserTest extends SelectorTestCase
 {
     private ClassReflection $classReflection;
@@ -96,5 +99,41 @@ final class AnalyserTest extends SelectorTestCase
         $actual = $this->analyser->analyse($this->classReflection);
 
         $this->assertTrue($actual->hasTrivialImplementation);
+    }
+
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('nonConcreteClassProvider')]
+    public function test_it_treats_non_concrete_classes_as_non_trivial_without_parsing_them(string $className): void
+    {
+        $this->fileSystemMock
+            ->expects($this->never())
+            ->method('readFile');
+
+        $this->parserMock
+            ->expects($this->never())
+            ->method('parse');
+
+        $actual = $this->analyser->analyse(
+            $this->createClassReflection($className),
+        );
+
+        $this->assertFalse($actual->hasTrivialImplementation);
+    }
+
+    public static function nonConcreteClassProvider(): iterable
+    {
+        yield 'abstract class' => [
+            BaseCommand::class,
+        ];
+
+        yield 'interface' => [
+            Mutator::class,
+        ];
+
+        yield 'trait' => [
+            CannotBeInstantiated::class,
+        ];
     }
 }


### PR DESCRIPTION
Updates the PHPat selector analyser so it can be called with non-concrete class reflections. Abstract classes, interfaces, and traits now return `hasTrivialImplementation=false` immediately, avoiding unnecessary parsing and visitor traversal.

