### PR TITLE
tests: Display details on all PHPUnit issues

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,11 +8,7 @@
          failOnDeprecation="true"
          failOnRisky="true"
          requireCoverageMetadata="true"
-         displayDetailsOnIncompleteTests="true"
-         displayDetailsOnPhpunitDeprecations="true"
-         displayDetailsOnSkippedTests="true"
-         displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnAllIssues="true"
          cacheDirectory="./var/cache/phpunit"
 >
 


### PR DESCRIPTION
PHPUnit allows to control when to display the details. In the recent versions a bunch of new controls were added.

Personally I find a bit tiring to check what all of those options are and figure out what option I am missing when a new issue without details pop up (e.g. in #3274 I had to enable `displayDetailsOnPhpunitNotices` which is only available as of PHPUnit 12).

Instead, I propose we unconditionally display all issues by default.