### PR TITLE
refactor(autoreview): Introduce a class reflection utility for PHPat

### DIFF
--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -321,6 +321,7 @@ parameters:
         - %currentWorkingDirectory%/tests/phpunit/Fixtures/*
         - %currentWorkingDirectory%/tests/phpunit/Architecture/PHPat/Selector/Support/Analyser/PublicPropertyAnalysisTest/Fixtures/*
         - %currentWorkingDirectory%/tests/phpunit/Architecture/PHPat/Selector/Support/EventArchitectureTest/Fixtures/*
+        - %currentWorkingDirectory%/tests/phpunit/Architecture/PHPat/Selector/Support/ClassReflectionPredicatesTest/Fixtures/*
         - %currentWorkingDirectory%/tests/phpunit/Architecture/PHPat/Selector/ClassWithNoArgumentPrivateConstructor/Fixtures/*
         - %currentWorkingDirectory%/tests/phpunit/Architecture/PHPat/Selector/StaticOrConstOnlyClass/Fixtures/*
         - ../tests/phpunit/Command/Debug/DumpAstCommand/Greeter.php

--- a/tests/Architecture/PHPat/Selector/HasInheritDoc.php
+++ b/tests/Architecture/PHPat/Selector/HasInheritDoc.php
@@ -35,9 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
+use Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicates;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
-use ReflectionMethod;
 use function Safe\preg_match;
 
 final readonly class HasInheritDoc implements SelectorInterface
@@ -58,7 +58,7 @@ final readonly class HasInheritDoc implements SelectorInterface
         }
 
         foreach ($nativeReflection->getMethods() as $methodReflection) {
-            if (self::isInheritedMethod($methodReflection, $classReflection)) {
+            if (ClassReflectionPredicates::isInheritedMethod($methodReflection, $classReflection)) {
                 continue;
             }
 
@@ -68,13 +68,6 @@ final readonly class HasInheritDoc implements SelectorInterface
         }
 
         return false;
-    }
-
-    private static function isInheritedMethod(
-        ReflectionMethod $methodReflection,
-        ClassReflection $classReflection,
-    ): bool {
-        return $methodReflection->getDeclaringClass()->getName() !== $classReflection->getName();
     }
 
     private static function containsInheritDoc(string|false $docComment): bool

--- a/tests/Architecture/PHPat/Selector/PHPUnitTestSupportConcreteClassWithoutCanonicalTest.php
+++ b/tests/Architecture/PHPat/Selector/PHPUnitTestSupportConcreteClassWithoutCanonicalTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Architecture\PHPat\Selector;
 
 use function in_array;
 use Infection\Framework\ClassName;
-use Infection\Tests\Architecture\PHPat\Selector\Support\ConcreteClassReflection;
+use Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicates;
 use Infection\Tests\FileSystem\Finder\MockVendor;
 use Infection\Tests\Framework\Iterable\GeneratorFactory\SimpleIteratorAggregate;
 use Infection\Tests\Mutator\MutatorFixturesProvider;
@@ -85,7 +85,7 @@ final class PHPUnitTestSupportConcreteClassWithoutCanonicalTest implements Selec
     public function matches(ClassReflection $classReflection): bool
     {
         if (
-            !ConcreteClassReflection::isConcreteClass($classReflection)
+            !ClassReflectionPredicates::isConcreteClass($classReflection)
             || InfectionSelector::isAnonymousClass()->matches($classReflection)
             || InfectionSelector::concretePHPUnitTestClass()->matches($classReflection)
             || self::isKnownPhpUnitDataProviderClass($classReflection)

--- a/tests/Architecture/PHPat/Selector/SingleEventSubscriberWithoutExpectedMethod.php
+++ b/tests/Architecture/PHPat/Selector/SingleEventSubscriberWithoutExpectedMethod.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Architecture\PHPat\Selector;
 use function array_filter;
 use function array_values;
 use function count;
+use Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicates;
 use Infection\Tests\Architecture\PHPat\Selector\Support\EventArchitecture;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
@@ -89,7 +90,7 @@ final readonly class SingleEventSubscriberWithoutExpectedMethod implements Selec
      */
     private function getDeclaredPublicMethods(ClassReflection $classReflection): array
     {
-        $isDeclaredByTheSubscriber = static fn (ReflectionMethod $method): bool => $method->getDeclaringClass()->getName() === $classReflection->getName();
+        $isDeclaredByTheSubscriber = static fn (ReflectionMethod $method): bool => !ClassReflectionPredicates::isInheritedMethod($method, $classReflection);
 
         return array_values(
             array_filter(

--- a/tests/Architecture/PHPat/Selector/SourceConcreteClassWithoutCanonicalTest.php
+++ b/tests/Architecture/PHPat/Selector/SourceConcreteClassWithoutCanonicalTest.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
 use Infection\Framework\ClassName;
-use Infection\Tests\Architecture\PHPat\Selector\Support\ConcreteClassReflection;
+use Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicates;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
 
@@ -49,7 +49,7 @@ final class SourceConcreteClassWithoutCanonicalTest implements SelectorInterface
 
     public function matches(ClassReflection $classReflection): bool
     {
-        if (!ConcreteClassReflection::isConcreteClass($classReflection)
+        if (!ClassReflectionPredicates::isConcreteClass($classReflection)
             || !InfectionSelector::sourceCode()->matches($classReflection)
             || InfectionSelector::hasTrivialImplementation()->matches($classReflection)
         ) {

--- a/tests/Architecture/PHPat/Selector/StaticOrConstOnlyClass.php
+++ b/tests/Architecture/PHPat/Selector/StaticOrConstOnlyClass.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat\Selector;
 
-use Infection\Tests\Architecture\PHPat\Selector\Support\ConcreteClassReflection;
+use Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicates;
 use PHPat\Selector\SelectorInterface;
 use PHPStan\Reflection\ClassReflection;
 use ReflectionClass;
@@ -51,7 +51,7 @@ final class StaticOrConstOnlyClass implements SelectorInterface
     public function matches(ClassReflection $classReflection): bool
     {
         if (
-            !ConcreteClassReflection::isConcreteClass($classReflection)
+            !ClassReflectionPredicates::isConcreteClass($classReflection)
             || $classReflection->isEnum()
         ) {
             return false;

--- a/tests/Architecture/PHPat/Selector/Support/Analyser/Analyser.php
+++ b/tests/Architecture/PHPat/Selector/Support/Analyser/Analyser.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Architecture\PHPat\Selector\Support\Analyser;
 use function array_filter;
 use Infection\FileSystem\FileSystem;
 use Infection\Framework\ClassName;
-use Infection\Tests\Architecture\PHPat\Selector\Support\ConcreteClassReflection;
+use Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicates;
 use Infection\Tests\Architecture\PHPat\Selector\Support\PHPUnitTestClassAnalysis;
 use PhpParser\ErrorHandler\Throwing;
 use PhpParser\Node;
@@ -77,7 +77,7 @@ final class Analyser
             return $this->analysisResultCache[$cacheKey];
         }
 
-        $isConcreteClass = ConcreteClassReflection::isConcreteClass($classReflection);
+        $isConcreteClass = ClassReflectionPredicates::isConcreteClass($classReflection);
 
         if (
             !$isConcreteClass
@@ -131,7 +131,7 @@ final class Analyser
         ClassReflection $classReflection,
         array $nodes,
     ): AnalysisResult {
-        $meaningfulImplementationVisitor = ConcreteClassReflection::isConcreteClass($classReflection)
+        $meaningfulImplementationVisitor = ClassReflectionPredicates::isConcreteClass($classReflection)
             ? new DetectConcreteClassMeaningfulImplementationVisitor(
                 ClassName::getShortClassName($classReflection->getName()),
             )

--- a/tests/Architecture/PHPat/Selector/Support/Analyser/PublicPropertyAnalysis.php
+++ b/tests/Architecture/PHPat/Selector/Support/Analyser/PublicPropertyAnalysis.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Tests\Architecture\PHPat\Selector\Support\Analyser;
 
 use Infection\CannotBeInstantiated;
+use Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicates;
 use PHPStan\Reflection\ClassReflection;
 use ReflectionProperty;
 
@@ -51,7 +52,7 @@ final class PublicPropertyAnalysis
 
         foreach ($publicProperties as $property) {
             if (
-                $property->getDeclaringClass()->getName() === $classReflection->getName()
+                !ClassReflectionPredicates::isInheritedProperty($property, $classReflection)
                 && !$property->isReadOnly()
             ) {
                 return true;

--- a/tests/Architecture/PHPat/Selector/Support/ClassReflectionPredicates.php
+++ b/tests/Architecture/PHPat/Selector/Support/ClassReflectionPredicates.php
@@ -37,8 +37,10 @@ namespace Infection\Tests\Architecture\PHPat\Selector\Support;
 
 use Infection\CannotBeInstantiated;
 use PHPStan\Reflection\ClassReflection;
+use ReflectionMethod;
+use ReflectionProperty;
 
-final class ConcreteClassReflection
+final class ClassReflectionPredicates
 {
     use CannotBeInstantiated;
 
@@ -47,5 +49,19 @@ final class ConcreteClassReflection
         return !$classReflection->isAbstract()
             && !$classReflection->isInterface()
             && !$classReflection->isTrait();
+    }
+
+    public static function isInheritedMethod(
+        ReflectionMethod $methodReflection,
+        ClassReflection $classReflection,
+    ): bool {
+        return $methodReflection->getDeclaringClass()->getName() !== $classReflection->getName();
+    }
+
+    public static function isInheritedProperty(
+        ReflectionProperty $propertyReflection,
+        ClassReflection $classReflection,
+    ): bool {
+        return $propertyReflection->getDeclaringClass()->getName() !== $classReflection->getName();
     }
 }

--- a/tests/Architecture/PHPat/Selector/Support/EventArchitecture.php
+++ b/tests/Architecture/PHPat/Selector/Support/EventArchitecture.php
@@ -74,7 +74,7 @@ final readonly class EventArchitecture
     public function isEvent(ClassReflection $classReflection): bool
     {
         return $this->isInEventDirectory($classReflection)
-            && ConcreteClassReflection::isConcreteClass($classReflection)
+            && ClassReflectionPredicates::isConcreteClass($classReflection)
             && !$this->isSubscriberName($classReflection->getName());
     }
 

--- a/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
+++ b/tests/Architecture/PHPat/Selector/Support/PHPUnitTestClassAnalysis.php
@@ -61,7 +61,7 @@ final class PHPUnitTestClassAnalysis
     public static function isPHPUnitTestCase(ClassReflection $classReflection): bool
     {
         return str_ends_with($classReflection->getName(), 'Test')
-            && ConcreteClassReflection::isConcreteClass($classReflection)
+            && ClassReflectionPredicates::isConcreteClass($classReflection)
             && $classReflection->isSubclassOf(TestCase::class);
     }
 

--- a/tests/phpunit/Architecture/PHPat/Selector/ClassReflectionPredicatesTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/ClassReflectionPredicatesTest.php
@@ -40,11 +40,15 @@ use Infection\Command\BaseCommand;
 use Infection\Engine;
 use Infection\Mutator\Mutator;
 use Infection\Tests\Architecture\PHPat\Selector\SelectorTestCase;
+use Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicatesTest\Fixtures\ChildWithInheritedMembers;
+use Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicatesTest\Fixtures\ParentWithDeclaredMembers;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionMethod;
+use ReflectionProperty;
 
-#[CoversClass(ConcreteClassReflection::class)]
-final class ConcreteClassReflectionTest extends SelectorTestCase
+#[CoversClass(ClassReflectionPredicates::class)]
+final class ClassReflectionPredicatesTest extends SelectorTestCase
 {
     /**
      * @param class-string $className
@@ -56,7 +60,7 @@ final class ConcreteClassReflectionTest extends SelectorTestCase
     ): void {
         $classReflection = $this->createClassReflection($className);
 
-        $actual = ConcreteClassReflection::isConcreteClass($classReflection);
+        $actual = ClassReflectionPredicates::isConcreteClass($classReflection);
 
         $this->assertSame($expected, $actual);
     }
@@ -82,5 +86,45 @@ final class ConcreteClassReflectionTest extends SelectorTestCase
             CannotBeInstantiated::class,
             false,
         ];
+    }
+
+    public function test_it_detects_inherited_methods(): void
+    {
+        $childClassReflection = $this->createClassReflection(ChildWithInheritedMembers::class);
+        $parentClassReflection = $this->createClassReflection(ParentWithDeclaredMembers::class);
+        $methodReflection = new ReflectionMethod(ChildWithInheritedMembers::class, 'execute');
+
+        $this->assertTrue(
+            ClassReflectionPredicates::isInheritedMethod(
+                $methodReflection,
+                $childClassReflection,
+            ),
+        );
+        $this->assertFalse(
+            ClassReflectionPredicates::isInheritedMethod(
+                $methodReflection,
+                $parentClassReflection,
+            ),
+        );
+    }
+
+    public function test_it_detects_inherited_properties(): void
+    {
+        $childClassReflection = $this->createClassReflection(ChildWithInheritedMembers::class);
+        $parentClassReflection = $this->createClassReflection(ParentWithDeclaredMembers::class);
+        $propertyReflection = new ReflectionProperty(ChildWithInheritedMembers::class, 'value');
+
+        $this->assertTrue(
+            ClassReflectionPredicates::isInheritedProperty(
+                $propertyReflection,
+                $childClassReflection,
+            ),
+        );
+        $this->assertFalse(
+            ClassReflectionPredicates::isInheritedProperty(
+                $propertyReflection,
+                $parentClassReflection,
+            ),
+        );
     }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestSupportConcreteClassWithoutCanonicalTestTest.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/PHPUnitTestSupportConcreteClassWithoutCanonicalTestTest.php
@@ -60,7 +60,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversClass(PHPUnitTestSupportConcreteClassWithoutCanonicalTest::class)]
 #[CoversClass(HasTrivialImplementation::class)]
 #[CoversClass(AnalysisResult::class)]
-#[CoversClass(Support\ConcreteClassReflection::class)]
+#[CoversClass(Support\ClassReflectionPredicates::class)]
 #[CoversClass(Analyser::class)]
 #[CoversClass(DetectConcreteClassMeaningfulImplementationVisitor::class)]
 final class PHPUnitTestSupportConcreteClassWithoutCanonicalTestTest extends SelectorTestCase

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/ClassReflectionPredicatesTest/Fixtures/ChildWithInheritedMembers.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/ClassReflectionPredicatesTest/Fixtures/ChildWithInheritedMembers.php
@@ -33,32 +33,8 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicatesTest\Fixtures;
 
-use Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicates;
-use PHPat\Selector\SelectorInterface;
-use PHPStan\Reflection\ClassReflection;
-
-final class ClassWithNoArgumentPrivateConstructor implements SelectorInterface
+final class ChildWithInheritedMembers extends ParentWithDeclaredMembers
 {
-    public function getName(): string
-    {
-        return 'class with a no-argument private constructor';
-    }
-
-    public function matches(ClassReflection $classReflection): bool
-    {
-        if (
-            !ClassReflectionPredicates::isConcreteClass($classReflection)
-            || $classReflection->isEnum()
-        ) {
-            return false;
-        }
-
-        $constructor = $classReflection->getNativeReflection()->getConstructor();
-
-        return $constructor !== null
-            && $constructor->isPrivate()
-            && $constructor->getNumberOfParameters() === 0;
-    }
 }

--- a/tests/phpunit/Architecture/PHPat/Selector/Support/ClassReflectionPredicatesTest/Fixtures/ParentWithDeclaredMembers.php
+++ b/tests/phpunit/Architecture/PHPat/Selector/Support/ClassReflectionPredicatesTest/Fixtures/ParentWithDeclaredMembers.php
@@ -33,32 +33,13 @@
 
 declare(strict_types=1);
 
-namespace Infection\Tests\Architecture\PHPat\Selector;
+namespace Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicatesTest\Fixtures;
 
-use Infection\Tests\Architecture\PHPat\Selector\Support\ClassReflectionPredicates;
-use PHPat\Selector\SelectorInterface;
-use PHPStan\Reflection\ClassReflection;
-
-final class ClassWithNoArgumentPrivateConstructor implements SelectorInterface
+abstract class ParentWithDeclaredMembers
 {
-    public function getName(): string
+    public string $value = '';
+
+    public function execute(): void
     {
-        return 'class with a no-argument private constructor';
-    }
-
-    public function matches(ClassReflection $classReflection): bool
-    {
-        if (
-            !ClassReflectionPredicates::isConcreteClass($classReflection)
-            || $classReflection->isEnum()
-        ) {
-            return false;
-        }
-
-        $constructor = $classReflection->getNativeReflection()->getConstructor();
-
-        return $constructor !== null
-            && $constructor->isPrivate()
-            && $constructor->getNumberOfParameters() === 0;
     }
 }


### PR DESCRIPTION
## Description

Generalises the PHPat selector support utility from the concrete-class-specific `ConcreteClassReflection` to `ClassReflectionPredicates`. The renamed utility now centralises predicates for concrete classes and inherited methods and properties, removing repeated reflection ownership checks from individual selectors and analyses.

This was prompted by https://github.com/infection/infection/pull/3371/changes/BASE..9076c9da60423442e92efa8e883771ffcad313cf.

## Changes

- Renames `ConcreteClassReflection` to `ClassReflectionPredicates` and updates all consumers.
- Adds `isInheritedMethod()` and `isInheritedProperty()` predicates.
- Reuses the inherited-method predicate in `HasInheritDoc` and single-event subscriber method analysis.
- Reuses the inherited-property predicate in public property analysis.
- Adds canonical tests covering concrete, abstract, interface, and trait detection.
- Adds parent/child fixtures covering declared and inherited methods and properties.
- Excludes the dedicated fixtures from PHPStan analysis consistently with other PHPat selector fixtures.