### PR TITLE
Deprecate `--filter` options in favor of new positional arguments for filtering source

### DIFF
--- a/src/Command/Option/SourceFilterOptions.php
+++ b/src/Command/Option/SourceFilterOptions.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Command\Option;
 
+use const E_USER_DEPRECATED;
 use Infection\CannotBeInstantiated;
 use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
 use Infection\Configuration\SourceFilter\PlainFilter;
@@ -47,6 +48,7 @@ use function sprintf;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use function trigger_error;
 use function trim;
 use Webmozart\Assert\Assert;
 
@@ -129,6 +131,13 @@ final class SourceFilterOptions
     private static function getPlainFilter(InputInterface $input): ?PlainFilter
     {
         $value = trim((string) $input->getOption(self::PLAIN_FILTER_NAME));
+
+        if ($value !== '') {
+            trigger_error(
+                '--filter is deprecated since 0.34.0 and will be removed in 0.35.0. Use positional arguments instead: infection <filter>',
+                E_USER_DEPRECATED,
+            );
+        }
 
         return PlainFilter::tryToCreate($value);
     }

--- a/src/Command/Option/SourceFilterOptions.php
+++ b/src/Command/Option/SourceFilterOptions.php
@@ -132,7 +132,7 @@ final class SourceFilterOptions
 
         if ($value !== '') {
             $io->warning(
-                'The "--filter" option is deprecated since 0.34.0 and will be removed in 0.35.0. Use positional arguments instead: infection <filter>',
+                'The "--filter" option is deprecated since 0.34.0 and will be removed in future versions. Use positional arguments instead: infection <filter>',
             );
         }
 

--- a/src/Command/Option/SourceFilterOptions.php
+++ b/src/Command/Option/SourceFilterOptions.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Command\Option;
 
-use const E_USER_DEPRECATED;
 use Infection\CannotBeInstantiated;
 use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
 use Infection\Configuration\SourceFilter\PlainFilter;
@@ -48,7 +47,6 @@ use function sprintf;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use function trigger_error;
 use function trim;
 use Webmozart\Assert\Assert;
 
@@ -116,7 +114,7 @@ final class SourceFilterOptions
     {
         $input = $io->getInput();
 
-        $filter = self::getPlainFilter($input);
+        $filter = self::getPlainFilter($io);
         $gitFilter = self::getGitFilter($input);
 
         self::assertOnlyOneTypeOfFiltering($filter, $gitFilter, $positionalPaths);
@@ -128,14 +126,13 @@ final class SourceFilterOptions
         return $filter ?? $gitFilter;
     }
 
-    private static function getPlainFilter(InputInterface $input): ?PlainFilter
+    private static function getPlainFilter(IO $io): ?PlainFilter
     {
-        $value = trim((string) $input->getOption(self::PLAIN_FILTER_NAME));
+        $value = trim((string) $io->getInput()->getOption(self::PLAIN_FILTER_NAME));
 
         if ($value !== '') {
-            trigger_error(
-                '--filter is deprecated since 0.34.0 and will be removed in 0.35.0. Use positional arguments instead: infection <filter>',
-                E_USER_DEPRECATED,
+            $io->warning(
+                'The "--filter" option is deprecated since 0.34.0 and will be removed in 0.35.0. Use positional arguments instead: infection <filter>',
             );
         }
 

--- a/tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php
+++ b/tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php
@@ -39,7 +39,6 @@ use Infection\Command\ListSourcesCommand;
 use Infection\Console\Application;
 use Infection\Container\Container;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use function Safe\chdir;
@@ -65,42 +64,43 @@ final class ListSourcesCommandTest extends TestCase
         chdir($this->cwd);
     }
 
-    /**
-     * @param array<string, string> $input
-     */
-    #[DataProvider('inputProvider')]
-    public function test_it_lists_source_files(
-        array $input,
-        string $expected,
-    ): void {
-        $application = new Application(Container::create());
-        $tester = new CommandTester($application->find('config:list-sources'));
-
-        $tester->execute($input);
-
-        $actual = $tester->getDisplay();
-
-        $this->assertSame($expected, $actual);
-        $tester->assertCommandIsSuccessful();
-    }
-
-    public static function inputProvider(): iterable
+    public function test_it_lists_all_source_files(): void
     {
-        yield 'no filter' => [
-            [],
+        $tester = $this->runCommand([]);
+
+        $this->assertSame(
             <<<'STDOUT'
                 File1.php
                 File2.php
 
                 STDOUT,
-        ];
+            $tester->getDisplay(),
+        );
+        $tester->assertCommandIsSuccessful();
+    }
 
-        yield 'with plain filter' => [
-            ['--filter' => 'File1'],
-            <<<'STDOUT'
-                File1.php
+    public function test_it_lists_filtered_source_files_and_warns_about_the_deprecated_filter_option(): void
+    {
+        $tester = $this->runCommand(['--filter' => 'File1']);
 
-                STDOUT,
-        ];
+        $actual = $tester->getDisplay();
+
+        $this->assertStringContainsString('File1.php', $actual);
+        $this->assertStringNotContainsString('File2.php', $actual);
+        $this->assertStringContainsString('The "--filter" option is deprecated', $actual);
+        $tester->assertCommandIsSuccessful();
+    }
+
+    /**
+     * @param array<string, string> $input
+     */
+    private function runCommand(array $input): CommandTester
+    {
+        $application = new Application(Container::create());
+        $tester = new CommandTester($application->find('config:list-sources'));
+
+        $tester->execute($input);
+
+        return $tester;
     }
 }


### PR DESCRIPTION
- [x] Doc PR https://github.com/infection/site/pull/304

There was an interesting idea during code review of https://github.com/infection/infection/pull/3284 - to deprecate `--filter` in favor of `infection source1 test1 ... sourceN testN` syntax, which makes sense to me.

This PR deprecates `--filter` by showing a yellow warning:

<img width="971" height="326" alt="image" src="https://github.com/user-attachments/assets/6b3ccb70-3a51-48ce-83d8-717afa822131" />
