### PR TITLE
test: Streamline EngineTest

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -6973,18 +6973,6 @@ message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Loc
 count = 1
 
 [[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unused-parameter"
-message = "Parameter `$event` is never used."
-count = 6
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unused-parameter"
-message = "Parameter `$input` is never used."
-count = 6
-
-[[issues]]
 file = "tests/phpunit/Environment/BuildContextResolverTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideBlankOrEmptyString` is imprecise, equivalent to `iterable<mixed, mixed>`."

--- a/tests/phpunit/EngineTest.php
+++ b/tests/phpunit/EngineTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests;
 
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\Configuration\Configuration;
 use Infection\Console\ConsoleOutput;
 use Infection\Engine;
 use Infection\Event\EventDispatcher\EventDispatcher;
@@ -57,117 +58,93 @@ use Infection\TestFramework\Coverage\CoverageChecker;
 use Infection\TestFramework\TestFrameworkExtraOptionsFilter;
 use Infection\Tests\Configuration\ConfigurationBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
 #[CoversClass(Engine::class)]
 final class EngineTest extends TestCase
 {
+    private MockObject&TestFrameworkAdapter $adapter;
+
+    private MockObject&CoverageChecker $coverageChecker;
+
+    private MockObject&EventDispatcher $eventDispatcher;
+
+    private MockObject&InitialTestsRunner $initialTestsRunner;
+
+    private MockObject&MemoryLimiter $memoryLimiter;
+
+    private MockObject&MutationGenerator $mutationGenerator;
+
+    private MockObject&MutationTestingRunner $mutationTestingRunner;
+
+    private MockObject&MinMsiChecker $minMsiChecker;
+
+    private MockObject&MaxTimeoutsChecker $maxTimeoutsChecker;
+
+    private MockObject&ConsoleOutput $consoleOutput;
+
+    private MockObject&MetricsCalculator $metricsCalculator;
+
+    private Stub&TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter;
+
+    protected function setUp(): void
+    {
+        $this->adapter = $this->createMock(TestFrameworkAdapter::class);
+        $this->coverageChecker = $this->createMock(CoverageChecker::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcher::class);
+        $this->initialTestsRunner = $this->createMock(InitialTestsRunner::class);
+        $this->memoryLimiter = $this->createMock(MemoryLimiter::class);
+        $this->mutationGenerator = $this->createMock(MutationGenerator::class);
+        $this->mutationTestingRunner = $this->createMock(MutationTestingRunner::class);
+        $this->minMsiChecker = $this->createMock(MinMsiChecker::class);
+        $this->maxTimeoutsChecker = $this->createMock(MaxTimeoutsChecker::class);
+        $this->consoleOutput = $this->createMock(ConsoleOutput::class);
+        $this->metricsCalculator = $this->createMock(MetricsCalculator::class);
+        $this->testFrameworkExtraOptionsFilter = $this->createStub(TestFrameworkExtraOptionsFilter::class);
+    }
+
     public function test_initial_test_run_fails(): void
     {
         $config = ConfigurationBuilder::withMinimalTestData()
             ->withSkipInitialTests(false)
             ->build();
 
-        $adapter = $this->createMock(TestFrameworkAdapter::class);
-        $adapter
+        $this->adapter
             ->expects($this->once())
             ->method('getName')
-            ->willReturn('foo')
-        ;
-        $adapter
+            ->willReturn('foo');
+        $this->adapter
             ->expects($this->once())
             ->method('getInitialTestsFailRecommendations')
-            ->willReturn('Run tests to see what failed')
-        ;
-
-        $coverageChecker = $this->createMock(CoverageChecker::class);
-        $coverageChecker->expects($this->never())->method($this->anything());
-
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher->expects($this->never())->method($this->anything());
-
-        $process = $this->createMock(Process::class);
-        $process
-            ->expects($this->once())
-            ->method('isSuccessful')
-            ->willReturn(false)
-        ;
-
-        $process
-            ->expects($this->once())
-            ->method('getCommandLine')
-            ->willReturn('/tmp/bar')
-        ;
-
+            ->willReturn('Run tests to see what failed');
+        $process = $this->createInitialTestProcess(false, '');
         $process
             ->expects($this->once())
             ->method('getExitCode')
-            ->willReturn(1)
-        ;
-
-        $process
-            ->expects($this->atLeastOnce())
-            ->method('getOutput')
-            ->willReturn('')
-        ;
-
+            ->willReturn(1);
         $process
             ->expects($this->atLeastOnce())
             ->method('getErrorOutput')
-            ->willReturn('')
-        ;
-
-        $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
-        $initialTestsRunner
+            ->willReturn('');
+        $this->initialTestsRunner
             ->expects($this->once())
             ->method('run')
-            ->willReturn($process)
-        ;
-
-        $memoryLimiter = $this->createMock(MemoryLimiter::class);
-        $memoryLimiter->expects($this->never())->method($this->anything());
-
-        $mutationGenerator = $this->createMock(MutationGenerator::class);
-        $mutationGenerator->expects($this->never())->method($this->anything());
-
-        $mutationTestingRunner = $this->createMock(MutationTestingRunner::class);
-        $mutationTestingRunner->expects($this->never())->method($this->anything());
-
-        $minMsiChecker = $this->createMock(MinMsiChecker::class);
-        $minMsiChecker->expects($this->never())->method($this->anything());
-
-        $consoleOutput = $this->createMock(ConsoleOutput::class);
-        $consoleOutput->expects($this->never())->method($this->anything());
-
-        $metricsCalculator = $this->createMock(MetricsCalculator::class);
-        $metricsCalculator->expects($this->never())->method($this->anything());
-
-        $testFrameworkExtraOptionsFilter = $this->createMock(TestFrameworkExtraOptionsFilter::class);
-        $testFrameworkExtraOptionsFilter->expects($this->never())->method($this->anything());
-
-        $maxTimeoutsChecker = $this->createMock(MaxTimeoutsChecker::class);
-        $maxTimeoutsChecker->expects($this->never())->method($this->anything());
-
-        $engine = new Engine(
-            $config,
-            $adapter,
-            $coverageChecker,
-            $eventDispatcher,
-            $initialTestsRunner,
-            $memoryLimiter,
-            $mutationGenerator,
-            $mutationTestingRunner,
-            $minMsiChecker,
-            $maxTimeoutsChecker,
-            $consoleOutput,
-            $metricsCalculator,
-            $testFrameworkExtraOptionsFilter,
-        );
+            ->willReturn($process);
+        $this->coverageChecker->expects($this->never())->method($this->anything());
+        $this->eventDispatcher->expects($this->never())->method($this->anything());
+        $this->memoryLimiter->expects($this->never())->method($this->anything());
+        $this->mutationGenerator->expects($this->never())->method($this->anything());
+        $this->mutationTestingRunner->expects($this->never())->method($this->anything());
+        $this->minMsiChecker->expects($this->never())->method($this->anything());
+        $this->metricsCalculator->expects($this->never())->method($this->anything());
+        $this->maxTimeoutsChecker->expects($this->never())->method($this->anything());
 
         $this->expectException(InitialTestsFailed::class);
 
-        $engine->execute();
+        $this->createEngine($config)->execute();
     }
 
     public function test_initial_test_run_succeeds(): void
@@ -177,117 +154,51 @@ final class EngineTest extends TestCase
             ->withUncovered(true)
             ->build();
 
-        $adapter = $this->createMock(TestFrameworkAdapter::class);
-        $adapter->expects($this->never())->method($this->anything());
+        $process = $this->createInitialTestProcess(true, 'testing');
 
-        $coverageChecker = $this->createMock(CoverageChecker::class);
-        $coverageChecker
-            ->expects($this->once())
-            ->method('checkCoverageHasBeenGenerated')
-        ;
-
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
-
-        $process = $this->createMock(Process::class);
-        $process
-            ->expects($this->once())
-            ->method('isSuccessful')
-            ->willReturn(true)
-        ;
-
-        $process
-            ->expects($this->once())
-            ->method('getCommandLine')
-            ->willReturn('/tmp/bar')
-        ;
-
-        $process
-            ->expects($this->exactly(2))
-            ->method('getOutput')
-            ->willReturn('testing')
-        ;
-
-        $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
-        $initialTestsRunner
+        $this->initialTestsRunner
             ->expects($this->once())
             ->method('run')
-            ->willReturn($process)
-        ;
-
-        $memoryLimiter = $this->createMock(MemoryLimiter::class);
-        $memoryLimiter
+            ->willReturn($process);
+        $this->coverageChecker
+            ->expects($this->once())
+            ->method('checkCoverageHasBeenGenerated')
+            ->with('/tmp/bar', 'testing');
+        $this->memoryLimiter
             ->expects($this->once())
             ->method('limitMemory')
-            ->with('testing', $adapter)
-        ;
-
-        $mutationGenerator = $this->createMock(MutationGenerator::class);
-        $mutationGenerator
+            ->with('testing', $this->adapter);
+        $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
             ->with(false)
-        ;
-
-        $mutationTestingRunner = $this->createMock(MutationTestingRunner::class);
-        $mutationTestingRunner
+            ->willReturn([]);
+        $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
-            ->with($this->callback(static fn (iterable $input): bool => true))
-        ;
-
-        $consoleOutput = $this->createMock(ConsoleOutput::class);
-        $consoleOutput->expects($this->never())->method($this->anything());
-
-        $minMsiChecker = $this->createMock(MinMsiChecker::class);
-        $minMsiChecker
+            ->with([], '');
+        $this->minMsiChecker
             ->expects($this->once())
             ->method('checkMetrics')
-            ->with(1000, 2.0, 3.0, $consoleOutput)
-        ;
-
-        $metricsCalculator = $this->createMock(MetricsCalculator::class);
-        $metricsCalculator
+            ->with(1000, 2.0, 3.0, $this->consoleOutput);
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getTestedMutantsCount')
-            ->willReturn(1000)
-        ;
-        $metricsCalculator
+            ->willReturn(1000);
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getMutationScoreIndicator')
-            ->willReturn(2.0)
-        ;
-        $metricsCalculator
+            ->willReturn(2.0);
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getCoveredCodeMutationScoreIndicator')
-            ->willReturn(3.0)
-        ;
+            ->willReturn(3.0);
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(ApplicationExecutionWasFinished::class));
 
-        $testFrameworkExtraOptionsFilter = $this->createMock(TestFrameworkExtraOptionsFilter::class);
-        $testFrameworkExtraOptionsFilter->expects($this->never())->method($this->anything());
-
-        $maxTimeoutsChecker = $this->createStub(MaxTimeoutsChecker::class);
-
-        $engine = new Engine(
-            $config,
-            $adapter,
-            $coverageChecker,
-            $eventDispatcher,
-            $initialTestsRunner,
-            $memoryLimiter,
-            $mutationGenerator,
-            $mutationTestingRunner,
-            $minMsiChecker,
-            $maxTimeoutsChecker,
-            $consoleOutput,
-            $metricsCalculator,
-            $testFrameworkExtraOptionsFilter,
-        );
-
-        $engine->execute();
+        $this->createEngine($config)->execute();
     }
 
     public function test_memory_limiter_is_applied_after_static_analysis_when_enabled(): void
@@ -298,142 +209,69 @@ final class EngineTest extends TestCase
             ->withUncovered(true)
             ->build();
 
-        $adapter = $this->createStub(TestFrameworkAdapter::class);
+        $callOrder = [];
 
-        $coverageChecker = $this->createMock(CoverageChecker::class);
-        $coverageChecker
+        $this->initialTestsRunner
+            ->expects($this->once())
+            ->method('run')
+            ->willReturn($this->createInitialTestProcess(true, 'test output'));
+        $this->coverageChecker
             ->expects($this->once())
             ->method('checkCoverageHasBeenGenerated')
-        ;
-
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
-
-        $initialTestProcess = $this->createMock(Process::class);
-        $initialTestProcess
-            ->expects($this->once())
-            ->method('isSuccessful')
-            ->willReturn(true)
-        ;
-        $initialTestProcess
-            ->expects($this->once())
-            ->method('getCommandLine')
-            ->willReturn('/tmp/bar')
-        ;
-        $initialTestProcess
-            ->expects($this->exactly(2))
-            ->method('getOutput')
-            ->willReturn('test output')
-        ;
-
+            ->with('/tmp/bar', 'test output');
         $staticAnalysisProcess = $this->createMock(Process::class);
         $staticAnalysisProcess
             ->expects($this->once())
             ->method('isSuccessful')
-            ->willReturn(true)
-        ;
-
-        $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
-        $initialTestsRunner
-            ->expects($this->once())
-            ->method('run')
-            ->willReturn($initialTestProcess)
-        ;
-
+            ->willReturn(true);
         $initialStaticAnalysisRunner = $this->createMock(InitialStaticAnalysisRunner::class);
         $initialStaticAnalysisRunner
             ->expects($this->once())
             ->method('run')
-            ->willReturn($staticAnalysisProcess)
-        ;
+            ->willReturn($staticAnalysisProcess);
 
         $staticAnalysisToolAdapter = $this->createStub(StaticAnalysisToolAdapter::class);
 
-        $callOrder = [];
-
-        $memoryLimiter = $this->createMock(MemoryLimiter::class);
-        $memoryLimiter
+        $this->memoryLimiter
             ->expects($this->once())
             ->method('limitMemory')
-            ->with('test output', $adapter)
+            ->with('test output', $this->adapter)
             ->willReturnCallback(static function () use (&$callOrder): void {
                 $callOrder[] = 'limitMemory';
-            })
-        ;
-
-        $mutationGenerator = $this->createMock(MutationGenerator::class);
-        $mutationGenerator
+            });
+        $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
             ->with(false)
-            ->willReturnCallback(static function () use (&$callOrder) {
+            ->willReturnCallback(static function () use (&$callOrder): array {
                 $callOrder[] = 'generate';
 
                 return [];
-            })
-        ;
-
-        $mutationTestingRunner = $this->createMock(MutationTestingRunner::class);
-        $mutationTestingRunner
+            });
+        $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
-            ->with($this->callback(static fn (iterable $input): bool => true))
-        ;
-
-        $consoleOutput = $this->createStub(ConsoleOutput::class);
-
-        $minMsiChecker = $this->createMock(MinMsiChecker::class);
-        $minMsiChecker
+            ->with([], '');
+        $this->minMsiChecker
             ->expects($this->once())
             ->method('checkMetrics')
-            ->with(100, 80.0, 85.0, $consoleOutput)
-        ;
-
-        $metricsCalculator = $this->createMock(MetricsCalculator::class);
-        $metricsCalculator
-            ->expects($this->once())
+            ->with(100, 80.0, 85.0, $this->consoleOutput);
+        $this->metricsCalculator
             ->method('getTestedMutantsCount')
-            ->willReturn(100)
-        ;
-        $metricsCalculator
-            ->expects($this->once())
+            ->willReturn(100);
+        $this->metricsCalculator
             ->method('getMutationScoreIndicator')
-            ->willReturn(80.0)
-        ;
-        $metricsCalculator
-            ->expects($this->once())
+            ->willReturn(80.0);
+        $this->metricsCalculator
             ->method('getCoveredCodeMutationScoreIndicator')
-            ->willReturn(85.0)
-        ;
+            ->willReturn(85.0);
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(ApplicationExecutionWasFinished::class));
 
-        $testFrameworkExtraOptionsFilter = $this->createStub(TestFrameworkExtraOptionsFilter::class);
+        $this->createEngine($config, $initialStaticAnalysisRunner, $staticAnalysisToolAdapter)->execute();
 
-        $maxTimeoutsChecker = $this->createStub(MaxTimeoutsChecker::class);
-
-        $engine = new Engine(
-            $config,
-            $adapter,
-            $coverageChecker,
-            $eventDispatcher,
-            $initialTestsRunner,
-            $memoryLimiter,
-            $mutationGenerator,
-            $mutationTestingRunner,
-            $minMsiChecker,
-            $maxTimeoutsChecker,
-            $consoleOutput,
-            $metricsCalculator,
-            $testFrameworkExtraOptionsFilter,
-            $initialStaticAnalysisRunner,
-            $staticAnalysisToolAdapter,
-        );
-
-        $engine->execute();
-
-        // Verify that limitMemory is called before mutation generation
         $this->assertSame(['limitMemory', 'generate'], $callOrder);
     }
 
@@ -444,91 +282,44 @@ final class EngineTest extends TestCase
             ->withUncovered(true)
             ->build();
 
-        $adapter = $this->createStub(TestFrameworkAdapter::class);
-
-        $coverageChecker = $this->createMock(CoverageChecker::class);
-        $coverageChecker
+        $this->coverageChecker
             ->expects($this->once())
-            ->method('checkCoverageExists')
-        ;
-
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
+            ->method('checkCoverageExists');
+        $this->consoleOutput
             ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
-
-        $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
-        $initialTestsRunner->expects($this->never())->method($this->anything());
-
-        $memoryLimiter = $this->createMock(MemoryLimiter::class);
-        $memoryLimiter->expects($this->never())->method('limitMemory');
-
-        $mutationGenerator = $this->createMock(MutationGenerator::class);
-        $mutationGenerator
+            ->method('logSkippingInitialTests');
+        $this->initialTestsRunner->expects($this->never())->method($this->anything());
+        $this->memoryLimiter->expects($this->never())->method('limitMemory');
+        $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
             ->with(false)
-            ->willReturn([])
-        ;
-
-        $mutationTestingRunner = $this->createMock(MutationTestingRunner::class);
-        $mutationTestingRunner
+            ->willReturn([]);
+        $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
-            ->with($this->callback(static fn (iterable $input): bool => true))
-        ;
-
-        $consoleOutput = $this->createMock(ConsoleOutput::class);
-        $consoleOutput
+            ->with([], '');
+        $this->minMsiChecker
             ->expects($this->once())
-            ->method('logSkippingInitialTests')
-        ;
-
-        $minMsiChecker = $this->createMock(MinMsiChecker::class);
-        $minMsiChecker
-            ->expects($this->once())
-            ->method('checkMetrics')
-        ;
-
-        $metricsCalculator = $this->createMock(MetricsCalculator::class);
-        $metricsCalculator
+            ->method('checkMetrics');
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getTestedMutantsCount')
-            ->willReturn(0)
-        ;
-        $metricsCalculator
+            ->willReturn(0);
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getMutationScoreIndicator')
-            ->willReturn(0.0)
-        ;
-        $metricsCalculator
+            ->willReturn(0.0);
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getCoveredCodeMutationScoreIndicator')
-            ->willReturn(0.0)
-        ;
+            ->willReturn(0.0);
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(ApplicationExecutionWasFinished::class));
 
-        $testFrameworkExtraOptionsFilter = $this->createStub(TestFrameworkExtraOptionsFilter::class);
-
-        $maxTimeoutsChecker = $this->createStub(MaxTimeoutsChecker::class);
-
-        $engine = new Engine(
-            $config,
-            $adapter,
-            $coverageChecker,
-            $eventDispatcher,
-            $initialTestsRunner,
-            $memoryLimiter,
-            $mutationGenerator,
-            $mutationTestingRunner,
-            $minMsiChecker,
-            $maxTimeoutsChecker,
-            $consoleOutput,
-            $metricsCalculator,
-            $testFrameworkExtraOptionsFilter,
-        );
-
-        $engine->execute();
+        $this->createEngine($config)->execute();
     }
 
     public function test_max_timeouts_checker_receives_correct_timed_out_count(): void
@@ -538,101 +329,50 @@ final class EngineTest extends TestCase
             ->withUncovered(true)
             ->build();
 
-        $adapter = $this->createStub(TestFrameworkAdapter::class);
-
-        $coverageChecker = $this->createMock(CoverageChecker::class);
-        $coverageChecker
+        $this->coverageChecker
             ->expects($this->once())
-            ->method('checkCoverageExists')
-        ;
-
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
+            ->method('checkCoverageExists');
+        $this->consoleOutput
             ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
-
-        $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
-        $initialTestsRunner->expects($this->never())->method($this->anything());
-
-        $memoryLimiter = $this->createMock(MemoryLimiter::class);
-        $memoryLimiter->expects($this->never())->method('limitMemory');
-
-        $mutationGenerator = $this->createMock(MutationGenerator::class);
-        $mutationGenerator
+            ->method('logSkippingInitialTests');
+        $this->initialTestsRunner->expects($this->never())->method($this->anything());
+        $this->memoryLimiter->expects($this->never())->method('limitMemory');
+        $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
             ->with(false)
-            ->willReturn([])
-        ;
-
-        $mutationTestingRunner = $this->createMock(MutationTestingRunner::class);
-        $mutationTestingRunner
+            ->willReturn([]);
+        $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
-            ->with($this->callback(static fn (iterable $input): bool => true))
-        ;
-
-        $consoleOutput = $this->createMock(ConsoleOutput::class);
-        $consoleOutput
-            ->expects($this->once())
-            ->method('logSkippingInitialTests')
-        ;
-
-        $minMsiChecker = $this->createMock(MinMsiChecker::class);
-        $minMsiChecker
-            ->expects($this->once())
-            ->method('checkMetrics')
-        ;
-
-        $metricsCalculator = $this->createMock(MetricsCalculator::class);
-        $metricsCalculator
+            ->with([], '');
+        $this->minMsiChecker->expects($this->once())->method('checkMetrics');
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getTimedOutCount')
-            ->willReturn(42)
-        ;
-        $metricsCalculator
+            ->willReturn(42);
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getTestedMutantsCount')
-            ->willReturn(0)
-        ;
-        $metricsCalculator
+            ->willReturn(0);
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getMutationScoreIndicator')
-            ->willReturn(0.0)
-        ;
-        $metricsCalculator
+            ->willReturn(0.0);
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getCoveredCodeMutationScoreIndicator')
-            ->willReturn(0.0)
-        ;
-
-        $testFrameworkExtraOptionsFilter = $this->createStub(TestFrameworkExtraOptionsFilter::class);
-
-        $maxTimeoutsChecker = $this->createMock(MaxTimeoutsChecker::class);
-        $maxTimeoutsChecker
+            ->willReturn(0.0);
+        $this->maxTimeoutsChecker
             ->expects($this->once())
             ->method('checkTimeouts')
-            ->with(42)
-        ;
+            ->with(42);
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(ApplicationExecutionWasFinished::class));
 
-        $engine = new Engine(
-            $config,
-            $adapter,
-            $coverageChecker,
-            $eventDispatcher,
-            $initialTestsRunner,
-            $memoryLimiter,
-            $mutationGenerator,
-            $mutationTestingRunner,
-            $minMsiChecker,
-            $maxTimeoutsChecker,
-            $consoleOutput,
-            $metricsCalculator,
-            $testFrameworkExtraOptionsFilter,
-        );
-
-        $engine->execute();
+        $this->createEngine($config)->execute();
     }
 
     public function test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws(): void
@@ -642,86 +382,41 @@ final class EngineTest extends TestCase
             ->withUncovered(true)
             ->build();
 
-        $adapter = $this->createStub(TestFrameworkAdapter::class);
-
-        $coverageChecker = $this->createMock(CoverageChecker::class);
-        $coverageChecker
+        $this->coverageChecker
             ->expects($this->once())
-            ->method('checkCoverageExists')
-        ;
-
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
+            ->method('checkCoverageExists');
+        $this->consoleOutput
             ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
-
-        $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
-        $initialTestsRunner->expects($this->never())->method($this->anything());
-
-        $memoryLimiter = $this->createMock(MemoryLimiter::class);
-        $memoryLimiter->expects($this->never())->method('limitMemory');
-
-        $mutationGenerator = $this->createMock(MutationGenerator::class);
-        $mutationGenerator
+            ->method('logSkippingInitialTests');
+        $this->initialTestsRunner->expects($this->never())->method($this->anything());
+        $this->memoryLimiter->expects($this->never())->method('limitMemory');
+        $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
             ->with(false)
-            ->willReturn([])
-        ;
-
-        $mutationTestingRunner = $this->createMock(MutationTestingRunner::class);
-        $mutationTestingRunner
+            ->willReturn([]);
+        $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
-            ->with($this->callback(static fn (iterable $input): bool => true))
-        ;
-
-        $consoleOutput = $this->createMock(ConsoleOutput::class);
-        $consoleOutput
-            ->expects($this->once())
-            ->method('logSkippingInitialTests')
-        ;
-
-        $minMsiChecker = $this->createMock(MinMsiChecker::class);
-        $minMsiChecker->expects($this->never())->method($this->anything());
-
-        $metricsCalculator = $this->createMock(MetricsCalculator::class);
-        $metricsCalculator
+            ->with([], '');
+        $this->minMsiChecker->expects($this->never())->method($this->anything());
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getTimedOutCount')
-            ->willReturn(100)
-        ;
-
-        $testFrameworkExtraOptionsFilter = $this->createStub(TestFrameworkExtraOptionsFilter::class);
-
-        $maxTimeoutsChecker = $this->createMock(MaxTimeoutsChecker::class);
-        $maxTimeoutsChecker
+            ->willReturn(100);
+        $this->maxTimeoutsChecker
             ->expects($this->once())
             ->method('checkTimeouts')
             ->with(100)
-            ->willThrowException(MaxTimeoutCountReached::create(10, 100))
-        ;
-
-        $engine = new Engine(
-            $config,
-            $adapter,
-            $coverageChecker,
-            $eventDispatcher,
-            $initialTestsRunner,
-            $memoryLimiter,
-            $mutationGenerator,
-            $mutationTestingRunner,
-            $minMsiChecker,
-            $maxTimeoutsChecker,
-            $consoleOutput,
-            $metricsCalculator,
-            $testFrameworkExtraOptionsFilter,
-        );
+            ->willThrowException(MaxTimeoutCountReached::create(10, 100));
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(ApplicationExecutionWasFinished::class));
 
         $this->expectException(MaxTimeoutCountReached::class);
 
-        $engine->execute();
+        $this->createEngine($config)->execute();
     }
 
     public function test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws(): void
@@ -731,104 +426,99 @@ final class EngineTest extends TestCase
             ->withUncovered(true)
             ->build();
 
-        $adapter = $this->createStub(TestFrameworkAdapter::class);
-
-        $coverageChecker = $this->createMock(CoverageChecker::class);
-        $coverageChecker
+        $this->coverageChecker
             ->expects($this->once())
-            ->method('checkCoverageExists')
-        ;
-
-        $eventDispatcher = $this->createMock(EventDispatcher::class);
-        $eventDispatcher
+            ->method('checkCoverageExists');
+        $this->consoleOutput
             ->expects($this->once())
-            ->method('dispatch')
-            ->with($this->callback(static fn (ApplicationExecutionWasFinished $event): bool => true));
-
-        $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
-        $initialTestsRunner->expects($this->never())->method($this->anything());
-
-        $memoryLimiter = $this->createMock(MemoryLimiter::class);
-        $memoryLimiter->expects($this->never())->method('limitMemory');
-
-        $mutationGenerator = $this->createMock(MutationGenerator::class);
-        $mutationGenerator
+            ->method('logSkippingInitialTests');
+        $this->initialTestsRunner->expects($this->never())->method($this->anything());
+        $this->memoryLimiter->expects($this->never())->method('limitMemory');
+        $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
             ->with(false)
-            ->willReturn([])
-        ;
-
-        $mutationTestingRunner = $this->createMock(MutationTestingRunner::class);
-        $mutationTestingRunner
+            ->willReturn([]);
+        $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
-            ->with($this->callback(static fn (iterable $input): bool => true))
-        ;
-
-        $consoleOutput = $this->createMock(ConsoleOutput::class);
-        $consoleOutput
-            ->expects($this->once())
-            ->method('logSkippingInitialTests')
-        ;
-
-        $minMsiChecker = $this->createMock(MinMsiChecker::class);
-        $minMsiChecker
+            ->with([], '');
+        $this->minMsiChecker
             ->expects($this->once())
             ->method('checkMetrics')
-            ->with(100, 50.0, 55.0, $consoleOutput)
-            ->willThrowException(MinMsiCheckFailed::createForMsi(80.0, 50.0))
-        ;
-
-        $metricsCalculator = $this->createMock(MetricsCalculator::class);
-        $metricsCalculator
+            ->with(100, 50.0, 55.0, $this->consoleOutput)
+            ->willThrowException(MinMsiCheckFailed::createForMsi(80.0, 50.0));
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getTimedOutCount')
-            ->willReturn(0)
-        ;
-        $metricsCalculator
+            ->willReturn(0);
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getTestedMutantsCount')
-            ->willReturn(100)
-        ;
-        $metricsCalculator
+            ->willReturn(100);
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getMutationScoreIndicator')
-            ->willReturn(50.0)
-        ;
-        $metricsCalculator
+            ->willReturn(50.0);
+        $this->metricsCalculator
             ->expects($this->once())
             ->method('getCoveredCodeMutationScoreIndicator')
-            ->willReturn(55.0)
-        ;
-
-        $testFrameworkExtraOptionsFilter = $this->createStub(TestFrameworkExtraOptionsFilter::class);
-
-        $maxTimeoutsChecker = $this->createMock(MaxTimeoutsChecker::class);
-        $maxTimeoutsChecker
+            ->willReturn(55.0);
+        $this->maxTimeoutsChecker
             ->expects($this->once())
             ->method('checkTimeouts')
-            ->with(0)
-        ;
-
-        $engine = new Engine(
-            $config,
-            $adapter,
-            $coverageChecker,
-            $eventDispatcher,
-            $initialTestsRunner,
-            $memoryLimiter,
-            $mutationGenerator,
-            $mutationTestingRunner,
-            $minMsiChecker,
-            $maxTimeoutsChecker,
-            $consoleOutput,
-            $metricsCalculator,
-            $testFrameworkExtraOptionsFilter,
-        );
+            ->with(0);
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(ApplicationExecutionWasFinished::class));
 
         $this->expectException(MinMsiCheckFailed::class);
 
-        $engine->execute();
+        $this->createEngine($config)->execute();
+    }
+
+    private function createInitialTestProcess(bool $successful, string $output): MockObject&Process
+    {
+        $process = $this->createMock(Process::class);
+        $process
+            ->expects($this->once())
+            ->method('isSuccessful')
+            ->willReturn($successful);
+        $process
+            ->method('getCommandLine')
+            ->willReturn('/tmp/bar');
+        $process
+            ->method('getOutput')
+            ->willReturn($output);
+
+        return $process;
+    }
+
+    private function createEngine(
+        ?Configuration $config = null,
+        ?InitialStaticAnalysisRunner $initialStaticAnalysisRunner = null,
+        ?StaticAnalysisToolAdapter $staticAnalysisToolAdapter = null,
+    ): Engine {
+        return new Engine(
+            config: $config ?? ConfigurationBuilder::withMinimalTestData()
+                ->withSkipInitialTests(false)
+                ->withUncovered(true)
+                ->build(),
+            adapter: $this->adapter,
+            coverageChecker: $this->coverageChecker,
+            eventDispatcher: $this->eventDispatcher,
+            initialTestsRunner: $this->initialTestsRunner,
+            memoryLimiter: $this->memoryLimiter,
+            mutationGenerator: $this->mutationGenerator,
+            mutationTestingRunner: $this->mutationTestingRunner,
+            minMsiChecker: $this->minMsiChecker,
+            maxTimeoutsChecker: $this->maxTimeoutsChecker,
+            consoleOutput: $this->consoleOutput,
+            metricsCalculator: $this->metricsCalculator,
+            testFrameworkExtraOptionsFilter: $this->testFrameworkExtraOptionsFilter,
+            initialStaticAnalysisRunner: $initialStaticAnalysisRunner,
+            staticAnalysisToolAdapter: $staticAnalysisToolAdapter,
+        );
     }
 }

--- a/tests/phpunit/EngineTest.php
+++ b/tests/phpunit/EngineTest.php
@@ -120,6 +120,7 @@ final class EngineTest extends TestCase
             ->expects($this->once())
             ->method('getInitialTestsFailRecommendations')
             ->willReturn('Run tests to see what failed');
+
         $process = $this->createInitialTestProcess(false, '');
         $process
             ->expects($this->once())
@@ -129,10 +130,12 @@ final class EngineTest extends TestCase
             ->expects($this->atLeastOnce())
             ->method('getErrorOutput')
             ->willReturn('');
+
         $this->initialTestsRunner
             ->expects($this->once())
             ->method('run')
             ->willReturn($process);
+
         $this->coverageChecker->expects($this->never())->method($this->anything());
         $this->eventDispatcher->expects($this->never())->method($this->anything());
         $this->memoryLimiter->expects($this->never())->method($this->anything());
@@ -160,27 +163,33 @@ final class EngineTest extends TestCase
             ->expects($this->once())
             ->method('run')
             ->willReturn($process);
+
         $this->coverageChecker
             ->expects($this->once())
             ->method('checkCoverageHasBeenGenerated')
             ->with('/tmp/bar', 'testing');
+
         $this->memoryLimiter
             ->expects($this->once())
             ->method('limitMemory')
             ->with('testing', $this->adapter);
+
         $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
             ->with(false)
             ->willReturn([]);
+
         $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
             ->with([], '');
+
         $this->minMsiChecker
             ->expects($this->once())
             ->method('checkMetrics')
             ->with(1000, 2.0, 3.0, $this->consoleOutput);
+
         $this->metricsCalculator
             ->expects($this->once())
             ->method('getTestedMutantsCount')
@@ -193,6 +202,7 @@ final class EngineTest extends TestCase
             ->expects($this->once())
             ->method('getCoveredCodeMutationScoreIndicator')
             ->willReturn(3.0);
+
         $this->eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
@@ -215,15 +225,18 @@ final class EngineTest extends TestCase
             ->expects($this->once())
             ->method('run')
             ->willReturn($this->createInitialTestProcess(true, 'test output'));
+
         $this->coverageChecker
             ->expects($this->once())
             ->method('checkCoverageHasBeenGenerated')
             ->with('/tmp/bar', 'test output');
+
         $staticAnalysisProcess = $this->createMock(Process::class);
         $staticAnalysisProcess
             ->expects($this->once())
             ->method('isSuccessful')
             ->willReturn(true);
+
         $initialStaticAnalysisRunner = $this->createMock(InitialStaticAnalysisRunner::class);
         $initialStaticAnalysisRunner
             ->expects($this->once())
@@ -239,6 +252,7 @@ final class EngineTest extends TestCase
             ->willReturnCallback(static function () use (&$callOrder): void {
                 $callOrder[] = 'limitMemory';
             });
+
         $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
@@ -248,14 +262,17 @@ final class EngineTest extends TestCase
 
                 return [];
             });
+
         $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
             ->with([], '');
+
         $this->minMsiChecker
             ->expects($this->once())
             ->method('checkMetrics')
             ->with(100, 80.0, 85.0, $this->consoleOutput);
+
         $this->metricsCalculator
             ->method('getTestedMutantsCount')
             ->willReturn(100);
@@ -265,12 +282,19 @@ final class EngineTest extends TestCase
         $this->metricsCalculator
             ->method('getCoveredCodeMutationScoreIndicator')
             ->willReturn(85.0);
+
         $this->eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
             ->with($this->isInstanceOf(ApplicationExecutionWasFinished::class));
 
-        $this->createEngine($config, $initialStaticAnalysisRunner, $staticAnalysisToolAdapter)->execute();
+        $engine = $this->createEngine(
+            $config,
+            $initialStaticAnalysisRunner,
+            $staticAnalysisToolAdapter,
+        );
+
+        $engine->execute();
 
         $this->assertSame(['limitMemory', 'generate'], $callOrder);
     }
@@ -285,23 +309,29 @@ final class EngineTest extends TestCase
         $this->coverageChecker
             ->expects($this->once())
             ->method('checkCoverageExists');
+
         $this->consoleOutput
             ->expects($this->once())
             ->method('logSkippingInitialTests');
+
         $this->initialTestsRunner->expects($this->never())->method($this->anything());
         $this->memoryLimiter->expects($this->never())->method('limitMemory');
+
         $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
             ->with(false)
             ->willReturn([]);
+
         $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
             ->with([], '');
+
         $this->minMsiChecker
             ->expects($this->once())
             ->method('checkMetrics');
+
         $this->metricsCalculator
             ->expects($this->once())
             ->method('getTestedMutantsCount')
@@ -314,6 +344,7 @@ final class EngineTest extends TestCase
             ->expects($this->once())
             ->method('getCoveredCodeMutationScoreIndicator')
             ->willReturn(0.0);
+
         $this->eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
@@ -332,21 +363,27 @@ final class EngineTest extends TestCase
         $this->coverageChecker
             ->expects($this->once())
             ->method('checkCoverageExists');
+
         $this->consoleOutput
             ->expects($this->once())
             ->method('logSkippingInitialTests');
+
         $this->initialTestsRunner->expects($this->never())->method($this->anything());
         $this->memoryLimiter->expects($this->never())->method('limitMemory');
+
         $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
             ->with(false)
             ->willReturn([]);
+
         $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
             ->with([], '');
+
         $this->minMsiChecker->expects($this->once())->method('checkMetrics');
+
         $this->metricsCalculator
             ->expects($this->once())
             ->method('getTimedOutCount')
@@ -363,10 +400,12 @@ final class EngineTest extends TestCase
             ->expects($this->once())
             ->method('getCoveredCodeMutationScoreIndicator')
             ->willReturn(0.0);
+
         $this->maxTimeoutsChecker
             ->expects($this->once())
             ->method('checkTimeouts')
             ->with(42);
+
         $this->eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
@@ -385,30 +424,38 @@ final class EngineTest extends TestCase
         $this->coverageChecker
             ->expects($this->once())
             ->method('checkCoverageExists');
+
         $this->consoleOutput
             ->expects($this->once())
             ->method('logSkippingInitialTests');
+
         $this->initialTestsRunner->expects($this->never())->method($this->anything());
         $this->memoryLimiter->expects($this->never())->method('limitMemory');
+
         $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
             ->with(false)
             ->willReturn([]);
+
         $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
             ->with([], '');
+
         $this->minMsiChecker->expects($this->never())->method($this->anything());
+
         $this->metricsCalculator
             ->expects($this->once())
             ->method('getTimedOutCount')
             ->willReturn(100);
+
         $this->maxTimeoutsChecker
             ->expects($this->once())
             ->method('checkTimeouts')
             ->with(100)
             ->willThrowException(MaxTimeoutCountReached::create(10, 100));
+
         $this->eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
@@ -429,25 +476,31 @@ final class EngineTest extends TestCase
         $this->coverageChecker
             ->expects($this->once())
             ->method('checkCoverageExists');
+
         $this->consoleOutput
             ->expects($this->once())
             ->method('logSkippingInitialTests');
+
         $this->initialTestsRunner->expects($this->never())->method($this->anything());
         $this->memoryLimiter->expects($this->never())->method('limitMemory');
+
         $this->mutationGenerator
             ->expects($this->once())
             ->method('generate')
             ->with(false)
             ->willReturn([]);
+
         $this->mutationTestingRunner
             ->expects($this->once())
             ->method('run')
             ->with([], '');
+
         $this->minMsiChecker
             ->expects($this->once())
             ->method('checkMetrics')
             ->with(100, 50.0, 55.0, $this->consoleOutput)
             ->willThrowException(MinMsiCheckFailed::createForMsi(80.0, 50.0));
+
         $this->metricsCalculator
             ->expects($this->once())
             ->method('getTimedOutCount')
@@ -468,6 +521,7 @@ final class EngineTest extends TestCase
             ->expects($this->once())
             ->method('checkTimeouts')
             ->with(0);
+
         $this->eventDispatcher
             ->expects($this->once())
             ->method('dispatch')


### PR DESCRIPTION
Preparatory step for #3312, this PR refactors `EngineTest` to simplify the setup which significantly reduces the amount of boilerplate.