### PR TITLE
ci: Prevent GitHub rate limiting when downloading mago in e2e fixtures

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -123,6 +123,12 @@ jobs:
           ls tests/e2e/*/composer.json | xargs dirname |
              xargs -I{} -P 4 $CHRONIC composer --working-dir={} install --no-interaction --prefer-dist --no-progress || true
 
+      - name: Download mago used in some E2E tests
+        run: vendor/bin/mago --version
+        working-directory: tests/e2e/Mago_Integration
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run the Windows compatible subset of E2E tests
         if: runner.os == 'Windows'
         shell: bash


### PR DESCRIPTION
I noticed an E2E test fail due to the mago binary not being downloaded. Given not `GITHUB_TOKEN` was available in the failing task, this is likely due to a rate limiting.

This PR fixes this issue the same way we did for the autoreview step.
