### PR TITLE
feat: Allow php://output as logger stream target

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -10920,13 +10920,13 @@ count = 1
 file = "tests/phpunit/Reporter/FileReporterTest.php"
 code = "no-value"
 message = 'Argument #3 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
-count = 4
+count = 5
 
 [[issues]]
 file = "tests/phpunit/Reporter/FileReporterTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Reporter\DummyLineMutationTestingResultsReporter` not found.'
-count = 4
+count = 5
 
 [[issues]]
 file = "tests/phpunit/Reporter/GitHubActionsLogTextFileReporterTest.php"

--- a/src/Reporter/FileReporter.php
+++ b/src/Reporter/FileReporter.php
@@ -50,7 +50,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final readonly class FileReporter implements Reporter
 {
-    public const array ALLOWED_PHP_STREAMS = ['php://stdout', 'php://stderr'];
+    public const array ALLOWED_PHP_STREAMS = ['php://stdout', 'php://stderr', 'php://output'];
 
     public function __construct(
         private string $filePath,
@@ -72,8 +72,8 @@ final readonly class FileReporter implements Reporter
                 // The Symfony filesystem component doesn't support using streams so provide a
                 // sensible error message
                 $this->logger->error(sprintf(
-                    '<error>The only streams supported are "php://stdout" and "php://stderr"'
-                    . '. Got "%s"</error>',
+                    '<error>The only streams supported are "%s". Got "%s"</error>',
+                    implode('", "', self::ALLOWED_PHP_STREAMS),
                     $this->filePath,
                 ));
             }

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -398,6 +398,15 @@ final class ConfigurationFactoryTest extends TestCase
                 ),
         ];
 
+        yield 'PHP output stream text file log path' => [
+            $defaultScenario
+                ->forValueForTextLogFilePath(
+                    'php://output',
+                    null,
+                    'php://output',
+                ),
+        ];
+
         yield 'override text file log path from CLI option with existing path from config file' => [
             $defaultScenario
                 ->forValueForTextLogFilePath(

--- a/tests/phpunit/Reporter/FileReporterTest.php
+++ b/tests/phpunit/Reporter/FileReporterTest.php
@@ -40,13 +40,13 @@ use Infection\Reporter\FileReporter;
 use Infection\Tests\FileSystem\FileSystemTestCase;
 use Infection\Tests\Fixtures\Reporter\DummyLineMutationTestingResultsReporter;
 use Infection\Tests\Logger\DummyLogger;
-use function ob_get_clean;
-use function ob_start;
 use const PHP_EOL;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LogLevel;
+use function Safe\ob_get_clean;
+use function Safe\ob_start;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 

--- a/tests/phpunit/Reporter/FileReporterTest.php
+++ b/tests/phpunit/Reporter/FileReporterTest.php
@@ -40,6 +40,9 @@ use Infection\Reporter\FileReporter;
 use Infection\Tests\FileSystem\FileSystemTestCase;
 use Infection\Tests\Fixtures\Reporter\DummyLineMutationTestingResultsReporter;
 use Infection\Tests\Logger\DummyLogger;
+use function ob_get_clean;
+use function ob_start;
+use const PHP_EOL;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -106,6 +109,23 @@ final class FileReporterTest extends FileSystemTestCase
         $this->assertSame([], $this->logger->getLogs());
     }
 
+    public function test_it_can_log_on_php_output_stream(): void
+    {
+        $reporter = new FileReporter(
+            'php://output',
+            $this->fileSystemMock,
+            new DummyLineMutationTestingResultsReporter(['foo', 'bar']),
+            $this->logger,
+        );
+
+        ob_start();
+
+        $reporter->report();
+
+        $this->assertSame('foo' . PHP_EOL . 'bar', ob_get_clean());
+        $this->assertSame([], $this->logger->getLogs());
+    }
+
     public function test_it_cannot_log_on_invalid_streams(): void
     {
         $reporter = new FileReporter(
@@ -121,7 +141,7 @@ final class FileReporterTest extends FileSystemTestCase
             [
                 [
                     LogLevel::ERROR,
-                    '<error>The only streams supported are "php://stdout" and "php://stderr". Got "php://memory"</error>',
+                    '<error>The only streams supported are "php://stdout", "php://stderr", "php://output". Got "php://memory"</error>',
                     [],
                 ],
             ],


### PR DESCRIPTION
## Description

Allows `php://output` as a logger stream target.

This lets same-process PHP wrappers capture logger output via PHP output buffering, e.g. when using `--logger-summary-json=php://output`.

## Changes

- Add `php://output` to the allowed PHP streams for file reporters
- Keep `php://output` unchanged during configuration path normalization
- Add regression coverage for `php://output` output buffering

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (provide link to PR: https://github.com/infection/site/pull/302)
- [ ] CHANGELOG.md updated (if deprecations/breaking changes)
- [ ] Appropriate labels applied (e.g. `performance`, `feature`).


## Breaking Changes

None.

## Reviewer Notes

Please check whether the added test coverage is sufficient for both stream writing and configuration path normalization.

## Related issues

Fixes https://github.com/infection/infection/issues/3287

This PR:

- [x] Adds new feature: `php://output` logger stream support
- [x] Covered by tests
- [x] Doc PR: https://github.com/infection/site/pull/302
