### PR TITLE
refactor(autoreview): Move the exceptions of the PHPat public property rule as PHPStan false-positives

### DIFF
--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -269,6 +269,25 @@ parameters:
             path: ../tests/phpunit/Architecture/PHPat/Selector/Support/Analyser/DetectConcreteClassMeaningfulImplementationVisitor/Fixture
             message: '#.+#'
 
+        # Having public properties on those DTOs for performance reasons.
+        -
+            rawMessage: 'Infection\Process\Runner\IndexedMutantProcessContainer should not exist'
+            identifier: phpat.testSourceClassesDoNotExposePublicProperties
+            count: 1
+            path: ../src/Process/Runner/IndexedMutantProcessContainer.php
+
+        -
+            rawMessage: 'Infection\TestFramework\Coverage\JUnit\TestFileTimeData should not exist'
+            identifier: phpat.testSourceClassesDoNotExposePublicProperties
+            count: 1
+            path: ../src/TestFramework/Coverage/JUnit/TestFileTimeData.php
+
+        -
+            rawMessage: 'Infection\TestFramework\Tracing\Trace\NodeLineRangeData should not exist'
+            identifier: phpat.testSourceClassesDoNotExposePublicProperties
+            count: 1
+            path: ../src/TestFramework/Tracing/Trace/NodeLineRangeData.php
+
     level: 8
     paths:
         - ../src

--- a/tests/Architecture/PHPat/SourceClassesShouldNotExposePublicPropertiesTest.php
+++ b/tests/Architecture/PHPat/SourceClassesShouldNotExposePublicPropertiesTest.php
@@ -35,13 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat;
 
-use Infection\Process\Runner\IndexedMutantProcessContainer;
-use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
-use Infection\TestFramework\Tracing\Trace\NodeLineRangeData;
-use Infection\TestFramework\Tracing\Trace\SourceMethodLineRange;
-use Infection\TestFramework\Tracing\Trace\TestLocations;
 use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
-use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
 
@@ -51,14 +45,6 @@ final class SourceClassesShouldNotExposePublicPropertiesTest
     {
         return PHPat::rule()
             ->classes(InfectionSelector::sourceClassWithPublicNonReadonlyProperty())
-            ->excluding(
-                // Having public properties on DTO is for performance reasons.
-                Selector::classname(TestLocations::class),
-                Selector::classname(SourceMethodLineRange::class),
-                Selector::classname(NodeLineRangeData::class),
-                Selector::classname(TestFileTimeData::class),
-                Selector::classname(IndexedMutantProcessContainer::class),
-            )
             ->shouldNot()
             ->exist()
             ->because('Source classes should use getters instead of public properties.');


### PR DESCRIPTION
Follow up of https://github.com/infection/infection/pull/3330.

Instead of keeping those exceptions explicitly in the rule `phpat.testSourceClassesDoNotExposePublicProperties`, this PR removes them to add them as false-positive via the PHPStan configuration.

The effect is the same in that we do not get an error for those cases. However, if they ever come to be updated and they no longer need to be made into an exception (i.e. they no longer violate the rule), PHPStan will now be able to tell that it is the case.
