### PR TITLE
Add support for positional arguments for `config:list-sources` command

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -722,12 +722,6 @@ count = 1
 
 [[issues]]
 file = "src/Configuration/PositionalPathsClassifier.php"
-code = "redundant-condition"
-message = "This condition (type `true`) will always evaluate to true."
-count = 1
-
-[[issues]]
-file = "src/Configuration/PositionalPathsClassifier.php"
 code = "redundant-logical-operation"
 message = "Redundant `&&` operation: left operand is evaluated and right operand is always truthy."
 count = 1
@@ -5702,20 +5696,20 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `inputProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::runCommand`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::test_it_lists_source_files`.'
+message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::test_it_lists_all_source_files`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::test_it_lists_source_files`.'
+message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::test_it_lists_filtered_source_files_and_warns_about_the_deprecated_filter_option`.'
 count = 1
 
 [[issues]]

--- a/src/Command/ListSourcesCommand.php
+++ b/src/Command/ListSourcesCommand.php
@@ -37,6 +37,7 @@ namespace Infection\Command;
 
 use function array_map;
 use Infection\Command\Option\ConfigurationOption;
+use Infection\Command\Option\PathsArgument;
 use Infection\Command\Option\SourceFilterOptions;
 use Infection\Console\IO;
 use Infection\Logger\Console\ConsoleLogger;
@@ -58,6 +59,8 @@ final class ListSourcesCommand extends BaseCommand
 
     protected function configure(): void
     {
+        PathsArgument::addArgument($this);
+
         ConfigurationOption::addOption($this);
         SourceFilterOptions::addOption($this);
 
@@ -72,7 +75,7 @@ final class ListSourcesCommand extends BaseCommand
             logger: new ConsoleLogger($io),
             output: $io->getOutput(),
             configFile: ConfigurationOption::get($io),
-            sourceFilter: SourceFilterOptions::get($io),
+            sourceFilter: SourceFilterOptions::get($io, PathsArgument::get($io)),
         );
 
         $filePaths = self::collectPaths(


### PR DESCRIPTION
This allows to do

```shell
bin/infection config:list-sources src/Mutator/Number/
```

which displays

```
src/Mutator/Number/AbstractNumberMutator.php
src/Mutator/Number/DecrementInteger.php
src/Mutator/Number/IncrementInteger.php
src/Mutator/Number/OneZeroFloat.php
```

