### PR TITLE
refactor: Rename CachedSourceCollector to MemoizedSourceCollector

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -11537,6 +11537,12 @@ message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceF
 count = 1
 
 [[issues]]
+file = "tests/phpunit/Source/Collector/MemoizedSourceCollectorTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Collector\MemoizedSourceCollectorTest::test_it_memoizes_the_collected_files`.'
+count = 1
+
+[[issues]]
 file = "tests/phpunit/Source/Collector/SourceCollectorFactoryTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `sourceFilterProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -199,7 +199,7 @@ parameters:
 			path: ../src/FileSystem/Finder/NonExecutableFinder.php
 
 		-
-			rawMessage: 'Offset 1 might not exist on list{0?: string, 1?: non-empty-string}.'
+			rawMessage: 'Offset 1 might not exist on array{}|array{non-falsy-string, non-empty-string}.'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: ../src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php
@@ -211,7 +211,7 @@ parameters:
 			path: ../src/FileSystem/Finder/TestFrameworkFinder.php
 
 		-
-			rawMessage: 'Offset 1 might not exist on list{0?: string, 1?: non-empty-string}.'
+			rawMessage: 'Offset 1 might not exist on array{}|array{non-falsy-string, non-empty-string}.'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: ../src/FileSystem/Finder/TestFrameworkFinder.php
@@ -526,7 +526,7 @@ parameters:
 			path: ../src/Reporter/Html/StrykerHtmlReportBuilder.php
 
 		-
-			rawMessage: 'Offset ''name'' might not exist on array{0?: string, name?: non-falsy-string, 1?: non-falsy-string, dataname?: non-falsy-string, 2?: non-falsy-string}.'
+			rawMessage: 'Offset ''name'' might not exist on array{}|array{0: non-falsy-string, name: non-falsy-string, 1: non-falsy-string, dataname?: non-falsy-string, 2?: non-falsy-string}.'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: ../src/Reporter/Html/StrykerHtmlReportBuilder.php
@@ -634,7 +634,7 @@ parameters:
 			path: ../src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
 
 		-
-			rawMessage: 'Offset 1 might not exist on list{0?: string, 1?: non-falsy-string}.'
+			rawMessage: 'Offset 1 might not exist on array{}|array{non-falsy-string, non-falsy-string}.'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: ../src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -676,7 +676,7 @@ parameters:
 			path: ../src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php
 
 		-
-			rawMessage: 'Offset 1 might not exist on list{0?: string, 1?: non-falsy-string, 2?: ''/phpunit''}.'
+			rawMessage: 'Offset 1 might not exist on array{}|array{0: non-falsy-string, 1: non-falsy-string, 2?: ''/phpunit''}.'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: ../src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -143,8 +143,8 @@ use Infection\Resource\Memory\MemoryLimiter;
 use Infection\Resource\Memory\MemoryLimiterEnvironment;
 use Infection\Resource\Time\Stopwatch;
 use Infection\Resource\Time\TimeFormatter;
-use Infection\Source\Collector\CachedSourceCollector;
 use Infection\Source\Collector\LazySourceCollector;
+use Infection\Source\Collector\MemoizedSourceCollector;
 use Infection\Source\Collector\SourceCollector;
 use Infection\Source\Collector\SourceCollectorFactory;
 use Infection\Source\Exception\NoSourceFound;
@@ -628,7 +628,7 @@ final class Container extends DIContainer
                 static function () use ($container): SourceCollector {
                     $configuration = $container->getConfiguration();
 
-                    return new CachedSourceCollector(
+                    return new MemoizedSourceCollector(
                         $container->get(SourceCollectorFactory::class)->create(
                             $configuration->configurationPathname,
                             $configuration->source,

--- a/src/Source/Collector/MemoizedSourceCollector.php
+++ b/src/Source/Collector/MemoizedSourceCollector.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Source\Collector;
+
+use SplFileInfo;
+
+/**
+ * @internal
+ */
+final class MemoizedSourceCollector implements SourceCollector
+{
+    /**
+     * @var SplFileInfo[]
+     */
+    private ?array $sourceFiles = null;
+
+    public function __construct(
+        private readonly SourceCollector $decoratedCollector,
+    ) {
+    }
+
+    public function collect(): array
+    {
+        if ($this->sourceFiles === null) {
+            $this->sourceFiles = $this->decoratedCollector->collect();
+        }
+
+        return $this->sourceFiles;
+    }
+}

--- a/tests/phpunit/Source/Collector/MemoizedSourceCollectorTest.php
+++ b/tests/phpunit/Source/Collector/MemoizedSourceCollectorTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Source\Collector;
+
+use Infection\Source\Collector\MemoizedSourceCollector;
+use Infection\Source\Collector\SourceCollector;
+use Infection\Testing\FileSystem\MockSplFileInfo;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MemoizedSourceCollector::class)]
+final class MemoizedSourceCollectorTest extends TestCase
+{
+    private SourceCollector&MockObject $decoratedCollectorMock;
+
+    private MemoizedSourceCollector $collector;
+
+    protected function setUp(): void
+    {
+        $this->decoratedCollectorMock = $this->createMock(SourceCollector::class);
+
+        $this->collector = new MemoizedSourceCollector(
+            $this->decoratedCollectorMock,
+        );
+    }
+
+    public function test_it_memoizes_the_collected_files(): void
+    {
+        $expected = [
+            new MockSplFileInfo('src/File1.php'),
+            new MockSplFileInfo('src/File2.php'),
+        ];
+
+        $this->decoratedCollectorMock
+            ->expects($this->once())
+            ->method('collect')
+            ->willReturn($expected);
+
+        $actual1 = $this->collector->collect();
+        $actual2 = $this->collector->collect();
+
+        $this->assertSame($expected, $actual1);
+        $this->assertSame($actual1, $actual2);
+    }
+}


### PR DESCRIPTION
Rename `CachedSourceCollector` to `MemoizedSourceCollector` to follow the project conventions as described in #3328.