### PR TITLE
refactor(autoreview): Move the PHPUnit related code from IoCodeDetector to the PHPUnit utility

### DIFF
--- a/tests/Architecture/PHPat/Selector/Support/IoCodeDetector.php
+++ b/tests/Architecture/PHPat/Selector/Support/IoCodeDetector.php
@@ -37,18 +37,12 @@ namespace Infection\Tests\Architecture\PHPat\Selector\Support;
 
 use function count;
 use Infection\Tests\Architecture\PHPat\Selector\Support\Analyser\Analyser;
-use function is_string;
-use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use function str_starts_with;
 
 final class IoCodeDetector
 {
-    private const string COVERS_ATTRIBUTE_NAMESPACE = 'PHPUnit\\Framework\\Attributes\\Covers';
-
     /**
      * @var array<class-string, bool>
      */
@@ -66,9 +60,12 @@ final class IoCodeDetector
             return true;
         }
 
-        $coveredClassNames = $this->getCoveredClassNames($testCaseReflection);
+        $coveredClassNames = PHPUnitTestClassAnalysis::getCoveredClassNames(
+            $testCaseReflection,
+            $this->reflectionProvider,
+        );
 
-        if ($coveredClassNames === null) {
+        if (count($coveredClassNames) === 0) {
             return true;
         }
 
@@ -83,7 +80,12 @@ final class IoCodeDetector
 
     public function hasCoveredClass(ClassReflection $testCaseReflection): bool
     {
-        return $this->getCoveredClassNames($testCaseReflection) !== null;
+        $coveredClassNames = PHPUnitTestClassAnalysis::getCoveredClassNames(
+            $testCaseReflection,
+            $this->reflectionProvider,
+        );
+
+        return count($coveredClassNames) > 0;
     }
 
     /**
@@ -131,64 +133,6 @@ final class IoCodeDetector
         return false;
     }
 
-    /**
-     * @return list<class-string>|null
-     */
-    private function getCoveredClassNames(ClassReflection $testCaseReflection): ?array
-    {
-        $coveredClassNames = [];
-        $hasCoverageAttribute = false;
-
-        foreach (self::getAttributes($testCaseReflection) as $attribute) {
-            if (!self::isCoverageAttribute($attribute)) {
-                continue;
-            }
-
-            $hasCoverageAttribute = true;
-
-            $coveredClassName = $this->getCoveredClassName($attribute);
-
-            if ($coveredClassName === null) {
-                return null;
-            }
-
-            $coveredClassNames[] = $coveredClassName;
-        }
-
-        return $hasCoverageAttribute && count($coveredClassNames) > 0
-            ? $coveredClassNames
-            : null;
-    }
-
-    /**
-     * TODO: eventually we should support functions, methods and traits too.
-     * @see CoversClass
-     *
-     * @return class-string|null
-     */
-    private function getCoveredClassName(ReflectionAttribute $attribute): ?string
-    {
-        if ($attribute->getName() !== CoversClass::class) {
-            return null;
-        }
-
-        $arguments = $attribute->getArguments();
-        $coveredClassName = $arguments[0] ?? $arguments['className'] ?? null;
-
-        $classNameExists = is_string($coveredClassName)
-            && $this->reflectionProvider->hasClass($coveredClassName);
-
-        return $classNameExists ? $coveredClassName : null;
-    }
-
-    private static function isCoverageAttribute(ReflectionAttribute $attribute): bool
-    {
-        return str_starts_with(
-            $attribute->getName(),
-            self::COVERS_ATTRIBUTE_NAMESPACE,
-        );
-    }
-
     private function doesClassUseIo(ClassReflection $classReflection): bool
     {
         $className = $classReflection->getName();
@@ -201,19 +145,5 @@ final class IoCodeDetector
 
         return $this->classUsesIoCache[$className] = $fileName !== null
             && $this->analyser->analyse($classReflection, analyseNonConcreteClasses: true)->usesIo;
-    }
-
-    /**
-     * @return iterable<ReflectionAttribute>
-     */
-    private static function getAttributes(ClassReflection $classReflection): iterable
-    {
-        $attributes = $classReflection->getNativeReflection()->getAttributes();
-
-        foreach ($attributes as $attribute) {
-            if ($attribute instanceof ReflectionAttribute) {
-                yield $attribute;
-            }
-        }
     }
 }

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
@@ -36,15 +36,21 @@ declare(strict_types=1);
 namespace Infection\Tests\Architecture\PHPat\Selector\Support;
 
 use function count;
+use function is_string;
 use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use function str_ends_with;
+use function str_starts_with;
 
 final class PHPUnitTestClassAnalysis
 {
+    private const string COVERS_ATTRIBUTE_NAMESPACE = 'PHPUnit\\Framework\\Attributes\\Covers';
+
     private const string GROUP_NAME = 'integration';
 
     public static function isPHPUnitTestCase(ClassReflection $classReflection): bool
@@ -71,6 +77,30 @@ final class PHPUnitTestClassAnalysis
     }
 
     /**
+     * @return list<class-string>
+     */
+    public static function getCoveredClassNames(
+        ClassReflection $testCaseReflection,
+        ReflectionProvider $reflectionProvider,
+    ): array {
+        $coveredClassNames = [];
+
+        foreach (self::getAttributes($testCaseReflection) as $attribute) {
+            if (!self::isCoverageAttribute($attribute)) {
+                continue;
+            }
+
+            $coveredClassName = self::getCoveredClassName($attribute, $reflectionProvider);
+
+            if ($coveredClassName !== null) {
+                $coveredClassNames[] = $coveredClassName;
+            }
+        }
+
+        return $coveredClassNames;
+    }
+
+    /**
      * @see Group
      */
     private static function isIntegrationGroup(ReflectionAttribute $attribute): bool
@@ -83,6 +113,37 @@ final class PHPUnitTestClassAnalysis
         $groupName = $arguments[0] ?? $arguments['name'] ?? null;
 
         return $groupName === self::GROUP_NAME;
+    }
+
+    /**
+     * TODO: eventually we should support functions, methods and traits too.
+     * @see CoversClass
+     *
+     * @return class-string|null
+     */
+    private static function getCoveredClassName(
+        ReflectionAttribute $attribute,
+        ReflectionProvider $reflectionProvider,
+    ): ?string {
+        if ($attribute->getName() !== CoversClass::class) {
+            return null;
+        }
+
+        $arguments = $attribute->getArguments();
+        $coveredClassName = $arguments[0] ?? $arguments['className'] ?? null;
+
+        $classNameExists = is_string($coveredClassName)
+            && $reflectionProvider->hasClass($coveredClassName);
+
+        return $classNameExists ? $coveredClassName : null;
+    }
+
+    private static function isCoverageAttribute(ReflectionAttribute $attribute): bool
+    {
+        return str_starts_with(
+            $attribute->getName(),
+            self::COVERS_ATTRIBUTE_NAMESPACE,
+        );
     }
 
     /**

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysisTest.php
@@ -37,6 +37,11 @@ namespace Infection\Tests\Architecture\PHPat\Selector\Support;
 
 use Infection\Command\ConfigureCommand;
 use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestNotRequiringIoWithIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoAndIntegrationGroupTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\CoveredClassWithIo;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\CoveredClassWithoutIo;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoveredClassWithoutIoTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithCoversNothingWithoutIntegrationGroupTest;
+use Infection\Tests\Architecture\PHPat\Selector\PHPUnitTestRequiringIoWithoutIntegrationGroup\Fixtures\FixtureWithMultipleCoveredClassesTest;
 use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
 use Infection\Tests\Architecture\PHPat\Selector\Support\Fixtures\FixturePHPUnitTestCase;
 use Infection\Tests\Architecture\PHPat\Selector\Support\Fixtures\PHPUnitTestWithUnitGroupFixture;
@@ -121,6 +126,51 @@ final class PHPUnitTestClassAnalysisTest extends SelectorTestCase
         yield 'no group' => [
             self::class,
             false,
+        ];
+    }
+
+    /**
+     * @param class-string $className
+     * @param list<class-string> $expected
+     */
+    #[DataProvider('coveredClassNamesProvider')]
+    public function test_it_gets_covered_class_names(
+        string $className,
+        array $expected,
+    ): void {
+        $actual = PHPUnitTestClassAnalysis::getCoveredClassNames(
+            $this->createClassReflection($className),
+            $this->getReflectionProvider(),
+        );
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function coveredClassNamesProvider(): iterable
+    {
+        yield 'single covered class' => [
+            FixtureWithCoveredClassWithoutIoTest::class,
+            [
+                CoveredClassWithoutIo::class,
+            ],
+        ];
+
+        yield 'multiple covered classes' => [
+            FixtureWithMultipleCoveredClassesTest::class,
+            [
+                CoveredClassWithoutIo::class,
+                CoveredClassWithIo::class,
+            ],
+        ];
+
+        yield 'unsupported coverage attribute' => [
+            FixtureWithCoversNothingWithoutIntegrationGroupTest::class,
+            [],
+        ];
+
+        yield 'no coverage attribute' => [
+            AbstractPHPUnitTest::class,
+            [],
         ];
     }
 }


### PR DESCRIPTION
Now that we have `PHPUnitTestClassAnalysis`, it makes more sense to have the parsing of the test case attributes to collect the covered classes to this utility instead of within `IoCodeDetector`.