### PR TITLE
refactor(process): Leverage the ShellCommandLineExecutor

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -981,181 +981,181 @@ count = 1
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:306:49}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:307:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:315:37}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:317:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:328:45}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:330:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:331:50}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:333:50}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:334:51}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:336:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:342:41}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:344:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:359:39}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:361:39}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:374:42}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:376:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:378:37}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:380:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:387:42}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:389:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:390:46}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:392:46}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:409:76}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:411:76}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:418:58}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:420:58}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:429:67}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:431:67}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:441:55}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:443:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:453:51}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:455:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:466:44}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:468:44}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:471:43}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:473:43}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:487:32}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:489:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:522:55}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:524:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:533:44}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:535:44}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:541:49}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:543:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:558:53}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:560:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:577:41}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:579:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:587:45}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:589:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:610:41}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:612:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:628:17}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:630:17}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:640:32}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:642:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:644:53}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:646:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:756:13}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:758:13}`.'
 count = 1
 
 [[issues]]
@@ -1179,181 +1179,181 @@ count = 1
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:306:49}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:307:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:315:37}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:317:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:328:45}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:330:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:331:50}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:333:50}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:334:51}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:336:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:342:41}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:344:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:359:39}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:361:39}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:374:42}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:376:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:378:37}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:380:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:387:42}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:389:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:390:46}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:392:46}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:409:76}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:411:76}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:418:58}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:420:58}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:429:67}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:431:67}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:441:55}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:443:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:453:51}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:455:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:466:44}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:468:44}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:471:43}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:473:43}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:487:32}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:489:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:522:55}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:524:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:533:44}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:535:44}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:541:49}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:543:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:558:53}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:560:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:577:41}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:579:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:587:45}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:589:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:610:41}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:612:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:628:17}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:630:17}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:640:32}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:642:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:644:53}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:646:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:756:13}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:758:13}`.'
 count = 1
 
 [[issues]]
@@ -1609,6 +1609,12 @@ message = 'Potentially unhandled exception `Infection\FileSystem\Finder\Exceptio
 count = 1
 
 [[issues]]
+file = "src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder::addVendorBinToPath`.'
+count = 1
+
+[[issues]]
 file = "src/FileSystem/Finder/TestFrameworkFinder.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #3 of `Safe\preg_match`: expected `array<array-key, string>|null`, but found `mixed`.'
@@ -1648,6 +1654,12 @@ count = 1
 file = "src/FileSystem/Finder/TestFrameworkFinder.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\FileSystem\Finder\Exception\FinderException` in `Infection\FileSystem\Finder\TestFrameworkFinder::shouldUseCustomPath`.'
+count = 1
+
+[[issues]]
+file = "src/FileSystem/Finder/TestFrameworkFinder.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\FileSystem\Finder\TestFrameworkFinder::addVendorBinToPath`.'
 count = 1
 
 [[issues]]
@@ -3055,9 +3067,21 @@ message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrD
 count = 1
 
 [[issues]]
+file = "src/StaticAnalysis/Mago/Adapter/MagoAdapter.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\StaticAnalysis\Mago\Adapter\MagoAdapter::retrieveVersion`.'
+count = 1
+
+[[issues]]
 file = "src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::assertMinimumVersionSatisfied`.'
+count = 1
+
+[[issues]]
+file = "src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::retrieveVersion`.'
 count = 1
 
 [[issues]]
@@ -3069,19 +3093,7 @@ count = 1
 [[issues]]
 file = "src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::retrieveVersion`.'
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::retrieveVersion`.'
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter::retrieveVersion`.'
 count = 1
 
 [[issues]]
@@ -3123,25 +3135,19 @@ count = 1
 [[issues]]
 file = "src/TestFramework/AbstractTestFrameworkAdapter.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\TestFramework\AbstractTestFrameworkAdapter::retrieveVersion`.'
+count = 1
+
+[[issues]]
+file = "src/TestFramework/AbstractTestFrameworkAdapter.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\TestFramework\AbstractTestFrameworkAdapter::retrieveVersion`.'
 count = 1
 
 [[issues]]
 file = "src/TestFramework/AbstractTestFrameworkAdapter.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\TestFramework\AbstractTestFrameworkAdapter::retrieveVersion`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/AbstractTestFrameworkAdapter.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\TestFramework\AbstractTestFrameworkAdapter::retrieveVersion`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/AbstractTestFrameworkAdapter.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\TestFramework\AbstractTestFrameworkAdapter::retrieveVersion`.'
 count = 1
 
 [[issues]]
@@ -3453,7 +3459,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
 code = "falsable-return-statement"
-message = "Function `{closure:src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php:104:21}` is declared to return `string` but possibly returns 'false' (inferred as `false|string`)."
+message = "Function `{closure:src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php:107:21}` is declared to return `string` but possibly returns 'false' (inferred as `false|string`)."
 count = 1
 
 [[issues]]
@@ -3465,7 +3471,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
 code = "invalid-return-statement"
-message = "Invalid return type for function `{closure:src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php:104:21}`: expected `string`, but found `false|string`."
+message = "Invalid return type for function `{closure:src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php:107:21}`: expected `string`, but found `false|string`."
 count = 1
 
 [[issues]]
@@ -7276,7 +7282,7 @@ count = 2
 file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
 code = "possibly-false-argument"
 message = "Argument #2 of function `explode` is possibly `false`, but parameter type `string` does not accept it."
-count = 1
+count = 2
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
@@ -7306,7 +7312,7 @@ count = 2
 file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
 code = "possibly-false-argument"
 message = "Argument #2 of function `explode` is possibly `false`, but parameter type `string` does not accept it."
-count = 1
+count = 2
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
@@ -11617,7 +11623,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_retrieves_version_with_the_shell_command_line_executor`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_returns_version`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_retrieves_version_with_the_shell_command_line_executor`.'
 count = 1
 
 [[issues]]
@@ -11629,7 +11647,19 @@ count = 1
 [[issues]]
 file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_retrieves_version_with_the_shell_command_line_executor`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_returns_version`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_retrieves_version_with_the_shell_command_line_executor`.'
 count = 1
 
 [[issues]]
@@ -12806,6 +12836,12 @@ count = 1
 file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `syntaxErrorOutputProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\AbstractTestFramework\InvalidVersion` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapter\PhpUnitAdapterTest::test_it_retrieves_version`.'
 count = 1
 
 [[issues]]

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -957,7 +957,7 @@ parameters:
 		-
 			rawMessage: 'Parameter #2 $string of function explode expects string, string|false given.'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: ../tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php
 
 		-
@@ -981,7 +981,7 @@ parameters:
 		-
 			rawMessage: 'Parameter #2 $string of function explode expects string, string|false given.'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: ../tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
 
 		-

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -139,7 +139,8 @@ final class ConfigureCommand extends BaseCommand
             $this->abort();
         }
 
-        $fileSystem = $this->getApplication()->getContainer()->getFileSystem();
+        $container = $this->getApplication()->getContainer();
+        $fileSystem = $container->getFileSystem();
 
         $excludeDirsProvider = new ExcludeDirsProvider(
             $consoleHelper,
@@ -157,8 +158,8 @@ final class ConfigureCommand extends BaseCommand
         );
 
         $phpUnitExecutableFinder = new TestFrameworkFinder(
-            $this->getApplication()->getContainer()->getComposerExecutableFinder(),
-            $this->getApplication()->getContainer()->getShellCommandLineExecutor(),
+            $container->getComposerExecutableFinder(),
+            $container->getShellCommandLineExecutor(),
         );
         $phpUnitCustomExecutablePathProvider = new PhpUnitCustomExecutablePathProvider($phpUnitExecutableFinder, $consoleHelper, $questionHelper);
         $phpUnitCustomExecutablePath = $phpUnitCustomExecutablePathProvider->get($io);

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -156,7 +156,10 @@ final class ConfigureCommand extends BaseCommand
             $io->getInput()->getOption(self::OPTION_TEST_FRAMEWORK),
         );
 
-        $phpUnitExecutableFinder = new TestFrameworkFinder($this->getApplication()->getContainer()->getComposerExecutableFinder());
+        $phpUnitExecutableFinder = new TestFrameworkFinder(
+            $this->getApplication()->getContainer()->getComposerExecutableFinder(),
+            $this->getApplication()->getContainer()->getShellCommandLineExecutor(),
+        );
         $phpUnitCustomExecutablePathProvider = new PhpUnitCustomExecutablePathProvider($phpUnitExecutableFinder, $consoleHelper, $questionHelper);
         $phpUnitCustomExecutablePath = $phpUnitCustomExecutablePathProvider->get($io);
 

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -301,6 +301,7 @@ final class Container extends DIContainer
                     $config,
                     $container->getSourceCollector(),
                     GeneratedExtensionsConfig::EXTENSIONS,
+                    $container->getShellCommandLineExecutor(),
                 );
             },
             StaticAnalysisToolFactory::class => static function (self $container): StaticAnalysisToolFactory {
@@ -310,6 +311,7 @@ final class Container extends DIContainer
                     $config,
                     $container->getStaticAnalysisToolExecutableFinder(),
                     $container->getStaticAnalysisConfigLocator(),
+                    $container->getShellCommandLineExecutor(),
                 );
             },
             MutantFactory::class => static fn (self $container): MutantFactory => new MutantFactory(

--- a/src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php
+++ b/src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php
@@ -40,6 +40,7 @@ use function dirname;
 use function file_exists;
 use function getenv;
 use Infection\FileSystem\Finder\Exception\FinderException;
+use Infection\Process\ShellCommandLineExecutor;
 use function ltrim;
 use const PATH_SEPARATOR;
 use function rtrim;
@@ -51,7 +52,6 @@ use function Safe\putenv;
 use function Safe\realpath;
 use function substr;
 use Symfony\Component\Process\ExecutableFinder;
-use Symfony\Component\Process\Process;
 use function trim;
 use Webmozart\Assert\Assert;
 
@@ -70,6 +70,7 @@ class StaticAnalysisToolExecutableFinder
 
     public function __construct(
         private readonly ComposerExecutableFinder $executableFinder,
+        private readonly ShellCommandLineExecutor $shellCommandLineExecutor,
     ) {
     }
 
@@ -110,14 +111,11 @@ class StaticAnalysisToolExecutableFinder
         $vendorPath = null;
 
         try {
-            $process = new Process([
+            $vendorPath = $this->shellCommandLineExecutor->execute([
                 ...$this->findComposer(),
                 'config',
                 'bin-dir',
             ]);
-
-            $process->mustRun();
-            $vendorPath = trim($process->getOutput());
         } catch (RuntimeException) {
             $candidate = getcwd() . '/vendor/bin';
 

--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -40,6 +40,7 @@ use function dirname;
 use function file_exists;
 use function getenv;
 use Infection\FileSystem\Finder\Exception\FinderException;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\TestFramework\TestFrameworkTypes;
 use function ltrim;
 use const PATH_SEPARATOR;
@@ -52,7 +53,6 @@ use function Safe\putenv;
 use function Safe\realpath;
 use function substr;
 use Symfony\Component\Process\ExecutableFinder;
-use Symfony\Component\Process\Process;
 use function trim;
 use Webmozart\Assert\Assert;
 
@@ -70,6 +70,7 @@ class TestFrameworkFinder
 
     public function __construct(
         private readonly ComposerExecutableFinder $executableFinder,
+        private readonly ShellCommandLineExecutor $shellCommandLineExecutor,
     ) {
     }
 
@@ -110,14 +111,11 @@ class TestFrameworkFinder
         $vendorPath = null;
 
         try {
-            $process = new Process([
+            $vendorPath = $this->shellCommandLineExecutor->execute([
                 ...$this->findComposer(),
                 'config',
                 'bin-dir',
             ]);
-
-            $process->mustRun();
-            $vendorPath = trim($process->getOutput());
         } catch (RuntimeException) {
             $candidate = getcwd() . '/vendor/bin';
 

--- a/src/StaticAnalysis/Mago/Adapter/MagoAdapter.php
+++ b/src/StaticAnalysis/Mago/Adapter/MagoAdapter.php
@@ -38,6 +38,7 @@ namespace Infection\StaticAnalysis\Mago\Adapter;
 use function array_merge;
 use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Process\Factory\LazyMutantProcessFactory;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\StaticAnalysis\Mago\Process\MagoMutantProcessFactory;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\TestFramework\CommandLineBuilder;
@@ -48,7 +49,6 @@ use function sprintf;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
-use Symfony\Component\Process\Process;
 use function version_compare;
 
 /**
@@ -67,7 +67,8 @@ final class MagoAdapter implements StaticAnalysisToolAdapter
         private readonly VersionParser $versionParser,
         private readonly float $timeout,
         private readonly array $staticAnalysisToolOptions,
-        private ?string $version = null,
+        private ?string $version,
+        private readonly ShellCommandLineExecutor $shellCommandLineExecutor,
     ) {
     }
 
@@ -140,9 +141,8 @@ final class MagoAdapter implements StaticAnalysisToolAdapter
             ['--version'],
         );
 
-        $process = new Process($testFrameworkVersionExecutable);
-        $process->mustRun();
-
-        return $this->versionParser->parse($process->getOutput());
+        return $this->versionParser->parse(
+            $this->shellCommandLineExecutor->execute($testFrameworkVersionExecutable),
+        );
     }
 }

--- a/src/StaticAnalysis/Mago/Adapter/MagoAdapter.php
+++ b/src/StaticAnalysis/Mago/Adapter/MagoAdapter.php
@@ -67,8 +67,8 @@ final class MagoAdapter implements StaticAnalysisToolAdapter
         private readonly VersionParser $versionParser,
         private readonly float $timeout,
         private readonly array $staticAnalysisToolOptions,
-        private ?string $version,
         private readonly ShellCommandLineExecutor $shellCommandLineExecutor,
+        private ?string $version = null,
     ) {
     }
 

--- a/src/StaticAnalysis/Mago/Adapter/MagoAdapterFactory.php
+++ b/src/StaticAnalysis/Mago/Adapter/MagoAdapterFactory.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\StaticAnalysis\Mago\Adapter;
 
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapterFactory;
@@ -56,6 +57,7 @@ final class MagoAdapterFactory implements StaticAnalysisToolAdapterFactory
         float $timeout,
         string $tmpDir,
         array $staticAnalysisToolOptions,
+        ShellCommandLineExecutor $shellCommandLineExecutor,
     ): StaticAnalysisToolAdapter {
         return new MagoAdapter(
             new MagoMutantExecutionResultFactory(),
@@ -67,6 +69,8 @@ final class MagoAdapterFactory implements StaticAnalysisToolAdapterFactory
             new VersionParser(),
             $timeout,
             $staticAnalysisToolOptions,
+            null,
+            $shellCommandLineExecutor,
         );
     }
 }

--- a/src/StaticAnalysis/Mago/Adapter/MagoAdapterFactory.php
+++ b/src/StaticAnalysis/Mago/Adapter/MagoAdapterFactory.php
@@ -70,7 +70,6 @@ final class MagoAdapterFactory implements StaticAnalysisToolAdapterFactory
             $timeout,
             $staticAnalysisToolOptions,
             $shellCommandLineExecutor,
-            null,
         );
     }
 }

--- a/src/StaticAnalysis/Mago/Adapter/MagoAdapterFactory.php
+++ b/src/StaticAnalysis/Mago/Adapter/MagoAdapterFactory.php
@@ -69,8 +69,8 @@ final class MagoAdapterFactory implements StaticAnalysisToolAdapterFactory
             new VersionParser(),
             $timeout,
             $staticAnalysisToolOptions,
-            null,
             $shellCommandLineExecutor,
+            null,
         );
     }
 }

--- a/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
+++ b/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
@@ -39,6 +39,7 @@ use function array_merge;
 use function explode;
 use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Process\Factory\LazyMutantProcessFactory;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\TestFramework\CommandLineBuilder;
@@ -47,7 +48,6 @@ use RuntimeException;
 use function sprintf;
 use function str_starts_with;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Process\Process;
 use function version_compare;
 
 /**
@@ -72,7 +72,8 @@ final class PHPStanAdapter implements StaticAnalysisToolAdapter
         private readonly float $timeout,
         private readonly string $tmpDir,
         private readonly array $staticAnalysisToolOptions,
-        private ?string $version = null,
+        private ?string $version,
+        private readonly ShellCommandLineExecutor $shellCommandLineExecutor,
     ) {
     }
 
@@ -170,9 +171,8 @@ final class PHPStanAdapter implements StaticAnalysisToolAdapter
             ['--version'],
         );
 
-        $process = new Process($testFrameworkVersionExecutable);
-        $process->mustRun();
-
-        return $this->versionParser->parse($process->getOutput());
+        return $this->versionParser->parse(
+            $this->shellCommandLineExecutor->execute($testFrameworkVersionExecutable),
+        );
     }
 }

--- a/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
+++ b/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapter.php
@@ -72,8 +72,8 @@ final class PHPStanAdapter implements StaticAnalysisToolAdapter
         private readonly float $timeout,
         private readonly string $tmpDir,
         private readonly array $staticAnalysisToolOptions,
-        private ?string $version,
         private readonly ShellCommandLineExecutor $shellCommandLineExecutor,
+        private ?string $version = null,
     ) {
     }
 

--- a/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterFactory.php
+++ b/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterFactory.php
@@ -72,7 +72,6 @@ final class PHPStanAdapterFactory implements StaticAnalysisToolAdapterFactory
             $timeout,
             $tmpDir,
             $staticAnalysisToolOptions,
-            null,
             $shellCommandLineExecutor,
         );
     }

--- a/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterFactory.php
+++ b/src/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterFactory.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\StaticAnalysis\PHPStan\Adapter;
 
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapterFactory;
@@ -57,6 +58,7 @@ final class PHPStanAdapterFactory implements StaticAnalysisToolAdapterFactory
         float $timeout,
         string $tmpDir,
         array $staticAnalysisToolOptions,
+        ShellCommandLineExecutor $shellCommandLineExecutor,
     ): StaticAnalysisToolAdapter {
         return new PHPStanAdapter(
             new Filesystem(),
@@ -70,6 +72,8 @@ final class PHPStanAdapterFactory implements StaticAnalysisToolAdapterFactory
             $timeout,
             $tmpDir,
             $staticAnalysisToolOptions,
+            null,
+            $shellCommandLineExecutor,
         );
     }
 }

--- a/src/StaticAnalysis/StaticAnalysisToolAdapterFactory.php
+++ b/src/StaticAnalysis/StaticAnalysisToolAdapterFactory.php
@@ -35,6 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\StaticAnalysis;
 
+use Infection\Process\ShellCommandLineExecutor;
+
 /**
  * @internal
  */
@@ -49,5 +51,6 @@ interface StaticAnalysisToolAdapterFactory
         float $timeout,
         string $tmpDir,
         array $staticAnalysisToolOptions,
+        ShellCommandLineExecutor $shellCommandLineExecutor,
     ): StaticAnalysisToolAdapter;
 }

--- a/src/StaticAnalysis/StaticAnalysisToolFactory.php
+++ b/src/StaticAnalysis/StaticAnalysisToolFactory.php
@@ -38,6 +38,7 @@ namespace Infection\StaticAnalysis;
 use function implode;
 use Infection\Configuration\Configuration;
 use Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\StaticAnalysis\Mago\Adapter\MagoAdapterFactory;
 use Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterFactory;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
@@ -53,6 +54,7 @@ final readonly class StaticAnalysisToolFactory
         private Configuration $infectionConfig,
         private StaticAnalysisToolExecutableFinder $staticAnalysisToolExecutableFiner,
         private TestFrameworkConfigLocatorInterface $staticAnalysisConfigLocator,
+        private ShellCommandLineExecutor $shellCommandLineExecutor,
     ) {
     }
 
@@ -70,6 +72,7 @@ final readonly class StaticAnalysisToolFactory
                 $timeout,
                 $this->infectionConfig->tmpDir,
                 $this->infectionConfig->getStaticAnalysisToolOptions(),
+                $this->shellCommandLineExecutor,
             );
         }
 
@@ -85,6 +88,7 @@ final readonly class StaticAnalysisToolFactory
                 $timeout,
                 $this->infectionConfig->tmpDir,
                 $this->infectionConfig->getStaticAnalysisToolOptions(),
+                $this->shellCommandLineExecutor,
             );
         }
 

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -37,10 +37,10 @@ namespace Infection\TestFramework;
 
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\TestFramework\Config\InitialConfigBuilder;
 use Infection\TestFramework\Config\MutationConfigBuilder;
 use function sprintf;
-use Symfony\Component\Process\Process;
 
 /**
  * @internal
@@ -54,7 +54,8 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         private readonly CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder,
         private readonly VersionParser $versionParser,
         private readonly CommandLineBuilder $commandLineBuilder,
-        private ?string $version = null,
+        private ?string $version,
+        private readonly ShellCommandLineExecutor $shellCommandLineExecutor,
     ) {
     }
 
@@ -170,9 +171,8 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
             ['--version'],
         );
 
-        $process = new Process($testFrameworkVersionExecutable);
-        $process->mustRun();
-
-        return $this->versionParser->parse($process->getOutput());
+        return $this->versionParser->parse(
+            $this->shellCommandLineExecutor->execute($testFrameworkVersionExecutable),
+        );
     }
 }

--- a/src/TestFramework/AbstractTestFrameworkAdapter.php
+++ b/src/TestFramework/AbstractTestFrameworkAdapter.php
@@ -52,10 +52,10 @@ abstract class AbstractTestFrameworkAdapter implements TestFrameworkAdapter
         private readonly InitialConfigBuilder $initialConfigBuilder,
         private readonly MutationConfigBuilder $mutationConfigBuilder,
         private readonly CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder,
+        private readonly ShellCommandLineExecutor $shellCommandLineExecutor,
         private readonly VersionParser $versionParser,
         private readonly CommandLineBuilder $commandLineBuilder,
-        private ?string $version,
-        private readonly ShellCommandLineExecutor $shellCommandLineExecutor,
+        private ?string $version = null,
     ) {
     }
 

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -40,6 +40,7 @@ use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
 use Infection\Configuration\Configuration;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\Source\Collector\SourceCollector;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory;
@@ -66,6 +67,7 @@ final readonly class Factory
         private Configuration $infectionConfig,
         private SourceCollector $sourceCollector,
         private array $installedExtensions,
+        private ShellCommandLineExecutor $shellCommandLineExecutor,
     ) {
     }
 
@@ -89,6 +91,7 @@ final readonly class Factory
                 $this->infectionConfig->executeOnlyCoveringTestCases,
                 $this->getFilteredSourceFilesToMutate(),
                 $this->infectionConfig->mapSourceClassToTestStrategy,
+                $this->shellCommandLineExecutor,
             );
         }
 

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -69,12 +69,21 @@ final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements Memor
         InitialConfigBuilder $initialConfigBuilder,
         MutationConfigBuilder $mutationConfigBuilder,
         CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder,
+        ShellCommandLineExecutor $shellCommandLineExecutor,
         VersionParser $versionParser,
         CommandLineBuilder $commandLineBuilder,
-        ?string $version,
-        ShellCommandLineExecutor $shellCommandLineExecutor,
+        ?string $version = null,
     ) {
-        parent::__construct($testFrameworkExecutable, $initialConfigBuilder, $mutationConfigBuilder, $argumentsAndOptionsBuilder, $versionParser, $commandLineBuilder, $version, $shellCommandLineExecutor);
+        parent::__construct(
+            $testFrameworkExecutable,
+            $initialConfigBuilder,
+            $mutationConfigBuilder,
+            $argumentsAndOptionsBuilder,
+            $shellCommandLineExecutor,
+            $versionParser,
+            $commandLineBuilder,
+            $version,
+        );
     }
 
     public function hasJUnitReport(): bool

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -40,6 +40,7 @@ use function implode;
 use Infection\AbstractTestFramework\MemoryUsageAware;
 use Infection\AbstractTestFramework\SyntaxErrorAware;
 use Infection\Config\ValueProvider\PCOVDirectoryProvider;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\TestFramework\AbstractTestFrameworkAdapter;
 use Infection\TestFramework\CommandLineArgumentsAndOptionsBuilder;
 use Infection\TestFramework\CommandLineBuilder;
@@ -70,9 +71,10 @@ final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements Memor
         CommandLineArgumentsAndOptionsBuilder $argumentsAndOptionsBuilder,
         VersionParser $versionParser,
         CommandLineBuilder $commandLineBuilder,
-        ?string $version = null,
+        ?string $version,
+        ShellCommandLineExecutor $shellCommandLineExecutor,
     ) {
-        parent::__construct($testFrameworkExecutable, $initialConfigBuilder, $mutationConfigBuilder, $argumentsAndOptionsBuilder, $versionParser, $commandLineBuilder, $version);
+        parent::__construct($testFrameworkExecutable, $initialConfigBuilder, $mutationConfigBuilder, $argumentsAndOptionsBuilder, $versionParser, $commandLineBuilder, $version, $shellCommandLineExecutor);
     }
 
     public function hasJUnitReport(): bool

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -121,12 +121,11 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
                 $filteredSourceFilesToMutate,
                 $mapSourceClassToTestStrategy,
             ),
+            $shellCommandLineExecutor,
             new VersionParser(),
             new CommandLineBuilder(
                 new PhpExecutableFinder(),
             ),
-            null,
-            $shellCommandLineExecutor,
         );
     }
 

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -39,6 +39,7 @@ use function array_map;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
 use Infection\Config\ValueProvider\PCOVDirectoryProvider;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\PhpUnit\CommandLine\ArgumentsAndOptionsBuilder;
 use Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder;
@@ -75,8 +76,10 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
         bool $executeOnlyCoveringTestCases = false,
         array $filteredSourceFilesToMutate = [],
         ?string $mapSourceClassToTestStrategy = null,
+        ?ShellCommandLineExecutor $shellCommandLineExecutor = null,
     ): TestFrameworkAdapter {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the adapter');
+        Assert::notNull($shellCommandLineExecutor);
 
         $testFrameworkConfigContent = file_get_contents($testFrameworkConfigPath);
 
@@ -122,6 +125,8 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
             new CommandLineBuilder(
                 new PhpExecutableFinder(),
             ),
+            null,
+            $shellCommandLineExecutor,
         );
     }
 

--- a/tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php
@@ -50,6 +50,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\Stub;
+use RuntimeException;
 use function Safe\chdir;
 use function Safe\putenv;
 use function Safe\realpath;
@@ -164,6 +165,47 @@ final class StaticAnalysisToolExecutableFinderTest extends FileSystemTestCase
             strlen($path),
             strlen($pathAfterTest),
             'PATH with vendor added is shorter than without it added, make sure it isn\'t overwritten.',
+        );
+    }
+
+    public function test_it_falls_back_to_local_vendor_bin_when_composer_command_fails(): void
+    {
+        chdir($this->tmp);
+
+        $mock = new MockVendor($this->tmp, $this->fileSystem);
+        $mock->setUpPlatformTest();
+
+        putenv(sprintf('%s=%s', self::$pathName, $this->tmp));
+        putenv('PATHEXT=');
+
+        $shellCommandLineExecutor = $this->createMock(ShellCommandLineExecutor::class);
+        $shellCommandLineExecutor
+            ->expects($this->once())
+            ->method('execute')
+            ->with(['/usr/bin/composer', 'config', 'bin-dir'])
+            ->willThrowException(new RuntimeException())
+        ;
+
+        $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder, $shellCommandLineExecutor);
+
+        if (OperatingSystem::isWindows()) {
+            // This .bat has no code, so main script will not be found
+            $expected = $mock->getVendorBinBat();
+        } else {
+            $expected = $mock->getVendorBinLink();
+        }
+
+        $this->assertSame(
+            Path::canonicalize($expected),
+            Path::canonicalize($frameworkFinder->find($mock::PACKAGE)),
+        );
+
+        $pathAfterTest = getenv(self::$pathName);
+        $pathList = explode(PATH_SEPARATOR, $pathAfterTest);
+
+        $this->assertSame(
+            Path::canonicalize($this->tmp . '/vendor/bin'),
+            Path::canonicalize($pathList[0]),
         );
     }
 

--- a/tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php
@@ -41,6 +41,7 @@ use Infection\FileSystem\Finder\ComposerExecutableFinder;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder;
 use Infection\Framework\OperatingSystem;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\TestFramework\TestFrameworkTypes;
 use Infection\Tests\EnvVariableManipulation\BacksUpEnvironmentVariables;
 use Infection\Tests\FileSystem\FileSystemTestCase;
@@ -73,6 +74,8 @@ final class StaticAnalysisToolExecutableFinderTest extends FileSystemTestCase
 
     private ComposerExecutableFinder&Stub $composerFinder;
 
+    private ShellCommandLineExecutor $shellCommandLineExecutor;
+
     /**
      * Saves the current environment
      */
@@ -96,6 +99,8 @@ final class StaticAnalysisToolExecutableFinderTest extends FileSystemTestCase
         $this->composerFinder = $this->createStub(ComposerExecutableFinder::class);
         $this->composerFinder->method('find')
             ->willReturn(['/usr/bin/composer']);
+
+        $this->shellCommandLineExecutor = new ShellCommandLineExecutor();
     }
 
     protected function tearDown(): void
@@ -109,7 +114,7 @@ final class StaticAnalysisToolExecutableFinderTest extends FileSystemTestCase
     {
         $filename = $this->fileSystem->tempnam($this->tmp, 'test');
 
-        $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder);
+        $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder, $this->shellCommandLineExecutor);
 
         $this->assertSame($filename, $frameworkFinder->find('not-used', $filename), 'Should return the custom path');
     }
@@ -120,7 +125,7 @@ final class StaticAnalysisToolExecutableFinderTest extends FileSystemTestCase
         // Remove it so that the file doesn't exist
         $this->fileSystem->remove($filename);
 
-        $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder);
+        $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder, $this->shellCommandLineExecutor);
 
         $this->expectException(FinderException::class);
         $this->expectExceptionMessage('custom path');
@@ -132,7 +137,7 @@ final class StaticAnalysisToolExecutableFinderTest extends FileSystemTestCase
     {
         $path = getenv(self::$pathName);
 
-        $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder);
+        $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder, $this->shellCommandLineExecutor);
 
         if (OperatingSystem::isWindows()) {
             // The main script must be found from the .bat file
@@ -171,7 +176,7 @@ final class StaticAnalysisToolExecutableFinderTest extends FileSystemTestCase
         putenv(sprintf('%s=%s', self::$pathName, $mock->getVendorBinDir()));
         putenv('PATHEXT=');
 
-        $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder);
+        $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder, $this->shellCommandLineExecutor);
 
         if (OperatingSystem::isWindows()) {
             // This .bat has no code, so main script will not be found
@@ -197,7 +202,7 @@ final class StaticAnalysisToolExecutableFinderTest extends FileSystemTestCase
         putenv(sprintf('%s=%s', self::$pathName, $mock->getVendorBinDir()));
         putenv('PATHEXT=');
 
-        $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder);
+        $frameworkFinder = new StaticAnalysisToolExecutableFinder($this->composerFinder, $this->shellCommandLineExecutor);
 
         $this->assertSame(
             Path::canonicalize($mock->getPackageScript()),

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -42,6 +42,7 @@ use Infection\FileSystem\Finder\ConcreteComposerExecutableFinder;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\Framework\OperatingSystem;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\TestFramework\TestFrameworkTypes;
 use Infection\Tests\EnvVariableManipulation\BacksUpEnvironmentVariables;
 use Infection\Tests\FileSystem\FileSystemTestCase;
@@ -76,6 +77,8 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
 
     private ComposerExecutableFinder&Stub $composerFinder;
 
+    private ShellCommandLineExecutor $shellCommandLineExecutor;
+
     /**
      * Saves the current environment
      */
@@ -99,6 +102,8 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $this->composerFinder = $this->createStub(ComposerExecutableFinder::class);
         $this->composerFinder->method('find')
             ->willReturn(['/usr/bin/composer']);
+
+        $this->shellCommandLineExecutor = new ShellCommandLineExecutor();
     }
 
     protected function tearDown(): void
@@ -112,7 +117,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
     {
         $filename = $this->fileSystem->tempnam($this->tmp, 'test');
 
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder);
+        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $this->shellCommandLineExecutor);
 
         $this->assertSame($filename, $frameworkFinder->find('not-used', $filename), 'Should return the custom path');
     }
@@ -123,7 +128,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         // Remove it so that the file doesn't exist
         $this->fileSystem->remove($filename);
 
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder);
+        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $this->shellCommandLineExecutor);
 
         $this->expectException(FinderException::class);
         $this->expectExceptionMessage('custom path');
@@ -135,7 +140,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
     {
         $path = getenv(self::$pathName);
 
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder);
+        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $this->shellCommandLineExecutor);
 
         if (OperatingSystem::isWindows()) {
             // The main script must be found from the .bat file
@@ -178,6 +183,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
 
         $frameworkFinder = new TestFrameworkFinder(
             new ConcreteComposerExecutableFinder(),
+            $this->shellCommandLineExecutor,
         );
 
         $expected = Path::canonicalize($phpUnitPath);
@@ -197,7 +203,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         putenv(sprintf('%s=%s', self::$pathName, $mock->getVendorBinDir()));
         putenv('PATHEXT=');
 
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder);
+        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $this->shellCommandLineExecutor);
 
         if (OperatingSystem::isWindows()) {
             // This .bat has no code, so main script will not be found
@@ -223,7 +229,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         putenv(sprintf('%s=%s', self::$pathName, $mock->getVendorBinDir()));
         putenv('PATHEXT=');
 
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder);
+        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $this->shellCommandLineExecutor);
 
         $this->assertSame(
             Path::canonicalize($mock->getPackageScript()),

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -51,6 +51,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\Stub;
+use RuntimeException;
 use function Safe\chdir;
 use function Safe\chmod;
 use function Safe\mkdir;
@@ -167,6 +168,49 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
             strlen($path),
             strlen($pathAfterTest),
             'PATH with vendor added is shorter than without it added, make sure it isn\'t overwritten.',
+        );
+    }
+
+    public function test_it_falls_back_to_local_vendor_bin_when_composer_command_fails(): void
+    {
+        chdir($this->tmp);
+
+        $mock = new MockVendor($this->tmp, $this->fileSystem);
+        $mock->setUpPlatformTest();
+
+        putenv(sprintf('%s=%s', self::$pathName, $this->tmp));
+        putenv('PATHEXT=');
+
+        $shellCommandLineExecutor = $this->createMock(ShellCommandLineExecutor::class);
+        $shellCommandLineExecutor
+            ->expects($this->once())
+            ->method('execute')
+            ->with(['/usr/bin/composer', 'config', 'bin-dir'])
+            ->willThrowException(new RuntimeException());
+
+        $frameworkFinder = new TestFrameworkFinder(
+            $this->composerFinder,
+            $shellCommandLineExecutor,
+        );
+
+        if (OperatingSystem::isWindows()) {
+            // This .bat has no code, so main script will not be found
+            $expected = $mock->getVendorBinBat();
+        } else {
+            $expected = $mock->getVendorBinLink();
+        }
+
+        $this->assertSame(
+            Path::canonicalize($expected),
+            Path::canonicalize($frameworkFinder->find($mock::PACKAGE)),
+        );
+
+        $pathAfterTest = getenv(self::$pathName);
+        $pathList = explode(PATH_SEPARATOR, $pathAfterTest);
+
+        $this->assertSame(
+            Path::canonicalize($this->tmp . '/vendor/bin'),
+            Path::canonicalize($pathList[0]),
         );
     }
 

--- a/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterFactoryTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\StaticAnalysis\Mago\Adapter;
 
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\StaticAnalysis\Mago\Adapter\MagoAdapterFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -50,6 +51,7 @@ final class MagoAdapterFactoryTest extends TestCase
             32.3,
             '/tmp',
             [],
+            new ShellCommandLineExecutor(),
         );
 
         $this->assertSame('Mago', $adapter->getName());

--- a/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\StaticAnalysis\Mago\Adapter;
 
 use Infection\Mutant\MutantExecutionResultFactory;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\StaticAnalysis\Mago\Adapter\MagoAdapter;
 use Infection\StaticAnalysis\Mago\Process\MagoMutantProcessFactory;
 use Infection\TestFramework\CommandLineBuilder;
@@ -56,9 +57,12 @@ final class MagoAdapterTest extends TestCase
 
     private CommandLineBuilder&MockObject $commandLineBuilder;
 
+    private ShellCommandLineExecutor $shellCommandLineExecutor;
+
     protected function setUp(): void
     {
         $this->commandLineBuilder = $this->createMock(CommandLineBuilder::class);
+        $this->shellCommandLineExecutor = $this->createStub(ShellCommandLineExecutor::class);
 
         $this->adapter = new MagoAdapter(
             $this->createStub(MutantExecutionResultFactory::class),
@@ -69,6 +73,7 @@ final class MagoAdapterTest extends TestCase
             31.0,
             [],
             '9.0',
+            $this->shellCommandLineExecutor,
         );
     }
 
@@ -104,6 +109,7 @@ final class MagoAdapterTest extends TestCase
             31.0,
             ['--sort'],
             '9.0',
+            $this->shellCommandLineExecutor,
         );
 
         $this->commandLineBuilder
@@ -135,6 +141,7 @@ final class MagoAdapterTest extends TestCase
             31.0,
             ['--no-progress'],
             '9.0',
+            $this->shellCommandLineExecutor,
         );
 
         $this->commandLineBuilder
@@ -167,6 +174,7 @@ final class MagoAdapterTest extends TestCase
             31.0,
             ['--no-stubs', '--baseline /path/to/baseline.toml'],
             '9.0',
+            $this->shellCommandLineExecutor,
         );
 
         $this->commandLineBuilder
@@ -195,6 +203,39 @@ final class MagoAdapterTest extends TestCase
         $this->assertSame('9.0', $this->adapter->getVersion());
     }
 
+    public function test_it_retrieves_version_with_the_shell_command_line_executor(): void
+    {
+        $shellCommandLineExecutor = $this->createMock(ShellCommandLineExecutor::class);
+
+        $this->commandLineBuilder
+            ->expects($this->once())
+            ->method('build')
+            ->with('/path/to/mago', [], ['--version'])
+            ->willReturn(['/path/to/mago', '--version'])
+        ;
+
+        $shellCommandLineExecutor
+            ->expects($this->once())
+            ->method('execute')
+            ->with(['/path/to/mago', '--version'])
+            ->willReturn('mago 1.23.0')
+        ;
+
+        $adapter = new MagoAdapter(
+            $this->createStub(MutantExecutionResultFactory::class),
+            '/path/to/mago-config-path',
+            '/path/to/mago',
+            $this->commandLineBuilder,
+            new VersionParser(),
+            31.0,
+            [],
+            null,
+            $shellCommandLineExecutor,
+        );
+
+        $this->assertSame('1.23.0', $adapter->getVersion());
+    }
+
     public function test_it_creates_mutant_process_creator(): void
     {
         $this->assertInstanceOf(
@@ -217,6 +258,7 @@ final class MagoAdapterTest extends TestCase
             31.0,
             [],
             $version,
+            $this->shellCommandLineExecutor,
         );
 
         // This should not throw an exception
@@ -235,6 +277,7 @@ final class MagoAdapterTest extends TestCase
             31.0,
             [],
             $version,
+            $this->shellCommandLineExecutor,
         );
 
         $this->expectException(RuntimeException::class);

--- a/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php
@@ -72,8 +72,8 @@ final class MagoAdapterTest extends TestCase
             new VersionParser(),
             31.0,
             [],
-            '9.0',
             $this->shellCommandLineExecutor,
+            '9.0',
         );
     }
 
@@ -108,8 +108,8 @@ final class MagoAdapterTest extends TestCase
             new VersionParser(),
             31.0,
             ['--sort'],
-            '9.0',
             $this->shellCommandLineExecutor,
+            '9.0',
         );
 
         $this->commandLineBuilder
@@ -140,8 +140,8 @@ final class MagoAdapterTest extends TestCase
             new VersionParser(),
             31.0,
             ['--no-progress'],
-            '9.0',
             $this->shellCommandLineExecutor,
+            '9.0',
         );
 
         $this->commandLineBuilder
@@ -173,8 +173,8 @@ final class MagoAdapterTest extends TestCase
             new VersionParser(),
             31.0,
             ['--no-stubs', '--baseline /path/to/baseline.toml'],
-            '9.0',
             $this->shellCommandLineExecutor,
+            '9.0',
         );
 
         $this->commandLineBuilder
@@ -229,7 +229,6 @@ final class MagoAdapterTest extends TestCase
             new VersionParser(),
             31.0,
             [],
-            null,
             $shellCommandLineExecutor,
         );
 
@@ -257,8 +256,8 @@ final class MagoAdapterTest extends TestCase
             new VersionParser(),
             31.0,
             [],
-            $version,
             $this->shellCommandLineExecutor,
+            $version,
         );
 
         // This should not throw an exception
@@ -276,8 +275,8 @@ final class MagoAdapterTest extends TestCase
             new VersionParser(),
             31.0,
             [],
-            $version,
             $this->shellCommandLineExecutor,
+            $version,
         );
 
         $this->expectException(RuntimeException::class);

--- a/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterFactoryTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\StaticAnalysis\PHPStan\Adapter;
 
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapterFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
@@ -52,6 +53,7 @@ final class PHPStanAdapterFactoryTest extends TestCase
             32.3,
             '/tmp',
             [],
+            new ShellCommandLineExecutor(),
         );
 
         $this->assertSame('PHPStan', $adapter->getName());

--- a/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php
@@ -75,8 +75,8 @@ final class PHPStanAdapterTest extends TestCase
             31.0,
             '/tmp',
             [],
-            '9.0',
             $this->shellCommandLineExecutor,
+            '9.0',
         );
     }
 
@@ -113,8 +113,8 @@ final class PHPStanAdapterTest extends TestCase
             31.0,
             '/tmp',
             ['--memory-limit=1G'],
-            '9.0',
             $this->shellCommandLineExecutor,
+            '9.0',
         );
 
         $this->commandLineBuilder
@@ -147,8 +147,8 @@ final class PHPStanAdapterTest extends TestCase
             31.0,
             '/tmp',
             ['--memory-limit=-1', '--no-progress'],
-            '9.0',
             $this->shellCommandLineExecutor,
+            '9.0',
         );
 
         $this->commandLineBuilder
@@ -183,8 +183,8 @@ final class PHPStanAdapterTest extends TestCase
             31.0,
             '/tmp',
             ['--memory-limit=2G', '--level=max', '--no-progress'],
-            '9.0',
             $this->shellCommandLineExecutor,
+            '9.0',
         );
 
         $this->commandLineBuilder
@@ -242,7 +242,6 @@ final class PHPStanAdapterTest extends TestCase
             31.0,
             '/tmp',
             [],
-            null,
             $shellCommandLineExecutor,
         );
 
@@ -272,8 +271,8 @@ final class PHPStanAdapterTest extends TestCase
             31.0,
             '/tmp',
             ['--memory-limit=-1'],
-            $version,
             $this->shellCommandLineExecutor,
+            $version,
         );
 
         // This should not throw an exception
@@ -293,8 +292,8 @@ final class PHPStanAdapterTest extends TestCase
             31.0,
             '/tmp',
             [],
-            $version,
             $this->shellCommandLineExecutor,
+            $version,
         );
 
         $this->expectException(RuntimeException::class);

--- a/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\StaticAnalysis\PHPStan\Adapter;
 
 use Infection\Mutant\MutantExecutionResultFactory;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\StaticAnalysis\PHPStan\Adapter\PHPStanAdapter;
 use Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory;
 use Infection\TestFramework\CommandLineBuilder;
@@ -57,9 +58,12 @@ final class PHPStanAdapterTest extends TestCase
 
     private CommandLineBuilder&MockObject $commandLineBuilder;
 
+    private ShellCommandLineExecutor $shellCommandLineExecutor;
+
     protected function setUp(): void
     {
         $this->commandLineBuilder = $this->createMock(CommandLineBuilder::class);
+        $this->shellCommandLineExecutor = $this->createStub(ShellCommandLineExecutor::class);
 
         $this->adapter = new PHPStanAdapter(
             $this->createStub(Filesystem::class),
@@ -72,6 +76,7 @@ final class PHPStanAdapterTest extends TestCase
             '/tmp',
             [],
             '9.0',
+            $this->shellCommandLineExecutor,
         );
     }
 
@@ -109,6 +114,7 @@ final class PHPStanAdapterTest extends TestCase
             '/tmp',
             ['--memory-limit=1G'],
             '9.0',
+            $this->shellCommandLineExecutor,
         );
 
         $this->commandLineBuilder
@@ -142,6 +148,7 @@ final class PHPStanAdapterTest extends TestCase
             '/tmp',
             ['--memory-limit=-1', '--no-progress'],
             '9.0',
+            $this->shellCommandLineExecutor,
         );
 
         $this->commandLineBuilder
@@ -177,6 +184,7 @@ final class PHPStanAdapterTest extends TestCase
             '/tmp',
             ['--memory-limit=2G', '--level=max', '--no-progress'],
             '9.0',
+            $this->shellCommandLineExecutor,
         );
 
         $this->commandLineBuilder
@@ -206,6 +214,41 @@ final class PHPStanAdapterTest extends TestCase
         $this->assertSame('9.0', $this->adapter->getVersion());
     }
 
+    public function test_it_retrieves_version_with_the_shell_command_line_executor(): void
+    {
+        $shellCommandLineExecutor = $this->createMock(ShellCommandLineExecutor::class);
+
+        $this->commandLineBuilder
+            ->expects($this->once())
+            ->method('build')
+            ->with('/path/to/phpstan', [], ['--version'])
+            ->willReturn(['/usr/bin/php', '/path/to/phpstan', '--version'])
+        ;
+
+        $shellCommandLineExecutor
+            ->expects($this->once())
+            ->method('execute')
+            ->with(['/usr/bin/php', '/path/to/phpstan', '--version'])
+            ->willReturn('PHPStan 2.1.17')
+        ;
+
+        $adapter = new PHPStanAdapter(
+            $this->createStub(Filesystem::class),
+            $this->createStub(MutantExecutionResultFactory::class),
+            '/path/to/phpstan-config-path',
+            '/path/to/phpstan',
+            $this->commandLineBuilder,
+            new VersionParser(),
+            31.0,
+            '/tmp',
+            [],
+            null,
+            $shellCommandLineExecutor,
+        );
+
+        $this->assertSame('2.1.17', $adapter->getVersion());
+    }
+
     public function test_it_creates_mutant_process_creator(): void
     {
         $this->assertInstanceOf(
@@ -230,6 +273,7 @@ final class PHPStanAdapterTest extends TestCase
             '/tmp',
             ['--memory-limit=-1'],
             $version,
+            $this->shellCommandLineExecutor,
         );
 
         // This should not throw an exception
@@ -250,6 +294,7 @@ final class PHPStanAdapterTest extends TestCase
             '/tmp',
             [],
             $version,
+            $this->shellCommandLineExecutor,
         );
 
         $this->expectException(RuntimeException::class);

--- a/tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/StaticAnalysisToolFactoryTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\StaticAnalysis;
 
 use Infection\FileSystem\Finder\StaticAnalysisToolExecutableFinder;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\StaticAnalysis\StaticAnalysisToolFactory;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\Tests\Configuration\ConfigurationBuilder;
@@ -52,6 +53,7 @@ final class StaticAnalysisToolFactoryTest extends TestCase
             ConfigurationBuilder::withMinimalTestData()->build(),
             $this->createStub(StaticAnalysisToolExecutableFinder::class),
             $this->createStub(TestFrameworkConfigLocatorInterface::class),
+            $this->createStub(ShellCommandLineExecutor::class),
         );
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/phpunit/TestFramework/FactoryTest.php
+++ b/tests/phpunit/TestFramework/FactoryTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework;
 
 use Infection\FileSystem\Finder\TestFrameworkFinder;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\Source\Collector\FakeSourceCollector;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\Factory;
@@ -60,6 +61,7 @@ final class FactoryTest extends TestCase
             ConfigurationBuilder::withMinimalTestData()->build(),
             new FakeSourceCollector(),
             [],
+            $this->createStub(ShellCommandLineExecutor::class),
         );
 
         $this->expectException(InvalidArgumentException::class);
@@ -83,6 +85,7 @@ final class FactoryTest extends TestCase
                     'version' => '1.0.0',
                 ],
             ],
+            $this->createStub(ShellCommandLineExecutor::class),
         );
 
         $adapter = $factory->create('dummy', false);

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
@@ -117,6 +117,31 @@ final class PhpUnitAdapterTest extends TestCase
         $this->assertTrue($this->adapter->hasJUnitReport());
     }
 
+    public function test_it_retrieves_version(): void
+    {
+        $shellCommandLineExecutor = $this->createMock(ShellCommandLineExecutor::class);
+        $shellCommandLineExecutor
+            ->expects($this->once())
+            ->method('execute')
+            ->with([self::PHP_EXECUTABLE, '/path/to/phpunit', '--version'])
+            ->willReturn('PHPUnit 10.5.1 by Sebastian Bergmann and contributors.');
+
+        $expected = '10.5.1';
+
+        $adapter = $this->createAdapter(
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <phpunit/>
+                XML,
+            version: null,
+            shellCommandLineExecutor: $shellCommandLineExecutor,
+        );
+
+        $actual = $adapter->getVersion();
+
+        $this->assertSame($expected, $actual);
+    }
+
     #[DataProvider('passOutputProvider')]
     public function test_it_can_tell_if_tests_pass_from_the_output(
         string $output,
@@ -1593,10 +1618,11 @@ final class PhpUnitAdapterTest extends TestCase
      */
     private function createAdapter(
         string $testFrameworkConfigContent,
-        string $version = self::DEFAULT_PHPUNIT_VERSION,
+        ?string $version = self::DEFAULT_PHPUNIT_VERSION,
         array $filteredSourceFilesToMutate = [],
         bool $executeOnlyCoveringTestCases = false,
         ?string $mapSourceClassToTestStrategy = null,
+        ?ShellCommandLineExecutor $shellCommandLineExecutor = null,
     ): PhpUnitAdapter {
         $tmpDir = '/tmp';
         $projectDir = '/path/to/project';
@@ -1641,7 +1667,7 @@ final class PhpUnitAdapterTest extends TestCase
                 $filteredSourceFilesToMutate,
                 $mapSourceClassToTestStrategy,
             ),
-            $this->createStub(ShellCommandLineExecutor::class),
+            $shellCommandLineExecutor ?? $this->createStub(ShellCommandLineExecutor::class),
             new VersionParser(),    // won't be used since we pass the version
             new CommandLineBuilder($this->phpExecutableFinderMock),
             $version,

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
@@ -40,6 +40,7 @@ use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\Config\ValueProvider\PCOVDirectoryProvider;
 use Infection\FileSystem\FileSystem;
 use Infection\Framework\OperatingSystem;
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\TestFramework\CommandLineBuilder;
 use Infection\TestFramework\MapSourceClassToTestStrategy;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter;
@@ -1643,6 +1644,7 @@ final class PhpUnitAdapterTest extends TestCase
             new VersionParser(),    // won't be used since we pass the version
             new CommandLineBuilder($this->phpExecutableFinderMock),
             $version,
+            $this->createStub(ShellCommandLineExecutor::class),
         );
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
@@ -1641,10 +1641,10 @@ final class PhpUnitAdapterTest extends TestCase
                 $filteredSourceFilesToMutate,
                 $mapSourceClassToTestStrategy,
             ),
+            $this->createStub(ShellCommandLineExecutor::class),
             new VersionParser(),    // won't be used since we pass the version
             new CommandLineBuilder($this->phpExecutableFinderMock),
             $version,
-            $this->createStub(ShellCommandLineExecutor::class),
         );
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\PhpUnit\Adapter;
 
+use Infection\Process\ShellCommandLineExecutor;
 use Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
@@ -55,6 +56,7 @@ final class PhpUnitAdapterFactoryTest extends TestCase
             '/path/to/project',
             [],
             true,
+            shellCommandLineExecutor: new ShellCommandLineExecutor(),
         );
 
         $this->assertSame('PHPUnit', $adapter->getName());


### PR DESCRIPTION
## Description

This PR leverages `ShellCommandLineExecutor` instead of using inlined `Process` objects.

## Changes

- Inject `ShellCommandLineExecutor` wherever possible.
- Introduce tests that were previously not possible thanks to `ShellCommandLineExecutor`.

## Related issues

- https://github.com/infection/infection/issues/3322