### PR TITLE
ai: Add the ADR index list to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,19 @@ Do not suggest ADRs for implementation descriptions, subsystem invariants, contr
 workflows, command lists, or one-off details. Put those in architecture documentation,
 contributor documentation, or code comments as appropriate.
 
+Consult this generated index before reading the ADRs relevant to the task:
+
+<!-- adr-index:start -->
+- [ADR 0001: Inheritdoc usage](adr/0001-inheritdoc.md) — Accepted
+- [ADR 0002: `@covers` annotations usage](adr/0002-@covers-annotations.md) — Deprecated
+- [ADR 0003: Use `$this` instead of `self` for PHPUnit assertions](adr/0003-PHPUnit-this-over-self.md) — Accepted
+- [ADR 0004: Use PHPUnit `expectException*()` API over `try-catch`](adr/0004-PHPUnit-expect-exception-over-try-catch.md) — Accepted
+- [ADR 0005: Bumping PHP version requirements](adr/0005-Bump-PHP-versions.md) — Superseded by ADR 0008
+- [ADR 0006: Use `Memoized` over `Cached` for object-local result reuse](adr/0006-memoized-over-cached-nomenclature.md) — Accepted
+- [ADR 0007: Declare PHPUnit coverage metadata explicitly](adr/0007-declare-phpunit-coverage-metadata.md) — Accepted
+- [ADR 0008: PHP version support policy](adr/0008-PHP-version-support-policy.md) — Accepted
+<!-- adr-index:end -->
+
 ## Commands
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,16 @@ sbx-image-test:
 check_trailing_whitespaces:
 	./devTools/check_trailing_whitespaces.sh
 
+.PHONY: adr-index-update
+adr-index-update:	## Updates the ADR index in AGENTS.md
+adr-index-update: vendor
+	php devTools/update-adr-index.php
+
+.PHONY: adr-index-check
+adr-index-check:	## Checks that the ADR index in AGENTS.md is up to date
+adr-index-check: vendor
+	php devTools/update-adr-index.php --check
+
 .PHONY: cs
 cs:	  	 	## Runs PHP-CS-Fixer
 cs: $(PHP_CS_FIXER)
@@ -234,7 +244,7 @@ benchmark_tracing: vendor $(BENCHMARK_TRACING_SUBMODULE) $(BENCHMARK_TRACING_COV
 
 .PHONY: autoreview
 autoreview: 	 	## Runs various checks (static analysis & AutoReview test suite)
-autoreview: cs-check phpstan mago validate test-autoreview rector-check detect-collisions $(if $(CI),,zizmor)
+autoreview: adr-index-check cs-check phpstan mago validate test-autoreview rector-check detect-collisions $(if $(CI),,zizmor)
 
 .PHONY: test
 test:		 	## Runs all the tests

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -5155,6 +5155,90 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 3
 
 [[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexGenerator.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `UnexpectedValueException` in `Infection\Tests\AutoReview\AI\AdrIndexGenerator::generateEntry`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexGenerator.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `UnexpectedValueException` in `Infection\Tests\AutoReview\AI\AdrIndexGenerator::normalizeStatus`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexGenerator.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `UnexpectedValueException` in `Infection\Tests\AutoReview\AI\AdrIndexGenerator::replace`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexGeneratorTest.php"
+code = "imprecise-type"
+message = "Type `iterable` in return type of `invalidAdrProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexGeneratorTest.php"
+code = "imprecise-type"
+message = "Type `iterable` in return type of `invalidIndexProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexGeneratorTest.php"
+code = "imprecise-type"
+message = "Type `iterable` in return type of `statusProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexUpdater.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\AutoReview\AI\AdrIndexUpdater::findAdrs`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexUpdaterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\AutoReview\AI\AdrIndexUpdaterTest::test_it_accepts_an_up_to_date_index_in_check_mode`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexUpdaterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\AutoReview\AI\AdrIndexUpdaterTest::test_it_rejects_an_outdated_index_in_check_mode`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexUpdaterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\AutoReview\AI\AdrIndexUpdaterTest::test_it_updates_the_index`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexUpdaterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\AutoReview\AI\AdrIndexUpdaterTest::setUp`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexUpdaterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\AutoReview\AI\AdrIndexUpdaterTest::test_it_accepts_an_up_to_date_index_in_check_mode`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexUpdaterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\AutoReview\AI\AdrIndexUpdaterTest::test_it_rejects_an_outdated_index_in_check_mode`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/AutoReview/AI/AdrIndexUpdaterTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\AutoReview\AI\AdrIndexUpdaterTest::test_it_updates_the_index`.'
+count = 1
+
+[[issues]]
 file = "tests/phpunit/AutoReview/BuildConfigYmlTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `providesYamlFilesForTesting` is imprecise, equivalent to `iterable<mixed, mixed>`."

--- a/devTools/update-adr-index.php
+++ b/devTools/update-adr-index.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Infection\FileSystem\FileSystem;
+use Infection\Tests\AutoReview\AI\AdrIndexGenerator;
+use Infection\Tests\AutoReview\AI\AdrIndexUpdater;
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+$checkOnly = match ($argc) {
+    1 => false,
+    2 => '--check' === $argv[1],
+    default => null,
+};
+
+if (null === $checkOnly) {
+    fwrite(STDERR, "Usage: php devTools/update-adr-index.php [--check]\n");
+
+    exit(2);
+}
+
+$updater = new AdrIndexUpdater(
+    new FileSystem(),
+    new AdrIndexGenerator(),
+);
+
+$updater->update(__DIR__.'/..', $checkOnly);
+
+fwrite(STDOUT, "Done.\n");

--- a/tests/phpunit/AutoReview/AI/AdrIndexGenerator.php
+++ b/tests/phpunit/AutoReview/AI/AdrIndexGenerator.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\AutoReview\AI;
+
+use function basename;
+use function implode;
+use function ksort;
+use function preg_quote;
+use function Safe\preg_match;
+use function Safe\preg_replace;
+use function sprintf;
+use function str_starts_with;
+use function trim;
+use UnexpectedValueException;
+use Webmozart\Assert\Assert;
+
+/**
+ * Generates an index for the given ADRs.
+ */
+final class AdrIndexGenerator
+{
+    private const string START_MARKER = '<!-- adr-index:start -->';
+
+    private const string END_MARKER = '<!-- adr-index:end -->';
+
+    private const string TEMPLATE_ADR = '0000-template.md';
+
+    /**
+     * @param array<string, string> $adrs Indexed by filename
+     */
+    public function generate(string $contents, array $adrs): string
+    {
+        ksort($adrs);
+
+        $entries = [];
+
+        foreach ($adrs as $filename => $adrContents) {
+            if (basename($filename) === self::TEMPLATE_ADR) {
+                continue;
+            }
+
+            $entries[] = self::generateEntry($filename, $adrContents);
+        }
+
+        $index = self::START_MARKER . "\n" . implode("\n", $entries) . "\n" . self::END_MARKER;
+
+        return self::replace($contents, $index);
+    }
+
+    private static function replace(string $contents, string $index): string
+    {
+        $replacementCount = 0;
+        $updatedContents = preg_replace(
+            '/' . preg_quote(self::START_MARKER, '/') . '.*?' . preg_quote(self::END_MARKER, '/') . '/s',
+            $index,
+            $contents,
+            -1,
+            $replacementCount,
+        );
+
+        if ($replacementCount !== 1) {
+            throw new UnexpectedValueException('Expected exactly one ADR index in AGENTS.md.');
+        }
+        Assert::string($updatedContents);
+
+        return $updatedContents;
+    }
+
+    private static function generateEntry(string $filename, string $contents): string
+    {
+        $titleMatches = [];
+
+        if (preg_match('/^# (?<title>.+)$/m', $contents, $titleMatches) !== 1) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Could not find the title in %s.',
+                    $filename,
+                ),
+            );
+        }
+
+        Assert::isArray($titleMatches);
+        Assert::keyExists($titleMatches, 'title');
+        Assert::string($titleMatches['title']);
+
+        $statusMatches = [];
+
+        if (preg_match('/^#{2,3} Status\R+(?<status>[^\r\n]+)/m', $contents, $statusMatches) !== 1) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Could not find the status in %s.',
+                    $filename,
+                ),
+            );
+        }
+        Assert::isArray($statusMatches);
+        Assert::keyExists($statusMatches, 'status');
+        Assert::string($statusMatches['status']);
+
+        $numberMatches = [];
+
+        if (preg_match('/^(?<number>\d{4})-/', basename($filename), $numberMatches) !== 1) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Could not find the ADR number in %s.',
+                    $filename,
+                ),
+            );
+        }
+
+        Assert::isArray($numberMatches);
+        Assert::keyExists($numberMatches, 'number');
+        Assert::string($numberMatches['number']);
+
+        return sprintf(
+            '- [ADR %s: %s](adr/%s) — %s',
+            $numberMatches['number'],
+            $titleMatches['title'],
+            basename($filename),
+            self::normalizeStatus($filename, $statusMatches['status']),
+        );
+    }
+
+    private static function normalizeStatus(string $filename, string $status): string
+    {
+        $status = trim($status, ". \t\n\r\0\x0B");
+
+        foreach (['Accepted', 'Deprecated', 'Proposed', 'Rejected'] as $knownStatus) {
+            if (str_starts_with($status, $knownStatus)) {
+                return $knownStatus;
+            }
+        }
+
+        $matches = [];
+
+        if (
+            str_starts_with($status, 'Superseded')
+            && preg_match('/ADR (?<number>\d{4})/', $status, $matches) === 1
+        ) {
+            Assert::isArray($matches);
+            Assert::keyExists($matches, 'number');
+            Assert::string($matches['number']);
+
+            return sprintf(
+                'Superseded by ADR %s',
+                $matches['number'],
+            );
+        }
+
+        throw new UnexpectedValueException(
+            sprintf(
+                'Could not determine the status in %s.',
+                $filename,
+            ),
+        );
+    }
+}

--- a/tests/phpunit/AutoReview/AI/AdrIndexGeneratorTest.php
+++ b/tests/phpunit/AutoReview/AI/AdrIndexGeneratorTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\AutoReview\AI;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+#[CoversClass(AdrIndexGenerator::class)]
+final class AdrIndexGeneratorTest extends TestCase
+{
+    #[DataProvider('statusProvider')]
+    public function test_it_generates_an_index(string $status, string $expectedStatus): void
+    {
+        $generator = new AdrIndexGenerator();
+
+        $actual = $generator->generate(
+            "Before\n<!-- adr-index:start -->\nstale\n<!-- adr-index:end -->\nAfter",
+            [
+                '0002-second.md' => "# Second\n\n## Status\n\nAccepted.",
+                '0000-template.md' => "# Template\n\n## Status\n\nProposed.",
+                '0001-first.md' => "# First\n\n### Status\n\n{$status}",
+            ],
+        );
+
+        $this->assertSame(
+            <<<MARKDOWN
+                Before
+                <!-- adr-index:start -->
+                - [ADR 0001: First](adr/0001-first.md) — {$expectedStatus}
+                - [ADR 0002: Second](adr/0002-second.md) — Accepted
+                <!-- adr-index:end -->
+                After
+                MARKDOWN,
+            $actual,
+        );
+    }
+
+    public static function statusProvider(): iterable
+    {
+        yield 'proposed' => ['Proposed.', 'Proposed'];
+
+        yield 'accepted with metadata' => ['Accepted ([#123](example.com)).', 'Accepted'];
+
+        yield 'deprecated' => ['Deprecated.', 'Deprecated'];
+
+        yield 'rejected' => ['Rejected.', 'Rejected'];
+
+        yield 'superseded' => ['Superseded by [ADR 0042](0042-example.md).', 'Superseded by ADR 0042'];
+    }
+
+    #[DataProvider('invalidAdrProvider')]
+    public function test_it_rejects_an_invalid_adr(string $filename, string $contents, string $expectedMessage): void
+    {
+        $generator = new AdrIndexGenerator();
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $generator->generate(
+            '<!-- adr-index:start --><!-- adr-index:end -->',
+            [$filename => $contents],
+        );
+    }
+
+    public static function invalidAdrProvider(): iterable
+    {
+        yield 'missing title' => [
+            '0001-example.md',
+            "## Status\n\nAccepted.",
+            'Could not find the title in 0001-example.md.',
+        ];
+
+        yield 'missing status' => [
+            '0001-example.md',
+            '# Example',
+            'Could not find the status in 0001-example.md.',
+        ];
+
+        yield 'invalid number' => [
+            'example.md',
+            "# Example\n\n## Status\n\nAccepted.",
+            'Could not find the ADR number in example.md.',
+        ];
+
+        yield 'unknown status' => [
+            '0001-example.md',
+            "# Example\n\n## Status\n\nUnknown.",
+            'Could not determine the status in 0001-example.md.',
+        ];
+
+        yield 'superseded without a replacement' => [
+            '0001-example.md',
+            "# Example\n\n## Status\n\nSuperseded.",
+            'Could not determine the status in 0001-example.md.',
+        ];
+    }
+
+    #[DataProvider('invalidIndexProvider')]
+    public function test_it_rejects_an_invalid_index(string $contents): void
+    {
+        $generator = new AdrIndexGenerator();
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Expected exactly one ADR index in AGENTS.md.');
+
+        $generator->generate($contents, []);
+    }
+
+    public static function invalidIndexProvider(): iterable
+    {
+        yield 'missing index' => ['No index'];
+
+        yield 'multiple indexes' => [
+            '<!-- adr-index:start --><!-- adr-index:end -->'
+            . '<!-- adr-index:start --><!-- adr-index:end -->',
+        ];
+    }
+}

--- a/tests/phpunit/AutoReview/AI/AdrIndexUpdater.php
+++ b/tests/phpunit/AutoReview/AI/AdrIndexUpdater.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\AutoReview\AI;
+
+use Infection\FileSystem\FileSystem;
+use RuntimeException;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Finder\Finder;
+
+final readonly class AdrIndexUpdater
+{
+    private const string ADR_NAME_PATTERN = '/^\d{4}-.+\.md$/';
+
+    public function __construct(
+        private FileSystem $fileSystem,
+        private AdrIndexGenerator $generator,
+    ) {
+    }
+
+    public function update(string $projectRoot, bool $checkOnly): void
+    {
+        $adrs = $this->findAdrs($projectRoot);
+
+        $agentsPath = $projectRoot . '/AGENTS.md';
+        $contents = $this->fileSystem->readFile($agentsPath);
+        $updatedContents = $this->generator->generate($contents, $adrs);
+
+        if ($updatedContents === $contents) {
+            return;
+        }
+
+        if ($checkOnly) {
+            throw new RuntimeException(
+                'The ADR index in AGENTS.md is outdated. Run `make adr-index-update`.',
+            );
+        }
+
+        $this->fileSystem->dumpFile($agentsPath, $updatedContents);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function findAdrs(string $projectRoot): array
+    {
+        $adrs = [];
+
+        $finder = $this->createAdrFinder($projectRoot);
+
+        foreach ($finder as $adr) {
+            $adrs[$adr->getFilename()] = $this->fileSystem->readFile($adr->getPathname());
+        }
+
+        return $adrs;
+    }
+
+    private function createAdrFinder(string $projectRoot): Finder
+    {
+        return $this->fileSystem
+            ->createFinder()
+            ->files()
+            ->in($projectRoot . '/adr')
+            ->depth('== 0')
+            ->name(self::ADR_NAME_PATTERN)
+            ->sortByName();
+    }
+}

--- a/tests/phpunit/AutoReview/AI/AdrIndexUpdaterTest.php
+++ b/tests/phpunit/AutoReview/AI/AdrIndexUpdaterTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\AutoReview\AI;
+
+use Infection\FileSystem\FileSystem;
+use Infection\Tests\FileSystem\FileSystemTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use RuntimeException;
+
+#[Group('integration')]
+#[CoversClass(AdrIndexUpdater::class)]
+final class AdrIndexUpdaterTest extends FileSystemTestCase
+{
+    private FileSystem $fileSystem;
+
+    private AdrIndexUpdater $updater;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fileSystem = new FileSystem();
+        $this->updater = new AdrIndexUpdater(
+            $this->fileSystem,
+            new AdrIndexGenerator(),
+        );
+
+        $this->fileSystem->mkdir($this->tmp . '/adr');
+        $this->fileSystem->dumpFile(
+            $this->tmp . '/adr/0001-example.md',
+            "# Example\n\n## Status\n\nAccepted.",
+        );
+        $this->fileSystem->dumpFile(
+            $this->tmp . '/AGENTS.md',
+            "Before\n<!-- adr-index:start -->\nstale\n<!-- adr-index:end -->\nAfter",
+        );
+    }
+
+    public function test_it_updates_the_index(): void
+    {
+        $this->updater->update($this->tmp, false);
+
+        $this->assertSame(
+            <<<MARKDOWN
+                Before
+                <!-- adr-index:start -->
+                - [ADR 0001: Example](adr/0001-example.md) — Accepted
+                <!-- adr-index:end -->
+                After
+                MARKDOWN,
+            $this->fileSystem->readFile($this->tmp . '/AGENTS.md'),
+        );
+    }
+
+    public function test_it_rejects_an_outdated_index_in_check_mode(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The ADR index in AGENTS.md is outdated. Run `make adr-index-update`.');
+
+        $this->updater->update($this->tmp, true);
+    }
+
+    public function test_it_accepts_an_up_to_date_index_in_check_mode(): void
+    {
+        $this->updater->update($this->tmp, false);
+        $expectedContents = $this->fileSystem->readFile($this->tmp . '/AGENTS.md');
+
+        $this->updater->update($this->tmp, true);
+
+        $this->assertSame(
+            $expectedContents,
+            $this->fileSystem->readFile($this->tmp . '/AGENTS.md'),
+        );
+    }
+}

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -265,6 +265,8 @@ final class MakefileTest extends BaseMakefileTestCase
             [33msbx-kit-validate:[0m	 Validates the sbx kit specs
             [33msbx-image-build:[0m	 Builds the PHP sbx image
             [33msbx-image-test:[0m	 Verifies the PHP sbx image contains the expected tooling
+            [33madr-index-update:[0m	 Updates the ADR index in AGENTS.md
+            [33madr-index-check:[0m	 Checks that the ADR index in AGENTS.md is up to date
             [33mcs:[0m	  	 	 Runs PHP-CS-Fixer
             [33mcs-docker:[0m		 Runs PHP-CS-Fixer in docker
             [33mcs-check:[0m		 Runs PHP-CS-Fixer in dry-run mode


### PR DESCRIPTION
## Description

Follow up of https://github.com/infection/infection/pull/3384/changes#r3613071151.

This PR introduces two new make commands `adr-index-{update,check}` which will ensure we have an up to date list of ADRs in `AGENTS.md`. 

`adr-index-check` has been added to `autoreview` so ensuring the list is up to date will also be done in the CI.

## Changes

Since there was a bit too many regexing to do for my liking, I added a PHP script `devTools/update-adr-index.php`. To allow minimal testing, I added the used classes to `tests/phpunit/AutoReview/AI/`. It is not the most perfect location but it allows to easily bootstrap utilities with tests without setting up an entire project just for a small script.

