### PR TITLE
chore(autoreview): Exclude AutoReview code from the PHPUnit integration group rules

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -763,24 +763,6 @@ parameters:
 			path: ../src/Testing/SingletonContainer.php
 
 		-
-			rawMessage: Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup\PHPUnitTestNotRequiringIoWithIntegrationGroupTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/PHPUnitTestNotRequiringIoWithIntegrationGroupTest.php
-
-		-
-			rawMessage: Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\PHPUnitTestRequiringIoWithoutIntegrationGroupTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
-
-		-
-			rawMessage: Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirementsTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
-
-		-
 			rawMessage: Infection\Tests\AutoReview\ConcreteClassReflector should not exist
 			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
 			count: 1
@@ -791,12 +773,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/AutoReview/ConcreteClassReflector.php
-
-		-
-			rawMessage: Infection\Tests\AutoReview\EnvVariableManipulation\EnvManipulationTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvManipulationTest.php
 
 		-
 			rawMessage: 'Method Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestCaseForEnvManipulations() should return string|null but returns string|false.'
@@ -829,12 +805,6 @@ parameters:
 			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
 
 		-
-			rawMessage: Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProviderTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProviderTest.php
-
-		-
 			rawMessage: 'Cannot call method getPrerequisites() on Fidry\Makefile\Rule|null.'
 			identifier: method.nonObject
 			count: 2
@@ -845,12 +815,6 @@ parameters:
 			identifier: argument.type
 			count: 2
 			path: ../tests/phpunit/AutoReview/Mutator/MutatorProviderTest.php
-
-		-
-			rawMessage: Infection\Tests\AutoReview\Mutator\MutatorTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/AutoReview/Mutator/MutatorTest.php
 
 		-
 			rawMessage: 'Method Infection\Tests\AutoReview\Mutator\MutatorTest::getPublicMethods() has parameter $reflectionClass with generic class ReflectionClass but does not specify its types: T'
@@ -887,12 +851,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php
-
-		-
-			rawMessage: Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/AutoReview/ProjectCode/ProjectCodeTest.php
 
 		-
 			rawMessage: 'Parameter #1 $objectOrClass of class ReflectionClass constructor expects class-string<T of object>|T of object, string given.'

--- a/tests/Architecture/PHPat/PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest.php
+++ b/tests/Architecture/PHPat/PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroupTest.php
@@ -51,7 +51,10 @@ final readonly class PHPUnitTestsNotRequiringIoShouldNotBelongToIntegrationGroup
     {
         return PHPat::rule()
             ->classes(InfectionSelector::phpunitTestNotRequiringIoWithIntegrationGroup($this->reflectionProvider))
-            ->excluding(InfectionSelector::selectorFixtures())
+            ->excluding(
+                InfectionSelector::selectorFixtures(),
+                InfectionSelector::autoreviewTestCode(),
+            )
             ->shouldNot()
             ->exist()
             ->because('PHPUnit tests covering code without detected I/O should not be marked with the integration group.');

--- a/tests/Architecture/PHPat/PHPUnitTestsRequiringIoShouldBelongToIntegrationGroupTest.php
+++ b/tests/Architecture/PHPat/PHPUnitTestsRequiringIoShouldBelongToIntegrationGroupTest.php
@@ -51,7 +51,10 @@ final readonly class PHPUnitTestsRequiringIoShouldBelongToIntegrationGroupTest
     {
         return PHPat::rule()
             ->classes(InfectionSelector::phpunitTestRequiringIoWithoutIntegrationGroup($this->reflectionProvider))
-            ->excluding(InfectionSelector::selectorFixtures())
+            ->excluding(
+                InfectionSelector::selectorFixtures(),
+                InfectionSelector::autoreviewTestCode(),
+            )
             ->shouldNot()
             ->exist()
             ->because('PHPUnit tests using I/O should be marked with the integration group.');

--- a/tests/Architecture/PHPat/Selector/InfectionSelector.php
+++ b/tests/Architecture/PHPat/Selector/InfectionSelector.php
@@ -99,10 +99,13 @@ final class InfectionSelector
         return new PHPUnitTestSupportConcreteClassWithoutCanonicalTest();
     }
 
-    public static function phpunitTestRequiringIoWithoutIntegrationGroup(ReflectionProvider $reflectionProvider): PHPUnitTestRequiringIoWithoutIntegrationGroup
+    public static function phpunitTestRequiringIoWithoutIntegrationGroup(ReflectionProvider $reflectionProvider): SelectorInterface
     {
-        return new PHPUnitTestRequiringIoWithoutIntegrationGroup(
-            self::phpUnitTestIoRequirements($reflectionProvider),
+        return Selector::AllOf(
+            new PHPUnitTestRequiringIoWithoutIntegrationGroup(
+                self::phpUnitTestIoRequirements($reflectionProvider),
+            ),
+            Selector::Not(self::autoreviewTestCode()),
         );
     }
 
@@ -110,6 +113,17 @@ final class InfectionSelector
     {
         return new PHPUnitTestNotRequiringIoWithIntegrationGroup(
             self::phpUnitTestIoRequirements($reflectionProvider),
+        );
+    }
+
+    public static function autoreviewTestCode(): SelectorInterface
+    {
+        return Selector::AllOf(
+            Selector::AnyOf(
+                Selector::inNamespace('Infection\Tests\Architecture'),
+                Selector::inNamespace('Infection\Tests\AutoReview'),
+            ),
+            Selector::Not(self::selectorFixtures()),
         );
     }
 

--- a/tests/phpunit/Architecture/PHPat/Selector/InfectionSelectorTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/InfectionSelectorTest.php
@@ -37,9 +37,13 @@ namespace Infection\Tests\Architecture\PHPat\Selector;
 
 use Infection\Benchmark\Instrumentor;
 use Infection\Engine;
+use Infection\Tests\Architecture\PHPat\ClassesShouldBeFinalTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\CoveredClassWithIo;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\PHPUnitTestRequiringIoWithoutIntegrationGroupTest;
+use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
+use Infection\Tests\AutoReview\ProjectCode\ProjectCodeTest;
+use Infection\Tests\Logger\Console\BasicConsoleLoggerTest;
 use LogicException;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -68,6 +72,43 @@ final class InfectionSelectorTest extends SelectorTestCase
 
             $this->assertSame($expected, $actual, $message);
         }
+    }
+
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('autoreviewTestCodeClassProvider')]
+    public function test_it_matches_autoreview_test_code(
+        string $className,
+        bool $expected,
+    ): void {
+        $selector = InfectionSelector::autoreviewTestCode();
+        $classReflection = $this->createClassReflection($className);
+
+        $actual = $selector->matches($classReflection);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function autoreviewTestCodeClassProvider(): iterable
+    {
+        yield 'PHPat architecture test class' => [ClassesShouldBeFinalTest::class, true];
+
+        yield 'PHPat custom selector' => [InfectionSelector::class, true];
+
+        yield 'PHPat selector PHPUnit test' => [self::class, true];
+
+        yield 'PHPat selector fixture for PHPUnit tests' => [FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest::class, false];
+
+        yield 'AutoReview PHPunit test' => [ProjectCodeTest::class, true];
+
+        yield 'AutoReview source code' => [ProjectCodeProvider::class, true];
+
+        yield 'infection source class' => [Engine::class, false];
+
+        yield 'regular PHPUnit test class' => [BasicConsoleLoggerTest::class, false];
+
+        yield 'vendor class' => [TestCase::class, false];
     }
 
     /**


### PR DESCRIPTION
## Description

`#[Group('integration)` is used to be executed separately, are more sensitive or slower tests, and we have PHPat rules (previously AutoReview) rules to enforce them.

However, for the AutoReview code (rules enforced via PHPUnit tests, or tests for the PHPat rules), are executed separately (via the `phpunit_autoreview.xml` configuration file), it does not need to make use of any PHPUnit group.

This PR tweaks the configuration of the rule checking that the `#[Group('integration')` attribute is properly used for the autoreview code.

## Changes

- Adds `InfectionSelector::autoreviewTestCode()` for AutoReview and PHPat architecture code.
- Excludes AutoReview/architecture code from the PHPat rules checking missing or unnecessary PHPUnit `integration` groups.
- Adds selector coverage for `InfectionSelector::autoreviewTestCode()`.
- Removes obsolete PHPat baseline entries for AutoReview/architecture tests now excluded by the rules.

## Reviewer Notes

The code is quite boring, what you can easily observe is the PHPStan violations with the identifier `phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup` being dropped for the autoreview code.
