### PR TITLE
ci: Collect performance metrics on release tag pushes

### DIFF
--- a/.github/workflows/perf-metrics.yaml
+++ b/.github/workflows/perf-metrics.yaml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - master
+    tags:
+      - '*'
     paths:
       - '.github/workflows/perf-metrics.yaml'
       - 'src/**'
@@ -150,12 +152,14 @@ jobs:
           TRIGGER: ${{ github.event_name }}
           CPU_MODEL: ${{ steps.runner-specs.outputs.cpu_model }}
           CPU_ARCH: ${{ steps.runner-specs.outputs.cpu_arch }}
-          REF_INPUT: ${{ github.event.inputs.ref }}
           TOTAL_MEM: ${{ steps.runner-specs.outputs.total_memory_kb }}
         run: |
           export COMMIT_DATE=$(git log -1 --format='%cI')
           export GIT_SHA=$(git rev-parse HEAD)
           export IMAGE_VERSION="${ImageVersion:-unknown}"
+
+          # extract tags from bare refs (refs/tags/<tag>)
+          export GIT_REF="${GIT_REF#refs/tags/}"
 
           php metrics-repo/scripts/prepare-metrics.php timing.json entry.json
 
@@ -179,12 +183,11 @@ jobs:
           git diff --staged --quiet && echo "No changes to commit" && exit 0
 
           # Build commit message with tag (if provided) and short SHA
-          SHORT_SHA="${{ github.sha }}"
-          SHORT_SHA="${SHORT_SHA:0:7}"
-          if [[ -n "$REF_INPUT" ]]; then
-            COMMIT_MSG="perf: Add metrics for $REF_INPUT ($SHORT_SHA)"
-          else
+          SHORT_SHA="${GIT_SHA:0:7}"
+          if [[ "$GIT_REF" == refs/heads/* ]]; then
             COMMIT_MSG="perf: Add metrics for $SHORT_SHA"
+          else
+            COMMIT_MSG="perf: Add metrics for $GIT_REF ($SHORT_SHA)"
           fi
 
           git commit -m "$COMMIT_MSG"


### PR DESCRIPTION
## Description

I noticed that tags (releases) aren't getting [into the dashboard](https://infection.github.io/infection-metrics/); turns out it was a bug.

## Changes

- Fixes metrics attribution bug.
