### PR TITLE
fix(autoreview): Exclude `PHPUnit\Framework\TestCase` from the environment variables analysis

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -777,7 +777,7 @@ parameters:
 		-
 			rawMessage: 'Method Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestCaseForEnvManipulations() should return string|null but returns string|false.'
 			identifier: return.type
-			count: 1
+			count: 2
 			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
 
 		-
@@ -789,7 +789,7 @@ parameters:
 		-
 			rawMessage: 'Parameter #1 $filename of function Safe\file_get_contents expects string, string|false given.'
 			identifier: argument.type
-			count: 2
+			count: 3
 			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
 
 		-

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -777,7 +777,7 @@ parameters:
 		-
 			rawMessage: 'Method Infection\Tests\AutoReview\EnvVariableManipulation\EnvTestCasesProvider::checkTestCaseForEnvManipulations() should return string|null but returns string|false.'
 			identifier: return.type
-			count: 2
+			count: 1
 			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
 
 		-
@@ -789,7 +789,7 @@ parameters:
 		-
 			rawMessage: 'Parameter #1 $filename of function Safe\file_get_contents expects string, string|false given.'
 			identifier: argument.type
-			count: 3
+			count: 2
 			path: ../tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
 
 		-

--- a/tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
+++ b/tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
@@ -39,6 +39,7 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use function class_exists;
+use const DIRECTORY_SEPARATOR;
 use Infection\CannotBeInstantiated;
 use Infection\Framework\ClassName;
 use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
@@ -46,11 +47,16 @@ use function iterator_to_array;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use function Safe\file_get_contents;
+use function str_starts_with;
 use Webmozart\Assert\Assert;
 
 final class EnvTestCasesProvider
 {
     use CannotBeInstantiated;
+
+    private const SRC_DIR = __DIR__ . '/../../../../src';
+
+    private const TESTS_DIR = __DIR__ . '/../../../../tests';
 
     /**
      * @var string[][]|null
@@ -138,6 +144,10 @@ final class EnvTestCasesProvider
         while ($parentTestCaseClassReflection->getName() !== TestCase::class) {
             $parentTestCaseFileName = $parentTestCaseClassReflection->getFileName();
 
+            if ($parentTestCaseFileName === false || !self::isProjectCodeFile($parentTestCaseFileName)) {
+                break;
+            }
+
             $testCaseCode = file_get_contents($parentTestCaseFileName);
 
             if (EnvManipulatorCodeDetector::codeManipulatesEnvVariables($testCaseCode)) {
@@ -175,6 +185,10 @@ final class EnvTestCasesProvider
                 break;
             }
 
+            if (!self::isProjectCodeFile($parentClassFileName)) {
+                break;
+            }
+
             $parentClassCode = file_get_contents($parentClassFileName);
 
             if (EnvManipulatorCodeDetector::codeManipulatesEnvVariables($parentClassCode)) {
@@ -185,5 +199,11 @@ final class EnvTestCasesProvider
         }
 
         return null;
+    }
+
+    private static function isProjectCodeFile(string $fileName): bool
+    {
+        return str_starts_with($fileName, self::SRC_DIR . DIRECTORY_SEPARATOR)
+            || str_starts_with($fileName, self::TESTS_DIR . DIRECTORY_SEPARATOR);
     }
 }

--- a/tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
+++ b/tests/phpunit/AutoReview/EnvVariableManipulation/EnvTestCasesProvider.php
@@ -39,7 +39,6 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use function class_exists;
-use const DIRECTORY_SEPARATOR;
 use Infection\CannotBeInstantiated;
 use Infection\Framework\ClassName;
 use Infection\Tests\AutoReview\ProjectCode\ProjectCodeProvider;
@@ -47,16 +46,11 @@ use function iterator_to_array;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use function Safe\file_get_contents;
-use function str_starts_with;
 use Webmozart\Assert\Assert;
 
 final class EnvTestCasesProvider
 {
     use CannotBeInstantiated;
-
-    private const SRC_DIR = __DIR__ . '/../../../../src';
-
-    private const TESTS_DIR = __DIR__ . '/../../../../tests';
 
     /**
      * @var string[][]|null
@@ -144,10 +138,6 @@ final class EnvTestCasesProvider
         while ($parentTestCaseClassReflection->getName() !== TestCase::class) {
             $parentTestCaseFileName = $parentTestCaseClassReflection->getFileName();
 
-            if ($parentTestCaseFileName === false || !self::isProjectCodeFile($parentTestCaseFileName)) {
-                break;
-            }
-
             $testCaseCode = file_get_contents($parentTestCaseFileName);
 
             if (EnvManipulatorCodeDetector::codeManipulatesEnvVariables($testCaseCode)) {
@@ -179,13 +169,13 @@ final class EnvTestCasesProvider
         $parentClassReflection = $classReflection->getParentClass();
 
         while ($parentClassReflection !== false) {
-            $parentClassFileName = $parentClassReflection->getFileName();
-
-            if ($parentClassFileName === false) {
+            if ($parentClassReflection->getName() === TestCase::class) {
                 break;
             }
 
-            if (!self::isProjectCodeFile($parentClassFileName)) {
+            $parentClassFileName = $parentClassReflection->getFileName();
+
+            if ($parentClassFileName === false) {
                 break;
             }
 
@@ -199,11 +189,5 @@ final class EnvTestCasesProvider
         }
 
         return null;
-    }
-
-    private static function isProjectCodeFile(string $fileName): bool
-    {
-        return str_starts_with($fileName, self::SRC_DIR . DIRECTORY_SEPARATOR)
-            || str_starts_with($fileName, self::TESTS_DIR . DIRECTORY_SEPARATOR);
     }
 }


### PR DESCRIPTION
## Description

Extracted from #3274 for greater visibility and to properly re-assess the solution.

Currently `EnvTestCasesProvider` works as follows:

- picks the source code files
- look for its canonical test
- check the environment variable usage for the source file, its canonical test and the parent classes of that test

In PHPUnit 12, `PHPUnit\Framework\TestCase` does some environment variable manipulation, tricking the current `EnvTestCasesProvider` to believe `BaseMutatorTestCase` was manipulating environment variables too.

This PR proposes to exclude `PHPUnit\Framework\TestCase` from the analysis (which for the record is something we already do when looking for files manipulating I/O).

## Changes

Stop the parent traversal at `PHPUnit\Framework\TestCase` and do not inspect the latter for environment variable usages.
