### PR TITLE
fix: Correct the PCOV coverage when covered code is outside of the current working directory

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -24,6 +24,7 @@ jobs:
       contents: read
 
     strategy:
+      fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
         php-version: [ '8.3' ]

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -3483,7 +3483,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
 code = "falsable-return-statement"
-message = "Function `{closure:src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php:110:21}` is declared to return `string` but possibly returns 'false' (inferred as `false|string`)."
+message = "Function `{closure:src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php:124:21}` is declared to return `string` but possibly returns 'false' (inferred as `false|string`)."
 count = 1
 
 [[issues]]
@@ -3495,7 +3495,7 @@ count = 1
 [[issues]]
 file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
 code = "invalid-return-statement"
-message = "Invalid return type for function `{closure:src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php:110:21}`: expected `string`, but found `false|string`."
+message = "Invalid return type for function `{closure:src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php:124:21}`: expected `string`, but found `false|string`."
 count = 1
 
 [[issues]]

--- a/src/Config/ValueProvider/PCOVDirectoryProvider.php
+++ b/src/Config/ValueProvider/PCOVDirectoryProvider.php
@@ -57,7 +57,7 @@ use function Safe\ini_get;
 readonly class PCOVDirectoryProvider
 {
     // https://github.com/krakjoe/pcov/blob/57e143363aa6ba3c4d1e1b0a2e68556e28f38950/pcov.c#L80-L83
-    private const string DEFAULT_DIRECTORY = '.';
+    private const string DEFAULT_DIRECTORY = '';
 
     private ?string $phpConfiguredPcovDirectory;
 

--- a/src/Config/ValueProvider/PCOVDirectoryProvider.php
+++ b/src/Config/ValueProvider/PCOVDirectoryProvider.php
@@ -37,6 +37,7 @@ namespace Infection\Config\ValueProvider;
 
 use Safe\Exceptions\InfoException;
 use function Safe\ini_get;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Provides value for pcov.directory configuration option. Can be injected with a configuration object to provide a better, precise, value.
@@ -48,8 +49,13 @@ class PCOVDirectoryProvider
 {
     private ?string $phpConfiguredPcovDirectory = null;
 
-    public function __construct(?string $iniValue = null)
-    {
+    /**
+     * @param list<string> $sourceDirectoryPaths
+     */
+    public function __construct(
+        private readonly array $sourceDirectoryPaths,
+        ?string $iniValue,
+    ) {
         try {
             $this->phpConfiguredPcovDirectory = $iniValue ?? ini_get('pcov.directory');
         } catch (InfoException) {
@@ -67,7 +73,12 @@ class PCOVDirectoryProvider
 
     public function getDirectory(): string
     {
-        // Returning CWD simplicity's sake.
-        return '.';
+        if ($this->sourceDirectoryPaths === []) {
+            return '.';
+        }
+
+        return Path::getLongestCommonBasePath(
+            ...$this->sourceDirectoryPaths,
+        ) ?? '.';
     }
 }

--- a/src/Config/ValueProvider/PCOVDirectoryProvider.php
+++ b/src/Config/ValueProvider/PCOVDirectoryProvider.php
@@ -39,14 +39,27 @@ use Safe\Exceptions\InfoException;
 use function Safe\ini_get;
 
 /**
- * Provides value for pcov.directory configuration option. Can be injected with a configuration object to provide a better, precise, value.
+ * When used as the coverage driver, PCOV selects the first existing directory
+ * from `src`, `lib`, `app`, and the current working directory by default. This
+ * may exclude source code located outside the selected directory.
+ *
+ * The `pcov.directory` setting overrides this behaviour.
+ *
+ * Infection knows which source code it targets and can therefore refine this
+ * setting to provide a safer default.
+ *
+ * @see https://github.com/krakjoe/pcov
+ * @see https://github.com/krakjoe/pcov/blob/57e143363aa6ba3c4d1e1b0a2e68556e28f38950/pcov.c#L357-L387
  *
  * @internal
  * @final
  */
-class PCOVDirectoryProvider
+readonly class PCOVDirectoryProvider
 {
-    private ?string $phpConfiguredPcovDirectory = null;
+    // https://github.com/krakjoe/pcov/blob/57e143363aa6ba3c4d1e1b0a2e68556e28f38950/pcov.c#L80-L83
+    private const string DEFAULT_DIRECTORY = '.';
+
+    private ?string $phpConfiguredPcovDirectory;
 
     public function __construct(?string $iniValue = null)
     {
@@ -58,11 +71,9 @@ class PCOVDirectoryProvider
         }
     }
 
-    public function shallProvide(): bool
+    public function shouldProvide(): bool
     {
-        // That's the default value as per:
-        // https://github.com/krakjoe/pcov/blob/57e143363aa6ba3c4d1e1b0a2e68556e28f38950/pcov.c#L80-L83
-        return $this->phpConfiguredPcovDirectory === '';
+        return $this->phpConfiguredPcovDirectory === self::DEFAULT_DIRECTORY;
     }
 
     public function getDirectory(): string

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework;
 
+use function dirname;
 use function implode;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
@@ -92,6 +93,7 @@ final readonly class Factory
                 $this->getFilteredSourceFilesToMutate(),
                 $this->infectionConfig->mapSourceClassToTestStrategy,
                 $this->shellCommandLineExecutor,
+                sourceDirectoryBasePath: dirname($this->infectionConfig->configurationPathname),
             );
         }
 

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -122,7 +122,9 @@ final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements Memor
                 ),
             );
 
-            if ($this->pcovDirectoryProvider->shallProvide()) {
+            // PCOV may require an adjusted `pcov.directory` setting to include
+            // all target source code in the coverage report.
+            if ($this->pcovDirectoryProvider->shouldProvide()) {
                 $phpExtraArgs[] = '-d';
                 $phpExtraArgs[] = sprintf('pcov.directory=%s', escapeshellarg($this->pcovDirectoryProvider->getDirectory()));
             }

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\TestFramework\PhpUnit\Adapter;
 
 use function array_map;
+use function array_values;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
 use Infection\CannotBeInstantiated;
@@ -53,6 +54,7 @@ use Infection\TestFramework\Tracing\TestRunOrderResolver;
 use function Safe\file_get_contents;
 use SplFileInfo;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Webmozart\Assert\Assert;
 
@@ -80,6 +82,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
         array $filteredSourceFilesToMutate = [],
         ?string $mapSourceClassToTestStrategy = null,
         ?ShellCommandLineExecutor $shellCommandLineExecutor = null,
+        ?string $sourceDirectoryBasePath = null,
     ): TestFrameworkAdapter {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the adapter');
         Assert::notNull($shellCommandLineExecutor);
@@ -94,11 +97,22 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
             $testFrameworkConfigDir,
         );
 
+        $sourceDirectoryBasePath ??= $projectDir;
+        $sourceDirectoryPaths = array_values(
+            array_map(
+                static fn (string $sourceDirectory): string => Path::makeAbsolute(
+                    $sourceDirectory,
+                    $sourceDirectoryBasePath,
+                ),
+                $sourceDirectories,
+            ),
+        );
+
         return new PhpUnitAdapter(
             $testFrameworkExecutable,
             $tmpDir,
             $jUnitFilePath,
-            new PCOVDirectoryProvider(),
+            new PCOVDirectoryProvider($sourceDirectoryPaths, null),
             new InitialConfigBuilder(
                 $tmpDir,
                 $testFrameworkConfigContent,

--- a/tests/e2e/PCOV_Source_Outside_Working_Directory/.gitignore
+++ b/tests/e2e/PCOV_Source_Outside_Working_Directory/.gitignore
@@ -1,0 +1,2 @@
+/server/.var/
+/server/vendor/

--- a/tests/e2e/PCOV_Source_Outside_Working_Directory/README.md
+++ b/tests/e2e/PCOV_Source_Outside_Working_Directory/README.md
@@ -1,0 +1,30 @@
+# PCOV source outside the working directory
+
+This scenario covers a PHP project whose configured sources include both a directory below
+the working directory and a sibling directory. PHPUnit includes both directories in its
+coverage configuration.
+
+When PCOV has no configured `pcov.directory`, Infection must not restrict instrumentation to
+the current working directory: doing so silently drops coverage for the sibling source and
+makes its mutations ineligible.
+
+## Running the scenario
+
+Run it with a PHP installation that loads PCOV:
+
+```shell
+php -m | grep -i '^pcov$'
+./tests/e2e_tests bin/infection PCOV_Source_Outside_Working_Directory
+```
+
+Run it without PCOV after selecting a PHP installation that uses another coverage driver,
+such as Xdebug:
+
+```shell
+! php -m | grep -i '^pcov$'
+php -m | grep -i '^xdebug$'
+./tests/e2e_tests bin/infection PCOV_Source_Outside_Working_Directory
+```
+
+Setting `pcov.enabled=0` is not equivalent to the second setup: the PCOV extension remains
+loaded, and Infection will still detect it as the coverage driver.

--- a/tests/e2e/PCOV_Source_Outside_Working_Directory/expected-output.txt
+++ b/tests/e2e/PCOV_Source_Outside_Working_Directory/expected-output.txt
@@ -1,0 +1,11 @@
+Total: 2
+
+Killed by Test Framework: 2
+Killed by Static Analysis: 0
+Errored: 0
+Syntax Errors: 0
+Escaped: 0
+Timed Out: 0
+Skipped: 0
+Ignored: 0
+Not Covered: 0

--- a/tests/e2e/PCOV_Source_Outside_Working_Directory/run_tests.bash
+++ b/tests/e2e/PCOV_Source_Outside_Working_Directory/run_tests.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+INFECTION=$(realpath "../../../${1}")
+readonly INFECTION
+
+composer install --working-dir=server --no-interaction --quiet
+
+(
+    cd server
+    php "$INFECTION"
+)
+
+diff --ignore-all-space expected-output.txt server/.var/infection.log

--- a/tests/e2e/PCOV_Source_Outside_Working_Directory/server/composer.json
+++ b/tests/e2e/PCOV_Source_Outside_Working_Directory/server/composer.json
@@ -1,0 +1,19 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^12.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "PCOVSourceOutsideWorkingDirectory\\": "src/",
+            "PCOVSourceOutsideWorkingDirectory\\Shared\\": "../shared/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PCOVSourceOutsideWorkingDirectory\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/tests/e2e/PCOV_Source_Outside_Working_Directory/server/infection.json5
+++ b/tests/e2e/PCOV_Source_Outside_Working_Directory/server/infection.json5
@@ -1,0 +1,21 @@
+{
+    "$schema": "../../../../resources/schema.json",
+    "timeout": 25,
+    "threads": 1,
+    "source": {
+        "directories": [
+            "src",
+            "../shared"
+        ]
+    },
+    "logs": {
+        "summary": ".var/infection.log"
+    },
+    "phpUnit": {
+        "customPath": "vendor/bin/phpunit"
+    },
+    "mutators": {
+        "TrueValue": true
+    },
+    "tmpDir": ".var/infection-tmp"
+}

--- a/tests/e2e/PCOV_Source_Outside_Working_Directory/server/phpunit.xml
+++ b/tests/e2e/PCOV_Source_Outside_Working_Directory/server/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".var/phpunit-cache"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>src</directory>
+            <directory>../shared</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/e2e/PCOV_Source_Outside_Working_Directory/server/src/SourceClass.php
+++ b/tests/e2e/PCOV_Source_Outside_Working_Directory/server/src/SourceClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PCOVSourceOutsideWorkingDirectory;
+
+final class SourceClass
+{
+    public function returnsTrue(): bool
+    {
+        return true;
+    }
+}

--- a/tests/e2e/PCOV_Source_Outside_Working_Directory/server/tests/SourceClassTest.php
+++ b/tests/e2e/PCOV_Source_Outside_Working_Directory/server/tests/SourceClassTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PCOVSourceOutsideWorkingDirectory\Tests;
+
+use PCOVSourceOutsideWorkingDirectory\Shared\SharedClass;
+use PCOVSourceOutsideWorkingDirectory\SourceClass;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SourceClass::class)]
+#[CoversClass(SharedClass::class)]
+final class SourceClassTest extends TestCase
+{
+    public function test_it_returns_true(): void
+    {
+        $this->assertTrue((new SourceClass())->returnsTrue());
+        $this->assertTrue((new SharedClass())->returnsTrue());
+    }
+}

--- a/tests/e2e/PCOV_Source_Outside_Working_Directory/shared/SharedClass.php
+++ b/tests/e2e/PCOV_Source_Outside_Working_Directory/shared/SharedClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PCOVSourceOutsideWorkingDirectory\Shared;
+
+final class SharedClass
+{
+    public function returnsTrue(): bool
+    {
+        return true;
+    }
+}

--- a/tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php
@@ -35,41 +35,42 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Config\ValueProvider;
 
-use function extension_loaded;
 use Infection\Config\ValueProvider\PCOVDirectoryProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
-use Safe\Exceptions\InfoException;
 use function Safe\ini_get;
 
 #[CoversClass(PCOVDirectoryProvider::class)]
 final class PCOVDirectoryProviderTest extends TestCase
 {
-    public function test_it_shall_provide_directory_for_default_value(): void
+    public function test_it_provides_a_directory_when_pcov_directory_is_unset(): void
     {
         $provider = new PCOVDirectoryProvider('');
-        $this->assertTrue($provider->shallProvide());
+
+        $this->assertTrue($provider->shouldProvide());
         $this->assertSame('.', $provider->getDirectory());
     }
 
-    public function test_it_shall_not_provide_directory_for_non_default_value(): void
+    public function test_it_does_not_provide_a_directory_when_pcov_directory_is_configured(): void
     {
         $provider = new PCOVDirectoryProvider('example');
-        $this->assertFalse($provider->shallProvide());
+
+        $this->assertFalse($provider->shouldProvide());
     }
 
-    public function test_it_loads_current_value_from_environment(): void
+    #[RequiresPhpExtension('pcov')]
+    public function test_it_reads_pcov_directory_from_the_ini_configuration(): void
     {
         $provider = new PCOVDirectoryProvider();
 
-        try {
-            $this->assertSame(ini_get('pcov.directory') === '', $provider->shallProvide());
-        } catch (InfoException $e) {
-            if (extension_loaded('pcov')) {
-                throw $e;
-            }
+        // Note that `pcov.directory` is a `PHP_INI_SYSTEM | PHP_INI_PERDIR` so
+        // it cannot be set at runtime.
+        // As a result, this test is a bit light, but being more thorough would
+        // be too expensive infrastructure-wise.
+        // See https://github.com/krakjoe/pcov/blob/57e143363aa6ba3c4d1e1b0a2e68556e28f38950/pcov.c#L80-L83
+        $expected = ini_get('pcov.directory') === '';
 
-            $this->markTestSkipped('Skipped without PCOV');
-        }
+        $this->assertSame($expected, $provider->shouldProvide());
     }
 }

--- a/tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php
@@ -47,20 +47,40 @@ final class PCOVDirectoryProviderTest extends TestCase
 {
     public function test_it_shall_provide_directory_for_default_value(): void
     {
-        $provider = new PCOVDirectoryProvider('');
+        $provider = new PCOVDirectoryProvider([], '');
         $this->assertTrue($provider->shallProvide());
         $this->assertSame('.', $provider->getDirectory());
     }
 
+    public function test_it_provides_the_common_source_directory(): void
+    {
+        $provider = new PCOVDirectoryProvider(
+            [
+                '/project/server/src',
+                '/project/shared',
+            ],
+            '',
+        );
+
+        $this->assertSame('/project', $provider->getDirectory());
+    }
+
+    public function test_it_provides_the_parent_directory_for_one_source_file(): void
+    {
+        $provider = new PCOVDirectoryProvider(['/project/src'], '');
+
+        $this->assertSame('/project/src', $provider->getDirectory());
+    }
+
     public function test_it_shall_not_provide_directory_for_non_default_value(): void
     {
-        $provider = new PCOVDirectoryProvider('example');
+        $provider = new PCOVDirectoryProvider([], 'example');
         $this->assertFalse($provider->shallProvide());
     }
 
     public function test_it_loads_current_value_from_environment(): void
     {
-        $provider = new PCOVDirectoryProvider();
+        $provider = new PCOVDirectoryProvider([], null);
 
         try {
             $this->assertSame(ini_get('pcov.directory') === '', $provider->shallProvide());

--- a/tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php
+++ b/tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php
@@ -224,6 +224,7 @@ final class ParentConnectorTest extends VisitorTestCase
             'Expected a root node to not have any parent.',
         );
 
+        $this->expectException();
         $failure = $this->expectToThrow(
             static fn () => ParentConnector::getParent($functionNode),
         );

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
@@ -100,7 +100,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $this->assertSame('PHPUnit', $this->adapter->getName());
     }
@@ -112,7 +112,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $this->assertTrue($this->adapter->hasJUnitReport());
     }
@@ -152,7 +152,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $actual = $this->adapter->testsPass($output);
 
@@ -169,7 +169,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $actual = $this->adapter->isSyntaxError($output);
 
@@ -186,7 +186,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $result = $this->adapter->getMemoryUsed($output);
 
@@ -200,7 +200,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $options = $this->adapter->getInitialRunOnlyOptions();
 
@@ -222,7 +222,7 @@ final class PhpUnitAdapterTest extends TestCase
 
         $this->pcovDirectoryProvider
             ->expects($scenario->skipCoverage ? $this->never() : $this->once())
-            ->method('shallProvide')
+            ->method('shouldProvide')
             ->willReturn($scenario->pcovDirectory !== '');
         $this->pcovDirectoryProvider
             ->expects($this->atMost(1))
@@ -260,7 +260,7 @@ final class PhpUnitAdapterTest extends TestCase
 
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $adapter = $this->createAdapter(
             testFrameworkConfigContent: $scenario->testFrameworkConfigContent,


### PR DESCRIPTION
This bug was identified in #3399. Figuring out the test & fix is still an on-going process.

Depends on https://github.com/infection/infection/pull/3408.

<hr/>

## Description

<!-- Explain what this PR does and why. Link to relevant context. -->

## Changes

- Adds/Fixes/Updates ...

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (provide link to PR: https://github.com/infection/site/pull/XXX)
- [ ] CHANGELOG.md updated (if deprecations/breaking changes)
- [ ] Appropriate labels applied (e.g. `performance`, `feature`).


## Breaking Changes

<!-- Remove if not applicable -->


## Reviewer Notes

<!-- What should reviewers focus on? Any areas of concern? -->

## Related issues

Fixes https://github.com/infection/infection/issues/XXX.

This PR:

- [ ] Adds new feature ...
- [ ] Covered by tests
- [ ] Doc PR: https://github.com/infection/site/pull/XXX

<!--
Remove if not relevant
-->

Fixes https://github.com/infection/infection/issues/XXX
