### PR TITLE
fix(test-framework): Correctly leverage the vendor bin path fallback when Composer could not provide it

### DIFF
--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -92,12 +92,12 @@ class TestFrameworkFinder
         return $this->cachedPath[$testFrameworkName];
     }
 
-    public function getVendorDirProcess(): Process
+    private function getBinDirProcess(): Process
     {
         return new Process([
             ...$this->findComposer(),
             'config',
-            'vendor-dir',
+            'bin-dir',
         ]);
     }
 
@@ -202,7 +202,7 @@ class TestFrameworkFinder
     private function getComposerBinDir(): ?string
     {
         try {
-            $process = $this->getVendorDirProcess();
+            $process = $this->getBinDirProcess();
 
             $process->mustRun();
             $binDir = trim($process->getOutput());

--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -92,6 +92,15 @@ class TestFrameworkFinder
         return $this->cachedPath[$testFrameworkName];
     }
 
+    public function getVendorDirProcess(): Process
+    {
+        return new Process([
+            ...$this->findComposer(),
+            'config',
+            'vendor-dir',
+        ]);
+    }
+
     private function shouldUseCustomPath(string $testFrameworkName, string $customPath): bool
     {
         if ($customPath === '') {
@@ -107,28 +116,11 @@ class TestFrameworkFinder
 
     private function addVendorBinToPath(): void
     {
-        $vendorPath = null;
+        $composerBinDir = $this->getComposerBinDir();
 
-        try {
-            $process = new Process([
-                ...$this->findComposer(),
-                'config',
-                'bin-dir',
-            ]);
-
-            $process->mustRun();
-            $vendorPath = trim($process->getOutput());
-        } catch (RuntimeException) {
-            $candidate = getcwd() . '/vendor/bin';
-
-            if (file_exists($candidate)) {
-                $vendorPath = $candidate;
-            }
-        }
-
-        if ($vendorPath !== null) {
+        if ($composerBinDir !== null) {
             $pathName = getenv('PATH') !== false ? 'PATH' : 'Path';
-            putenv($pathName . '=' . $vendorPath . PATH_SEPARATOR . getenv($pathName));
+            putenv($pathName . '=' . $composerBinDir . PATH_SEPARATOR . getenv($pathName));
         }
     }
 
@@ -205,5 +197,29 @@ class TestFrameworkFinder
         }
 
         return $path;
+    }
+
+    private function getComposerBinDir(): ?string
+    {
+        try {
+            $process = $this->getVendorDirProcess();
+
+            $process->mustRun();
+            $binDir = trim($process->getOutput());
+
+            if ($binDir !== '') {
+                return $binDir;
+            }
+        } catch (RuntimeException) {
+            // Continue
+        }
+
+        $candidate = getcwd() . '/vendor/bin';
+
+        if (file_exists($candidate)) {
+            return $candidate;
+        }
+
+        return null;
     }
 }

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -46,6 +46,7 @@ use Infection\TestFramework\TestFrameworkTypes;
 use Infection\Tests\EnvVariableManipulation\BacksUpEnvironmentVariables;
 use Infection\Tests\FileSystem\FileSystemTestCase;
 use const PATH_SEPARATOR;
+use const PHP_BINARY;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -184,6 +185,30 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $actual = Path::canonicalize(
             $frameworkFinder->find(TestFrameworkTypes::PHPUNIT),
         );
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function test_it_falls_back_to_vendor_bin_when_composer_bin_dir_output_is_empty(): void
+    {
+        chdir($this->tmp);
+
+        $vendorBinDir = $this->tmp . '/vendor/bin';
+        $this->fileSystem->mkdir($vendorBinDir);
+
+        $expected = Path::canonicalize($this->createPhpUnitExecutableFixture($vendorBinDir));
+
+        putenv(sprintf('%s=%s', self::$pathName, $this->tmp));
+        putenv('PATHEXT=');
+
+        $composerFinder = $this->createStub(ComposerExecutableFinder::class);
+        $composerFinder
+            ->method('find')
+            ->willReturn([PHP_BINARY, '-r', '']);
+
+        $frameworkFinder = new TestFrameworkFinder($composerFinder);
+
+        $actual = Path::canonicalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT));
 
         $this->assertSame($expected, $actual);
     }


### PR DESCRIPTION
## Description

As of now, if `composer config bin-dir` returns an empty output, the fallback that we have (`$PWD/vendor/bin`) did not kick in. I think it is a mistake.

From #3315, it was identified that if the composer executable was incorrect (`php /app/composer`), but `/app/composer` was a directory, not the Composer executable.

A surprising behaviour is that PHP does not bail out:

```
# src is an existing directory, not an executable!
php src config bin-dir
# exists 0, no output
```

The conclusion is that **executing `php <composer> config bin-dir` fails if `<composer>` points to a directory**. That in itself is a bug too that should be addressed, but will be done separately.

## Changes

TODO: Extract the introduction of utility methods to make the diff less noisy.

## Related issues

- https://github.com/infection/infection/issues/3315