### PR TITLE
chore(sbx): Update the usages of docker sandbox

### DIFF
--- a/devTools/sbx/README.md
+++ b/devTools/sbx/README.md
@@ -70,7 +70,7 @@ To add user-specific sandbox customisation, edit:
 devTools/sbx/kits/project-local/spec.yaml
 ```
 
-You can use the `--branch` or `--name` option to further adjust your setup.
+You can use the `--clone` or `--name` option to further adjust your setup.
 
 [docker sandbox]: https://www.docker.com/products/docker-sandboxes/
 [docker-sandbox-templates-codex]: https://hub.docker.com/layers/docker/sandbox-templates/codex-docker/images

--- a/devTools/sbx/kits/codex-otel/spec.yaml
+++ b/devTools/sbx/kits/codex-otel/spec.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: infection-codex-otel
 displayName: Infection Codex OTEL

--- a/devTools/sbx/project-local-kit.yaml
+++ b/devTools/sbx/project-local-kit.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "1"
+schemaVersion: "2"
 kind: mixin
 name: infection-project-local
 displayName: Infection Project (local)


### PR DESCRIPTION
After some updates from docker sandbox a few changes are in order:

- kits schema 2 are available.
- `--branch` was removed in favour of `--clone`.
