### PR TITLE
Support sebastian/diff: 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "sanmai/duoclock": "^0.1.0",
         "sanmai/later": "^0.1.7",
         "sanmai/pipeline": "^7.2",
-        "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "symfony/console": "^6.4 || ^7.4 || ^8.0",
         "symfony/filesystem": "^6.4 || ^7.4 || ^8.0",
         "symfony/finder": "^6.4 || ^7.4 || ^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70f7c41c5bfb7f1408d068484531e9a5",
+    "content-hash": "156a732deefa827dea919e83930a6924",
     "packages": [
         {
             "name": "colinodell/json5",

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -180,7 +180,7 @@ use PhpParser\PrettyPrinterAbstract;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SebastianBergmann\Diff\Differ as BaseDiffer;
-use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
+use SebastianBergmann\Diff\Output\StrictUnifiedDiffOutputBuilder;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webmozart\Assert\Assert;
@@ -322,7 +322,7 @@ final class Container extends DIContainer
             MutantCodePrinter::class => static fn (self $container): MutantCodePrinter => new MutantCodePrinter(
                 $container->getPrinter(),
             ),
-            Differ::class => static fn (): Differ => new Differ(new BaseDiffer(new UnifiedDiffOutputBuilder(''))),
+            Differ::class => static fn (): Differ => new Differ(new BaseDiffer(new StrictUnifiedDiffOutputBuilder(['fromFile' => 'Original', 'toFile' => 'New']))),
             SyncEventDispatcher::class => static fn (): SyncEventDispatcher => new SyncEventDispatcher(),
             ParallelProcessRunner::class => static fn (self $container): ParallelProcessRunner => new ParallelProcessRunner(
                 $container->getConfiguration()->threadCount,

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -322,7 +322,7 @@ final class Container extends DIContainer
             MutantCodePrinter::class => static fn (self $container): MutantCodePrinter => new MutantCodePrinter(
                 $container->getPrinter(),
             ),
-            Differ::class => static fn (): Differ => new Differ(new BaseDiffer(new StrictUnifiedDiffOutputBuilder(['fromFile' => 'Original', 'toFile' => 'New']))),
+            Differ::class => static fn (): Differ => new Differ(new BaseDiffer(new StrictUnifiedDiffOutputBuilder(['fromFile' => 'Original', 'toFile' => 'Mutated']))),
             SyncEventDispatcher::class => static fn (): SyncEventDispatcher => new SyncEventDispatcher(),
             ParallelProcessRunner::class => static fn (self $container): ParallelProcessRunner => new ParallelProcessRunner(
                 $container->getConfiguration()->threadCount,

--- a/tests/phpunit/Differ/DifferTest.php
+++ b/tests/phpunit/Differ/DifferTest.php
@@ -112,7 +112,9 @@ final class DifferTest extends TestCase
 
                 PHP,
             <<<'PHP'
-                @@ @@
+                --- Original
+                +++ New
+                @@ -1,5 +1,5 @@
 
                  public function echo(): void
                  {
@@ -209,7 +211,9 @@ final class DifferTest extends TestCase
                 15
                 PHP,
             <<<'PHP'
-                @@ @@
+                --- Original
+                +++ New
+                @@ -4,7 +4,7 @@
                  3
                  4
                  5
@@ -282,7 +286,9 @@ final class DifferTest extends TestCase
                 15
                 PHP,
             <<<'PHP'
-                @@ @@
+                --- Original
+                +++ New
+                @@ -4,10 +4,10 @@
                  3
                  4
                  5
@@ -340,12 +346,14 @@ final class DifferTest extends TestCase
                 1{$windowsLineReturn}2
                 PHP,
             <<<'PHP'
-                @@ @@
-                 #Warning: Strings contain different line endings!
+                --- Original
+                +++ New
+                @@ -1,3 +1,3 @@
                  0
                 -1
                 +1
                  2
+                \ No newline at end of file
 
                 PHP,
             [
@@ -372,12 +380,14 @@ final class DifferTest extends TestCase
                 (1){$windowsLineReturn}2
                 PHP,
             <<<'PHP'
-                @@ @@
-                 #Warning: Strings contain different line endings!
+                --- Original
+                +++ New
+                @@ -1,3 +1,3 @@
                  0
                 -1
                 +(1)
                  2
+                \ No newline at end of file
 
                 PHP,
             [

--- a/tests/phpunit/Differ/DifferTest.php
+++ b/tests/phpunit/Differ/DifferTest.php
@@ -113,7 +113,7 @@ final class DifferTest extends TestCase
                 PHP,
             <<<'PHP'
                 --- Original
-                +++ New
+                +++ Mutated
                 @@ -1,5 +1,5 @@
 
                  public function echo(): void
@@ -212,7 +212,7 @@ final class DifferTest extends TestCase
                 PHP,
             <<<'PHP'
                 --- Original
-                +++ New
+                +++ Mutated
                 @@ -4,7 +4,7 @@
                  3
                  4
@@ -287,7 +287,7 @@ final class DifferTest extends TestCase
                 PHP,
             <<<'PHP'
                 --- Original
-                +++ New
+                +++ Mutated
                 @@ -4,10 +4,10 @@
                  3
                  4
@@ -347,7 +347,7 @@ final class DifferTest extends TestCase
                 PHP,
             <<<'PHP'
                 --- Original
-                +++ New
+                +++ Mutated
                 @@ -1,3 +1,3 @@
                  0
                 -1
@@ -381,7 +381,7 @@ final class DifferTest extends TestCase
                 PHP,
             <<<'PHP'
                 --- Original
-                +++ New
+                +++ Mutated
                 @@ -1,3 +1,3 @@
                  0
                 -1


### PR DESCRIPTION
## Description
This PR brings [sebastian/diff: 9](https://github.com/sebastianbergmann/diff/releases/tag/9.0.0) support.

## Changes

Replaces `UnifiedDiffOutputBuilder` with `StrictUnifiedDiffOutputBuilder` as `UnifiedDiffOutputBuilder` has been removed in the diff >= 9.

## Checklist

- [x] Tests added/updated
- [ ] CHANGELOG.md updated (if deprecations/breaking changes)
- [ ] Appropriate labels applied (e.g. `performance`, `feature`).


## Breaking Changes

Output changed from:
<img width="2374" height="472" alt="Screenshot from 2026-06-21 16-01-11" src="https://github.com/user-attachments/assets/a05dc95c-1df2-46b1-b5c8-a80f3d455d7e" />

To:
<img width="2397" height="559" alt="Screenshot from 2026-06-21 15-57-50" src="https://github.com/user-attachments/assets/dc7f9718-9240-4c71-b356-1d387e6f572d" />

