### PR TITLE
Allow skipping `run` command with positional args

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -925,6 +925,12 @@ message = 'Invalid return type for function `Infection\Configuration\SourceFilte
 count = 1
 
 [[issues]]
+file = "src/Console/Application.php"
+code = "implicit-to-string-cast"
+message = 'Implicit conversion to `string` for right operand via `Symfony\Component\Console\Input\InputInterface::__toString()`.'
+count = 1
+
+[[issues]]
 file = "src/Console/LogVerbosity.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
@@ -6232,6 +6238,60 @@ count = 1
 file = "tests/phpunit/Configuration/SourceFilter/PlainFilterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `valueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/ApplicationTest.php"
+code = "imprecise-type"
+message = "Type `iterable` in return type of `provideNonCommandArguments` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/ApplicationTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Exception` in `Infection\Tests\Console\ApplicationTest::test_it_configures_the_input_when_routing_to_the_run_command`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/ApplicationTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Exception` in `Infection\Tests\Console\ApplicationTest::test_it_does_not_alter_routing_for_known_commands`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/ApplicationTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Exception` in `Infection\Tests\Console\ApplicationTest::test_it_preserves_programmatic_interactivity_when_routing_to_the_run_command`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/ApplicationTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Exception` in `Infection\Tests\Console\ApplicationTest::test_it_routes_to_run_command_when_first_argument_is_not_a_known_command`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/ApplicationTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\ApplicationTest::test_it_configures_the_input_when_routing_to_the_run_command`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/ApplicationTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\ApplicationTest::test_it_does_not_alter_routing_for_known_commands`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/ApplicationTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\ApplicationTest::test_it_preserves_programmatic_interactivity_when_routing_to_the_run_command`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Console/ApplicationTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\ApplicationTest::test_it_routes_to_run_command_when_first_argument_is_not_a_known_command`.'
 count = 1
 
 [[issues]]

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -91,20 +91,30 @@ final class Application extends BaseApplication
     #[Override]
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
-        $firstArgument = $input->getFirstArgument();
-
-        // this allows to run `infection tests/` instead of `infection run tests/`
-        if ($firstArgument !== null && !$this->has($firstArgument)) {
-            $newInput = new StringInput('run ' . $input);
-
-            if (!$input->isInteractive()) {
-                $newInput->setInteractive(false);
-            }
-
-            $input = $newInput;
+        // This allows to run `infection tests/` instead of `infection run tests/`.
+        if ($this->isUnknownCommand($input)) {
+            $input = $this->defaultToRunCommand($input);
         }
 
         return parent::doRun($input, $output);
+    }
+
+    private function isUnknownCommand(InputInterface $input): bool
+    {
+        $firstArgument = $input->getFirstArgument();
+
+        return $firstArgument !== null && !$this->has($firstArgument);
+    }
+
+    private function defaultToRunCommand(InputInterface $input): InputInterface
+    {
+        $newInput = new StringInput('run ' . $input);
+
+        if (!$input->isInteractive()) {
+            $newInput->setInteractive(false);
+        }
+
+        return $newInput;
     }
 
     public function getContainer(): Container

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -54,6 +54,7 @@ use OutOfBoundsException;
 use Override;
 use function sprintf;
 use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -89,32 +90,16 @@ final class Application extends BaseApplication
     }
 
     #[Override]
-    public function doRun(InputInterface $input, OutputInterface $output): int
+    public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {
+        $input ??= new ArgvInput();
+
         // This allows to run `infection tests/` instead of `infection run tests/`.
         if ($this->isUnknownCommand($input)) {
             $input = $this->defaultToRunCommand($input);
         }
 
-        return parent::doRun($input, $output);
-    }
-
-    private function isUnknownCommand(InputInterface $input): bool
-    {
-        $firstArgument = $input->getFirstArgument();
-
-        return $firstArgument !== null && !$this->has($firstArgument);
-    }
-
-    private function defaultToRunCommand(InputInterface $input): InputInterface
-    {
-        $newInput = new StringInput('run ' . $input);
-
-        if (!$input->isInteractive()) {
-            $newInput->setInteractive(false);
-        }
-
-        return $newInput;
+        return parent::run($input, $output);
     }
 
     public function getContainer(): Container
@@ -172,5 +157,26 @@ final class Application extends BaseApplication
         }
 
         OutputFormatterStyleConfigurator::configure($output);
+    }
+
+    private function isUnknownCommand(InputInterface $input): bool
+    {
+        $firstArgument = $input->getFirstArgument();
+
+        return $firstArgument !== null && !$this->has($firstArgument);
+    }
+
+    private function defaultToRunCommand(InputInterface $input): InputInterface
+    {
+        $newInput = new StringInput('run ' . $input);
+
+        // preserve interactivity that was set programmatically on the input
+        // rather than through a flag (e.g. when the input is built by tests).
+        // Flag- and CI-based interactivity is handled by `configureIO()`.
+        if (!$input->isInteractive()) {
+            $newInput->setInteractive(false);
+        }
+
+        return $newInput;
     }
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -55,6 +55,7 @@ use Override;
 use function sprintf;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use function trim;
 
@@ -85,6 +86,25 @@ final class Application extends BaseApplication
     ) {
         parent::__construct(self::NAME, $infectionVersion->prettyVersion());
         $this->setDefaultCommand('run');
+    }
+
+    #[Override]
+    public function doRun(InputInterface $input, OutputInterface $output): int
+    {
+        $firstArgument = $input->getFirstArgument();
+
+        // this allows to run `infection tests/` instead of `infection run tests/`
+        if ($firstArgument !== null && !$this->has($firstArgument)) {
+            $newInput = new StringInput('run ' . $input);
+
+            if (!$input->isInteractive()) {
+                $newInput->setInteractive(false);
+            }
+
+            $input = $newInput;
+        }
+
+        return parent::doRun($input, $output);
     }
 
     public function getContainer(): Container

--- a/tests/phpunit/Console/ApplicationTest.php
+++ b/tests/phpunit/Console/ApplicationTest.php
@@ -39,7 +39,10 @@ use Infection\Console\Application;
 use Infection\Framework\InfectionVersion;
 use Infection\Testing\SingletonContainer;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 #[CoversClass(Application::class)]
 final class ApplicationTest extends TestCase
@@ -58,5 +61,44 @@ final class ApplicationTest extends TestCase
         );
 
         $this->assertSame('1.2.3', $application->getVersion());
+    }
+
+    #[DataProvider('provideNonCommandArguments')]
+    public function test_it_routes_to_run_command_when_first_argument_is_not_a_known_command(string $argument): void
+    {
+        $application = new Application(SingletonContainer::getContainer());
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(true);
+
+        $output = new BufferedOutput();
+        $application->run(new StringInput($argument), $output);
+
+        $display = $output->fetch();
+
+        // Without this routing, running 'infection src/' would produce "Command 'src/' is not defined".
+        // With this routing, it forwards to the 'run' command instead.
+        self::assertStringNotContainsString(\sprintf('Command "%s" is not defined', $argument), $display);
+        self::assertStringNotContainsString(\sprintf("Command '%s' is not defined", $argument), $display);
+    }
+
+    public static function provideNonCommandArguments(): iterable
+    {
+        yield 'source directory' => ['src/'];
+        yield 'test directory' => ['tests/'];
+        yield 'nested path' => ['src/Foo/Bar/'];
+    }
+
+    public function test_it_does_not_alter_routing_for_known_commands(): void
+    {
+        $application = new Application(SingletonContainer::getContainer());
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(true);
+
+        $output = new BufferedOutput();
+        $application->run(new StringInput('run --help'), $output);
+
+        $display = $output->fetch();
+
+        self::assertStringContainsString('Runs the mutation testing', $display);
     }
 }

--- a/tests/phpunit/Console/ApplicationTest.php
+++ b/tests/phpunit/Console/ApplicationTest.php
@@ -81,7 +81,6 @@ final class ApplicationTest extends TestCase
         $display = $output->fetch();
 
         $this->assertStringNotContainsString(sprintf('Command "%s" is not defined', $argument), $display);
-        $this->assertStringNotContainsString(sprintf("Command '%s' is not defined", $argument), $display);
     }
 
     public static function provideNonCommandArguments(): iterable

--- a/tests/phpunit/Console/ApplicationTest.php
+++ b/tests/phpunit/Console/ApplicationTest.php
@@ -41,6 +41,7 @@ use Infection\Testing\SingletonContainer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use function sprintf;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -75,16 +76,16 @@ final class ApplicationTest extends TestCase
 
         $display = $output->fetch();
 
-        // Without this routing, running 'infection src/' would produce "Command 'src/' is not defined".
-        // With this routing, it forwards to the 'run' command instead.
-        self::assertStringNotContainsString(\sprintf('Command "%s" is not defined', $argument), $display);
-        self::assertStringNotContainsString(\sprintf("Command '%s' is not defined", $argument), $display);
+        $this->assertStringNotContainsString(sprintf('Command "%s" is not defined', $argument), $display);
+        $this->assertStringNotContainsString(sprintf("Command '%s' is not defined", $argument), $display);
     }
 
     public static function provideNonCommandArguments(): iterable
     {
         yield 'source directory' => ['src/'];
+
         yield 'test directory' => ['tests/'];
+
         yield 'nested path' => ['src/Foo/Bar/'];
     }
 
@@ -99,6 +100,6 @@ final class ApplicationTest extends TestCase
 
         $display = $output->fetch();
 
-        self::assertStringContainsString('Runs the mutation testing', $display);
+        $this->assertStringContainsString('Runs the mutation testing', $display);
     }
 }

--- a/tests/phpunit/Console/ApplicationTest.php
+++ b/tests/phpunit/Console/ApplicationTest.php
@@ -42,8 +42,12 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use function sprintf;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[CoversClass(Application::class)]
 final class ApplicationTest extends TestCase
@@ -101,5 +105,61 @@ final class ApplicationTest extends TestCase
         $display = $output->fetch();
 
         $this->assertStringContainsString('Runs the mutation testing', $display);
+    }
+
+    public function test_it_configures_the_input_when_routing_to_the_run_command(): void
+    {
+        $command = $this->createRunCommandSpy();
+
+        $application = new Application(SingletonContainer::getContainer());
+        $application->setAutoExit(false);
+        $application->addCommand($command);
+
+        $application->run(new StringInput('src/ --no-interaction'), new BufferedOutput());
+
+        $this->assertFalse($command->wasInteractive);
+    }
+
+    public function test_it_preserves_programmatic_interactivity_when_routing_to_the_run_command(): void
+    {
+        $command = $this->createRunCommandSpy();
+
+        $application = new Application(SingletonContainer::getContainer());
+        $application->setAutoExit(false);
+        $application->addCommand($command);
+
+        $input = new StringInput('src/');
+        $input->setInteractive(false);
+
+        $application->run($input, new BufferedOutput());
+
+        $this->assertFalse($command->wasInteractive);
+    }
+
+    /**
+     * Replaces the real `run` command with a spy recording the interactivity of
+     * the input it ends up receiving.
+     *
+     * @return Command&object{wasInteractive: bool|null}
+     */
+    private function createRunCommandSpy(): Command
+    {
+        return new class extends Command {
+            public ?bool $wasInteractive = null;
+
+            protected function configure(): void
+            {
+                $this
+                    ->setName('run')
+                    ->addArgument('paths', InputArgument::IS_ARRAY | InputArgument::OPTIONAL);
+            }
+
+            protected function execute(InputInterface $input, OutputInterface $output): int
+            {
+                $this->wasInteractive = $input->isInteractive();
+
+                return Command::SUCCESS;
+            }
+        };
     }
 }

--- a/tests/phpunit/Console/ApplicationTest.php
+++ b/tests/phpunit/Console/ApplicationTest.php
@@ -41,7 +41,6 @@ use Infection\Testing\SingletonContainer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use function sprintf;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -71,16 +70,15 @@ final class ApplicationTest extends TestCase
     #[DataProvider('provideNonCommandArguments')]
     public function test_it_routes_to_run_command_when_first_argument_is_not_a_known_command(string $argument): void
     {
+        $command = $this->createRunCommandSpy();
+
         $application = new Application(SingletonContainer::getContainer());
         $application->setAutoExit(false);
-        $application->setCatchExceptions(true);
+        $application->addCommands([$command]);
 
-        $output = new BufferedOutput();
-        $application->run(new StringInput($argument), $output);
+        $application->run(new StringInput($argument), new BufferedOutput());
 
-        $display = $output->fetch();
-
-        $this->assertStringNotContainsString(sprintf('Command "%s" is not defined', $argument), $display);
+        $this->assertTrue($command->wasExecuted);
     }
 
     public static function provideNonCommandArguments(): iterable
@@ -136,14 +134,17 @@ final class ApplicationTest extends TestCase
     }
 
     /**
-     * Replaces the real `run` command with a spy recording the interactivity of
-     * the input it ends up receiving.
+     * Replaces the real `run` command with a spy, so that routing can be asserted
+     * without actually executing a mutation run. It records whether it was reached
+     * and the interactivity of the input it ends up receiving.
      *
-     * @return Command&object{wasInteractive: bool|null}
+     * @return Command&object{wasExecuted: bool, wasInteractive: bool|null}
      */
     private function createRunCommandSpy(): Command
     {
         return new class extends Command {
+            public bool $wasExecuted = false;
+
             public ?bool $wasInteractive = null;
 
             protected function configure(): void
@@ -155,6 +156,7 @@ final class ApplicationTest extends TestCase
 
             protected function execute(InputInterface $input, OutputInterface $output): int
             {
+                $this->wasExecuted = true;
                 $this->wasInteractive = $input->isInteractive();
 
                 return Command::SUCCESS;

--- a/tests/phpunit/Console/ApplicationTest.php
+++ b/tests/phpunit/Console/ApplicationTest.php
@@ -113,7 +113,7 @@ final class ApplicationTest extends TestCase
 
         $application = new Application(SingletonContainer::getContainer());
         $application->setAutoExit(false);
-        $application->addCommand($command);
+        $application->addCommands([$command]);
 
         $application->run(new StringInput('src/ --no-interaction'), new BufferedOutput());
 
@@ -126,7 +126,7 @@ final class ApplicationTest extends TestCase
 
         $application = new Application(SingletonContainer::getContainer());
         $application->setAutoExit(false);
-        $application->addCommand($command);
+        $application->addCommands([$command]);
 
         $input = new StringInput('src/');
         $input->setInteractive(false);


### PR DESCRIPTION
In https://github.com/infection/infection/pull/3284 we add support for passing positional arguments to `infection` binary, like:

```shell
infection run src/Mutator/Number/ tests/phpunit/Mutator/Number/
```

Note, that when you pass positional arguments, Symfony console requires you to pass our default `run` command, because our application has many commands.

This PR checks, if the first positional argument is a known command, and if not  - it means we pass `run`'s command positional arguments so we can default to `run` command.

Having this allows us to do:

```diff
- infection run src/Mutator/Number/ tests/phpunit/Mutator/Number/
+ infection src/Mutator/Number/ tests/phpunit/Mutator/Number/
```

which is even more easier to work with

Related to:

- https://github.com/infection/infection/pull/3284