### PR TITLE
ci: Ignore zizimor error in the metrics collection workflow

### DIFF
--- a/.github/workflows/perf-metrics.yaml
+++ b/.github/workflows/perf-metrics.yaml
@@ -67,7 +67,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        # zizmor: ignore[cache-poisoning] the tag trigger only collects metrics
+        # zizmor: ignore[cache-poisoning] This workflow only collects metrics (no publishing) and runs with read-only repo permissions.
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/perf-metrics.yaml
+++ b/.github/workflows/perf-metrics.yaml
@@ -65,6 +65,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
+        # zizmor: ignore[cache-poisoning] the tag trigger only collects metrics
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}


### PR DESCRIPTION
## Description

The workflow runs on tags, and Zizimor assumes that it helps with released artifacts, so it flags the use of caches. But we don't touch release artifacts here.

## Changes

- Silence an irrelevant issue.
