### PR TITLE
refactor(phpunit): Clarify PCOV directory handling

### DIFF
--- a/src/Config/ValueProvider/PCOVDirectoryProvider.php
+++ b/src/Config/ValueProvider/PCOVDirectoryProvider.php
@@ -57,7 +57,7 @@ use function Safe\ini_get;
 readonly class PCOVDirectoryProvider
 {
     // https://github.com/krakjoe/pcov/blob/57e143363aa6ba3c4d1e1b0a2e68556e28f38950/pcov.c#L80-L83
-    private const string DEFAULT_DIRECTORY = '.';
+    private const string DEFAULT_DIRECTORY = '';
 
     private ?string $phpConfiguredPcovDirectory;
 

--- a/src/Config/ValueProvider/PCOVDirectoryProvider.php
+++ b/src/Config/ValueProvider/PCOVDirectoryProvider.php
@@ -39,14 +39,27 @@ use Safe\Exceptions\InfoException;
 use function Safe\ini_get;
 
 /**
- * Provides value for pcov.directory configuration option. Can be injected with a configuration object to provide a better, precise, value.
+ * When used as the coverage driver, PCOV selects the first existing directory
+ * from `src`, `lib`, `app`, and the current working directory by default. This
+ * may exclude source code located outside the selected directory.
+ *
+ * The `pcov.directory` setting overrides this behaviour.
+ *
+ * Infection knows which source code it targets and can therefore refine this
+ * setting to provide a safer default.
+ *
+ * @see https://github.com/krakjoe/pcov
+ * @see https://github.com/krakjoe/pcov/blob/57e143363aa6ba3c4d1e1b0a2e68556e28f38950/pcov.c#L357-L387
  *
  * @internal
  * @final
  */
-class PCOVDirectoryProvider
+readonly class PCOVDirectoryProvider
 {
-    private ?string $phpConfiguredPcovDirectory = null;
+    // https://github.com/krakjoe/pcov/blob/57e143363aa6ba3c4d1e1b0a2e68556e28f38950/pcov.c#L80-L83
+    private const string DEFAULT_DIRECTORY = '.';
+
+    private ?string $phpConfiguredPcovDirectory;
 
     public function __construct(?string $iniValue = null)
     {
@@ -58,11 +71,9 @@ class PCOVDirectoryProvider
         }
     }
 
-    public function shallProvide(): bool
+    public function shouldProvide(): bool
     {
-        // That's the default value as per:
-        // https://github.com/krakjoe/pcov/blob/57e143363aa6ba3c4d1e1b0a2e68556e28f38950/pcov.c#L80-L83
-        return $this->phpConfiguredPcovDirectory === '';
+        return $this->phpConfiguredPcovDirectory === self::DEFAULT_DIRECTORY;
     }
 
     public function getDirectory(): string

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -122,7 +122,9 @@ final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements Memor
                 ),
             );
 
-            if ($this->pcovDirectoryProvider->shallProvide()) {
+            // PCOV may require an adjusted `pcov.directory` setting to include
+            // all target source code in the coverage report.
+            if ($this->pcovDirectoryProvider->shouldProvide()) {
                 $phpExtraArgs[] = '-d';
                 $phpExtraArgs[] = sprintf('pcov.directory=%s', escapeshellarg($this->pcovDirectoryProvider->getDirectory()));
             }

--- a/tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php
@@ -35,41 +35,42 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Config\ValueProvider;
 
-use function extension_loaded;
 use Infection\Config\ValueProvider\PCOVDirectoryProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
-use Safe\Exceptions\InfoException;
 use function Safe\ini_get;
 
 #[CoversClass(PCOVDirectoryProvider::class)]
 final class PCOVDirectoryProviderTest extends TestCase
 {
-    public function test_it_shall_provide_directory_for_default_value(): void
+    public function test_it_provides_a_directory_when_pcov_directory_is_unset(): void
     {
         $provider = new PCOVDirectoryProvider('');
-        $this->assertTrue($provider->shallProvide());
+
+        $this->assertTrue($provider->shouldProvide());
         $this->assertSame('.', $provider->getDirectory());
     }
 
-    public function test_it_shall_not_provide_directory_for_non_default_value(): void
+    public function test_it_does_not_provide_a_directory_when_pcov_directory_is_configured(): void
     {
         $provider = new PCOVDirectoryProvider('example');
-        $this->assertFalse($provider->shallProvide());
+
+        $this->assertFalse($provider->shouldProvide());
     }
 
-    public function test_it_loads_current_value_from_environment(): void
+    #[RequiresPhpExtension('pcov')]
+    public function test_it_reads_pcov_directory_from_the_ini_configuration(): void
     {
         $provider = new PCOVDirectoryProvider();
 
-        try {
-            $this->assertSame(ini_get('pcov.directory') === '', $provider->shallProvide());
-        } catch (InfoException $e) {
-            if (extension_loaded('pcov')) {
-                throw $e;
-            }
+        // Note that `pcov.directory` is a `PHP_INI_SYSTEM | PHP_INI_PERDIR` so
+        // it cannot be set at runtime.
+        // As a result, this test is a bit light, but being more thorough would
+        // be too expensive infrastructure-wise.
+        // See https://github.com/krakjoe/pcov/blob/57e143363aa6ba3c4d1e1b0a2e68556e28f38950/pcov.c#L80-L83
+        $expected = ini_get('pcov.directory') === '';
 
-            $this->markTestSkipped('Skipped without PCOV');
-        }
+        $this->assertSame($expected, $provider->shouldProvide());
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
@@ -100,7 +100,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $this->assertSame('PHPUnit', $this->adapter->getName());
     }
@@ -112,7 +112,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $this->assertTrue($this->adapter->hasJUnitReport());
     }
@@ -152,7 +152,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $actual = $this->adapter->testsPass($output);
 
@@ -169,7 +169,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $actual = $this->adapter->isSyntaxError($output);
 
@@ -186,7 +186,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $result = $this->adapter->getMemoryUsed($output);
 
@@ -200,7 +200,7 @@ final class PhpUnitAdapterTest extends TestCase
             ->method('dumpFile');
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $options = $this->adapter->getInitialRunOnlyOptions();
 
@@ -222,7 +222,7 @@ final class PhpUnitAdapterTest extends TestCase
 
         $this->pcovDirectoryProvider
             ->expects($scenario->skipCoverage ? $this->never() : $this->once())
-            ->method('shallProvide')
+            ->method('shouldProvide')
             ->willReturn($scenario->pcovDirectory !== '');
         $this->pcovDirectoryProvider
             ->expects($this->atMost(1))
@@ -260,7 +260,7 @@ final class PhpUnitAdapterTest extends TestCase
 
         $this->pcovDirectoryProvider
             ->expects($this->never())
-            ->method('shallProvide');
+            ->method('shouldProvide');
 
         $adapter = $this->createAdapter(
             testFrameworkConfigContent: $scenario->testFrameworkConfigContent,


### PR DESCRIPTION
## Description

In https://github.com/infection/infection/pull/3407, I had to dig further into the PCOV configuration and finding out what we are doing and why was a bit obscure and took too much digging.

This PR does a pass on `PCOVDirectoryProvider` to improve its documentation and do a tiny housekeeping pass.

## Changes

- Document PCOV's default directory-selection behaviour and link to its source.
- Make `PCOVDirectoryProvider` readonly and name its default directory value.
- Rename `shallProvide()` to `shouldProvide()` and update the PHPUnit adapter and tests accordingly to align with the tone chosen in the project.
- Use PHPUnit's `RequiresPhpExtension` attribute for the test that reads the live PCOV INI configuration.
- Improve the provider test names to describe the configuration conditions they exercise.
