### PR TITLE
refactor(git): Return absolute changed paths

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -7737,6 +7737,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Git/CommandLineGitTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_absolute_paths_of_the_changed_files`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/Git/CommandLineGitTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitTest::test_it_throws_no_code_to_mutate_exception_when_diff_is_empty`.'
 count = 1
 

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -5031,7 +5031,7 @@ count = 1
 [[issues]]
 file = "tests/benchmark/ParseGitDiff/parse-diff.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:tests/benchmark/ParseGitDiff/parse-diff.php:66:8}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:tests/benchmark/ParseGitDiff/parse-diff.php:72:8}`.'
 count = 1
 
 [[issues]]

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -169,6 +169,12 @@ message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceF
 count = 1
 
 [[issues]]
+file = "src/Command/Git/GitChangedFilesCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\Git\GitChangedFilesCommand::getFiles`.'
+count = 1
+
+[[issues]]
 file = "src/Command/Git/GitChangedLinesCommand.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Command\Git\GitChangedLinesCommand::executeCommand`.'
@@ -969,193 +975,193 @@ count = 1
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:284:47}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:285:47}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:292:31}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:293:31}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:307:49}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:308:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:317:37}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:318:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:330:45}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:331:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:333:50}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:334:50}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:336:51}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:337:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:344:41}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:345:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:361:39}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:362:39}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:376:42}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:377:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:380:37}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:381:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:389:42}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:390:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:392:46}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:393:46}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:411:76}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:412:76}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:420:58}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:421:58}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:431:67}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:432:67}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:443:55}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:444:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:455:51}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:456:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:468:44}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:469:44}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:473:43}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:474:43}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:489:32}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:490:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:524:55}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:525:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:535:44}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:536:44}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:543:49}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:544:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:560:53}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:561:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:579:41}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:580:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:589:45}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:590:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:612:41}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:613:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:630:17}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:631:17}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:642:32}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:643:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:646:53}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:647:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:758:13}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:759:13}`.'
 count = 1
 
 [[issues]]
@@ -1167,193 +1173,193 @@ count = 1
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:284:47}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:285:47}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:292:31}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:293:31}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:307:49}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:308:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:317:37}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:318:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:330:45}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:331:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:333:50}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:334:50}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:336:51}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:337:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:344:41}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:345:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:361:39}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:362:39}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:376:42}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:377:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:380:37}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:381:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:389:42}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:390:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:392:46}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:393:46}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:411:76}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:412:76}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:420:58}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:421:58}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:431:67}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:432:67}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:443:55}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:444:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:455:51}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:456:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:468:44}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:469:44}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:473:43}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:474:43}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:489:32}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:490:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:524:55}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:525:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:535:44}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:536:44}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:543:49}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:544:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:560:53}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:561:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:579:41}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:580:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:589:45}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:590:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:612:41}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:613:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:630:17}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:631:17}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:642:32}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:643:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:646:53}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:647:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:758:13}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:759:13}`.'
 count = 1
 
 [[issues]]
@@ -1773,7 +1779,7 @@ count = 1
 [[issues]]
 file = "src/Git/CommandLineGit.php"
 code = "less-specific-nested-return-statement"
-message = '''Returned type `list<mixed>` is less specific than the declared return type `list<string>` for function `Infection\Git\CommandLineGit::diff` due to nested 'mixed'.'''
+message = '''Returned type `list{string, list<mixed>}` is less specific than the declared return type `array{0: string, 1: list<string>}` for function `Infection\Git\CommandLineGit::diff` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -3052,12 +3058,6 @@ count = 1
 file = "src/Source/Collector/GitDiffSourceCollector.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Source\Collector\GitDiffSourceCollector::create`.'
-count = 1
-
-[[issues]]
-file = "src/Source/Matcher/GitDiffSourceLineMatcher.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Source\Matcher\GitDiffSourceLineMatcher::getFilesChangedLinesRanges`.'
 count = 1
 
 [[issues]]
@@ -7701,12 +7701,6 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_gets_the_relative_paths_of_the_changed_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\Tests\Git\CommandLineGitIntegrationTest::checkIfCommitReferenceExists`.'
 count = 1
 
@@ -7738,12 +7732,6 @@ count = 1
 file = "tests/phpunit/Git/CommandLineGitTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitTest::test_it_get_the_changed_lines_ranges_by_files_relative_paths`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_relative_paths_of_the_changed_files_as_a_string`.'
 count = 1
 
 [[issues]]

--- a/src/Command/Git/GitChangedFilesCommand.php
+++ b/src/Command/Git/GitChangedFilesCommand.php
@@ -35,14 +35,19 @@ declare(strict_types=1);
 
 namespace Infection\Command\Git;
 
+use function array_map;
 use Infection\Command\BaseCommand;
 use Infection\Command\Git\Option\BaseOption;
 use Infection\Command\Git\Option\FilterOption;
 use Infection\Command\Option\ConfigurationOption;
+use Infection\Configuration\Configuration;
 use Infection\Configuration\SourceFilter\GitDiffFilter;
 use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
 use Infection\Console\IO;
+use Infection\Git\Git;
+use function Safe\getcwd;
 use function sprintf;
+use Symfony\Component\Filesystem\Path;
 use Webmozart\Assert\Assert;
 
 /**
@@ -101,14 +106,35 @@ final class GitChangedFilesCommand extends BaseCommand
             ),
         );
 
-        $files = $git->getChangedFileRelativePaths(
-            $sourceFilter->value,
-            $sourceFilter->base,
-            $container->getConfiguration()->source->directories,
+        $files = self::getFiles(
+            $container->getConfiguration(),
+            $git,
+            $sourceFilter,
         );
 
         $io->writeln($files);
 
         return true;
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function getFiles(
+        Configuration $configuration,
+        Git $git,
+        GitDiffFilter $sourceFilter,
+    ): array {
+        $workingDirectory = getcwd();
+
+        return array_map(
+            static fn (string $path): string => Path::makeRelative($path, $workingDirectory),
+            $git->getChangedFilePaths(
+                $sourceFilter->value,
+                $sourceFilter->base,
+                $configuration->source->directories,
+                $workingDirectory,
+            ),
+        );
     }
 }

--- a/src/Command/Git/GitChangedLinesCommand.php
+++ b/src/Command/Git/GitChangedLinesCommand.php
@@ -43,8 +43,10 @@ use Infection\Configuration\SourceFilter\GitDiffFilter;
 use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
 use Infection\Console\IO;
 use Infection\Differ\ChangedLinesRange;
+use function Safe\getcwd;
 use function sprintf;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Path;
 use Webmozart\Assert\Assert;
 
 /**
@@ -103,13 +105,16 @@ final class GitChangedLinesCommand extends BaseCommand
             ),
         );
 
-        $changedLines = $git->getChangedLinesRangesByFileRelativePaths(
+        $workingDirectory = getcwd();
+
+        $changedLines = $git->getChangedLinesRangesByFilePaths(
             $sourceFilter->value,
             $sourceFilter->base,
             $container->getConfiguration()->source->directories,
+            $workingDirectory,
         );
 
-        self::printChangedLines($changedLines, $io);
+        self::printChangedLines($changedLines, $workingDirectory, $io);
 
         return true;
     }
@@ -119,14 +124,17 @@ final class GitChangedLinesCommand extends BaseCommand
      */
     private static function printChangedLines(
         array $changedLines,
+        string $workingDirectory,
         OutputInterface $output,
     ): void {
         foreach ($changedLines as $file => $fileChangedLines) {
+            $relativePath = Path::makeRelative($file, $workingDirectory);
+
             foreach ($fileChangedLines as $fileChangedLine) {
                 $output->writeln(
                     sprintf(
                         '%s: [%s,%s]',
-                        $file,
+                        $relativePath,
                         $fileChangedLine->startLine,
                         $fileChangedLine->endLine,
                     ),

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -38,6 +38,7 @@ namespace Infection\Container;
 use function array_filter;
 use Closure;
 use DIContainer\Container as DIContainer;
+use function dirname;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\CI\MemoizedCiDetector;
 use Infection\CI\NullCiDetector;
@@ -616,10 +617,10 @@ final class Container extends DIContainer
                 return $sourceFilter instanceof GitDiffFilter
                     ? new GitDiffSourceLineMatcher(
                         $container->getGit(),
-                        $container->getFileSystem(),
                         $sourceFilter->base,
                         $sourceFilter->value,
                         $configuration->source->directories,
+                        dirname($configuration->configurationPathname),
                     )
                     : new NullSourceLineMatcher();
             },

--- a/src/Git/CommandLineGit.php
+++ b/src/Git/CommandLineGit.php
@@ -51,6 +51,7 @@ use function Safe\preg_match;
 use function Safe\preg_split;
 use function sprintf;
 use function str_starts_with;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
 use Webmozart\Assert\Assert;
 
@@ -83,36 +84,45 @@ final readonly class CommandLineGit implements Git
         return $this->readSymbolicReference(self::DEFAULT_SYMBOLIC_REFERENCE) ?? Git::FALLBACK_BASE;
     }
 
-    public function getChangedFileRelativePaths(string $diffFilter, string $base, array $sourceDirectories): array
-    {
-        $lines = $this->diff(
-            $diffFilter,
-            $base,
-            $sourceDirectories,
-            nameOnly: true,
-        );
-
-        if (count($lines) === 0) {
-            throw NoSourceFound::noFilesForGitDiff($diffFilter, $base);
-        }
-
-        Assert::allStringNotEmpty($lines);
-
-        return $lines;
-    }
-
-    public function getChangedLinesRangesByFileRelativePaths(
+    public function getChangedFilePaths(
         string $diffFilter,
         string $base,
         array $sourceDirectories,
+        string $workingDirectory,
     ): array {
-        $lines = $this->diff(
+        [$projectDirectory, $lines] = $this->diff(
             $diffFilter,
             $base,
             $sourceDirectories,
+            $workingDirectory,
+            nameOnly: true,
+        );
+        $paths = self::makePathsAbsolute($lines, $projectDirectory);
+
+        if (count($paths) === 0) {
+            throw NoSourceFound::noFilesForGitDiff($diffFilter, $base);
+        }
+
+        return $paths;
+    }
+
+    public function getChangedLinesRangesByFilePaths(
+        string $diffFilter,
+        string $base,
+        array $sourceDirectories,
+        string $workingDirectory,
+    ): array {
+        [$projectDirectory, $lines] = $this->diff(
+            $diffFilter,
+            $base,
+            $sourceDirectories,
+            $workingDirectory,
             noContext: true,
         );
-        $changedLines = self::parsedChangedLines($lines);
+        $changedLines = self::makeChangedPathsAbsolute(
+            self::parsedChangedLines($lines),
+            $projectDirectory,
+        );
 
         if (count($changedLines) === 0) {
             throw NoSourceFound::noChangedLinesForGitDiff(
@@ -196,6 +206,50 @@ final readonly class CommandLineGit implements Git
         return $result;
     }
 
+    /**
+     * @param list<string> $paths
+     *
+     * @return list<non-empty-string>
+     */
+    private static function makePathsAbsolute(
+        array $paths,
+        string $projectDirectory,
+    ): array {
+        return array_map(
+            static fn (string $path): string => self::makePathAbsolute($projectDirectory, $path),
+            $paths,
+        );
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function makePathAbsolute(string $projectDirectory, string $path): string
+    {
+        $absolutePath = Path::join($projectDirectory, $path);
+        Assert::stringNotEmpty($absolutePath);
+
+        return $absolutePath;
+    }
+
+    /**
+     * @param array<string, list<ChangedLinesRange>> $changedLinesByPath
+     *
+     * @return array<string, list<ChangedLinesRange>>
+     */
+    private static function makeChangedPathsAbsolute(
+        array $changedLinesByPath,
+        string $projectDirectory,
+    ): array {
+        $result = [];
+
+        foreach ($changedLinesByPath as $path => $changedLines) {
+            $result[Path::join($projectDirectory, $path)] = $changedLines;
+        }
+
+        return $result;
+    }
+
     private static function parseFilePathFromLine(string $line): string
     {
         preg_match(self::DIFF_LINE_REGEX, $line, $matches);
@@ -263,17 +317,28 @@ final readonly class CommandLineGit implements Git
     /**
      * @param string[] $sourceDirectories
      *
-     * @return list<string>
+     * @return array{string, list<string>}
      */
     private function diff(
         string $diffFilter,
         string $base,
         array $sourceDirectories,
+        string $workingDirectory,
         bool $nameOnly = false,
         bool $noContext = false,
     ): array {
+        $projectDirectory = $this->shellCommandLineExecutor->execute([
+            'git',
+            '-C',
+            $workingDirectory,
+            'rev-parse',
+            '--show-toplevel',
+        ]);
+
         $command = [
             'git',
+            '-C',
+            $workingDirectory,
             '--no-pager',
             'diff',
             $base,
@@ -293,10 +358,13 @@ final readonly class CommandLineGit implements Git
         );
 
         if ($diff === '') {
-            return [];
+            return [$projectDirectory, []];
         }
 
-        return preg_split('/\n|\r\n?/', $diff);
+        return [
+            $projectDirectory,
+            preg_split('/\n|\r\n?/', $diff),
+        ];
     }
 
     /**

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -78,21 +78,22 @@ interface Git
     public function getDefaultBase(): string;
 
     /**
-     * Finds the list of relative paths (relative to the current working directory) of the changed files that changed
-     * compared to the base branch used and matching the given filter.
+     * Finds the absolute paths of the changed files compared to the base branch and matching the given filter.
      *
      * @param non-empty-string $diffFilter E.g. 'AM'.
      * @param non-empty-string $base E.g. 'origin/main' or a commit hash.
      * @param non-empty-string[] $sourceDirectories
+     * @param non-empty-string $workingDirectory Directory from which to interpret source paths.
      *
      * @throws NoSourceFound
      *
      * @return non-empty-list<non-empty-string>
      */
-    public function getChangedFileRelativePaths(
+    public function getChangedFilePaths(
         string $diffFilter,
         string $base,
         array $sourceDirectories,
+        string $workingDirectory,
     ): array;
 
     /**
@@ -103,23 +104,25 @@ interface Git
      *
      * ```php
      * [
-     *     src/File1.php => [ChangedLinesRange(1, 2)],
-     *     src/File2.php => [ChangedLinesRange(1, 20), ChangedLinesRange(33, 33)],
+     *     /path/to/project/src/File1.php => [ChangedLinesRange(1, 2)],
+     *     /path/to/project/src/File2.php => [ChangedLinesRange(1, 20), ChangedLinesRange(33, 33)],
      * ]
      * ```
      *
      * @param non-empty-string $diffFilter E.g. 'AM'.
      * @param non-empty-string $base E.g. 'origin/main' or a commit hash.
      * @param non-empty-string[] $sourceDirectories
+     * @param non-empty-string $workingDirectory Directory from which to interpret source paths.
      *
      * @throws NoSourceFound
      *
      * @return non-empty-array<string, list<ChangedLinesRange>>
      */
-    public function getChangedLinesRangesByFileRelativePaths(
+    public function getChangedLinesRangesByFilePaths(
         string $diffFilter,
         string $base,
         array $sourceDirectories,
+        string $workingDirectory,
     ): array;
 
     /**

--- a/src/Source/Collector/GitDiffSourceCollector.php
+++ b/src/Source/Collector/GitDiffSourceCollector.php
@@ -35,10 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Source\Collector;
 
+use function dirname;
 use Infection\Configuration\SourceFilter\GitDiffFilter;
 use Infection\Configuration\SourceFilter\PlainFilter;
 use Infection\Git\Git;
 use Infection\Source\Exception\NoSourceFound;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal
@@ -67,7 +69,12 @@ final readonly class GitDiffSourceCollector implements SourceCollector
                 $configurationPathname,
                 $sourceDirectories,
                 $excludedFilesOrDirectories,
-                self::convertToPlainFilter($git, $filter, $sourceDirectories),
+                self::convertToPlainFilter(
+                    $git,
+                    $filter,
+                    $sourceDirectories,
+                    $configurationPathname,
+                ),
             ),
         );
     }
@@ -86,12 +93,17 @@ final readonly class GitDiffSourceCollector implements SourceCollector
         Git $git,
         GitDiffFilter $sourceFilter,
         array $sourceDirectories,
+        string $configurationPathname,
     ): PlainFilter {
+        $workingDirectory = dirname($configurationPathname);
+        Assert::stringNotEmpty($workingDirectory);
+
         return new PlainFilter(
-            $git->getChangedFileRelativePaths(
+            $git->getChangedFilePaths(
                 $sourceFilter->value,
                 $sourceFilter->base,
                 $sourceDirectories,
+                $workingDirectory,
             ),
         );
     }

--- a/src/Source/Matcher/GitDiffSourceLineMatcher.php
+++ b/src/Source/Matcher/GitDiffSourceLineMatcher.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Source\Matcher;
 
 use Infection\Differ\ChangedLinesRange;
-use Infection\FileSystem\FileSystem;
 use Infection\Git\Git;
 use Infection\Source\Exception\NoSourceFound;
 
@@ -52,13 +51,14 @@ final class GitDiffSourceLineMatcher implements SourceLineMatcher
      * @param non-empty-string $gitDiffBase
      * @param non-empty-string $gitDiffFilter
      * @param non-empty-string[] $sourceDirectories
+     * @param non-empty-string $workingDirectory
      */
     public function __construct(
         private readonly Git $git,
-        private readonly FileSystem $filesystem,
         private readonly string $gitDiffBase,
         private readonly string $gitDiffFilter,
         private readonly array $sourceDirectories,
+        private readonly string $workingDirectory,
     ) {
     }
 
@@ -92,18 +92,11 @@ final class GitDiffSourceLineMatcher implements SourceLineMatcher
      */
     private function getFilesChangedLinesRanges(): array
     {
-        $changedLinesByRelativePaths = $this->git->getChangedLinesRangesByFileRelativePaths(
+        return $this->git->getChangedLinesRangesByFilePaths(
             $this->gitDiffFilter,
             $this->gitDiffBase,
             $this->sourceDirectories,
+            $this->workingDirectory,
         );
-
-        $changedLinesByAbsolutePaths = [];
-
-        foreach ($changedLinesByRelativePaths as $relativeFilePath => $changedLines) {
-            $changedLinesByAbsolutePaths[$this->filesystem->realPath($relativeFilePath)] = $changedLines;
-        }
-
-        return $changedLinesByAbsolutePaths;
     }
 }

--- a/tests/benchmark/ParseGitDiff/parse-diff.php
+++ b/tests/benchmark/ParseGitDiff/parse-diff.php
@@ -63,4 +63,4 @@ $git = new CommandLineGit($executorMock);
 /**
  * @return Closure(): positive-int|0
  */
-return static fn (): int => count($git->getChangedLinesRangesByFileRelativePaths('AM', 'unknown', []));
+return static fn (): int => count($git->getChangedLinesRangesByFilePaths('AM', 'unknown', [], __DIR__));

--- a/tests/benchmark/ParseGitDiff/parse-diff.php
+++ b/tests/benchmark/ParseGitDiff/parse-diff.php
@@ -46,13 +46,19 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 $diff = file_get_contents(__DIR__ . '/diff');
 
 // @phpstan-ignore class.extendsFinalByPhpDoc
-$executorMock = new class($diff) extends ShellCommandLineExecutor {
-    public function __construct(private readonly string $diff)
-    {
+$executorMock = new class($diff, __DIR__) extends ShellCommandLineExecutor {
+    public function __construct(
+        private readonly string $diff,
+        private readonly string $workingDirectory,
+    ) {
     }
 
     public function execute(array $command): string
     {
+        if ($command === ['git', '-C', $this->workingDirectory, 'rev-parse', '--show-toplevel']) {
+            return $this->workingDirectory;
+        }
+
         return $this->diff;
     }
 };

--- a/tests/phpunit/Command/Git/GitChangedFilesCommandTest.php
+++ b/tests/phpunit/Command/Git/GitChangedFilesCommandTest.php
@@ -51,12 +51,15 @@ use function Safe\chdir;
 use function Safe\getcwd;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Path;
 
 #[Group('integration')]
 #[CoversClass(GitChangedFilesCommand::class)]
 final class GitChangedFilesCommandTest extends TestCase
 {
     private const string REFERENCE = 'xyz1234';
+
+    private const string CONFIGURATION_PATHNAME = '/configuration/infection.json5';
 
     private const string FIXTURES_DIR = __DIR__ . '/Fixtures';
 
@@ -77,7 +80,7 @@ final class GitChangedFilesCommandTest extends TestCase
 
     /**
      * @param array<string, string> $arguments
-     * @param non-empty-list<non-empty-string> $files
+     * @param list<string> $files
      */
     #[DataProvider('commandExecutionProvider')]
     public function test_it_outputs_changed_files(
@@ -97,8 +100,8 @@ final class GitChangedFilesCommandTest extends TestCase
             ->with($expectedBase)
             ->willReturn(self::REFERENCE);
         $gitMock
-            ->method('getChangedFileRelativePaths')
-            ->with($expectedFilter, self::REFERENCE, ['src', 'lib'])
+            ->method('getChangedFilePaths')
+            ->with($expectedFilter, self::REFERENCE, ['src', 'lib'], self::FIXTURES_DIR)
             ->willReturn($files);
 
         $tester = $this->createCommandTester($gitMock);
@@ -133,7 +136,10 @@ final class GitChangedFilesCommandTest extends TestCase
                 '--base' => 'origin/main',
             ],
             'defaultBase' => 'origin/default',
-            'files' => ['src/File1.php', 'src/File2.php'],
+            'files' => [
+                Path::canonicalize(self::FIXTURES_DIR . '/src/File1.php'),
+                Path::canonicalize(self::FIXTURES_DIR . '/src/File2.php'),
+            ],
             'expectedBase' => 'origin/main',
             'expectedFilter' => Git::DEFAULT_GIT_DIFF_FILTER,
             'expectedStdout' => <<<STDOUT
@@ -156,7 +162,9 @@ final class GitChangedFilesCommandTest extends TestCase
         yield 'default base and default filter' => [
             [],
             'defaultBase' => 'origin/default',
-            'files' => ['tests/File1Test.php'],
+            'files' => [
+                Path::canonicalize(self::FIXTURES_DIR . '/tests/File1Test.php'),
+            ],
             'expectedBase' => 'origin/default',
             'expectedFilter' => Git::DEFAULT_GIT_DIFF_FILTER,
             'expectedStdout' => <<<STDOUT
@@ -181,7 +189,9 @@ final class GitChangedFilesCommandTest extends TestCase
                 '--base' => '  feature/test  ',
             ],
             'defaultBase' => 'origin/default',
-            'files' => ['src/Test.php'],
+            'files' => [
+                Path::canonicalize(self::FIXTURES_DIR . '/src/Test.php'),
+            ],
             'expectedBase' => 'feature/test',
             'expectedFilter' => Git::DEFAULT_GIT_DIFF_FILTER,
             'expectedStdout' => <<<STDOUT
@@ -205,7 +215,9 @@ final class GitChangedFilesCommandTest extends TestCase
                 '--filter' => '  D  ',
             ],
             'defaultBase' => 'origin/default',
-            'files' => ['src/Deleted.php'],
+            'files' => [
+                Path::canonicalize(self::FIXTURES_DIR . '/src/Deleted.php'),
+            ],
             'expectedBase' => 'origin/main',
             'expectedFilter' => 'D',
             'expectedStdout' => <<<STDOUT
@@ -226,7 +238,9 @@ final class GitChangedFilesCommandTest extends TestCase
         yield 'single file' => [
             [],
             'defaultBase' => 'origin/main',
-            'files' => ['src/SingleFile.php'],
+            'files' => [
+                Path::canonicalize(self::FIXTURES_DIR . '/src/SingleFile.php'),
+            ],
             'expectedBase' => 'origin/main',
             'expectedFilter' => Git::DEFAULT_GIT_DIFF_FILTER,
             'expectedStdout' => <<<STDOUT
@@ -289,6 +303,7 @@ final class GitChangedFilesCommandTest extends TestCase
     private function createSchemaConfiguration(): SchemaConfiguration
     {
         return SchemaConfigurationBuilder::withMinimalTestData()
+            ->withPathname(self::CONFIGURATION_PATHNAME)
             ->withSource(
                 new Source(
                     self::SOURCE_DIRECTORIES,

--- a/tests/phpunit/Command/Git/GitChangedLinesCommandTest.php
+++ b/tests/phpunit/Command/Git/GitChangedLinesCommandTest.php
@@ -59,6 +59,8 @@ final class GitChangedLinesCommandTest extends TestCase
 {
     private const string REFERENCE = 'xyz1234';
 
+    private const string CONFIGURATION_PATHNAME = '/configuration/infection.json5';
+
     private const string FIXTURES_DIR = __DIR__ . '/Fixtures';
 
     private const array SOURCE_DIRECTORIES = ['src', 'lib'];
@@ -78,7 +80,7 @@ final class GitChangedLinesCommandTest extends TestCase
 
     /**
      * @param array<string, string> $arguments
-     * @param array<string, ChangedLinesRange[]> $changedLines
+     * @param array<string, list<ChangedLinesRange>> $changedLines
      */
     #[DataProvider('commandExecutionProvider')]
     public function test_it_outputs_changed_lines(
@@ -98,8 +100,13 @@ final class GitChangedLinesCommandTest extends TestCase
             ->with($expectedBase)
             ->willReturn(self::REFERENCE);
         $gitMock
-            ->method('getChangedLinesRangesByFileRelativePaths')
-            ->with($expectedFilter, self::REFERENCE, self::SOURCE_DIRECTORIES)
+            ->method('getChangedLinesRangesByFilePaths')
+            ->with(
+                $expectedFilter,
+                self::REFERENCE,
+                self::SOURCE_DIRECTORIES,
+                self::FIXTURES_DIR,
+            )
             ->willReturn($changedLines);
 
         $tester = $this->createCommandTester($gitMock);
@@ -135,8 +142,8 @@ final class GitChangedLinesCommandTest extends TestCase
             ],
             'defaultBase' => 'origin/default',
             'changedLines' => [
-                'src/File1.php' => [ChangedLinesRange::create(1, 5), ChangedLinesRange::create(10, 15)],
-                'src/File2.php' => [ChangedLinesRange::create(20, 20)],
+                self::FIXTURES_DIR . '/src/File1.php' => [ChangedLinesRange::create(1, 5), ChangedLinesRange::create(10, 15)],
+                self::FIXTURES_DIR . '/src/File2.php' => [ChangedLinesRange::create(20, 20)],
             ],
             'expectedBase' => 'origin/main',
             'expectedFilter' => Git::DEFAULT_GIT_DIFF_FILTER,
@@ -163,7 +170,7 @@ final class GitChangedLinesCommandTest extends TestCase
             [],
             'defaultBase' => 'origin/default',
             'changedLines' => [
-                'tests/File1Test.php' => [ChangedLinesRange::create(1, 10)],
+                self::FIXTURES_DIR . '/tests/File1Test.php' => [ChangedLinesRange::create(1, 10)],
             ],
             'expectedBase' => 'origin/default',
             'expectedFilter' => Git::DEFAULT_GIT_DIFF_FILTER,
@@ -190,7 +197,7 @@ final class GitChangedLinesCommandTest extends TestCase
             ],
             'defaultBase' => 'origin/default',
             'changedLines' => [
-                'src/Test.php' => [ChangedLinesRange::create(1, 1)],
+                self::FIXTURES_DIR . '/src/Test.php' => [ChangedLinesRange::create(1, 1)],
             ],
             'expectedBase' => 'feature/test',
             'expectedFilter' => Git::DEFAULT_GIT_DIFF_FILTER,
@@ -216,7 +223,7 @@ final class GitChangedLinesCommandTest extends TestCase
             ],
             'defaultBase' => 'origin/default',
             'changedLines' => [
-                'src/Deleted.php' => [ChangedLinesRange::create(1, 100)],
+                self::FIXTURES_DIR . '/src/Deleted.php' => [ChangedLinesRange::create(1, 100)],
             ],
             'expectedBase' => 'origin/main',
             'expectedFilter' => 'D',
@@ -278,6 +285,7 @@ final class GitChangedLinesCommandTest extends TestCase
     private function createSchemaConfiguration(): SchemaConfiguration
     {
         return SchemaConfigurationBuilder::withMinimalTestData()
+            ->withPathname(self::CONFIGURATION_PATHNAME)
             ->withSource(
                 new Source(
                     self::SOURCE_DIRECTORIES,

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryGit.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryGit.php
@@ -54,18 +54,20 @@ final readonly class ConfigurationFactoryGit implements Git
         return $this->defaultBaseBranch;
     }
 
-    public function getChangedFileRelativePaths(
+    public function getChangedFilePaths(
         string $diffFilter,
         string $base,
         array $sourceDirectories,
+        string $workingDirectory,
     ): array {
         throw new DomainException('Not implemented.');
     }
 
-    public function getChangedLinesRangesByFileRelativePaths(
+    public function getChangedLinesRangesByFilePaths(
         string $diffFilter,
         string $base,
         array $sourceDirectories,
+        string $workingDirectory,
     ): never {
         throw new DomainException('Not implemented.');
     }

--- a/tests/phpunit/Git/CommandLineGitIntegrationTest.php
+++ b/tests/phpunit/Git/CommandLineGitIntegrationTest.php
@@ -41,11 +41,17 @@ use Infection\Git\CommandLineGit;
 use Infection\Git\Git;
 use Infection\Git\NoGitProjectFound;
 use Infection\Process\ShellCommandLineExecutor;
+use Infection\Source\Exception\NoSourceFound;
 use Infection\Tests\FileSystem\FileSystemTestCase;
+use Infection\Tests\TestingUtility\FS;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use function Safe\chdir;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Webmozart\Assert\Assert;
 
 /**
  * This is an integration to smoke test that the adapter works. More accurate
@@ -90,19 +96,21 @@ final class CommandLineGitIntegrationTest extends FileSystemTestCase
         );
     }
 
-    public function test_it_gets_the_relative_paths_of_the_changed_files(): void
+    /** @throws NoSourceFound */
+    public function test_it_gets_the_absolute_paths_of_the_changed_files(): void
     {
         $this->skipIfCommitReferenceIsNotAvailable();
 
-        $output = $this->git->getChangedFileRelativePaths(
+        $output = $this->git->getChangedFilePaths(
             'AM',
             self::COMMIT_REFERENCE,
             ['src/Git'],
+            $this->getWorkingDirectory(),
         );
 
         $expectedFiles = [
-            'src/Git/CommandLineGit.php',
-            'src/Git/Git.php',
+            $this->cwd . '/src/Git/CommandLineGit.php',
+            $this->cwd . '/src/Git/Git.php',
         ];
 
         foreach ($expectedFiles as $expectedFile) {
@@ -112,6 +120,55 @@ final class CommandLineGitIntegrationTest extends FileSystemTestCase
                 implode("\n", $output),
             );
         }
+    }
+
+    /**
+     * @throws IOException
+     * @throws NoSourceFound
+     * @throws ProcessException
+     * @throws ProcessFailedException
+     * @throws ProcessTimedOutException
+     */
+    public function test_it_gets_changed_files_from_a_source_directory_outside_the_working_directory(): void
+    {
+        $projectDirectory = $this->tmp . '/project';
+
+        FS::dumpFile($projectDirectory . '/src/SourceClass.php', 'before');
+        FS::dumpFile($this->tmp . '/shared/SharedClass.php', 'before');
+
+        $executor = new ShellCommandLineExecutor();
+        $executor->execute(['git', '-C', $this->tmp, 'init', '--quiet']);
+        $executor->execute(['git', '-C', $this->tmp, 'add', '.']);
+        $executor->execute([
+            'git',
+            '-C',
+            $this->tmp,
+            '-c',
+            'user.name=Infection',
+            '-c',
+            'user.email=infection@infection.github.io',
+            'commit',
+            '--quiet',
+            '-m',
+            'baseline',
+        ]);
+
+        FS::dumpFile($projectDirectory . '/src/SourceClass.php', 'after');
+        FS::dumpFile($this->tmp . '/shared/SharedClass.php', 'after');
+
+        $expected = [
+            $projectDirectory . '/src/SourceClass.php',
+            $this->tmp . '/shared/SharedClass.php',
+        ];
+
+        $actual = $this->git->getChangedFilePaths(
+            'M',
+            'HEAD',
+            ['src', '../shared'],
+            $projectDirectory,
+        );
+
+        $this->assertSame($expected, $actual);
     }
 
     public function test_it_fails_at_getting_the_relative_paths_of_the_changed_files_if_getting_the_merge_base_failed_unexpectedly(): void
@@ -135,11 +192,12 @@ final class CommandLineGitIntegrationTest extends FileSystemTestCase
             ),
         );
 
-        $this->git->getChangedFileRelativePaths(
+        $this->git->getChangedFilePaths(
             'AM',
             // This cannot be a correct revision.
             $badCommitReference,
             ['src'],
+            $this->getWorkingDirectory(),
         );
     }
 
@@ -147,28 +205,30 @@ final class CommandLineGitIntegrationTest extends FileSystemTestCase
     {
         $this->skipIfCommitReferenceIsNotAvailable();
 
-        $actual = $this->git->getChangedLinesRangesByFileRelativePaths(
+        $actual = $this->git->getChangedLinesRangesByFilePaths(
             'AM',
             self::COMMIT_REFERENCE,
             ['src', 'tests'],
+            $this->getWorkingDirectory(),
         );
 
-        $this->assertArrayHasKey('src/Git/Git.php', $actual);
-        $this->assertArrayHasKey('tests/phpunit/Git/CommandLineGitTest.php', $actual);
+        $this->assertArrayHasKey($this->cwd . '/src/Git/Git.php', $actual);
+        $this->assertArrayHasKey($this->cwd . '/tests/phpunit/Git/CommandLineGitTest.php', $actual);
     }
 
     public function test_it_get_the_changed_lines_excluding_the_files_that_are_not_part_of_the_source_directories(): void
     {
         $this->skipIfCommitReferenceIsNotAvailable();
 
-        $actual = $this->git->getChangedLinesRangesByFileRelativePaths(
+        $actual = $this->git->getChangedLinesRangesByFilePaths(
             'AM',
             self::COMMIT_REFERENCE,
             ['src'],
+            $this->getWorkingDirectory(),
         );
 
-        $this->assertArrayHasKey('src/Git/Git.php', $actual);
-        $this->assertArrayNotHasKey('tests/phpunit/Git/CommandLineGitTest.php', $actual);
+        $this->assertArrayHasKey($this->cwd . '/src/Git/Git.php', $actual);
+        $this->assertArrayNotHasKey($this->cwd . '/tests/phpunit/Git/CommandLineGitTest.php', $actual);
     }
 
     public function test_it_fails_at_getting_the_modified_lines_if_getting_the_merge_base_failed_unexpectedly(): void
@@ -192,10 +252,11 @@ final class CommandLineGitIntegrationTest extends FileSystemTestCase
             ),
         );
 
-        $this->git->getChangedLinesRangesByFileRelativePaths(
+        $this->git->getChangedLinesRangesByFilePaths(
             'AM',
             $badCommitReference,
             ['src'],
+            $this->getWorkingDirectory(),
         );
     }
 
@@ -232,6 +293,14 @@ final class CommandLineGitIntegrationTest extends FileSystemTestCase
         $this->expectException(NoGitProjectFound::class);
 
         $this->git->getProjectDirectory();
+    }
+
+    /** @return non-empty-string */
+    private function getWorkingDirectory(): string
+    {
+        Assert::stringNotEmpty($this->cwd);
+
+        return $this->cwd;
     }
 
     private function skipIfCommitReferenceIsNotAvailable(): void

--- a/tests/phpunit/Git/CommandLineGitTest.php
+++ b/tests/phpunit/Git/CommandLineGitTest.php
@@ -121,33 +121,20 @@ final class CommandLineGitTest extends TestCase
         $this->assertEquals($expectedRecords, $this->logger->records);
     }
 
-    /** @throws NoSourceFound */
     public function test_it_gets_the_absolute_paths_of_the_changed_files(): void
     {
-        $this->configureDiffCommands(
-            [
-                'git',
-                '-C',
-                '/project',
-                '--no-pager',
-                'diff',
-                'main',
-                '--no-ext-diff',
-                '--no-color',
-                '--name-only',
-                '--diff-filter=AM',
-                '--',
-                'app/',
-                'my lib/',
-            ],
-            Str::toSystemLineEndings(
-                <<<'EOF'
-                    project/app/A.php
-                    project/my lib/B.php
-                    EOF,
-            ),
-            '/repository',
-        );
+        $this->commandLineMock
+            ->expects($this->exactly(2))
+            ->method('execute')
+            ->willReturnOnConsecutiveCalls(
+                '/repository',
+                Str::toSystemLineEndings(
+                    <<<'EOF'
+                        project/app/A.php
+                        project/my lib/B.php
+                        EOF,
+                ),
+            );
 
         $expected = [
             '/repository/project/app/A.php',
@@ -171,24 +158,10 @@ final class CommandLineGitTest extends TestCase
             $this->expectException($expected);
         }
 
-        $this->configureDiffCommands(
-            [
-                'git',
-                '-C',
-                '/project',
-                '--no-pager',
-                'diff',
-                'main',
-                '--no-ext-diff',
-                '--no-color',
-                '--unified=0',
-                '--diff-filter=AM',
-                '--',
-                'src',
-                'lib',
-            ],
-            $diff,
-        );
+        $this->commandLineMock
+            ->expects($this->exactly(2))
+            ->method('execute')
+            ->willReturnOnConsecutiveCalls('/', $diff);
 
         $actual = $this->git->getChangedLinesRangesByFilePaths(
             'AM',
@@ -687,36 +660,5 @@ final class CommandLineGitTest extends TestCase
         $actual = $this->git->getProjectDirectory();
 
         $this->assertSame($expected, $actual);
-    }
-
-    /**
-     * @param list<string> $diffCommand
-     */
-    private function configureDiffCommands(
-        array $diffCommand,
-        string $diff,
-        string $projectDirectory = '/',
-    ): void {
-        $commands = [
-            [
-                'git',
-                '-C',
-                '/project',
-                'rev-parse',
-                '--show-toplevel',
-            ],
-            $diffCommand,
-        ];
-        $outputs = [$projectDirectory, $diff];
-        $callIndex = 0;
-
-        $this->commandLineMock
-            ->expects($this->exactly(2))
-            ->method('execute')
-            ->willReturnCallback(function (array $command) use (&$callIndex, $commands, $outputs): string {
-                $this->assertSame($commands[$callIndex], $command);
-
-                return $outputs[$callIndex++];
-            });
     }
 }

--- a/tests/phpunit/Git/CommandLineGitTest.php
+++ b/tests/phpunit/Git/CommandLineGitTest.php
@@ -81,7 +81,7 @@ final class CommandLineGitTest extends TestCase
 
         $this->expectException(NoSourceFound::class);
 
-        $this->git->getChangedFileRelativePaths('AM', 'master', ['src/']);
+        $this->git->getChangedFilePaths('AM', 'master', ['src/'], '/project');
     }
 
     public function test_it_gets_the_merge_base(): void
@@ -121,37 +121,40 @@ final class CommandLineGitTest extends TestCase
         $this->assertEquals($expectedRecords, $this->logger->records);
     }
 
-    public function test_it_gets_the_relative_paths_of_the_changed_files_as_a_string(): void
+    /** @throws NoSourceFound */
+    public function test_it_gets_the_absolute_paths_of_the_changed_files(): void
     {
-        $this->commandLineMock
-            ->method('execute')
-            ->with(
-                [
-                    'git',
-                    '--no-pager',
-                    'diff',
-                    'main',
-                    '--no-ext-diff',
-                    '--no-color',
-                    '--name-only',
-                    '--diff-filter=AM',
-                    '--',
-                    'app/',
-                    'my lib/',
-                ],
-            )
-            ->willReturn(
-                Str::toSystemLineEndings(
-                    <<<'EOF'
-                        app/A.php
-                        my lib/B.php
-                        EOF,
-                ),
-            );
+        $this->configureDiffCommands(
+            [
+                'git',
+                '-C',
+                '/project',
+                '--no-pager',
+                'diff',
+                'main',
+                '--no-ext-diff',
+                '--no-color',
+                '--name-only',
+                '--diff-filter=AM',
+                '--',
+                'app/',
+                'my lib/',
+            ],
+            Str::toSystemLineEndings(
+                <<<'EOF'
+                    project/app/A.php
+                    project/my lib/B.php
+                    EOF,
+            ),
+            '/repository',
+        );
 
-        $expected = ['app/A.php', 'my lib/B.php'];
+        $expected = [
+            '/repository/project/app/A.php',
+            '/repository/project/my lib/B.php',
+        ];
 
-        $actual = $this->git->getChangedFileRelativePaths('AM', 'main', ['app/', 'my lib/']);
+        $actual = $this->git->getChangedFilePaths('AM', 'main', ['app/', 'my lib/'], '/project');
 
         $this->assertSame($expected, $actual);
     }
@@ -168,10 +171,11 @@ final class CommandLineGitTest extends TestCase
             $this->expectException($expected);
         }
 
-        $this->commandLineMock
-            ->method('execute')
-            ->with([
+        $this->configureDiffCommands(
+            [
                 'git',
+                '-C',
+                '/project',
                 '--no-pager',
                 'diff',
                 'main',
@@ -182,13 +186,15 @@ final class CommandLineGitTest extends TestCase
                 '--',
                 'src',
                 'lib',
-            ])
-            ->willReturn($diff);
+            ],
+            $diff,
+        );
 
-        $actual = $this->git->getChangedLinesRangesByFileRelativePaths(
+        $actual = $this->git->getChangedLinesRangesByFilePaths(
             'AM',
             'main',
             ['src', 'lib'],
+            '/project',
         );
 
         if (!is_string($expected)) {
@@ -212,7 +218,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -10,5 +12,7 @@ line change example
                 DIFF,
             [
-                'src/Container.php' => [ChangedLinesRange::create(12, 18)],
+                '/src/Container.php' => [ChangedLinesRange::create(12, 18)],
             ],
         ];
 
@@ -225,7 +231,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -10,0 +11,5 @@ line change example
                 DIFF,
             [
-                'src/Container.php' => [ChangedLinesRange::create(11, 15)],
+                '/src/Container.php' => [ChangedLinesRange::create(11, 15)],
             ],
         ];
 
@@ -249,7 +255,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -10 +10,2 @@ line change example
                 DIFF,
             [
-                'src/Container.php' => [ChangedLinesRange::create(10, 11)],
+                '/src/Container.php' => [ChangedLinesRange::create(10, 11)],
             ],
         ];
 
@@ -262,7 +268,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -10,1 +10,2 @@ line change example
                 DIFF,
             [
-                'src/Container.php' => [ChangedLinesRange::create(10, 11)],
+                '/src/Container.php' => [ChangedLinesRange::create(10, 11)],
             ],
         ];
 
@@ -275,7 +281,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -10,2 +10 @@ line change example
                 DIFF,
             [
-                'src/Container.php' => [ChangedLinesRange::create(10, 10)],
+                '/src/Container.php' => [ChangedLinesRange::create(10, 10)],
             ],
         ];
 
@@ -288,7 +294,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -10,2 +10,1 @@ line change example
                 DIFF,
             [
-                'src/Container.php' => [ChangedLinesRange::create(10, 10)],
+                '/src/Container.php' => [ChangedLinesRange::create(10, 10)],
             ],
         ];
 
@@ -301,7 +307,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -10 +10 @@ line change example
                 DIFF,
             [
-                'src/Container.php' => [ChangedLinesRange::create(10, 10)],
+                '/src/Container.php' => [ChangedLinesRange::create(10, 10)],
             ],
         ];
 
@@ -314,7 +320,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -10,1 +10,1 @@ line change example
                 DIFF,
             [
-                'src/Container.php' => [ChangedLinesRange::create(10, 10)],
+                '/src/Container.php' => [ChangedLinesRange::create(10, 10)],
             ],
         ];
 
@@ -327,7 +333,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -0,0 +1,18 @@ line change example
                 DIFF,
             [
-                'src/Container.php' => [ChangedLinesRange::create(1, 18)],
+                '/src/Container.php' => [ChangedLinesRange::create(1, 18)],
             ],
         ];
 
@@ -351,7 +357,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -1,0 +1 @@ line change example
                 DIFF,
             [
-                'src/Container.php' => [ChangedLinesRange::create(1, 1)],
+                '/src/Container.php' => [ChangedLinesRange::create(1, 1)],
             ],
         ];
 
@@ -378,7 +384,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -1207,0 +1213,5 @@ final class Container
                 DIFF,
             [
-                'src/Container.php' => [
+                '/src/Container.php' => [
                     ChangedLinesRange::create(38, 38),
                     ChangedLinesRange::create(534, 535),
                     ChangedLinesRange::create(538, 540),
@@ -405,13 +411,13 @@ final class CommandLineGitTest extends TestCase
                 @@ -0,0 +1,18 @@
                 DIFF,
             [
-                'src/Container.php' => [
+                '/src/Container.php' => [
                     ChangedLinesRange::create(38, 38),
                     ChangedLinesRange::create(534, 535),
                     ChangedLinesRange::create(538, 540),
                     ChangedLinesRange::create(1213, 1217),
                 ],
-                'src/Differ/FilesDiffChangedLines.php' => [
+                '/src/Differ/FilesDiffChangedLines.php' => [
                     ChangedLinesRange::create(1, 18),
                 ],
             ],
@@ -426,7 +432,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -50 +51 @@ interface Git
                 DIFF,
             [
-                'src/Git/Git.php' => [
+                '/src/Git/Git.php' => [
                     ChangedLinesRange::create(51, 51),
                 ],
             ],
@@ -442,7 +448,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -0,0 +1,5 @@
                 DIFF,
             [
-                'src/Git/CommandLineGit.php' => [
+                '/src/Git/CommandLineGit.php' => [
                     ChangedLinesRange::create(1, 5),
                 ],
             ],
@@ -458,7 +464,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -15234,0 +15238,10 @@ final class CommandLineGitTest
                 DIFF,
             [
-                'tests/phpunit/Git/CommandLineGitTest.php' => [
+                '/tests/phpunit/Git/CommandLineGitTest.php' => [
                     ChangedLinesRange::create(10001, 10003),
                     ChangedLinesRange::create(15238, 15247),
                 ],
@@ -475,7 +481,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -10,0 +11,5 @@ new lines added
                 DIFF,
             [
-                'src/Source.php' => [ChangedLinesRange::create(11, 15)],
+                '/src/Source.php' => [ChangedLinesRange::create(11, 15)],
             ],
         ];
 
@@ -499,13 +505,13 @@ final class CommandLineGitTest extends TestCase
                 @@ -200 +202,3 @@ final class CommandLineGitTest
                 DIFF,
             [
-                'src/Git/Git.php' => [
+                '/src/Git/Git.php' => [
                     ChangedLinesRange::create(11, 12),
                 ],
-                'src/Git/CommandLineGit.php' => [
+                '/src/Git/CommandLineGit.php' => [
                     ChangedLinesRange::create(21, 25),
                 ],
-                'tests/phpunit/Git/CommandLineGitTest.php' => [
+                '/tests/phpunit/Git/CommandLineGitTest.php' => [
                     ChangedLinesRange::create(101, 101),
                     ChangedLinesRange::create(202, 204),
                 ],
@@ -524,7 +530,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -50 +54 @@ final class CommandLineGit
                 DIFF,
             [
-                'src/Git/CommandLineGit.php' => [
+                '/src/Git/CommandLineGit.php' => [
                     ChangedLinesRange::create(6, 6),
                     ChangedLinesRange::create(14, 14),
                     ChangedLinesRange::create(28, 28),
@@ -542,7 +548,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -42,0 +43,8 @@ interface Git
                 DIFF,
             [
-                'src/Git/Git.php' => [
+                '/src/Git/Git.php' => [
                     ChangedLinesRange::create(43, 50),
                 ],
             ],
@@ -562,7 +568,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -75,0 +82,10 @@ final class CommandLineGitTest
                 DIFF,
             [
-                'tests/phpunit/Git/CommandLineGitTest.php' => [
+                '/tests/phpunit/Git/CommandLineGitTest.php' => [
                     ChangedLinesRange::create(11, 11),
                     ChangedLinesRange::create(22, 24),
                     ChangedLinesRange::create(34, 38),
@@ -587,7 +593,7 @@ final class CommandLineGitTest extends TestCase
                 @@ -10,18 +10,2 @@ line change example
                 DIFF,
             [
-                'src/NewLinesAdded.php' => [ChangedLinesRange::create(10, 11)],
+                '/src/NewLinesAdded.php' => [ChangedLinesRange::create(10, 11)],
             ],
         ];
 
@@ -681,5 +687,36 @@ final class CommandLineGitTest extends TestCase
         $actual = $this->git->getProjectDirectory();
 
         $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @param list<string> $diffCommand
+     */
+    private function configureDiffCommands(
+        array $diffCommand,
+        string $diff,
+        string $projectDirectory = '/',
+    ): void {
+        $commands = [
+            [
+                'git',
+                '-C',
+                '/project',
+                'rev-parse',
+                '--show-toplevel',
+            ],
+            $diffCommand,
+        ];
+        $outputs = [$projectDirectory, $diff];
+        $callIndex = 0;
+
+        $this->commandLineMock
+            ->expects($this->exactly(2))
+            ->method('execute')
+            ->willReturnCallback(function (array $command) use (&$callIndex, $commands, $outputs): string {
+                $this->assertSame($commands[$callIndex], $command);
+
+                return $outputs[$callIndex++];
+            });
     }
 }

--- a/tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php
+++ b/tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php
@@ -36,7 +36,6 @@ declare(strict_types=1);
 namespace Infection\Tests\Source\Matcher;
 
 use Infection\Differ\ChangedLinesRange;
-use Infection\FileSystem\FileSystem;
 use Infection\Git\Git;
 use Infection\Source\Matcher\GitDiffSourceLineMatcher;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -50,26 +49,14 @@ use function sprintf;
 #[CoversClass(GitDiffSourceLineMatcher::class)]
 final class GitDiffSourceLineMatcherTest extends TestCase
 {
-    private FileSystem&MockObject $fileSystemStub;
-
-    protected function setUp(): void
-    {
-        $this->fileSystemStub = $this->createMock(FileSystem::class);
-        $this->fileSystemStub
-            ->method('realPath')
-            ->willReturnCallback(
-                static fn (string $path): string => '/path/to/' . $path,
-            );
-    }
-
     public function test_it_memoizes_parsed_results(): void
     {
         $matcher = new GitDiffSourceLineMatcher(
             $this->createGitStub([]),
-            $this->fileSystemStub,
             'main',
             'AM',
             ['src', 'lib'],
+            '/path/to',
         );
 
         $matcher->touches('/path/to/File.php', 1, 1);
@@ -93,10 +80,10 @@ final class GitDiffSourceLineMatcherTest extends TestCase
     ): void {
         $matcher = new GitDiffSourceLineMatcher(
             $this->createGitStub($changedLinesRangesByFilePathname),
-            $this->fileSystemStub,
             'main',
             'AM',
             ['src', 'lib'],
+            '/path/to',
         );
 
         $actual = $matcher->touches(
@@ -116,7 +103,7 @@ final class GitDiffSourceLineMatcherTest extends TestCase
     {
         yield 'the mutation touches no changed line' => [
             [
-                'src/File.php' => [ChangedLinesRange::forLine(3)],
+                '/path/to/src/File.php' => [ChangedLinesRange::forLine(3)],
             ],
             '/path/to/src/File.php',
             1,
@@ -126,7 +113,7 @@ final class GitDiffSourceLineMatcherTest extends TestCase
 
         yield 'the mutation touches a changed line' => [
             [
-                'src/File.php' => [ChangedLinesRange::forLine(3)],
+                '/path/to/src/File.php' => [ChangedLinesRange::forLine(3)],
             ],
             '/path/to/src/File.php',
             2,
@@ -136,7 +123,7 @@ final class GitDiffSourceLineMatcherTest extends TestCase
 
         yield 'the mutation touches none of the changed lines' => [
             [
-                'src/File1.php' => [
+                '/path/to/src/File1.php' => [
                     ChangedLinesRange::forLine(10),
                     ChangedLinesRange::create(30, 50),
                 ],
@@ -149,7 +136,7 @@ final class GitDiffSourceLineMatcherTest extends TestCase
 
         yield 'the mutation touches one of the changed lines' => [
             [
-                'src/File1.php' => [
+                '/path/to/src/File1.php' => [
                     ChangedLinesRange::forLine(10),
                     ChangedLinesRange::create(30, 50),
                 ],
@@ -162,11 +149,11 @@ final class GitDiffSourceLineMatcherTest extends TestCase
 
         yield 'the mutation touches one of the changed lines of a different file' => [
             [
-                'src/File1.php' => [
+                '/path/to/src/File1.php' => [
                     ChangedLinesRange::forLine(10),
                     ChangedLinesRange::create(30, 50),
                 ],
-                'src/File2.php' => [
+                '/path/to/src/File2.php' => [
                     ChangedLinesRange::create(1, 1),
                     ChangedLinesRange::create(3, 5),
                 ],
@@ -187,8 +174,8 @@ final class GitDiffSourceLineMatcherTest extends TestCase
         $git = $this->createMock(Git::class);
         $git
             ->expects($this->once())
-            ->method('getChangedLinesRangesByFileRelativePaths')
-            ->with('AM', 'main', ['src', 'lib'])
+            ->method('getChangedLinesRangesByFilePaths')
+            ->with('AM', 'main', ['src', 'lib'], '/path/to')
             ->willReturn($changedLinesRangesByFilePathname);
 
         return $git;

--- a/tests/phpunit/TestingUtility/FS.php
+++ b/tests/phpunit/TestingUtility/FS.php
@@ -158,4 +158,17 @@ final class FS
             ),
         );
     }
+
+    /**
+     * Atomically dumps content into a file.
+     *
+     * @param string|resource $content The data to write into the file
+     *
+     * @throws IOException if the file cannot be written to
+     */
+    public static function dumpFile(string $filename, mixed $content): void
+    {
+        $filesystem = new Filesystem();
+        $filesystem->dumpFile($filename, $content);
+    }
 }


### PR DESCRIPTION
## Description

Make the Git service's working-directory and path contracts explicit, regardless of the directory from which Infection is invoked.

## Motivations

To implement https://github.com/infection/infection/pull/3399, Git must know where to interpret the configured source directories, and callers need an unambiguous reference for the returned paths.

This refactor provides that foundation: the Git service receives the intended working directory explicitly, executes its queries from that directory, and returns absolute paths.

Source collection and changed-line matching can therefore compare Git results with collected source files and mutations using a single, unambiguous representation.

## Changes

- Passes an explicit working directory to Git changed-file and changed-line queries.
- Replaces methods returning relative paths with equivalents returning absolute paths.
- Uses absolute paths directly in source collection and changed-line matching.
- Removes the filesystem path-resolution dependency from `GitDiffSourceLineMatcher`.
- Keeps Git command output relative to the current working directory.

## Related issues

- Prerequisite for https://github.com/infection/infection/pull/3399.
- Related to https://github.com/infection/infection/issues/3397.
