### PR TITLE
refactor(phpunit): Remove handling of non-realistic path for the PCOV directory provider

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -33,6 +33,11 @@
                 "Infection\\Logger\\GitHub\\GitDiffFileProvider::provideDefaultBase"
             ]
         },
+        "ArrayOneItem": {
+            "ignore": [
+                "Infection\\TestFramework\\PhpUnit\\Adapter\\PhpUnitAdapterFactory::makeSourcePathsAbsolute"
+            ]
+        },
         "FalseValue": {
             "ignore": [
                 "Infection\\TestFramework\\PhpUnit\\Adapter\\PhpUnitAdapterFactory::create"

--- a/src/Config/ValueProvider/PCOVDirectoryProvider.php
+++ b/src/Config/ValueProvider/PCOVDirectoryProvider.php
@@ -64,7 +64,7 @@ readonly class PCOVDirectoryProvider
     private ?string $phpConfiguredPcovDirectory;
 
     /**
-     * @param list<string> $sourceDirectoryPaths
+     * @param non-empty-list<string> $sourceDirectoryPaths
      */
     public function __construct(
         private array $sourceDirectoryPaths,
@@ -85,10 +85,6 @@ readonly class PCOVDirectoryProvider
 
     public function getDirectory(): string
     {
-        if ($this->sourceDirectoryPaths === []) {
-            return '.';
-        }
-
         $longestCommonBasePath = Path::getLongestCommonBasePath(...$this->sourceDirectoryPaths);
 
         Assert::notNull(

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -85,6 +85,10 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
         ?string $sourceDirectoryBasePath = null,
     ): TestFrameworkAdapter {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the adapter');
+        Assert::notEmpty(
+            $sourceDirectories,
+            'The source directories cannot be empty. This indicates that an invalid configuration reached the test framework adapter factory.',
+        );
         Assert::notNull($shellCommandLineExecutor);
         Assert::notNull($sourceDirectoryBasePath);
 
@@ -116,7 +120,13 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
                 new Filesystem(),
                 $sourceDirectories,
                 array_map(
-                    static fn (SplFileInfo $fileInfo): string => $fileInfo->getRealPath(),
+                    static function (SplFileInfo $fileInfo): string {
+                        $realPath = $fileInfo->getRealPath();
+
+                        Assert::string($realPath, 'The filtered source file must have a real path.');
+
+                        return $realPath;
+                    },
                     $filteredSourceFilesToMutate,
                 ),
             ),
@@ -152,15 +162,15 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
     }
 
     /**
-     * @param string[] $sourceDirectories
+     * @param non-empty-array<string> $sourceDirectories
      *
-     * @return list<string>
+     * @return non-empty-list<string>
      */
     private static function makeSourcePathsAbsolute(
         string $sourceDirectoryBasePath,
         array $sourceDirectories,
     ): array {
-        return array_values(
+        $absolutePaths = array_values(
             array_map(
                 static fn (string $sourceDirectory): string => Path::makeAbsolute(
                     $sourceDirectory,
@@ -169,5 +179,9 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
                 $sourceDirectories,
             ),
         );
+
+        Assert::notEmpty($absolutePaths);
+
+        return $absolutePaths;
     }
 }

--- a/tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php
@@ -47,7 +47,7 @@ use function Safe\ini_get;
 final class PCOVDirectoryProviderTest extends TestCase
 {
     /**
-     * @param list<string> $sourceDirectoryPaths
+     * @param non-empty-list<string> $sourceDirectoryPaths
      */
     #[DataProvider('sourceDirectoryPathsProvider')]
     public function test_it_provides_the_source_directory(
@@ -65,7 +65,7 @@ final class PCOVDirectoryProviderTest extends TestCase
     #[RequiresPhpExtension('pcov')]
     public function test_it_reads_pcov_directory_from_the_ini_configuration(): void
     {
-        $provider = new PCOVDirectoryProvider([]);
+        $provider = new PCOVDirectoryProvider(['/project/src']);
 
         // Note that `pcov.directory` is a `PHP_INI_SYSTEM | PHP_INI_PERDIR` so
         // it cannot be set at runtime.
@@ -94,11 +94,6 @@ final class PCOVDirectoryProviderTest extends TestCase
 
     public static function sourceDirectoryPathsProvider(): iterable
     {
-        yield 'no source directory paths' => [
-            'sourceDirectoryPaths' => [],
-            'expectedDirectory' => '.',
-        ];
-
         yield 'source directory paths with a common base path' => [
             'sourceDirectoryPaths' => [
                 '/path/to/project/src',
@@ -114,8 +109,8 @@ final class PCOVDirectoryProviderTest extends TestCase
         ];
 
         yield 'configured PCOV directory' => [
-            'sourceDirectoryPaths' => [],
-            'expectedDirectory' => '.',
+            'sourceDirectoryPaths' => ['/project/src'],
+            'expectedDirectory' => '/project/src',
             'expectedShouldProvide' => false,
             'iniValue' => 'example',
         ];

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
@@ -54,7 +54,7 @@ final class PhpUnitAdapterFactoryTest extends TestCase
             '/path/to/config-dir',
             '/path/to/junit.xml',
             '/path/to/project',
-            [],
+            ['src'],
             true,
             shellCommandLineExecutor: new ShellCommandLineExecutor(),
             sourceDirectoryBasePath: '/path/to/project',


### PR DESCRIPTION
As part of the train of investigating all of those pcov related issues, I had strong suspicions that `pcov.directory="."` was an incorrect value. With the previous changes, the only remaining case where this can happen is when the infection configuration has no source defined, which is not possible (will result in a schema failure).

In fact, in `Factory.php`:

```php
$factory::create(
    // ...
    sourceDirectories: $this->infectionConfig->source->directories,
    // ...
);
```

Already has the type `non-empty-array<string>`. But `TestFrameworkAdapterFactory::create(sourceDirectories)` does not yet (and is an external package).

So this PR contents itself from updating the downstream code, `PhpUnitAdapterFactory`, to tighten that type and allow to simplify `PCOVDirectoryProvider`, removing this non-realistic and otherwise buggy scenario.
