### PR TITLE
test: Exclude create-main.php from PHPStan

### DIFF
--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -290,6 +290,7 @@ parameters:
         - ../tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/Fixtures/*
         # Current PHPStan version doesn't support `array<int, callable<mixed>>` syntax (callable)
         - %currentWorkingDirectory%/tests/phpunit/WithConsecutive.php
+        - %currentWorkingDirectory%/tests/benchmark/MutationGenerator/create-main.php
         - ../tests/benchmark/MutationGenerator/sources (?)
         - ../tests/benchmark/Tracing/coverage (?)
         - ../tests/benchmark/Tracing/sources (?)


### PR DESCRIPTION
Currently PHPStan complains about `tests/benchmark/MutationGenerator/create-main.php` relying on `sources/autoload.php` but the latter does not exist.

Indeed, the mutation generator benchmark fixtures may not be materialized hence the issue is legitimate. However, silencing it would also cause an issue when those fixtures are materialized.

Consequently, this PR proposes to exclude this file from the inspection. It is preferable than materializing the fixtures all the time IMO.
