### PR TITLE
refactor(git): Return changed file paths as an array

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -1767,19 +1767,13 @@ count = 1
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "invalid-return-statement"
-message = 'Invalid return type for function `Infection\Git\CommandLineGit::getChangedFileRelativePaths`: expected `non-empty-string`, but found `string`.'
-count = 1
-
-[[issues]]
-file = "src/Git/CommandLineGit.php"
-code = "invalid-return-statement"
 message = 'Invalid return type for function `Infection\Git\CommandLineGit::parseFilePathFromLine`: expected `string`, but found `null|string`.'
 count = 1
 
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `list<mixed>` is less specific than the declared return type `array<array-key, string>` for function `Infection\Git\CommandLineGit::diff` due to nested 'mixed'.'''
+message = '''Returned type `list<mixed>` is less specific than the declared return type `list<string>` for function `Infection\Git\CommandLineGit::diff` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -7707,7 +7701,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_gets_the_relative_paths_of_the_changed_files_as_a_string`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_gets_the_relative_paths_of_the_changed_files`.'
 count = 1
 
 [[issues]]

--- a/src/Command/Git/GitChangedFilesCommand.php
+++ b/src/Command/Git/GitChangedFilesCommand.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Command\Git;
 
-use function explode;
 use Infection\Command\BaseCommand;
 use Infection\Command\Git\Option\BaseOption;
 use Infection\Command\Git\Option\FilterOption;
@@ -102,13 +101,10 @@ final class GitChangedFilesCommand extends BaseCommand
             ),
         );
 
-        $files = explode(
-            ',',
-            $git->getChangedFileRelativePaths(
-                $sourceFilter->value,
-                $sourceFilter->base,
-                $container->getConfiguration()->source->directories,
-            ),
+        $files = $git->getChangedFileRelativePaths(
+            $sourceFilter->value,
+            $sourceFilter->base,
+            $container->getConfiguration()->source->directories,
         );
 
         $io->writeln($files);

--- a/src/Git/CommandLineGit.php
+++ b/src/Git/CommandLineGit.php
@@ -83,7 +83,7 @@ final readonly class CommandLineGit implements Git
         return $this->readSymbolicReference(self::DEFAULT_SYMBOLIC_REFERENCE) ?? Git::FALLBACK_BASE;
     }
 
-    public function getChangedFileRelativePaths(string $diffFilter, string $base, array $sourceDirectories): string
+    public function getChangedFileRelativePaths(string $diffFilter, string $base, array $sourceDirectories): array
     {
         $lines = $this->diff(
             $diffFilter,
@@ -96,7 +96,9 @@ final readonly class CommandLineGit implements Git
             throw NoSourceFound::noFilesForGitDiff($diffFilter, $base);
         }
 
-        return implode(',', $lines);
+        Assert::allStringNotEmpty($lines);
+
+        return $lines;
     }
 
     public function getChangedLinesRangesByFileRelativePaths(
@@ -261,7 +263,7 @@ final readonly class CommandLineGit implements Git
     /**
      * @param string[] $sourceDirectories
      *
-     * @return string[]
+     * @return list<string>
      */
     private function diff(
         string $diffFilter,

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -81,21 +81,19 @@ interface Git
      * Finds the list of relative paths (relative to the current working directory) of the changed files that changed
      * compared to the base branch used and matching the given filter.
      *
-     * Returns a comma-separated list of the relative paths.
-     *
      * @param non-empty-string $diffFilter E.g. 'AM'.
      * @param non-empty-string $base E.g. 'origin/main' or a commit hash.
      * @param non-empty-string[] $sourceDirectories
      *
      * @throws NoSourceFound
      *
-     * @return non-empty-string
+     * @return non-empty-list<non-empty-string>
      */
     public function getChangedFileRelativePaths(
         string $diffFilter,
         string $base,
         array $sourceDirectories,
-    ): string;
+    ): array;
 
     /**
      * Gets the modifications with their line numbers of the files that changed compared to the base branch used and

--- a/src/Source/Collector/GitDiffSourceCollector.php
+++ b/src/Source/Collector/GitDiffSourceCollector.php
@@ -86,8 +86,8 @@ final readonly class GitDiffSourceCollector implements SourceCollector
         Git $git,
         GitDiffFilter $sourceFilter,
         array $sourceDirectories,
-    ): ?PlainFilter {
-        return PlainFilter::tryToCreate(
+    ): PlainFilter {
+        return new PlainFilter(
             $git->getChangedFileRelativePaths(
                 $sourceFilter->value,
                 $sourceFilter->base,

--- a/tests/phpunit/Command/Git/GitChangedFilesCommandTest.php
+++ b/tests/phpunit/Command/Git/GitChangedFilesCommandTest.php
@@ -77,12 +77,13 @@ final class GitChangedFilesCommandTest extends TestCase
 
     /**
      * @param array<string, string> $arguments
+     * @param non-empty-list<non-empty-string> $files
      */
     #[DataProvider('commandExecutionProvider')]
     public function test_it_outputs_changed_files(
         array $arguments,
         string $defaultBase,
-        string $files,
+        array $files,
         string $expectedBase,
         string $expectedFilter,
         string $expectedStdout,
@@ -132,7 +133,7 @@ final class GitChangedFilesCommandTest extends TestCase
                 '--base' => 'origin/main',
             ],
             'defaultBase' => 'origin/default',
-            'files' => 'src/File1.php,src/File2.php',
+            'files' => ['src/File1.php', 'src/File2.php'],
             'expectedBase' => 'origin/main',
             'expectedFilter' => Git::DEFAULT_GIT_DIFF_FILTER,
             'expectedStdout' => <<<STDOUT
@@ -155,7 +156,7 @@ final class GitChangedFilesCommandTest extends TestCase
         yield 'default base and default filter' => [
             [],
             'defaultBase' => 'origin/default',
-            'files' => 'tests/File1Test.php',
+            'files' => ['tests/File1Test.php'],
             'expectedBase' => 'origin/default',
             'expectedFilter' => Git::DEFAULT_GIT_DIFF_FILTER,
             'expectedStdout' => <<<STDOUT
@@ -180,7 +181,7 @@ final class GitChangedFilesCommandTest extends TestCase
                 '--base' => '  feature/test  ',
             ],
             'defaultBase' => 'origin/default',
-            'files' => 'src/Test.php',
+            'files' => ['src/Test.php'],
             'expectedBase' => 'feature/test',
             'expectedFilter' => Git::DEFAULT_GIT_DIFF_FILTER,
             'expectedStdout' => <<<STDOUT
@@ -204,7 +205,7 @@ final class GitChangedFilesCommandTest extends TestCase
                 '--filter' => '  D  ',
             ],
             'defaultBase' => 'origin/default',
-            'files' => 'src/Deleted.php',
+            'files' => ['src/Deleted.php'],
             'expectedBase' => 'origin/main',
             'expectedFilter' => 'D',
             'expectedStdout' => <<<STDOUT
@@ -225,7 +226,7 @@ final class GitChangedFilesCommandTest extends TestCase
         yield 'single file' => [
             [],
             'defaultBase' => 'origin/main',
-            'files' => 'src/SingleFile.php',
+            'files' => ['src/SingleFile.php'],
             'expectedBase' => 'origin/main',
             'expectedFilter' => Git::DEFAULT_GIT_DIFF_FILTER,
             'expectedStdout' => <<<STDOUT

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryGit.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryGit.php
@@ -58,7 +58,7 @@ final readonly class ConfigurationFactoryGit implements Git
         string $diffFilter,
         string $base,
         array $sourceDirectories,
-    ): string {
+    ): array {
         throw new DomainException('Not implemented.');
     }
 

--- a/tests/phpunit/Git/CommandLineGitIntegrationTest.php
+++ b/tests/phpunit/Git/CommandLineGitIntegrationTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Git;
 
-use function explode;
 use function implode;
 use Infection\Framework\Str;
 use Infection\Git\CommandLineGit;
@@ -91,7 +90,7 @@ final class CommandLineGitIntegrationTest extends FileSystemTestCase
         );
     }
 
-    public function test_it_gets_the_relative_paths_of_the_changed_files_as_a_string(): void
+    public function test_it_gets_the_relative_paths_of_the_changed_files(): void
     {
         $this->skipIfCommitReferenceIsNotAvailable();
 
@@ -100,7 +99,6 @@ final class CommandLineGitIntegrationTest extends FileSystemTestCase
             self::COMMIT_REFERENCE,
             ['src/Git'],
         );
-        $paths = explode(',', $output);
 
         $expectedFiles = [
             'src/Git/CommandLineGit.php',
@@ -110,8 +108,8 @@ final class CommandLineGitIntegrationTest extends FileSystemTestCase
         foreach ($expectedFiles as $expectedFile) {
             $this->assertContains(
                 $expectedFile,
-                $paths,
-                implode("\n", $paths),
+                $output,
+                implode("\n", $output),
             );
         }
     }

--- a/tests/phpunit/Git/CommandLineGitTest.php
+++ b/tests/phpunit/Git/CommandLineGitTest.php
@@ -149,7 +149,7 @@ final class CommandLineGitTest extends TestCase
                 ),
             );
 
-        $expected = 'app/A.php,my lib/B.php';
+        $expected = ['app/A.php', 'my lib/B.php'];
 
         $actual = $this->git->getChangedFileRelativePaths('AM', 'main', ['app/', 'my lib/']);
 


### PR DESCRIPTION
## Description

Change `Git::getChangedFileRelativePaths()` to return a non-empty list of relative paths rather than encoding them as a comma-separated string.

The Git service already obtains the paths as individual lines. Returning this list directly preserves each path as a distinct value and removes the need for consumers to split the result.

## Motivations

The main reason for this change is https://github.com/infection/infection/pull/3399. Changing this return type is a bit noisy and requires some code adaptation that is easy to miss in the mist of other, broader changes.

Independently of that change, it was a bit strange to reconstruct a comma separated string to then undo it in the consumers.

## Changes

Update the Git contract and command-line implementation to return a list of non-empty relative paths.

## Related issues

Preparatory step for https://github.com/infection/infection/issues/3397.