### PR TITLE
fix(autoreview): Fix PHPat I/O detection for PHPUnit covers attributes

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -991,12 +991,6 @@ parameters:
 			path: ../tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
 
 		-
-			rawMessage: Infection\Tests\Framework\Enum\ImplodableEnum\ImplodableEnumTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/Framework/Enum/ImplodableEnum/ImplodableEnumTest.php
-
-		-
 			rawMessage: Infection\Tests\Logger\Console\BufferedOutputWithStdErrOutput should not exist
 			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
 			count: 1
@@ -1061,18 +1055,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../tests/phpunit/MockedContainer.php
-
-		-
-			rawMessage: Infection\Tests\Mutant\MutantAssertionsTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/Mutant/MutantAssertionsTest.php
-
-		-
-			rawMessage: Infection\Tests\Mutant\MutantExecutionResultAssertionsTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/Mutant/MutantExecutionResultAssertionsTest.php
 
 		-
 			rawMessage: 'Parameter #3 $mutators of method Infection\Mutation\FileMutationGenerator::generate() expects array<Infection\Mutator\Mutator<PhpParser\Node>>, array{Infection\Mutator\Arithmetic\Plus} given.'
@@ -1613,12 +1595,6 @@ parameters:
 			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
 			count: 1
 			path: ../tests/phpunit/TestingUtility/Console/Command/TestOptionCommand.php
-
-		-
-			rawMessage: Infection\Tests\TestingUtility\PHPUnit\ExpectsThrowablesTest should not exist
-			identifier: phpat.testPHPUnitTestsRequiringIoBelongToIntegrationGroup
-			count: 1
-			path: ../tests/phpunit/TestingUtility/PHPUnit/ExpectsThrowablesTest.php
 
 		-
 			rawMessage: Infection\Tests\TestingUtility\Process\TestPhpExecutableFinder should not exist

--- a/rector.php
+++ b/rector.php
@@ -88,6 +88,7 @@ $skippedPaths = [
     __DIR__ . '/tests/benchmark/Tracing/benchmark-source',
     __DIR__ . '/tests/benchmark/Tracing/coverage',
     __DIR__ . '/tests/phpunit/Architecture/PHPat/Selector/Support/Analyser/DetectConcreteClassMeaningfulImplementationVisitor/Fixture',
+    __DIR__ . '/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/Fixtures/CoveredClassWithoutIo.php',
 ];
 
 $config = RectorConfig::configure()

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
@@ -56,7 +56,7 @@ final readonly class PHPUnitTestNotRequiringIoWithIntegrationGroup implements Se
     {
         return InfectionSelector::phpunitTestCode()->matches($classReflection)
             && InfectionSelector::concretePHPUnitTestClass()->matches($classReflection)
-            && $this->ioCodeDetector->hasCoveredClass($classReflection)
+            && $this->ioCodeDetector->isCoveringCode($classReflection)
             && !$this->ioCodeDetector->isUsingIo($classReflection)
             && PHPUnitTestClassAnalysis::belongsToIntegrationGroup($classReflection);
     }

--- a/tests/Architecture/PHPat/Selector/Support/IoCodeDetector.php
+++ b/tests/Architecture/PHPat/Selector/Support/IoCodeDetector.php
@@ -69,13 +69,13 @@ final class IoCodeDetector
             return true;
         }
 
-        $coveredClassNames = PHPUnitTestClassAnalysis::getCoveredClassNames(
+        $coveredClassNames = PHPUnitTestClassAnalysis::getCoveredSymbols(
             $classReflection,
             $this->reflectionProvider,
         );
 
         if (count($coveredClassNames) === 0) {
-            return !PHPUnitTestClassAnalysis::hasCoverageAttribute($classReflection);
+            return true;
         }
 
         foreach ($coveredClassNames as $coveredClassName) {
@@ -89,7 +89,7 @@ final class IoCodeDetector
 
     public function hasCoveredClass(ClassReflection $testCaseReflection): bool
     {
-        $coveredClassNames = PHPUnitTestClassAnalysis::getCoveredClassNames(
+        $coveredClassNames = PHPUnitTestClassAnalysis::getCoveredSymbols(
             $testCaseReflection,
             $this->reflectionProvider,
         );

--- a/tests/Architecture/PHPat/Selector/Support/IoCodeDetector.php
+++ b/tests/Architecture/PHPat/Selector/Support/IoCodeDetector.php
@@ -69,17 +69,17 @@ final class IoCodeDetector
             return true;
         }
 
-        $coveredClassNames = PHPUnitTestClassAnalysis::getCoveredSymbols(
+        $coveredSymbols = PHPUnitTestClassAnalysis::getCoveredSymbols(
             $classReflection,
             $this->reflectionProvider,
         );
 
-        if (count($coveredClassNames) === 0) {
+        if (count($coveredSymbols) === 0) {
             return true;
         }
 
-        foreach ($coveredClassNames as $coveredClassName) {
-            if ($this->isTestedClassUsingIo($coveredClassName)) {
+        foreach ($coveredSymbols as $coveredSymbol) {
+            if ($this->isTestedClassUsingIo($coveredSymbol)) {
                 return true;
             }
         }
@@ -87,14 +87,14 @@ final class IoCodeDetector
         return false;
     }
 
-    public function hasCoveredClass(ClassReflection $testCaseReflection): bool
+    public function isCoveringCode(ClassReflection $testCaseReflection): bool
     {
-        $coveredClassNames = PHPUnitTestClassAnalysis::getCoveredSymbols(
+        $coveredSymbols = PHPUnitTestClassAnalysis::getCoveredSymbols(
             $testCaseReflection,
             $this->reflectionProvider,
         );
 
-        return count($coveredClassNames) > 0;
+        return count($coveredSymbols) > 0;
     }
 
     /**

--- a/tests/Architecture/PHPat/Selector/Support/IoCodeDetector.php
+++ b/tests/Architecture/PHPat/Selector/Support/IoCodeDetector.php
@@ -75,7 +75,7 @@ final class IoCodeDetector
         );
 
         if (count($coveredSymbols) === 0) {
-            return true;
+            return false;
         }
 
         foreach ($coveredSymbols as $coveredSymbol) {

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
@@ -78,21 +78,10 @@ final class PHPUnitTestClassAnalysis
         return false;
     }
 
-    public static function hasCoverageAttribute(ClassReflection $classReflection): bool
-    {
-        foreach (self::getAttributes($classReflection) as $attribute) {
-            if (self::isCoverageAttribute($attribute)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     /**
      * @return list<class-string>
      */
-    public static function getCoveredClassNames(
+    public static function getCoveredSymbols(
         ClassReflection $testCaseReflection,
         ReflectionProvider $reflectionProvider,
     ): array {
@@ -103,7 +92,7 @@ final class PHPUnitTestClassAnalysis
                 continue;
             }
 
-            $coveredClassName = self::getCoveredClassName($attribute, $reflectionProvider);
+            $coveredClassName = self::getCoveredSymbol($attribute, $reflectionProvider);
 
             if ($coveredClassName !== null) {
                 $coveredClassNames[] = $coveredClassName;
@@ -131,25 +120,35 @@ final class PHPUnitTestClassAnalysis
     /**
      * @return class-string|null
      */
-    private static function getCoveredClassName(
+    private static function getCoveredSymbol(
         ReflectionAttribute $attribute,
         ReflectionProvider $reflectionProvider,
     ): ?string {
-        $coveredClassName = match ($attribute->getName()) {
+        $symbol = match ($attribute->getName()) {
             CoversClass::class,
-            CoversMethod::class => self::getStringArgument($attribute, 0, 'className'),
-            CoversTrait::class => self::getStringArgument($attribute, 0, 'traitName'),
+            CoversMethod::class => self::getStringArgument(
+                attribute: $attribute,
+                index: 0,
+                name: 'className',
+            ),
+            CoversTrait::class => self::getStringArgument(
+                attribute: $attribute,
+                index: 0,
+                name: 'traitName',
+            ),
             default => null,
         };
 
-        $classNameExists = is_string($coveredClassName)
-            && $reflectionProvider->hasClass($coveredClassName);
+        $symbolExists = $symbol !== null && $reflectionProvider->hasClass($symbol);
 
-        return $classNameExists ? $coveredClassName : null;
+        return $symbolExists ? $symbol : null;
     }
 
-    private static function getStringArgument(ReflectionAttribute $attribute, int $index, string $name): ?string
-    {
+    private static function getStringArgument(
+        ReflectionAttribute $attribute,
+        int $index,
+        string $name,
+    ): ?string {
         $arguments = $attribute->getArguments();
         $value = $arguments[$index] ?? $arguments[$name] ?? null;
 

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirements.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirements.php
@@ -42,14 +42,15 @@ use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-use function str_starts_with;
 
 final class PHPUnitTestIoRequirements
 {
-    private const string COVERS_ATTRIBUTE_NAMESPACE = 'PHPUnit\\Framework\\Attributes\\Covers';
-
     private const string GROUP_NAME = 'integration';
 
     /**
@@ -65,18 +66,12 @@ final class PHPUnitTestIoRequirements
 
     public function requiresIntegrationGroup(ClassReflection $testCaseReflection): bool
     {
-        if ($this->testCaseUsesIo($testCaseReflection)) {
+        if ($this->isTestCaseUsingIo($testCaseReflection)) {
             return true;
         }
 
-        $coveredClassNames = $this->getCoveredClassNames($testCaseReflection);
-
-        if ($coveredClassNames === null) {
-            return true;
-        }
-
-        foreach ($coveredClassNames as $coveredClassName) {
-            if ($this->testedClassUsesIo($coveredClassName)) {
+        foreach ($this->getCoveredClassNames($testCaseReflection) as $coveredClassName) {
+            if ($this->isTestedClassUsingIo($coveredClassName)) {
                 return true;
             }
         }
@@ -86,7 +81,7 @@ final class PHPUnitTestIoRequirements
 
     public function hasCoveredClass(ClassReflection $testCaseReflection): bool
     {
-        return $this->getCoveredClassNames($testCaseReflection) !== null;
+        return count($this->getCoveredClassNames($testCaseReflection)) > 0;
     }
 
     public function hasIntegrationGroup(ClassReflection $classReflection): bool
@@ -103,9 +98,9 @@ final class PHPUnitTestIoRequirements
     /**
      * Check the test case code.
      */
-    private function testCaseUsesIo(ClassReflection $testCaseReflection): bool
+    private function isTestCaseUsingIo(ClassReflection $testCaseReflection): bool
     {
-        if ($this->classUsesIo($testCaseReflection)) {
+        if ($this->isClassUsingIo($testCaseReflection)) {
             return true;
         }
 
@@ -115,7 +110,7 @@ final class PHPUnitTestIoRequirements
             $parentTestCaseClassReflection !== null
             && $parentTestCaseClassReflection->getName() !== TestCase::class
         ) {
-            if ($this->classUsesIo($parentTestCaseClassReflection)) {
+            if ($this->isClassUsingIo($parentTestCaseClassReflection)) {
                 return true;
             }
 
@@ -130,12 +125,12 @@ final class PHPUnitTestIoRequirements
      *
      * @param class-string $sourceClassName
      */
-    private function testedClassUsesIo(string $sourceClassName): bool
+    private function isTestedClassUsingIo(string $sourceClassName): bool
     {
         $classReflection = $this->reflectionProvider->getClass($sourceClassName);
 
         do {
-            if ($this->classUsesIo($classReflection)) {
+            if ($this->isClassUsingIo($classReflection)) {
                 return true;
             }
 
@@ -146,64 +141,59 @@ final class PHPUnitTestIoRequirements
     }
 
     /**
-     * @return list<class-string>|null
+     * @return list<class-string>
      */
-    private function getCoveredClassNames(ClassReflection $testCaseReflection): ?array
+    private function getCoveredClassNames(ClassReflection $testCaseReflection): array
     {
         $coveredClassNames = [];
-        $hasCoverageAttribute = false;
 
         foreach (self::getAttributes($testCaseReflection) as $attribute) {
-            if (!self::isCoverageAttribute($attribute)) {
-                continue;
-            }
-
-            $hasCoverageAttribute = true;
-
             $coveredClassName = $this->getCoveredClassName($attribute);
 
             if ($coveredClassName === null) {
-                return null;
+                continue;
             }
 
             $coveredClassNames[] = $coveredClassName;
         }
 
-        return $hasCoverageAttribute && count($coveredClassNames) > 0
-            ? $coveredClassNames
-            : null;
+        return $coveredClassNames;
     }
 
     /**
-     * TODO: eventually we should support functions, methods and traits too.
-     * @see CoversClass
+     * Gets the class-like target from a `#[Covers*]` PHPUnit attribute.
      *
      * @return class-string|null
      */
     private function getCoveredClassName(ReflectionAttribute $attribute): ?string
     {
-        if ($attribute->getName() !== CoversClass::class) {
+        $coveredClassName = match ($attribute->getName()) {
+            CoversClass::class,
+            CoversMethod::class => self::getStringArgument($attribute, 0, 'className'),
+            CoversTrait::class => self::getStringArgument($attribute, 0, 'traitName'),
+            CoversFunction::class,
+            CoversNothing::class => null,
+            default => null,
+        };
+
+        if (!is_string($coveredClassName)) {
             return null;
         }
 
-        $arguments = $attribute->getArguments();
-        $coveredClassName = $arguments[0] ?? $arguments['className'] ?? null;
-
-        $classNameExists = is_string($coveredClassName)
-            && $this->reflectionProvider->hasClass($coveredClassName);
-
-        return $classNameExists ? $coveredClassName : null;
+        return $this->reflectionProvider->hasClass($coveredClassName)
+            ? $coveredClassName
+            : null;
     }
 
-    private static function isCoverageAttribute(ReflectionAttribute $attribute): bool
+    private static function getStringArgument(ReflectionAttribute $attribute, int $index, string $name): ?string
     {
-        return str_starts_with(
-            $attribute->getName(),
-            self::COVERS_ATTRIBUTE_NAMESPACE,
-        );
+        $arguments = $attribute->getArguments();
+        $value = $arguments[$index] ?? $arguments[$name] ?? null;
+
+        return is_string($value) ? $value : null;
     }
 
-    private function classUsesIo(ClassReflection $classReflection): bool
+    private function isClassUsingIo(ClassReflection $classReflection): bool
     {
         $className = $classReflection->getName();
 

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/Fixtures/CoveredTraitWithoutIo.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/Fixtures/CoveredTraitWithoutIo.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures;
+
+trait CoveredTraitWithoutIo
+{
+}

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/Fixtures/FixtureWithCoveredFunctionTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/Fixtures/FixtureWithCoveredFunctionTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+function covered_function_without_io(): string
+{
+    return 'fixture';
+}
+
+#[CoversFunction(__NAMESPACE__ . '\covered_function_without_io')]
+final class FixtureWithCoveredFunctionTest extends TestCase
+{
+    public function test_fixture(): void
+    {
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/Fixtures/FixtureWithCoveredMethodWithoutIoTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/Fixtures/FixtureWithCoveredMethodWithoutIoTest.php
@@ -35,12 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures;
 
-final class CoveredClassWithoutIo
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\TestCase;
+
+#[CoversMethod(CoveredClassWithoutIo::class, 'coveredMethod')]
+final class FixtureWithCoveredMethodWithoutIoTest extends TestCase
 {
-    /**
-     * @phpstan-ignore shipmonk.deadMethod
-     */
-    public function coveredMethod(): void
+    public function test_fixture(): void
     {
+        $this->expectNotToPerformAssertions();
     }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/Fixtures/FixtureWithCoveredTraitWithoutIoTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/Fixtures/FixtureWithCoveredTraitWithoutIoTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures;
+
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\TestCase;
+
+#[CoversTrait(CoveredTraitWithoutIo::class)]
+final class FixtureWithCoveredTraitWithoutIoTest extends TestCase
+{
+    public function test_fixture(): void
+    {
+        $fixture = new class {
+            use CoveredTraitWithoutIo;
+        };
+
+        $this->assertIsObject($fixture);
+    }
+}

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
@@ -42,6 +42,8 @@ use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutInt
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithFileSystemIoTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithIoTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredFunctionTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredTraitWithoutIoTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoversNothingWithIntegrationGroupTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoversNothingWithoutIntegrationGroupTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithIoInTestCaseTest;
@@ -86,7 +88,7 @@ final class PHPUnitTestRequiringIoWithoutIntegrationGroupTest extends SelectorTe
     {
         yield 'test with CoversNothing' => [
             FixtureWithCoversNothingWithoutIntegrationGroupTest::class,
-            true,
+            false,
         ];
 
         yield 'test without CoversClass with integration group' => [
@@ -96,6 +98,16 @@ final class PHPUnitTestRequiringIoWithoutIntegrationGroupTest extends SelectorTe
 
         yield 'test covering class without I/O' => [
             FixtureWithCoveredClassWithoutIoTest::class,
+            false,
+        ];
+
+        yield 'test covering trait without I/O' => [
+            FixtureWithCoveredTraitWithoutIoTest::class,
+            false,
+        ];
+
+        yield 'test covering function' => [
+            FixtureWithCoveredFunctionTest::class,
             false,
         ];
 

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/IoCodeDetectorTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/IoCodeDetectorTest.php
@@ -53,7 +53,6 @@ use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutInt
 use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
 use Infection\Tests\Architecture\PHPat\Selector\Support\Analyser\Analyser;
 use Infection\Tests\Architecture\PHPat\Selector\Support\Fixtures\ClassWithIoParent;
-use Infection\Tests\Architecture\PHPat\Selector\Support\Fixtures\FixturePHPUnitTestCase;
 use Infection\Tests\Command\Debug\DumpAstCommand\DumpAstCommandTest;
 use Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest;
 use Infection\Tests\Reporter\FileReporterTest;
@@ -111,13 +110,6 @@ final class IoCodeDetectorTest extends SelectorTestCase
             false,
             false,
             true,
-        ];
-
-        yield 'test without coverage attribute' => [
-            FixturePHPUnitTestCase::class,
-            true,
-            false,
-            false,
         ];
 
         yield 'test covering class without I/O' => [

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/IoCodeDetectorTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/IoCodeDetectorTest.php
@@ -71,7 +71,7 @@ final class IoCodeDetectorTest extends SelectorTestCase
     public function test_it_detects_whether_phpunit_tests_use_io(
         string $className,
         bool $expectedIsUsingIo,
-        bool $expectedHasCoveredClass,
+        bool $expectedIsCoveringCode,
         bool $expectedHasIntegrationGroup,
     ): void {
         $ioCodeDetector = new IoCodeDetector(
@@ -88,8 +88,8 @@ final class IoCodeDetectorTest extends SelectorTestCase
             $ioCodeDetector->isUsingIo($classReflection),
         );
         $this->assertSame(
-            $expectedHasCoveredClass,
-            $ioCodeDetector->hasCoveredClass($classReflection),
+            $expectedIsCoveringCode,
+            $ioCodeDetector->isCoveringCode($classReflection),
         );
         $this->assertSame(
             $expectedHasIntegrationGroup,

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
@@ -138,7 +138,7 @@ final class PHPUnitTestClassAnalysisTest extends SelectorTestCase
         string $className,
         array $expected,
     ): void {
-        $actual = PHPUnitTestClassAnalysis::getCoveredClassNames(
+        $actual = PHPUnitTestClassAnalysis::getCoveredSymbols(
             $this->createClassReflection($className),
             $this->getReflectionProvider(),
         );

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
@@ -40,6 +40,8 @@ use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithInt
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\CoveredClassWithIo;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\CoveredClassWithoutIo;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredFunctionTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredMethodWithoutIoTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoversNothingWithoutIntegrationGroupTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithMultipleCoveredClassesTest;
 use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
@@ -155,6 +157,13 @@ final class PHPUnitTestClassAnalysisTest extends SelectorTestCase
             ],
         ];
 
+        yield 'covered method' => [
+            FixtureWithCoveredMethodWithoutIoTest::class,
+            [
+                CoveredClassWithoutIo::class,
+            ],
+        ];
+
         yield 'multiple covered classes' => [
             FixtureWithMultipleCoveredClassesTest::class,
             [
@@ -165,6 +174,11 @@ final class PHPUnitTestClassAnalysisTest extends SelectorTestCase
 
         yield 'unsupported coverage attribute' => [
             FixtureWithCoversNothingWithoutIntegrationGroupTest::class,
+            [],
+        ];
+
+        yield 'covered function' => [
+            FixtureWithCoveredFunctionTest::class,
             [],
         ];
 

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
@@ -42,6 +42,8 @@ use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutInt
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithFileSystemIoTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithIoTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredFunctionTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredTraitWithoutIoTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoversNothingWithIntegrationGroupTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoversNothingWithoutIntegrationGroupTest;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithIoInTestCaseTest;
@@ -94,14 +96,14 @@ final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
     {
         yield 'test with CoversNothing without integration group' => [
             FixtureWithCoversNothingWithoutIntegrationGroupTest::class,
-            true,
+            false,
             false,
             false,
         ];
 
         yield 'test with CoversNothing with integration group' => [
             FixtureWithCoversNothingWithIntegrationGroupTest::class,
-            true,
+            false,
             false,
             true,
         ];
@@ -110,6 +112,20 @@ final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
             FixtureWithCoveredClassWithoutIoTest::class,
             false,
             true,
+            false,
+        ];
+
+        yield 'test covering trait without I/O' => [
+            FixtureWithCoveredTraitWithoutIoTest::class,
+            false,
+            true,
+            false,
+        ];
+
+        yield 'test covering function' => [
+            FixtureWithCoveredFunctionTest::class,
+            false,
+            false,
             false,
         ];
 


### PR DESCRIPTION
When detecting I/O, we currently do not check the target symbol for `#[CoversTrait]`, resulting in some false-positives (e.g. `ImplodableEnumTest`) which will be marked as requiring I/O when they do not (note that when a test covers no code, e.g. it uses `#[CoversNothing]`, we require it to belong to the `integration` PHPUnit group, see https://github.com/infection/infection/pull/3277).

This PR extends the covers attribute support to `#[CoversTrait]`, resulting in the deletion of some false-positives from the PHPStan baseline.

As a bonus, I added support for `#[CoversMethod]` (new in PHPUnit 11) too as it was easy to do, although unused at the moment. `#[CoversFunction]` seems more complicated, so I left it alone.
