### PR TITLE
refactor(autoreview): Rename PHPUnit test I/O detector

### DIFF
--- a/tests/Architecture/PHPat/Selector/InfectionSelector.php
+++ b/tests/Architecture/PHPat/Selector/InfectionSelector.php
@@ -39,7 +39,7 @@ use Infection\CannotBeInstantiated;
 use Infection\Testing\SingletonContainer;
 use Infection\Tests\Architecture\PHPat\Selector\Support\Analyser\Analyser;
 use Infection\Tests\Architecture\PHPat\Selector\Support\EventArchitecture;
-use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
+use Infection\Tests\Architecture\PHPat\Selector\Support\IoCodeDetector;
 use PHPat\Selector\Selector;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ReflectionProvider;
@@ -53,7 +53,7 @@ final class InfectionSelector
 
     private static ?Analyser $analyser = null;
 
-    private static ?PHPUnitTestIoRequirements $phpUnitTestIoRequirements = null;
+    private static ?IoCodeDetector $phpUnitTestIoRequirements = null;
 
     private static ?ReflectionProvider $phpUnitTestIoRequirementsReflectionProvider = null;
 
@@ -213,12 +213,12 @@ final class InfectionSelector
         return self::$analyser;
     }
 
-    private static function phpUnitTestIoRequirements(ReflectionProvider $reflectionProvider): PHPUnitTestIoRequirements
+    private static function phpUnitTestIoRequirements(ReflectionProvider $reflectionProvider): IoCodeDetector
     {
         if (self::$phpUnitTestIoRequirements === null) {
             self::$phpUnitTestIoRequirementsReflectionProvider = $reflectionProvider;
 
-            return self::$phpUnitTestIoRequirements = new PHPUnitTestIoRequirements(
+            return self::$phpUnitTestIoRequirements = new IoCodeDetector(
                 self::analyser(),
                 $reflectionProvider,
             );

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup.php
@@ -35,15 +35,15 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
+use Infection\Tests\Architecture\PHPat\Selector\Support\IoCodeDetector;
 use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestClassAnalysis;
-use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
 
 final readonly class PHPUnitTestNotRequiringIoWithIntegrationGroup implements SelectorInterface
 {
     public function __construct(
-        private PHPUnitTestIoRequirements $ioRequirements,
+        private IoCodeDetector $ioCodeDetector,
     ) {
     }
 
@@ -56,8 +56,8 @@ final readonly class PHPUnitTestNotRequiringIoWithIntegrationGroup implements Se
     {
         return InfectionSelector::phpunitTestCode()->matches($classReflection)
             && InfectionSelector::concretePHPUnitTestClass()->matches($classReflection)
-            && $this->ioRequirements->hasCoveredClass($classReflection)
-            && !$this->ioRequirements->requiresIntegrationGroup($classReflection)
+            && $this->ioCodeDetector->hasCoveredClass($classReflection)
+            && !$this->ioCodeDetector->isUsingIo($classReflection)
             && PHPUnitTestClassAnalysis::belongsToIntegrationGroup($classReflection);
     }
 }

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup.php
@@ -36,14 +36,14 @@ declare(strict_types=1);
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
 use Infection\Tests\Architecture\PHPat\Selector\Support\Analyser\Analyser;
-use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
+use Infection\Tests\Architecture\PHPat\Selector\Support\IoCodeDetector;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
 
 final readonly class PHPUnitTestRequiringIoWithoutIntegrationGroup implements SelectorInterface
 {
     public function __construct(
-        private PHPUnitTestIoRequirements $ioRequirements,
+        private IoCodeDetector $ioCodeDetector,
         private Analyser $analyser,
     ) {
     }
@@ -60,7 +60,7 @@ final readonly class PHPUnitTestRequiringIoWithoutIntegrationGroup implements Se
         return InfectionSelector::phpunitTestCode()->matches($classReflection)
             && $analysisResult->isAConcretePHPUnitTestCase
             && !$analysisResult->hasCoversNothing
-            && $this->ioRequirements->requiresIntegrationGroup($classReflection)
+            && $this->ioCodeDetector->isUsingIo($classReflection)
             && !$analysisResult->belongsToIntegrationGroup;
     }
 }

--- a/tests/Architecture/PHPat/Selector/Support/IoCodeDetector.php
+++ b/tests/Architecture/PHPat/Selector/Support/IoCodeDetector.php
@@ -45,7 +45,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use function str_starts_with;
 
-final class PHPUnitTestIoRequirements
+final class IoCodeDetector
 {
     private const string COVERS_ATTRIBUTE_NAMESPACE = 'PHPUnit\\Framework\\Attributes\\Covers';
 
@@ -60,7 +60,7 @@ final class PHPUnitTestIoRequirements
     ) {
     }
 
-    public function requiresIntegrationGroup(ClassReflection $testCaseReflection): bool
+    public function isUsingIo(ClassReflection $testCaseReflection): bool
     {
         if ($this->testCaseUsesIo($testCaseReflection)) {
             return true;

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/PHPUnitTestNotRequiringIoWithIntegrationGroupTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestNotRequiringIoWithIntegrationGroup/PHPUnitTestNotRequiringIoWithIntegrationGroupTest.php
@@ -45,7 +45,7 @@ use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutInt
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithIoInTestCaseTest;
 use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
 use Infection\Tests\Architecture\PHPat\Selector\Support\Analyser\Analyser;
-use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
+use Infection\Tests\Architecture\PHPat\Selector\Support\IoCodeDetector;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -62,7 +62,7 @@ final class PHPUnitTestNotRequiringIoWithIntegrationGroupTest extends SelectorTe
         bool $expected,
     ): void {
         $selector = new PHPUnitTestNotRequiringIoWithIntegrationGroup(
-            new PHPUnitTestIoRequirements(
+            new IoCodeDetector(
                 new Analyser(
                     SingletonContainer::getContainer()->getParser(),
                     new FileSystem(),

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestRequiringIoWithoutIntegrationGroup/PHPUnitTestRequiringIoWithoutIntegrationGroupTest.php
@@ -49,7 +49,7 @@ use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutInt
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithSymfonyFileSystemInTestCaseTest;
 use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
 use Infection\Tests\Architecture\PHPat\Selector\Support\Analyser\Analyser;
-use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestIoRequirements;
+use Infection\Tests\Architecture\PHPat\Selector\Support\IoCodeDetector;
 use Infection\Tests\Command\CommandOptionTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -73,7 +73,7 @@ final class PHPUnitTestRequiringIoWithoutIntegrationGroupTest extends SelectorTe
         );
 
         $selector = new PHPUnitTestRequiringIoWithoutIntegrationGroup(
-            new PHPUnitTestIoRequirements(
+            new IoCodeDetector(
                 $analyser,
                 $this->getReflectionProvider(),
             ),
@@ -159,7 +159,7 @@ final class PHPUnitTestRequiringIoWithoutIntegrationGroupTest extends SelectorTe
         );
 
         $selector = new PHPUnitTestRequiringIoWithoutIntegrationGroup(
-            new PHPUnitTestIoRequirements(
+            new IoCodeDetector(
                 $analyser,
                 $this->getReflectionProvider(),
             ),

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/IoCodeDetectorTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/IoCodeDetectorTest.php
@@ -54,20 +54,20 @@ use Infection\Tests\Reporter\FileReporterTest;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-#[CoversClass(PHPUnitTestIoRequirements::class)]
-final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
+#[CoversClass(IoCodeDetector::class)]
+final class IoCodeDetectorTest extends SelectorTestCase
 {
     /**
      * @param class-string $className
      */
     #[DataProvider('classProvider')]
-    public function test_it_detects_phpunit_test_io_requirements(
+    public function test_it_detects_phpunit_test_io_usage(
         string $className,
         bool $expectedRequiresIntegrationGroup,
         bool $expectedHasCoveredClass,
         bool $expectedHasIntegrationGroup,
     ): void {
-        $ioRequirements = new PHPUnitTestIoRequirements(
+        $ioCodeDetector = new IoCodeDetector(
             new Analyser(
                 SingletonContainer::getContainer()->getParser(),
                 new FileSystem(),
@@ -78,11 +78,11 @@ final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
 
         $this->assertSame(
             $expectedRequiresIntegrationGroup,
-            $ioRequirements->requiresIntegrationGroup($classReflection),
+            $ioCodeDetector->isUsingIo($classReflection),
         );
         $this->assertSame(
             $expectedHasCoveredClass,
-            $ioRequirements->hasCoveredClass($classReflection),
+            $ioCodeDetector->hasCoveredClass($classReflection),
         );
         $this->assertSame(
             $expectedHasIntegrationGroup,
@@ -172,7 +172,7 @@ final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
             ->method('readFile')
             ->willReturn('contents');
 
-        $ioRequirements = new PHPUnitTestIoRequirements(
+        $ioCodeDetector = new IoCodeDetector(
             new Analyser(
                 SingletonContainer::getContainer()->getParser(),
                 $fileSystemMock,
@@ -180,19 +180,19 @@ final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
             $this->getReflectionProvider(),
         );
 
-        $ioRequirements->requiresIntegrationGroup(
+        $ioCodeDetector->isUsingIo(
             $this->createClassReflection(FixtureWithCoversNothingWithoutIntegrationGroupTest::class),
         );
-        $ioRequirements->requiresIntegrationGroup(
+        $ioCodeDetector->isUsingIo(
             $this->createClassReflection(FixtureWithCoveredClassWithIoTest::class),
         );
-        $ioRequirements->requiresIntegrationGroup(
+        $ioCodeDetector->isUsingIo(
             $this->createClassReflection(FixtureWithCoveredClassWithIoTest::class),
         );
-        $ioRequirements->requiresIntegrationGroup(
+        $ioCodeDetector->isUsingIo(
             $this->createClassReflection(FixtureWithMultipleCoveredClassesTest::class),
         );
-        $ioRequirements->requiresIntegrationGroup(
+        $ioCodeDetector->isUsingIo(
             $this->createClassReflection(FixtureWithMultipleCoveredClassesTest::class),
         );
     }
@@ -201,9 +201,9 @@ final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
      * @param class-string $className
      */
     #[DataProvider('fileSystemTestCaseChildProvider')]
-    public function test_file_system_test_case_children_require_integration_group(string $className): void
+    public function test_file_system_test_case_children_uses_io(string $className): void
     {
-        $ioRequirements = new PHPUnitTestIoRequirements(
+        $ioCodeDetector = new IoCodeDetector(
             new Analyser(
                 SingletonContainer::getContainer()->getParser(),
                 new FileSystem(),
@@ -211,7 +211,7 @@ final class PHPUnitTestIoRequirementsTest extends SelectorTestCase
             $this->getReflectionProvider(),
         );
 
-        $requiresIntegrationGroup = $ioRequirements->requiresIntegrationGroup(
+        $requiresIntegrationGroup = $ioCodeDetector->isUsingIo(
             $this->createClassReflection($className),
         );
 


### PR DESCRIPTION
Rename the PHPat support service that detects I/O usage in PHPUnit tests from `PHPUnitTestIoRequirements` to `IoCodeDetector`, and align its public API with the behaviour it provides. Indeed, its role is to detect the I/O usage, to decide if the `integration` group is required depends on the selector/rule, not this support class.
