### PR TITLE
fix(autoreview): Exclude test cases found in fixtures from PHPUnit

### DIFF
--- a/phpunit_autoreview.xml
+++ b/phpunit_autoreview.xml
@@ -24,6 +24,10 @@
         <testsuite name="Auto-Review Test Suite">
             <directory>tests/phpunit/Architecture</directory>
             <directory>tests/phpunit/AutoReview</directory>
+
+            <exclude>tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/Fixtures</exclude>
+            <exclude>tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/Fixtures</exclude>
+            <exclude>tests/phpunit/Architecture/PHPat/Selector/Support/EventArchitectureTest/Fixtures</exclude>
         </testsuite>
     </testsuites>
 
@@ -33,5 +37,11 @@
             <directory>tests/phpunit/Architecture</directory>
             <directory>tests/phpunit/AutoReview</directory>
         </include>
+
+        <exclude>
+            <directory>tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/Fixtures</directory>
+            <directory>tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/Fixtures</directory>
+            <directory>tests/phpunit/Architecture/PHPat/Selector/Support/EventArchitectureTest/Fixtures</directory>
+        </exclude>
     </source>
 </phpunit>


### PR DESCRIPTION
Those test cases are there for tests, but not meant to be to be executed.
