### PR TITLE
Clarify finality requirement in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,16 +134,13 @@ why. These rules come from comparing agent designs with the real subsystems.
 
 ### Finality: `final` keyword vs `@final` docblock
 
-Agents often mark everything `final`. Here, hard `final` is for classes never mocked (mutators,
-visitors, value objects, leaf utilities); services that tests mock get `/** @internal
-@final */` with NO keyword (e.g. `src/Mutation/Mutation.php`,
-`src/Configuration/ConfigurationFactory.php`). The PHPat finality rule accepts either form;
-adding the keyword to a mocked class breaks the suite. A third form exists for special cases:
-`ParallelProcessRunner` is plain `@internal` with a dedicated PHPat exemption whose test name
-states the reason ("intentionally non-final only to allow PHPUnit partial mocks",
-`tests/Architecture/PHPat/ClassesShouldBeFinalTest.php`). Mockability is the only accepted
-reason for `@final`. If no test mocks the class, use the keyword. Reviewers ask "is there a
-reason this is `@final` rather than `final`?" Have the answer ("it is mocked in X").
+Agents often mark everything `final`. Here, hard `final` is only for classes never mocked
+(mutators, visitors, value objects, leaf utilities); services that tests mock get `/** @internal
+@final */` with NO keyword. The PHPat finality rule accepts either form; adding the keyword
+to a mocked class breaks the suite. Mockability is the only accepted reason for `@final`.
+If no test mocks the class, use the keyword. Do not expect `BypassFinals`. Do not add interfaces
+just to mock a single class. Reviewers ask "is there a reason this is `@final` rather
+than `final`?" Have the answer ("it is mocked in X").
 
 ### `@internal` everywhere; the public API is a whitelist
 

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -535,18 +535,6 @@ parameters:
 			path: ../src/Process/OriginalPhpProcess.php
 
 		-
-			rawMessage: Infection\Process\Runner\ParallelProcessRunner should be final
-			identifier: phpat.testInterfaceImplementationsAreFinal
-			count: 1
-			path: ../src/Process/Runner/ParallelProcessRunner.php
-
-		-
-			rawMessage: Infection\Process\Runner\ParallelProcessRunner should not exist
-			identifier: phpat.testSourceConcreteClassesAreFinals
-			count: 1
-			path: ../src/Process/Runner/ParallelProcessRunner.php
-
-		-
 			rawMessage: 'Method Infection\Reflection\AnonymousClassReflection::__construct() has parameter $reflectionClass with generic class ReflectionClass but does not specify its types: T'
 			identifier: missingType.generics
 			count: 1

--- a/src/Process/Runner/ParallelProcessRunner.php
+++ b/src/Process/Runner/ParallelProcessRunner.php
@@ -48,6 +48,7 @@ use Webmozart\Assert\Assert;
 
 /**
  * @internal
+ * @final
  *
  * This ProcessManager is an elaborate wrapper to enable parallel processing using Symfony Process component
  */

--- a/tests/Architecture/PHPat/ClassesShouldBeFinalTest.php
+++ b/tests/Architecture/PHPat/ClassesShouldBeFinalTest.php
@@ -86,6 +86,6 @@ final class ClassesShouldBeFinalTest
             ->classes(Selector::extends(ParallelProcessRunner::class))
             ->shouldNot()
             ->exist()
-            ->because('ParallelProcessRunner is intentionally non-final only to allow PHPUnit partial mocks.');
+            ->because('ParallelProcessRunner is intentionally soft-final only to allow PHPUnit partial mocks.');
     }
 }


### PR DESCRIPTION
## Description

Follow-up to #3381.

## Changes

- Makes `ParallelProcessRunner` soft-final like it should be.

## Checklist

- [x] Appropriate labels applied (e.g. `performance`, `feature`).

