### PR TITLE
fix(sbx): Fix the base image template Docker build

### DIFF
--- a/devTools/sbx/Dockerfile
+++ b/devTools/sbx/Dockerfile
@@ -9,8 +9,16 @@ ARG PHP_VERSION=8.4
 # PHP
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     set -o errexit -o nounset -o pipefail \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        lsb-release \
+        gnupg \
+    && curl -fsSL https://packages.sury.org/php/apt.gpg | gpg --dearmor > /usr/share/keyrings/php-sury.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/php-sury.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/sury-php.list \
+    && DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         # CLI SAPI
         php${PHP_VERSION}-cli \
         # Extensions used by infection to not have to rely on polyfills


### PR DESCRIPTION
I noticed via [this job](https://github.com/infection/infection/actions/runs/28147142481/job/83356635791) that the Docker build for the Docker Sandbox template image fails.

<details>
<summary>Logs</summary>

```
> Run ./devTools/sbx/build-image.sh
+ docker buildx build --load --platform=linux/amd64 --cache-from=type=gha,scope=sbx-image-linux-amd64 --cache-to=type=gha,mode=max,ignore-error=true,scope=sbx-image-linux-amd64 --build-arg=PHP_VERSION=8.4 --build-arg=CONTAINER_STRUCTURE_TEST_VERSION=1.22.1 --file=/home/runner/work/infection/infection/devTools/sbx/Dockerfile --label=org.infection.sbx.cache-key=eea26e6d8a265f69108530d95eda318563ded296fce000d90115ecc5ea9ec6ae --tag=infection-sbx-php-8.4:latest /home/runner/work/infection/infection/devTools/sbx
#0 building with "builder-83e31ee5-4b7a-46eb-b369-c1ddf123fbab" instance using docker-container driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 2.60kB done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/docker/sandbox-templates:codex-docker
#2 ...

#3 [auth] docker/sandbox-templates:pull token for registry-1.docker.io
#3 DONE 0.0s

#4 [auth] composer/composer:pull token for registry-1.docker.io
#4 DONE 0.0s

#5 [internal] load metadata for docker.io/composer/composer:2-bin
#5 ...

#2 [internal] load metadata for docker.io/docker/sandbox-templates:codex-docker
#2 DONE 0.9s

#5 [internal] load metadata for docker.io/composer/composer:2-bin
#5 DONE 0.9s

#6 [internal] load .dockerignore
#6 transferring context: 2B done
#6 DONE 0.0s

#7 [stage-0 1/5] FROM docker.io/docker/sandbox-templates:codex-docker@sha256:1f2aa02d3f17039439718c8a1b1976504e05fb17cc78dc3b88d53ac9f203703c
#7 resolve docker.io/docker/sandbox-templates:codex-docker@sha256:1f2aa02d3f17039439718c8a1b1976504e05fb17cc78dc3b88d53ac9f203703c done
#7 DONE 0.0s
--------------------
   9 |     # PHP
  10 | >>> RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
  11 | >>>     set -o errexit -o nounset -o pipefail \
  12 | >>>     && apt-get update \
  13 | >>>     && apt-get install -y --no-install-recommends \
  14 | >>>         # CLI SAPI
  15 | >>>         php${PHP_VERSION}-cli \
  16 | >>>         # Extensions used by infection to not have to rely on polyfills
  17 | >>>         php${PHP_VERSION}-curl \
  18 | >>>         php${PHP_VERSION}-mbstring \
  19 | >>>         php${PHP_VERSION}-xml \
  20 | >>>         php${PHP_VERSION}-zip \
  21 | >>>         # Coverage driver
  22 | >>>         php${PHP_VERSION}-xdebug \
  23 | >>>         # Build tools required by PIE to install PHP extensions that compile locally
  24 | >>>         autoconf \
  25 | >>>         bison \
  26 | >>>         gcc \
  27 | >>>         libtool \
  28 | >>>         make \
  29 | >>>         php${PHP_VERSION}-dev \
  30 | >>>         pkg-config \
  31 | >>>         re2c \
  32 | >>>         # CA bundle used by curl for HTTPS downloads
  33 | >>>         ca-certificates \
  34 | >>>         # Downloads files during image build and sandbox usage
  35 | >>>         curl \
  36 | >>>         wget \
  37 | >>>     && echo 'xdebug.mode=coverage' > /etc/php/${PHP_VERSION}/cli/conf.d/xdebug.ini \
  38 | >>>     && echo 'memory_limit=-1' > /etc/php/${PHP_VERSION}/cli/conf.d/memory-limit.ini \
  39 | >>>     && rm -rf /tmp/*
  40 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c set -o errexit -o nounset -o pipefail     && apt-get update     && apt-get install -y --no-install-recommends         php${PHP_VERSION}-cli         php${PHP_VERSION}-curl         php${PHP_VERSION}-mbstring         php${PHP_VERSION}-xml         php${PHP_VERSION}-zip         php${PHP_VERSION}-xdebug         autoconf         bison         gcc         libtool         make         php${PHP_VERSION}-dev         pkg-config         re2c         ca-certificates         curl         wget     && echo 'xdebug.mode=coverage' > /etc/php/${PHP_VERSION}/cli/conf.d/xdebug.ini     && echo 'memory_limit=-1' > /etc/php/${PHP_VERSION}/cli/conf.d/memory-limit.ini     && rm -rf /tmp/*" did not complete successfully: exit code: 100
Error: Process completed with exit code 1.

```

</details>
<!-- Explain what this PR does and why. Link to relevant context. -->

This is caused by a recent change from the base image `docker/sandbox-templates:codex-docker` that jumped from Ubuntu 24 to 26 and for which the `ppa:ondrej/php` package do not support the newer PHP versions yet.

This PR fixes this by using the [Sury repository](https://deb.sury.org/) to install PHP.
