### PR TITLE
fix(autoreview): Fix PHPUnit test detection

### DIFF
--- a/tests/Architecture/PHPat/Selector/ConcretePHPUnitTestClass.php
+++ b/tests/Architecture/PHPat/Selector/ConcretePHPUnitTestClass.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
-use Infection\Tests\Architecture\PHPat\Selector\Support\ConcreteClassReflection;
 use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestClassAnalysis;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
@@ -49,7 +48,6 @@ final class ConcretePHPUnitTestClass implements SelectorInterface
 
     public function matches(ClassReflection $classReflection): bool
     {
-        return ConcreteClassReflection::isConcreteClass($classReflection)
-            && PHPUnitTestClassAnalysis::isPHPUnitTestCase($classReflection);
+        return PHPUnitTestClassAnalysis::isPHPUnitTestCase($classReflection);
     }
 }

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
@@ -47,8 +47,9 @@ final class PHPUnitTestClassAnalysis
 
     public static function isPHPUnitTestCase(ClassReflection $classReflection): bool
     {
-        return $classReflection->isSubclassOf(TestCase::class)
-            && str_ends_with($classReflection->getName(), 'Test');
+        return str_ends_with($classReflection->getName(), 'Test')
+            && ConcreteClassReflection::isConcreteClass($classReflection)
+            && $classReflection->isSubclassOf(TestCase::class);
     }
 
     public static function belongsToIntegrationGroup(ClassReflection $classReflection): bool

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
@@ -39,6 +39,7 @@ use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
 use PHPStan\Reflection\ClassReflection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use function str_ends_with;
 
 final class PHPUnitTestClassAnalysis
 {
@@ -46,7 +47,8 @@ final class PHPUnitTestClassAnalysis
 
     public static function isPHPUnitTestCase(ClassReflection $classReflection): bool
     {
-        return $classReflection->isSubclassOf(TestCase::class);
+        return $classReflection->isSubclassOf(TestCase::class)
+            && str_ends_with($classReflection->getName(), 'Test');
     }
 
     public static function belongsToIntegrationGroup(ClassReflection $classReflection): bool

--- a/tests/phpunit/Architecture/PHPat/Selector/ConcretePHPUnitTestClassTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/ConcretePHPUnitTestClassTest.php
@@ -35,7 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
+use Infection\Tests\Architecture\PHPat\Selector\Support\Fixtures\FixturePHPUnitTestCase;
 use Infection\Tests\PhpParser\Visitor\BaseVisitorTestCase;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\ConcreteVisitorTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -73,6 +75,16 @@ final class ConcretePHPUnitTestClassTest extends SelectorTestCase
 
         yield 'PHPUnit support class' => [
             ConcretePHPUnitTestClass::class,
+            false,
+        ];
+
+        yield 'concrete PHPUnit helper class without Test suffix' => [
+            FixturePHPUnitTestCase::class,
+            false,
+        ];
+
+        yield 'concrete visitor test case helper class' => [
+            ConcreteVisitorTestCase::class,
             false,
         ];
 

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/Fixtures/FixturePHPUnitTestCase.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/Fixtures/FixturePHPUnitTestCase.php
@@ -33,23 +33,10 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\Support\Fixtures;
 
-use Infection\Tests\Architecture\PHPat\Selector\Support\ConcreteClassReflection;
-use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestClassAnalysis;
-use PHPat\Selector\SelectorInterface;
-use PHPStan\Reflection\ClassReflection;
+use PHPUnit\Framework\TestCase;
 
-final class ConcretePHPUnitTestClass implements SelectorInterface
+final class FixturePHPUnitTestCase extends TestCase
 {
-    public function getName(): string
-    {
-        return 'concrete PHPUnit test class';
-    }
-
-    public function matches(ClassReflection $classReflection): bool
-    {
-        return ConcreteClassReflection::isConcreteClass($classReflection)
-            && PHPUnitTestClassAnalysis::isPHPUnitTestCase($classReflection);
-    }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
@@ -38,7 +38,9 @@ namespace Infection\Tests\Architecture\PHPat\Selector\Support;
 use Infection\Command\ConfigureCommand;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest;
 use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
+use Infection\Tests\Architecture\PHPat\Selector\Support\Fixtures\FixturePHPUnitTestCase;
 use Infection\Tests\Architecture\PHPat\Selector\Support\Fixtures\PHPUnitTestWithUnitGroupFixture;
+use Infection\Tests\PhpParser\Visitor\VisitorTestCase\ConcreteVisitorTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -65,6 +67,16 @@ final class PHPUnitTestClassAnalysisTest extends SelectorTestCase
         yield 'PHPUnit test case' => [
             self::class,
             true,
+        ];
+
+        yield 'concrete PHPUnit helper class without Test suffix' => [
+            FixturePHPUnitTestCase::class,
+            false,
+        ];
+
+        yield 'concrete visitor test case helper class' => [
+            ConcreteVisitorTestCase::class,
+            false,
         ];
 
         yield 'source class' => [

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
@@ -43,6 +43,7 @@ use Infection\Tests\Architecture\PHPat\Selector\Support\Fixtures\PHPUnitTestWith
 use Infection\Tests\PhpParser\Visitor\VisitorTestCase\ConcreteVisitorTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 
 #[CoversClass(PHPUnitTestClassAnalysis::class)]
 final class PHPUnitTestClassAnalysisTest extends SelectorTestCase
@@ -67,6 +68,11 @@ final class PHPUnitTestClassAnalysisTest extends SelectorTestCase
         yield 'PHPUnit test case' => [
             self::class,
             true,
+        ];
+
+        yield 'abstract PHPUnit test' => [
+            AbstractPHPUnitTest::class,
+            false,
         ];
 
         yield 'concrete PHPUnit helper class without Test suffix' => [
@@ -117,4 +123,8 @@ final class PHPUnitTestClassAnalysisTest extends SelectorTestCase
             false,
         ];
     }
+}
+
+abstract class AbstractPHPUnitTest extends TestCase
+{
 }


### PR DESCRIPTION
An "executable" PHPUnit test is defined as follows:

- It must be a concrete class (not an interface or abstract).
- It must be a `PHPUnit\Framework\TestCase` instance.
- It must have the suffix `Test` as the classname.

I put quotes because I am not too happy with the term. "Test" doesn't do it justice, and "exercisable", (from "a test framework exercises tests") may not be the most obvious too. For now the method is called `::isPHPUnitTestCase()` but suggestions are welcomed.

This PR updates `PHPUnitTestClassAnalysis::isPHPUnitTestCase()` to reflect those requirements.
