### PR TITLE
refactor(autoreview): Extract PHPUnit test analysis into a dedicated helper

### DIFF
--- a/tests/Architecture/PHPat/Selector/ConcretePHPUnitTestClass.php
+++ b/tests/Architecture/PHPat/Selector/ConcretePHPUnitTestClass.php
@@ -36,9 +36,9 @@ declare(strict_types=1);
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
 use Infection\Tests\Architecture\PHPat\Selector\Support\ConcreteClassReflection;
+use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestClassAnalysis;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
-use PHPUnit\Framework\TestCase;
 use function str_ends_with;
 
 final class ConcretePHPUnitTestClass implements SelectorInterface
@@ -52,6 +52,6 @@ final class ConcretePHPUnitTestClass implements SelectorInterface
     {
         return ConcreteClassReflection::isConcreteClass($classReflection)
             && str_ends_with($classReflection->getName(), 'Test')
-            && $classReflection->isSubclassOf(TestCase::class);
+            && PHPUnitTestClassAnalysis::isPHPUnitTestCase($classReflection);
     }
 }

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
+use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestClassAnalysis;
 use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
@@ -57,6 +58,6 @@ final readonly class PHPUnitTestNotRequiringIoWithIntegrationGroup implements Se
             && InfectionSelector::concretePHPUnitTestClass()->matches($classReflection)
             && $this->ioRequirements->hasCoveredClass($classReflection)
             && !$this->ioRequirements->requiresIntegrationGroup($classReflection)
-            && $this->ioRequirements->hasIntegrationGroup($classReflection);
+            && PHPUnitTestClassAnalysis::belongsToIntegrationGroup($classReflection);
     }
 }

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
+use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestClassAnalysis;
 use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
@@ -56,6 +57,6 @@ final readonly class PHPUnitTestRequiringIoWithoutIntegrationGroup implements Se
         return InfectionSelector::phpunitTestCode()->matches($classReflection)
             && InfectionSelector::concretePHPUnitTestClass()->matches($classReflection)
             && $this->ioRequirements->requiresIntegrationGroup($classReflection)
-            && !$this->ioRequirements->hasIntegrationGroup($classReflection);
+            && !PHPUnitTestClassAnalysis::belongsToIntegrationGroup($classReflection);
     }
 }

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Architecture\PHPat\Selector\Support;
+
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
+use PHPStan\Reflection\ClassReflection;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+final class PHPUnitTestClassAnalysis
+{
+    private const string GROUP_NAME = 'integration';
+
+    public static function isPHPUnitTestCase(ClassReflection $classReflection): bool
+    {
+        return $classReflection->is(TestCase::class);
+    }
+
+    public static function hasCoversNothing(ClassReflection $classReflection): bool
+    {
+        return $classReflection->getNativeReflection()->getAttributes(CoversNothing::class) !== [];
+    }
+
+    public static function belongsToIntegrationGroup(ClassReflection $classReflection): bool
+    {
+        foreach (self::getAttributes($classReflection) as $groupAttribute) {
+            if (self::isIntegrationGroup($groupAttribute)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @see Group
+     */
+    private static function isIntegrationGroup(ReflectionAttribute $attribute): bool
+    {
+        if ($attribute->getName() !== Group::class) {
+            return false;
+        }
+
+        $arguments = $attribute->getArguments();
+        $groupName = $arguments[0] ?? $arguments['name'] ?? null;
+
+        return $groupName === self::GROUP_NAME;
+    }
+
+    /**
+     * @return iterable<ReflectionAttribute>
+     */
+    private static function getAttributes(ClassReflection $classReflection): iterable
+    {
+        $attributes = $classReflection->getNativeReflection()->getAttributes();
+
+        foreach ($attributes as $attribute) {
+            if ($attribute instanceof ReflectionAttribute) {
+                yield $attribute;
+            }
+        }
+    }
+}

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
@@ -37,7 +37,6 @@ namespace Infection\Tests\Architecture\PHPat\Selector\Support;
 
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
 use PHPStan\Reflection\ClassReflection;
-use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -47,12 +46,7 @@ final class PHPUnitTestClassAnalysis
 
     public static function isPHPUnitTestCase(ClassReflection $classReflection): bool
     {
-        return $classReflection->is(TestCase::class);
-    }
-
-    public static function hasCoversNothing(ClassReflection $classReflection): bool
-    {
-        return $classReflection->getNativeReflection()->getAttributes(CoversNothing::class) !== [];
+        return $classReflection->isSubclassOf(TestCase::class);
     }
 
     public static function belongsToIntegrationGroup(ClassReflection $classReflection): bool

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirements.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirements.php
@@ -136,10 +136,6 @@ final class PHPUnitTestIoRequirements
      */
     private function getCoveredClassNames(ClassReflection $testCaseReflection): ?array
     {
-        if (PHPUnitTestClassAnalysis::hasCoversNothing($testCaseReflection)) {
-            return null;
-        }
-
         $coveredClassNames = [];
         $hasCoverageAttribute = false;
 

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirements.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirements.php
@@ -42,15 +42,12 @@ use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use function str_starts_with;
 
 final class PHPUnitTestIoRequirements
 {
     private const string COVERS_ATTRIBUTE_NAMESPACE = 'PHPUnit\\Framework\\Attributes\\Covers';
-
-    private const string GROUP_NAME = 'integration';
 
     /**
      * @var array<class-string, bool>
@@ -87,17 +84,6 @@ final class PHPUnitTestIoRequirements
     public function hasCoveredClass(ClassReflection $testCaseReflection): bool
     {
         return $this->getCoveredClassNames($testCaseReflection) !== null;
-    }
-
-    public function hasIntegrationGroup(ClassReflection $classReflection): bool
-    {
-        foreach (self::getAttributes($classReflection) as $groupAttribute) {
-            if (self::isIntegrationGroup($groupAttribute)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -150,6 +136,10 @@ final class PHPUnitTestIoRequirements
      */
     private function getCoveredClassNames(ClassReflection $testCaseReflection): ?array
     {
+        if (PHPUnitTestClassAnalysis::hasCoversNothing($testCaseReflection)) {
+            return null;
+        }
+
         $coveredClassNames = [];
         $hasCoverageAttribute = false;
 
@@ -215,21 +205,6 @@ final class PHPUnitTestIoRequirements
 
         return $this->classUsesIoCache[$className] = $fileName !== null
             && $this->analyser->analyse($classReflection, analyseNonConcreteClasses: true)->usesIo;
-    }
-
-    /**
-     * @see Group
-     */
-    private static function isIntegrationGroup(ReflectionAttribute $attribute): bool
-    {
-        if ($attribute->getName() !== Group::class) {
-            return false;
-        }
-
-        $arguments = $attribute->getArguments();
-        $groupName = $arguments[0] ?? $arguments['name'] ?? null;
-
-        return $groupName === self::GROUP_NAME;
     }
 
     /**

--- a/tests/phpunit/Architecture/PHPat/Selector/ConcretePHPUnitTestClassTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/ConcretePHPUnitTestClassTest.php
@@ -35,12 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
+use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestClassAnalysis;
 use Infection\Tests\PhpParser\Visitor\BaseVisitorTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ConcretePHPUnitTestClass::class)]
+#[CoversClass(PHPUnitTestClassAnalysis::class)]
 final class ConcretePHPUnitTestClassTest extends SelectorTestCase
 {
     /**

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/Fixtures/PHPUnitTestWithUnitGroupFixture.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/Fixtures/PHPUnitTestWithUnitGroupFixture.php
@@ -33,52 +33,12 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\Support\Fixtures;
 
-use Infection\Tests\PhpParser\Visitor\BaseVisitorTestCase;
-use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(ConcretePHPUnitTestClass::class)]
-final class ConcretePHPUnitTestClassTest extends SelectorTestCase
+#[Group('unit')]
+final class PHPUnitTestWithUnitGroupFixture extends TestCase
 {
-    /**
-     * @param class-string $className
-     */
-    #[DataProvider('classProvider')]
-    public function test_it_matches_concrete_phpunit_test_classes(
-        string $className,
-        bool $expected,
-    ): void {
-        $selector = new ConcretePHPUnitTestClass();
-        $classReflection = $this->createClassReflection($className);
-
-        $actual = $selector->matches($classReflection);
-
-        $this->assertSame($expected, $actual);
-    }
-
-    public static function classProvider(): iterable
-    {
-        yield 'concrete PHPUnit test' => [
-            self::class,
-            true,
-        ];
-
-        yield 'abstract PHPUnit test' => [
-            BaseVisitorTestCase::class,
-            false,
-        ];
-
-        yield 'PHPUnit support class' => [
-            ConcretePHPUnitTestClass::class,
-            false,
-        ];
-
-        yield 'vendor test case' => [
-            TestCase::class,
-            false,
-        ];
-    }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
@@ -33,51 +33,75 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\Support;
 
-use Infection\Tests\PhpParser\Visitor\BaseVisitorTestCase;
+use Infection\Command\ConfigureCommand;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest;
+use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
+use Infection\Tests\Architecture\PHPat\Selector\Support\Fixtures\PHPUnitTestWithUnitGroupFixture;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-#[CoversClass(ConcretePHPUnitTestClass::class)]
-final class ConcretePHPUnitTestClassTest extends SelectorTestCase
+#[CoversClass(PHPUnitTestClassAnalysis::class)]
+final class PHPUnitTestClassAnalysisTest extends SelectorTestCase
 {
     /**
      * @param class-string $className
      */
-    #[DataProvider('classProvider')]
-    public function test_it_matches_concrete_phpunit_test_classes(
+    #[DataProvider('phpUnitTestCaseProvider')]
+    public function test_it_detects_phpunit_test_cases(
         string $className,
         bool $expected,
     ): void {
-        $selector = new ConcretePHPUnitTestClass();
-        $classReflection = $this->createClassReflection($className);
-
-        $actual = $selector->matches($classReflection);
+        $actual = PHPUnitTestClassAnalysis::isPHPUnitTestCase(
+            $this->createClassReflection($className),
+        );
 
         $this->assertSame($expected, $actual);
     }
 
-    public static function classProvider(): iterable
+    public static function phpUnitTestCaseProvider(): iterable
     {
-        yield 'concrete PHPUnit test' => [
+        yield 'PHPUnit test case' => [
             self::class,
             true,
         ];
 
-        yield 'abstract PHPUnit test' => [
-            BaseVisitorTestCase::class,
+        yield 'source class' => [
+            ConfigureCommand::class,
+            false,
+        ];
+    }
+
+    /**
+     * @param class-string $className
+     */
+    #[DataProvider('integrationGroupProvider')]
+    public function test_it_detects_integration_group(
+        string $className,
+        bool $expected,
+    ): void {
+        $actual = PHPUnitTestClassAnalysis::belongsToIntegrationGroup(
+            $this->createClassReflection($className),
+        );
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function integrationGroupProvider(): iterable
+    {
+        yield 'positional integration group' => [
+            FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest::class,
+            true,
+        ];
+
+        yield 'non-integration group' => [
+            PHPUnitTestWithUnitGroupFixture::class,
             false,
         ];
 
-        yield 'PHPUnit support class' => [
-            ConcretePHPUnitTestClass::class,
-            false,
-        ];
-
-        yield 'vendor test case' => [
-            TestCase::class,
+        yield 'no group' => [
+            self::class,
             false,
         ];
     }

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
@@ -55,7 +55,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(PHPUnitTestIoRequirements::class)]
-#[CoversClass(PHPUnitTestClassAnalysis::class)]
 final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
 {
     /**

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestIoRequirementsTest.php
@@ -55,6 +55,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(PHPUnitTestIoRequirements::class)]
+#[CoversClass(PHPUnitTestClassAnalysis::class)]
 final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
 {
     /**
@@ -86,7 +87,7 @@ final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
         );
         $this->assertSame(
             $expectedHasIntegrationGroup,
-            $ioRequirements->hasIntegrationGroup($classReflection),
+            PHPUnitTestClassAnalysis::belongsToIntegrationGroup($classReflection),
         );
     }
 


### PR DESCRIPTION
## Description

Future PHPat rules will need more PHPUnit-related information from PHPStan `ClassReflection` objects.

This PR takes the first step by extracting existing PHPUnit-specific checks into a reusable helper, `PHPUnitTestClassAnalysis`. The goal is not to reduce much code immediately, but to make the intent explicit and keep the next behaviour changes small and easier to review.

## Changes

Adds `PHPUnitTestClassAnalysis`, which:

- Determines whether a PHPStan `ClassReflection` represents a PHPUnit test case.
- Moves the `#[Group('integration')]` attribute parsing out of `PHPUnitTestIoRequirements`.
- Gives future PHPat rules a dedicated place for PHPUnit test-class analysis.

The PHPUnit test-case check is intentionally unchanged for now. It remains a small wrapper around the existing logic so that later fixes can be reviewed as behaviour changes, rather than being mixed into this extraction.

## Reviewer Notes

This PR is intended as a refactor with no behaviour change.

This is a small step to untangle #3277 which itself is a PR made to untangle things. It's partly about refining the modelisation of our rules with PHPat and partly adjusting AI generated code I previously did not care as much about.