### PR TITLE
test: Fix MemoryLimiterEnvironmentTest intermitent failures

### DIFF
--- a/tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php
+++ b/tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php
@@ -148,7 +148,7 @@ final class MemoryLimiterEnvironmentTest extends TestCase
         ];
 
         yield 'limit without unit' => [
-            '268435456',    // 256M
+            '1073741824',   // 1G
             true,
         ];
     }


### PR DESCRIPTION
I occasionally saw the following failure:

```
[7](https://github.com/infection/infection/actions/runs/30089371537/job/89468927125?pr=3408#step:7:208)
         1)                                                                     
         Infection\Tests\Resource\Memory\MemoryLimiterEnvironmentTest::test_it_c
         an_detect_if_a_memory_limit_is_set@limit without unit with data        
         ('268435456', true)                                                    
         Safe\Exceptions\InfoException: Failed to set memory limit to 268435456 
         bytes (Current memory usage is 272109568 bytes)                        
                                                                                
         /home/runner/work/infection/infection/vendor/thecodingmachine/safe/gene
         rated/Exceptions/InfoException.php:9                                   
         /home/runner/work/infection/infection/vendor/thecodingmachine/safe/gene
         rated/8.1/info.php:237                                                 
         /home/runner/work/infection/infection/tests/phpunit/Resource/Memory/Mem
         oryLimiterEnvironmentTest.php:71
```

The failing test was introduced [in 2020](https://github.com/infection/infection/pull/1216/changes#diff-4c022b7cfa33ba065a6c6979f0517c9f29cd24e524a5608d818e9357bd8c2384R149), and the current failure appears to be caused because PHP cannot lower the `memory_limit` bellow the current allocated memory, so `Safe\ini_set()` throws an `InfoException`.

I did not conduct a thorough investigation, but it seems reasonable that the PHPUnit consumption rose over time as we added more tests and now we currently face the issue. Since this depends on the currently allocated memory limit, the randomness can be explained by at what time this test is executed in the test suite: it may be executed early enough that we do not reach 256MB of allocated memory limit yet.

In the end, this test is about testing the limit for a value without units, so I bumped the value and this should do the trick.